### PR TITLE
[FIX] pos_mercado_pago: fix callback

### DIFF
--- a/addons/pos_mercado_pago/static/src/app/pos_store.js
+++ b/addons/pos_mercado_pago/static/src/app/pos_store.js
@@ -8,9 +8,11 @@ patch(PosStore.prototype, {
         await super.setup(...arguments);
         this.onNotified("MERCADO_PAGO_LATEST_MESSAGE", (payload) => {
             if (payload.config_id === this.config.id) {
-                this.getPendingPaymentLine(
-                    "mercado_pago"
-                ).payment_method.payment_terminal.handleMercadoPagoWebhook();
+                const pendingLine = this.getPendingPaymentLine("mercado_pago");
+
+                if (pendingLine) {
+                    pendingLine.payment_method.payment_terminal.handleMercadoPagoWebhook();
+                }
             }
         });
     },


### PR DESCRIPTION
Add a check on MP callback when paying. Verify if the pending payment line exist before processing the callback.

Same as:
- https://github.com/odoo/odoo/pull/186580
- https://github.com/odoo/odoo/pull/190735

opw-4349957

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
