### PR TITLE
[IMP] project: Link SOLs to project's associated SOs

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -49,7 +49,7 @@ class SaleOrderLine(models.Model):
                     try:
                         project_so = self.env['project.project'].browse(project_id).sale_order_id
                         project_so.check_access('write')
-                        sale_order = project_so
+                        sale_order = project_so or self.env['sale.order'].search([('project_id', '=', project_id)], limit=1)
                     except AccessError:
                         pass
                     if not sale_order:


### PR DESCRIPTION
[IMP] project: Link SOLs to project's associated SOs
Before this commit:
1- create a billable project and do not set an SO/SOL on the project form view
2- link the project to an SO by setting the project field
3- go to dashboard > SOL stat button > create a new SOL
-> a new SO is created

After this commit:
in the absence of an SO on the project, the SOL is added to the SO with the highest
date_order to which the project is linked

task-4462052