### PR TITLE
[ADD] l10n_sa_edi_branch: Added Branch CRN

### DIFF
--- a/addons/l10n_sa_edi_branch/__init__.py
+++ b/addons/l10n_sa_edi_branch/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/l10n_sa_edi_branch/__manifest__.py
+++ b/addons/l10n_sa_edi_branch/__manifest__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Saudi Arabia - E-Invoicing Branches',
+    'icon': '/l10n_sa/static/description/icon.png',
+    'version': '0.1',
+    'depends': [
+        'l10n_sa_edi',
+    ],
+    'author': 'Odoo',
+    'summary': """
+        E-Invoicing, Branches
+    """,
+    'description': """
+Allows the support for ZATCA branches multiple commercial registrations
+    """,
+    'category': 'Accounting/Localizations/EDI',
+    'license': 'LGPL-3',
+    'data': [
+        'views/res_config_settings_views.xml',
+        'views/account_journal_views.xml',
+    ],
+}

--- a/addons/l10n_sa_edi_branch/i18n/ar.po
+++ b/addons/l10n_sa_edi_branch/i18n/ar.po
@@ -1,0 +1,63 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_sa_edi_branch
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-14 10:37+0000\n"
+"PO-Revision-Date: 2025-01-14 10:37+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_sa_edi_branch
+#: model:ir.model.fields,field_description:l10n_sa_edi_branch.field_account_journal__l10n_sa_branch_crn
+#: model:ir.model.fields,field_description:l10n_sa_edi_branch.field_account_journal__l10n_sa_use_branch_crn
+#: model:ir.model.fields,field_description:l10n_sa_edi_branch.field_res_company__l10n_sa_use_branch_crn
+#: model:ir.model.fields,field_description:l10n_sa_edi_branch.field_res_config_settings__l10n_sa_use_branch_crn
+msgid "Branch CRN"
+msgstr "رقم السجل التجاري للفرع"
+
+#. module: l10n_sa_edi_branch
+#: model:ir.model.fields,help:l10n_sa_edi_branch.field_account_journal__l10n_sa_branch_crn
+msgid ""
+"Can be used when the company has multiple branches that share the same VAT "
+"number, but have different commercial registration numbers."
+"                                    Keep this field empty to use the "
+"Identification Number set on the company."
+msgstr "يمكن استخدامه عندما يكون لدى الشركة عدة فروع تشترك في نفس الرقم الضريبي ولكن لديها أرقام سجل تجاري مختلفة. اترك هذا الحقل فارغا لاستخدام رقم التعريف المحدد على الشركة"
+
+#. module: l10n_sa_edi_branch
+#: model:ir.model,name:l10n_sa_edi_branch.model_res_company
+msgid "Companies"
+msgstr "الشركات "
+
+#. module: l10n_sa_edi_branch
+#: model:ir.model,name:l10n_sa_edi_branch.model_res_config_settings
+msgid "Config Settings"
+msgstr "تهيئة الإعدادات "
+
+#. module: l10n_sa_edi_branch
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi_branch.res_config_settings_view_form_inherit
+msgid "Define the Branch Company Registry Number on the sales-type journal"
+msgstr "حدد رقم سجل الشركة الفرعي على دفتر اليومية من نوع المبيعات."
+
+#. module: l10n_sa_edi_branch
+#: model:ir.model,name:l10n_sa_edi_branch.model_account_journal
+msgid "Journal"
+msgstr "دفتر اليومية"
+
+#. module: l10n_sa_edi_branch
+#: model:ir.model,name:l10n_sa_edi_branch.model_account_edi_xml_ubl_21_zatca
+msgid "UBL 2.1 (ZATCA)"
+msgstr "UBL 2.1 (زاتكا)"
+
+#. module: l10n_sa_edi_branch
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi_branch.view_account_journal_form
+msgid "e.g: 3999999999"
+msgstr ""

