### PR TITLE
[FIX] account_peppol: Handle non-Peppol EDI proxy

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -23,8 +23,14 @@ class AccountEdiProxyClientUser(models.Model):
     # HELPER METHODS
     # -------------------------------------------------------------------------
 
-    @handle_demo
+
     def _make_request(self, url, params=False):
+        if self.proxy_type == 'peppol':
+            return self._make_request_peppol(url, params=params)
+        return super()._make_request(url, params=params)
+
+    @handle_demo
+    def _make_request_peppol(self, url, params=False):
         # extends account_edi_proxy_client to update peppol_proxy_state
         # of archived users
         try:

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -119,7 +119,7 @@ def _mock_migrate_participant(func, self, *args, **kwargs):
     self.account_peppol_migration_key = 'I9cz9yw*ruDM%4VSj94s'
 
 _demo_behaviour = {
-    '_make_request': _mock_make_request,
+    '_make_request_peppol': _mock_make_request,
     'button_account_peppol_check_partner_endpoint': _mock_button_verify_partner_endpoint,
     'button_create_peppol_proxy_user': _mock_user_creation,
     'button_deregister_peppol_participant': _mock_deregister_participant,


### PR DESCRIPTION
An error can occur when the EDI proxy is not Peppol, because the mocked request does not exist in the mocked dictionary.

Steps to reproduce:
- Install l10n_it_edi and account_peppol
- Set up production for Italian Electronic Invoicing
- Set up demo mode for Peppol
- Create a new invoice and click on Send & Print
- Check the "Send To Tax Agency" box

An error will occur:
```
File
"/home/odoo/src/odoo/saas-17.4/addons/account_peppol/tools/demo_utils.py",
line 74, in _mock_make_request
    return {
KeyError: 'SdiRiceviFile'
```

This error arises because the EDI proxy is not Peppol, and thus the request should not be mocked. This fix ensures that the EDI proxy is Peppol before mocking the request.

opw-4438740
