### PR TITLE
[FIX] core: inconsistent pypdf metadata in 5.1

### DIFF
--- a/odoo/tools/pdf/_pypdf.py
+++ b/odoo/tools/pdf/_pypdf.py
@@ -1,3 +1,5 @@
+from typing import Dict, Any
+
 import pypdf
 from pypdf import errors, filters, generic, PdfReader as _Reader, PdfWriter as _Writer
 from pypdf.generic import create_string_object
@@ -42,6 +44,11 @@ class PdfReader(_Reader):
 
 
 class PdfWriter(_Writer):
+    def add_metadata(self, infos: Dict[str, Any]) -> None:
+        if hasattr(self, '_info') and self._info is None:
+            self._info = generic.DictionaryObject()
+        super().add_metadata(infos)
+
     def getPage(self, pageNumber):
         return self.pages[pageNumber]
 


### PR DESCRIPTION
Even if 5.1 is not technically supported, debuntu might switch to it any moment and we don't know if / when upstream will fix it, so it's not worth the time bomb.

While technically it was always typed such, since py-pdf/pypdf#2820 it looks like `_info` is a lot more likely to be `None` as e.g. `clone_reader_document_root` now starts with unsetting `_info_obj` and never re-sets it.

Except `add_metadata` was not updated to handle this case, likely because mypy interprets `assert isinstance(self._info, DictionaryObject)` as a type narrowing and trusts the developer, thus does not report the type mismatch... and the assertion ends up blowing in the user's face at runtime with a simple

    >>> r = pypdf.PdfReader(some_pdf_document)
    >>> w = pypdf.PdfWriter()
    >>> w.clone_reader_document_root(r)
    >>> w.add_metadata({"/foo": "bar"})
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "lib/python3.12/site-packages/pypdf/_writer.py", line 1622, in add_metadata
        assert isinstance(self._info, DictionaryObject)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    AssertionError

This is rather inconsiderate, so monkeypatch `add_metadata` to handle the case where `_info` exists and is `None`.

Most of the credit goes to juwu for uncovering the issue.

opw-4372052
opw-4426881
Fixes #185673

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
