### PR TITLE
[FIX] html_editor: handle toggling background color for tabs

### DIFF
--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -1,7 +1,7 @@
 import { Plugin } from "../plugin";
 import { isBlock } from "../utils/blocks";
 import { fillEmpty, splitTextNode } from "../utils/dom";
-import { isTextNode, isVisible } from "../utils/dom_info";
+import { isEditorTab, isTextNode, isVisible } from "../utils/dom_info";
 import { prepareUpdate } from "../utils/dom_state";
 import { childNodes, closestElement, firstLeaf, lastLeaf } from "../utils/dom_traversal";
 import { DIRECTIONS, childNodeIndex, nodeSize } from "../utils/position";
@@ -212,8 +212,12 @@ export class SplitPlugin extends Plugin {
         if ([firstNode, lastNode].includes(limitAncestor)) {
             return limitAncestor;
         }
-        let before = firstNode.previousSibling;
-        let after = lastNode.nextSibling;
+        let before = isEditorTab(firstNode.parentElement)
+            ? firstNode.parentElement.previousSibling
+            : firstNode.previousSibling;
+        let after = isEditorTab(lastNode.parentElement)
+            ? lastNode.parentElement.nextSibling
+            : lastNode.nextSibling;
         let beforeSplit, afterSplit;
         if (!before && !after && elements[0] !== limitAncestor) {
             return this.splitAroundUntil(elements[0].parentElement, limitAncestor);

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -9,7 +9,10 @@ import {
 } from "@html_editor/utils/color";
 import { fillEmpty } from "@html_editor/utils/dom";
 import {
+    getDeepestPosition,
+    isAtStart,
     isContentEditable,
+    isEditorTab,
     isEmptyBlock,
     isTextNode,
     isWhitespace,
@@ -91,7 +94,10 @@ export class ColorPlugin extends Plugin {
         if (nodes.length === 0) {
             return;
         }
-        const el = closestElement(nodes[0]);
+        let el = closestElement(nodes[0]);
+        if (isEditorTab(el)) {
+            el = el.parentElement;
+        }
         if (!el) {
             return;
         }
@@ -202,16 +208,30 @@ export class ColorPlugin extends Plugin {
             selection = this.dependencies.split.splitSelection();
             selectionNodes = this.dependencies.selection
                 .getSelectedNodes()
-                .filter((node) => isContentEditable(node) && node.nodeName !== "T");
+                .filter(
+                    (node) =>
+                        (isContentEditable(node) && node.nodeName !== "T") ||
+                        isEditorTab(node) ||
+                        isEditorTab(node.parentElement)
+                );
             if (isEmptyBlock(selection.endContainer)) {
                 selectionNodes.push(selection.endContainer, ...descendants(selection.endContainer));
             }
         }
 
-        const selectedNodes =
+        let selectedNodes =
             mode === "backgroundColor" && color
                 ? selectionNodes.filter((node) => !closestElement(node, "table.o_selected_table"))
                 : selectionNodes;
+
+        // exclude starting tabs
+        selectedNodes = selectedNodes.filter((node) => {
+            const current = isTextNode(node) ? node.parentElement : node;
+            if (!isEditorTab(current)) {
+                return true;
+            }
+            return !isAtStart(current, ["DIV", "P"], (node) => isEditorTab(node));
+        });
 
         const selectedFieldNodes = new Set(
             this.dependencies.selection
@@ -280,6 +300,16 @@ export class ColorPlugin extends Plugin {
             });
         };
 
+        const [deepFocusNode, deepFocusOffset] = getDeepestPosition(
+            selection.focusNode,
+            selection.focusOffset
+        );
+
+        const [deepAnchorNode, deepAnchorOffset] = getDeepestPosition(
+            selection.anchorNode,
+            selection.anchorOffset
+        );
+
         for (const fieldNode of selectedFieldNodes) {
             this.colorElement(fieldNode, color, mode);
         }
@@ -308,7 +338,25 @@ export class ColorPlugin extends Plugin {
                 fontsSet.delete(font);
             }
         }
-        this.dependencies.selection.setSelection(selection, { normalize: false });
+
+        const correctedSelection = {
+            anchorNode: selection.anchorNode,
+            anchorOffset: selection.anchorOffset,
+            focusNode: selection.focusNode,
+            focusOffset: selection.focusOffset,
+        };
+
+        if (!correctedSelection.anchorNode.parentElement && deepAnchorNode) {
+            // node has been removed we should restore it.
+            correctedSelection.anchorNode = deepAnchorNode;
+            correctedSelection.anchorOffset = deepAnchorOffset;
+        }
+        if (!correctedSelection.focusNode.parentElement && deepFocusNode) {
+            // node has been removed we should restore it.
+            correctedSelection.focusNode = deepFocusNode;
+            correctedSelection.focusOffset = deepFocusOffset;
+        }
+        this.dependencies.selection.setSelection(correctedSelection, { normalize: false });
     }
 
     getUsedCustomColors(mode) {

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -666,3 +666,31 @@ export function isContentEditable(node) {
     const element = isTextNode(node) ? node.parentElement : node;
     return element.isContentEditable;
 }
+
+/**
+ * Returns true if the node and all its ancestors (up to stopNodeNames) are the first valid visible
+ * node in their respective parents.
+ *
+ * @param {Node} node - The node to start checking from
+ * @param {String[]} stopNodeNames - Stop checking when we hit a parent with one of these node names
+ * @param {Function} skipNode - Optional function to determine if a node should be skipped
+ * @returns {boolean} - True if no valid nodes exist before this node in each ancestor level
+ */
+export function isAtStart(node, stopNodeNames, skipNode = () => false) {
+    let currentNode = node;
+    while (!stopNodeNames.includes(currentNode.nodeName)) {
+        const parent = currentNode.parentNode;
+        while ((currentNode = currentNode.previousSibling)) {
+            if (
+                isVisible(currentNode) &&
+                isContentEditable(currentNode) &&
+                !skipNode(currentNode)
+            ) {
+                return false;
+            }
+        }
+        currentNode = parent;
+    }
+
+    return true;
+}

--- a/addons/html_editor/static/tests/tabs.test.js
+++ b/addons/html_editor/static/tests/tabs.test.js
@@ -313,6 +313,50 @@ describe("insert tabulation", () => {
                 `<blockquote>${oeTab(tabInBlockquote)}f${oeTab(tabAfterFinBlockquote)}]g</blockquote>`,
         });
     });
