### PR TITLE
[FIX] account: fix account opening from CoA with archived branches

### DIFF
--- a/addons/account/models/account_code_mapping.py
+++ b/addons/account/models/account_code_mapping.py
@@ -50,7 +50,7 @@ class AccountCodeMapping(models.Model):
                 return self.browse([
                     account_id * COMPANY_OFFSET + company.id
                     for account_id in account_ids
-                    for company in self.env.user.company_ids.sorted(lambda c: (c.sequence, c.name))
+                    for company in self.env.user.with_context(active_test=True).company_ids.sorted(lambda c: (c.sequence, c.name))
                 ]).filtered_domain(remaining_domain)._as_query()
         raise NotImplementedError
 


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Create a branch
- Archive the branch
- Go to "Accounting / Configuration / Accounting / Chart of Accounts"
- Click on the "View" button of any account

**Issue:**
An AccessError is raised:
"Access to unauthorized or invalid companies."

**Cause:**
The "account.code.mapping" records are fetched for all the companies of the current user, even the archived ones.
{'active_test': False} is added in the context in the read method of the One2many class in fields.py

opw-4450588




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
