### PR TITLE
[imp] account: unambiguous cross-report aggregations

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -5104,6 +5104,13 @@ msgid "Credit limit specific to this partner."
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_report.py:0
+msgid ""
+"Cross report expressions must follow this format: cross_report(xml_id|id)"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_line__cumulated_balance
 msgid "Cumulated Balance"
 msgstr ""

--- a/addons/l10n_es/data/mod390/mod390_section1.xml
+++ b/addons/l10n_es/data/mod390/mod390_section1.xml
@@ -31,7 +31,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_150.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -54,7 +54,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_165.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -66,7 +66,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_167.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -78,7 +78,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_01.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -90,7 +90,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_03.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -102,7 +102,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_153.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -114,7 +114,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_155.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -148,7 +148,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_04.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -160,7 +160,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_06.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -172,7 +172,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_07.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -184,7 +184,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_09.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -1074,7 +1074,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_12.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -1086,7 +1086,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_13.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -1104,7 +1104,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_14.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -1116,7 +1116,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_15.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -1242,7 +1242,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_16.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -1254,7 +1254,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_18.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -1266,7 +1266,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_19.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -1278,7 +1278,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_21.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -1290,7 +1290,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_22.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -1302,7 +1302,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_24.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -1344,7 +1344,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_25.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>
@@ -1356,7 +1356,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">aggregation</field>
                                     <field name="formula">aeat_mod_303_26.balance</field>
-                                    <field name="subformula">cross_report</field>
+                                    <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                 </record>
                             </field>
                         </record>

--- a/addons/l10n_es/data/mod390/mod390_section2.xml
+++ b/addons/l10n_es/data/mod390/mod390_section2.xml
@@ -1589,7 +1589,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">aeat_mod_303_40.balance</field>
-                                        <field name="subformula">cross_report</field>
+                                        <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                     </record>
                                 </field>
                             </record>
@@ -1601,7 +1601,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">aeat_mod_303_41.balance</field>
-                                        <field name="subformula">cross_report</field>
+                                        <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                     </record>
                                 </field>
                             </record>
@@ -1645,7 +1645,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">aeat_mod_303_43.balance</field>
-                                <field name="subformula">cross_report</field>
+                                <field name="subformula">cross_report(l10n_es.mod_303)</field>
                             </record>
                         </field>
                     </record>
@@ -1657,7 +1657,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">aeat_mod_303_44.balance</field>
-                                <field name="subformula">cross_report</field>
+                                <field name="subformula">cross_report(l10n_es.mod_303)</field>
                             </record>
                         </field>
                     </record>
@@ -1681,8 +1681,13 @@
                             <record id="mod_390_casilla_65_balance" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">aeat_mod_390_47.balance - aeat_mod_390_64.balance</field>
-                                <field name="subformula">cross_report</field>
+                                <field name="formula">aeat_mod_390_65.result_cross_aeat_mod_390_47 - aeat_mod_390_64.balance</field>
+                            </record>
+                            <record id="mod_390_casilla_65_result_cross_aeat_mod_390_47" model="account.report.expression">
+                                <field name="label">result_cross_aeat_mod_390_47</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">aeat_mod_390_47.balance</field>
+                                <field name="subformula">cross_report(l10n_es.mod_390_section_1)</field>
                             </record>
                         </field>
                     </record>

--- a/addons/l10n_es/data/mod390/mod390_section3.xml
+++ b/addons/l10n_es/data/mod390/mod390_section3.xml
@@ -38,8 +38,13 @@
                             <record id="mod_390_casilla_84_balance" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">aeat_mod_390_65.balance + aeat_mod_390_658.balance</field>
-                                <field name="subformula">cross_report</field>
+                                <field name="formula">aeat_mod_390_84.result_cross_aeat_mod_390_65 + aeat_mod_390_658.balance</field>
+                            </record>
+                            <record id="mod_390_casilla_84_result_cross_aeat_mod_390_65" model="account.report.expression">
+                                <field name="label">result_cross_aeat_mod_390_65</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">aeat_mod_390_65.balance</field>
+                                <field name="subformula">cross_report(l10n_es.mod_390_section_2)</field>
                             </record>
                         </field>
                     </record>
