### PR TITLE
[FIX] survey: create question at the end of survey

### DIFF
--- a/addons/survey/static/src/question_page/question_page_one2many_field.js
+++ b/addons/survey/static/src/question_page/question_page_one2many_field.js
@@ -49,6 +49,7 @@ class QuestionPageOneToManyField extends X2ManyField {
             await superSaveRecord(record);
             try {
                 await self.props.record.save();
+                this.ensureLastPageLoaded();
             } catch (error) {
                 // In case of error occurring when saving.
                 // Remove erroneous question row added to the embedded list
@@ -83,9 +84,19 @@ class QuestionPageOneToManyField extends X2ManyField {
             if (params.record) {
                 params.record = record.data[name].records.find(r => r.resId === params.record.resId);
             }
+            if (params.context.question_create) {
+                this.ensureLastPageLoaded();
+            }
             await openRecord(params);
         };
         this.canOpenRecord = true;
+    }
+    async ensureLastPageLoaded() {
+        const limit = this.list.config.limit;
+        const offset = (Math.ceil(this.list.count / limit) - 1) * limit;
+        if (this.list.offset < offset) {
+            await this.list.load({ limit: limit, offset: offset });
+        }
     }
 }
 QuestionPageOneToManyField.components = {

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -82,7 +82,7 @@
                                     <widget name="survey_question_trigger" width="30px"/>
                                     <button name="copy" type="object" icon="fa-clone" title="Duplicate Question"/>
                                     <control>
-                                        <create name="add_question_control" string="Add a question"/>
+                                        <create name="add_question_control" string="Add a question" context="{'question_create': True}"/>
                                         <create name="add_section_control" string="Add a section" context="{'default_is_page': True, 'default_questions_selection': 'all'}"/>
                                     </control>
                                 </tree>


### PR DESCRIPTION
Currently when a survey has more than 1 page of questions, creating questions from the last page, last line, will add the question at the correct page but all other questions created further from the 'same' wizard will be added at the end of page 1 (beginning of page 2).

Steps to reproduce:
-------------------
* Open any survey and duplicate any question to have more than 50 questions.
* Navigate to the second page
* Select **"Add a question"**
* Add a title and seleect **Save & new** (repeat a couple times)
* Close the wizard
> Observation: The first question is added at the end of the survey. The
rest is added at the beginning of page 2

Why the fix:
------------
Since this commit was introduced https://github.com/odoo/odoo/commit/b1d185624599b9e4a5457399a99525a04de9d9bb the survey is saved each time a question is added. Globally speaking, when a form containing a list is saved, the list is refreshed back to page 1.

In our case, when we select **'Add a question'**, the list in the background is on page 2 and the last line will be used for the sequence of the new question. When selecting **save & New**, we can see in the background that the list is refreshed back to page 1 and the last line of page 1 will now be used for the sequence. So technically the questions are added at the end of page 1, and because page 1 is already full, they show at the beginning of page 2.

Now we systematically add the questions at the end of the survey by loading the last page of the list renderer after each save.

opw-4352543
