### PR TITLE
[FIX] sale_timesheet: Allow users without Sales access to record time

### DIFF
--- a/addons/sale_timesheet/models/hr_timesheet.py
+++ b/addons/sale_timesheet/models/hr_timesheet.py
@@ -213,7 +213,7 @@ class AccountAnalyticLine(models.Model):
 
     def _timesheet_preprocess_get_accounts(self, vals):
         so_line = self.env['sale.order.line'].browse(vals.get('so_line'))
-        if not (so_line and (distribution := so_line.analytic_distribution)):
+        if not (so_line and (distribution := so_line.sudo().analytic_distribution)):
             return super()._timesheet_preprocess_get_accounts(vals)
 
         company = self.env['res.company'].browse(vals.get('company_id'))

--- a/addons/sale_timesheet/tests/common.py
+++ b/addons/sale_timesheet/tests/common.py
@@ -32,6 +32,16 @@ class TestCommonSaleTimesheet(TestSaleProjectCommon):
             company_id=cls.company_data_2['company'].id,
             company_ids=[cls.company_data_2['company'].id, cls.env.company.id],
         )
+        # What's important here is that this user does not have access to read Sales data,
+        # but can still log time on a timesheet.
+        cls.user_employee_without_sales_access = mail_new_test_user(
+            cls.env,
+            name='Tyrion Lannister Employee',
+            login='tyrion',
+            email='tyrion@example.com',
+            notification_type='email',
+            groups='project.group_project_manager,hr_timesheet.group_hr_timesheet_user',
+        )
 
         cls.employee_user = cls.env['hr.employee'].create({
             'name': 'Employee User',
@@ -52,6 +62,12 @@ class TestCommonSaleTimesheet(TestSaleProjectCommon):
             'name': 'Cersei Lannister',
             'user_id': cls.user_manager_company_B.id,
             'hourly_cost': 45,
+        })
+        
+        cls.employee_without_sales_access = cls.env['hr.employee'].create({
+            'name': 'Tyrion Lannister',
+            'user_id': cls.user_employee_without_sales_access.id,
+            'hourly_cost': 25,
         })
 
         # Account and project


### PR DESCRIPTION
This PR addresses the issue of users without Sales access not being able to record on time on timesheets that are linked to a sale order line.

If a user with access to Projects and Timesheets, but not Sales, wants to record time on a timesheet linked to a sales order, they will get an access rights error. This is because we check to see if there is an analytic distribution associated with the sale order line associated with the project task. However, this check is done without `sudo()` access in its current state. This PR provides that access because the result is not propagated further than simply evaluating whether or not there is an analytic distribution at all.

The result is that this workflow is no longer blocking for users who should be able to timesheet, but not necessarily view or edit the sale order.

This can be tested on Runbot by following these steps:

Configuration:
- User A does not have any Sales access, but has full rights to Projects and Timesheets
- Have a service product that creates a task in a project
- Have a sale order made for this product by User B, who does have Sales access

Now, 
1) On User A, navigate to the associated project and task made by the sale order from earlier
2) Click on the Timesheets tab in the notebook part of the view
3) Attempt to record an hour of work by adding a line to the timesheet, then clicking the "save" button

Prior to this PR, the user will get an access rights error. Once this is merged, that error will no longer appear. 

opw-4409571
