### PR TITLE
[IMP] website: allow to bypass the website domain redirection

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -3,6 +3,7 @@
 import { registry } from '@web/core/registry';
 import { useService, useBus } from '@web/core/utils/hooks';
 import core from 'web.core';
+import { session } from "@web/session";
 import { AceEditorAdapterComponent } from '../../components/ace_editor/ace_editor';
 import { WebsiteEditorComponent } from '../../components/editor/editor';
 import { WebsiteTranslator } from '../../components/translator/translator';
@@ -57,7 +58,9 @@ export class WebsitePreview extends Component {
             this.backendWebsiteId = unslugHtmlDataObject(backendWebsiteRepr).id;
 
             const encodedPath = encodeURIComponent(this.path);
-            if (this.websiteDomain && !wUtils.isHTTPSorNakedDomainRedirection(this.websiteDomain, window.location.origin)) {
+            if (!session.website_bypass_domain_redirect // Used by the Odoo support (bugs to be expected)
+                    && this.websiteDomain
+                    && !wUtils.isHTTPSorNakedDomainRedirection(this.websiteDomain, window.location.origin)) {
                 // The website domain might be the naked one while the naked one
                 // is actually redirecting to `www` (or the other way around).
                 // In such a case, we need to consider those 2 from the same

--- a/addons/website/static/src/systray_items/website_switcher.js
+++ b/addons/website/static/src/systray_items/website_switcher.js
@@ -5,6 +5,7 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { session } from "@web/session";
 import wUtils from 'website.utils';
 
 const { Component } = owl;
@@ -28,7 +29,11 @@ export class WebsiteSwitcherSystray extends Component {
                 tooltipPosition: 'left',
             }),
             callback: () => {
-                if (website.domain && !wUtils.isHTTPSorNakedDomainRedirection(website.domain, window.location.origin)) {
+                // TODO share this condition with the website_preview somehow
+                // -> we should probably show the redirection warning here too
+                if (!session.website_bypass_domain_redirect // Used by the Odoo support (bugs to be expected)
+                        && website.domain
+                        && !wUtils.isHTTPSorNakedDomainRedirection(website.domain, window.location.origin)) {
                     const { location: { pathname, search, hash } } = this.websiteService.contentWindow;
                     const path = pathname + search + hash;
                     window.location.href = `${website.domain}/web#action=website.website_preview&path=${encodeURIComponent(path)}&website_id=${encodeURIComponent(website.id)}`;


### PR DESCRIPTION
When we go to the website preview in the Odoo backend, if the current domain used (to access the backend) is not the same as the one of the previewed website, we redirect the user, and he might have to reconnect. The same is done when using the website switcher.
Note: in the first case, the user is warned. We should probably do the same for the second case (?).

This is a problem for the Odoo support team. When they connect to a customer database upon user request, the <customer_db_name>.odoo.com address is used. But as soon as they are using the website app, they are redirected to the real website domains... where they are disconnected and cannot connect themselves.
To fix this issue, we allow setting up a session info parameter to bypass those website redirections. This is not to be done by real users: this will come with bugs (for the support team). Indeed, we are normally redirecting for a reason: many flows rely on using the right domain when visiting a specific website. Depending on what users have in their page, this could also simply make the website preview iframe crash.

task-4069779
