### PR TITLE
[FIX] spreadsheet_account: fix misleading function description

### DIFF
--- a/addons/spreadsheet_account/i18n/spreadsheet_account.pot
+++ b/addons/spreadsheet_account/i18n/spreadsheet_account.pot
@@ -73,7 +73,7 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/spreadsheet_account/static/src/accounting_functions.js:0
 #, python-format
-msgid "Returns the account ids of a given group."
+msgid "Returns the account codes of a given group."
 msgstr ""
 
 #. module: spreadsheet_account
@@ -104,13 +104,6 @@ msgstr ""
 #: code:addons/spreadsheet_account/static/src/accounting_functions.js:0
 #, python-format
 msgid "Set to TRUE to include unposted entries."
-msgstr ""
-
-#. module: spreadsheet_account
-#. odoo-javascript
-#: code:addons/spreadsheet_account/static/src/accounting_functions.js:0
-#, python-format
-msgid "The account type (income, expense, asset_current,...)."
 msgstr ""
 
 #. module: spreadsheet_account
@@ -163,6 +156,13 @@ msgstr ""
 #: code:addons/spreadsheet_account/static/src/accounting_functions.js:0
 #, python-format
 msgid "The prefix of the accounts."
+msgstr ""
+
+#. module: spreadsheet_account
+#. odoo-javascript
+#: code:addons/spreadsheet_account/static/src/accounting_functions.js:0
+#, python-format
+msgid "The technical account type (possible values are: %s)."
 msgstr ""
 
 #. module: spreadsheet_account

--- a/addons/spreadsheet_account/static/src/accounting_functions.js
+++ b/addons/spreadsheet_account/static/src/accounting_functions.js
@@ -294,9 +294,35 @@ functionRegistry.add("ODOO.FISCALYEAR.END", {
     },
 });
 
+const ACCOUNT_TYPES = [
+    "asset_receivable",
+    "asset_cash",
+    "asset_current",
+    "asset_non_current",
+    "asset_prepayments",
+    "asset_fixed",
+    "liability_payable",
+    "liability_credit_card",
+    "liability_current",
+    "liability_non_current",
+    "equity",
+    "equity_unaffected",
+    "income",
+    "income_other",
+    "expense",
+    "expense_depreciation",
+    "expense_direct_cost",
+    "off_balance",
+];
+
 functionRegistry.add("ODOO.ACCOUNT.GROUP", {
-    description: _t("Returns the account ids of a given group."),
-    args: [arg("type (string)", _t("The account type (income, expense, asset_current,...)."))],
+    description: _t("Returns the account codes of a given group."),
+    args: [
+        arg(
+            "type (string)",
+            _t("The technical account type (possible values are: %s).", ACCOUNT_TYPES.join(", "))
+        ),
+    ],
     category: "Odoo",
     returns: ["NUMBER"],
     compute: function (accountType) {


### PR DESCRIPTION
The example of values in the description are translated in other languages. It should not because only the technical values are accepted (which are never translated)

It's not needed to backport to 16.0 because function description were not translated at that time.

Task: 4471424

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