@@ -51,7 +56,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">aeat_mod_303_77.balance</field>
-                                <field name="subformula">cross_report</field>
+                                <field name="subformula">cross_report(l10n_es.mod_303)</field>
                             </record>
                         </field>
                     </record>
@@ -63,7 +68,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">aeat_mod_303_67.balance</field>
-                                <field name="subformula">cross_report</field>
+                                <field name="subformula">cross_report(l10n_es.mod_303)</field>
                             </record>
                         </field>
                     </record>

--- a/addons/l10n_es/data/mod390/mod390_section4.xml
+++ b/addons/l10n_es/data/mod390/mod390_section4.xml
@@ -31,7 +31,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">aeat_mod_390_86.balance</field>
-                                         <field name="subformula">cross_report</field>
+                                         <field name="subformula">cross_report(l10n_es.mod_390_section_3)</field>
                                     </record>
                                 </field>
                             </record>

--- a/addons/l10n_es/data/mod390/mod390_section5.xml
+++ b/addons/l10n_es/data/mod390/mod390_section5.xml
@@ -102,7 +102,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">aeat_mod_303_122.balance</field>
-                                        <field name="subformula">cross_report</field>
+                                        <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                     </record>
                                 </field>
                             </record>
@@ -114,7 +114,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">aeat_mod_303_123.balance</field>
-                                        <field name="subformula">cross_report</field>
+                                        <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                     </record>
                                 </field>
                             </record>
@@ -126,7 +126,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">aeat_mod_303_124.balance</field>
-                                        <field name="subformula">cross_report</field>
+                                        <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                     </record>
                                 </field>
                             </record>

--- a/addons/l10n_es/data/mod390/mod390_section6.xml
+++ b/addons/l10n_es/data/mod390/mod390_section6.xml
@@ -123,7 +123,7 @@
                                                         <field name="label">balance</field>
                                                         <field name="engine">aggregation</field>
                                                         <field name="formula">aeat_mod_303_62.balance</field>
-                                                        <field name="subformula">cross_report</field>
+                                                        <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                                     </record>
                                                 </field>
                                             </record>
@@ -135,7 +135,7 @@
                                                         <field name="label">balance</field>
                                                         <field name="engine">aggregation</field>
                                                         <field name="formula">aeat_mod_303_63.balance</field>
-                                                        <field name="subformula">cross_report</field>
+                                                        <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                                     </record>
                                                 </field>
                                             </record>
@@ -153,7 +153,7 @@
                                                         <field name="label">balance</field>
                                                         <field name="engine">aggregation</field>
                                                         <field name="formula">aeat_mod_303_74.balance</field>
-                                                        <field name="subformula">cross_report</field>
+                                                        <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                                     </record>
                                                 </field>
                                             </record>
@@ -165,7 +165,7 @@
                                                         <field name="label">balance</field>
                                                         <field name="engine">aggregation</field>
                                                         <field name="formula">aeat_mod_303_75.balance</field>
-                                                        <field name="subformula">cross_report</field>
+                                                        <field name="subformula">cross_report(l10n_es.mod_303)</field>
                                                     </record>
                                                 </field>
                                             </record>

--- a/addons/l10n_it/data/tax_report/annual_report_sections/vl.xml
+++ b/addons/l10n_it/data/tax_report/annual_report_sections/vl.xml
@@ -27,8 +27,19 @@
                                     <record id="tax_annual_report_line_vl1_tag" model="account.report.expression">
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
-                                        <field name="formula">VE26.balance + VJ19.balance</field>
-                                        <field name="subformula">cross_report</field>
+                                        <field name="formula">VL1.cross_report_ve26 + VL1.cross_report_vj19</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_vl1_cross_report_ve26" model="account.report.expression">
+                                        <field name="label">cross_report_ve26</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE26.balance</field>
+                                        <field name="subformula">cross_report(l10n_it.tax_annual_report_vat_ve)</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_vl1_cross_report_vj19" model="account.report.expression">
+                                        <field name="label">cross_report_vj19</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VJ19.balance</field>
+                                        <field name="subformula">cross_report(l10n_it.tax_annual_report_vat_vj)</field>
                                     </record>
                                 </field>
                             </record>
