### PR TITLE
[FIX] web: Fix Autocomplete active items style

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.scss
+++ b/addons/web/static/src/core/autocomplete/autocomplete.scss
@@ -10,6 +10,15 @@
     }
 
     .ui-menu-item {
+        > a {
+            @include o-hover-text-color($dropdown-link-color, $dropdown-link-hover-color);
+            &.ui-state-active {
+                font-weight: $font-weight-normal;
+                color: $dropdown-link-hover-color;
+                background-color: $dropdown-link-hover-bg;
+            }
+        }
+
         &.o_m2o_dropdown_option, &.o_m2o_start_typing, &.o_m2o_no_result {
             text-indent: $o-dropdown-hpadding * .5;
         }


### PR DESCRIPTION
The active style of the css class `.ui-state-active` was removed in a previous commit and made it impossible to see the active element.

Commit that caused the issue: https://github.com/odoo/odoo/commit/6d77fb2d823688fcdd3085cd15c7a28771e783b6
Task: 4467153

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
