### PR TITLE
[FIX] project_todo: avoid clicking in step of project_task_activities_split tour

### DIFF
--- a/addons/project_todo/static/tests/tours/project_task_activities_split.js
+++ b/addons/project_todo/static/tests/tours/project_task_activities_split.js
@@ -16,7 +16,6 @@ registry.category("web_tour.tours").add('project_task_activities_split', {
         }, {
             content: 'Task "New Task!" is listed in the activity view',
             trigger: '.o_activity_record .d-block:contains("New Task!")',
-            run: "click",
         }, {
             content: 'Task "New Sub-Task!" is listed in the activity view',
             trigger: '.o_activity_record .d-block:contains("New Sub-Task!")',


### PR DESCRIPTION
Before this commit, the test running the `project_task_activities_split` tour could failed because a step clicks on a task displayed in the activity view instead of just checking if the task expected is present on the view.

This commit removes the click event on that step to just check if we found the node with the trigger defined in that step to be sure the task is on the activity view. By doing that, the next step checking if another task is also there in the activity.

Closes #192995
