### PR TITLE
[FIX] im_livechat: livechat button loader template

### DIFF
--- a/addons/im_livechat/views/im_livechat_channel_templates.xml
+++ b/addons/im_livechat/views/im_livechat_channel_templates.xml
@@ -95,8 +95,10 @@
                 if (!window.odoo) {
                     window.odoo = {};
                 }
-                odoo.__session_info__ = Object.assign(odoo.__session_info__ || {}, {
-                    websocket_worker_version: <t t-out="json.dumps(info.get('websocket_worker_version', ''))"/>,
+                odoo.__session_info__ = odoo.__session_info__ || {
+                    websocket_worker_version: <t t-out="json.dumps(info.get('websocket_worker_version', ''))"/>
+                }
+                odoo.__session_info__ = Object.assign(odoo.__session_info__, {
                     livechatData: {
                         isAvailable: <t t-out="'true' if info['available'] else 'false'"/>,
                         serverUrl: "<t t-out="info['server_url']"/>",


### PR DESCRIPTION
The livechat button loader template adds `websocket_worker_version` to the Odoo session. However, when the loader is called through `chatbot_test_script_page`, it does not receive the `websocket_worker_version`. In the standard Odoo environment, this value is already available in the session

This fix ensures the `websocket_worker_version` is properly handled in scenarios involving `chatbot_test_script_page`.

Task-4462067

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