--- a/addons/l10n_sa_edi_branch/i18n/l10n_sa_edi_branch.pot
+++ b/addons/l10n_sa_edi_branch/i18n/l10n_sa_edi_branch.pot
@@ -1,0 +1,63 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_sa_edi_branch
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-14 10:54+0000\n"
+"PO-Revision-Date: 2025-01-14 10:54+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_sa_edi_branch
+#: model:ir.model.fields,field_description:l10n_sa_edi_branch.field_account_journal__l10n_sa_branch_crn
+#: model:ir.model.fields,field_description:l10n_sa_edi_branch.field_account_journal__l10n_sa_use_branch_crn
+#: model:ir.model.fields,field_description:l10n_sa_edi_branch.field_res_company__l10n_sa_use_branch_crn
+#: model:ir.model.fields,field_description:l10n_sa_edi_branch.field_res_config_settings__l10n_sa_use_branch_crn
+msgid "Branch CRN"
+msgstr ""
+
+#. module: l10n_sa_edi_branch
+#: model:ir.model.fields,help:l10n_sa_edi_branch.field_account_journal__l10n_sa_branch_crn
+msgid ""
+"Can be used when the company has multiple branches that share the same VAT "
+"number, but have different commercial registration numbers."
+"                                    Keep this field empty to use the "
+"Identification Number set on the company."
+msgstr ""
+
+#. module: l10n_sa_edi_branch
+#: model:ir.model,name:l10n_sa_edi_branch.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: l10n_sa_edi_branch
+#: model:ir.model,name:l10n_sa_edi_branch.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_sa_edi_branch
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi_branch.res_config_settings_view_form_inherit
+msgid "Define the Branch Company Registry Number on the sales-type journal"
+msgstr ""
+
+#. module: l10n_sa_edi_branch
+#: model:ir.model,name:l10n_sa_edi_branch.model_account_journal
+msgid "Journal"
+msgstr ""
+
+#. module: l10n_sa_edi_branch
+#: model:ir.model,name:l10n_sa_edi_branch.model_account_edi_xml_ubl_21_zatca
+msgid "UBL 2.1 (ZATCA)"
+msgstr ""
+
+#. module: l10n_sa_edi_branch
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi_branch.view_account_journal_form
+msgid "e.g: 3999999999"
+msgstr ""

--- a/addons/l10n_sa_edi_branch/models/__init__.py
+++ b/addons/l10n_sa_edi_branch/models/__init__.py
@@ -1,0 +1,5 @@
+from . import account_edi_format
+from . import account_edi_xml_ubl_21_zatca
+from . import account_journal
+from . import res_company
+from . import res_config_settings

--- a/addons/l10n_sa_edi_branch/models/account_edi_format.py
+++ b/addons/l10n_sa_edi_branch/models/account_edi_format.py
@@ -1,0 +1,47 @@
+from odoo import _, models
+
+
+class AccountEdiFormat(models.Model):
+    _inherit = 'account.edi.format'
+
+    def _l10n_sa_check_seller_missing_info(self, invoice):  # Override of l10n_sa_edi function
+        """
+            Helper function to check if ZATCA mandated partner fields are missing for the seller
+        """
+        partner_id = invoice.company_id.partner_id.commercial_partner_id
+        fields_to_check = [
+            ('l10n_sa_edi_building_number', _('Building Number for the Buyer is required on Standard Invoices')),
+            ('street2', _('Neighborhood for the Seller is required on Standard Invoices')),
+            ('l10n_sa_additional_identification_scheme',
+             _('Additional Identification Scheme is required for the Seller, and must be one of CRN, MOM, MLS, SAG or OTH'),
+             lambda p, v: v in ('CRN', 'MOM', 'MLS', 'SAG', 'OTH')
+             ),
+            ('l10n_sa_additional_identification_number',
+             _('Additional Identification Number is required for the Seller.'),
+             lambda p, v: p.l10n_sa_additional_identification_scheme == 'TIN'
+             ),
+            ('vat',
+             _('VAT is required when Identification Scheme is set to Tax Identification Number'),
+             lambda p, v: p.l10n_sa_additional_identification_scheme != 'TIN'
+             ),
+            ('state_id', _('State / Country subdivision'))
+        ]
+        if invoice.company_id.l10n_sa_use_branch_crn:  # Special Checks when using branch crn
+            return self._l10n_sa_check_journal_missing_info(invoice, fields_to_check)
+
+        return self._l10n_sa_check_partner_missing_info(partner_id, fields_to_check)
+
+    def _l10n_sa_check_journal_missing_info(self, invoice, fields_to_check):
+        """
+            Helper function to check if Journal CRN is populated if branch CRN is enabled
+        """
+        missing = []
+        partner_id = invoice.company_id.partner_id.commercial_partner_id
+        journal_id = invoice.journal_id
+        fields_to_check.pop(2)
+        fields_to_check.pop(2)
+        if not journal_id.l10n_sa_branch_crn:
+            missing.append(_(f"The Branch CRN on {journal_id.name} needs to be set. Otherwise, you need set the Identification Scheme\
+                and Identification Number on {invoice.company_id.name} to be either CRN, MOM, MLS, SAG, or OTH"))
+
+        return missing + self._l10n_sa_check_partner_missing_info(partner_id, fields_to_check)

