### PR TITLE
[FIX] account: prevent value error when company is archived

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -388,7 +388,9 @@ class ResCompany(models.Model):
     @api.depends('hard_lock_date')
     def _compute_user_hard_lock_date(self):
         for company in self:
-            company.user_hard_lock_date = max(c.hard_lock_date or date.min for c in company.sudo().parent_ids)
+            company.user_hard_lock_date = max(
+                c.hard_lock_date or date.min for c in company.sudo().with_context(active_test=False).parent_ids
+                )
 
     def _initiate_account_onboardings(self):
         account_onboarding_routes = [


### PR DESCRIPTION
Currently below error occurs when user archive the company
and run the cron job, 'Account:Post draft entries with auto_post
enabled and accounting date up to today'.

Error: `ValueError('max() iterable argument is empty')
 while evaluating 'model._autopost_draft_entries()'`

### Steps to reproduce the error:-
- Install 'Accounting' App.
- Create a new company, add its address and switch to that company.
- Now create an invoice, add a product, change 'Auto-post' to 'At Date', fill the previous dates and hit 'Save'.
- Archive the company that user created and run the cron job, Account:Post draft entries with auto_post enabled and accounting date up to today
- The error appears in the log.

This commit solves the above issue by  adding `.with_context(active_test=False)` to consider the archived company.
sentry-6187450960