### PR TITLE
[FIX] project_timesheet_holidays: make task field translatable

### DIFF
--- a/addons/project_timesheet_holidays/i18n/project_timesheet_holidays.pot
+++ b/addons/project_timesheet_holidays/i18n/project_timesheet_holidays.pot
@@ -96,6 +96,7 @@ msgstr ""
 
 #. module: project_timesheet_holidays
 #: model:ir.model,name:project_timesheet_holidays.model_project_task
+#: model:ir.model.fields,field_description:project_timesheet_holidays.field_account_analytic_line__task_id
 #: model:ir.model.fields,field_description:project_timesheet_holidays.field_hr_leave_type__timesheet_task_id
 #: model_terms:ir.ui.view,arch_db:project_timesheet_holidays.res_config_settings_view_form
 msgid "Task"

--- a/addons/project_timesheet_holidays/models/account_analytic.py
+++ b/addons/project_timesheet_holidays/models/account_analytic.py
@@ -11,7 +11,7 @@ class AccountAnalyticLine(models.Model):
 
     holiday_id = fields.Many2one("hr.leave", string='Time Off Request', copy=False, index='btree_not_null', export_string_translation=False)
     global_leave_id = fields.Many2one("resource.calendar.leaves", string="Global Time Off", index='btree_not_null', ondelete='cascade', export_string_translation=False)
-    task_id = fields.Many2one(domain="[('allow_timesheets', '=', True), ('project_id', '=?', project_id), ('is_timeoff_task', '=', False)]", export_string_translation=False)
+    task_id = fields.Many2one(domain="[('allow_timesheets', '=', True), ('project_id', '=?', project_id), ('is_timeoff_task', '=', False)]")
 
     def _get_redirect_action(self):
         leave_form_view_id = self.env.ref('hr_holidays.hr_leave_view_form').id


### PR DESCRIPTION
The label of the "Task" field in the wizard that opens when you "Add a line" to "My Timesheets" was not exportable for translation after [this commit] and thus never translated in the UI.

This commit fixes that.

<img width="851" alt="image" src="https://github.com/user-attachments/assets/5477ab35-7f84-402e-8d62-1dd8d8edd8ca" />

[this commit]: https://github.com/odoo/odoo/commit/e82567f9d5842bd95fe01ba3b9f54a65437e313f

[task-4421055](https://www.odoo.com/odoo/project.task/4421055)