### PR TITLE
[FIX] l10n_in_hr_holidays: fixed duration of the sandwich leave

### DIFF
--- a/addons/l10n_in_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_in_hr_holidays/models/hr_leave.py
@@ -1,8 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import pytz
 from datetime import datetime, timedelta
 
-from odoo import models, fields
+from odoo import api, fields, models
 
 
 class HolidaysRequest(models.Model):
@@ -10,67 +11,218 @@ class HolidaysRequest(models.Model):
 
     l10n_in_contains_sandwich_leaves = fields.Boolean()
 
-    def _l10n_in_apply_sandwich_rule(self, public_holidays, employee_leaves):
-        self.ensure_one()
-        if not self.request_date_from or not self.request_date_to:
-            return
-        date_from = self.request_date_from
-        date_to = self.request_date_to
-        total_leaves = (self.request_date_to - self.request_date_from).days + (0.5 if self.request_unit_half else 1)
+    def _l10n_in_is_working(self, on_date, public_holiday_dates, resource_calendar):
+        return on_date not in public_holiday_dates and resource_calendar._works_on_date(on_date)
 
-        def is_non_working_day(calendar, date):
-            return not calendar._works_on_date(date) or any(
-                datetime.date(holiday['date_from']) <= date <= datetime.date(holiday['date_to']) for holiday in public_holidays
+    def _l10n_in_count_adjacent_non_working(self, start_date, public_holiday_dates, resource_calendar, reverse=False, include_start=False):
+        step = -1 if reverse else 1
+        current = start_date if include_start else start_date + timedelta(days=step)
+        count = 0
+        while not self._l10n_in_is_working(current, public_holiday_dates, resource_calendar) and count < 30:
+            count += 1
+            current += timedelta(days=step)
+        return count
+
+    def _l10n_in_find_linked_leave(self, start_date, public_holiday_dates, resource_calendar, leaves_by_date, reverse=False):
+        step = -1 if reverse else 1
+        current_date = start_date
+        for _ in range(30):
+            current_date += timedelta(days=step)
+            if self._l10n_in_is_working(current_date, public_holiday_dates, resource_calendar):
+                break
+        linked_leave = leaves_by_date.get(current_date, self.env["hr.leave"])
+        if linked_leave and (linked_leave.request_unit_half or linked_leave.request_unit_hours):
+            return self.env["hr.leave"]
+        return linked_leave
+
+    def _l10n_in_get_linked_leaves(self, leaves_dates_by_employee, public_holidays_date_by_company):
+        linked_before = self.env["hr.leave"]
+        linked_after = self.env["hr.leave"]
+
+        for leave in self:
+            public_holiday_dates = public_holidays_date_by_company.get(leave.company_id, {})
+            leaves_by_date = leaves_dates_by_employee.get(leave.employee_id, {})
+            linked_before |= self._l10n_in_find_linked_leave(
+                leave.request_date_from, public_holiday_dates, leave.resource_calendar_id, leaves_by_date, reverse=True
             )
+            linked_after |= self._l10n_in_find_linked_leave(
+                leave.request_date_to, public_holiday_dates, leave.resource_calendar_id, leaves_by_date, reverse=False
+            )
+        return linked_before, linked_after
 
-        def count_sandwich_days(calendar, date, direction):
-            current_date = date + timedelta(days=direction)
-            days_count = 0
-            while is_non_working_day(calendar, current_date):
-                days_count += 1
-                current_date += timedelta(days=direction)
-            for leave in employee_leaves:
-                if leave['request_date_from'] <= current_date <= leave['request_date_to']:
-                    return days_count
+    def _l10n_in_prepare_sandwich_context(self):
+        """
+            Build and return a tuple:
+                (indian_leaves, leaves_by_employee, public_holidays_by_company_id)
+            - Filters Indian, full-day, sandwich-enabled leaves.
+            - Prepares dicts for sibling employee leaves and company public holidays.
+        """
+        indian_leaves = self.filtered(
+            lambda leave: leave.company_id.country_id.code == "IN"
+            and leave.holiday_status_id.l10n_in_is_sandwich_leave
+            and not leave.request_unit_half
+            and not leave.request_unit_hours
+        )
+        if not indian_leaves:
+            return (indian_leaves, {}, {})
+
+        leaves_dates_by_employee = {
+            emp_id: {
+                (leave.request_date_from + timedelta(days=offset)): leave
+                for leave in recs
+                for offset in range((leave.request_date_to - leave.request_date_from).days + 1)
+            }
+            for emp_id, recs in self._read_group(
+                domain=[
+                    ('id', 'not in', self.ids),
+                    ('employee_id', 'in', self.employee_id.ids),
+                    ('state', 'not in', ['cancel', 'refuse']),
+                    ('request_unit_half', '=', False),
+                    ('request_unit_hours', '=', False),
+                    ('holiday_status_id.l10n_in_is_sandwich_leave', '=', True),
+                ],
+                groupby=['employee_id'],
+                aggregates=['id:recordset'],
+            )
+        }
+
+        tz = pytz.timezone(self.env.context.get("tz") or self.env.user.tz or "UTC")
+        public_holidays_dates_by_company = {
+            company_id: {
+                (datetime.date(holiday.date_from.astimezone(tz)) + timedelta(days=offset)): holiday
+                for holiday in recs
+                for offset in range((holiday.date_to.date() - holiday.date_from.date()).days + 1)
+            }
+            for company_id, recs in self.env['resource.calendar.leaves']._read_group(
+                domain=[
+                    ('resource_id', '=', False),
+                    ('company_id', 'in', indian_leaves.company_id.ids),
+                ],
+                groupby=['company_id'],
+                aggregates=['id:recordset'],
+            )
+        }
+
+        return indian_leaves, leaves_dates_by_employee, public_holidays_dates_by_company
+
+    def _l10n_in_apply_sandwich_rule(self, public_holidays_date_by_company, leaves_dates_by_employee):
+        self.ensure_one()
+        if not (self.request_date_from and self.request_date_to):
             return 0
 
-        calendar = self.resource_calendar_id
-        total_leaves += count_sandwich_days(calendar, date_from, -1) + count_sandwich_days(calendar, date_to, 1)
-        while is_non_working_day(calendar, date_from):
-            total_leaves -= 1
-            date_from += timedelta(days=1)
-        while is_non_working_day(calendar, date_to):
-            total_leaves -= 1
-            date_to -= timedelta(days=1)
+        date_from = self.request_date_from
+        date_to = self.request_date_to
+        public_holiday_dates = public_holidays_date_by_company.get(self.company_id, {})
+        is_non_working_from = not self._l10n_in_is_working(date_from, public_holiday_dates, self.resource_calendar_id)
+        is_non_working_to = not self._l10n_in_is_working(date_to, public_holiday_dates, self.resource_calendar_id)
+
+        if is_non_working_from and is_non_working_to and not any(
+            self._l10n_in_is_working(date_from + timedelta(days=x), public_holiday_dates, self.resource_calendar_id)
+            for x in range(1, (date_to - date_from).days)
+        ):
+            return 0
+
+        total_leaves = (date_to - date_from).days + 1
+        linked_before, linked_after = self._l10n_in_get_linked_leaves(leaves_dates_by_employee, public_holidays_date_by_company)
+        linked_before_leave = linked_before[:1]
+        linked_after_leave = linked_after[:1]
+        # Only expand the current leave when the linked record starts before it.
+        has_previous_link = bool(linked_before_leave and linked_before_leave.request_date_from < date_from)
+        has_next_link = bool(linked_after_leave and linked_after_leave.request_date_from > date_to)
+
+        if has_previous_link:
+            total_leaves += self._l10n_in_count_adjacent_non_working(
+                date_from, public_holiday_dates, self.resource_calendar_id, reverse=True
+            )
+        elif is_non_working_from:
+            total_leaves -= self._l10n_in_count_adjacent_non_working(
+                date_from, public_holiday_dates, self.resource_calendar_id, include_start=True,
+            )
+
+        if has_next_link:
+            total_leaves += self._l10n_in_count_adjacent_non_working(
+                date_to, public_holiday_dates, self.resource_calendar_id
+            )
+        elif is_non_working_to:
+            total_leaves = total_leaves - self._l10n_in_count_adjacent_non_working(
+                date_to, public_holiday_dates, self.resource_calendar_id, reverse=True, include_start=True,
+            )
         return total_leaves
 
     def _get_durations(self, check_leave_type=True, resource_calendar=None):
         result = super()._get_durations(check_leave_type, resource_calendar)
-        indian_leaves = self.filtered(lambda c: c.company_id.country_id.code == 'IN')
+
+        indian_leaves, leaves_dates_by_employee, public_holidays_date_by_company = self._l10n_in_prepare_sandwich_context()
         if not indian_leaves:
+            self.l10n_in_contains_sandwich_leaves = False
             return result
 
-        public_holidays = self.env['resource.calendar.leaves'].search([
-            ('resource_id', '=', False),
-            ('company_id', 'in', indian_leaves.company_id.ids),
-        ])
-        leaves_by_employee = dict(self._read_group(
-            domain=[
-                ('id', 'not in', self.ids),
-                ('employee_id', 'in', self.employee_id.ids),
-                ('state', 'not in', ['cancel', 'refuse']),
-                ('leave_type_request_unit', '=', 'day'),
-            ],
-            groupby=['employee_id'],
-            aggregates=['id:recordset'],
-        ))
         for leave in indian_leaves:
-            if leave.holiday_status_id.l10n_in_is_sandwich_leave:
-                days, hours = result[leave.id]
-                updated_days = leave._l10n_in_apply_sandwich_rule(public_holidays, leaves_by_employee.get(leave.employee_id, []))
-                result[leave.id] = (updated_days, hours)
-                if updated_days and leave.state not in ['validate', 'validate1']:
-                    leave.l10n_in_contains_sandwich_leaves = updated_days != days
-            elif leave.state not in ['validate', 'validate1']:
+            leave_days, hours = result[leave.id]
+            if not leave_days or (
+                leave.state in ["validate", "validate1"]
+                and not self.env.user.has_group("hr_holidays.group_hr_holidays_user")
+            ):
+                continue
+            updated_days = leave._l10n_in_apply_sandwich_rule(public_holidays_date_by_company, leaves_dates_by_employee)
+            if updated_days and updated_days != leave_days:
+                updated_hours = (updated_days * (hours / leave_days)) if leave_days else hours
+                result[leave.id] = (updated_days, updated_hours)
+                leave.l10n_in_contains_sandwich_leaves = True
+            else:
                 leave.l10n_in_contains_sandwich_leaves = False
         return result
+
+    def _l10n_in_update_neighbors_duration_after_change(self):
+        indian_leaves, leaves_dates_by_employee, public_holidays_dates_by_company = self._l10n_in_prepare_sandwich_context()
+        if not indian_leaves:
+            return
+        self.l10n_in_contains_sandwich_leaves = False
+
+        linked_before, linked_after = indian_leaves._l10n_in_get_linked_leaves(
+            leaves_dates_by_employee, public_holidays_dates_by_company
+        )
+        neighbors = (linked_before | linked_after) - self
+        if not neighbors:
+            return
+
+        # Recompute neighbor durations with the baseline (non-sandwich) logic.
+        base_map = super(HolidaysRequest, neighbors)._get_durations(
+            check_leave_type=True,
+            resource_calendar=None,
+        )
+
+        for neighbor in neighbors:
+            base_days, base_hours = base_map.get(neighbor.id, (neighbor.number_of_days, neighbor.number_of_hours))
+            updated_days = neighbor._l10n_in_apply_sandwich_rule(
+                public_holidays_date_by_company=public_holidays_dates_by_company,
+                leaves_dates_by_employee=leaves_dates_by_employee,
+            )
+            if updated_days and updated_days != base_days:
+                new_hours = (updated_days * (base_hours / base_days)) if base_days else base_hours
+                neighbor.write({
+                    'number_of_days': updated_days,
+                    'number_of_hours': new_hours,
+                    'l10n_in_contains_sandwich_leaves': True,
+                })
+            else:
+                neighbor.write({
+                    'number_of_days': base_days,
+                    'number_of_hours': base_hours,
+                    'l10n_in_contains_sandwich_leaves': False,
+                })
+
+    @api.ondelete(at_uninstall=False)
+    def _ondelete_refresh_neighbors(self):
+        """Pre-delete hook: update neighbors as if these records were already deleted"""
+        self._l10n_in_update_neighbors_duration_after_change()
+
+    def action_refuse(self):
+        res = super().action_refuse()
+        self._l10n_in_update_neighbors_duration_after_change()
+        return res
+
+    def _action_user_cancel(self, reason):
+        res = super()._action_user_cancel(reason)
+        self._l10n_in_update_neighbors_duration_after_change()
+        return res

--- a/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
+++ b/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
@@ -13,7 +13,7 @@ class TestSandwichLeave(TransactionCase):
             'name': 'Test Indian Company',
             'country_id': self.env.ref('base.in').id
         })