@@ -40,7 +51,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">VF71.tax</field>
-                                        <field name="subformula">cross_report</field>
+                                        <field name="subformula">cross_report(l10n_it.tax_annual_report_vat_vf)</field>
                                     </record>
                                 </field>
                             </record>

--- a/addons/l10n_lu/data/tax_report/section_1.xml
+++ b/addons/l10n_lu/data/tax_report/section_1.xml
@@ -45,8 +45,7 @@
                                             <record id="account_tax_report_line_1a_other_sales_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
                                                 <field name="engine">aggregation</field>
-                                                <field name="formula">LUTAX_021.balance + LUTAX_022.balance - LUTAX_456.balance - LUTAX_455.balance - LUTAX_471.balance</field>
-                                                <field name="subformula">cross_report</field>
+                                                <field name="formula">LUTAX_021.balance + LUTAX_022.balance - LUTAX_456.balance + LUTAX_455.balance - LUTAX_471.balance</field>
                                             </record>
                                         </field>
                                     </record>
@@ -214,7 +213,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">LUTAX_037.balance</field>
-                                <field name="subformula">cross_report</field>
+                                <field name="subformula">cross_report(l10n_lu.l10n_lu_tax_report_section_2)</field>
                             </record>
                         </field>
                     </record>

--- a/addons/l10n_lu/data/tax_report/section_2.xml
+++ b/addons/l10n_lu/data/tax_report/section_2.xml
@@ -1375,7 +1375,6 @@
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">LUTAX_046.balance + LUTAX_056.balance + LUTAX_407.balance + LUTAX_410.balance + LUTAX_768.balance + LUTAX_227.balance</field>
-                                <field name="subformula">cross_report</field>
                             </record>
                         </field>
                     </record>

--- a/addons/l10n_lu/data/tax_report/sections_34.xml
+++ b/addons/l10n_lu/data/tax_report/sections_34.xml
@@ -159,7 +159,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">LUTAX_076.balance</field>
-                                <field name="subformula">cross_report</field>
+                                <field name="subformula">cross_report(l10n_lu.l10n_lu_tax_report_section_2)</field>
                             </record>
                         </field>
                     </record>

--- a/addons/l10n_sg/data/account_tax_report_data.xml
+++ b/addons/l10n_sg/data/account_tax_report_data.xml
@@ -181,7 +181,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">REV.balance</field>
-                                <field name="subformula">cross_report</field>
+                                <field name="subformula">cross_report(account_reports.profit_and_loss)</field>
                             </record>
                         </field>
                     </record>

--- a/addons/l10n_ug/data/account_tax_report_data.xml
+++ b/addons/l10n_ug/data/account_tax_report_data.xml
@@ -520,20 +520,25 @@
                             <record id="F31_normal_tax_part1" model="account.report.expression">
                                 <field name="label">normal_formula_part1</field>
                                 <field name="engine">aggregation</field>
+                                <field name="formula">UG_TAX_F31.result_cross_normal_formula_part1 - UG_TAX_F30.disallowed</field>
+                            </record>
+                            <record id="F31_normal_tax_result_cross_part1" model="account.report.expression">
+                                <field name="label">result_cross_normal_formula_part1</field>
+                                <field name="engine">aggregation</field>
                                 <field name="formula">UG_TAX_D20.tax - UG_TAX_F30.disallowed</field>
-                                <field name="subformula">cross_report</field>
+                                <field name="subformula">cross_report(l10n_ug.section_CD)</field>
                             </record>
                             <record id="F31_normal_tax_part2" model="account.report.expression">
                                 <field name="label">normal_formula_part2</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">UG_TAX_C1.base + UG_TAX_C2.base + UG_TAX_C4.base + UG_TAX_C5.base + UG_TAX_C6.base + UG_TAX_C7.base</field>
