### PR TITLE
[IMP] l10n_tr_nilvera{_einvoice}: unit codes legal requirement

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -34,6 +34,10 @@ UOM_TO_UNECE_CODE = {
     'uom.product_uom_gal': 'GLL',
     'uom.product_uom_cubic_inch': 'INQ',
     'uom.product_uom_cubic_foot': 'FTQ',
+    'uom.uom_square_meter': 'MTK',
+    'uom.uom_square_foot': 'FTK',
+    'uom.product_uom_yard': 'YRD',
+    'uom.product_uom_millimeter': 'MMT',
 }
 
 # -------------------------------------------------------------------------

--- a/addons/l10n_tr_nilvera/__manifest__.py
+++ b/addons/l10n_tr_nilvera/__manifest__.py
@@ -10,6 +10,7 @@ Base module containing core functionalities required by other Nilvera modules.
         'security/ir.model.access.csv',
         'views/res_config_settings_views.xml',
         'views/res_partner_views.xml',
+        'data/uom_data.xml',
     ],
     'post_init_hook': '_l10n_tr_nilvera_post_init',
     'license': 'LGPL-3',

--- a/addons/l10n_tr_nilvera/data/uom_data.xml
+++ b/addons/l10n_tr_nilvera/data/uom_data.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="product_uom_categ_energy" model="uom.category">
+        <field name="name">Energy</field>
+    </record>
+
+    <record id="product_uom_pk" model="uom.uom">
+        <field name="category_id" ref="uom.product_uom_categ_unit"/>
+        <field name="name">Parcel</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">bigger</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_pf" model="uom.uom">
+        <field name="category_id" ref="uom.product_uom_categ_unit"/>
+        <field name="name">Pallet</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">bigger</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_cr" model="uom.uom">
+        <field name="category_id" ref="uom.product_uom_categ_unit"/>
+        <field name="name">Crate</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">bigger</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_standard_cubic_meter" model="uom.uom">
+        <field name="category_id" ref="uom.product_uom_categ_vol"/>
+        <field name="name">Standard Cubic Meter</field>
+        <field name="factor_inv" eval="1000.0"/>
+        <field name="uom_type">bigger</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_sa" model="uom.uom">
+        <field name="category_id" ref="uom.product_uom_categ_unit"/>
+        <field name="name">Bags</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">bigger</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_cmq" model="uom.uom">
+        <field name="category_id" ref="uom.product_uom_categ_vol"/>
+        <field name="name">Cubic Centimeter - cm³</field>
+        <field name="factor" eval="1000.0"/>
+        <field name="uom_type">smaller</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_mlt" model="uom.uom">
+        <field name="category_id" ref="uom.product_uom_categ_vol"/>
+        <field name="name">Milliliter - ml</field>
+        <field name="factor" eval="1000.0"/>
+        <field name="uom_type">smaller</field>
+    </record>
+    <record id="product_uom_mmq" model="uom.uom">
+        <field name="category_id" ref="uom.product_uom_categ_vol"/>
+        <field name="name">Cubic Millimeter - mm³</field>
+        <field name="factor" eval="1000000.0"/>
+        <field name="uom_type">smaller</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_cmk" model="uom.uom">
+        <field name="category_id" ref="uom.uom_categ_surface"/>
+        <field name="name">Square Centimeter - cm²</field>
+        <field name="factor" eval="10000.0"/>
+        <field name="uom_type">smaller</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_bg" model="uom.uom">
+        <field name="category_id" ref="uom.product_uom_categ_unit"/>
+        <field name="name">Pack</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">bigger</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_bx" model="uom.uom">
+        <field name="category_id" ref="uom.product_uom_categ_unit"/>
+        <field name="name">Box</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">bigger</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_pr" model="uom.uom">
+        <field name="category_id" ref="uom.product_uom_categ_unit"/>
+        <field name="name">Pair</field>
+        <field name="factor" eval="0.5"/>
+        <field name="uom_type">bigger</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_mgm" model="uom.uom">
+        <field name="category_id" ref="uom.product_uom_categ_kgm"/>
+        <field name="name">Milligram - mg</field>
+        <field name="factor" eval="1000000.0"/>
+        <field name="uom_type">smaller</field>
+    </record>
+    <record id="product_uom_mon" model="uom.uom">
+        <field name="category_id" ref="uom.uom_categ_wtime"/>
+        <field name="name">Month</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">bigger</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_gt" model="uom.uom">
+        <field name="category_id" ref="uom.product_uom_categ_kgm"/>
+        <field name="name">Gross Ton</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">bigger</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_ann" model="uom.uom">
+        <field name="category_id" ref="uom.uom_categ_wtime"/>
+        <field name="name">Year</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">bigger</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_d61" model="uom.uom">
+        <field name="category_id" ref="uom.uom_categ_wtime"/>
+        <field name="name">Minute</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">smaller</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_d62" model="uom.uom">
+        <field name="category_id" ref="uom.uom_categ_wtime"/>
+        <field name="name">Second</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">smaller</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_pa" model="uom.uom">
+        <field name="category_id" ref="uom.product_uom_categ_unit"/>
+        <field name="name">Package</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">bigger</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_kwt" model="uom.uom">
+        <field name="category_id" ref="l10n_tr_nilvera.product_uom_categ_energy"/>
+        <field name="name">Kilowatt</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">reference</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_mwh" model="uom.uom">
+        <field name="category_id" ref="l10n_tr_nilvera.product_uom_categ_energy"/>
+        <field name="name">Megawatt Hour</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">bigger</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_kwh" model="uom.uom">
+        <field name="category_id" ref="l10n_tr_nilvera.product_uom_categ_energy"/>
+        <field name="name">Kilowatt Hour</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">bigger</field>
+        <field name="active">False</field>
+    </record>
+    <record id="product_uom_set" model="uom.uom">
+        <field name="category_id" ref="uom.product_uom_categ_unit"/>
+        <field name="name">Set</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">bigger</field>
+        <field name="active">False</field>
+    </record>
+</odoo>

