### PR TITLE
[FIX] point_of_sale: redesign categories shown

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/category_selector/category_selector.scss
+++ b/addons/point_of_sale/static/src/app/generic_components/category_selector/category_selector.scss
@@ -3,10 +3,12 @@
 }
 
 .category-list {
-    @include media-breakpoint-down(sm) {
-        overflow-y: auto;
-        flex-shrink: 0;
-        margin-bottom: map-get($spacers, 2);
+    overflow-y: auto;
+    flex-shrink: 0;
+    margin-bottom: map-get($spacers, 2);
+    max-height: 13.5rem;
+
+    @include media-breakpoint-down(md) {
         max-height: 9rem;
     }
 }


### PR DESCRIPTION
Currently when users have too many categories in their pos, their are not able to see the products and cannot scroll.

Steps to reproduce:
-------------------
* Add categories to the pos `> 100`
* Open pos shop
> Observation: We cannot see all categories, cannot scroll through them,
and cannot see/select products

Why the fix:
------------

This issue is the same as the one in this commit: https://github.com/odoo/odoo/commit/dd14967a037a93346123265ed489a0b4ce5f8218

But this time we expend the scope of the fix because the issue can also appear on other size screens.

The number of rows of category displayed depends of the size of the screen.

opw-4457772