### PR TITLE
[FIX] l10n_*: load taxes for only root companies

### DIFF
--- a/addons/l10n_ar_withholding/__init__.py
+++ b/addons/l10n_ar_withholding/__init__.py
@@ -12,7 +12,7 @@ _logger = logging.getLogger(__name__)
 def _l10n_ar_withholding_post_init(env):
     """ Existing companies that have the Argentinean Chart of Accounts set """
     template_codes = ['ar_ri', 'ar_ex', 'ar_base']
-    ar_companies = env['res.company'].search([('chart_template', 'in', template_codes)], order="parent_path")
+    ar_companies = env['res.company'].search([('chart_template', 'in', template_codes), ('parent_id', '=', False)])
     used_template_codes = set(ar_companies.mapped('chart_template'))
     for template_code in used_template_codes:
         data = {

--- a/addons/l10n_es_edi_facturae/__init__.py
+++ b/addons/l10n_es_edi_facturae/__init__.py
@@ -10,12 +10,7 @@ def _l10n_es_edi_facturae_post_init_hook(env):
     """
     We need to replace the existing spanish taxes following the template so the new fields are set properly
     """
-    concerned_companies = [
-        company
-        for company in env.companies
-        if company.chart_template and company.chart_template.startswith('es_')
-    ]
-    for company in concerned_companies:
+    for company in env['res.company'].search([('chart_template', '=like', 'es_%'), ('parent_id', '=', False)]):
         Template = env['account.chart.template'].with_company(company)
         Template._load_data({
             'account.tax': Template._get_es_facturae_account_tax(),

--- a/addons/l10n_it_edi_doi/__init__.py
+++ b/addons/l10n_it_edi_doi/__init__.py
@@ -4,7 +4,7 @@ from . import models
 
 
 def _l10n_it_edi_doi_post_init(env):
-    for company in env['res.company'].search([('chart_template', '=', 'it')], order="parent_path"):
+    for company in env['res.company'].search([('chart_template', '=', 'it'), ('parent_id', '=', False)]):
         template = env['account.chart.template'].with_company(company)
         template._load_data({
             'account.tax': template._get_it_edi_doi_account_tax(),

--- a/addons/l10n_it_edi_withholding/__init__.py
+++ b/addons/l10n_it_edi_withholding/__init__.py
@@ -7,7 +7,7 @@ _logger = logging.getLogger(__name__)
 
 def _l10n_it_edi_withholding_post_init(env):
     """ Existing companies that have the Italian Chart of Accounts set """
-    for company in env['res.company'].search([('chart_template', '=', 'it')], order="parent_path"):
+    for company in env['res.company'].search([('chart_template', '=', 'it') , ('parent_id', '=', False)]):
         _logger.info("Company %s already has the Italian localization installed, updating...", company.name)
         ChartTemplate = env['account.chart.template'].with_company(company)
         ChartTemplate._load_data({


### PR DESCRIPTION
To reproduce:
1) install localization of any of the below modules. 
2) Make branch companies in that localization.
3) install one of the modules below.

we get this
error:https://github.com/odoo/odoo/blob/17.0/addons/account/models/account_tax.py#L200, `Tax names must be unique`, so only load taxes for root companies.

and for tax_group we get this error:

```
The operation cannot be completed:
- Create/update: a mandatory field is not set.
- Delete: another model requires the record being deleted. If possible, archive it instead.

Model: Tax Group (account.tax.group)
Field: Name (name)
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
