### PR TITLE
[FIX] utm: correct typo in archive and restore buttons

### DIFF
--- a/addons/utm/views/utm_campaign_views.xml
+++ b/addons/utm/views/utm_campaign_views.xml
@@ -97,8 +97,8 @@
                         <t t-if="widget.deletable">
                             <a role="menuitem" type="delete" class="dropdown-item">Delete</a>
                         </t>
-                        <a role="menuitem" class="dropdown-item o_kanban_mailing_active" name="action_archive" type="object" t-if="record.active.raw_value">>Archive</a>
-                        <a role="menuitem" class="dropdown-item o_kanban_mailing_active" name="action_unarchive" type="object" t-if="!record.active.raw_value">>Restore</a>
+                        <a role="menuitem" class="dropdown-item o_kanban_mailing_active" name="action_archive" type="object" t-if="record.active.raw_value">Archive</a>
+                        <a role="menuitem" class="dropdown-item o_kanban_mailing_active" name="action_unarchive" type="object" t-if="!record.active.raw_value">Restore</a>
                         <div role="separator" class="dropdown-divider"/>
                         <field name="color" widget="kanban_color_picker"/>
                     </t>


### PR DESCRIPTION
This commit addresses a typo in the archive and restore buttons within the kanban menu, introduced in this commit https://github.com/odoo/odoo/commit/d220bb4c872d3660d15373d15565c846e3a35d9f

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
