### PR TITLE
[IMP] base_automation: improve computed fields

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -2,16 +2,27 @@
 
 import datetime
 import logging
+import re
 import traceback
 from collections import defaultdict
 from uuid import uuid4
-from dateutil.relativedelta import relativedelta
 
+from dateutil.relativedelta import relativedelta
 from odoo import _, api, exceptions, fields, models
-from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, safe_eval
 from odoo.http import request
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, safe_eval
 
 _logger = logging.getLogger(__name__)
+
+DOMAIN_FIELDS_RE = re.compile(r"""
+    [([]\s*                 # opening bracket with any whitespace
+    (?P<quote>['"])         # opening quote
+    (?P<field>[a-z]\w*)     # field name, should start with a letter then any [a-z0-9_]
+    (?:\.[.\w]*)?           # dot followed by dots or text in between i.e. relation traversal (optional)
+    (?P=quote)              # closing quote, matching the opening one
+    (?:[^,]*?,){2}          # anything with two commas (to ensure that we are inside a triplet)
+    [^,]*?[()[\]]           # anything except a comma followed by a closing bracket or another opening bracket
+""", re.VERBOSE)
 
 DATE_RANGE_FUNCTION = {
     'minutes': lambda interval: relativedelta(minutes=interval),
@@ -259,12 +270,12 @@ class BaseAutomation(models.Model):
             if actions_to_remove:
                 rule.action_server_ids = [(3, action.id) for action in actions_to_remove]
 
-    @api.depends('trigger', 'trigger_field_ids')
+    @api.depends('trigger')
     def _compute_trg_date_id(self):
-        to_reset = self.filtered(lambda a: a.trigger not in TIME_TRIGGERS or len(a.trigger_field_ids) != 1)
+        to_reset = self.filtered(lambda a: a.trigger not in TIME_TRIGGERS)
         to_reset.trg_date_id = False
         for record in (self - to_reset):
-            record.trg_date_id = record.trigger_field_ids
+            record.trg_date_id = record._get_trigger_specific_field()
 
     @api.depends('trigger')
     def _compute_trg_date_range_data(self):
@@ -280,15 +291,15 @@ class BaseAutomation(models.Model):
         )
         to_reset.trg_date_calendar_id = False
 
-    @api.depends('trigger', 'trigger_field_ids')
+    @api.depends('trigger')
     def _compute_trg_selection_field_id(self):
         self.trg_selection_field_id = False
 
-    @api.depends('trigger', 'trigger_field_ids')
+    @api.depends('trigger')
     def _compute_trg_field_ref(self):
         self.trg_field_ref = False
 
-    @api.depends('trg_field_ref', 'trigger_field_ids')
+    @api.depends('trigger', 'trg_field_ref')
     def _compute_trg_field_ref_model_name(self):
         to_compute = self.filtered(lambda a: a.trigger in ['on_stage_set', 'on_tag_set'] and a.trg_field_ref is not False)
         # wondering why we check based on 'is not'? Because the ref could be an empty recordset
@@ -296,90 +307,79 @@ class BaseAutomation(models.Model):
         to_reset = (self - to_compute)
         to_reset.trg_field_ref_model_name = False
         for automation in to_compute:
-            relation = automation.trigger_field_ids.relation
+            relation = automation._get_trigger_specific_field().relation
             if not relation:
                 automation.trg_field_ref_model_name = False
                 continue
             automation.trg_field_ref_model_name = relation
 
-    @api.depends('trigger', 'trigger_field_ids', 'trg_field_ref')
+    @api.depends('trigger', 'trg_field_ref')
     def _compute_filter_pre_domain(self):
-        to_reset = self.filtered(lambda a: a.trigger != 'on_tag_set' or len(a.trigger_field_ids) != 1)
+        to_reset = self.filtered(lambda a: a.trigger != 'on_tag_set')
         to_reset.filter_pre_domain = False
         for automation in (self - to_reset):
-            field = automation.trigger_field_ids.name
+            field = automation._get_trigger_specific_field().name
             value = automation.trg_field_ref
