### PR TITLE
[IMP] point_of_sale:  manage favorite products directly from the frontend

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
@@ -29,4 +29,9 @@ export class ProductInfoPopup extends Component {
     get allowProductEdition() {
         return true; // Overrided in pos_hr
     }
+    toggleFavorite() {
+        this.pos.data.write("product.template", [this.props.productTemplate.id], {
+            is_favorite: !this.props.productTemplate.is_favorite,
+        });
+    }
 }

--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.ProductInfoPopup">
-        <Dialog title="props.productTemplate.display_name + ' | ' + env.utils.formatCurrency(props.info.productInfo.all_prices.price_with_tax)">
+        <Dialog>
+            <t t-set-slot="header">
+                <button t-on-click="toggleFavorite" class="border-0 bg-transparent mb-2" t-att-disabled="this.pos.cashier._role == 'minimal'">
+                    <i t-attf-class="fa fa-lg fa-fw  {{props.productTemplate.is_favorite ? 'fa-star' : 'fa-star-o'}}"
+                        t-att-style="props.productTemplate.is_favorite ? 'color: #f3cc00;' : ''"
+                        role="img"/>
+                </button>
+                <h3 class="section-title" t-out="props.productTemplate.display_name + ' | ' + env.utils.formatCurrency(props.info.productInfo.all_prices.price_with_tax)"/>
+                <button type="button" class="btn-close mb-2" aria-label="Close" tabindex="-1" t-on-click="props.close"/>
+            </t>
             <div class="section-public-description mt-3 mb-4 pb-4 border-bottom text-start" t-if="props.productTemplate.productDescriptionMarkup">
                 <h3 class="section-title">
                     Description

--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.scss
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.scss
@@ -69,3 +69,6 @@
 .red-tag {
     border-color: transparent #e75b5b63 transparent transparent;
 }
+.favorite-product {
+    border-color: transparent #f3cc00 transparent transparent;
+}

--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
@@ -8,7 +8,7 @@
             t-on-click="props.onClick"
             t-att-data-product-id="props.productId"
             t-attf-aria-labelledby="article_product_{{props.productId}}">
-            <div t-if="props.productInfo" class="product-information-tag position-absolute top-0 end-0 z-2 w-0 h-0 rounded-end-2 text-light text-center" t-on-click.stop="props.onProductInfoClick" t-att-class="{'red-tag' : props.showWarning}">
+            <div t-if="props.productInfo" class="product-information-tag position-absolute top-0 end-0 z-2 w-0 h-0 rounded-end-2 text-light text-center" t-on-click.stop="props.onProductInfoClick" t-att-class="{'red-tag' : props.showWarning, 'favorite-product': props.product.is_favorite}">
                 <i class="product-information-tag-logo fa fa-info" role="img" aria-label="Product Information" title="Product Information" />
             </div>
             <div t-if="props.imageUrl" class="product-img ratio ratio-4x3 rounded-top rounded-3">


### PR DESCRIPTION
In this commit:
===============
Users can now mark or unmark products as favorites directly from the POS frontend. Reduces the need for user redirection from the frontend to the backend for managing favorite products.

Task-4452738

