### PR TITLE
[FIX] product: setting display uom

### DIFF
--- a/addons/product/models/res_config_settings.py
+++ b/addons/product/models/res_config_settings.py
@@ -12,12 +12,12 @@ class ResConfigSettings(models.TransientModel):
     group_product_pricelist = fields.Boolean("Pricelists",
         implied_group='product.group_product_pricelist')
     product_weight_in_lbs = fields.Selection([
-        ('0', 'Kilograms'),
-        ('1', 'Pounds'),
+        ('0', 'Kilograms (kg)'),
+        ('1', 'Pounds (lb)'),
     ], 'Weight unit of measure', config_parameter='product.weight_in_lbs', default='0')
     product_volume_volume_in_cubic_feet = fields.Selection([
-        ('0', 'Cubic Meters'),
-        ('1', 'Cubic Feet'),
+        ('0', 'Cubic Meters (m³)'),
+        ('1', 'Cubic Feet (ft³)'),
     ], 'Volume unit of measure', config_parameter='product.volume_in_cubic_feet', default='0')
 
     @api.onchange('group_product_pricelist')

--- a/addons/product/views/res_config_settings_views.xml
+++ b/addons/product/views/res_config_settings_views.xml
@@ -8,10 +8,10 @@
                 <xpath expr="//div[@id='companies']" position="after">
                     <block title="Units of Measure" id="product_general_settings">
                         <setting id="weight_uom_setting" string="Weight" help="Define your weight unit of measure">
-                            <field name="product_weight_in_lbs" class="o_light_label" widget="radio" options="{'horizontal': true}"/>
+                            <field name="product_weight_in_lbs" class="o_light_label" widget="radio"/>
                         </setting>
                         <setting id="manage_volume_uom_setting" string="Volume" help="Define your volume unit of measure">
-                            <field name="product_volume_volume_in_cubic_feet" class="o_light_label" widget="radio" options="{'horizontal': true}"/>
+                            <field name="product_volume_volume_in_cubic_feet" class="o_light_label" widget="radio"/>
                         </setting>
                     </block>
                 </xpath>


### PR DESCRIPTION
Issue Before This Commit:
-----------------------------------------------
- In General Settings, the radio button for Weight is displayed horizontally, while the radio button for Volume is displayed vertically. Both units of measure need to be displayed in the same manner.

With this commit:
-----------------------------------------------
- Both Weight and Volume radio buttons are now displayed vertically to ensure a consistent and uniform layout.
- Added symbols as well, e.g., kg, lb (for weight), and m³, ft³ (for volume).

Task-id: 4438804