### PR TITLE
[FIX] website: Resolve padding issue inside large boxes

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4445,7 +4445,7 @@ registry.sizing = SnippetOptionWidget.extend({
                 _.each(resize[0], function (val, key) {
                     if (self.$target.hasClass(val)) {
                         current = key;
-                    } else if (resize[1][key] === cssPropertyValue) {
+                    } else if (parseInt(resize[1][key]) === cssPropertyValue) {
                         current = key;
                     }
                 });

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4781,7 +4781,7 @@ registry['sizing_x'] = registry.sizing.extend({
 
             if (compass === 'w') {
                 // don't change the right border position when we change the offset (replace col size)
-                var beginCol = Number(beginClass.match(/col-lg-([0-9]+)|$/)[1] || 0);
+                var beginCol = Number(beginClass.match(/col-lg-([0-9]+)|$/)[1] || 12);
                 var offset = Number(this.grid.w[0][current].match(/offset-lg-([0-9-]+)|$/)[1] || 0);
                 if (offset < 0) {
                     offset = 0;

--- a/addons/website/static/src/snippets/s_color_blocks_2/000.scss
+++ b/addons/website/static/src/snippets/s_color_blocks_2/000.scss
@@ -18,10 +18,12 @@
             width: 0;
         }
     }
-    [class*="col-lg-"] {
-        padding: 8% 5%;
-        padding-top: 8vw; // A flex item cannot have % padding top and bottom (even if it works on chrome)
-        padding-bottom: 8vw; // Solution is vw units but we keep 8% as a fallback
+    > .container, > .container-fluid, > .o_container_small {
+        > .row > [class*="col-lg-"] {
+            padding: 8% 5%;
+            padding-top: 8vw; // A flex item cannot have % padding top and bottom (even if it works on chrome)
+            padding-bottom: 8vw; // Solution is vw units but we keep 8% as a fallback
+        }
     }
     @include media-breakpoint-down(lg) {
         [class*="col-lg-"] {


### PR DESCRIPTION
Previously, adjusting the width of a form field within a large box resulted in excessive padding being applied above and below the form field. This commit refines the CSS rules,
ensuring the padding is applied only to the outer large box and not to the inner elements.

task-4370763