### PR TITLE
[16.0][FIX] hr_holidays: Auto-confirm allocation if allowed to be created by employees

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -583,7 +583,7 @@ class HolidaysAllocation(models.Model):
             holiday.message_subscribe(partner_ids=tuple(partners_to_subscribe))
             if not self._context.get('import_file'):
                 holiday.activity_update()
-            if holiday.validation_type == 'no' and holiday.state == 'draft':
+            if (holiday.validation_type == 'no' or holiday.holiday_status_id.employee_requests == 'yes') and holiday.state == 'draft':
                 holiday.action_confirm()
         return holidays
 

--- a/addons/hr_holidays/tests/test_allocation_access_rights.py
+++ b/addons/hr_holidays/tests/test_allocation_access_rights.py
@@ -85,8 +85,6 @@ class TestAccessRightsSimpleUser(TestAllocationRights):
             'holiday_status_id': self.lt_validation_manager.id,
         }
         allocation = self.request_allocation(self.user_employee.id, values)
-        self.assertEqual(allocation.state, 'draft')
-        allocation.action_confirm()
         self.assertEqual(allocation.state, 'confirm', "It should be confirmed")
         allocation.action_draft()
         self.assertEqual(allocation.state, 'draft', "It should have been reset to draft")
@@ -118,7 +116,6 @@ class TestAccessRightsEmployeeManager(TestAllocationRights):
             'holiday_status_id': self.lt_validation_manager.id,
         }
         allocation = self.request_allocation(self.user_employee.id, values)
-        allocation.action_confirm()
         allocation.action_validate()
         self.assertEqual(allocation.state, 'validate', "The allocation should be validated")
 
@@ -129,7 +126,6 @@ class TestAccessRightsEmployeeManager(TestAllocationRights):
             'holiday_status_id': self.lt_validation_manager.id,
         }
         allocation = self.request_allocation(self.user_employee.id, values)
-        allocation.action_confirm()
         allocation.action_refuse()
         self.assertEqual(allocation.state, 'refuse', "The allocation should be validated")
 
@@ -162,7 +158,6 @@ class TestAccessRightsHolidayUser(TestAllocationRights):
             'holiday_status_id': self.lt_validation_manager.id,
         }
         allocation = self.request_allocation(self.user_hruser.id, values)
-        allocation.action_confirm()
         allocation.action_validate()
         self.assertEqual(allocation.state, 'validate', "It should have been validated")
 
@@ -183,7 +178,6 @@ class TestAccessRightsHolidayUser(TestAllocationRights):
             'holiday_status_id': self.lt_validation_manager.id,
         }
         allocation = self.request_allocation(self.user_hruser.id, values)
-        allocation.action_confirm()
         with self.assertRaises(UserError):
             allocation.action_validate()
 
@@ -197,7 +191,6 @@ class TestAccessRightsHolidayManager(TestAllocationRights):
             'holiday_status_id': self.lt_validation_manager.id,
         }
         allocation = self.request_allocation(self.user_hrmanager.id, values)
-        allocation.action_confirm()
         allocation.action_validate()
         self.assertEqual(allocation.state, 'validate', "It should have been validated")
 
@@ -208,7 +201,6 @@ class TestAccessRightsHolidayManager(TestAllocationRights):
             'holiday_status_id': self.lt_validation_manager.id,
         }
         allocation = self.request_allocation(self.user_hrmanager.id, values)
-        allocation.action_confirm()
         allocation.action_validate()
         self.assertEqual(allocation.state, 'validate', "It should have been validated")
         allocation.action_refuse()


### PR DESCRIPTION
Auto-confirm allocation if allowed to be created by employees

Example use case:
- Create a Time Off Type with the option Employee Requests: Extra Days Requests Allowed + Approval: Approved by Time Off Officer.
- Go to the Time off dashboard.
- Click on the Allocation request button.
- Create an allocation linked to the previously created Time Off Type.

Expected behavior: The allocation must be auto-confirmed.

If the allocation is created by an employee with “basic” permissions, wait for the allocation to auto-confirm, otherwise the employee will have to go to the allocation list to confirm it, generating confusion (the employee will think that the allocation created from the modal does not need anything else).

Related to https://github.com/odoo/odoo/pull/106306

@Tecnativa TT52597

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
