### PR TITLE
[FIX] l10n_my_*: Enable invoicing foreign customers.

### DIFF
--- a/addons/l10n_my_edi/data/my_ubl_templates.xml
+++ b/addons/l10n_my_edi/data/my_ubl_templates.xml
@@ -2,14 +2,8 @@
 <odoo>
     <template id="ubl_21_InvoiceType_my" inherit_id="account_edi_ubl_cii.ubl_21_InvoiceType" primary="True">
         <xpath expr="//*[local-name()='DocumentCurrencyCode']" position="after">
-            <!-- When applicable, the tax exchange rate MUST be provided. -->
             <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
                xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
-                <cac:TaxExchangeRate t-if="invoice.currency_id.name.upper() != 'MYR'">
-                    <cbc:CalculationRate t-out="vals.get('tax_exchange_rate')"/>
-                    <cbc:SourceCurrencyCode t-out="vals.get('document_currency_code')"/>
-                    <cbc:TargetCurrencyCode>MYR</cbc:TargetCurrencyCode>
-                </cac:TaxExchangeRate>
                 <cac:AdditionalDocumentReference t-if="vals.get('invoice_incoterm_code')">
                     <cbc:ID t-out="vals['invoice_incoterm_code']"/>
                 </cac:AdditionalDocumentReference>
@@ -17,6 +11,17 @@
                     <cbc:ID t-out="vals['custom_form_reference']"/>
                     <cbc:DocumentType>CustomsImportForm</cbc:DocumentType>
                 </cac:AdditionalDocumentReference>
+            </t>
+        </xpath>
+        <xpath expr="//*[local-name()='Delivery']" position="after">
+            <!-- When applicable, the tax exchange rate MUST be provided. -->
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+               xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <cac:TaxExchangeRate t-if="invoice.currency_id.name != 'MYR'">
+                    <cbc:SourceCurrencyCode t-out="invoice.currency_id.name"/>
+                    <cbc:TargetCurrencyCode>MYR</cbc:TargetCurrencyCode>
+                    <cbc:CalculationRate t-out="vals.get('tax_exchange_rate')"/>
+                </cac:TaxExchangeRate>
             </t>
         </xpath>
         <xpath expr="//*[local-name()='IssueDate']" position="after">

--- a/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
@@ -229,7 +229,7 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
             'id': partner.vat,
         })
 
-        if partner.country_code == 'MY':
+        if partner.l10n_my_identification_type and partner.l10n_my_identification_number:
             vals.append({
                 'id_attrs': {'schemeID': partner.l10n_my_identification_type},
                 'id': partner.l10n_my_identification_number,

--- a/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
@@ -198,19 +198,6 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
             'registration_name': partner.name,
         }]
 
-    def _get_invoice_tax_totals_vals_list(self, invoice, taxes_vals):
-        # EXTENDS 'account_edi_ubl_cii'
-        vals_list = super()._get_invoice_tax_totals_vals_list(invoice, taxes_vals)
-        company_currency = invoice.company_id.currency_id
-        if invoice.currency_id != company_currency:
-            vals_list.append({
-                'currency': company_currency,
-                'currency_dp': company_currency.decimal_places,
-                'tax_amount': taxes_vals['tax_amount'],
-                'tax_subtotal_vals': [],
-            })
-        return vals_list
-
     def _get_partner_party_identification_vals_list(self, partner):
         """ The id vals list must be filled with two values.
         The TIN, and then one of either:

--- a/addons/l10n_my_edi/tests/test_file_generation.py
+++ b/addons/l10n_my_edi/tests/test_file_generation.py
@@ -51,6 +51,16 @@ class L10nMyEDITestFileSubmission(AccountTestInvoicingCommon):
             'city': 'Main city',
             'phone': '+60123456786',
         })
+        cls.partner_b.write({
+            'vat': 'EI00000000020',
+            'l10n_my_identification_type': 'BRN',
+            'l10n_my_identification_number': 'NA',
+            'country_id': cls.env.ref('base.us').id,
+            'state_id': cls.env.ref('base.state_us_1'),
+            'street': 'that other street, 3',
+            'city': 'Main city',
+            'phone': '+60123456785',
+        })
 
         cls.fakenow = datetime(2024, 7, 15, 10, 00, 00)
         cls.startClassPatcher(freeze_time(cls.fakenow))
@@ -283,6 +293,34 @@ class L10nMyEDITestFileSubmission(AccountTestInvoicingCommon):
         # Check the invoice type to endure that it is marked as credit note.
         node = root.xpath('cac:OrderReference', namespaces=NS_MAP)
         self.assertEqual(node, [])
+
+    def test_06_foreigner(self):
+        """
+        Check that the file is correct with a foreign customer.
+        """
+        basic_invoice = self.init_invoice(
+            'out_invoice', amounts=[100], partner=self.partner_b
+        )
+        basic_invoice.action_post()
+
+        file, errors = basic_invoice._l10n_my_edi_generate_invoice_xml()
+        self.assertEqual(errors, set())
+        self.assertTrue(file)
+        # The file is working! Now we assert that the foreign customer information is in there.
+        root = etree.fromstring(file)
+        customer_root = root.xpath('cac:AccountingCustomerParty/cac:Party', namespaces=NS_MAP)[0]
+
+        # Party Identifications - TIN and BRN should be set.
+        self._assert_node_values(
+            customer_root,
+            'cac:PartyIdentification/cbc:ID[@schemeID="TIN"]',
+            self.partner_b.vat,
+        )
+        self._assert_node_values(
+            customer_root,
+            'cac:PartyIdentification/cbc:ID[@schemeID="BRN"]',
+            self.partner_b.l10n_my_identification_number,
+        )
 
     def _assert_node_values(self, root, node_path, text, attributes=None):
         node = root.xpath(node_path, namespaces=NS_MAP)

--- a/addons/l10n_my_edi/tests/test_file_generation.py
+++ b/addons/l10n_my_edi/tests/test_file_generation.py
@@ -153,7 +153,7 @@ class L10nMyEDITestFileSubmission(AccountTestInvoicingCommon):
         Simply ensure that in a multi currency environment, the rate is found in the file and is the expected one.
         """
         basic_invoice = self.init_invoice(
-            'out_invoice', amounts=[100], currency=self.currency_data['currency']
+            'out_invoice', amounts=[100], currency=self.currency_data['currency'], taxes=self.company_data['default_tax_sale']
         )
         basic_invoice.action_post()
 
