### PR TITLE
[FIX] point_of_sale: fix receipt screen error

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
@@ -49,7 +49,7 @@
                                 </div>
                             </div>
                         </div>
-                        <t t-set="splittedOrder" t-value="isContinueSplitting()"/>
+                        <t t-set="splittedOrder" t-value="this.currentOrder.originalSplittedOrder and !this.currentOrder.originalSplittedOrder.finalized"/>
                         <div id="action_btn_desktop" t-if="!ui.isSmall" class="validation-buttons d-flex w-100 gap-2 p-2 sticky-bottom">
                             <button class="button next validation btn btn-primary btn-lg w-100 py-4 lh-lg" t-att-class="{ highlight: !locked }" t-if="!splittedOrder" t-on-click="orderDone" name="done">
                                 New Order


### PR DESCRIPTION
isContinueSplitting function is defined in pos_restaurant, but is being called in point_of_sale. This gives us errors when pos_restaurant is not installed.






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
