### PR TITLE
[FIX] hr_recruitment: action_unarchive does not return recordset

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -694,10 +694,9 @@ class HrApplicant(models.Model):
         return super(HrApplicant, self.with_context(just_unarchived=True)).action_archive()
 
     def action_unarchive(self):
-        active_applicants = super(HrApplicant, self.with_context(just_unarchived=True)).action_unarchive()
-        if active_applicants:
-            active_applicants.reset_applicant()
-        return active_applicants
+        res = super(HrApplicant, self.with_context(just_unarchived=True)).action_unarchive()
+        self.reset_applicant()
+        return res
 
     def action_send_email(self):
         return {


### PR DESCRIPTION
The `action_unarchive` returns None by default. Rollback the change from odoo/odoo#183691 on this file which is incorrect.

task-4453279

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
