### PR TITLE
[FIX] web_editor: call _applyColspan with a valid element

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -283,7 +283,9 @@ function bootstrapToTable(editable) {
                 } else {
                     // Fill the row with what was in the grid before it
                     // overflowed.
-                    _applyColspan(grid[gridIndex], 12 - gridIndex, containerWidth);
+                    if (grid[gridIndex]) {
+                        _applyColspan(grid[gridIndex], 12 - gridIndex, containerWidth);
+                    }
                     currentRow.append(...grid.filter(td => td.getAttribute('colspan')));
                     // Start a new row that starts with the current col.
                     const previousRow = currentRow;


### PR DESCRIPTION
**Problem**:
The function `_getColumnSize` returns the size of the columns. When `gridIndex = columnSize;` is assigned and `columnSize` equals 12, it causes an overflow in the `grid` array. This leads to invalid elements being passed to `_applyColspan`.

**Solution**:
Ensure `_applyColspan` is only called when `gridIndex` is within valid bounds.

**Steps to reproduce**:
1. Open an email marketing template.
2. Extend the "Centered Logo" snippet to the maximum size (`col-12`).
3. Observe a traceback error.

opw-4381159

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
