### PR TITLE
[FIX] account: add bottom margin to payment alert

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -159,7 +159,7 @@
                                 invisible="not id or not (state == 'draft' or (state == 'in_process' and is_sent))" data-hotkey="x"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,in_process,paid"/>
                     </header>
-                    <div class="alert alert-warning mb-0" role="alert" invisible="not duplicate_payment_ids or state!='draft'">
+                    <div class="alert alert-warning mb-2" role="alert" invisible="not duplicate_payment_ids or state!='draft'">
                         <span>This payment has the same partner, amount and date as </span>
                         <field name="duplicate_payment_ids" widget="x2many_buttons" string="Duplicated Payments"/>
                     </div>


### PR DESCRIPTION
Currently the alert specifying that a payment is potentially a duplicate is touching the form. This commit adds a bottom margin to ensure consistency with the rest of the UI.

Task ID: 4255207