### PR TITLE
[FIX] stock_account: add model_create_multi decorator to stock.lot

### DIFF
--- a/addons/stock_account/models/stock_lot.py
+++ b/addons/stock_account/models/stock_lot.py
@@ -61,6 +61,7 @@ class StockLot(models.Model):
             lot.avg_cost = avg_cost
             lot.total_value = avg_cost * quantity_sum
 
+    @api.model_create_multi
     def create(self, vals_list):
         lots = super().create(vals_list)
         for product, lots_by_product in lots.grouped('product_id').items():


### PR DESCRIPTION
Before this commit: creating stock lot records (multi) via the xml.rpc resulted in a bug: missing argument 'vals_list'. 

After this commit: It is possible to create multiple stock lot records without this bug




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