--- a/addons/l10n_tr_nilvera/i18n/l10n_tr_nilvera.pot
+++ b/addons/l10n_tr_nilvera/i18n/l10n_tr_nilvera.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-29 09:38+0000\n"
-"PO-Revision-Date: 2024-10-29 09:38+0000\n"
+"POT-Creation-Date: 2025-03-28 16:01+0000\n"
+"PO-Revision-Date: 2025-03-28 16:01+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -35,11 +35,6 @@ msgid "API KEY"
 msgstr ""
 
 #. module: l10n_tr_nilvera
-#: model:ir.model.fields,field_description:l10n_tr_nilvera.field_account_journal__is_nilvera_journal
-msgid "Journal used for Nilvera"
-msgstr ""
-
-#. module: l10n_tr_nilvera
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_partner__l10n_tr_nilvera_customer_alias_id
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_users__l10n_tr_nilvera_customer_alias_id
 msgid "Alias"
@@ -47,10 +42,19 @@ msgstr ""
 
 #. module: l10n_tr_nilvera
 #. odoo-python
-#: code:addons/l10n_tr_nilvera/lib/nilvera_client.py:0
-#: code:addons/l10n_tr_nilvera/lib/nilvera_client.py:0
+#: code:addons/l10n_tr_nilvera/models/res_config_settings.py:0
 #, python-format
 msgid "An error occurred. Try again later."
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_sa
+msgid "Bags"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_bx
+msgid "Box"
 msgstr ""
 
 #. module: l10n_tr_nilvera
@@ -74,6 +78,11 @@ msgid "Contact"
 msgstr ""
 
 #. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_cr
+msgid "Crate"
+msgstr ""
+
+#. module: l10n_tr_nilvera
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_l10n_tr_nilvera_alias__create_uid
 msgid "Created by"
 msgstr ""
@@ -81,6 +90,16 @@ msgstr ""
 #. module: l10n_tr_nilvera
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_l10n_tr_nilvera_alias__create_date
 msgid "Created on"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_cmq
+msgid "Cubic Centimeter - cm³"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_mmq
+msgid "Cubic Millimeter - mm³"
 msgstr ""
 
 #. module: l10n_tr_nilvera
@@ -104,6 +123,11 @@ msgid "E-Invoice"
 msgstr ""
 
 #. module: l10n_tr_nilvera