-            automation.filter_pre_domain = f"[('{field}', 'not in', [{value}])]" if value else False
+            automation.filter_pre_domain = repr([(field, 'not in', [value])]) if value else False
 
-    @api.depends('trigger', 'trigger_field_ids', 'trg_selection_field_id', 'trg_field_ref')
+    @api.depends('trigger', 'trg_selection_field_id', 'trg_field_ref')
     def _compute_filter_domain(self):
-        for record in self:
-            trigger_fields_count = len(record.trigger_field_ids)
-            if trigger_fields_count == 0:
-                record.filter_domain = False
+        for automation in self:
+            field = (
+                automation._get_trigger_specific_field()
+                if automation.trigger not in TIME_TRIGGERS
+                else False
+            )
+            if not field:
+                automation.filter_domain = False
+                continue
 
-            elif trigger_fields_count == 1:
-                field = record.trigger_field_ids.name
-                trigger = record.trigger
-                if trigger in ['on_state_set', 'on_priority_set']:
-                    value = record.trg_selection_field_id.value
-                    record.filter_domain = f"[('{field}', '=', '{value}')]" if value else False
-                elif trigger == 'on_stage_set':
-                    value = record.trg_field_ref
-                    record.filter_domain = f"[('{field}', '=', {value})]" if value else False
-                elif trigger == 'on_tag_set':
-                    value = record.trg_field_ref
-                    record.filter_domain = f"[('{field}', 'in', [{value}])]" if value else False
-                elif trigger == 'on_user_set':
-                    record.filter_domain = f"[('{field}', '!=', False)]"
-                elif trigger in ['on_archive', 'on_unarchive']:
-                    record.filter_domain = f"[('{field}', '=', {trigger == 'on_unarchive'})]"
-                else:
-                    record.filter_domain = False
+            # some triggers require a domain
+            match automation.trigger:
+                case 'on_state_set' | 'on_priority_set':
+                    value = automation.trg_selection_field_id.value
+                    automation.filter_domain = repr([(field.name, '=', value)]) if value else False
+                case 'on_stage_set':
+                    value = automation.trg_field_ref
+                    automation.filter_domain = repr([(field.name, '=', value)]) if value else False
+                case 'on_tag_set':
+                    value = automation.trg_field_ref
+                    automation.filter_domain = repr([(field.name, 'in', [value])]) if value else False
+                case 'on_user_set':
+                    automation.filter_domain = repr([(field.name, '!=', False)])
+                case 'on_archive':
+                    automation.filter_domain = repr([(field.name, '=', False)])
+                case 'on_unarchive':
+                    automation.filter_domain = repr([(field.name, '=', True)])
 
-    @api.depends('model_id', 'trigger')
+    @api.depends('model_id', 'trigger', 'filter_domain')
     def _compute_on_change_field_ids(self):
         to_reset = self.filtered(lambda a: a.trigger != 'on_change')
         to_reset.on_change_field_ids = False
-        for record in (self - to_reset).filtered('on_change_field_ids'):
-            record.on_change_field_ids = record.on_change_field_ids.filtered(lambda field: field.model_id == record.model_id)
+        for automation in (self - to_reset):
+            automation.on_change_field_ids |= automation._get_filter_domain_fields()
 
-    @api.depends('model_id', 'trigger')
+    @api.depends('model_id', 'trigger', 'filter_domain')
     def _compute_trigger_field_ids(self):
         for automation in self:
