### PR TITLE
[REV] website_sale: pricelist previously removed override

### DIFF
--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -32,22 +32,6 @@ class SaleOrderLine(models.Model):
             return fields.Datetime.now()
         return super()._get_order_date()
 
-    def _get_pricelist_price_before_discount(self):
-        """On ecommerce orders, the base price must always be the sales price."""
-        self.ensure_one()
-        self.product_id.ensure_one()
-
-        if self.order_id.website_id:
-            return self.env['product.pricelist.item']._compute_price_before_discount(
-                product=self.product_id.with_context(**self._get_product_price_context()),
-                quantity=self.product_uom_qty or 1.0,
-                uom=self.product_uom,
-                date=self._get_order_date(),
-                currency=self.currency_id,
-            )
-
-        return super()._get_pricelist_price_before_discount()
-
     def _get_shop_warning(self, clear=True):
         self.ensure_one()
         warn = self.shop_warning


### PR DESCRIPTION
Partial Revert of 2f7bc1e606809b9a65d357c08fea26b364d81941 The fix applied in 17.0 when forward porting it reintroduced a function that was previously removed.

[Mentioned diff](https://github.com/odoo/odoo/commit/b25e8e2cfefcf2af9af7a7cbe04110ac35f81f3d#diff-60accb44cf04ef4bd2a178a0dfefeb9facdf3724caf4ba080ffa63d8b08c807eR35:~:text=%2B-,def%20_get_pricelist_price_before_discount(self)%3A,-36)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
