### PR TITLE
[FIX] mail, website_{sale,slides}: refine emoji reactions for comments

### DIFF
--- a/addons/mail/static/src/core/common/message_reaction_list.js
+++ b/addons/mail/static/src/core/common/message_reaction_list.js
@@ -84,6 +84,9 @@ export class MessageReactionList extends Component {
     }
 
     onClickReaction(reaction) {
+        if (!this.props.message.canAddReaction()) {
+            return;
+        }
         if (this.hasSelfReacted(reaction)) {
             reaction.remove();
         } else {

--- a/addons/mail/static/src/core/common/message_reaction_list.xml
+++ b/addons/mail/static/src/core/common/message_reaction_list.xml
@@ -15,6 +15,7 @@
             'bg-view border-secondary': !hasSelfReacted(props.reaction),
             'ms-1': env.inChatWindow and env.alignedRight,
             'me-1': !(env.inChatWindow and env.alignedRight),
+            'cursor-default': !props.message.canAddReaction(),
         }">
             <span t-esc="props.reaction.content"/>
             <span class="small" t-esc="props.reaction.count"/>

--- a/addons/mail/static/src/core/common/message_reactions.xml
+++ b/addons/mail/static/src/core/common/message_reactions.xml
@@ -10,7 +10,7 @@
         <t t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content">
             <MessageReactionList message="this.props.message" openReactionMenu="this.props.openReactionMenu" reaction="reaction"/>
         </t>
-        <button class="o-mail-MessageReactions-add btn bg-inherit d-flex px-1 py-0 border-0 rounded-0 mb-1 align-items-center fs-5 opacity-75 opacity-100-hover" title="Add Reaction" t-ref="add"><i class="oi fa-fw oi-smile-add"/></button>
+        <button t-if="props.message.canAddReaction()" class="o-mail-MessageReactions-add btn bg-inherit d-flex px-1 py-0 border-0 rounded-0 mb-1 align-items-center fs-5 opacity-75 opacity-100-hover" title="Add Reaction" t-ref="add"><i class="oi fa-fw oi-smile-add"/></button>
     </div>
 </t>
 </templates>

--- a/addons/website_sale/static/tests/tours/website_sale_product_reviews_reactions_public.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_reviews_reactions_public.js
@@ -26,5 +26,28 @@ registry
                     }
                 },
             },
+            {
+                trigger: "#chatterRoot:shadow .o-mail-Message-core",
+                run: () => {
+                    const reactionButton = document.querySelector("#chatterRoot").shadowRoot.querySelector(".o-mail-MessageReaction")
+                    reactionButton.dispatchEvent(new Event("mouseenter"));
+                },
+            },
+            {
+                trigger: "#chatterRoot:shadow .o-mail-MessageReactionList-preview",
+                run: "click",
+            },
+            {
+                trigger: "#chatterRoot:shadow .o-mail-MessageReactionMenu",
+            },
+            {
+                trigger: "#chatterRoot:shadow .o-mail-Message-core",
+                run: () => {
+                    const addReaction = document.querySelector("#chatterRoot").shadowRoot.querySelector(".o-mail-MessageReactions-add")
+                    if (addReaction) {
+                        throw new Error("Non-authenticated user should not be able to add a reaction to a message");
+                    }
+                },
+            },
         ],
    });

--- a/addons/website_sale/tests/test_website_sale_product_page.py
+++ b/addons/website_sale/tests/test_website_sale_product_page.py
@@ -31,6 +31,9 @@ class TestWebsiteSaleProductPage(HttpCase, ProductVariantsCommon, WebsiteSaleCom
 
     def test_product_reviews_reactions_public(self):
         """ Check that public users can not react to reviews """
+        password = "Pl1bhD@2!kXZ"
+        manager = self.env.ref("base.user_admin")
+        manager.write({"password": password})
 
         self.env["ir.ui.view"].with_context(active_test=False).search([
             ("key", "=", "website_sale.product_comment")
@@ -43,11 +46,23 @@ class TestWebsiteSaleProductPage(HttpCase, ProductVariantsCommon, WebsiteSaleCom
             "website_published": True,
             "invoice_policy": "delivery",
         })
-        self.product_product_7.product_tmpl_id.message_post(
+        message = self.product_product_7.product_tmpl_id.message_post(
             body="Bad box!",
             message_type="comment",
             rating_value="1",
             subtype_xmlid="mail.mt_comment"
         )
+        self.authenticate(manager.login, password)
+        self._add_reaction(message, "😊")
 
         self.start_tour("/", "website_sale_product_reviews_reactions_public", login=None)
+
+    def _add_reaction(self, message, reaction):
+        self.make_jsonrpc_request(
+            "/mail/message/reaction",
+            {
+                "action": "add",
+                "content": reaction,
+                "message_id": message.id,
+            },
+        )

--- a/addons/website_slides/static/tests/tours/slides_course_reviews.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews.js
@@ -69,6 +69,18 @@ registry.category("web_tour.tours").add("course_reviews", {
         },
         {
             trigger: "#chatterRoot:shadow .o-mail-Message [title='Add a Reaction']",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-Emoji[data-codepoints='😃']",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-MessageReactions-add:not(:visible)",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-MessageReaction",
+            run: "click",
         },
     ],
 });

--- a/addons/website_slides/static/tests/tours/slides_course_reviews_reaction_public.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews_reaction_public.js
@@ -29,5 +29,28 @@ registry.category("web_tour.tours").add("course_reviews_reaction_public", {
                 }
             },
         },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message-core",
+            run: () => {
+                const reactionButton = document.querySelector("#chatterRoot").shadowRoot.querySelector(".o-mail-MessageReaction")
+                reactionButton.dispatchEvent(new Event("mouseenter"));
+            },
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-MessageReactionList-preview",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-MessageReactionMenu",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message-core",
+            run: () => {
+                const addReaction = document.querySelector("#chatterRoot").shadowRoot.querySelector(".o-mail-MessageReactions-add")
+                if (addReaction) {
+                    throw new Error("Non-authenticated user should not be able to add a reaction to a message");
+                }
+            },
+        },
     ],
 });

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -197,14 +197,30 @@ class TestUi(TestUICommon):
         self.start_tour('/slides', 'course_reviews', login=user_demo.login)
 
     def test_course_reviews_reaction_public(self):
-        self.channel.message_post(
+        password = "Pl1bhD@2!kXZ"
+        manager = self.user_admin
+        manager.write({"password": password})
+
+        message = self.channel.message_post(
             body="Bad course!",
             message_type="comment",
             rating_value="1",
             subtype_xmlid="mail.mt_comment"
         )
+        self.authenticate(manager.login, password)
+        self._add_reaction(message, "😊")
 
         self.start_tour("/slides", "course_reviews_reaction_public", login=None)
+
+    def _add_reaction(self, message, reaction):
+        self.make_jsonrpc_request(
+            "/mail/message/reaction",
+            {
+                "action": "add",
+                "content": reaction,
+                "message_id": message.id,
+            },
+        )
 
 @tests.common.tagged('post_install', '-at_install')
 class TestUiPublisher(HttpCaseGamification):


### PR DESCRIPTION
Before this PR:
- A user with no access attempts to react with emojis on a comment, resulting in a traceback.

After this PR:
- The buttons for adding emoji reactions to comments will be hidden for that users.

Task-4452408
