### PR TITLE
[FIX] account: skip readonly check on synchronize from moves

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -796,7 +796,7 @@ class AccountBankStatementLine(models.Model):
                     'currency_id': (st_line.foreign_currency_id or journal_currency or company_currency).id,
                 })
 
-            move.write(move._cleanup_write_orm_values(move, move_vals_to_write))
+            move.with_context(skip_readonly_check=True).write(move._cleanup_write_orm_values(move, move_vals_to_write))
             st_line.write(move._cleanup_write_orm_values(st_line, st_line_vals_to_write))
 
     def _synchronize_to_moves(self, changed_fields):


### PR DESCRIPTION
This commit adds a missing skip_readonly_check context from the changes
to add readonly check in https://github.com/odoo/odoo/commit/b5d94f5563641adfd93bf431c139bc2b78d67beb

Steps to reproduce:
- create a statement line
- edit the partner of the liquidity line using the accounting items list
  view
- -> UserError: You cannot modify the following readonly fields on a posted move

opw-4453940