### PR TITLE
[FIX] google_address_autocomplete: field should become dirty when typ…

### DIFF
--- a/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.js
+++ b/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.js
@@ -3,10 +3,22 @@ import { _t } from "@web/core/l10n/translation";
 import { CharField, charField } from "@web/views/fields/char/char_field";
 import { AutoComplete } from "@web/core/autocomplete/autocomplete";
 import { googlePlacesSession } from "../google_places_session";
+import { useChildRef } from "@web/core/utils/hooks";
+import { useInputField } from "@web/views/fields/input_field_hook";
 
 export class AddressAutoComplete extends CharField {
     static template = "google_address_autocomplete.AddressAutoCompleteTemplate";
     static components = { AutoComplete, ...CharField.components };
+
+    setup() {
+        super.setup();
+        this.input = useChildRef();
+        useInputField({
+            ref: this.input,
+            getValue: () => this.props.record.data[this.props.name] || "",
+            parse: (v) => this.parse(v),
+        });
+    }
 
     get sources() {
         return [

--- a/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.xml
+++ b/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.xml
@@ -9,6 +9,7 @@
             placeholder="props.placeholder"
             searchOnInputClick="false"
             inputDebounceDelay="350"
+            input="input"
          />
     </t>
     <t t-name="google_address_autocomplete.CharFieldDropdownOption">

--- a/addons/google_address_autocomplete/static/tests/google_address_autocomplete.test.js
+++ b/addons/google_address_autocomplete/static/tests/google_address_autocomplete.test.js
@@ -80,7 +80,9 @@ test("correctly fill all standard fields", async () => {
             city: "Ramillies",
             country_id: 13,
             state_id: 2,
-            street: "rue des Bourlottes 9",
+            // this was input by the user
+            // save as is
+            street: "odoo farm 3",
             street2: "Ferme 2",
             zip: "1367",
         });
@@ -163,4 +165,22 @@ test("fills current field with values of unknown ones", async () => {
     for (const [field, value] of Object.entries(expectedFields)) {
         expect(`.o_field_widget[name='${field}'] input`).toHaveValue(value);
     }
+});
+
+test("typing in input should make form dirty", async () => {
+    onRpc("web_save", ({ args }) => {
+        expect.step(args[1])
+    });
+    await mountView({
+        type: "form",
+        resModel: "res.partner",
+        arch: `<form>
+            <field name="street" widget="google_address_autocomplete"/>
+        </form>`,
+        resId: 1,
+    });
+    expect(".o_form_button_save:visible").toHaveCount(0);
+    await contains(".o_field_widget[name='street'] input").edit("odoo farm 3", { confirm: false });
+    await contains(".o_form_button_save:visible").click();
+    expect.verifySteps([{street: 'odoo farm 3'}]);
 });


### PR DESCRIPTION
…ing in it

Before this commit, when typing in the field, the change did not make the record dirty.

After this commit it does.

opw-4464355

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
