### PR TITLE
[FIX] hw_drivers: wrong foot pedal name

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/KeyboardUSBDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/KeyboardUSBDriver_L.py
@@ -118,10 +118,11 @@ class KeyboardUSBDriver(Driver):
         try:
             manufacturer = util.get_string(self.dev, self.dev.iManufacturer)
             product = util.get_string(self.dev, self.dev.iProduct)
-            return re.sub(r"[^\w \-+/*&]", '', "%s - %s" % (manufacturer, product))
+            if manufacturer and product:
+                return re.sub(r"[^\w \-+/*&]", '', "%s - %s" % (manufacturer, product))
         except ValueError as e:
             _logger.warning(e)
-            return _('Unknown input device')
+        return _('Unknown input device')
 
     def run(self):
         try:


### PR DESCRIPTION
Devices detected through usb don't always have there manufactured and product name which can be retrieved.
For example, our foot pedal in the office doesn't which leads to it having a name `"None - None"` in Odoo.

After this PR if a device doesn't have a product name / manufacturer name it will be saved as `"Unknown input device"`

task-4472585
