### PR TITLE
[FIX] crm: expected revenues not properly displayed in mobile view

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -50,7 +50,7 @@
                         <widget name="web_ribbon" title="Won" attrs="{'invisible': [('probability', '&lt;', 100)]}" />
                         <div class="oe_title">
                             <h1><field class="text-break" name="name" placeholder="e.g. Product Pricing"/></h1>
-                            <h2 class="d-flex gap-2 g-0 align-items-end pb-3">
+                            <h2 class="d-flex flex-wrap gap-2 g-0 align-items-end pb-3">
                                 <div attrs="{'invisible': [('type', '=', 'lead')]}">
                                     <label for="expected_revenue" class="oe_edit_only pb-1" />
                                     <div class="d-flex align-items-end">
@@ -60,21 +60,21 @@
                                         <span class="oe_grey p-2" groups="!crm.group_use_recurring_revenues"> at </span>
                                     </div>
                                 </div>
-                                <div attrs="{'invisible': [('type', '=', 'lead')]}" groups="crm.group_use_recurring_revenues">
+                                <div class="mx-auto mx-sm-0" attrs="{'invisible': [('type', '=', 'lead')]}" groups="crm.group_use_recurring_revenues">
                                     <field name="recurring_revenue" class="oe_inline o_input_10ch" widget="monetary" options="{'currency_field': 'company_currency'}"/>
                                 </div>
                                 <div attrs="{'invisible': [('type', '=', 'lead')]}" groups="crm.group_use_recurring_revenues">
                                     <div class="d-flex align-items-end ps-2">
                                         <field name="recurring_plan" class="oe_inline o_input_12ch" placeholder="E.g. Monthly"
                                                attrs="{'required': [('recurring_revenue', '!=', 0)]}" options="{'no_create': True, 'no_open': True}"/>
-                                        <span class="oe_grey p-2"> at </span>
+                                        <span class="oe_grey p-2 d-none d-sm-block"> at </span>
                                     </div>
                                 </div>
                                 <div>
-                                    <div class="oe_edit_only d-md-flex align-items-center">
+                                    <div class="oe_edit_only d-flex pb-1">
                                         <label for="probability"/>
                                         <div class="d-flex align-items-center">
-                                            <button class="ps-0 ps-md-2 btn btn-link" name="action_set_automated_probability" type="object"
+                                            <button class="px-2 py-0 btn btn-link" name="action_set_automated_probability" type="object"
                                                     attrs="{'invisible': [('is_automated_probability', '=', True)]}">
                                                 <i class="fa fa-gear" role="img" title="Switch to automatic probability" aria-label="Switch to automatic probability"></i>
                                             </button>


### PR DESCRIPTION
**Steps to reproduce**:
- Activate recurring revenues and open the form in mobile
- The expected revenue, duration and probability is not properly displayed, it's gets out of the container.

**After this PR:**
- they will displayed currently, plus we'll not show `at` in mobile view.

Task-4438997
