### PR TITLE
[FIX] project_todo: allow user to edit tag and users in todo on mobile

### DIFF
--- a/addons/project_todo/static/src/views/todo_form/todo_form_renderer.js
+++ b/addons/project_todo/static/src/views/todo_form/todo_form_renderer.js
@@ -1,0 +1,12 @@
+/* @odoo-module */
+
+import { FormRenderer } from "@web/views/form/form_renderer";
+
+import { TodoFormStatusBarButtons } from "./todo_form_status_bar_button";
+
+export class TodoFormRenderer extends FormRenderer {
+    static components = {
+        ...FormRenderer.components,
+        StatusBarButtons: TodoFormStatusBarButtons,
+    };
+}

--- a/addons/project_todo/static/src/views/todo_form/todo_form_status_bar_button.js
+++ b/addons/project_todo/static/src/views/todo_form/todo_form_status_bar_button.js
@@ -1,0 +1,6 @@
+/* @odoo-module */
+import { StatusBarButtons } from "@web/views/form/status_bar_buttons/status_bar_buttons";
+
+export class TodoFormStatusBarButtons extends StatusBarButtons {
+    static template = "project_todo.TodoFormStatusBarButtons";
+}

--- a/addons/project_todo/static/src/views/todo_form/todo_form_status_bar_buttons.xml
+++ b/addons/project_todo/static/src/views/todo_form/todo_form_status_bar_buttons.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="project_todo.TodoFormStatusBarButtons" t-inherit="web.StatusBarButtons">
+        <xpath expr="//DropdownItem" position="attributes">
+            <attribute name="parentClosingMode">'none'</attribute>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/project_todo/static/src/views/todo_form/todo_form_view.js
+++ b/addons/project_todo/static/src/views/todo_form/todo_form_view.js
@@ -4,11 +4,13 @@ import { registry } from "@web/core/registry";
 import { formView } from "@web/views/form/form_view";
 import { TodoFormControlPanel } from "./todo_form_control_panel";
 import { TodoFormController } from "./todo_form_controller";
+import { TodoFormRenderer } from "./todo_form_renderer";
 
 export const todoFormView = {
     ...formView,
     ControlPanel: TodoFormControlPanel,
     Controller: TodoFormController,
+    Renderer: TodoFormRenderer,
 };
 
 registry.category("views").add("todo_form", todoFormView);


### PR DESCRIPTION
Before this commit, when the user is on mobile and try to edit/create a new todo, the user cannot edit a tag or users because those fields are displayed in actions dropdown and that dropdown is closed each time the user clicks on one of those fields.

This commit prevents to close the dropdown in todo form view since that dropdown contains fields and not buttons to let the user to edit those fields.