### PR TITLE
[FIX] pos_restaurant: fix split order and release table

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -47,9 +47,8 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
 
         if (prepaCategoryIds.size === 0 || productCategoryIds.length > 0) {
             const quantity = orderline.get_quantity();
-            const quantityDiff = oldChanges[lineKey]
-                ? quantity - oldChanges[lineKey].quantity
-                : quantity;
+            const quantityDiff =
+                (oldChanges[lineKey] ? quantity - oldChanges[lineKey].quantity : quantity) || 0;
 
             if (quantityDiff && orderline.skip_change === skipped) {
                 changes[lineKey] = {
@@ -79,6 +78,7 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
     // was last sent to the preparation tools. If so we add this to the changes.
     for (const [lineKey, lineResume] of Object.entries(order.last_order_preparation_change)) {
         if (!order.models["pos.order.line"].getBy("uuid", lineResume["uuid"])) {
+            const quantity = isNaN(lineResume["quantity"]) ? 0 : lineResume["quantity"];
             if (!changes[lineKey]) {
                 changes[lineKey] = {
                     uuid: lineResume["uuid"],
@@ -86,12 +86,12 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
                     name: lineResume["name"],
                     note: lineResume["note"],
                     attribute_value_ids: lineResume["attribute_value_ids"],
-                    quantity: -lineResume["quantity"],
+                    quantity: -quantity,
                 };
-                changeAbsCount += Math.abs(lineResume["quantity"]);
-                changesCount += lineResume["quantity"];
+                changeAbsCount += Math.abs(quantity);
+                changesCount += quantity;
             } else {
-                changes[lineKey]["quantity"] -= lineResume["quantity"];
+                changes[lineKey]["quantity"] -= quantity;
             }
         }
     }

--- a/addons/point_of_sale/static/src/app/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.js
@@ -62,6 +62,14 @@ export class Navbar extends Component {
     get showCashMoveButton() {
         return Boolean(this.pos.config.cash_control && this.pos.session._has_cash_move_perm);
     }
+    async clearCache() {
+        await this.pos.data.resetIndexedDB();
+        const items = { ...localStorage };
+        for (const key in items) {
+            localStorage.removeItem(key);
+        }
+        window.location.reload();
+    }
     onCashMoveButtonClick() {
         this.hardwareProxy.openCashbox(_t("Cash in / out"));
         this.dialog.add(CashMovePopup);

--- a/addons/point_of_sale/static/src/app/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.xml
@@ -50,6 +50,9 @@
                         <DropdownItem onSelected="() => this.closeSession()">
                             Close Register
                         </DropdownItem>
+                        <DropdownItem t-if="this.env.debug" onSelected="() => this.clearCache()">
+                            Clear Cache
+                        </DropdownItem>
                         <DropdownItem t-if="this.env.debug" onSelected="() => debug.toggleWidget()">
                             Debug Window
                         </DropdownItem>

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -31,7 +31,10 @@ export class ReceiptScreen extends Component {
         onMounted(() => {
             const order = this.pos.get_order();
             this.currentOrder.uiState.locked = true;
-            this.pos.sendOrderInPreparation(order);
+
+            if (!this.pos.config.module_pos_restaurant) {
+                this.pos.sendOrderInPreparation(order);
+            }
         });
     }
 

--- a/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.js
+++ b/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.js
@@ -20,8 +20,10 @@ patch(OrderSummary.prototype, {
             )
         );
     },
-    unbookTable() {
-        this.pos.removeOrder(this.pos.get_order(), true);
+    async unbookTable() {
+        const order = this.pos.get_order();
+        await this.pos._onBeforeDeleteOrder(order);
+        order.state = "cancel";
         this.pos.showScreen("FloorScreen");
     },
     showUnbookButton() {

--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
@@ -121,8 +121,7 @@ export class SplitBillScreen extends Component {
             newOrder.last_order_preparation_change[linePreparationKey]["quantity"] =
                 sentQty[linePreparationKey];
         });
-        this.pos.addPendingOrder([originalOrder.id, newOrder.id]);
-
+        await this.pos.syncAllOrders({ orders: [originalOrder, newOrder] });
         originalOrder.customer_count -= 1;
         await this.postSplitOrder(originalOrder, newOrder);
         originalOrder.set_screen_data({ name: "ProductScreen" });

--- a/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
@@ -169,11 +169,6 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickValidate(),
-            {
-                ...Dialog.confirm(),
-                content:
-                    "acknowledge printing error ( because we don't have printer in the test. )",
-            },
             ReceiptScreen.clickNextOrder(),
             Utils.negateStep(FloorScreen.isChildTable("5")),
 

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -105,11 +105,6 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickValidate(),
-            {
-                ...Dialog.confirm(),
-                content:
-                    "acknowledge printing error ( because we don't have printer in the test. )",
-            },
             ReceiptScreen.clickNextOrder(),
 
             // order on another table with a product variant
@@ -193,7 +188,8 @@ registry.category("web_tour.tours").add("pos_restaurant_sync_second_login", {
             FloorScreen.clickTable("4"),
 
             // Test if products still get merged after transfering the order
-            ProductScreen.clickDisplayedProduct("Water", true, "2.0"),
+            ProductScreen.totalAmountIs("4.40"),
+            ProductScreen.clickDisplayedProduct("Water"),
             ProductScreen.totalAmountIs("6.60"),
             ProductScreen.clickNumpad("1"),
             ProductScreen.totalAmountIs("4.40"),

--- a/addons/pos_restaurant/static/tests/tours/refund_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/refund_tour.js
@@ -24,11 +24,6 @@ registry.category("web_tour.tours").add("RefundStayCurrentTableTour", {
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickValidate(),
-            {
-                ...Dialog.confirm(),
-                content:
-                    "acknowledge printing error ( because we don't have printer in the test. )",
-            },
             ReceiptScreen.clickNextOrder(),
 
             // Go to another table and refund one of the products

--- a/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
@@ -42,6 +42,7 @@ registry.category("web_tour.tours").add("SplitBillScreenTour", {
 
             // click pay to split, go back to check the lines
             SplitBillScreen.clickPay(),
+            ProductScreen.totalAmountIs("8.0"),
             ProductScreen.clickOrderline("Water", "3.0"),
             ProductScreen.clickOrderline("Coca-Cola", "1.0"),
 
@@ -75,6 +76,7 @@ registry.category("web_tour.tours").add("SplitBillScreenTour2", {
             SplitBillScreen.orderlineHas("Coca-Cola", "1", "1"),
             SplitBillScreen.clickPay(),
             PaymentScreen.clickBack(),
+            ProductScreen.totalAmountIs("4.00"),
             Chrome.clickMenuOption("Orders"),
             TicketScreen.selectOrder("-0002"),
             TicketScreen.loadSelectedOrder(),
@@ -109,14 +111,10 @@ registry.category("web_tour.tours").add("SplitBillScreenTour3", {
 
             // click pay to split, and pay
             SplitBillScreen.clickPay(),
+            ProductScreen.totalAmountIs("2.0"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
-            {
-                ...Dialog.confirm(),
-                content:
-                    "acknowledge printing error ( because we don't have printer in the test. )",
-            },
             ReceiptScreen.clickContinueOrder(),
 
             // Check if there is still water in the order
@@ -125,12 +123,6 @@ registry.category("web_tour.tours").add("SplitBillScreenTour3", {
             ProductScreen.clickPayButton(true),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
-            // Check if there is no more order to continue
-            {
-                ...Dialog.confirm(),
-                content:
-                    "acknowledge printing error ( because we don't have printer in the test. )",
-            },
             ReceiptScreen.clickNextOrder(),
         ].flat(),
 });
@@ -176,14 +168,10 @@ registry.category("web_tour.tours").add("SplitBillScreenTour4PosCombo", {
 
             ...SplitBillScreen.subtotalIs("53.80"),
             ...SplitBillScreen.clickPay(),
+            ProductScreen.totalAmountIs("53.80"),
             ProductScreen.clickPayButton(),
             ...PaymentScreen.clickPaymentMethod("Bank"),
             ...PaymentScreen.clickValidate(),
-            {
-                ...Dialog.confirm(),
-                content:
-                    "acknowledge printing error ( because we don't have printer in the test. )",
-            },
             ...ReceiptScreen.clickContinueOrder(),
 
             // Check if there is still water in the order

--- a/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
@@ -132,11 +132,6 @@ registry.category("web_tour.tours").add("PosResTipScreenTour", {
             PaymentScreen.emptyPaymentlines("5.0"),
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickValidate(),
-            {
-                ...Dialog.confirm(),
-                content:
-                    "acknowledge printing error ( because we don't have printer in the test. )",
-            },
             ReceiptScreen.isShown(),
 
             // order 5
@@ -150,11 +145,6 @@ registry.category("web_tour.tours").add("PosResTipScreenTour", {
             PaymentScreen.clickValidate(),
             TipScreen.isShown(),
             TipScreen.clickSettle(),
-            {
-                ...Dialog.confirm(),
-                content:
-                    "acknowledge printing error ( because we don't have printer in the test. )",
-            },
             ReceiptScreen.isShown(),
             ReceiptScreen.clickNextOrder(),
             FloorScreen.isShown(),


### PR DESCRIPTION
Fonctionnal changes:
- Add a `Clear cache` button in debug mode to allow Android and IOS
devices to clear the cache easily.
- Ensure that the splitting and transferring of orders works correctly
when the order is sent to the server.

Technical changes:
- Ensure that change quantities are numbers (technical change).
- Do not send items that wasn't sent to the preparation display when
reaching the receipt screen.
- When deleting all orderlines with backspace on the product_screen and
clicking on release table, cancel the order if it was sent to the server