### PR TITLE
[FIX] portal: view chatter messages with partner reactions

### DIFF
--- a/addons/portal/models/mail_message.py
+++ b/addons/portal/models/mail_message.py
@@ -120,8 +120,9 @@ class MailMessage(models.Model):
                                         for guest in reactions.guest_id
                                     ]
                                     + [
+                                        # sudo: res.partner - reading partners of reaction on accessible message is allowed
                                         {"id": partner.id, "name": partner.name, "type": "partner"}
-                                        for partner in reactions.partner_id
+                                        for partner in reactions.partner_id.sudo()
                                     ],
                         "message": message.id,
                     }

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -206,3 +206,14 @@ registry.category("web_tour.tours").add("portal_project_sharing_tour_with_disall
         },
     ],
 });
+
+registry.category("web_tour.tours").add("test_04_project_sharing_chatter_message_reactions", {
+    url: "/my/projects",
+    steps: () => [
+        { trigger: "table > tbody > tr a:has(span:contains(Project Sharing))", run: "click" },
+        { trigger: ":iframe .o_project_sharing" },
+        { trigger: ":iframe .o_kanban_record:contains('Test Task with messages')", run: "click" },
+        { trigger: ":iframe .o-mail-Message" },
+        { trigger: ":iframe .o-mail-Message .o-mail-MessageReaction:contains('👀')" },
+    ],
+});


### PR DESCRIPTION
Before this commit, when accessing a shared chatter from a portal user that has edit access, chatter messages could not be loaded when a partner added at least one emoji reaction on a message.

Steps to reproduce:
- Share a project with Joel Willis with edit access
- Create a task with Joel Willis on this project
- Post a message as Joel Willis on the new task
- Let Mitchell Admin add a reaction on the new message

=> Joel Willis cannot load messages:

```
An error occurred while fetching messages.
```

This happens because the custom mail message formatter of portal chatter messages was crafting the reaction data of the messages to return. When providing people that have reacted to the message, Access to reacted partners was denied due to ACL.

This commit fixes the issue by sudo() the partners of message reaction to retrieve their data to the portal user. This is ok because the portal has access to the message, therefore access to the reaction and related data are fine. Note that data of partner that have reacted is very limited: only the name is returned.

opw-4454427
