### PR TITLE
[FIX] web_editor: position buttons under cropper

### DIFF
--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -345,7 +345,7 @@
     <div t-name="wysiwyg.widgets.crop" class="o_we_crop_widget" contenteditable="false">
         <div class="o_we_cropper_wrapper">
             <img class="o_we_cropper_img"/>
-            <div class="o_we_crop_buttons text-center mt16 position-fixed o_we_no_overlay" contenteditable="false">
+            <div class="o_we_crop_buttons text-center mt16 o_we_no_overlay" contenteditable="false">
                 <div class="btn-group btn-group-toggle" title="Aspect Ratio" data-bs-toggle="buttons">
                     <t t-foreach="widget.aspectRatios" t-as="ratio">
                         <t t-set="is_active" t-value="ratio === widget.aspectRatio"/>


### PR DESCRIPTION
**Problem**:
The cropper buttons are positioned at the end of the page instead of directly under the image being cropped.

**Solution**:
Remove `position: fixed` from the buttons container, allowing it to be positioned just below the image being cropped/edited.

**Steps to Reproduce**:
1. Navigate to Email Marketing > Start from scratch.
2. Add "Blocks" > "Body" > "Columns".
3. Open the cropping tool on the first image.
4. Observe that the cropping buttons appear at the end of the page, requiring scrolling to access them.

opw-4461565

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