--- a/addons/l10n_sa_edi_branch/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi_branch/models/account_edi_xml_ubl_21_zatca.py
@@ -1,0 +1,23 @@
+from odoo import models
+
+
+class AccountEdiXmlUBL21Zatca(models.AbstractModel):
+    _inherit = "account.edi.xml.ubl_21.zatca"
+
+    def _export_invoice_vals(self, invoice):
+        vals = super()._export_invoice_vals(invoice)
+        vals['vals']['accounting_supplier_party_vals']['party_vals'].update(
+            self._l10n_sa_get_supplier_party_vals(invoice)
+        )
+
+        return vals
+
+    def _l10n_sa_get_supplier_party_vals(self, invoice):
+        if invoice.journal_id.l10n_sa_use_branch_crn and invoice.journal_id.l10n_sa_branch_crn:
+            return {
+                'party_identification_vals': [{
+                    'id_attrs': {'schemeID': 'CRN'},
+                    'id': invoice.journal_id.l10n_sa_branch_crn,
+                }]
+            }
+        return {}

--- a/addons/l10n_sa_edi_branch/models/account_journal.py
+++ b/addons/l10n_sa_edi_branch/models/account_journal.py
@@ -1,0 +1,20 @@
+from odoo import api, fields, models
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    l10n_sa_branch_crn = fields.Char("Branch CRN",
+        copy=False,
+        help="Can be used when the company has multiple branches that share the same VAT number, but have different commercial registration numbers.\
+        Keep this field empty to use the Identification Number set on the company.",
+        compute="_compute_l10n_sa_branch_crn",
+        store=True,
+        readonly=False,
+        tracking=True,)
+    l10n_sa_use_branch_crn = fields.Boolean(related="company_id.l10n_sa_use_branch_crn")
+
+    @api.depends("company_id.l10n_sa_use_branch_crn")
+    def _compute_l10n_sa_branch_crn(self):
+        # Reset l10n_sa_branch_crn to False when Branch CRN setting is deactivated
+        self.filtered(lambda journal: not journal.company_id.l10n_sa_use_branch_crn).l10n_sa_branch_crn = False

--- a/addons/l10n_sa_edi_branch/models/res_company.py
+++ b/addons/l10n_sa_edi_branch/models/res_company.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    l10n_sa_use_branch_crn = fields.Boolean(string='Branch CRN')

--- a/addons/l10n_sa_edi_branch/models/res_config_settings.py
+++ b/addons/l10n_sa_edi_branch/models/res_config_settings.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    l10n_sa_use_branch_crn = fields.Boolean(related='company_id.l10n_sa_use_branch_crn', readonly=False)

