### PR TITLE
[FIX] stock_picking_batch: forbid picking free sml wave transfer

### DIFF
--- a/addons/stock_picking_batch/views/stock_picking_wave_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_wave_views.xml
@@ -6,7 +6,7 @@
         <field name="view_mode">list</field>
         <field name="view_id" ref="view_move_line_tree_detailed_wave"/>
         <field name="target">new</field>
-        <field name="domain">[('state', '!=', 'done'), ('picking_type_id', '=', active_id)]</field>
+        <field name="domain">[('state', '!=', 'done'), ('picking_type_id', '=', active_id), ('picking_id', '!=', False)]</field>
         <field name="context">{'active_wave_id': False, 'search_default_by_location': True}</field>
     </record>
     <record id="action_prepare_wave" model="ir.actions.act_window">
@@ -15,7 +15,7 @@
         <field name="view_mode">list</field>
         <field name="view_id" ref="view_move_line_tree_detailed_wave"/>
         <field name="target">new</field>
-        <field name="domain">[('state', '!=', 'done')]</field>
+        <field name="domain">[('state', '!=', 'done'), ('picking_id', '!=', False)]</field>
         <field name="context">{'active_wave_id': False, 'search_default_by_location': True}</field>
     </record>
     <record id="stock_picking_wave_tree" model="ir.ui.view">


### PR DESCRIPTION
### Steps to reproduce:
- In the settings enable: 1) Multi-Steps Routes 2) "Batch, Wave and cluster Transfers"
- Inventory > Operations > Jobs > Wave transfer
- Click on "Prepare Wave".
> A read group of the stock.move.line model is performed for you to compose your wave transfer.

### Issue:

Move lines without picking are also displayed. Hence if selected raise a traceback during the `_add_to_wave` call.

### Note:

The `action_prepare_wave` and `action_prepare_wave_for_picking_type` actions performing the read groups were added to the 18.0 versions by commit 71eeeae5c7212a709c0b18181d195975b5ca6a99 so that there is no issue prior to that version.

opw-4464695
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
