### PR TITLE
[FIX] stock: allow validation of MO if no access to vendor

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -608,7 +608,7 @@ class StockWarehouseOrderpoint(models.Model):
         return True
 
     def _get_orderpoint_procurement_date(self):
-        return timezone(self.company_id.partner_id.tz or 'UTC').localize(datetime.combine(self.lead_days_date, time(12))).astimezone(UTC).replace(tzinfo=None)
+        return timezone(self.company_id.partner_id.tz or 'UTC').localize(datetime.combine(self.sudo().lead_days_date, time(12))).astimezone(UTC).replace(tzinfo=None)
 
     def _get_orderpoint_products(self):
         return self.env['product.product'].search([('type', '=', 'product'), ('stock_move_ids', '!=', False)])


### PR DESCRIPTION
Currently a manufactury worker cannot validate a MO if one of the products has to be purchased and he does not have access to the contact.

Steps to reproduce:
-------------------
* Create a contact and add a tag 'vendor'
* Create a product 1:
  * Storable, routes: buy, purchase: the contact created
  * Inventory O
* Create a reordering route for product 1:
  * Min 0, max 0, qty to order 1
* Create a product 2:
  * Storable, route: manufacture
* Create a bom for product 2, requires 1 product 1
* Go to the record rules, find `res.partner.rule.private`
* Modify the current domain. Keep initial plus add `& tags not vendor`
* Your current user should not see the contact anymore
* Make a manufacturing order for product 2, confirm it
> Observation: Access error, Mitchell Admin does not have 'read' access
to contact 'x'

This is a simplified workflow but it could simulate a setup where we have multiple groups of internal users, 'sales', 'manufacture', '...' and they have restrictions on the types of contact they can access to.

Manufactury workers should still be able to confirm the MO, which would create a PO. It would then be up to the sales users to confirm the PO.

Why the fix:
------------
The access error is triggered when computing the procurement date here: https://github.com/odoo/odoo/blob/775c5c95cf763c14715fd0e82e88ff841371d212/addons/stock/models/stock_orderpoint.py#L552

https://github.com/odoo/odoo/blob/775c5c95cf763c14715fd0e82e88ff841371d212/addons/stock/models/stock_orderpoint.py#L612-L613

And more specially it is `self.lead_days_date` which triggers it because it is a computed field which depends on the `seller_id`.

https://github.com/odoo/odoo/blob/775c5c95cf763c14715fd0e82e88ff841371d212/addons/stock/models/stock_orderpoint.py#L117-L118

opw-4321965