### PR TITLE
[FIX] l10n_id_pos: tests: load only test product

### DIFF
--- a/addons/l10n_id_pos/tests/test_qris_pos.py
+++ b/addons/l10n_id_pos/tests/test_qris_pos.py
@@ -26,6 +26,9 @@ class TestPosQris(AccountTestInvoicingHttpCommon):
             'l10n_id_qris_mid': 'mid',
         })
 
+        cls.env['product.combo.item'].search([]).unlink()
+        cls.env['product.product'].search([]).write({'available_in_pos': False})
+
         cls.product_1 = cls.env['product.product'].create({
             'name': 'Test Product',
             'available_in_pos': True,


### PR DESCRIPTION
This fixes the indeterminate test failures where the Test Product isn't found in the product list.

Related: https://github.com/odoo/enterprise/pull/76517