### PR TITLE
[FIX] odoo/tools: error processing Factur-X XML

### DIFF
--- a/odoo/tools/xml_utils.py
+++ b/odoo/tools/xml_utils.py
@@ -140,7 +140,8 @@ def cleanup_xml_node(xml_node_or_string, remove_blank_text=True, remove_blank_no
     if isinstance(xml_node, str):
         xml_node = xml_node.encode()  # misnomer: fromstring actually reads bytes
     if isinstance(xml_node, bytes):
-        xml_node = etree.fromstring(remove_control_characters(xml_node))
+        parser = etree.XMLParser(recover=True, resolve_entities=False)
+        xml_node = etree.fromstring(remove_control_characters(xml_node), parser=parser)
 
     # Process leaf nodes iteratively
     # Depth-first, so any inner node may become a leaf too (if children are removed)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR is to fix an issue encountered when copying information from an editor for a product for example, and pasting it on the product label. On Odoo the label was appearing fine but when the invoice was confirmed and sent, the XML file content is created with hidden characters.This produced the web service to return an error when trying to validate the electronic invoice. 

Current behavior before PR:
Special or hidden characters appear on the XML file of an electronic invoice.

Steps to reproduce:
1. Install Uruguay - Electronic Invoice module
2. Create EDI invoice, add special character to the description of the product you are using. Example used for testing (copy-paste it): ‭219179120011‬
3. Validate the invoice
4. Print and send it
5. Check "DscItem" field on the XML file created.

Here is a one minute [video](https://drive.google.com/file/d/18JcnKCbaq7cH_NVyPol4CWXHdqZAxAdo/view) reproducing the error on runbot.

Desired behavior after PR is merged:
These characters are cleaned up at the xml level on cleanup_xml_node method to avoid them to appear and prevent errors when validating the XML on localizations web services.

Related PR on v16 regarding the same issue in another context: https://github.com/odoo/odoo/pull/154509

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
