### PR TITLE
[FIX] hr_recruitment: include inactive applications in the application count of the candidate

### DIFF
--- a/addons/hr_recruitment/models/hr_candidate.py
+++ b/addons/hr_recruitment/models/hr_candidate.py
@@ -185,7 +185,7 @@ class HrCandidate(models.Model):
             candidate.attachment_count = attach_data.get(candidate.id, 0)
 
     def _compute_application_count(self):
-        read_group_res = self.env['hr.applicant']._read_group(
+        read_group_res = self.env['hr.applicant'].with_context(active_test=False)._read_group(
             [('candidate_id', 'in', self.ids)],
             ['candidate_id'], ['__count'])
         application_data = dict(read_group_res)

--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -186,3 +186,18 @@ class TestRecruitment(TransactionCase):
         application3 = self.env['hr.applicant'].create({'candidate_id': candidate.id})
         res = application1.action_open_other_applications()
         self.assertEqual(len(res['domain'][0][2]), 3, "The list view should display 3 applications")
+
+    def test_candidate_application_count(self):
+        """
+            The computed field 'application_count' on the hr.candidate model should return the
+            number of all active and inactive applications linked to the candidate.
+        """
+        candidate = self.env['hr.candidate'].create({'partner_name': 'Test'})
+        application1, application2 = self.env['hr.applicant'].create([
+            {'candidate_id': candidate.id},
+            {'candidate_id': candidate.id}
+        ])
+        self.assertEqual(candidate.application_count, 2, "The application_count should return 2 applications")
+        application2.action_archive()
+        self.env.invalidate_all()
+        self.assertEqual(candidate.application_count, 2, 'The applications_count should not change after archiving an application')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On the candidate form view, the "Applications" smart button doesn't show the correct count. It counts only active applications.

Desired behavior after PR is merged:
On the candidate form view,  show the correct count on the "Applications" smart button including both active and refused applications.

task-4473067

**Forward port:** 18.0 -> 18.1
Candidate was removed in 18.2

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