-                                <field name="subformula">cross_report</field>
+                                <field name="subformula">cross_report(l10n_ug.section_CD)</field>
                             </record>
                             <record id="F31_normal_tax_part3" model="account.report.expression">
                                 <field name="label">normal_formula_part3</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">UG_TAX_C1.base + UG_TAX_C2.base + UG_TAX_C3.base + UG_TAX_C4.base + UG_TAX_C5.base + UG_TAX_C6.base + UG_TAX_C7.base</field>
-                                <field name="subformula">cross_report</field>
+                                <field name="subformula">cross_report(l10n_ug.section_CD)</field>
                             </record>
                             <record id="F31_sam_tax" model="account.report.expression">
                                 <field name="label">hidden_computation_of_F31_using_sam_formula</field>
@@ -544,20 +549,25 @@
                             <record id="F31_sam_tax_part1" model="account.report.expression">
                                 <field name="label">sam_formula_part1</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">UG_TAX_D20.tax - UG_TAX_F29.allowed - UG_TAX_F30.disallowed</field>
-                                <field name="subformula">cross_report</field>
+                                <field name="formula">UG_TAX_F31.result_cross_sam_formula_part1 - UG_TAX_F29.allowed - UG_TAX_F30.disallowed</field>
+                            </record>
+                            <record id="F31_sam_tax_result_cross_part1" model="account.report.expression">
+                                <field name="label">result_cross_sam_formula_part1</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">UG_TAX_D20.tax</field>
+                                <field name="subformula">cross_report(l10n_ug.section_CD)</field>
                             </record>
                             <record id="F31_sam_tax_part2" model="account.report.expression">
                                 <field name="label">sam_formula_part2</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">UG_TAX_C1.base + UG_TAX_C2.base + UG_TAX_C4.base + UG_TAX_C5.base + UG_TAX_C6.base + UG_TAX_C7.base</field>
-                                <field name="subformula">cross_report</field>
+                                <field name="subformula">cross_report(l10n_ug.section_CD)</field>
                             </record>
                             <record id="F31_sam_tax_part3" model="account.report.expression">
                                 <field name="label">sam_formula_part3</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">UG_TAX_C1.base + UG_TAX_C2.base + UG_TAX_C3.base + UG_TAX_C4.base + UG_TAX_C5.base + UG_TAX_C6.base + UG_TAX_C7.base</field>
-                                <field name="subformula">cross_report</field>
+                                <field name="subformula">cross_report(l10n_ug.section_CD)</field>
                             </record>
                         </field>
                     </record>
@@ -592,12 +602,18 @@
                     </record>
                     <record id="F34" model="account.report.line">
                         <field name="name">Total Input tax credit Allowed for the period</field>
+                        <field name="code">UG_TAX_F34</field>
                         <field name="expression_ids">
                             <record id="F34_tax" model="account.report.expression">
                                 <field name="label">allowed</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">UG_TAX_F32.allowed + UG_TAX_F33_a.allowed + UG_TAX_D21_i.tax + UG_TAX_D21_iii.tax + UG_TAX_D21_iv.tax</field>
-                                <field name="subformula">cross_report</field>
+                                <field name="formula">UG_TAX_F32.allowed + UG_TAX_F33_a.allowed + UG_TAX_F34.result_cross</field>
+                            </record>
+                            <record id="F34_tax_result_cross" model="account.report.expression">
+                                <field name="label">result_cross</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">UG_TAX_D21_i.tax + UG_TAX_D21_iii.tax + UG_TAX_D21_iv.tax</field>
+                                <field name="subformula">cross_report(l10n_ug.section_CD)</field>
                             </record>
                         </field>
                     </record>


### PR DESCRIPTION
Before this commit, when using cross_report subformula it would search for a report that has an line with this code.
We had to ensure there was no duplicate codes and so it was difficult to maintain.

Now, when we use a cross_report subformula, we need to explicitly target the report from where the code is from.

task-4457667