### PR TITLE
[FIX] repair,sale_stock,stock_account: repair with auto FIFO component

### DIFF
--- a/addons/repair/models/account_move.py
+++ b/addons/repair/models/account_move.py
@@ -20,3 +20,12 @@ class AccountMoveLine(models.Model):
 
     repair_line_ids = fields.One2many('repair.line', 'invoice_line_id', readonly=True, copy=False)
     repair_fee_ids = fields.One2many('repair.fee', 'invoice_line_id', readonly=True, copy=False)
+
+    def _stock_account_get_anglo_saxon_price_unit(self):
+        price_unit = super()._stock_account_get_anglo_saxon_price_unit()
+        ro_line = self.sudo().repair_line_ids
+        if ro_line:
+            am = ro_line.invoice_line_id.move_id.sudo(False)
+            sm = ro_line.move_id.sudo(False)
+            price_unit = self._deduce_anglo_saxon_unit_price(am, sm)
+        return price_unit

--- a/addons/repair/tests/__init__.py
+++ b/addons/repair/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_anglo_saxon_valuation
 from . import test_repair

--- a/addons/repair/tests/test_anglo_saxon_valuation.py
+++ b/addons/repair/tests/test_anglo_saxon_valuation.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import Form, tagged
+from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
+from odoo.exceptions import UserError
+
+
+@tagged('post_install', '-at_install')
+class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.env.user.company_id.anglo_saxon_accounting = True
+
+        cls.fifo_product = cls.env['product.product'].create({
+            'name': 'product',
+            'type': 'product',
+            'categ_id': cls.stock_account_product_categ.id,
+        })
+
+        cls.basic_accountman = cls.env['res.users'].create({
+            'name': 'Basic Accountman',
+            'login': 'basic_accountman',
+            'password': 'basic_accountman',
+            'groups_id': [(6, 0, cls.env.ref('account.group_account_invoice').ids)],
+        })
+
+    def _make_in_move(self, product, quantity=1, unit_cost=None):
+        unit_cost = unit_cost or product.standard_price
+        move = self.env['stock.move'].create({
+            'name': product.name,
+            'product_id': product.id,
+            'location_id': self.env.ref('stock.stock_location_suppliers').id,
+            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
+            'product_uom': product.uom_id.id,
+            'product_uom_qty': quantity,
+            'price_unit': unit_cost,
+        })
+        move._action_confirm()
+        move.quantity_done = quantity
+        move._action_done()
+        return move
+
+    def test_inv_ro_with_auto_fifo_part(self):
+        self.fifo_product.standard_price = 100
+
+        self._make_in_move(self.fifo_product, unit_cost=10)
+        self._make_in_move(self.fifo_product, unit_cost=25)
+
+        ro = self.env['repair.order'].create({
+            'product_id': self.product_a.id,
+            'partner_id': self.partner_a.id,
+            'invoice_method': 'after_repair',
+            'operations': [(0, 0, {
+                'name': self.fifo_product.name,
+                'type': 'add',
+                'product_id': self.fifo_product.id,
+                'price_unit': 1,
+            })],
+        })
+        ro.action_repair_confirm()
+        ro.action_repair_start()
+        ro.action_repair_end()
+
+        wizard_ctx = {
+            "active_model": 'repair_order',
+            "active_ids": [ro.id],
+            "active_id": ro.id
+        }
+        self.env['repair.order.make_invoice'].with_context(wizard_ctx).create({}).make_invoices()
+        invoice = ro.invoice_id
+
+        self.env.invalidate_all()
+        invoice.with_user(self.basic_accountman).action_post()
+
+        self.assertRecordValues(invoice.line_ids, [
+            {'debit': 0, 'credit': 1, 'account_id': self.company_data['default_account_revenue'].id},
+            {'debit': 1, 'credit': 0, 'account_id': self.company_data['default_account_receivable'].id},
+            {'debit': 0, 'credit': 10, 'account_id': self.company_data['default_account_stock_out'].id},
+            {'debit': 10, 'credit': 0, 'account_id': self.company_data['default_account_expense'].id},
+        ])

--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -132,49 +132,7 @@ class AccountMoveLine(models.Model):
         price_unit = super(AccountMoveLine, self)._stock_account_get_anglo_saxon_price_unit()
 
         so_line = self.sale_line_ids and self.sale_line_ids[-1] or False
-        move_is_downpayment = self.env.context.get("move_is_downpayment")
-        if move_is_downpayment is None:
-            move_is_downpayment = self.move_id.invoice_line_ids.filtered(
-            lambda line: any(line.sale_line_ids.mapped("is_downpayment"))
-        )
         if so_line:
-            is_line_reversing = False
-            if self.move_id.move_type == 'out_refund' and not move_is_downpayment:
-                is_line_reversing = True
-            qty_to_invoice = self.product_uom_id._compute_quantity(self.quantity, self.product_id.uom_id)
-            if self.move_id.move_type == 'out_refund' and move_is_downpayment:
-                qty_to_invoice = -qty_to_invoice
-            account_moves = so_line.invoice_lines.move_id.filtered(lambda m: m.state == 'posted' and bool(m.reversed_entry_id) == is_line_reversing)
+            price_unit = self._deduce_anglo_saxon_unit_price(so_line.invoice_lines.move_id, so_line.move_ids)
 
-            posted_cogs = self.env['account.move.line'].search([
-                ('move_id', 'in', account_moves.ids),
-                ('display_type', '=', 'cogs'),
-                ('product_id', '=', self.product_id.id),
-                ('balance', '>', 0),
-            ])
-            qty_invoiced = 0
-            product_uom = self.product_id.uom_id
-            for line in posted_cogs:
-                if float_compare(line.quantity, 0, precision_rounding=product_uom.rounding) and line.move_id.move_type == 'out_refund' and any(line.move_id.invoice_line_ids.sale_line_ids.mapped('is_downpayment')):
-                    qty_invoiced += line.product_uom_id._compute_quantity(abs(line.quantity), line.product_id.uom_id)
-                else:
-                    qty_invoiced += line.product_uom_id._compute_quantity(line.quantity, line.product_id.uom_id)
-            value_invoiced = sum(posted_cogs.mapped('balance'))
-            reversal_moves = self.env['account.move']._search([('reversed_entry_id', 'in', posted_cogs.move_id.ids)])
-            reversal_cogs = self.env['account.move.line'].search([
-                ('move_id', 'in', reversal_moves),
-                ('display_type', '=', 'cogs'),
-                ('product_id', '=', self.product_id.id),
-                ('balance', '>', 0)
-            ])
-            for line in reversal_cogs:
-                if float_compare(line.quantity, 0, precision_rounding=product_uom.rounding) and line.move_id.move_type == 'out_refund' and any(line.move_id.invoice_line_ids.sale_line_ids.mapped('is_downpayment')):
-                    qty_invoiced -= line.product_uom_id._compute_quantity(abs(line.quantity), line.product_id.uom_id)
-                else:
-                    qty_invoiced -= line.product_uom_id._compute_quantity(line.quantity, line.product_id.uom_id)
-            value_invoiced -= sum(reversal_cogs.mapped('balance'))
-
-            product = self.product_id.with_company(self.company_id).with_context(value_invoiced=value_invoiced)
-            average_price_unit = product._compute_average_price(qty_invoiced, qty_to_invoice, so_line.move_ids, is_returned=is_line_reversing)
-            price_unit = self.product_id.uom_id.with_company(self.company_id)._compute_price(average_price_unit, self.product_uom_id)
         return price_unit


### PR DESCRIPTION
When using an auto fifo product as part of the repair, the COGS
won't be based on the used product

To reproduce the issue:
1. Setup auto fifo product
2. Receive 1@10 and 1@20
3. Process a RO:
   - Invoice method: After repair
   - Parts:
     - Add 1 x fifo product
4. Create and post the invoice
5. Open its journal items

Error: Cogs are $20 instead of $10

When posting the invoice, we generate the COGS:
https://github.com/odoo/odoo/blob/4df156164cf1d2764ba23682beee588777457fd6/addons/stock_account/models/account_move.py#L47-L48
We therefore compute the "anglo saxon unit price":
https://github.com/odoo/odoo/blob/4df156164cf1d2764ba23682beee588777457fd6/addons/stock_account/models/account_move.py#L133
However, there isn't any override to handle the RO case, so it leads
to the default mechanism, i.e. the standard price of the product:
https://github.com/odoo/odoo/blob/4df156164cf1d2764ba23682beee588777457fd6/addons/stock_account/models/account_move.py#L294-L295
https://github.com/odoo/odoo/blob/4df156164cf1d2764ba23682beee588777457fd6/addons/stock_account/models/account_move.py#L294-L295
https://github.com/odoo/odoo/blob/7cd7563f6708331bb6baf0e06d07a9f9ee329e38/addons/stock_account/models/product.py#L753-L757

And, since the first product is out, its standard price is now based
on the next candidate: $20

About the `sudo`: an accountman has not any access to `repair`, so
posting such an invoice would raise an error. Since this diff is
specific to Odoo 16, the idea is not to impact any security rules
and rather minimize the changes.

Note: Indeed, `repair` does not depend on `stock_account`, so this
commit could lead to a traceback if the bridge is removed. I delegate
this issue to the error of dependencies. Anyway, removing the bridge
would lead to other bugs. Hopefully, this has been fixed on master [1].

[1] https://github.com/odoo/odoo/commit/f7dbdec11b74f8c7d969763d8c5cf09542a47f86

OPW-4166570