-            domain = [('model_id', '=', automation.model_id.id)]
-            if automation.trigger == 'on_stage_set':
-                domain += [('ttype', '=', 'many2one'), ('name', 'in', ['stage_id', 'x_studio_stage_id'])]
-            elif automation.trigger == 'on_tag_set':
-                domain += [('ttype', '=', 'many2many'), ('name', 'in', ['tag_ids', 'x_studio_tag_ids'])]
-            elif automation.trigger == 'on_priority_set':
-                domain += [('ttype', '=', 'selection'), ('name', 'in', ['priority', 'x_studio_priority'])]
-            elif automation.trigger == 'on_state_set':
-                domain += [('ttype', '=', 'selection'), ('name', 'in', ['state', 'x_studio_state'])]
-            elif automation.trigger == 'on_user_set':
-                domain += [
-                    ('relation', '=', 'res.users'),
-                    ('ttype', 'in', ['many2one', 'many2many']),
-                    ('name', 'in', ['user_id', 'user_ids', 'x_studio_user_id', 'x_studio_user_ids']),
-                ]
-            elif automation.trigger in ['on_archive', 'on_unarchive']:
-                domain += [('ttype', '=', 'boolean'), ('name', 'in', ['active', 'x_active'])]
-            elif automation.trigger == 'on_time_created':
-                domain += [('ttype', '=', 'datetime'), ('name', '=', 'create_date')]
-            elif automation.trigger == 'on_time_updated':
-                domain += [('ttype', '=', 'datetime'), ('name', '=', 'write_date')]
-            else:
-                automation.trigger_field_ids = False
+            if automation.trigger == "on_create_or_write":
+                automation.trigger_field_ids |= automation._get_filter_domain_fields()
                 continue
-            if automation.model_id.is_mail_thread and automation.trigger in MAIL_TRIGGERS:
-                continue
+            automation._onchange_trigger()
 
-            automation.trigger_field_ids = self.env['ir.model.fields'].search(domain, limit=1)
-
-    @api.depends('trigger_field_ids')
+    @api.depends('model_id')
     def _compute_trigger(self):
-        for automation in self:
-            automation.trigger = False if not automation.trigger_field_ids else automation.trigger
+        self.trigger = False
+
+    @api.onchange('trigger')
+    def _onchange_trigger(self):
+        field = (
+            self._get_trigger_specific_field()
+            if self.trigger not in TIME_TRIGGERS
+            else False
+        )
+        self.trigger_field_ids = field
+
 
     @api.onchange('trigger', 'action_server_ids')
     def _onchange_trigger_or_actions(self):
@@ -468,6 +468,49 @@ class BaseAutomation(models.Model):
             'view_mode': 'list,form',
             'domain': [('path', '=', "base_automation(%s)" % self.id)],
         }
+
+    def _get_filter_domain_fields(self):
+        self.ensure_one()
+        if not self.filter_domain or not self.model_id:
+            return self.env['ir.model.fields']
+        model = self.model_id.model
+        fields = self.env["ir.model.fields"]
+        # wondering why we use a regex instead of safe_eval?
+        # because this method is called on a compute method hence could be triggered
+        # from an onchange call (i.e. a manually crafted malicious one)
+        # see: https://github.com/odoo/odoo/pull/189772#issuecomment-2548804283
+        for match in DOMAIN_FIELDS_RE.finditer(self.filter_domain):
+            if field := match.groupdict().get('field'):
+                fields |= self.env["ir.model.fields"]._get(model, field)
+        return fields
+
+    def _get_trigger_specific_field(self):
+        self.ensure_one()
+        match self.trigger:
+            case 'on_stage_set':
+                domain = [('ttype', '=', 'many2one'), ('name', 'in', ['stage_id', 'x_studio_stage_id'])]
+            case 'on_tag_set':
+                domain = [('ttype', '=', 'many2many'), ('name', 'in', ['tag_ids', 'x_studio_tag_ids'])]
+            case 'on_priority_set':
+                domain = [('ttype', '=', 'selection'), ('name', 'in', ['priority', 'x_studio_priority'])]
+            case 'on_state_set':
+                domain = [('ttype', '=', 'selection'), ('name', 'in', ['state', 'x_studio_state'])]
+            case 'on_user_set':
+                domain = [
+                    ('relation', '=', 'res.users'),
+                    ('ttype', 'in', ['many2one', 'many2many']),
+                    ('name', 'in', ['user_id', 'user_ids', 'x_studio_user_id', 'x_studio_user_ids']),
+                ]
+            case 'on_archive' | 'on_unarchive':
+                domain = [('ttype', '=', 'boolean'), ('name', 'in', ['active', 'x_active'])]
+            case 'on_time_created':
+                domain = [('ttype', '=', 'datetime'), ('name', '=', 'create_date')]
+            case 'on_time_updated':
+                domain = [('ttype', '=', 'datetime'), ('name', '=', 'write_date')]
+            case _:
+                return self.env['ir.model.fields']
+        domain += [('model_id', '=', self.model_id.id)]
+        return self.env['ir.model.fields'].search(domain, limit=1)
 
     def _prepare_loggin_values(self, **values):
         self.ensure_one()