+#: model:uom.category,name:l10n_tr_nilvera.product_uom_categ_energy
+msgid "Energy"
+msgstr ""
+
+#. module: l10n_tr_nilvera
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera.res_config_settings_view_form
 msgid "Environment"
 msgstr ""
@@ -112,6 +136,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_partner__ubl_cii_format
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_users__ubl_cii_format
 msgid "Format"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_gt
+msgid "Gross Ton"
 msgstr ""
 
 #. module: l10n_tr_nilvera
@@ -130,6 +159,27 @@ msgid "Journal"
 msgstr ""
 
 #. module: l10n_tr_nilvera
+#: model:ir.model.fields,field_description:l10n_tr_nilvera.field_account_journal__is_nilvera_journal
+msgid "Journal used for Nilvera"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_kwt
+msgid "Kilowatt"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_kwh
+msgid "Kilowatt Hour"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_partner__l10n_tr_nilvera_customer_alias_ids
+#: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_users__l10n_tr_nilvera_customer_alias_ids
+msgid "L10N Tr Nilvera Customer Alias"
+msgstr ""
+
+#. module: l10n_tr_nilvera
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_l10n_tr_nilvera_alias__write_uid
 msgid "Last Updated by"
 msgstr ""
@@ -137,6 +187,31 @@ msgstr ""
 #. module: l10n_tr_nilvera
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_l10n_tr_nilvera_alias__write_date
 msgid "Last Updated on"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_mwh
+msgid "Megawatt Hour"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_mgm
+msgid "Milligram - mg"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_mlt
+msgid "Milliliter - ml"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_d61
+msgid "Minute"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_mon
+msgid "Month"
 msgstr ""
 
 #. module: l10n_tr_nilvera
@@ -203,19 +278,28 @@ msgid "Not Checked"
 msgstr ""
 
 #. module: l10n_tr_nilvera
-#. odoo-python
-#: code:addons/l10n_tr_nilvera/lib/nilvera_client.py:0
-#, python-format
-msgid "Odoo could not perform this action at the moment, try again later."
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_bg
+msgid "Pack"
 msgstr ""
 
 #. module: l10n_tr_nilvera
-#. odoo-python
-#: code:addons/l10n_tr_nilvera/lib/nilvera_client.py:0
-#, python-format
-msgid ""
-"Oops, seems like you're unauthorised to do this. Try another API key with "
-"more rights or contact Nilvera."
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_pa
+msgid "Package"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_pr
+msgid "Pair"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_pf
+msgid "Pallet"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_pk
+msgid "Parcel"
 msgstr ""
 
 #. module: l10n_tr_nilvera
@@ -226,6 +310,26 @@ msgstr ""
 #. module: l10n_tr_nilvera
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera.selection__res_company__l10n_tr_nilvera_environment__production
 msgid "Production"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_d62
+msgid "Second"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_set
+msgid "Set"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_cmk
+msgid "Square Centimeter - cm²"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_standard_cubic_meter
+msgid "Standard Cubic Meter"
 msgstr ""
 
 #. module: l10n_tr_nilvera
@@ -246,4 +350,9 @@ msgstr ""
 #. module: l10n_tr_nilvera
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera.view_partner_property_form_inherit_ubl_tr
 msgid "Verify partner on Nilvera"
+msgstr ""
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_ann
+msgid "Year"
 msgstr ""

--- a/addons/l10n_tr_nilvera/i18n/tr.po
+++ b/addons/l10n_tr_nilvera/i18n/tr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-29 09:38+0000\n"
-"PO-Revision-Date: 2024-10-29 09:38+0000\n"
+"POT-Creation-Date: 2025-03-28 16:01+0000\n"
+"PO-Revision-Date: 2025-03-28 16:01+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -39,11 +39,6 @@ msgid "API KEY"
 msgstr ""
 
 #. module: l10n_tr_nilvera
-#: model:ir.model.fields,field_description:l10n_tr_nilvera.field_account_journal__is_nilvera_journal
-msgid "Journal used for Nilvera"
-msgstr "Nilvera için kullanılan dergi"
-
-#. module: l10n_tr_nilvera
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_partner__l10n_tr_nilvera_customer_alias_id
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_users__l10n_tr_nilvera_customer_alias_id
 msgid "Alias"
