### PR TITLE
[FIX] point_of_sale: correctly apply multiple pricelist rules

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -90,26 +90,30 @@ export class ProductProduct extends Base {
     getApplicablePricelistRules(pricelistRules) {
         const applicableRules = {};
         for (const pricelistId in pricelistRules) {
-            if (pricelistRules[pricelistId].productItems[this.id]) {
-                applicableRules[pricelistId] = pricelistRules[pricelistId].productItems[this.id];
-                continue;
-            }
-            const productTmplId = this.raw.product_tmpl_id;
-            if (pricelistRules[pricelistId].productTmlpItems[productTmplId]) {
-                applicableRules[pricelistId] =
-                    pricelistRules[pricelistId].productTmlpItems[productTmplId];
-                continue;
-            }
-            for (const category of this.parentCategories) {
-                if (pricelistRules[pricelistId].categoryItems[category]) {
-                    applicableRules[pricelistId] =
-                        pricelistRules[pricelistId].categoryItems[category];
-                    break;
+            applicableRules[pricelistId] = [];
+            const rules = pricelistRules[pricelistId];
+            if (rules.productItems[this.id]) {
+                applicableRules[pricelistId].push(...rules.productItems[this.id]);
+                if (!rules.productItems[this.id][0].min_quantity) {
+                    continue;
                 }
             }
-            if (!applicableRules[pricelistId]) {
-                applicableRules[pricelistId] = pricelistRules[pricelistId].globalItems;
+            const productTmplId = this.raw.product_tmpl_id;
+            if (rules.productTmlpItems[productTmplId]) {
+                applicableRules[pricelistId].push(...rules.productTmlpItems[productTmplId]);
+                if (!rules.productTmlpItems[productTmplId][0].min_quantity) {
+                    continue;
+                }
             }
+            for (const category of this.parentCategories) {
+                if (rules.categoryItems[category]) {
+                    applicableRules[pricelistId].push(...rules.categoryItems[category]);
+                    if (!rules.categoryItems[category][0].min_quantity) {
+                        break;
+                    }
+                }
+            }
+            applicableRules[pricelistId].push(...rules.globalItems);
         }
         return applicableRules;
     }

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -240,6 +240,21 @@ registry.category("web_tour.tours").add("limitedProductPricelistLoading", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("multiPricelistRulesTour", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickDisplayedProduct("Test Product 1"),
+            ProductScreen.selectedOrderlineHas("Test Product 1", "1.0", "200.0"),
+            ProductScreen.clickDisplayedProduct("Test Product 1"),
+            ProductScreen.selectedOrderlineHas("Test Product 1", "2.0", "200.0"), // 100.0 * 2
+            ProductScreen.clickDisplayedProduct("Test Product 1"),
+            ProductScreen.selectedOrderlineHas("Test Product 1", "3.0", "150.0"), // 50.0 * 3
+            Chrome.endTour(),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("MultiProductOptionsTour", {
     test: true,
     steps: () =>

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1252,6 +1252,33 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'limitedProductPricelistLoading', login="pos_user")
 
+    def test_multi_product_pricelist_rules(self):
+        product_1 = self.env['product.product'].create({
+            'name': 'Test Product 1',
+            'list_price': 1,
+            'taxes_id': False,
+            'available_in_pos': True,
+        })
+
+        pricelist_item = self.env['product.pricelist.item'].create([{
+            'applied_on': '3_global',
+            'fixed_price': 200,
+            'min_quantity': 0,
+        }, {
+            'applied_on': '1_product',
+            'product_tmpl_id': product_1.product_tmpl_id.id,
+            'fixed_price': 100,
+             'min_quantity': 2,
+        }, {
+            'applied_on': '0_product_variant',
+            'product_id': product_1.id,
+            'fixed_price': 50,
+            'min_quantity': 3,
+        }])
+        self.main_pos_config.pricelist_id.write({'item_ids': [(6, 0, pricelist_item.ids)]})
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'multiPricelistRulesTour', login="pos_user")
+
     def test_multi_product_options(self):
         self.pos_user.write({
             'groups_id': [


### PR DESCRIPTION
Before this commit, if there were multiple pricelist rules applicable to a product but they had minimum quantity conditions, PoS did not compute the price with the correct applicable pricelist rules if the top pricelist rule's minimum quantity was not satisfied.

opw-4407515

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