+
+    test("should insert a tab without background color if the selection is at the beginning of the `p`", async () => {
+        const expectedTabWidth = TAB_WIDTH;
+        await testTabulation({
+            contentBefore: `<p><font style="background-color: rgb(255, 0, 0);">[]ab</font></p>`,
+            stepFunction: keydownTab,
+            contentAfter: `<p>${oeTab(
+                expectedTabWidth
+            )}[]<font style="background-color: rgb(255, 0, 0);">ab</font></p>`,
+        });
+    });
+
+    test("should insert a tab character with background color when selection is inside text", async () => {
+        const expectedTabWidth = TAB_WIDTH;
+        await testTabulation({
+            contentBefore: `<p><font style="background-color: rgb(255, 0, 0);">a[]b</font></p>`,
+            stepFunction: keydownTab,
+            contentAfter: `<p><font style="background-color: rgb(255, 0, 0);">a${oeTab(
+                expectedTabWidth - getCharWidth("p", "a")
+            )}[]b</font></p>`,
+        });
+    });
+
+    test("should insert a tab character with background color when selection is at end of text", async () => {
+        const expectedTabWidth = TAB_WIDTH;
+        await testTabulation({
+            contentBefore: `<p><font style="background-color: rgb(255, 0, 0);">ab[]</font></p>`,
+            stepFunction: keydownTab,
+            contentAfter: `<p><font style="background-color: rgb(255, 0, 0);">ab${oeTab(
+                expectedTabWidth - getCharWidth("p", "b") - getCharWidth("p", "a")
+            )}[]</font></p>`,
+        });
+    });
+
+    test("should insert a tab character without background color when there is no `p` parent", async () => {
+        const expectedTabWidth = TAB_WIDTH;
+        await testTabulation({
+            contentBefore: `<h1><font style="background-color: rgb(255, 0, 0);">[]ab</font></h1>`,
+            stepFunction: keydownTab,
+            contentAfter: `<h1>${oeTab(
+                expectedTabWidth
+            )}[]<font style="background-color: rgb(255, 0, 0);">ab</font></h1>`,
+        });
+    });
 });
 
 describe("delete backward tabulation", () => {


### PR DESCRIPTION
**Problem**:
Background color handling for tabs is inconsistent and incorrect in various scenarios:
- Adding a tab at the start of a paragraph with background color applies the background to the tab, which is incorrect.
- Adding a tab inside or at the end of text with a background color and selecting the tab does not reflect the background color in the toolbar (the color button state is off).
- Removing the background color from a tab does not work as the tab is not recognized as having a background.

**Solution**:
Improve color application and checks to handle tabs correctly, ensuring consistent behavior for adding, recognizing, and removing background colors.

**Steps to Reproduce**:
1. Add text with a background color.
2. Insert a tab at the start of the text.
   - The tab incorrectly inherits the background color.
3. Insert a tab at the end of the text.
4. Select the tab to remove the background color.
   - The background color button in the toolbar remains off (as if no background color exists).
5. Attempt to remove the background color.
   - Nothing happens.

opw-4381135

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