@@ -51,11 +46,20 @@ msgstr "Takma ad"
 
 #. module: l10n_tr_nilvera
 #. odoo-python
-#: code:addons/l10n_tr_nilvera/lib/nilvera_client.py:0
-#: code:addons/l10n_tr_nilvera/lib/nilvera_client.py:0
+#: code:addons/l10n_tr_nilvera/models/res_config_settings.py:0
 #, python-format
 msgid "An error occurred. Try again later."
 msgstr "Bir hata oluştu. Daha sonra tekrar deneyin."
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_sa
+msgid "Bags"
+msgstr "Çuval"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_bx
+msgid "Box"
+msgstr "Kutu"
 
 #. module: l10n_tr_nilvera
 #: model:ir.model,name:l10n_tr_nilvera.model_res_company
@@ -75,7 +79,12 @@ msgstr "Nilvera ayarlarını yapılandırma"
 #. module: l10n_tr_nilvera
 #: model:ir.model,name:l10n_tr_nilvera.model_res_partner
 msgid "Contact"
-msgstr "İletişim"
+msgstr "Kontak"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_cr
+msgid "Crate"
+msgstr "Sandik"
 
 #. module: l10n_tr_nilvera
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_l10n_tr_nilvera_alias__create_uid
@@ -86,6 +95,16 @@ msgstr "Tarafından oluşturuldu"
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_l10n_tr_nilvera_alias__create_date
 msgid "Created on"
 msgstr "Üzerinde oluşturuldu"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_cmq
+msgid "Cubic Centimeter - cm³"
+msgstr "Santimetre Küp - cm³"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_mmq
+msgid "Cubic Millimeter - mm³"
+msgstr "Milimetre Küp - mm³"
 
 #. module: l10n_tr_nilvera
 #: model:ir.model,name:l10n_tr_nilvera.model_l10n_tr_nilvera_alias
@@ -108,6 +127,11 @@ msgid "E-Invoice"
 msgstr "E-Fatura"
 
 #. module: l10n_tr_nilvera
+#: model:uom.category,name:l10n_tr_nilvera.product_uom_categ_energy
+msgid "Energy"
+msgstr "Enerji"
+
+#. module: l10n_tr_nilvera
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera.res_config_settings_view_form
 msgid "Environment"
 msgstr "Çevre"
@@ -117,6 +141,11 @@ msgstr "Çevre"
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_users__ubl_cii_format
 msgid "Format"
 msgstr "Biçim"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_gt
+msgid "Gross Ton"
+msgstr "Brüt Ton"
 
 #. module: l10n_tr_nilvera
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_l10n_tr_nilvera_alias__id
@@ -131,7 +160,28 @@ msgstr "Gelen Faturalar Günlüğü"
 #. module: l10n_tr_nilvera
 #: model:ir.model,name:l10n_tr_nilvera.model_account_journal
 msgid "Journal"
-msgstr "Dergi"
+msgstr "Yevmiye"
+
+#. module: l10n_tr_nilvera
+#: model:ir.model.fields,field_description:l10n_tr_nilvera.field_account_journal__is_nilvera_journal
+msgid "Journal used for Nilvera"
+msgstr "Nilvera için kullanılan dergi"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_kwt
+msgid "Kilowatt"
+msgstr "Kilowatt"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_kwh
+msgid "Kilowatt Hour"
+msgstr "Kilowatt Saat"
+
+#. module: l10n_tr_nilvera
+#: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_partner__l10n_tr_nilvera_customer_alias_ids
+#: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_users__l10n_tr_nilvera_customer_alias_ids
+msgid "L10N Tr Nilvera Customer Alias"
+msgstr "L10N Tr Nilvera Müşteri Takma Adı"
 
 #. module: l10n_tr_nilvera
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_l10n_tr_nilvera_alias__write_uid
@@ -142,6 +192,31 @@ msgstr "Son Güncelleme Tarihi"
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_l10n_tr_nilvera_alias__write_date
 msgid "Last Updated on"
 msgstr "Son Güncelleme Tarihi"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_mwh
