### PR TITLE
[FIX] account: fix activity date display

### DIFF
--- a/addons/account/static/src/components/journal_dashboard_activity/journal_dashboard_activity.xml
+++ b/addons/account/static/src/components/journal_dashboard_activity/journal_dashboard_activity.xml
@@ -13,7 +13,7 @@
                         <t t-out="activity.name"/>
                     </a>
                 </div>
-                <div class="col text-end">
+                <div class="col text-end text-nowrap">
                     <span><t t-out="activity.date"/></span>
                 </div>
             </div>


### PR DESCRIPTION
After commit odoo/odoo@6e4a036, the activity date component breaks onto a new line. This fix ensures that the activity date remains on the same line and no longer wraps.

opw-4402682

**Description of the issue/feature this PR addresses:**

- In the Accounting dashboard, when an activity is set on an account journal of type `Miscellaneous`, the `date` component of the `activity` is not aligned properly.
- The date component breaks into a new line, causing a misalignment in the display.
- This fix aims to fix the display issue by ensuring the activity date remains properly aligned on the same line as the rest of the content.
- It prevents the date component from wrapping onto the next line, thereby improving the visual consistency of the dashboard.

**Current behavior before PR:**
The `activity date` falls onto the next line.
![Acc-Dashboard-before-FIX](https://github.com/user-attachments/assets/b3282744-3b11-41e7-9e03-2bd4d2a00116)

**Desired behavior after PR is merged:**
The `activity date` stays on the same line.
![Acc-Dashboard-After-FIX](https://github.com/user-attachments/assets/a574f260-f727-435e-b5c8-65eaa3b8e0be)


**Steps to reproduce activity date display issue :**

- Install the Accounting module.
- Navigate to the Accounting dashboard.
- Create a new account journal of type `Miscellaneous`
- Set an `activity` on that journal.
- Return to the dashboard.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
