### PR TITLE
[FIX] point_of_sale: fix load onboarding scenario from company branch

### DIFF
--- a/addons/l10n_be_pos_restaurant/models/template_be.py
+++ b/addons/l10n_be_pos_restaurant/models/template_be.py
@@ -8,6 +8,10 @@ class AccountChartTemplate(models.AbstractModel):
 
     @template('be', 'account.tax')
     def _get_be_pos_restaurant_account_tax(self):
-        pos_taxes = self._parse_csv('be', 'account.tax', module='l10n_be_pos_restaurant')
-        self._deref_account_tags('be_comp', pos_taxes)
-        return pos_taxes
+        be_restaurant_tax = self._parse_csv('be', 'account.tax', module='l10n_be_pos_restaurant')
+        existing_taxes = self.env['account.tax'].search([('company_id', 'child_of', self.env.company.root_id.id)])
+        # Filter out taxes that already exist
+        existing_tax_names = set(existing_taxes.mapped('name'))
+        taxes_to_create = {name: tax for name, tax in be_restaurant_tax.items() if tax['name'] not in existing_tax_names}
+        self._deref_account_tags('be_comp', be_restaurant_tax)
+        return taxes_to_create

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -851,13 +851,23 @@ class PosConfig(models.Model):
     def _create_cash_payment_method(self, cash_journal_vals=None):
         if cash_journal_vals is None:
             cash_journal_vals = {}
-
-        cash_journal = self.env['account.journal'].create({
+        journal_vals = {
             'name': _('Cash'),
             'type': 'cash',
             'company_id': self.env.company.id,
             **cash_journal_vals,
-        })
+        }
+
+        default_cash_account = self.env['account.account'].search([
+            ('account_type', '=', 'asset_cash'),
+            ('name', '=', 'Cash'),
+            ('company_ids', 'in', self.env.company.root_id.id)
+        ], limit=1)
+
+        if default_cash_account:
+            journal_vals['default_account_id'] = default_cash_account.id
+
+        cash_journal = self.env['account.journal'].create(journal_vals)
         return self.env['pos.payment.method'].create({
             'name': _('Cash'),
             'journal_id': cash_journal.id,


### PR DESCRIPTION
- `point_of_sale`: when creating cash payment methods, we now use the default cash account if it exists.
- `l10n_be_pos_restaurant`: filter taxes to create to avoid recreating same tax in sub company

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
