### PR TITLE
[FIX] pos_loyalty: traceback for loyalty program used with fixed timeline

### DIFF
--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -545,15 +545,6 @@ patch(PosStore.prototype, {
             this.computeDiscountProductIdsForAllRewards.bind(this)
         );
 
-        for (const program of this.models["loyalty.program"].getAll()) {
-            if (program.date_to) {
-                program.date_to = DateTime.fromISO(program.date_to);
-            }
-            if (program.date_from) {
-                program.date_from = DateTime.fromISO(program.date_from);
-            }
-        }
-
         for (const rule of this.models["loyalty.rule"].getAll()) {
             rule.validProductIds = new Set(rule.raw.valid_product_ids);
         }


### PR DESCRIPTION
Steps:
==========
- Install pos_loyalty.
- Create a loyalty program with a start date set.
- Open the register and then try to close it.

Issue:
==========
- Showing loading screen and not able to close register.

Cause:
==========
- The start date was converted to an ISO string while being stored in indexedDB.

FIX:
=========
- Removed unnecessary code which caused the issue.

task-4441753