### PR TITLE
[FIX] rpc: re-raise exceptions for http.py

### DIFF
--- a/addons/auth_totp/tests/test_totp.py
+++ b/addons/auth_totp/tests/test_totp.py
@@ -70,7 +70,7 @@ class TestTOTP(TestTOTPMixin, HttpCase):
             'Trying to fake the auth type should not work'
         )
         uid = self.user_test.id
-        with self.assertRaisesRegex(Fault, r'Access Denied'):
+        with self.assertRaisesRegex(Fault, r'Access Denied'), mute_logger("odoo.http"):
             self.xmlrpc_object.execute_kw(
                 get_db_name(), uid, 'test_user',
                 'res.users', 'read', [uid, ['login']]

--- a/addons/rpc/controllers.py
+++ b/addons/rpc/controllers.py
@@ -148,8 +148,12 @@ class RPC(Controller):
         _check_request()
         try:
             response = self._xmlrpc(service)
-        except Exception as error:  # noqa: BLE001
-            response = xmlrpc_handle_exception_string(error)
+        except Exception as error:
+            error.error_response = Response(
+                response=xmlrpc_handle_exception_string(error),
+                mimetype='text/xml',
+            )
+            raise
         return Response(response=response, mimetype='text/xml')
 
     @route("/xmlrpc/2/<service>", auth="none", methods=["POST"], csrf=False, save_session=False)
@@ -158,8 +162,12 @@ class RPC(Controller):
         _check_request()
         try:
             response = self._xmlrpc(service)
-        except Exception as error:  # noqa: BLE001
-            response = xmlrpc_handle_exception_int(error)
+        except Exception as error:
+            error.error_response = Response(
+                response=xmlrpc_handle_exception_int(error),
+                mimetype='text/xml',
+            )
+            raise
         return Response(response=response, mimetype='text/xml')
 
     @route('/jsonrpc', type='jsonrpc', auth="none", save_session=False)

--- a/odoo/addons/test_rpc/tests/test_error.py
+++ b/odoo/addons/test_rpc/tests/test_error.py
@@ -19,7 +19,7 @@ class TestError(common.HttpCase):
     def test_01_create(self):
         """ Create: mandatory field not provided """
         self.rpc("test_rpc.model_b", "create", {"name": "B1"})
-        with self.assertRaises(Fault) as ctx, mute_logger("odoo.sql_db"):
+        with self.assertRaises(Fault) as ctx, mute_logger("odoo.sql_db", "odoo.http"):
             self.rpc("test_rpc.model_b", "create", {})
 
         e = ctx.exception
@@ -38,7 +38,7 @@ class TestError(common.HttpCase):
         b2 = self.rpc("test_rpc.model_b", "create", {"name": "B2"})
         self.rpc("test_rpc.model_a", "create", {"name": "A1", "field_b1": b1, "field_b2": b2})
 
-        with self.assertRaises(Fault) as ctx, mute_logger("odoo.sql_db"):
+        with self.assertRaises(Fault) as ctx, mute_logger("odoo.sql_db", "odoo.http"):
             self.rpc("test_rpc.model_b", "unlink", b1)
 
         e = ctx.exception
@@ -51,7 +51,7 @@ class TestError(common.HttpCase):
         self.assertIn("Foreign key: 'required field'", e.faultString)
 
         # Unlink b2 => ON DELETE RESTRICT constraint raises
-        with self.assertRaises(Fault) as ctx, mute_logger("odoo.sql_db"):
+        with self.assertRaises(Fault) as ctx, mute_logger("odoo.sql_db", "odoo.http"):
             self.rpc("test_rpc.model_b", "unlink", b2)
 
         e = ctx.exception
@@ -64,9 +64,10 @@ class TestError(common.HttpCase):
         self.assertIn("Foreign key: 'restricted field'", e.faultString)
 
     def test_03_sql_constraint(self):
-        with mute_logger("odoo.sql_db"):
+        with mute_logger("odoo.sql_db"), self.assertLogs("odoo.http", level="WARNING") as capture:
             with self.assertRaisesRegex(Fault, r'The operation cannot be completed: The value must be positive'):
                 self.rpc("test_rpc.model_b", "create", {"name": "B1", "value": -1})
+            self.assertEqual(len(capture.output), 1)
 
     def test_04_multi_db(self):
         def db_list(**kwargs):

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -2006,7 +2006,8 @@ class Request:
                         and self.dispatcher.routing_type != JsonRPCDispatcher.routing_type
                     ):
                         raise  # bubble up to werkzeug.debug.DebuggedApplication
-                    exc.error_response = self.registry['ir.http']._handle_error(exc)
+                    if not hasattr(exc, 'error_response'):
+                        exc.error_response = self.registry['ir.http']._handle_error(exc)
                     raise
 
 


### PR DESCRIPTION
Exceptions in RPC are handled and a Response is returned directly. It is a different behaviour than jsonrpc where the exception is raised and the dispatcher wraps it is a Response after logging the exception. The xmlrpc code should also raise an exception so that it can be handled in http.py. Adding here a way to detect if a Response was already generated for an exception in the exception handler of HTTP.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
