### PR TITLE
[FIX] web: hoot: correctly garbage collect between suites

### DIFF
--- a/addons/web/static/tests/_framework/module_set.hoot.js
+++ b/addons/web/static/tests/_framework/module_set.hoot.js
@@ -325,7 +325,7 @@ const runTests = async () => {
         const running = await start(suite);
 
         moduleSetLoader.cleanup();
-        __gcAndLogMemory(suite.fullName, suite.reporting.tests);
+        await __gcAndLogMemory(suite.fullName, suite.reporting.tests);
 
         if (!running) {
             break;
@@ -333,7 +333,7 @@ const runTests = async () => {
     }
 
     await stop();
-    __gcAndLogMemory("tests done");
+    await __gcAndLogMemory("tests done");
 };
 
 /**
@@ -350,7 +350,7 @@ const runTests = async () => {
  * @param {string} label
  * @param {number} [testCount]
  */
-const __gcAndLogMemory = (label, testCount) => {
+const __gcAndLogMemory = async (label, testCount) => {
     if (typeof window.gc !== "function") {
         return;
     }
@@ -363,7 +363,7 @@ const __gcAndLogMemory = (label, testCount) => {
     textarea.remove();
 
     // Run garbage collection
-    window.gc();
+    await window.gc({ type: "major", execution: "async" });
 
     // Log memory usage
     const logs = [


### PR DESCRIPTION
Since [1], we force the garbage collector to run between each hoot test suite. However, since chrome 124, this no longer seemed to produce the desirable effect. Indeed, memory graphs of the test suites were no longer predictable. The garbage collector seemed to work differently from a build to another, even with the same code.

This is probably due to this change [2] in chrome, coming with version 124. Hopefully, the commit message gave us a hint on a way to fix our issue.

[1] https://github.com/odoo/odoo/commit/a3ef39dae4a7cd6c96f14958744ac8d8bd2064c9
[2] https://chromium.googlesource.com/chromium/src/+/ae7269f134ede59c815b22c1fd042b26bab96b7a

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
