### PR TITLE
[IMP] mass_mailing_sms: remove unnecessary ´<group>´

### DIFF
--- a/addons/mass_mailing_sms/views/utm_campaign_views.xml
+++ b/addons/mass_mailing_sms/views/utm_campaign_views.xml
@@ -26,26 +26,24 @@
                 <page string="SMS" name="sms"
                     invisible="mailing_sms_count == 0 or not is_mailing_campaign_activated"
                     groups="mass_mailing.group_mass_mailing_user">
-                    <group>
-                        <field name="mailing_sms_ids" nolabel="1">
-                            <list>
-                                <field name="calendar_date" string="Date"/>
-                                <field name="subject" string="Title"/>
-                                <field name="mailing_type" column_invisible="True"/>
-                                <field name="mailing_model_id" string="Recipients" optional="hide"/>
-                                <field name="user_id" widget="many2one_avatar_user"/>
-                                <field name="campaign_id" string="Campaign" groups="mass_mailing.group_mass_mailing_campaign" optional="hide"/>
-                                <field name="ab_testing_enabled" string="A/B Test"
-                                    groups="mass_mailing.group_mass_mailing_campaign"
-                                    column_invisible="parent.ab_testing_mailings_sms_count == 0"/>
-                                <field name="sent" sum="Total Sent"/>
-                                <field name="clicked" string="Clicked (%)" avg="Average of Clicked"/>
-                                <field name="bounced" string="Bounced (%)" optional="hide" avg="Average of Bounced"/>
-                                <field name="state" decoration-info="state in ('draft', 'in_queue')" decoration-success="state in ('sending', 'done')" widget="badge"/>
-                                <button name="action_duplicate" type="object" string="Duplicate"/>
-                            </list>
-                        </field>
-                    </group>
+                    <field name="mailing_sms_ids">
+                        <list>
+                            <field name="calendar_date" string="Date"/>
+                            <field name="subject" string="Title"/>
+                            <field name="mailing_type" column_invisible="True"/>
+                            <field name="mailing_model_id" string="Recipients" optional="hide"/>
+                            <field name="user_id" widget="many2one_avatar_user"/>
+                            <field name="campaign_id" string="Campaign" groups="mass_mailing.group_mass_mailing_campaign" optional="hide"/>
+                            <field name="ab_testing_enabled" string="A/B Test"
+                                groups="mass_mailing.group_mass_mailing_campaign"
+                                column_invisible="parent.ab_testing_mailings_sms_count == 0"/>
+                            <field name="sent" sum="Total Sent"/>
+                            <field name="clicked" string="Clicked (%)" avg="Average of Clicked"/>
+                            <field name="bounced" string="Bounced (%)" optional="hide" avg="Average of Bounced"/>
+                            <field name="state" decoration-info="state in ('draft', 'in_queue')" decoration-success="state in ('sending', 'done')" widget="badge"/>
+                            <button name="action_duplicate" type="object" string="Duplicate"/>
+                        </list>
+                    </field>
                 </page>
             </xpath>
             <xpath expr="//group[@name='ab_test_group']" position="attributes">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
