### PR TITLE
[FIX] point_of_sale: handle custom one2many fields

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -102,7 +102,8 @@ class PosSession(models.Model):
             response[model]['relations'] = {}
 
         for name, params in model_fields.items():
-            if name not in response[model]['fields'] and len(response[model]['fields']) != 0:
+            fields_count = len(response[model]['fields'])
+            if (fields_count and name not in response[model]['fields']) or (params.manual and not fields_count):
                 continue
 
             if params.comodel_name:


### PR DESCRIPTION
Before this commit, if there was a custom one2many field with the same related field as an existing one, it would cause issues in PoS when capturing an order. For example, if there was a custom field in pos.order with a related field of order_id, adding products to the order would not show them in the order summary.

opw-4462991

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
