### PR TITLE
[IMP] l10n_ar_withholding: better demo data

### DIFF
--- a/addons/l10n_ar_withholding/demo/account_demo.py
+++ b/addons/l10n_ar_withholding/demo/account_demo.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from odoo import models
+import re
 
 
 class AccountChartTemplate(models.AbstractModel):
@@ -32,5 +33,7 @@ class AccountChartTemplate(models.AbstractModel):
             self.env['l10n_ar.partner.tax'].create({'tax_id': arba_wth_applied.id, 'partner_id': self.env.ref('l10n_ar.res_partner_mipyme').id, 'company_id': company.id})
 
             # Because in demo we want to skip the config, while in data we want to require them to configure
-            self.env['account.tax'].search([('l10n_ar_withholding_payment_type', '!=', False), ('l10n_ar_tax_type', 'in', ('iibb_untaxed', 'iibb_total'))]).copy(default={'amount_type': 'percent', 'amount': 1})
+            for tax in self.env['account.tax'].search([('l10n_ar_withholding_payment_type', '!=', False), ('l10n_ar_tax_type', 'in', ('iibb_untaxed', 'iibb_total'))]):
+                name = re.sub(r'\b\d+(\.\d+)?\s*%', '1%', tax.name)
+                tax.copy(default={'amount_type': 'percent', 'amount': 1, 'name': name})
         return result

--- a/addons/l10n_ar_withholding/models/account_tax.py
+++ b/addons/l10n_ar_withholding/models/account_tax.py
@@ -33,7 +33,7 @@ class AccountTax(models.Model):
     l10n_ar_withholding_sequence_id = fields.Many2one(
         'ir.sequence',
         string='WTH Sequence',
-        copy=False, check_company=True,
+        check_company=True,
         help='If no sequence provided then it will be required for you to enter withholding number when registering one.')
     l10n_ar_code = fields.Char('AFIP Code')
     l10n_ar_non_taxable_amount = fields.Float(


### PR DESCRIPTION
### FIX 1: copy withholding sequence when duplicating a tax
Usually, when a user duplicate a tax, is to create a new one from the same type with a different rate.
On this use case the sequence should be copied as well.
Before this commit withholding sequence field was not copied

### FIX 2: better demo data
Before this commit demo taxes being copied has name on their names.
![image](https://github.com/user-attachments/assets/89fb28ba-b753-41a7-a713-0020c17ed7a0)


After this commit taxes names relects what users are supposed to do.
![image](https://github.com/user-attachments/assets/b6ffef7a-fbd0-480a-b7ff-da12f9f5ee34)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
