### PR TITLE
[FIX] point_of_sale: correctly sort products alphabetically

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2242,7 +2242,7 @@ export class PosStore extends WithLazyGetterTrap {
                   if (b.is_favorite !== a.is_favorite) {
                       return b.is_favorite - a.is_favorite;
                   }
-                  return a.display_name.localeCompare(b.display_name);
+                  return a.name.localeCompare(b.name);
               });
     }
 


### PR DESCRIPTION
Before this commit, products were sorted based on display_name, which included the internal reference, resulting in products being sorted by their internal references. This fix ensures that products are sorted alphabetically by their names.

opw-4456699

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
