### PR TITLE
[FIX] purchase_stock: use supplier info currency

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -670,16 +670,21 @@ class ProductProduct(models.Model):
 
     def _select_seller(self, partner_id=False, quantity=0.0, date=None, uom_id=False, ordered_by='price_discounted', params=False):
         # Always sort by discounted price but another field can take the primacy through the `ordered_by` param.
-        sort_key = itemgetter('price_discounted', 'sequence', 'id')
+        sort_key = ('price_discounted', 'sequence', 'id')
         if ordered_by != 'price_discounted':
-            sort_key = itemgetter(ordered_by, 'price_discounted', 'sequence', 'id')
+            sort_key = (ordered_by, 'price_discounted', 'sequence', 'id')
 
+        def sort_function(record):
+            vals = {
+                'price_discounted': record.currency_id._convert(record.price_discounted, record.env.company.currency_id, record.env.company, date or fields.Date.context_today(self))
+            }
+            return [vals.get(key, record[key]) for key in sort_key]
         sellers = self._get_filtered_sellers(partner_id=partner_id, quantity=quantity, date=date, uom_id=uom_id, params=params)
         res = self.env['product.supplierinfo']
         for seller in sellers:
             if not res or res.partner_id == seller.partner_id:
                 res |= seller
-        return res and res.sorted(sort_key)[:1]
+        return res and res.sorted(sort_function)[:1]
 
     def _get_product_price_context(self, combination):
         self.ensure_one()

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -1280,3 +1280,58 @@ class TestReorderingRule(TransactionCase):
         replenishment_info = self.env['stock.replenishment.info'].create({'orderpoint_id': orderpoint.id})
         supplier_info = replenishment_info.supplierinfo_ids
         self.assertEqual(supplier_info.last_purchase_date, dt.today().date(), "The last_purhchase_date should be set to the most recent date_order from the purchase orders")
+
+    def test_reordering_rule_multicurrency(self):
+        """
+            trigger a reordering rule in foreign currency
+        """
+        foreign_currency = self.env['res.currency'].create({
+            'name': 'Coin',
+            'symbol': '☺',
+        })
+        self.env['res.currency.rate'].create({
+            'name': '2019-01-01',
+            'rate': 0.50,
+            'currency_id': foreign_currency.id,
+            'company_id': self.env.company.id,
+        })
+
+        self.product_01.write({
+            'variant_seller_ids': [
+                Command.clear(),
+                Command.create({
+                    'partner_id': self.partner.id,
+                    'price': 100,
+                    'currency_id': self.env.company.currency_id.id,
+                    'product_tmpl_id': self.product_01.product_tmpl_id.id,
+                }),
+                Command.create({
+                    'partner_id': self.partner.id,
+                    'price': 10,
+                    'currency_id': foreign_currency.id,
+                    'product_tmpl_id': self.product_01.product_tmpl_id.id,
+                }),
+            ],
+        })
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+
+        po_line = self.env["purchase.order.line"].search(
+            [("product_id", "=", self.product_01.id)])
+        self.assertFalse(po_line)
+        self.env["procurement.group"].run(
+            [self.env["procurement.group"].Procurement(
+                self.product_01, 100, self.product_01.uom_id,
+                warehouse.lot_stock_id, "Test default vendor", "/",
+                self.env.company,
+                {
+                    "warehouse_id": warehouse,
+                    "date_planned": dt.today() + td(days=1),
+                    "rule_id": warehouse.buy_pull_id,
+                    "group_id": False,
+                    "route_ids": [],
+                }
+            )])
+        po_line = self.env["purchase.order.line"].search(
+            [("product_id", "=", self.product_01.id)])
+        self.assertTrue(po_line)
+        self.assertEqual(po_line.order_id.currency_id, foreign_currency)


### PR DESCRIPTION
When the vendor price is set in a different currency than main one in product's form, the PO triggered by the procurement is created in main currency.

Steps to reproduce:
- Activate foreign currency
- Activate Route MTO
- Have a product [PROD] configured with
  - [General Info tab] Product Type: Storable Product
  - [Purchase tab] Set a Vendor, a price, and foreign currency
  - [Inventory Tab] Routes Buy, MTO
- Create a Sales Order with [PROD] and confirm it
- Open the created Purchase order

Issue: currency is in company currency and not the currency set in the product configuration

opw-4398597

