### PR TITLE
[IMP] mail: show call participants after stopping screen share

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -651,6 +651,13 @@ export class Rtc extends Record {
                     if (!session) {
                         return;
                     }
+                    if (
+                        this.state.channel.activeRtcSession === session &&
+                        session.is_screen_sharing_on &&
+                        !info.isScreenSharingOn
+                    ) {
+                        this.state.channel.activeRtcSession = undefined;
+                    }
                     // `isRaisingHand` is turned into the Date `raisingHand`
                     this.setRemoteRaiseHand(session, info.isRaisingHand);
                     delete info.isRaisingHand;
@@ -1338,6 +1345,9 @@ export class Rtc extends Record {
                 closeStream(session.videoStreams.get(type));
             }
             session.videoStreams.delete(type);
+            if (this.state.channel.activeRtcSession === this.selfSession) {
+                this.state.channel.activeRtcSession = undefined;
+            }
         } else {
             if (cleanup) {
                 for (const stream of session.videoStreams.values()) {

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -583,3 +583,34 @@ test("Use saved volume settings", async () => {
     expect(rangeInput.value).toBe(expectedVolume.toString());
     await click(".o-discuss-CallActionList button[aria-label='Disconnect']");
 });
+
+test("show call participants after stopping screen share", async () => {
+    mockGetMedia();
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Start a Call']");
+    await click("[title='Share Screen']");
+    await contains("video");
+    await triggerEvents(".o-discuss-Call-mainCards", ["mousemove"]); // show overlay
+    await click("[title='Stop Sharing Screen']");
+    await contains("video", { count: 0 });
+    // when all participant cards are shown they are minimized
+    await contains(".o-discuss-Call-mainCards .o-discuss-CallParticipantCard .o-minimized");
+});
+
+test("show call participants after stopping camera share", async () => {
+    mockGetMedia();
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Start a Call']");
+    await click("[title='Turn camera on']");
+    await contains("video");
+    await click("[title='Stop camera']");
+    await contains("video", { count: 0 });
+    // when all participant cards are shown they are minimized
+    await contains(".o-discuss-Call-mainCards .o-discuss-CallParticipantCard .o-minimized");
+});


### PR DESCRIPTION
With this commit after stopping screen share the focus will not be on the card of the user that was precedently sharing the screen.

task-4448823