+msgid "Megawatt Hour"
+msgstr "Megawatt Saat"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_mgm
+msgid "Milligram - mg"
+msgstr "Miligram - mg"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_mlt
+msgid "Milliliter - ml"
+msgstr "Mililitre - ml"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_d61
+msgid "Minute"
+msgstr "Dakika"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_mon
+msgid "Month"
+msgstr "Ay"
 
 #. module: l10n_tr_nilvera
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_l10n_tr_nilvera_alias__name
@@ -183,8 +258,11 @@ msgstr "Nilvera Durumu"
 #: code:addons/l10n_tr_nilvera/models/res_config_settings.py:0
 #, python-format
 msgid ""
-"Nilvera connection successful but the tax number on Nilvera and Odoo doesn't match. Check Nilvera."
-msgstr "Nilvera bağlantısı başarılı ancak Nilvera ve Odoo'daki vergi numarası eşleşmiyor. Nilvera'yı kontrol edin."
+"Nilvera connection successful but the tax number on Nilvera and Odoo doesn't"
+" match. Check Nilvera."
+msgstr ""
+"Nilvera bağlantısı başarılı ancak Nilvera ve Odoo'daki vergi numarası "
+"eşleşmiyor. Nilvera'yı kontrol edin."
 
 #. module: l10n_tr_nilvera
 #. odoo-python
@@ -206,22 +284,29 @@ msgid "Not Checked"
 msgstr "Kontrol Edilmedi"
 
 #. module: l10n_tr_nilvera
-#. odoo-python
-#: code:addons/l10n_tr_nilvera/lib/nilvera_client.py:0
-#, python-format
-msgid "Odoo could not perform this action at the moment, try again later."
-msgstr "Odoo şu anda bu işlemi gerçekleştiremedi, daha sonra tekrar deneyin."
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_bg
+msgid "Pack"
+msgstr "Poşet"
 
 #. module: l10n_tr_nilvera
-#. odoo-python
-#: code:addons/l10n_tr_nilvera/lib/nilvera_client.py:0
-#, python-format
-msgid ""
-"Oops, seems like you're unauthorised to do this. Try another API key with "
-"more rights or contact Nilvera."
-msgstr ""
-"Oops, bunu yapmak için yetkiniz yok gibi görünüyor. Daha fazla hakka sahip başka bir API anahtarı"
-"deneyin veya Nilvera ile iletişime geçin."
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_pa
+msgid "Package"
+msgstr "Paket"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_pr
+msgid "Pair"
+msgstr "Çift"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_pf
+msgid "Pallet"
+msgstr "Palet"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_pk
+msgid "Parcel"
+msgstr "Koli"
 
 #. module: l10n_tr_nilvera
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_l10n_tr_nilvera_alias__partner_id
@@ -231,11 +316,31 @@ msgstr "Ortak"
 #. module: l10n_tr_nilvera
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera.selection__res_company__l10n_tr_nilvera_environment__production
 msgid "Production"
-msgstr ""
+msgstr "Üretim"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_d62
+msgid "Second"
+msgstr "Saniye"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_set
+msgid "Set"
+msgstr "Set"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_cmk
+msgid "Square Centimeter - cm²"
+msgstr "Santimetre Kare - cm²"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_standard_cubic_meter
+msgid "Standard Cubic Meter"
+msgstr "Standart Metreküp"
 
 #. module: l10n_tr_nilvera
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera.selection__res_company__l10n_tr_nilvera_environment__sandbox
-msgid "Sandbox"
+msgid "Test"
 msgstr ""
 
 #. module: l10n_tr_nilvera
@@ -252,3 +357,8 @@ msgstr "Doğrulama"
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera.view_partner_property_form_inherit_ubl_tr
 msgid "Verify partner on Nilvera"
 msgstr "Nilvera'daki ortağı doğrulayın"
+
+#. module: l10n_tr_nilvera
+#: model:uom.uom,name:l10n_tr_nilvera.product_uom_ann
+msgid "Year"
+msgstr "Yıl"

--- a/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
@@ -6,14 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-29 13:53+0000\n"
-"PO-Revision-Date: 2024-10-29 13:53+0000\n"
+"POT-Creation-Date: 2025-03-26 15:09+0000\n"
+"PO-Revision-Date: 2025-03-26 15:09+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:ir.model,name:l10n_tr_nilvera_einvoice.model_account_move_send
+msgid "Account Move Send"
+msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
@@ -45,6 +50,16 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model,name:l10n_tr_nilvera_einvoice.model_account_move
 msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move_send__l10n_tr_nilvera_einvoice_enable_xml
