### PR TITLE
[FIX] hw_drivers: force using wifi.reconnect instead of simple connect

### DIFF
--- a/addons/hw_drivers/connection_manager.py
+++ b/addons/hw_drivers/connection_manager.py
@@ -21,9 +21,6 @@ class ConnectionManager(Thread):
         self.pairing_uuid = False
 
     def run(self):
-        if platform.system() == 'Linux' and wifi.is_access_point():
-            return
-
         if not helpers.get_odoo_server_url():
             end_time = datetime.now() + timedelta(minutes=5)
             while datetime.now() < end_time:
@@ -33,6 +30,9 @@ class ConnectionManager(Thread):
             self.pairing_uuid = False
 
     def _connect_box(self):
+        if not helpers.get_ip() or (platform.system() == 'Linux' and wifi.is_access_point()):
+            return
+
         data = {
             'jsonrpc': 2.0,
             'params': {

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -290,7 +290,7 @@ class IotBoxOwlHomePage(http.Controller):
 
     @http.route('/hw_posbox_homepage/update_wifi', auth="none", type="jsonrpc", methods=['POST'], cors='*')
     def update_wifi(self, essid, password):
-        if wifi.connect(essid, password):
+        if wifi.reconnect(essid, password, force_update=True):
             helpers.update_conf({'wifi_ssid': essid, 'wifi_password': password})
         server = helpers.get_odoo_server_url()
 

--- a/addons/hw_posbox_homepage/static/src/app/status.js
+++ b/addons/hw_posbox_homepage/static/src/app/status.js
@@ -26,6 +26,10 @@ class StatusPage extends Component {
         }
     }
 
+    get accessPointSsid() {
+        return this.state.data.network_interfaces.filter(i => i.is_wifi)[0]?.ssid;
+    }
+
     static template = xml`
     <div t-if="!state.loading" class="container-fluid">
         <div class="text-center pt-5">
@@ -42,7 +46,7 @@ class StatusPage extends Component {
                 <hr/>
                 <p class="mb-3">
                     Please connect your IoT Box to internet via an ethernet cable or connect to Wi-FI network<br/>
-                    <a class="alert-link" t-out="'IoTBox-' + (state.data.network_interfaces[0].ssid or state.data.mac.replace(':', ''))" /><br/>
+                    <a class="alert-link" t-out="accessPointSsid" /><br/>
                     to configure a Wi-Fi connection on the IoT Box
                 </p>
             </div>


### PR DESCRIPTION
Using `reconnect` will first try to re up the connection if the network is already known (much lighter) and ensure to restart access point if password is wrong.
