### PR TITLE
[FIX] portal: add modification of API keys expiration date

### DIFF
--- a/addons/portal/static/src/js/portal_security.js
+++ b/addons/portal/static/src/js/portal_security.js
@@ -32,13 +32,23 @@ publicWidget.registry.NewAPIKeyButton = publicWidget.Widget.extend({
             this.dialog
         );
 
+        const { duration } = await this.bindService("field").loadFields("res.users.apikeys.description", {
+            fieldNames: ["duration"],
+        });
+
         this.call("dialog", "add", InputConfirmationDialog, {
             title: _t("New API Key"),
-            body: renderToMarkup("portal.keydescription"),
+            body: renderToMarkup("portal.keydescription", {
+                // Remove `'Custom Date'` selection for portal user
+                duration_selection: duration.selection.filter((option) => option[0] !== "-1"),
+            }),
             confirmLabel: _t("Confirm"),
             confirm: async ({ inputEl }) => {
-                const description = inputEl.value;
-                const wizard_id = await this.orm.create("res.users.apikeys.description", [{ name: description }]);
+                const formData = Object.fromEntries(new FormData(inputEl.closest("form")));
+                const wizard_id = await this.orm.create("res.users.apikeys.description", [{
+                    name: formData['description'],
+                    duration: formData['duration']
+                }]);
                 const res = await handleCheckIdentity(
                     this.orm.call("res.users.apikeys.description", "make_key", [wizard_id]),
                     this.orm,

--- a/addons/portal/static/src/xml/portal_security.xml
+++ b/addons/portal/static/src/xml/portal_security.xml
@@ -21,6 +21,18 @@
                 and complete, <strong>it will be the only way to
                 identify the key once created</strong>.
             </p>
+            <h3 class="fw-bold">
+                Give a duration for the key's validity
+            </h3>
+            <select name="duration" class="form-control">
+                <option t-foreach="duration_selection" t-as="duration" t-key="duration[0]"
+                    t-att-id="`duration_${duration[0]}`"
+                    t-esc="duration[1]"
+                    t-att-value="duration[0]"/>
+            </select>
+            <p>
+                The key will be deleted once this period has elapsed.
+            </p>
         </form>
     </t>
     <t t-name="portal.keyshow">

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -626,6 +626,7 @@
                                 <th>Description</th>
                                 <th>Scope</th>
                                 <th>Added On</th>
+                                <th>Expiration Date</th>
                                 <th/>
                             </tr>
                         </thead>
@@ -635,6 +636,7 @@
                                     <td><span t-field="key.name"/></td>
                                     <td><span t-field="key.scope"/></td>
                                     <td><span t-field="key.create_date"/></td>
+                                    <td><span t-field="key.expiration_date"/></td>
                                     <td>
                                         <i class="fa fa-trash text-danger o_portal_remove_api_key" type="button" t-att-id="key.id"/>
                                     </td>


### PR DESCRIPTION
Before this commit, for a portal user, the creation of an API key will always be valid for one day.

This commit adds the option of selecting a period for which the API key will be valid.

The periods proposed take into account of the user's group. Consequently, in the case of a portal user, the administrator must enter a maximum number of days for the portal group
(the `api_key_duration` field in the `res.groups` model).

opw-4414586