### PR TITLE
[FIX] mail: chat/channel action menu position

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -15,7 +15,7 @@
         <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 z-1 shadow-sm" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall and !props.chatWindow.actionsDisabled }">
             <t t-if="hasActionsMenu">
                 <div class="d-flex text-truncate">
-                    <Dropdown position="'left-start'" onStateChanged="isOpen => this.onActionsMenuStateChanged(isOpen)" menuClass="'d-flex flex-column py-0 bg-100 border-secondary'">
+                    <Dropdown position="ui.isSmall ? 'bottom-end' : 'left-start'" onStateChanged="isOpen => this.onActionsMenuStateChanged(isOpen)" menuClass="'d-flex flex-column py-0 bg-100 border-secondary'">
                         <button
                             class="o-mail-ChatWindow-command o-actionsMenu btn rounded-0 d-flex align-items-center px-2 py-1 my-0 w-100 rounded-end-0"
                             t-att-class="{ 'rounded-top-3': !ui.isSmall, 'o-active': state.actionsMenuOpened, 'o-hover': actionsMenuButtonHover.isHover and !parentChannelHover.isHover }"

--- a/addons/mail/static/src/discuss/core/common/notification_settings.js
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.js
@@ -24,6 +24,7 @@ export class NotificationSettings extends Component {
     setup() {
         this.store = useService("mail.store");
         this.dialog = useService("dialog");
+        this.ui = useService("ui");
     }
 
     setMute(minutes) {

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -16,7 +16,7 @@
                     </button>
                 </t>
                 <div t-else="" class="d-flex">
-                    <Dropdown position="'right-start'" menuClass="'o-mail-NotificationSettings-submenu d-flex flex-column py-0 my-0'">
+                    <Dropdown position="ui.isSmall ? 'bottom-end' : 'right-start'" menuClass="'o-mail-NotificationSettings-submenu d-flex flex-column py-0 my-0'">
                         <button class="btn w-100 d-flex p-1 opacity-75">
                             <div class="d-flex flex-grow-1 align-items-center px-2 py-1 w-100 rounded">
                                 <span class="text-wrap text-start text-break">Mute Conversation</span>


### PR DESCRIPTION
Purpose of this Commit:
This commit resolves the issue of the action menu popover and the notification settings popover overflowing off the screen. Previously, before this PR, the popovers could flip to all four directions, but now they are restricted to only two directions. However, in some cases, the correct position is not among these two directions. This commit addresses and fixes this behavior.

task-4454161
