### PR TITLE
[FIX] hr: prevent error when loading sample data

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -678,6 +678,9 @@ class HrEmployeePrivate(models.Model):
         demo_tag = self.env.ref('hr.employee_category_demo', raise_if_not_found=False)
         if demo_tag:
             return
+        dep_administration = self.env.ref('hr.dep_administration', raise_if_not_found=False)
+        if not dep_administration:
+            convert.convert_file(self.env, 'hr', 'data/hr_data.xml', None, noupdate=True, mode='init', kind='data')
         convert.convert_file(self.env, 'hr', 'data/scenarios/hr_scenario.xml', None, mode='init', kind='data')
 
     # ---------------------------------------------------------


### PR DESCRIPTION
When the ``dep_administration(Administration)`` is deleted and the user tries
to load sample data,
a traceback will appear.

Steps to reproduce the error:
- Install ``hr_attendance`` module
- Go to Employees > Departments > Delete ``Administration``
- Go to Attendances > click on ``Load sample data``

Traceback:
```
ValueError: External ID not found in the system: hr.dep_administration

ParseError: while parsing /home/odoo/src/odoo/18.0/addons/hr/data/scenarios/hr_scenario.xml: 126 somewhere inside
<record id="employee_mw" model="hr.employee" forcecreate="1">
```

https://github.com/odoo/odoo/blob/7757de56b3038710f2958c71ec9b3f1fdfbc7936/addons/hr/models/hr_employee.py#L681 When the user clicks on ``Load sample data``, ``data/scenarios/hr_scenario.xml`` file will load,
but when ``dep_administration(Administration)`` is deleted,
It will lead to the above traceback because ``dep_administration`` is used
in ``data/scenarios/hr_scenario.xml`` file.

sentry-6002819667

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
