### PR TITLE
[FIX] discuss: prevent use of outdated sfu channel

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -1425,7 +1425,7 @@ export const rtcService = {
                 if (!rtc.selfSession) {
                     return;
                 }
-                if (rtc.serverInfo?.url === serverInfo?.url) {
+                if (rtc.serverInfo?.channelUUID === serverInfo.channelUUID) {
                     // no reason to swap if the server is the same, if at some point we want to force a swap
                     // there should be an explicit flag in the event payload.
                     return;


### PR DESCRIPTION
Before this commit, if a discuss channel was provided a new sfu channel, users that were already in a call on that old sfu channel would stay there instead of moving to the new one.

This commit also adds an icon if a rtc session is missing an expected `audioStream` so that it becomes easier to notice if a partial connectivity issue arises.

