### PR TITLE
[IMP] website, *: add tooltip on shared block

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2274,6 +2274,7 @@ export class Wysiwyg extends Component {
         // snippet is a media.
         const isInMedia = $target.is(mediaSelector) && !$target.parent().hasClass('o_stars') && e.target &&
             (e.target.isContentEditable || (e.target.parentElement && e.target.parentElement.isContentEditable));
+        const isSharedBlockEl = $target[0]?.closest("[data-tooltip-message]");
         this.toolbarEl.classList.toggle('oe-media', isInMedia);
 
         for (const el of this.toolbarEl.querySelectorAll([
@@ -2354,7 +2355,8 @@ export class Wysiwyg extends Component {
             this._updateMediaJustifyButton();
             this._updateFaResizeButtons();
         }
-        if (isInMedia && !this.options.onDblClickEditableMedia) {
+        if ((isInMedia && !this.options.onDblClickEditableMedia) || isSharedBlockEl) {
+            const tooltipMessage = isInMedia ? _t('Double-click to edit') : isSharedBlockEl.dataset.tooltipMessage;
             // Handle the media/link's tooltip.
             this.showTooltip = true;
             this.tooltipTimeouts.push(setTimeout(() => {
@@ -2364,7 +2366,7 @@ export class Wysiwyg extends Component {
                 }
                 // Tooltips need to be cleared before leaving the editor.
                 this.saving_mutex.exec(() => {
-                    const removeTooltip = this.popover.add(e.target, Tooltip, { tooltip: _t('Double-click to edit') });
+                    const removeTooltip = this.popover.add(e.target, Tooltip, { tooltip: tooltipMessage });
                     this.tooltipTimeouts.push(setTimeout(() => removeTooltip(), 800));
                 });
             }, 400));

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2274,7 +2274,7 @@ export class Wysiwyg extends Component {
         // snippet is a media.
         const isInMedia = $target.is(mediaSelector) && !$target.parent().hasClass('o_stars') && e.target &&
             (e.target.isContentEditable || (e.target.parentElement && e.target.parentElement.isContentEditable));
-        const isSharedBlockEl = $target[0]?.closest("[data-tooltip-message]");
+        const isSharedBlockEl = $target[0]?.closest("[data-shared-block-tooltip]");
         this.toolbarEl.classList.toggle('oe-media', isInMedia);
 
         for (const el of this.toolbarEl.querySelectorAll([
@@ -2356,7 +2356,6 @@ export class Wysiwyg extends Component {
             this._updateFaResizeButtons();
         }
         if ((isInMedia && !this.options.onDblClickEditableMedia) || isSharedBlockEl) {
-            const tooltipMessage = isInMedia ? _t('Double-click to edit') : isSharedBlockEl.dataset.tooltipMessage;
             // Handle the media/link's tooltip.
             this.showTooltip = true;
             this.tooltipTimeouts.push(setTimeout(() => {
@@ -2366,6 +2365,7 @@ export class Wysiwyg extends Component {
                 }
                 // Tooltips need to be cleared before leaving the editor.
                 this.saving_mutex.exec(() => {
+                    const tooltipMessage = isInMedia ? _t('Double-click to edit') : isSharedBlockEl.dataset.sharedBlockTooltip;
                     const removeTooltip = this.popover.add(e.target, Tooltip, { tooltip: tooltipMessage });
                     this.tooltipTimeouts.push(setTimeout(() => removeTooltip(), 800));
                 });

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2274,7 +2274,7 @@ export class Wysiwyg extends Component {
         // snippet is a media.
         const isInMedia = $target.is(mediaSelector) && !$target.parent().hasClass('o_stars') && e.target &&
             (e.target.isContentEditable || (e.target.parentElement && e.target.parentElement.isContentEditable));
-        const isSharedBlockEl = $target[0]?.closest("[data-shared-block-tooltip]");
+        const sharedBlockEl = $target[0]?.closest("[data-shared-block-message]");
         this.toolbarEl.classList.toggle('oe-media', isInMedia);
 
         for (const el of this.toolbarEl.querySelectorAll([
@@ -2355,7 +2355,7 @@ export class Wysiwyg extends Component {
             this._updateMediaJustifyButton();
             this._updateFaResizeButtons();
         }
-        if ((isInMedia && !this.options.onDblClickEditableMedia) || isSharedBlockEl) {
+        if ((isInMedia && !this.options.onDblClickEditableMedia) || sharedBlockEl) {
             // Handle the media/link's tooltip.
             this.showTooltip = true;
             this.tooltipTimeouts.push(setTimeout(() => {
@@ -2365,7 +2365,7 @@ export class Wysiwyg extends Component {
                 }
                 // Tooltips need to be cleared before leaving the editor.
                 this.saving_mutex.exec(() => {
-                    const tooltipMessage = isInMedia ? _t('Double-click to edit') : isSharedBlockEl.dataset.sharedBlockTooltip;
+                    const tooltipMessage = isInMedia ? _t('Double-click to edit') : sharedBlockEl.dataset.sharedBlockMessage;
                     const removeTooltip = this.popover.add(e.target, Tooltip, { tooltip: tooltipMessage });
                     this.tooltipTimeouts.push(setTimeout(() => removeTooltip(), 800));
                 });

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -14,7 +14,8 @@
             <div class="oe_structure oe_empty oe_structure_not_nearest"
                 id="oe_structure_blog_footer"
                 t-att-data-editor-sub-message="oe_structure_blog_footer_description"
-                t-att-data-tooltip-message="tooltip_message"/>
+                t-att-data-shared-block-tooltip="tooltip_message"
+            />
         </div>
     </t>
 </template>

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -10,9 +10,11 @@
 
             <!-- Droppable-area shared across all blog's pages -->
             <t t-set="oe_structure_blog_footer_description">Visible in all blogs' pages</t>
+            <t t-set="tooltip_message">Shared between all blog pages</t>
             <div class="oe_structure oe_empty oe_structure_not_nearest"
                 id="oe_structure_blog_footer"
-                t-att-data-editor-sub-message="oe_structure_blog_footer_description"/>
+                t-att-data-editor-sub-message="oe_structure_blog_footer_description"
+                t-att-data-tooltip-message="tooltip_message"/>
         </div>
     </t>
 </template>

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -14,7 +14,7 @@
             <div class="oe_structure oe_empty oe_structure_not_nearest"
                 id="oe_structure_blog_footer"
                 t-att-data-editor-sub-message="oe_structure_blog_footer_description"
-                t-att-data-shared-block-tooltip="tooltip_message"
+                t-att-data-shared-block-message="tooltip_message"
             />
         </div>
     </t>

--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -11,7 +11,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_crm_partner_assign_layout_1"
                 t-att-data-editor-message="editor_message"
-                t-att-data-shared-block-tooltip="tooltip_message"
+                t-att-data-shared-block-message="tooltip_message"
             />
             <div class="container my-4">
                 <t t-out="0" />
@@ -19,7 +19,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_crm_partner_assign_layout_2"
                 t-att-data-editor-message="editor_message"
-                t-att-data-shared-block-tooltip="tooltip_message"
+                t-att-data-shared-block-message="tooltip_message"
             />
         </div>
     </t>

--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -11,7 +11,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_crm_partner_assign_layout_1"
                 t-att-data-editor-message="editor_message"
-                t-att-data-tooltip-message="tooltip_message"
+                t-att-data-shared-block-tooltip="tooltip_message"
             />
             <div class="container my-4">
                 <t t-out="0" />
@@ -19,7 +19,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_crm_partner_assign_layout_2"
                 t-att-data-editor-message="editor_message"
-                t-att-data-tooltip-message="tooltip_message"
+                t-att-data-shared-block-tooltip="tooltip_message"
             />
         </div>
     </t>

--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -7,11 +7,20 @@
         <t t-set="additional_title">Resellers</t>
         <div id="wrap">
             <t t-set="editor_message">DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL RESELLERS</t>
-            <div class="oe_structure oe_empty" id="oe_structure_website_crm_partner_assign_layout_1" t-att-data-editor-message="editor_message"/>
+            <t t-set="tooltip_message">Shared between all resellers</t>
+            <div class="oe_structure oe_empty"
+                id="oe_structure_website_crm_partner_assign_layout_1"
+                t-att-data-editor-message="editor_message"
+                t-att-data-tooltip-message="tooltip_message"
+            />
             <div class="container my-4">
                 <t t-out="0" />
             </div>
-            <div class="oe_structure oe_empty" id="oe_structure_website_crm_partner_assign_layout_2" t-att-data-editor-message="editor_message"/>
+            <div class="oe_structure oe_empty"
+                id="oe_structure_website_crm_partner_assign_layout_2"
+                t-att-data-editor-message="editor_message"
+                t-att-data-tooltip-message="tooltip_message"
+            />
         </div>
     </t>
 </template>

--- a/addons/website_customer/views/website_customer_templates.xml
+++ b/addons/website_customer/views/website_customer_templates.xml
@@ -258,7 +258,7 @@
         <div class="oe_structure oe_empty"
             id="oe_structure_website_customer_details_1"
             t-att-data-editor-message="editor_message"
-            t-att-data-shared-block-tooltip="tooltip_message"
+            t-att-data-shared-block-message="tooltip_message"
         />
         <div class="container my-4">
             <div class="row">
@@ -275,7 +275,7 @@
         <div class="oe_structure oe_empty"
             id="oe_structure_website_customer_details_2"
             t-att-data-editor-message="editor_message"
-            t-att-data-shared-block-tooltip="tooltip_message"
+            t-att-data-shared-block-message="tooltip_message"
         />
     </div>
   </t>

--- a/addons/website_customer/views/website_customer_templates.xml
+++ b/addons/website_customer/views/website_customer_templates.xml
@@ -254,7 +254,12 @@
   <t t-call="website.layout">
     <div id="wrap">
         <t t-set="editor_message">DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL CUSTOMERS</t>
-        <div class="oe_structure oe_empty" id="oe_structure_website_customer_details_1" t-att-data-editor-message="editor_message"/>
+        <t t-set="tooltip_message">Shared between all customers</t>
+        <div class="oe_structure oe_empty"
+            id="oe_structure_website_customer_details_1"
+            t-att-data-editor-message="editor_message"
+            t-att-data-tooltip-message="tooltip_message"
+        />
         <div class="container my-4">
             <div class="row">
                 <div class="mb-3" t-if="not edit_page">
@@ -267,7 +272,11 @@
                 </t>
             </div>
         </div>
-        <div class="oe_structure oe_empty" id="oe_structure_website_customer_details_2" t-att-data-editor-message="editor_message"/>
+        <div class="oe_structure oe_empty"
+            id="oe_structure_website_customer_details_2"
+            t-att-data-editor-message="editor_message"
+            t-att-data-tooltip-message="tooltip_message"
+        />
     </div>
   </t>
 </template>

--- a/addons/website_customer/views/website_customer_templates.xml
+++ b/addons/website_customer/views/website_customer_templates.xml
@@ -258,7 +258,7 @@
         <div class="oe_structure oe_empty"
             id="oe_structure_website_customer_details_1"
             t-att-data-editor-message="editor_message"
-            t-att-data-tooltip-message="tooltip_message"
+            t-att-data-shared-block-tooltip="tooltip_message"
         />
         <div class="container my-4">
             <div class="row">
@@ -275,7 +275,7 @@
         <div class="oe_structure oe_empty"
             id="oe_structure_website_customer_details_2"
             t-att-data-editor-message="editor_message"
-            t-att-data-tooltip-message="tooltip_message"
+            t-att-data-shared-block-tooltip="tooltip_message"
         />
     </div>
   </t>

--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -14,7 +14,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_event_layout_1"
                 t-att-data-editor-sub-message="editor_sub_message"
-                t-att-data-shared-block-tooltip="tooltip_message"
+                t-att-data-shared-block-message="tooltip_message"
             />
         </div>
 

--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -14,7 +14,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_event_layout_1"
                 t-att-data-editor-sub-message="editor_sub_message"
-                t-att-data-tooltip-message="tooltip_message"
+                t-att-data-shared-block-tooltip="tooltip_message"
             />
         </div>
 

--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -10,7 +10,12 @@
             <t t-if="not hide_submenu" t-call="website_event.navbar"/>
             <t t-out="0"/>
             <t t-set="editor_sub_message">Following content will appear on all events.</t>
-            <div class="oe_structure oe_empty" id="oe_structure_website_event_layout_1" t-att-data-editor-sub-message="editor_sub_message"/>
+            <t t-set="tooltip_message">Shared between all events</t>
+            <div class="oe_structure oe_empty"
+                id="oe_structure_website_event_layout_1"
+                t-att-data-editor-sub-message="editor_sub_message"
+                t-att-data-tooltip-message="tooltip_message"
+            />
         </div>
 
         <!-- The registration modal is available in any event page  -->

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -34,7 +34,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_event_track_agenda_1"
                 t-att-data-editor-message="editor_message"
-                t-att-data-tooltip-message="tooltip_message"
+                t-att-data-shared-block-tooltip="tooltip_message"
             />
 
             <!-- Content -->
@@ -45,7 +45,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_event_track_agenda_2"
                 t-att-data-editor-message="editor_message"
-                t-att-data-tooltip-message="tooltip_message"
+                t-att-data-shared-block-tooltip="tooltip_message"
             />
         </t>
     </t>

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -30,14 +30,23 @@
             </div>
             <!-- Drag/Drop Area -->
             <t t-set="editor_message">Available on all event Agenda pages</t>
-            <div class="oe_structure oe_empty" id="oe_structure_website_event_track_agenda_1" t-att-data-editor-message="editor_message"/>
+            <t t-set="tooltip_message">Shared between all event Agenda pages</t>
+            <div class="oe_structure oe_empty"
+                id="oe_structure_website_event_track_agenda_1"
+                t-att-data-editor-message="editor_message"
+                t-att-data-tooltip-message="tooltip_message"
+            />
 
             <!-- Content -->
             <div class="o_wevent_online o_weagenda_index mb-3">
                 <t t-call="website_event_track.agenda_main"/>
             </div>
             <!-- Drag/Drop Area -->
-            <div class="oe_structure oe_empty" id="oe_structure_website_event_track_agenda_2" t-att-data-editor-message="editor_message"/>
+            <div class="oe_structure oe_empty"
+                id="oe_structure_website_event_track_agenda_2"
+                t-att-data-editor-message="editor_message"
+                t-att-data-tooltip-message="tooltip_message"
+            />
         </t>
     </t>
 </template>

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -34,7 +34,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_event_track_agenda_1"
                 t-att-data-editor-message="editor_message"
-                t-att-data-shared-block-tooltip="tooltip_message"
+                t-att-data-shared-block-message="tooltip_message"
             />
 
             <!-- Content -->
@@ -45,7 +45,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_event_track_agenda_2"
                 t-att-data-editor-message="editor_message"
-                t-att-data-shared-block-tooltip="tooltip_message"
+                t-att-data-shared-block-message="tooltip_message"
             />
         </t>
     </t>

--- a/addons/website_event_track/views/event_track_templates_proposal.xml
+++ b/addons/website_event_track/views/event_track_templates_proposal.xml
@@ -9,7 +9,7 @@
         <div class="oe_structure"
             id="oe_structure_website_event_track_proposal_1"
             t-att-data-editor-message="editor_message"
-            t-att-data-shared-block-tooltip="tooltip_message"
+            t-att-data-shared-block-message="tooltip_message"
         />
         <div class="container">
             <t t-call="website_event.navbar"/>
@@ -128,7 +128,7 @@
                     <div class="oe_structure"
                         id="oe_structure_website_event_track_proposal_2"
                         t-att-data-editor-message="editor_message"
-                        t-att-data-shared-block-tooltip="tooltip_message"
+                        t-att-data-shared-block-message="tooltip_message"
                     />
                 </div> <!-- Close main column -->
 
@@ -164,7 +164,7 @@
         <div class="oe_structure"
             id="oe_structure_website_event_track_proposal_3"
             t-att-data-editor-message="editor_message"
-            t-att-data-shared-block-tooltip="tooltip_message"
+            t-att-data-shared-block-message="tooltip_message"
         />
     </t>
 </template>

--- a/addons/website_event_track/views/event_track_templates_proposal.xml
+++ b/addons/website_event_track/views/event_track_templates_proposal.xml
@@ -5,7 +5,12 @@
     <t t-call="website_event.layout">
         <t t-set="hide_submenu" t-value="True"/>
         <t t-set="editor_message">DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PROPOSAL PAGES OF ALL EVENTS</t>
-        <div class="oe_structure" id="oe_structure_website_event_track_proposal_1" t-att-data-editor-message="editor_message"/>
+        <t t-set="tooltip_message">Shared between all proposal pages of all events</t>
+        <div class="oe_structure"
+            id="oe_structure_website_event_track_proposal_1"
+            t-att-data-editor-message="editor_message"
+            t-att-data-tooltip-message="tooltip_message"
+        />
         <div class="container">
             <t t-call="website_event.navbar"/>
 
@@ -120,7 +125,11 @@
                             </div>
                         </form>
                     </section>
-                    <div class="oe_structure" id="oe_structure_website_event_track_proposal_2" t-att-data-editor-message="editor_message"/>
+                    <div class="oe_structure"
+                        id="oe_structure_website_event_track_proposal_2"
+                        t-att-data-editor-message="editor_message"
+                        t-att-data-tooltip-message="tooltip_message"
+                    />
                 </div> <!-- Close main column -->
 
                 <!-- Sidebar: visible if proposals are allowed only -->
@@ -152,7 +161,11 @@
                 </aside>
             </div>
         </div>
-        <div class="oe_structure" id="oe_structure_website_event_track_proposal_3" t-att-data-editor-message="editor_message"/>
+        <div class="oe_structure"
+            id="oe_structure_website_event_track_proposal_3"
+            t-att-data-editor-message="editor_message"
+            t-att-data-tooltip-message="tooltip_message"
+        />
     </t>
 </template>
 

--- a/addons/website_event_track/views/event_track_templates_proposal.xml
+++ b/addons/website_event_track/views/event_track_templates_proposal.xml
@@ -9,7 +9,7 @@
         <div class="oe_structure"
             id="oe_structure_website_event_track_proposal_1"
             t-att-data-editor-message="editor_message"
-            t-att-data-tooltip-message="tooltip_message"
+            t-att-data-shared-block-tooltip="tooltip_message"
         />
         <div class="container">
             <t t-call="website_event.navbar"/>
@@ -128,7 +128,7 @@
                     <div class="oe_structure"
                         id="oe_structure_website_event_track_proposal_2"
                         t-att-data-editor-message="editor_message"
-                        t-att-data-tooltip-message="tooltip_message"
+                        t-att-data-shared-block-tooltip="tooltip_message"
                     />
                 </div> <!-- Close main column -->
 
@@ -164,7 +164,7 @@
         <div class="oe_structure"
             id="oe_structure_website_event_track_proposal_3"
             t-att-data-editor-message="editor_message"
-            t-att-data-tooltip-message="tooltip_message"
+            t-att-data-shared-block-tooltip="tooltip_message"
         />
     </t>
 </template>

--- a/addons/website_membership/views/website_membership_templates.xml
+++ b/addons/website_membership/views/website_membership_templates.xml
@@ -130,7 +130,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_membership_partner_1"
                 t-att-data-editor-message="editor_message"
-                t-att-data-tooltip-message="tooltip_message"
+                t-att-data-shared-block-tooltip="tooltip_message"
             />
             <div class="container">
                 <div class="row">
@@ -140,7 +140,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_membership_partner_2"
                 t-att-data-editor-message="editor_message"
-                t-att-data-tooltip-message="tooltip_message"
+                t-att-data-shared-block-tooltip="tooltip_message"
             />
         </div>
     </t>

--- a/addons/website_membership/views/website_membership_templates.xml
+++ b/addons/website_membership/views/website_membership_templates.xml
@@ -130,7 +130,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_membership_partner_1"
                 t-att-data-editor-message="editor_message"
-                t-att-data-shared-block-tooltip="tooltip_message"
+                t-att-data-shared-block-message="tooltip_message"
             />
             <div class="container">
                 <div class="row">
@@ -140,7 +140,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_membership_partner_2"
                 t-att-data-editor-message="editor_message"
-                t-att-data-shared-block-tooltip="tooltip_message"
+                t-att-data-shared-block-message="tooltip_message"
             />
         </div>
     </t>

--- a/addons/website_membership/views/website_membership_templates.xml
+++ b/addons/website_membership/views/website_membership_templates.xml
@@ -126,13 +126,22 @@
     <t t-call="website.layout">
         <div id="wrap">
             <t t-set="editor_message">DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL MEMBERS</t>
-            <div class="oe_structure oe_empty" id="oe_structure_website_membership_partner_1" t-att-data-editor-message="editor_message"/>
+            <t t-set="tooltip_message">Shared between all members</t>
+            <div class="oe_structure oe_empty"
+                id="oe_structure_website_membership_partner_1"
+                t-att-data-editor-message="editor_message"
+                t-att-data-tooltip-message="tooltip_message"
+            />
             <div class="container">
                 <div class="row">
                     <t t-call="website_partner.partner_detail"/>
                 </div>
             </div>
-            <div class="oe_structure oe_empty" id="oe_structure_website_membership_partner_2" t-att-data-editor-message="editor_message"/>
+            <div class="oe_structure oe_empty"
+                id="oe_structure_website_membership_partner_2"
+                t-att-data-editor-message="editor_message"
+                t-att-data-tooltip-message="tooltip_message"
+            />
         </div>
     </t>
 </template>

--- a/addons/website_partner/views/website_partner_templates.xml
+++ b/addons/website_partner/views/website_partner_templates.xml
@@ -8,7 +8,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_partner_partner_1"
                 t-att-data-editor-message="editor_message"
-                t-att-data-shared-block-tooltip="tooltip_message"
+                t-att-data-shared-block-message="tooltip_message"
             />
             <div class="container">
                 <div class="row">
@@ -18,7 +18,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_partner_partner_2"
                 t-att-data-editor-message="editor_message"
-                t-att-data-shared-block-tooltip="tooltip_message"
+                t-att-data-shared-block-message="tooltip_message"
             />
         </div>
     </t>

--- a/addons/website_partner/views/website_partner_templates.xml
+++ b/addons/website_partner/views/website_partner_templates.xml
@@ -8,7 +8,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_partner_partner_1"
                 t-att-data-editor-message="editor_message"
-                t-att-data-tooltip-message="tooltip_message"
+                t-att-data-shared-block-tooltip="tooltip_message"
             />
             <div class="container">
                 <div class="row">
@@ -18,7 +18,7 @@
             <div class="oe_structure oe_empty"
                 id="oe_structure_website_partner_partner_2"
                 t-att-data-editor-message="editor_message"
-                t-att-data-tooltip-message="tooltip_message"
+                t-att-data-shared-block-tooltip="tooltip_message"
             />
         </div>
     </t>

--- a/addons/website_partner/views/website_partner_templates.xml
+++ b/addons/website_partner/views/website_partner_templates.xml
@@ -4,13 +4,22 @@
     <t t-call="website.layout">
         <div id="wrap">
             <t t-set="editor_message">DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PARTNERS</t>
-            <div class="oe_structure oe_empty" id="oe_structure_website_partner_partner_1" t-att-data-editor-message="editor_message"/>
+            <t t-set="tooltip_message">Shared between all partners</t>
+            <div class="oe_structure oe_empty"
+                id="oe_structure_website_partner_partner_1"
+                t-att-data-editor-message="editor_message"
+                t-att-data-tooltip-message="tooltip_message"
+            />
             <div class="container">
                 <div class="row">
                     <t t-call="website_partner.partner_detail"></t>
                 </div>
             </div>
-            <div class="oe_structure oe_empty" id="oe_structure_website_partner_partner_2" t-att-data-editor-message="editor_message"/>
+            <div class="oe_structure oe_empty"
+                id="oe_structure_website_partner_partner_2"
+                t-att-data-editor-message="editor_message"
+                t-att-data-tooltip-message="tooltip_message"
+            />
         </div>
     </t>
 </template>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1290,7 +1290,7 @@
                 <div class="oe_structure oe_empty oe_structure_not_nearest"
                     id="oe_structure_website_sale_product_1"
                     t-att-data-editor-message="editor_message"
-                    t-att-data-shared-block-tooltip="tooltip_message"
+                    t-att-data-shared-block-message="tooltip_message"
                 />
                 <section id="product_detail"
                          t-attf-class="oe_website_sale container my-3 my-lg-4 #{'discount'
@@ -1498,7 +1498,7 @@
                             <div
                                 id="o_product_terms_and_share"
                                 class="d-flex justify-content-between flex-column flex-md-row align-items-md-end gap-3 mb-3"
-                                t-att-data-shared-block-tooltip="tooltip_message"
+                                t-att-data-shared-block-message="tooltip_message"
                             />
                         </div>
                     </div>
@@ -1511,7 +1511,7 @@
                 <div class="oe_structure oe_empty oe_structure_not_nearest mt16"
                     id="oe_structure_website_sale_product_2"
                     t-att-data-editor-message="editor_message"
-                    t-att-data-shared-block-tooltip="tooltip_message"
+                    t-att-data-shared-block-message="tooltip_message"
                 />
             </div>
         </t>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1290,7 +1290,7 @@
                 <div class="oe_structure oe_empty oe_structure_not_nearest"
                     id="oe_structure_website_sale_product_1"
                     t-att-data-editor-message="editor_message"
-                    t-att-data-tooltip-message="tooltip_message"
+                    t-att-data-shared-block-tooltip="tooltip_message"
                 />
                 <section id="product_detail"
                          t-attf-class="oe_website_sale container my-3 my-lg-4 #{'discount'
@@ -1498,7 +1498,7 @@
                             <div
                                 id="o_product_terms_and_share"
                                 class="d-flex justify-content-between flex-column flex-md-row align-items-md-end gap-3 mb-3"
-                                t-att-data-tooltip-message="tooltip_message"
+                                t-att-data-shared-block-tooltip="tooltip_message"
                             />
                         </div>
                     </div>
@@ -1511,7 +1511,7 @@
                 <div class="oe_structure oe_empty oe_structure_not_nearest mt16"
                     id="oe_structure_website_sale_product_2"
                     t-att-data-editor-message="editor_message"
-                    t-att-data-tooltip-message="tooltip_message"
+                    t-att-data-shared-block-tooltip="tooltip_message"
                 />
             </div>
         </t>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1286,7 +1286,12 @@
             <t t-set="additional_title" t-value="product.name" />
             <div id="wrap" class="js_sale o_wsale_product_page">
                 <t t-set="editor_message">DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PRODUCTS</t>
-                <div class="oe_structure oe_empty oe_structure_not_nearest" id="oe_structure_website_sale_product_1" t-att-data-editor-message="editor_message"/>
+                <t t-set="tooltip_message">Shared between all products</t>
+                <div class="oe_structure oe_empty oe_structure_not_nearest"
+                    id="oe_structure_website_sale_product_1"
+                    t-att-data-editor-message="editor_message"
+                    t-att-data-tooltip-message="tooltip_message"
+                />
                 <section id="product_detail"
                          t-attf-class="oe_website_sale container my-3 my-lg-4 #{'discount'
                             if combination_info['has_discounted_price'] else ''}"
@@ -1493,6 +1498,7 @@
                             <div
                                 id="o_product_terms_and_share"
                                 class="d-flex justify-content-between flex-column flex-md-row align-items-md-end gap-3 mb-3"
+                                t-att-data-tooltip-message="tooltip_message"
                             />
                         </div>
                     </div>
@@ -1502,7 +1508,11 @@
                     t-field="product.website_description"
                     class="oe_structure oe_empty mt16"
                 />
-                <div class="oe_structure oe_empty oe_structure_not_nearest mt16" id="oe_structure_website_sale_product_2" t-att-data-editor-message="editor_message"/>
+                <div class="oe_structure oe_empty oe_structure_not_nearest mt16"
+                    id="oe_structure_website_sale_product_2"
+                    t-att-data-editor-message="editor_message"
+                    t-att-data-tooltip-message="tooltip_message"
+                />
             </div>
         </t>
     </template>

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -294,7 +294,12 @@
         </t>
     </div>
     <t t-set="editor_message">BUILDING BLOCKS DROPPED HERE WILL BE SHOWN ACROSS ALL LESSONS</t>
-    <div class="oe_structure oe_empty" id="oe_structure_website_slides_lesson_top_1" t-att-data-editor-message="editor_message"/>
+    <t t-set="tooltip_message">Shared between all lessons</t>
+    <div class="oe_structure oe_empty"
+        id="oe_structure_website_slides_lesson_top_1"
+        t-att-data-editor-message="editor_message"
+        t-att-data-tooltip-message="tooltip_message"
+    />
     <div t-if="slide.slide_category == 'infographic'" class="o_wslides_lesson_content_type" t-field='slide.image_1920' t-options="{'widget': 'image', 'style': 'width: 100%;'}"/>
     <div t-else="" class="o_wslides_lesson_content_type">
         <div t-if="slide.slide_category == 'document'" class="ratio ratio-4x3 embed-responsive-item mb8" style="height: 600px;">

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -298,7 +298,7 @@
     <div class="oe_structure oe_empty"
         id="oe_structure_website_slides_lesson_top_1"
         t-att-data-editor-message="editor_message"
-        t-att-data-tooltip-message="tooltip_message"
+        t-att-data-shared-block-tooltip="tooltip_message"
     />
     <div t-if="slide.slide_category == 'infographic'" class="o_wslides_lesson_content_type" t-field='slide.image_1920' t-options="{'widget': 'image', 'style': 'width: 100%;'}"/>
     <div t-else="" class="o_wslides_lesson_content_type">

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -298,7 +298,7 @@
     <div class="oe_structure oe_empty"
         id="oe_structure_website_slides_lesson_top_1"
         t-att-data-editor-message="editor_message"
-        t-att-data-shared-block-tooltip="tooltip_message"
+        t-att-data-shared-block-message="tooltip_message"
     />
     <div t-if="slide.slide_category == 'infographic'" class="o_wslides_lesson_content_type" t-field='slide.image_1920' t-options="{'widget': 'image', 'style': 'width: 100%;'}"/>
     <div t-else="" class="o_wslides_lesson_content_type">


### PR DESCRIPTION
*= website_blog, website_crm_partner_assign, website_customer, website_event, website_event_meet, website_event_track, website_membership, website_partner, website_sale, website_slides

With  this commit, We introduces the `data-tooltip-message` attribute to dropzones that contain content accessible throughout all pages.With this attribute, we can show a tooltip message in edit mode when user tries to edit the `shared block`.

Enterprise: https://github.com/odoo/enterprise/pull/77728

task-4430496
