### PR TITLE
[FIX] point_of_sale: handle selection of a deleted orders

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1467,7 +1467,7 @@ export class PosStore extends Reactive {
 
     // return the list of unpaid orders
     get_open_orders() {
-        return this.models["pos.order"].filter((o) => !o.finalized);
+        return this.models["pos.order"].filter((o) => !o.finalized && o.uiState.displayed);
     }
 
     // To be used in the context of closing the POS


### PR DESCRIPTION
Resolved an issue where selecting a deleted order behaves correctly on the product screen but fails on the payment screen.

**Steps to reproduce:**

1. create an order (order 1)
2. add product
3. go to payment screen
4. create another draft order (order 2)
5. go to Orders in the dropdown of the navbar (TicketScreen)
6. delete order 1
7. select the order you deleted from the navbar draft orders

This will result in a traceback

A fix was introduced in 18.1: https://github.com/odoo/odoo/commit/acb11c422ebf2b4811804a14ae12f849817f229a
That commit in 18.1 can't just be backported because it changes the API of some related_models methods.

This PR redirects you to Order 2 because order 1 is already Deleted
If there isn't any other draft orders created, it redirects you to a new draft order.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
