### PR TITLE
[FIX] spreadsheet_account: auto-complete type of account group

### DIFF
--- a/addons/spreadsheet_account/static/src/account_group_auto_complete.js
+++ b/addons/spreadsheet_account/static/src/account_group_auto_complete.js
@@ -1,0 +1,51 @@
+import { _t } from "@web/core/l10n/translation";
+
+import { registries, tokenColors, helpers } from "@odoo/o-spreadsheet";
+
+const { insertTokenAfterLeftParenthesis } = helpers;
+
+// copy-pasted list of options from the `account_type` selection field.
+const ACCOUNT_TYPES = [
+    ["asset_receivable", _t("Receivable")],
+    ["asset_cash", _t("Bank and Cash")],
+    ["asset_current", _t("Current Assets")],
+    ["asset_non_current", _t("Non-current Assets")],
+    ["asset_prepayments", _t("Prepayments")],
+    ["asset_fixed", _t("Fixed Assets")],
+    ["liability_payable", _t("Payable")],
+    ["liability_credit_card", _t("Credit Card")],
+    ["liability_current", _t("Current Liabilities")],
+    ["liability_non_current", _t("Non-current Liabilities")],
+    ["equity", _t("Equity")],
+    ["equity_unaffected", _t("Current Year Earnings")],
+    ["income", _t("Income")],
+    ["income_other", _t("Other Income")],
+    ["expense", _t("Expenses")],
+    ["expense_depreciation", _t("Depreciation")],
+    ["expense_direct_cost", _t("Cost of Revenue")],
+    ["off_balance", _t("Off-Balance Sheet")],
+];
+
+registries.autoCompleteProviders.add("account_group_types", {
+    sequence: 50,
+    autoSelectFirstProposal: true,
+    getProposals(tokenAtCursor) {
+        const functionContext = tokenAtCursor.functionContext;
+        if (
+            functionContext?.parent.toUpperCase() === "ODOO.ACCOUNT.GROUP" &&
+            functionContext.argPosition === 0
+        ) {
+            return ACCOUNT_TYPES.map(([technicalName, displayName]) => {
+                const text = `"${technicalName}"`;
+                return {
+                    text,
+                    description: displayName,
+                    htmlContent: [{ value: text, color: tokenColors.STRING }],
+                    fuzzySearchKey: technicalName + displayName,
+                };
+            });
+        }
+        return;
+    },
+    selectProposal: insertTokenAfterLeftParenthesis,
+});

--- a/addons/spreadsheet_account/static/tests/model/account_groups_auto_complete.test.js
+++ b/addons/spreadsheet_account/static/tests/model/account_groups_auto_complete.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { stores } from "@odoo/o-spreadsheet";
+import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
+import { makeStore } from "@spreadsheet/../tests/helpers/stores";
+
+describe.current.tags("headless");
+defineSpreadsheetModels();
+
+const { CellComposerStore } = stores;
+
+test("ODOO.ACCOUNT.GROUP type", async function () {
+    const { store: composer } = await makeStore(CellComposerStore);
+
+    composer.startEdition("=ODOO.ACCOUNT.GROUP(");
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete.proposals.map((p) => p.text)).toEqual([
+        '"asset_receivable"',
+        '"asset_cash"',
+        '"asset_current"',
+        '"asset_non_current"',
+        '"asset_prepayments"',
+        '"asset_fixed"',
+        '"liability_payable"',
+        '"liability_credit_card"',
+        '"liability_current"',
+        '"liability_non_current"',
+        '"equity"',
+        '"equity_unaffected"',
+        '"income"',
+        '"income_other"',
+        '"expense"',
+        '"expense_depreciation"',
+        '"expense_direct_cost"',
+        '"off_balance"',
+    ]);
+    autoComplete.selectProposal(autoComplete.proposals[0].text);
+    expect(composer.currentContent).toBe('=ODOO.ACCOUNT.GROUP("asset_receivable"');
+    expect(composer.autocompleteProvider).toBe(undefined);
+});


### PR DESCRIPTION
Currently, there's no way to know what are the valid/expected values for the "type" argument of ODOO.ACCOUNT.GROUP.

It makes it almost impossible to use if you are not technical and you can't go and check the code.

The valid inputs are the *technical* value of the selection field `account_type`.

I had to copy-paste and hard-code the selection field option. This is clearly not ideal (not a single source of truth), but the current auto-complete system is synchronous. I can't make a server call to fetch all the options. Besides, the UX is better if the auto-complete shows up instantly rather than having to wait for a network round-trip.

Task: 4465573

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