--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -85,7 +85,15 @@
                                 </div>
                                 <field name="filter_pre_domain" widget="domain" groups="base.group_no_one"
                                        options="{'model': 'model_name', 'in_dialog': True}"
-                                       invisible="trigger in ['on_webhook', 'on_time', 'on_time_created', 'on_time_updated']"
+                                       invisible="trigger in [
+                                            'on_create',
+                                            'on_unlink',
+                                            'on_change',
+                                            'on_webhook',
+                                            'on_time',
+                                            'on_time_created',
+                                            'on_time_updated'
+                                        ]"
                                 />
                                 <field name="filter_domain" widget="domain" groups="base.group_no_one"
                                     options="{'model': 'model_name', 'in_dialog': True}"

--- a/addons/test_base_automation/models/test_base_automation.py
+++ b/addons/test_base_automation/models/test_base_automation.py
@@ -15,6 +15,7 @@ class LeadTest(models.Model):
                               ('pending', 'Pending'), ('done', 'Closed')],
                              string="Status", readonly=True, default='draft')
     active = fields.Boolean(default=True)
+    tag_ids = fields.Many2many('test_base_automation.tag')
     partner_id = fields.Many2one('res.partner', string='Partner')
     date_automation_last = fields.Datetime(string='Last Automation', readonly=True)
     employee = fields.Boolean(compute='_compute_employee_deadline', store=True)

--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -1,14 +1,14 @@
 # # -*- coding: utf-8 -*-
 # # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import json
-from unittest.mock import patch
 import sys
+from unittest.mock import patch
 
-from odoo.tools import mute_logger
-from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
-from odoo.tests import common, tagged
-from odoo.exceptions import AccessError, ValidationError
 from odoo import Command
+from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
+from odoo.exceptions import AccessError, ValidationError
+from odoo.tests import Form, common, tagged
+from odoo.tools import mute_logger
 
 
 def create_automation(self, **kwargs):
