### PR TITLE
[IMP] hw_drivers: add devtools to disable features

### DIFF
--- a/addons/hw_drivers/driver.py
+++ b/addons/hw_drivers/driver.py
@@ -4,6 +4,8 @@
 from threading import Thread, Event
 
 from odoo.addons.hw_drivers.main import drivers, iot_devices
+from odoo.addons.hw_drivers.tools.helpers import toggleable
+
 from odoo.tools.lru import LRU
 
 
@@ -47,11 +49,11 @@ class Driver(Thread, metaclass=DriverMetaClass):
         """
         return False
 
+    @toggleable
     def action(self, data):
         """Helper function that calls a specific action method on the device.
 
-        :param data: the `_actions` key mapped to the action method we want to call
-        :type data: string
+        :param dict data: the `_actions` key mapped to the action method we want to call
         """
         self._actions[data.get('action', '')](data)
 

--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -54,6 +54,7 @@ odoo_help() {
   echo 'odoo_stop           Stops Odoo service'
   echo 'odoo_restart        Restarts Odoo service'
   echo 'odoo_dev <branch>   Resets Odoo on the specified branch from odoo-dev repository'
+  echo 'devtools            Enables/Disables specific functions for development (more help with devtools help)'
   echo ''
   echo 'Odoo IoT online help: <https://www.odoo.com/documentation/master/applications/general/iot.html>'
 }
@@ -83,6 +84,45 @@ pip() {
     additional_arg=\"--user\"
   fi
   pip3 \"\$1\" \"\$2\" --break-system-package \"\$additional_arg\"
+}
+
+devtools() {
+  help_message() {
+    echo 'Usage: devtools <enable/disable> <general/actions> [action name]'
+    echo ''
+    echo 'Only provide an action name if you want to enable/disable a specific device action.'
+    echo 'If no action name is provided, all actions will be enabled/disabled.'
+    echo 'To enable/disable multiple actions, enclose them in quotes separated by commas.'
+  }
+  case \"\$1\" in
+    enable|disable)
+      case \"\$2\" in
+        general|actions)
+          write_mode
+          if ! grep -q '^\[devtools\]' /home/pi/odoo.conf; then
+            sudo -u odoo bash -c \"printf '\n[devtools]\n' >> /home/pi/odoo.conf\"
+          fi
+          if [ \"\$1\" == \"disable\" ]; then
+            value=\"\${3:-*}\" # Default to '*' if no action name is provided
+            devtools enable \"\$2\" # Remove action/general from conf to avoid duplicate keys
+            write_mode
+            sudo -u odoo sed -i \"/^\[devtools\]/a\\\\\$2 = \$value\" /home/pi/odoo.conf
+          elif [ \"\$1\" == \"enable\" ]; then
+            sudo -u odoo sed -i \"/\[devtools\]/,/\[/{/\$2 =/d}\" /home/pi/odoo.conf
+          fi
+          read_mode
+          ;;
+        *)
+          help_message
+          return 1
+          ;;
+      esac
+      ;;
+    *)
+      help_message
+      return 1
+      ;;
+  esac
 }
 " | tee -a ~/.bashrc /home/pi/.bashrc
 


### PR DESCRIPTION
While developing, we often disable features like the db checkout and the IoT handlers download to save some time.

Now, instead of going in the code and comment the lines we want to remove, we can just type:

- `devtools disable general`: to disable general features (checkout, handlers download),
- `devtools disable actions <optional action name>`: to disable a device action (printing for example).

**Note:** by default, if you don't specify `<action name>`, it will disable all actions.

Task: 4291487
