### PR TITLE
[FIX] website: snippet_translation tour

### DIFF
--- a/addons/website/static/tests/tours/snippet_translation.js
+++ b/addons/website/static/tests/tours/snippet_translation.js
@@ -39,14 +39,32 @@ registerWebsitePreviewTour('snippet_translation_changing_lang', {
     url: '/',
 }, () => [
     {
-        content: "Change language to Parseltongue",
+        content: "Open dropdown language selector",
         trigger: ':iframe .js_language_selector button',
         run: "click",
     },
     {
-        content: "Change the language to English",
-        trigger: ':iframe .js_language_selector .js_change_lang[data-url_code="en"]',
+        content: "Select the language to Parseltongue",
+        trigger: ":iframe .js_language_selector .js_change_lang[data-url_code=pa_GB]",
         run: "click",
+    },
+    {
+        content: "Wait the language has changed.",
+        trigger: ":iframe nav li:contains(parseltongue)",
+    },
+    {
+        content: "Open dropdown language selector",
+        trigger: ':iframe .js_language_selector button',
+        run: "click",
+    },
+    {
+        content: "Select the language to English",
+        trigger: ":iframe .js_language_selector .js_change_lang[data-url_code=en]",
+        run: "click",
+    },
+    {
+        content: "Wait the language has changed.",
+        trigger: ":iframe nav li:contains(english)",
     },
     {
         content: "Open Edit dropdown",


### PR DESCRIPTION
In this commit, we fix the tour snippet_translation_changing_lang. The problem is that we don't wait for the DOM to be re-rendered before clicking on the dropdown to open the editing dropdown. So, if we click before the DOM is re-rendered, it also re-renders the dropdown menu and it disappears.
So depending on the execution speed of the tour, it may fail. This commit fixes this behavior.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
