### PR TITLE
[FIX] stock: allow picking validation of already reserved package

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1913,7 +1913,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         for result_package in moves_todo\
                 .move_line_ids.filtered(lambda ml: ml.picked).mapped('result_package_id')\
                 .filtered(lambda p: p.quant_ids and len(p.quant_ids) > 1):
-            if len(result_package.quant_ids.filtered(lambda q: not float_is_zero(abs(q.quantity) + abs(q.reserved_quantity), precision_rounding=q.product_uom_id.rounding)).mapped('location_id')) > 1:
+            if len(result_package.quant_ids.filtered(lambda q: float_compare(q.quantity, 0.0, precision_rounding=q.product_uom_id.rounding) > 0).mapped('location_id')) > 1:
                 raise UserError(_('You cannot move the same package content more than once in the same transfer or split the same package into two location.'))
         if any(ml.package_id and ml.package_id == ml.result_package_id for ml in moves_todo.move_line_ids):
             self.env['stock.quant']._unlink_zero_quants()


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable: Multi-Step Routes, Operations > Packages
- Create a storable prodcut
- Update the on hand quantity:
  - 10 units in package PK
- Inventory > Configuration > Warehouse Management > Locations
- Create 2 warehouse locations: WH/LOC1, WH/LOC2
- Go to the barcode app and proceed with the scans:
    1. Scan the internal transfer picking type
    2. Scan WH/STOCK as a source location
    3. Scan the package name (PK)
    4. Scan WH/LOC1 as destination location
- Leave the barcode app without validation
- Go to the barcode app and proceed with the scans: i -> iii,  iv'. Scan WH/LOC2 as destination location
- Try to validate the picking
#### > Invalid operation: You cannot move the same package content more than once in the same transfer or split the same package into two location.

### Cause of the issue:

As both pickings were treated via the barcode app, they generated picked move lines related to the package. Both of these move lines have updated the reserved quantity of the stock.quant present in stock:
- WH/STOCK, quantity: 10, reserved_quantity: 20.

When you try to validate the second picking, you will launch an `_action_done` of its move line that will create a new quant in WH/LOC2 and update the quant in stock:
- WH/STOCK, quantity: 0, reserved_quantity: 10.
- WH/LOC2, quantity: 10, reserved_quantity: 0.

The error is raised just after since 2 quants with either a quantity or reserved quantity are found:
https://github.com/odoo/odoo/blob/6349fb0362d881672616bb4b800bd32be82f9a5f/addons/stock/models/stock_move.py#L1910-L1917

### Fix:

Since the check is made in order to check the consistency of result packages moved by the current validation the "reserved_quantity" should not matter.

opw-4456484
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
