### PR TITLE
[PERF] product: Speed-up `product.template._name_search`

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 
 from odoo import api, fields, models, tools, _, SUPERUSER_ID
 from odoo.exceptions import ValidationError, RedirectWarning, UserError
+from odoo.models import PREFETCH_MAX
 from odoo.osv import expression
 
 _logger = logging.getLogger(__name__)
@@ -505,10 +506,12 @@ class ProductTemplate(models.Model):
         while True:
             domain = templates and [('product_tmpl_id', 'not in', templates.ids)] or []
             args = args if args is not None else []
-            # Product._name_search has default value limit=100
-            # So, we either use that value or override it to None to fetch all products at once
-            kwargs = {} if limit else {'limit': None}
-            products_ids = Product._name_search(name, args+domain, operator=operator, name_get_uid=name_get_uid, **kwargs)
+            # Pathological case: there is no limit, so we'll need to search on all products.
+            # We iteratively _name_search with a larger bound, but not unbounded to avoid
+            # performance regressions or OOM errors while manipulating extremely large list of ids.
+            # For other cases, we use PREFETCH_MAX as an upper bound.
+            search_limit = PREFETCH_MAX * 10 if not limit else PREFETCH_MAX
+            products_ids = Product._name_search(name, args+domain, operator=operator, limit=search_limit, name_get_uid=name_get_uid)
             products = Product.browse(products_ids)
             new_templates = products.mapped('product_tmpl_id')
             if new_templates & templates:


### PR DESCRIPTION
## Description
Following ef90c22efda8a1d56d41eb0739d94733fb574f41, the delegated `_name_search` on `product.product` executed when performing a `name_search` on `product.template` is always unbounded (no limit). For non-selective domains on large databases, this can lead to manipulating extremely large lists of IDs, which are re-injected into other queries, resulting in performance regressions and excessive Postgres memory consumption.

We introduce an upper bound on the delegated `_name_search`. To avoid excessive iterations when there is no limit, the bound is set large enough but not so large that it causes blocking regressions. Each iteration becomes more selective than the previous one, as already found templates are excluded from the search scope.

## Benchmark
On a database with over half-million active products, a non-selective `name_search` that matches 1/3 of the products (For ex: `name='d', args=[('sale_ok', '=', True)]`, which happens during via dropdown of products on a `sale.order`):

|               | Before           | After |
|---------------|------------------|-------|
| Timings (hot) | 15min+ (timeout) | 50ms  |

## Reference
opw-4448182

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
