### PR TITLE
[IMP] html_editor: table reset size of columns and rows separately

### DIFF
--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -1,3 +1,4 @@
+import { closestElement } from "@html_editor/utils/dom_traversal";
 import { Component } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
@@ -13,6 +14,8 @@ export class TableMenu extends Component {
         moveRow: Function,
         addRow: Function,
         removeRow: Function,
+        resetRowHeight: Function,
+        resetColumnWidth: Function,
         resetTableSize: Function,
         clearColumnContent: Function,
         clearRowContent: Function,
@@ -36,9 +39,24 @@ export class TableMenu extends Component {
         this.items = this.props.type === "column" ? this.colItems() : this.rowItems();
     }
 
-    get hasCustomSize() {
+    get hasCustomTableSize() {
+        const table = closestElement(this.props.target, "table");
+        if (!table) {
+            return false;
+        }
+        const rows = [...table.rows];
+        const firstRowCells = [...rows[0].cells];
+        const rowHasHeight = rows.some((row) => row.style.height);
+        const cellHasWidth = firstRowCells.some((cell) => cell.style.width);
+        return rowHasHeight || cellHasWidth;
+    }
+
+    get hasCustomRowHeight() {
+        return !!this.props.target.closest("tr").style.height;
+    }
+
+    get hasCustomColumnWidth() {
         return (
-            !!this.props.target.closest("tr").style.height ||
             !!this.props.target.closest("td")?.style?.width ||
             !!this.props.target.closest("th")?.style?.width
         );
@@ -82,10 +100,16 @@ export class TableMenu extends Component {
                 text: _t("Delete"),
                 action: this.props.removeColumn.bind(this),
             },
-            this.hasCustomSize && {
-                name: "reset_size",
+            this.hasCustomColumnWidth && {
+                name: "reset_column_size",
                 icon: "fa-table",
-                text: _t("Reset Size"),
+                text: _t("Reset column size"),
+                action: (target) => this.props.resetColumnWidth(target.closest("td, th")),
+            },
+            this.hasCustomTableSize && {
+                name: "reset_table_size",
+                icon: "fa-table",
+                text: _t("Reset table size"),
                 action: (target) => this.props.resetTableSize(target.closest("table")),
             },
             {
@@ -129,10 +153,16 @@ export class TableMenu extends Component {
                 text: _t("Delete"),
                 action: (target) => this.props.removeRow(target.parentElement),
             },
-            this.hasCustomSize && {
-                name: "reset_size",
+            this.hasCustomRowHeight && {
+                name: "reset_row_size",
                 icon: "fa-table",
-                text: _t("Reset Size"),
+                text: _t("Reset row size"),
+                action: (target) => this.props.resetRowHeight(target.closest("tr")),
+            },
+            this.hasCustomTableSize && {
+                name: "reset_table_size",
+                icon: "fa-table",
+                text: _t("Reset table size"),
                 action: (target) => this.props.resetTableSize(target.closest("table")),
             },
             {

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -1077,6 +1077,9 @@ export class TablePlugin extends Plugin {
 
     selectTableCells(selection) {
         const table = closestElement(selection.commonAncestorContainer, "table");
+        if (!table) {
+            return;
+        }
         table.classList.toggle("o_selected_table", true);
         const columns = getTableCells(table);
         const startCol =

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -1,7 +1,12 @@
 import { Plugin } from "@html_editor/plugin";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { isBlock } from "@html_editor/utils/blocks";
-import { fillShrunkPhrasingParent, removeClass, splitTextNode } from "@html_editor/utils/dom";
+import {
+    fillEmpty,
+    fillShrunkPhrasingParent,
+    removeClass,
+    splitTextNode,
+} from "@html_editor/utils/dom";
 import {
     getDeepestPosition,
     isProtected,
@@ -519,15 +524,21 @@ export class TablePlugin extends Plugin {
         const table = closestElement(cell, "table");
         const cells = [...closestElement(cell, "tr").querySelectorAll("th, td")];
         const index = cells.findIndex((td) => td === cell);
-        table
-            .querySelectorAll(`tr td:nth-of-type(${index + 1})`)
-            .forEach((td) => (td.innerHTML = "<p><br></p>"));
+        table.querySelectorAll(`tr td:nth-of-type(${index + 1})`).forEach((td) => {
+            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            fillEmpty(baseContainer);
+            td.replaceChildren(baseContainer);
+        });
     }
     /**
      * @param {HTMLTableRowElement} row
      */
     clearRowContent(row) {
-        row.querySelectorAll("td").forEach((td) => (td.innerHTML = "<p><br></p>"));
+        row.querySelectorAll("td").forEach((td) => {
+            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            fillEmpty(baseContainer);
+            td.replaceChildren(baseContainer);
+        });
     }
     deleteTable(table) {
         table =

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -154,6 +154,8 @@ export class TableUIPlugin extends Plugin {
             moveRow: withAddStep(this.dependencies.table.moveRow),
             addRow: withAddStep(this.dependencies.table.addRow),
             removeRow: withAddStep(this.dependencies.table.removeRow),
+            resetRowHeight: withAddStep(this.dependencies.table.resetRowHeight),
+            resetColumnWidth: withAddStep(this.dependencies.table.resetColumnWidth),
             resetTableSize: withAddStep(this.dependencies.table.resetTableSize),
             clearColumnContent: withAddStep(this.dependencies.table.clearColumnContent),
             clearRowContent: withAddStep(this.dependencies.table.clearRowContent),

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -1023,7 +1023,7 @@ test("reset table size to remove custom width", async () => {
 
     await click("[data-type='row'].o-we-table-menu");
     await waitFor(".dropdown-menu");
-    await click(queryOne(".dropdown-menu [name='reset_size']"));
+    await click(queryOne(".dropdown-menu [name='reset_table_size']"));
     expect(getContent(el)).toBe(
         unformat(`
         <table>
@@ -1064,7 +1064,7 @@ test("reset table size to remove custom height", async () => {
 
     await click("[data-type='row'].o-we-table-menu");
     await waitFor(".dropdown-menu");
-    await click(queryOne(".dropdown-menu [name='reset_size']"));
+    await click(queryOne(".dropdown-menu [name='reset_table_size']"));
     expect(getContent(el)).toBe(
         unformat(`
         <table>
@@ -1084,5 +1084,177 @@ test("reset table size to remove custom height", async () => {
             <tr style="height: 50px;"><td class="b">2</td></tr>
             </tbody>
         </table>`)
+    );
+});
+
+test("reset row size to remove custom height", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+        <table class="table table-bordered o_table">
+            <tbody>
+                <tr style="height: 38px;">
+                    <td class="a">1</td>
+                    <td class="b">2</td>
+                    <td class="c">3</td>
+                </tr>
+                <tr style="height: 100px;">
+                    <td class="d">4[]</td>
+                    <td class="e">5</td>
+                    <td class="f">6</td>
+                </tr>
+                <tr style="height: 38px;">
+                    <td class="g">7</td>
+                    <td class="h">8</td>
+                    <td class="i">9</td>
+                </tr>
+            </tbody>
+        </table>`)
+    );
+    expect(".o-we-table-menu").toHaveCount(0);
+
+    await hover(el.querySelector("td.d"));
+    await waitFor(".o-we-table-menu");
+    expect("[data-type='row'].o-we-table-menu").toHaveCount(1);
+
+    await click("[data-type='row'].o-we-table-menu");
+    await waitFor(".dropdown-menu");
+    await click(queryOne(".dropdown-menu [name='reset_row_size']"));
+    expect(getContent(el)).toBe(
+        unformat(`
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr style="">
+                        <td class="a">1</td>
+                        <td class="b">2</td>
+                        <td class="c">3</td>
+                    </tr>
+                    <tr style="">
+                        <td class="d">4[]</td>
+                        <td class="e">5</td>
+                        <td class="f">6</td>
+                    </tr>
+                    <tr style="">
+                        <td class="g">7</td>
+                        <td class="h">8</td>
+                        <td class="i">9</td>
+                    </tr>
+                </tbody>
+            </table>`)
+    );
+});
+
+test("should redistribute excess width from current column to smaller columns", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+            <table class="table table-bordered o_table" style="width: 500px">
+                <tbody>
+                    <tr>
+                        <td style="width: 100px;" class="a">1</td>
+                        <td style="width: 120px;" class="b">2</td>
+                        <td style="width: 60px;" class="c">3[]</td>
+                        <td style="width: 120px;" class="d">4</td>
+                        <td style="width: 100px;" class="e">5</td>
+                    </tr>
+                    <tr>
+                        <td style="width: 100px;" class="f">6</td>
+                        <td style="width: 120px;" class="g">7</td>
+                        <td style="width: 60px;" class="h">8</td>
+                        <td style="width: 120px;" class="i">9</td>
+                        <td style="width: 100px;" class="j">10</td>
+                    </tr>
+                </tbody>
+            </table>`)
+    );
+    expect(".o-we-table-menu").toHaveCount(0);
+
+    await hover(el.querySelector("td.c"));
+    await waitFor(".o-we-table-menu");
+    expect("[data-type='column'].o-we-table-menu").toHaveCount(1);
+
+    await click("[data-type='column'].o-we-table-menu");
+    await waitFor(".dropdown-menu");
+    await click(queryOne(".dropdown-menu [name='reset_column_size']"));
+    expect(getContent(el)).toBe(
+        unformat(`
+            <table class="table table-bordered o_table" style="width: 500px">
+                <tbody>
+                    <tr>
+                        <td style="" class="a">1</td>
+                        <td style="" class="b">2</td>
+                        <td style="" class="c">3[]</td>
+                        <td style="" class="d">4</td>
+                        <td style="" class="e">5</td>
+                    </tr>
+                    <tr>
+                        <td style="" class="f">6</td>
+                        <td style="" class="g">7</td>
+                        <td style="" class="h">8</td>
+                        <td style="" class="i">9</td>
+                        <td style="" class="j">10</td>
+                    </tr>
+                </tbody>
+            </table>`)
+    );
+});
+
+test("should redistribute excess width from larger columns to current column", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+            <table class="table table-bordered o_table" style="width: 700px">
+                <tbody>
+                    <tr>
+                        <td style="width: 120px;" class="a">1</td>
+                        <td style="width: 80px;" class="b">2</td>
+                        <td style="width: 60px;" class="c">3</td>
+                        <td style="width: 180px;" class="d">4[]</td>
+                        <td style="width: 60px;" class="e">5</td>
+                        <td style="width: 80px;" class="f">6</td>
+                        <td style="width: 120px;" class="g">7</td>
+                    </tr>
+                    <tr>
+                        <td style="width: 120px;" class="h">8</td>
+                        <td style="width: 80px;" class="i">9</td>
+                        <td style="width: 60px;" class="j">10</td>
+                        <td style="width: 180px;" class="k">11</td>
+                        <td style="width: 60px;" class="l">12</td>
+                        <td style="width: 80px;" class="m">13</td>
+                        <td style="width: 120px;" class="n">14</td>
+                    </tr>
+                </tbody>
+            </table>`)
+    );
+    expect(".o-we-table-menu").toHaveCount(0);
+
+    await hover(el.querySelector("td.d"));
+    await waitFor(".o-we-table-menu");
+    expect("[data-type='column'].o-we-table-menu").toHaveCount(1);
+
+    await click("[data-type='column'].o-we-table-menu");
+    await waitFor(".dropdown-menu");
+    await click(queryOne(".dropdown-menu [name='reset_column_size']"));
+    expect(getContent(el)).toBe(
+        unformat(`
+            <table class="table table-bordered o_table" style="width: 700px">
+                <tbody>
+                    <tr>
+                        <td style="width: 120px;" class="a">1</td>
+                        <td style="width: 80px;" class="b">2</td>
+                        <td style="" class="c">3</td>
+                        <td style="" class="d">4[]</td>
+                        <td style="" class="e">5</td>
+                        <td style="width: 80px;" class="f">6</td>
+                        <td style="width: 120px;" class="g">7</td>
+                    </tr>
+                    <tr>
+                        <td style="width: 120px;" class="h">8</td>
+                        <td style="width: 80px;" class="i">9</td>
+                        <td style="" class="j">10</td>
+                        <td style="" class="k">11</td>
+                        <td style="" class="l">12</td>
+                        <td style="width: 80px;" class="m">13</td>
+                        <td style="width: 120px;" class="n">14</td>
+                    </tr>
+                </tbody>
+            </table>`)
     );
 });


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- The table menu only included a "Reset Table" , which removed both `width` styles from columns and the `height` styles from rows, resetting  entire table.

### Desired behavior after PR is merged:

- Added "Reset row size" and "Reset column size" options to the table menu.
- The row/column reset option is displayed when hovering over a row/column with applicable height/width styles.
- On clicking the column reset button:
  - If the current cell width is greater than default width, distribute the excess width proportionally to cells in the same
  row with smaller widths.
  - If the current cell width is smaller than  default width, distribute width proportionally from cells with larger widths
  in same row to current cell.
- After resetting the column or row, remove the width or height styles if they are set to the default values.
- Double-clicking the border of a column or row removes the width or height styles from elements sharing the clicked border.
- On clearing content the base container is inserted as a direct child of `<td>`.

task-4240783