### PR TITLE
[FIX] core: fix inverse x2many field in create()

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -21,7 +21,6 @@ class AccountPayment(models.Model):
     check_number = fields.Char(
         string="Check Number",
         store=True,
-        readonly=True,
         copy=False,
         compute='_compute_check_number',
         inverse='_inverse_check_number',
@@ -112,6 +111,15 @@ class AccountPayment(models.Model):
             if payment.check_number:
                 sequence = payment.journal_id.check_sequence_id.sudo()
                 sequence.padding = len(payment.check_number)
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        result = super().fields_get(allfields, attributes)
+        # pretend the field 'check_number' to be readonly
+        field_desc = result.get('check_number') or {}
+        if 'readonly' in field_desc:
+            field_desc['readonly'] = True
+        return result
 
     def _get_aml_default_display_name_list(self):
         # Extends 'account'

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -4566,6 +4566,20 @@ class TestComputeQueries(TransactionCase):
         self.assertEqual(record.foo, 'Bar')
         self.assertEqual(record.bar, 'Bar')
 
+    def test_x2many_computed_inverse(self):
+        record = self.env['test_new_api.compute.inverse'].create(
+            {'child_ids': [Command.create({'foo': 'child'})]},
+        )
+        self.assertEqual(
+            len(record.child_ids), 1,
+            f"Should be a single record: {record.child_ids!r}",
+        )
+        self.assertTrue(
+            record.child_ids.id,
+            f"Should be database records: {record.child_ids!r}",
+        )
+        self.assertEqual(record.foo, 'has one child')
+
     def test_multi_create(self):
         model = self.env['test_new_api.foo']
         model.create({})

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4985,7 +4985,7 @@ class BaseModel(metaclass=MetaModel):
                     (data['record'], {
                         name: data['inversed'][name]
                         for name in inv_names
-                        if name in data['inversed']
+                        if name in data['inversed'] and name not in data['stored']
                     })
                     for data in data_list
                     if not inv_names.isdisjoint(data['inversed'])


### PR DESCRIPTION
### To reproduce:
- Model A has an inverse X2many stored field pointing to model B.
- Calling `A.create({'X2many': [Command.create({...})]})` returns `A(1)`.
- `A(1).X2many` returns `B(1, <NewId NoOrigin>)`. This breaks one of the implicit invariants of the ORM, we shouldn't have a mix of real and New ids in the same recordset. Also, it may break some computation done on this X2many later in the same request, since `A(1).X2many` contains two records instead of one.

This happens because `create()` calls `_update_cache()` with X2many values, but the value of that X2many is already in the cache with the record created from the command values. This causes the X2many values to be duplicated with the new record version of the command values.

### Real Issue in the standard code

In the case of the 'sale.commission.plan' model and due to the inversed `target_commission_ids` field, it breaks the duplicate feature (`copy()` method):
```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/18.0/odoo/http.py", line 1960, in _transactioning
    return service_model.retrying(func, env=self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/18.0/odoo/service/model.py", line 138, in retrying
    result = func()
             ^^^^^^
  File "/home/odoo/src/odoo/18.0/odoo/http.py", line 1927, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/18.0/odoo/http.py", line 2174, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/18.0/odoo/addons/base/models/ir_http.py", line 329, in _dispatch
    result = endpoint(**request.params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/18.0/odoo/http.py", line 729, in route_wrapper
    result = endpoint(self, *args, **params_ok)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/18.0/addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/18.0/odoo/api.py", line 517, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 5921, in copy
    old_record.copy_translations(new_record, excluded=default or ())
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 5874, in copy_translations
    new_lines = new[name].sorted(key='id')
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 6690, in sorted
    ids = tuple(item.id for item in sorted(self, key=key, reverse=reverse))
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'NewId' and 'int'
```
Explanation of the traceback:
A `copy()` calls `create()` on 'sale.commission.plan', which returns a `commission` record that should contain the same `target_commission_ids` values. Instead of that, `commission.target_commission_ids` (after the create and before `copy_translations`) returns twice as many records and with a mix of New and real ids, causing `copy_translations()` to crash when sorting by id.

### Fix

To avoid this issue, we don't call `_update_cache()` for the stored fields because we are sure that the cache has already been set in `_create()` and not invalidated by `modified()`.