+msgid "L10N Tr Nilvera Einvoice Enable Xml"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move_send__l10n_tr_nilvera_warnings
+msgid "L10N Tr Nilvera Warnings"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
@@ -102,7 +117,6 @@ msgstr ""
 msgid "Sent and waiting response"
 msgstr ""
 
-
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
@@ -120,8 +134,8 @@ msgstr ""
 #: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
 #, python-format
 msgid ""
-"The following partner(s) are either not Turkish or are missing one of "
-"those fields: city, state and street."
+"The following partner(s) are either not Turkish or are missing one of those "
+"fields: city, state and street."
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
@@ -180,7 +194,6 @@ msgstr ""
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera_einvoice.selection__account_move__l10n_tr_nilvera_send_status__waiting
 msgid "Waiting"
 msgstr ""
-
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python

--- a/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
@@ -6,14 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-29 13:53+0000\n"
-"PO-Revision-Date: 2024-10-29 13:53+0000\n"
+"POT-Creation-Date: 2025-03-26 15:10+0000\n"
+"PO-Revision-Date: 2025-03-26 15:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:ir.model,name:l10n_tr_nilvera_einvoice.model_account_move_send
+msgid "Account Move Send"
+msgstr "Hesap Hareketi Yollandı"
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
@@ -40,12 +45,22 @@ msgstr "Nilvera'dan Getir"
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model,name:l10n_tr_nilvera_einvoice.model_account_journal
 msgid "Journal"
-msgstr "Dergi"
+msgstr "Yevmiye"
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model,name:l10n_tr_nilvera_einvoice.model_account_move
 msgid "Journal Entry"
-msgstr "Günlük Girişi"
+msgstr "Yevmiye Kaydı"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move_send__l10n_tr_nilvera_einvoice_enable_xml
+msgid "L10N Tr Nilvera Einvoice Enable Xml"
+msgstr "L10N Tr Nilvera Einvoice Etkinleştir Xml"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move_send__l10n_tr_nilvera_warnings
+msgid "L10N Tr Nilvera Warnings"
+msgstr "L10N Tr Nilvera Uyarıları"
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_bank_statement_line__l10n_tr_nilvera_uuid
@@ -91,8 +106,8 @@ msgid ""
 "Oops, seems like you're unauthorised to do this. Try another API key with "
 "more rights or contact Nilvera."
 msgstr ""
-"Oops, bunu yapmak için yetkiniz yok gibi görünüyor. Daha fazla hakka sahip başka bir API anahtarı "
-"deneyin veya Nilvera ile iletişime geçin."
+"Oops, bunu yapmak için yetkiniz yok gibi görünüyor. Daha fazla hakka sahip "
+"başka bir API anahtarı deneyin veya Nilvera ile iletişime geçin."
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move_send__l10n_tr_nilvera_einvoice_checkbox_xml
@@ -121,11 +136,11 @@ msgstr "Başarılı"
 #: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
 #, python-format
 msgid ""
-"The following partner(s) are either not Turkish or are missing one of "
-"those fields: city, state and street."
+"The following partner(s) are either not Turkish or are missing one of those "
+"fields: city, state and street."
 msgstr ""
-"Aşağıdaki ortak(lar) ya Türkçe değildir ya da bu alanlardan "
-"biri eksiktir: şehir, eyalet ve cadde."
+"Aşağıdaki ortak(lar) ya Türkçe değildir ya da bu alanlardan biri eksiktir: "
+"şehir, eyalet ve cadde."
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
@@ -165,7 +180,7 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_tr_nilvera_einvoice.field_account_move__l10n_tr_nilvera_uuid
 #: model:ir.model.fields,help:l10n_tr_nilvera_einvoice.field_account_payment__l10n_tr_nilvera_uuid
 msgid "Universally unique identifier of the Invoice"
-msgstr "Faturanın evrensel olarak benzersiz tanımlayıcısı"
+msgstr "Faturanın evrensel Olarak benzersiz tanımlayıcısı"
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera_einvoice.selection__account_move__l10n_tr_nilvera_send_status__unknown
@@ -189,5 +204,6 @@ msgstr "Bekliyorum"
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
 #, python-format
 msgid "You cannot reset to draft an entry that has been sent to Nilvera."
