### PR TITLE
[FIX] *_livechat: chatbot select answer might not post visitor msg

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -241,7 +241,7 @@ class DiscussChannel(models.Model):
                 )
                 question_msg.user_script_answer_id = selected_answer
                 if store := self.env.context.get("message_post_store"):
-                    store.add(question_msg.mail_message_id)
+                    store.add(message, for_current_user=True).add(question_msg.mail_message_id)
 
             self.env["chatbot.message"].sudo().create(
                 {


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/192076

PR above fixes issues regarding question-answer step of chatbot: to detect which answer was picked, it was comparing item selected text content with each possible answers. This worked as long as each possible answer had mutually exclusive text content. If one proposition had X and another had no X, one option could be unreachable.

To solve the issue, PR above tracks the `select_answer_id`. When the user posts a message, the selected answer is returned in RPC response as store data. The selected answer is put in the question message of chatbot. This means the `message_post` store data contains 2 messages.

The implementation of message_post in JS is naive and assumes the data contains only 1 message. Therefore when inserting the store data, it was assuming the 1st inserted message in store was the newly posted message.

However in this particular case, the 1st inserted message was the question message of chatbot, not the user answer message.

As a result, the test `test_complete_chatbot_flow_ui` had the following non-deterministic issue because of this:

```
Failed to find 1 of ".o-mail-Message" inside a specific target with text "I'd like to buy the software" (as parent). Found 0 instead.
```

This commit fixes the issue by putting the message_post message (the answer of user) before the question message of chatbot.

This is the chosen fix as this is minimal. The destruct of store.insert() in message_post is too naive and should be changed by something more robust in the future.

Note that this problem was not present in practice: the visitor message was visible but with minimal flicker. This is because the bus notification was adjusting the UI from the erroneous message_post result.

runbot-111747