### PR TITLE
[FIX] l10n_be_pos_restaurant: fix install restaurant scenario

### DIFF
--- a/addons/l10n_be_pos_restaurant/models/pos_config.py
+++ b/addons/l10n_be_pos_restaurant/models/pos_config.py
@@ -23,7 +23,9 @@ class PosConfig(models.Model):
                 'tax_dest_id': tax_6.id,
                 'position_id': fp.id
             })
-            config.write({'takeaway': True, 'takeaway_fp_id': fp.id})
+            takeaway_preset = self.env.ref('pos_restaurant.pos_takeout_preset', raise_if_not_found=False)
+            if takeaway_preset:
+                takeaway_preset.write({'fiscal_position_id': fp.id})
 
     @api.model
     def load_onboarding_bar_scenario(self):


### PR DESCRIPTION
Fix issue when trying to install "Restaurant" scenario in a belgian company. Now we put the dedicated belgian takeaway fiscal position inside take away presets (instead of old fields `takeaway` and `takeaway_fp_id`).

task-id: 4463785

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