-msgstr "Nilvera'ya gönderilmiş bir girişi taslak haline getirmek için sıfırlayamazsınız."
-
+msgstr ""
+"Nilvera'ya gönderilmiş bir girişi taslak haline getirmek için "
+"sıfırlayamazsınız."

--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -1,5 +1,31 @@
 from odoo import models
 
+UOM_TO_UNECE_CODE = {
+    'l10n_tr_nilvera.product_uom_pk': 'PK',
+    'l10n_tr_nilvera.product_uom_pf': 'PF',
+    'l10n_tr_nilvera.product_uom_cr': 'CR',
+    'l10n_tr_nilvera.product_uom_standard_cubic_meter': 'SM3',
+    'l10n_tr_nilvera.product_uom_sa': 'SA',
+    'l10n_tr_nilvera.product_uom_cmq': 'CMQ',
+    'l10n_tr_nilvera.product_uom_mlt': 'MLT',
+    'l10n_tr_nilvera.product_uom_mmq': 'MMQ',
+    'l10n_tr_nilvera.product_uom_cmk': 'CMK',
+    'l10n_tr_nilvera.product_uom_bg': 'BG',
+    'l10n_tr_nilvera.product_uom_bx': 'BX',
+    'l10n_tr_nilvera.product_uom_pr': 'PR',
+    'l10n_tr_nilvera.product_uom_mgm': 'MGM',
+    'l10n_tr_nilvera.product_uom_mon': 'MON',
+    'l10n_tr_nilvera.product_uom_gt': 'GT',
+    'l10n_tr_nilvera.product_uom_ann': 'ANN',
+    'l10n_tr_nilvera.product_uom_d61': 'D61',
+    'l10n_tr_nilvera.product_uom_d62': 'D62',
+    'l10n_tr_nilvera.product_uom_pa': 'PA',
+    'l10n_tr_nilvera.product_uom_mwh': 'MWH',
+    'l10n_tr_nilvera.product_uom_kwh': 'KWH',
+    'l10n_tr_nilvera.product_uom_kwt': 'KWT',
+    'l10n_tr_nilvera.product_uom_set': 'SET',
+}
+
 
 class AccountEdiXmlUblTr(models.AbstractModel):
     _name = "account.edi.xml.ubl.tr"
@@ -150,6 +176,26 @@ class AccountEdiXmlUblTr(models.AbstractModel):
                 'document_type_code': "SEND_TYPE",
             })
         return additional_document_reference_list
+
+    def _get_invoice_line_price_vals(self, line):
+        # EXTEND 'account.edi.common'
+        invoice_line_price_vals = super()._get_invoice_line_price_vals(line)
+        invoice_line_price_vals['base_quantity_attrs'] = {'unitCode': self._get_uom_unece_code(line)}
+        return invoice_line_price_vals
+
+    def _get_invoice_line_vals(self, line, line_id, taxes_vals):
+        invoice_line_vals = super()._get_invoice_line_vals(line, line_id, taxes_vals)
+        invoice_line_vals['line_quantity_attrs'] = {'unitCode': self._get_uom_unece_code(line)}
+        return invoice_line_vals
+
+    def _get_uom_unece_code(self, line):
+        """ This depends on the mapping from https://developer.nilvera.com/en/code-lists#birim-kodlari """
+        uom = super()._get_uom_unece_code(line)
+        if uom == 'C62':
+            xmlid = line.product_uom_id.get_external_id()
+            if xmlid and line.product_uom_id.id in xmlid:
+                return UOM_TO_UNECE_CODE.get(xmlid[line.product_uom_id.id], 'C62')
+        return uom
 
     # -------------------------------------------------------------------------
     # IMPORT


### PR DESCRIPTION
In the xml we sent, we have to specify the unit code, there is mapping for that on the documentation: https://developer.nilvera.com/en/code-lists#birim-kodlari

This commit will extend what has been done in the base edi module with the UOM_TO_UNECE_CODE dictionary. We added some new unit of measure and each unit of measure will be linked to a code.
The default value is C62.

task-4457115




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
