### PR TITLE
[FIX] hr_attendance : fix `get_base_url` ref

### DIFF
--- a/addons/hr_attendance/models/res_company.py
+++ b/addons/hr_attendance/models/res_company.py
@@ -37,7 +37,7 @@ class ResCompany(models.Model):
     @api.depends("attendance_kiosk_key")
     def _compute_attendance_kiosk_url(self):
         for company in self:
-            company.attendance_kiosk_url = url_join(company.get_base_url(), '/hr_attendance/%s' % company.attendance_kiosk_key)
+            company.attendance_kiosk_url = url_join(self.env['res.company'].get_base_url(), '/hr_attendance/%s' % company.attendance_kiosk_key)
 
     # ---------------------------------------------------------
     # ORM Overrides


### PR DESCRIPTION
Issue: when the website has a domain `get_base_url` return the domain if the record calling it has a company set on it

- call the function with an empty object to get the database url instead

Task: 3903743



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
