### PR TITLE
[FIX] mail: correctly handle iOS push notifications

### DIFF
--- a/addons/mail/static/src/core/web/messaging_menu.js
+++ b/addons/mail/static/src/core/web/messaging_menu.js
@@ -6,7 +6,7 @@ import { onExternalClick, useDiscussSystray } from "@mail/utils/common/hooks";
 
 import { Component, useState } from "@odoo/owl";
 
-import { hasTouch, isIOS } from "@web/core/browser/feature_detection";
+import { hasTouch } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
@@ -278,7 +278,7 @@ export class MessagingMenu extends Component {
     }
 
     get shouldAskPushPermission() {
-        return this.notification.permission === "prompt" && !isIOS();
+        return this.notification.permission === "prompt";
     }
 }
 


### PR DESCRIPTION
iOS push notifications do not work on Safari: they only work in apps. The notifications are managed by the apps, whether with native mobile app or PWA.

With PWA, it should normally rely on `Notification.permission`, but somehow it doesn't work and always has value "default". Its showing has been limited to the PWA, but it keeps showing a persistent notification. Clicking on it the 1st time displays a prompt to either accept or deny the permissions. Afterwards, further clicks on the "odoobot has a request" automatically display "granted" or "denied" based on user initial choice.

iOS push permissions seem to necessarily rely on
`serviceWorker.getRegistration().pushManager`, which works only on HTTPS, hence why iOS push notifications do not work on HTTP. Also actual push permission state are correct there whereas on Notification.permission they are wrong.

This commit fixes the issue by computing the push notification permisssion state correctly on iOS, using
`serviceWorker.getRegistration().pushManager`.

opw-4391766

Backport of
https://github.com/odoo/odoo/pull/178057
https://github.com/odoo/odoo/pull/187038
https://github.com/odoo/odoo/pull/188258