--- a/addons/l10n_sa_edi_branch/views/account_journal_views.xml
+++ b/addons/l10n_sa_edi_branch/views/account_journal_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_account_journal_form" model="ir.ui.view">
+            <field name="name">account.journal.form.l10n_sa_edi_branch</field>
+            <field name="model">account.journal</field>
+            <field name="inherit_id" ref="l10n_sa_edi.view_account_journal_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='l10n_sa_serial_number']" position="after">
+                    <field name="l10n_sa_use_branch_crn" invisible="1"/>
+                    <field name="l10n_sa_branch_crn" placeholder="e.g: 3999999999" attrs="{'invisible': [('l10n_sa_use_branch_crn', '=', False)]}"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/l10n_sa_edi_branch/views/res_config_settings_views.xml
+++ b/addons/l10n_sa_edi_branch/views/res_config_settings_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="res_config_settings_view_form_inherit" model="ir.ui.view">
+            <field name="name">res.config.settings.view.form.inherit.l10n_sa_edi_branch</field>
+            <field name="model">res.config.settings</field>
+            <field name="inherit_id" ref="l10n_sa_edi.res_config_settings_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//div[@name='saudi_zatca_edi']//div[hasclass('o_setting_right_pane')]" position="inside">
+                    <label for="l10n_sa_use_branch_crn"/>
+                    <div class="o_row">
+                        <field name="l10n_sa_use_branch_crn"/>
+                        <div class="text-muted">
+                            Define the Branch Commercial Registration Number on the sales-type journal
+                        </div>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/odoo/addons/base/i18n/ar.po
+++ b/odoo/addons/base/i18n/ar.po
@@ -1371,6 +1371,35 @@ msgstr ""
 "    "
 
 #. module: base
+#: model:ir.module.module,summary:base.module_l10n_sa_edi_branch
+msgid ""
+"\n"
+"        E-Invoicing, Branches\n"
+"    "
+msgstr ""
+"\n"
+"        الفوترة الإلكترونية، فروع\n"
+"    "
+
+#. module: base
+#: model:ir.module.module,description:base.module_l10n_sa_edi_branch
+msgid ""
+"\n"
+"Allows the support for ZATCA branches multiple commercial registrations\n"
+"    "
+msgstr ""
+"\n"
+"يسمح لتعدد السجلات التجارية لفروع الشركة\n"
+"    "
+
+#. module: base
+#: model:ir.module.module,shortdesc:base.module_l10n_sa_edi_branch
+msgid "Saudi Arabia - E-Invoicing Branches"
+"\n"
+"        المملكة العربية السعودية - الفوترة الإلكترونية فروع\n"
+"    "
+
+#. module: base
 #: model:ir.module.module,summary:base.module_l10n_sa_edi
 msgid ""
 "\n"

--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -880,6 +880,27 @@ msgid ""
 msgstr ""
 
 #. module: base
+#: model:ir.module.module,summary:base.module_l10n_sa_edi_branch
+msgid ""
+"\n"
+"        E-Invoicing, Branches\n"
+"    "
+msgstr ""
+
+#. module: base
+#: model:ir.module.module,description:base.module_l10n_sa_edi_branch
+msgid ""
+"\n"
+"Allows the support for ZATCA branches multiple commercial registrations\n"
+"    "
+msgstr ""
+
+#. module: base
+#: model:ir.module.module,shortdesc:base.module_l10n_sa_edi_branch
+msgid "Saudi Arabia - E-Invoicing Branches"
+msgstr ""
+
+#. module: base
 #: model:ir.module.module,summary:base.module_l10n_sa_edi
 msgid ""
 "\n"


### PR DESCRIPTION
[#Task](https://www.odoo.com/web#model=project.task&id=4119982)

As per ZATCA rule BR-KSA-08: In the case where a company has multiple commercial registrations, such as different branches, the seller should fill the commercial registration of the branch in respect of which the Tax Invoice is being issued. In the case of Odoo, the branch CRN will be set on the Journal.

Description of the issue/feature this PR addresses:
Currently there is no option to link a Branch CRN to a company, as the only option is to have multiple companies with the same VAT but different Additional Identification Number values.

Current behavior before PR:
Additional Identification Number submitted to ZATCA is set directly on the company and does not allow for multiple branches by company

Desired behavior after PR is merged:
Additional Identification Number (CRN) submitted to ZATCA can be set on the Journal which allows to have different registration numbers per journal


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