@@ -171,6 +171,18 @@ class L10nMyEDITestFileSubmission(AccountTestInvoicingCommon):
             root,
             'cac:TaxExchangeRate/cbc:TargetCurrencyCode',
             'MYR',
+        )
+        self._assert_node_values(
+            root,
+            'cac:TaxExchangeRate/cbc:SourceCurrencyCode',
+            'Gol',
+        )
+        # Check that the TaxAmount node has the correct currency too
+        self._assert_node_values(
+            root,
+            'cac:TaxTotal/cbc:TaxAmount',
+            text='10.000',
+            attributes={'currencyID': 'Gol'},
         )
 
     def test_03_optional_fields(self):

--- a/addons/l10n_my_edi/views/res_partner_view.xml
+++ b/addons/l10n_my_edi/views/res_partner_view.xml
@@ -9,10 +9,10 @@
                 <field name="l10n_my_tin_validation_state" invisible="1"/>
                 <field name="l10n_my_edi_display_tin_warning" invisible="1"/>
                 <!-- Foreigner with a tax number registered in Malaysia could be customer of an e-invoice. -->
-                <group name="l10n_my_edi" string="MyInvois Information">
+                <group name="l10n_my_edi" string="MyInvois Information" invisible="'MY' not in fiscal_country_codes">
                     <group colspan="2">
                         <label for="l10n_my_identification_type" string="Identification"/>
-                        <div class="d-flex gap-2" invisible="'MY' not in fiscal_country_codes">
+                        <div class="d-flex gap-2">
                             <field name="l10n_my_identification_type"/>
                             <span class="d-flex gap-2 w-100">
                                 <field name="l10n_my_identification_number" placeholder="202001234568"/>

--- a/addons/l10n_my_ubl_pint/views/res_partner_view.xml
+++ b/addons/l10n_my_ubl_pint/views/res_partner_view.xml
@@ -6,8 +6,8 @@
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='vat']" position="after">
-                <field name="sst_registration_number" invisible="country_code != 'MY'" placeholder="A01-2345-67891012"/>
-                <field name="ttx_registration_number" invisible="country_code != 'MY'" placeholder="123-4567-89012345"/>
+                <field name="sst_registration_number" invisible="'MY' not in fiscal_country_codes" placeholder="A01-2345-67891012"/>
+                <field name="ttx_registration_number" invisible="'MY' not in fiscal_country_codes" placeholder="123-4567-89012345"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
The current logic is not working when trying to invoice foreign customers. A few fields that could be useful are hidden, and we don't add the id information in the xml file which causes it to fail.

In practice, it is valid to invoice a foreign customer and use a generic TIN if they don't have a malaysian one when reporting to the tax authorities. This change will allow just that; we add the id information to the xml which allow to correctly issue a valid invoice for a foreign customer (tested on pre- production)

opw-4438259

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
