### PR TITLE
[FIX] mrp: fix late MO filter

### DIFF
--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -36,7 +36,7 @@ class StockPickingType(models.Model):
         domains = {
             'count_mo_waiting': [('reservation_state', '=', 'waiting')],
             'count_mo_todo': ['|', ('state', 'in', ('confirmed', 'draft', 'progress', 'to_close')), ('is_planned', '=', True)],
-            'count_mo_late': [('date_planned_start', '<', fields.Date.today()), ('state', '=', 'confirmed')],
+            'count_mo_late': ['|', ('delay_alert_date', '!=', False), '&', ('date_deadline', '<', fields.Date.today()), ('state', '=', 'confirmed')],
         }
         for field in domains:
             data = self.env['mrp.production']._read_group(domains[field] +


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a MO:
     -Product: Select any product to produce
     - Update the Scheduled Date to yesterday
      -> The Scheduled End Date is automatically set to the past.
- Go to the inventory overview:
    - Manufacturing picking type:
        - The "Late MO" button is correctly computed.
        - Click on it.
         -> The “Planning Issues” filter is applied.

Problem:
The MO is not found during the search, so it is not displayed. This occurs because the filter is incorrect: it is based solely on “date_deadlin”e being in the past. However, this field is computed and is only populated when the MO is created from a Reordering Rule (RR), MPS, or MTO. For other cases, we need to rely on “date_planned_finished” being in the past.

https://github.com/odoo/odoo/blob/16.0/addons/mrp/views/mrp_production_views.xml#L546-L547

opw-4453621
