### PR TITLE
[FIX] pos_hr, point_of_sale: fix error when re-entering payment screen

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1582,6 +1582,9 @@ export class PosStore extends Reactive {
         );
     }
     showScreen(name, props) {
+        if (name === "PaymentScreen" && !props.orderUuid) {
+            name = "ProductScreen";
+        }
         if (name === "ProductScreen") {
             this.get_order()?.deselect_orderline();
         }

--- a/addons/pos_hr/static/src/app/select_cashier_mixin.js
+++ b/addons/pos_hr/static/src/app/select_cashier_mixin.js
@@ -136,14 +136,22 @@ export function useCashierSelector({ exclusive, onScan } = { onScan: () => {}, e
         const currentScreen = pos.mainScreen.component.name;
         if (currentScreen === "LoginScreen" && login && employee) {
             const isRestaurant = pos.config.module_pos_restaurant;
-            const selectedScreen =
+            let selectedScreen =
                 pos.previousScreen && pos.previousScreen !== "LoginScreen"
                     ? pos.previousScreen
                     : isRestaurant
                     ? "FloorScreen"
                     : "ProductScreen";
 
-            pos.showScreen(selectedScreen);
+            const props = {};
+            if (selectedScreen === "PaymentScreen") {
+                if (!pos.selectedOrderUuid) {
+                    selectedScreen = isRestaurant ? "FloorScreen" : "ProductScreen";
+                } else {
+                    props.orderUuid = pos.selectedOrderUuid;
+                }
+            }
+            pos.showScreen(selectedScreen, props);
         }
 
         return employee;


### PR DESCRIPTION
Before this commit:
- Enable the "Log in with employees"
- Log in as any employee, add a product, and go to the payment screen
- Lock the session
- Enter the session again

This sequence of actions would result in an error in the console.

opw-4435559

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