@@ -929,6 +929,275 @@ if env.context.get('old_values', None):  # on write
 
 @common.tagged('post_install', '-at_install')
 class TestCompute(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.ref('base.user_admin').write({
+            'email': 'mitchell.admin@example.com',
+        })
+
+    def test_automation_form_view(self):
+        automation_form = Form(self.env['base.automation'], view='base_automation.view_base_automation_form')
+
+        # Initialize some fields
+        automation_form.name = "Test Automation"
+        automation_form.model_id = self.env.ref('test_base_automation.model_test_base_automation_project')
+        automation_form.trigger = 'on_create_or_write'
+        self.assertEqual(automation_form.trigger_field_ids.ids, [])
+        self.assertEqual(automation_form.filter_domain, False)
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+
+        # Changing the model must reset the trigger
+        automation_form.model_id = self.env.ref('test_base_automation.model_base_automation_lead_test')
+        self.assertEqual(automation_form.trigger, False)
+        self.assertEqual(automation_form.trigger_field_ids.ids, [])
+        self.assertEqual(automation_form.filter_domain, False)
+
+        # Some triggers must preset a filter_domain and trigger_field_ids
+        ## State is set to...
+        automation_form.trigger = 'on_state_set'
+        state_field_id = self.env.ref('test_base_automation.field_base_automation_lead_test__state').id
+        self.assertEqual(automation_form.trigger_field_ids.ids, [state_field_id])
+        self.assertEqual(automation_form.filter_domain, False)
+        automation_form.trg_selection_field_id = self.env['ir.model.fields.selection'].search([
+            ('field_id', '=', state_field_id),
+            ('value', '=', 'pending'),
+        ])
+        self.assertEqual(automation_form.trigger_field_ids.ids, [state_field_id])
+        self.assertEqual(automation_form.filter_domain, repr([('state', '=', 'pending')]))
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+
+        ## Priority is set to...
+        automation_form.model_id = self.env.ref('test_base_automation.model_test_base_automation_project')
+        automation_form.trigger = 'on_priority_set'
+        priority_field_id = self.env.ref('test_base_automation.field_test_base_automation_project__priority').id
+        self.assertEqual(automation_form.trigger_field_ids.ids, [priority_field_id])
+        self.assertEqual(automation_form.filter_domain, False)
+        automation_form.trg_selection_field_id = self.env['ir.model.fields.selection'].search([
+            ('field_id', '=', priority_field_id),
+            ('value', '=', '2'),
+        ])
+        self.assertEqual(automation_form.trigger_field_ids.ids, [priority_field_id])
+        self.assertEqual(automation_form.filter_domain, repr([('priority', '=', '2')]))
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+
+        ## Stage is set to...
+        automation_form.model_id = self.env.ref('test_base_automation.model_base_automation_lead_test')
+        automation_form.trigger = 'on_stage_set'
+        stage_field_id = self.env.ref('test_base_automation.field_base_automation_lead_test__stage_id').id
+        self.assertEqual(automation_form.trigger_field_ids.ids, [stage_field_id])
+        self.assertEqual(automation_form.filter_domain, False)
+        new_lead_stage = self.env['test_base_automation.stage'].create({'name': 'New'})
+        automation_form.trg_field_ref = new_lead_stage.id
+        self.assertEqual(automation_form.filter_domain, repr([('stage_id', '=', new_lead_stage.id)]))
+        self.assertEqual(automation_form.trigger_field_ids.ids, [stage_field_id])
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+
+        ## User is set
+        automation_form.trigger = 'on_user_set'
+        self.assertEqual(automation_form.trigger_field_ids.ids, [
+            self.env.ref('test_base_automation.field_base_automation_lead_test__user_id').id
+        ])
+        self.assertEqual(automation_form.filter_domain, repr([('user_id', '!=', False)]))
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+
+        ## On archive
+        automation_form.trigger = 'on_archive'
+        self.assertEqual(automation_form.trigger_field_ids.ids, [
+            self.env.ref('test_base_automation.field_base_automation_lead_test__active').id
+        ])
+        self.assertEqual(automation_form.filter_domain, repr([('active', '=', False)]))
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+
+        ## On unarchive
+        automation_form.trigger = 'on_unarchive'
+        self.assertEqual(automation_form.trigger_field_ids.ids, [
+            self.env.ref('test_base_automation.field_base_automation_lead_test__active').id
+        ])
+        self.assertEqual(automation_form.filter_domain, repr([('active', '=', True)]))
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+
+        ## Tag is set to...
+        automation_form.trigger = 'on_tag_set'
+        a_lead_tag = self.env['test_base_automation.tag'].create({'name': '*AWESOME*'})
+        automation_form.trg_field_ref = a_lead_tag.id
+        self.assertEqual(automation_form.filter_domain, repr([('tag_ids', 'in', [a_lead_tag.id])]))
+        self.assertEqual(automation_form.trigger_field_ids.ids, [
+            self.env.ref('test_base_automation.field_base_automation_lead_test__tag_ids').id
+        ])
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, repr([('tag_ids', 'not in', [a_lead_tag.id])]))
+
+    def test_automation_form_view_on_change_filter_domain(self):
+        a_lead_tag = self.env['test_base_automation.tag'].create({'name': '*AWESOME*'})
+        automation = self.env['base.automation'].create({
+            'name': 'Test Automation',
+            'model_id': self.env.ref('test_base_automation.model_base_automation_lead_test').id,
+            'trigger': 'on_tag_set',
+            'trg_field_ref': a_lead_tag.id,
+        })
+        self.assertEqual(automation.filter_pre_domain, repr([('tag_ids', 'not in', [a_lead_tag.id])]))
+        self.assertEqual(automation.filter_domain, repr([('tag_ids', 'in', [a_lead_tag.id])]))
+        self.assertEqual(automation.trigger_field_ids.ids, [
+            self.env.ref('test_base_automation.field_base_automation_lead_test__tag_ids').id
+        ])
+        self.assertEqual(automation.on_change_field_ids.ids, [])
+
+        # Change the trigger to "On save" will erase the domains and the trigger fields
+        automation_form = Form(automation, view='base_automation.view_base_automation_form')
+        automation_form.trigger = 'on_create_or_write'
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+        self.assertEqual(automation.filter_domain, False)
+        self.assertEqual(automation.trigger_field_ids.ids, [])
+        self.assertEqual(automation.on_change_field_ids.ids, [])
+
+        # Change the domain will append each used field to the trigger fields
+        automation_form.filter_domain = repr([('priority', '=', True), ('employee', '=', False)])
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+        self.assertEqual(automation.filter_domain, repr([('priority', '=', True), ('employee', '=', False)]))
+        self.assertSetEqual(set(automation.trigger_field_ids.ids), {
+            self.env.ref('test_base_automation.field_base_automation_lead_test__priority').id,
+            self.env.ref('test_base_automation.field_base_automation_lead_test__employee').id,
+        })
+        self.assertEqual(automation.on_change_field_ids.ids, [])
+
+        # Change the trigger fields will not change the domain
+        automation_form.trigger_field_ids.set(
+            self.env.ref('test_base_automation.field_base_automation_lead_test__tag_ids')
+        )
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+        self.assertEqual(automation.filter_domain, repr([('priority', '=', True), ('employee', '=', False)]))
+        self.assertEqual(automation.trigger_field_ids.ids, [
+            self.env.ref('test_base_automation.field_base_automation_lead_test__tag_ids').id
+        ])
+        self.assertEqual(automation.on_change_field_ids.ids, [])
+
+        # Erase the domain will not change the trigger fields
+        automation_form.filter_domain = False
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+        self.assertEqual(automation.filter_domain, False)
+        self.assertEqual(automation.trigger_field_ids.ids, [
+            self.env.ref('test_base_automation.field_base_automation_lead_test__tag_ids').id
+        ])
+        self.assertEqual(automation.on_change_field_ids.ids, [])
+
+    def test_automation_form_view_on_change_filter_domain_2(self):
+        a_lead_tag = self.env['test_base_automation.tag'].create({'name': '*AWESOME*'})
+        automation = self.env['base.automation'].create({
+            'name': 'Test Automation',
+            'model_id': self.env.ref('test_base_automation.model_base_automation_lead_test').id,
+            'trigger': 'on_tag_set',
+            'trg_field_ref': a_lead_tag.id,
+        })
+        self.assertEqual(automation.filter_pre_domain, repr([('tag_ids', 'not in', [a_lead_tag.id])]))
+        self.assertEqual(automation.filter_domain, repr([('tag_ids', 'in', [a_lead_tag.id])]))
+        self.assertEqual(automation.trigger_field_ids.ids, [
+            self.env.ref('test_base_automation.field_base_automation_lead_test__tag_ids').id
+        ])
+        self.assertEqual(automation.on_change_field_ids.ids, [])
+
+        # Change the trigger to "On UI change" will erase the domains and the trigger fields
+        automation_form = Form(automation, view='base_automation.view_base_automation_form')
+        automation_form.trigger = 'on_change'
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+        self.assertEqual(automation.filter_domain, False)
+        self.assertEqual(automation.trigger_field_ids.ids, [])
+        self.assertEqual(automation.on_change_field_ids.ids, [])
+
+        # Change the domain will append each used field to the onchange fields
+        automation_form.filter_domain = repr([('priority', '=', True), ('employee', '=', False)])
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+        self.assertEqual(automation.filter_domain, repr([('priority', '=', True), ('employee', '=', False)]))
+        self.assertEqual(automation.trigger_field_ids.ids, [])
+        self.assertSetEqual(set(automation.on_change_field_ids.ids), {
+            self.env.ref('test_base_automation.field_base_automation_lead_test__priority').id,
+            self.env.ref('test_base_automation.field_base_automation_lead_test__employee').id,
+        })
+
+        # Change the onchange fields will not change the domain
+        automation_form.on_change_field_ids.set(
+            self.env.ref('test_base_automation.field_base_automation_lead_test__tag_ids')
+        )
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+        self.assertEqual(automation.filter_domain, repr([('priority', '=', True), ('employee', '=', False)]))
+        self.assertEqual(automation.trigger_field_ids.ids, [])
+        self.assertEqual(automation.on_change_field_ids.ids, [
+            self.env.ref('test_base_automation.field_base_automation_lead_test__tag_ids').id
+        ])
+
+        # Erase the domain will not change the onchange fields
+        automation_form.filter_domain = False
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+        self.assertEqual(automation.filter_domain, False)
+        self.assertEqual(automation.trigger_field_ids.ids, [])
+        self.assertEqual(automation.on_change_field_ids.ids, [
+            self.env.ref('test_base_automation.field_base_automation_lead_test__tag_ids').id
+        ])
+
+    def test_automation_form_view_time_triggers(self):
+        # Starting from a "On save" automation
+        on_save_automation = self.env['base.automation'].create({
+            'name': 'Test Automation',
+            'model_id': self.env.ref('test_base_automation.model_base_automation_lead_test').id,
+            'trigger': 'on_create_or_write',
+            'filter_domain': repr([('employee', '=', False)]),
+            'trigger_field_ids': self.env.ref('test_base_automation.field_base_automation_lead_test__employee')
+        })
+
+        automation = on_save_automation.copy()
+        self.assertEqual(automation.filter_pre_domain, False)
+        self.assertEqual(automation.filter_domain, repr([('employee', '=', False)]))
+        self.assertEqual(automation.trg_date_id.id, False)
+        self.assertEqual(automation.trigger_field_ids.ids, [
+            self.env.ref('test_base_automation.field_base_automation_lead_test__employee').id
+        ])
+
+        # Changing to a time trigger must erase domains and trigger fields
+        ## Change the trigger to "On time created"
+        automation_form = Form(automation, view='base_automation.view_base_automation_form')
+        automation_form.trigger = 'on_time_created'
+        self.assertEqual(automation_form.filter_domain, False)
+        self.assertEqual(automation_form.trg_date_id, self.env.ref('test_base_automation.field_base_automation_lead_test__create_date'))
+        self.assertEqual(automation_form.trigger_field_ids.ids, [])
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+
+        ## Change the trigger to "On time updated"
+        automation = on_save_automation.copy()
+        automation_form = Form(automation, view='base_automation.view_base_automation_form')
+        automation_form.trigger = 'on_time_updated'
+        self.assertEqual(automation_form.filter_domain, False)
+        self.assertEqual(automation_form.trg_date_id, self.env.ref('test_base_automation.field_base_automation_lead_test__write_date'))
+        self.assertEqual(automation_form.trigger_field_ids.ids, [])
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+
+        ## Change the trigger to "On time"
+        automation = on_save_automation.copy()
+        automation_form = Form(automation, view='base_automation.view_base_automation_form')
+        automation_form.trigger = 'on_time'
+        automation_form.trg_date_id = self.env.ref('test_base_automation.field_base_automation_lead_test__create_date')
+        self.assertEqual(automation_form.filter_domain, False)
+        self.assertEqual(automation_form.trg_date_id, self.env.ref('test_base_automation.field_base_automation_lead_test__create_date'))
+        self.assertEqual(automation_form.trigger_field_ids.ids, [])
+        automation = automation_form.save()
+        self.assertEqual(automation.filter_pre_domain, False)
+
     def test_inversion(self):
         """ If a stored field B depends on A, an update to the trigger for A
         should trigger the recomputaton of A, then B.


### PR DESCRIPTION
Backport of 105e313775a6853d8dcd8ea89af7f710f4e1e2a1

**Purpose**
Currently, editing any trigger field of an automation erases the domain, which may lead to unexpected behavior as some "light" automations (i.e. in CRM) hide their domains (for user friendliness).

After this commit, any change in the trigger fields won't erase the domain. Also, any change in the domain will update the trigger fields. This is true for: `On save` and `On UI change` triggers.

opw-4367901