### PR TITLE
[FIX] l10n_ar_pos,l10n_es_pos,l10n_pe_pos: Fix limited partner override

### DIFF
--- a/addons/l10n_ar_pos/models/pos_config.py
+++ b/addons/l10n_ar_pos/models/pos_config.py
@@ -4,8 +4,8 @@ from odoo import models
 class PosConfig(models.Model):
     _inherit = 'pos.config'
 
-    def get_limited_partners_loading(self):
-        partner_ids = super().get_limited_partners_loading()
+    def get_limited_partners_loading(self, offset=0):
+        partner_ids = super().get_limited_partners_loading(offset)
         if (self.env.ref('l10n_ar.par_cfa').id,) not in partner_ids:
             partner_ids.append((self.env.ref('l10n_ar.par_cfa').id,))
         return partner_ids

--- a/addons/l10n_es_pos/models/pos_config.py
+++ b/addons/l10n_es_pos/models/pos_config.py
@@ -25,10 +25,10 @@ class PosConfig(models.Model):
         for config in self:
             config.simplified_partner_id = self.env.ref("l10n_es.partner_simplified").id
 
-    def get_limited_partners_loading(self):
+    def get_limited_partners_loading(self, offset=0):
         # this function normally returns 100 partners, but we have to make sure that
         # the simplified partner is also loaded
-        res = super().get_limited_partners_loading()
+        res = super().get_limited_partners_loading(offset)
         if (self.simplified_partner_id.id,) not in res:
             res.append((self.simplified_partner_id.id,))
         return res

--- a/addons/l10n_pe_pos/models/pos_config.py
+++ b/addons/l10n_pe_pos/models/pos_config.py
@@ -4,8 +4,8 @@ from odoo import models
 class PosConfig(models.Model):
     _inherit = 'pos.config'
 
-    def get_limited_partners_loading(self):
-        partner_ids = super().get_limited_partners_loading()
+    def get_limited_partners_loading(self, offset=0):
+        partner_ids = super().get_limited_partners_loading(offset)
         if (self.env.ref('l10n_pe_pos.partner_pe_cf').id,) not in partner_ids:
             partner_ids.append((self.env.ref('l10n_pe_pos.partner_pe_cf').id,))
         return partner_ids


### PR DESCRIPTION
Adapt the `get_limited_partners_loading` method to the new API.