-
+        self.env = self.env(context=dict(self.env.context, allowed_company_ids=self.indian_company.ids))
         self.demo_user = self.env['res.users'].with_company(self.indian_company).create({
             'name': 'Piyush User',
             'login': 'piyush_user',
@@ -25,53 +25,42 @@ class TestSandwichLeave(TransactionCase):
             'user_id': self.demo_user.id,
         })
 
-        self.leave_type = self.env['hr.leave.type'].create({
+        self.leave_type_day, self.leave_type_half_day, self.leave_type_hours = self.env['hr.leave.type'].create([{
             'name': 'Test Leave Type',
             'request_unit': 'day',
             'requires_allocation': 'no',
             'l10n_in_is_sandwich_leave': True,
             'company_id': self.indian_company.id,
+        }, {
+            'name': 'Test Leave Type 2',
+            'request_unit': 'half_day',
+            'requires_allocation': 'no',
+            'l10n_in_is_sandwich_leave': True,
+            'company_id': self.indian_company.id,
+        }, {
+            'name': 'Test Leave Type 3',
+            'request_unit': 'hour',
+            'requires_allocation': 'no',
+            'l10n_in_is_sandwich_leave': True,
+            'company_id': self.indian_company.id,
+        }])
+        self.rahul_emp = self.env['hr.employee'].create({
+            'name': 'Rahul',
+            'country_id': self.env.ref('base.in').id,
+            'company_id': self.indian_company.id,
         })
-
-    def test_sandwich_leave(self):
-        with freeze_time('2023-08-15'):
-            public_holiday = self.env['resource.calendar.leaves'].create({
-                'name': 'Independence Day',
-                'date_from': '2023-08-15',
-                'date_to': '2023-08-15',
-                'resource_id': False,
-                'company_id': self.indian_company.id,
-            })
-            before_holiday_leave = self.env['hr.leave'].create({
-                'name': 'Test Leave',
-                'employee_id': self.demo_employee.id,
-                'holiday_status_id': self.leave_type.id,
-                'request_date_from': "2023-08-14",
-                'request_date_to': "2023-08-14",
-            })
-            employee_leaves = self.env['hr.leave'].search([
-                ('employee_id', '=', self.demo_employee.id),
-                ('state', 'not in', ['cancel', 'refuse']),
-                ('leave_type_request_unit', '=', 'day'),
-            ])
-            after_holiday_leave = self.env['hr.leave'].create({
-                'name': 'Test Leave',
-                'employee_id': self.demo_employee.id,
-                'holiday_status_id': self.leave_type.id,
-                'request_date_from': "2023-08-16",
-                'request_date_to': "2023-08-16",
-            })
-
-            leave = before_holiday_leave._l10n_in_apply_sandwich_rule(public_holiday, employee_leaves)
-            self.assertEqual(leave, 1, "The total leaves should be 1")
-            sandwiched_leave = after_holiday_leave._l10n_in_apply_sandwich_rule(public_holiday, employee_leaves)
-            self.assertEqual(sandwiched_leave, 2, "The total leaves should be 2 including sandwich leave")
+        self.wednesday_public_holiday = self.env['resource.calendar.leaves'].create({
+            'name': 'test public holiday',
+            'date_from': '2025-01-29 00:00:00',
+            'date_to': '2025-01-29 23:59:59',
+            'resource_id': False,
+        })
 
     def test_approved_leave_does_not_raise_access_error(self):
         approved_leave = self.env['hr.leave'].create({
             'name': 'Approved Sandwich Leave',
             'employee_id': self.demo_employee.id,
-            'holiday_status_id': self.leave_type.id,
+            'holiday_status_id': self.leave_type_day.id,
             'request_date_from': '2025-08-14',
             'request_date_to': '2025-08-18',
             'state': 'confirm',
@@ -80,7 +69,7 @@ class TestSandwichLeave(TransactionCase):
         self.assertIsNotNone(approved_leave.with_user(self.demo_user).leave_type_increases_duration)
 
     def test_long_sandwich_leave(self):
-        public_holiday = self.env['resource.calendar.leaves'].create({
+        self.env['resource.calendar.leaves'].create({
             'name': "Independence Day",
             'date_from': "2025-08-15",
             'date_to': "2025-08-15",
@@ -89,23 +78,410 @@ class TestSandwichLeave(TransactionCase):
         })
         holiday_leave = self.env['hr.leave'].create({
             'name': "Test Leave",
-            'employee_id': self.demo_employee.id,
-            'holiday_status_id': self.leave_type.id,
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
             'request_date_from': "2025-08-13",
             'request_date_to': "2025-08-17",
         })
-        leave = holiday_leave._l10n_in_apply_sandwich_rule(public_holiday, holiday_leave)
-        self.assertEqual(leave, 2, "The total leaves should be 2")
+        self.assertEqual(holiday_leave.number_of_days, 2, "The total leaves should be 2")
 
     def test_half_day_leave(self):
         half_leave = self.env['hr.leave'].create({
-                'name': "Half Day Leave",
-                'employee_id': self.demo_employee.id,
-                'holiday_status_id': self.leave_type.id,
-                'request_date_from': "2025-08-29",
-                'request_date_to': "2025-08-29",
-                'request_unit_half': True
-            })
+            'name': "Half Day Leave",
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_half_day.id,
+            'request_date_from': "2025-08-29",
+            'request_date_to': "2025-08-29",
+            'request_unit_half': True
+        })
 
         leave = half_leave._get_durations()
         self.assertEqual(leave[half_leave.id][0], 0.5, "The total leaves should be 0.5")
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_leave_friday_monday(self):
+        holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-17",
+            'request_date_to': "2025-01-20",
+        })
+        self.assertTrue(holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(holiday_leave.number_of_days, 4)
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_leave_saturday_monday(self):
+        holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-18",
+            'request_date_to': "2025-01-20",
+        })
+        self.assertFalse(holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(holiday_leave.number_of_days, 1)
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_leave_friday_sunday(self):
+        holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-17",
+            'request_date_to': "2025-01-19",
+        })
+        self.assertFalse(holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(holiday_leave.number_of_days, 1)
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_leave_saturday_sunday(self):
+        holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-18",
+            'request_date_to': "2025-01-19",
+        })
+        self.assertFalse(holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(holiday_leave.number_of_days, 0)
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_leave_saturday(self):
+        holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-18",
+            'request_date_to': "2025-01-18",
+        })
+        self.assertFalse(holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(holiday_leave.number_of_days, 0)
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_leave_sunday(self):
+        holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-19",
+            'request_date_to': "2025-01-19",
+        })
+        self.assertFalse(holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(holiday_leave.number_of_days, 0)
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_leave_3days_with_public_holidays(self):
+        holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-28",
+            'request_date_to': "2025-01-30",
+        })
+        self.assertTrue(holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(holiday_leave.number_of_days, 3)
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_leave_2days_stop_with_public_holidays(self):
+        holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-28",
+            'request_date_to': "2025-01-29",
+        })
+        self.assertFalse(holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(holiday_leave.number_of_days, 1)
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_leave_2days_start_with_public_holidays(self):
+        holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-29",
+            'request_date_to': "2025-01-30",
+        })
+        self.assertFalse(holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(holiday_leave.number_of_days, 1)
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_leave_public_holidays(self):
+        holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-29",
+            'request_date_to': "2025-01-29",
+        })
+        self.assertFalse(holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(holiday_leave.number_of_days, 0)
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_in_two_weeks(self):
+        holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-18",
+            'request_date_to': "2025-02-01",
+        })
+        self.assertTrue(holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(holiday_leave.number_of_days, 12)
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_in_two_part_1(self):
+        """
+            -- woking days: 28th and 30th January
+            -- non-working days: 29th January (public holiday)
+        """
+        before_holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-28",
+            'request_date_to': "2025-01-28",
+        })
+        after_holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-30",
+            'request_date_to': "2025-01-30",
+        })
+
+        self.assertFalse(before_holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(before_holiday_leave.number_of_days, 1)
+        self.assertTrue(after_holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(after_holiday_leave.number_of_days, 2)
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_in_two_part_2(self):
+        """
+            -- woking days: 28th and 30th January
+            -- non-working days: 29th January (public holiday)
+        """
+        before_holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-28",
+            'request_date_to': "2025-01-28",
+        })
+        after_holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-30",
+            'request_date_to': "2025-01-30",
+        })
+        self.assertFalse(before_holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(before_holiday_leave.number_of_days, 1)
+        self.assertTrue(after_holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(after_holiday_leave.number_of_days, 2)
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_in_two_weeks_in_two(self):
+        before_holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-18",
+            'request_date_to': "2025-01-24",
+        })
+        after_holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-27",
+            'request_date_to': "2025-02-01",
+        })
+        self.assertFalse(before_holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(before_holiday_leave.number_of_days, 5)
+        self.assertTrue(after_holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(after_holiday_leave.number_of_days, 7)
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_for_leave_type_hours(self):
+        """
+            --working days: 24th and 27th January
+            --non-working days: 25th, 26th January
+        """
+        before_holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_hours.id,
+            'request_date_from': "2025-01-24",
+            'request_date_to': "2025-01-24",
+        })
+        after_holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_hours.id,
+            'request_date_from': "2025-01-27",
+            'request_date_to': "2025-01-27",
+        })
+        self.assertFalse(before_holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(before_holiday_leave.number_of_hours, 8)
+        self.assertTrue(after_holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(after_holiday_leave.number_of_hours, 24)
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_for_two_different_leave_type(self):
+        """
+            This test ensure that if we have different leave type around the non-working days and one of them
+            doesn't enabled sandwich leave then it's not calculated as sandwich leave
+            --working days: 24th and 27th January
+            --non-working days: 25th, 26th January
+        """
+        other_leave_type = self.env['hr.leave.type'].create({
+            'name': 'Test Leave Type',
+            'request_unit': 'day',
+            'requires_allocation': 'no',
+        })
+        before_holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': other_leave_type.id,
+            'request_date_from': "2025-01-24",
+            'request_date_to': "2025-01-24",
+        })
+        after_holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-27",
+            'request_date_to': "2025-01-27",
+        })
+        self.assertFalse(before_holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(before_holiday_leave.number_of_days, 1)
+        self.assertFalse(after_holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(after_holiday_leave.number_of_days, 1)
+
+        # checking for different leave type with sandwich set as True
+        other_leave_type.l10n_in_is_sandwich_leave = True
+        leave_duration_dict = after_holiday_leave._get_durations()
+        self.assertEqual(leave_duration_dict[after_holiday_leave.id][0], 3)
+
+    @freeze_time('2025-01-15')
+    def test_sandwich_for_two_different_leave_type_with_having_sandwich_leave(self):
+        """
+            This test ensure that if we have different leave type around the non-working days and one of them
+            doesn't enabled sandwich leave then it's not calculated as sandwich leave
+            --working days: 24th and 27th January
+            --non-working days: 25th, 26th January
+        """
+        before_holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_half_day.id,
+            'request_date_from': "2025-01-24",
+            'request_date_to': "2025-01-24",
+        })
+        after_holiday_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-01-27",
+            'request_date_to': "2025-01-27",
+        })
+        self.assertFalse(before_holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(before_holiday_leave.number_of_days, 1)
+        self.assertTrue(after_holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(after_holiday_leave.number_of_days, 3)
+
+        # checking for different leave type with sandwich set as True
+        self.leave_type_half_day.l10n_in_is_sandwich_leave = True
+        leave_duration_dict = after_holiday_leave._get_durations()
+        self.assertEqual(leave_duration_dict[after_holiday_leave.id][0], 3)
+
+    @freeze_time('2025-07-15')
+    def test_bidirectional_sandwich_leave(self):
+        """
+            This test case verifies that if a sandwich leave is created with a before and after linked sandwich leave,
+            -- public holiday: 9th July(wednesday)
+            -- working days: 3th-4th(Thu-Fri) July, 7th-8th(Mon-Tue) July, 10th-11th(Thu-Fri) July
+            -- non-working days: 5th-6th(Sat-Sun) July,
+        """
+        self.env['resource.calendar.leaves'].create({
+            'name': 'Public Holiday',
+            'date_from': '2025-07-09 00:00:00',
+            'date_to': '2025-07-09 23:59:59',
+        })
+        before_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave Before',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-07-03",
+            'request_date_to': "2025-07-04",
+        })
+        self.assertEqual(before_leave.number_of_days, 2)
+
+        after_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave After',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-07-10",
+            'request_date_to': "2025-07-11",
+        })
+        self.assertEqual(after_leave.number_of_days, 2)
+
+        middle_sandwich_leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-07-07",
+            'request_date_to': "2025-07-08",
+        })
+        self.assertTrue(middle_sandwich_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(middle_sandwich_leave.number_of_days, 5)
+
+    @freeze_time('2025-07-15')
+    def test_sandwich_when_linked_leave_delete(self):
+        before_leave = self.env['hr.leave'].create({
+            'name': 'Monday Leave',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-07-11",
+            'request_date_to': "2025-07-11",
+        })
+        self.assertEqual(before_leave.number_of_days, 1)
+
+        after_leave = self.env['hr.leave'].create({
+            'name': 'Friday',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-07-14",
+            'request_date_to': "2025-07-14",
+        })
+        self.assertTrue(after_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(after_leave.number_of_days, 3)
+
+        before_leave.unlink()
+        self.assertEqual(after_leave.number_of_days, 1)
+
+    @freeze_time('2025-07-15')
+    def test_sandwich_when_linked_leave_refuse(self):
+        before_leave = self.env['hr.leave'].create({
+            'name': 'Mon',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-07-11",
+            'request_date_to': "2025-07-11",
+        })
+        self.assertEqual(before_leave.number_of_days, 1)
+
+        after_leave = self.env['hr.leave'].create({
+            'name': 'Fri',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': "2025-07-14",
+            'request_date_to': "2025-07-14",
+        })
+        self.assertTrue(after_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(after_leave.number_of_days, 3)
+
+        # Refuse the linked Monday leave -> Friday should drop back to 1 day
+        before_leave.action_refuse()
+        self.assertEqual(after_leave.number_of_days, 1)


### PR DESCRIPTION
Before this PR, if you created a leave of a type that had sandwich leave
enabled on a non-working day, it would show a negative duration.

This PR fixes some issues related to sandwich leave cases

(where Saturday and Sunday are considered non-working days):
- Friday - Monday across weekend - counted (4 days).
- Hour-based leave types: weekend bridging increases hours accordingly
- Public holiday in the middle (Tue-Thu with Wed PH) - counted (3 days).
- Stop/Start exactly on a public holiday(Tue-Wed(Public holiday), or Wed(Public holiday)-Thu) - trimmed to 1 day.
- Public holiday only - 0 days.
- Two single-day leaves around a Public holiday
  - When the second leave is created, it bridges via a public holiday (2 days),
  - The first one remains 1 day if it stands alone
- Mixed leave types:
  - If the linked leave type doesn’t have sandwich enabled, no sandwich rules.
  - If both leave enable sandwich (with different types) - sandwich rule applies
- Refusing/canceling a linked leave must immediately adjust the other side’s duration
(e.g., Monday refused - Friday drops from 3 - 1 day)

Task-4430044

Co-authored-by: @mepe-odoo 


