### PR TITLE
[IMP] *: add t-autoprefix for assets bundle

### DIFF
--- a/addons/point_of_sale/views/report_saledetails.xml
+++ b/addons/point_of_sale/views/report_saledetails.xml
@@ -13,7 +13,7 @@
                     <meta charset="utf-8"/>
                     <meta name="viewport" content="initial-scale=1"/>
                     <title><t t-esc="title or 'Odoo Report'"/></title>
-                    <t t-call-assets="web.report_assets_common"/>
+                    <t t-call-assets="web.report_assets_common" t-autoprefix="true"/>
                     <script type="text/javascript">
                         document.addEventListener('DOMContentLoaded', () => {
                             if (window.self !== window.top) {

--- a/addons/snailmail/views/report_assets.xml
+++ b/addons/snailmail/views/report_assets.xml
@@ -2,12 +2,12 @@
 <odoo>
     <template id="report_layout" inherit_id="web.report_layout">
         <xpath expr="//head" position="inside">
-            <t t-if="env and env.context.get('snailmail_layout')" t-call-assets="snailmail.report_assets_snailmail"/>
+            <t t-if="env and env.context.get('snailmail_layout')" t-call-assets="snailmail.report_assets_snailmail" t-autoprefix="true"/>
         </xpath>
     </template>
     <template id="minimal_layout" inherit_id="web.minimal_layout">
         <xpath expr="//head" position="inside">
-            <t t-if="env and env.context.get('snailmail_layout')" t-call-assets="snailmail.report_assets_snailmail"/>
+            <t t-if="env and env.context.get('snailmail_layout')" t-call-assets="snailmail.report_assets_snailmail" t-autoprefix="true"/>
         </xpath>
     </template>
 </odoo>

--- a/addons/stock/views/report_stock_traceability.xml
+++ b/addons/stock/views/report_stock_traceability.xml
@@ -7,7 +7,7 @@
                 <base t-att-href="base_url"/>
             </t>
             <t t-set="head_end">
-                <t t-call-assets="stock.assets_stock_print_report" t-js="False"/>
+                <t t-call-assets="stock.assets_stock_print_report" t-js="False" t-autoprefix="true"/>
             </t>
             <t t-call='stock.report_stock_body_print'/>
         </t>

--- a/addons/web/controllers/binary.py
+++ b/addons/web/controllers/binary.py
@@ -123,7 +123,7 @@ class Binary(http.Controller):
                     if filename.endswith('.map'):
                         _logger.error(".map should have been generated through debug assets, (version %s most likely outdated)", unique)
                         raise request.not_found()
-                    bundle_name, rtl, asset_type = rw_env['ir.asset']._parse_bundle_name(filename, debug_assets)
+                    bundle_name, rtl, asset_type, autoprefix = rw_env['ir.asset']._parse_bundle_name(filename, debug_assets)
                     css = asset_type == 'css'
                     js = asset_type == 'js'
                     bundle = rw_env['ir.qweb']._get_asset_bundle(
@@ -132,6 +132,7 @@ class Binary(http.Controller):
                         js=js,
                         debug_assets=debug_assets,
                         rtl=rtl,
+                        autoprefix=autoprefix,
                         assets_params=assets_params,
                     )
                     # check if the version matches. If not, redirect to the last version

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -14,7 +14,7 @@
                 <meta charset="utf-8"/>
                 <meta name="viewport" content="initial-scale=1"/>
                 <title><t t-esc="title or 'Odoo Report'"/></title>
-                <t t-call-assets="web.report_assets_common"/>
+                <t t-call-assets="web.report_assets_common" t-autoprefix="true"/>
                 <!-- Temporary code: only used to maintain CSS for legacy HTML reports (full width...) -->
                 <!-- Should be removed once the reports are fully converted. -->
                 <script type="text/javascript">
@@ -231,8 +231,8 @@
         <html style="height: 0;">
             <head>
                 <base t-att-href="base_url"/>
-                <t t-call-assets="web.report_assets_pdf" t-js="false"/>
-                <t t-call-assets="web.report_assets_common" t-js="false"/>
+                <t t-call-assets="web.report_assets_pdf" t-js="false" t-autoprefix="true"/>
+                <t t-call-assets="web.report_assets_common" t-js="false" t-autoprefix="true"/>
                 <t t-call-assets="web.report_assets_pdf" t-css="false"/>
                 <meta charset="utf-8"/>
                 <script t-if="subst">

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -634,15 +634,15 @@ css_error_message {
         compiled = compiled.strip()
 
         # Post process the produced css to add required vendor prefixes here
-        compiled = re.sub(r'(appearance: (\w+);)', r'-webkit-appearance: \2; -moz-appearance: \2; \1', compiled)
+        compiled = re.sub(r'[ \t]\b(appearance: (\w+);)', r'-webkit-appearance: \2; -moz-appearance: \2; \1', compiled)
 
         # Most of those are only useful for wkhtmltopdf (some for old PhantomJS)
-        compiled = re.sub(r'(display: ((?:inline-)?)flex((?: ?!important)?);)', r'display: -webkit-\2box\3; display: -webkit-\2flex\3; \1', compiled)
-        compiled = re.sub(r'(justify-content: flex-(\w+)((?: ?!important)?);)', r'-webkit-box-pack: \2\3; \1', compiled)
-        compiled = re.sub(r'(flex-flow: (\w+ \w+);)', r'-webkit-flex-flow: \2; \1', compiled)
-        compiled = re.sub(r'(flex-direction: (column);)', r'-webkit-box-orient: vertical; -webkit-box-direction: normal; -webkit-flex-direction: \2; \1', compiled)
-        compiled = re.sub(r'(flex-wrap: (\w+);)', r'-webkit-flex-wrap: \2; \1', compiled)
-        compiled = re.sub(r'(flex: ((\d)+ \d+ (?:\d+|auto));)', r'-webkit-box-flex: \3; -webkit-flex: \2; \1', compiled)
+        compiled = re.sub(r'[ \t]\b(display: ((?:inline-)?)flex((?: ?!important)?);)', r'display: -webkit-\2box\3; display: -webkit-\2flex\3; \1', compiled)
+        compiled = re.sub(r'[ \t]\b(justify-content: flex-(\w+)((?: ?!important)?);)', r'-webkit-box-pack: \2\3; \1', compiled)
+        compiled = re.sub(r'[ \t]\b(flex-flow: (\w+ \w+);)', r'-webkit-flex-flow: \2; \1', compiled)
+        compiled = re.sub(r'[ \t]\b(flex-direction: (column);)', r'-webkit-box-orient: vertical; -webkit-box-direction: normal; -webkit-flex-direction: \2; \1', compiled)
+        compiled = re.sub(r'[ \t]\b(flex-wrap: (\w+);)', r'-webkit-flex-wrap: \2; \1', compiled)
+        compiled = re.sub(r'[ \t]\b(flex: ((\d)+ \d+ (?:\d+|auto));)', r'-webkit-box-flex: \3; -webkit-flex: \2; \1', compiled)
 
         return compiled
 

--- a/odoo/addons/base/models/ir_asset.py
+++ b/odoo/addons/base/models/ir_asset.py
@@ -105,11 +105,15 @@ class IrAsset(models.Model):
     def _parse_bundle_name(self, bundle_name, debug_assets):
         bundle_name, asset_type = bundle_name.rsplit('.', 1)
         rtl = False
+        autoprefix = False
         if not debug_assets:
             bundle_name, min_ = bundle_name.rsplit('.', 1)
             if min_ != 'min':
                 raise ValueError("'min' expected in extension in non debug mode")
         if asset_type == 'css':
+            if bundle_name.endswith('.autoprefixed'):
+                bundle_name = bundle_name[:-13]
+                autoprefix = True
             if bundle_name.endswith('.rtl'):
                 bundle_name = bundle_name[:-4]
                 rtl = True
@@ -117,7 +121,7 @@ class IrAsset(models.Model):
             raise ValueError('Only js and css assets bundle are supported for now')
         if len(bundle_name.split('.')) != 2:
             raise ValueError(f'{bundle_name} is not a valid bundle name, should have two parts')
-        return bundle_name, rtl, asset_type
+        return bundle_name, rtl, asset_type, autoprefix
 
     @tools.conditional(
         'xml' not in tools.config['dev_mode'],

--- a/odoo/addons/test_assetsbundle/static/src/scss/test_prefix.scss
+++ b/odoo/addons/test_assetsbundle/static/src/scss/test_prefix.scss
@@ -1,0 +1,78 @@
+.appearance-none {
+    appearance: none;
+}
+.appearance-auto {
+    appearance: auto;
+}
+
+.display-flex {
+    display: flex;
+}
+.display-inline-flex {
+    display: inline-flex;
+}
+.display-inline {
+    display: inline;
+}
+
+.justify-content-flex-start {
+    justify-content: flex-start;
+}
+.justify-content-flex-end {
+    justify-content: flex-end;
+}
+.justify-content-center {
+    justify-content: center;
+}
+
+.flex-flow-row-nowrap {
+    flex-flow: row nowrap;
+}
+.flex-flow-column-wrap {
+    flex-flow: column wrap;
+}
+.flex-flow-column-reverse-wrap-reverse {
+    flex-flow: column-reverse wrap-reverse;
+}
+.flex-flow-row {
+    flex-flow: row;
+}
+
+.flex-direction-column {
+    flex-direction: column;
+}
+.flex-direction-column-reverse {
+    flex-direction: column-reverse;
+}
+.flex-direction-row {
+    flex-direction: row;
+}
+
+.flex-wrap-wrap {
+    flex-wrap: wrap;
+}
+.flex-wrap-nowrap {
+    flex-wrap: nowrap;
+}
+.flex-wrap-wrap-reverse {
+    flex-wrap: wrap-reverse;
+}
+
+.flex-0-0-auto {
+    flex: 0 0 auto;
+}
+.flex-0-1-auto {
+    flex: 0 1 auto;
+}
+.flex-1-1-100 {
+    flex: 1 1 100;
+}
+.flex-1-1-100percent{
+    flex: 1 1 100%;
+}
+.flex-auto {
+    flex: auto;
+}
+.flex-1-30px {
+    flex: 1 30px;
+}

--- a/odoo/addons/test_assetsbundle/static/src/scss/test_prefix.scss
+++ b/odoo/addons/test_assetsbundle/static/src/scss/test_prefix.scss
@@ -4,6 +4,9 @@
 .appearance-auto {
     appearance: auto;
 }
+.appearance-none-prefixed {
+    -webkit-appearance: none;
+}
 
 .display-flex {
     display: flex;
@@ -13,6 +16,15 @@
 }
 .display-inline {
     display: inline;
+}
+.display-var-flex {
+    --dummy-display: flex;
+}
+.display-var-inline-flex {
+    --dummy-display: inline-flex;
+}
+.display-var-inline {
+    --dummy-display: inline;
 }
 
 .justify-content-flex-start {

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -1415,6 +1415,41 @@ class TestAssetsManifest(AddonManifestPatched):
             '''
         )
 
+    def test_20_css_compatibility_prefix(self):
+        self.env['ir.asset'].create({
+            'name': '1',
+            'bundle': 'test_assetsbundle.irasset2',
+            'path': 'test_assetsbundle/static/src/scss/test_prefix.scss',
+        })
+        bundle = self.env['ir.qweb']._get_asset_bundle('test_assetsbundle.irasset2', js=False)
+        content = bundle.css().raw.decode()
+        self.assertRegex(content, '.appearance-none{-webkit-appearance: none; -moz-appearance: none; appearance: none;}')
+        self.assertRegex(content, '.appearance-auto{-webkit-appearance: auto; -moz-appearance: auto; appearance: auto;}')
+
+        self.assertRegex(content, '.display-flex{display: -webkit-box; display: -webkit-flex; display: flex;}')
+        self.assertRegex(content, '.display-inline-flex{display: -webkit-inline-box; display: -webkit-inline-flex; display: inline-flex;}')
+        self.assertRegex(content, '.display-inline{display: inline;}')        
+
+        self.assertRegex(content, '.flex-flow-row-nowrap{-webkit-flex-flow: row nowrap; flex-flow: row nowrap;}')
+        self.assertRegex(content, '.flex-flow-column-wrap{-webkit-flex-flow: column wrap; flex-flow: column wrap;}')
+        self.assertRegex(content, '.flex-flow-column-reverse-wrap-reverse{flex-flow: column-reverse wrap-reverse;}')
+        self.assertRegex(content, '.flex-flow-row{flex-flow: row;}')
+        
+        self.assertRegex(content, '.flex-direction-column{-webkit-box-orient: vertical; -webkit-box-direction: normal; -webkit-flex-direction: column; flex-direction: column;}')
+        self.assertRegex(content, '.flex-direction-column-reverse{flex-direction: column-reverse;}')
+        self.assertRegex(content, '.flex-direction-row{flex-direction: row;}')
+        
+        self.assertRegex(content, '.flex-wrap-wrap{-webkit-flex-wrap: wrap; flex-wrap: wrap;}')
+        self.assertRegex(content, '.flex-wrap-nowrap{-webkit-flex-wrap: nowrap; flex-wrap: nowrap;}')
+        self.assertRegex(content, '.flex-wrap-wrap-reverse{flex-wrap: wrap-reverse;}')
+
+        self.assertRegex(content, '.flex-0-0-auto{-webkit-box-flex: 0; -webkit-flex: 0 0 auto; flex: 0 0 auto;}')
+        self.assertRegex(content, '.flex-0-1-auto{-webkit-box-flex: 0; -webkit-flex: 0 1 auto; flex: 0 1 auto;}')
+        self.assertRegex(content, '.flex-1-1-100{-webkit-box-flex: 1; -webkit-flex: 1 1 100; flex: 1 1 100;}')
+        self.assertRegex(content, '.flex-1-1-100percent{flex: 1 1 100%;}')
+        self.assertRegex(content, '.flex-auto{flex: auto;}')
+        self.assertRegex(content, '.flex-1-30px{flex: 1 30px;}')
+
     def test_21_js_before_css(self):
         '''Non existing target node: ignore the manifest line'''
         self.installed_modules.add('test_other')

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -1421,7 +1421,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'bundle': 'test_assetsbundle.irasset2',
             'path': 'test_assetsbundle/static/src/scss/test_prefix.scss',
         })
-        bundle = self.env['ir.qweb']._get_asset_bundle('test_assetsbundle.irasset2', js=False)
+        bundle = self.env['ir.qweb']._get_asset_bundle('test_assetsbundle.irasset2', js=False, autoprefix=True)
         content = bundle.css().raw.decode()
         self.assertRegex(content, '.appearance-none{-webkit-appearance: none; -moz-appearance: none; appearance: none;}')
         self.assertRegex(content, '.appearance-auto{-webkit-appearance: auto; -moz-appearance: auto; appearance: auto;}')

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -1425,10 +1425,14 @@ class TestAssetsManifest(AddonManifestPatched):
         content = bundle.css().raw.decode()
         self.assertRegex(content, '.appearance-none{-webkit-appearance: none; -moz-appearance: none; appearance: none;}')
         self.assertRegex(content, '.appearance-auto{-webkit-appearance: auto; -moz-appearance: auto; appearance: auto;}')
+        self.assertRegex(content, '.appearance-none-prefixed{-webkit-appearance: none;}')
 
         self.assertRegex(content, '.display-flex{display: -webkit-box; display: -webkit-flex; display: flex;}')
         self.assertRegex(content, '.display-inline-flex{display: -webkit-inline-box; display: -webkit-inline-flex; display: inline-flex;}')
         self.assertRegex(content, '.display-inline{display: inline;}')        
+        self.assertRegex(content, '.display-var-flex{--dummy-display: flex;}')
+        self.assertRegex(content, '.display-var-inline-flex{--dummy-display: inline-flex;}')
+        self.assertRegex(content, '.display-var-inline{--dummy-display: inline;}')
 
         self.assertRegex(content, '.flex-flow-row-nowrap{-webkit-flex-flow: row nowrap; flex-flow: row nowrap;}')
         self.assertRegex(content, '.flex-flow-column-wrap{-webkit-flex-flow: column wrap; flex-flow: column wrap;}')


### PR DESCRIPTION
This commit allows to only enable when needed the "autoprefixing" feature of CSS rules used for compatibility with (very) old browsers. To do so, it introduces the boolean t-autoprefix attribute on <t t-call-assets="..."/> in QWeb's templates.

As those prefixes (e.g. -webkit-, -moz-...) are basically only required for wkhtmltopdf compatibility nowadays, only the reports' bundles stil use it.

Also disabling it for the other bundles (backend, frontend...) result into a slight gain in the bundles' size (+/- 20ko uncompressed on a database "all").