### PR TITLE
[FIX] mass_mailing_crm: make demo data viewable

### DIFF
--- a/addons/mass_mailing_crm/data/mass_mailing_demo.xml
+++ b/addons/mass_mailing_crm/data/mass_mailing_demo.xml
@@ -13,7 +13,7 @@
         <field name="mailing_domain">[]</field>
         <field name="reply_to_mode">new</field>
         <field name="reply_to">{{ object.company_id.email }}</field>
-        <field name="body_html" type="html">
+        <field name="body_arch" type="html">
 <div class="oe_structure o_editable">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 24px; background-color: white; color: #454748; border-collapse:separate;">


### PR DESCRIPTION
The demo data for `mass_mailing_crm` is currently not viewable nor editable before being sent.

Steps to reproduce
-----
1. Open Email Marketing > Select the campaign titled "We want to hear from you !"
2. In the form view, a template picker is displayed instead of the existing contents

Cause
-----
The demo data is using `body_html` instead of `body_arch`, the latter of which is displayed in the form view before the campaign is sent. Since `body_arch = False`, the template picker is displayed instead.

Solution
-----
Use the `body_arch` field instead, `body_html` will be rendered when running the Test or Send actions.

opw-4440786