### PR TITLE
[FIX] stock: Fix calculation of Demand value in stock move

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -311,7 +311,11 @@ class StockRule(models.Model):
             picking_description += values['product_description_variants']
         # it is possible that we've already got some move done, so check for the done qty and create
         # a new move with the correct qty
-        qty_left = product_qty
+        if product_id.uom_id == product_id.uom_po_id:
+            qty_left = product_qty
+        else:
+            uom_po_qty = product_uom._compute_quantity(product_qty, product_id.uom_po_id, rounding_method='HALF-UP')
+            qty_left = uom_po_qty * product_id.uom_po_id.ratio
 
         move_dest_ids = []
         if not self.location_dest_id.should_bypass_reservation():


### PR DESCRIPTION

Steps to Reproduce:
---------------------

1. Open Inventory and create a storable product (e.g., test) and assign a vendor to it.
2. Create a Unit of Measure (UOM) with a ratio of 150, select the type to `bigger`,
and categorize it under Unit (e.g., name it KG_150).
3. Set the product's UOM to Unit and Purchase UOM to KG_150.
4. Enable Multi-Step Routes and set incoming shipments to two_steps.
5. Click on button `Replenish`
6. Assign a quantity of 100 and confirm.

Issue:
--------
A Purchase Order (PO) and a Transfers(stock.picking) record with the status
`Waiting for another operation` will be created. However, when the product UOM
and Purchase UOM differ, then the Demand (product_uom_qty) value in the
stock move is incorrectly set to 100 instead of 100.5.

Solution:
----------
We need to consider `product_qty` from purchase order line and Purchase UOM ratio
in order to resolve the issue.

opw-4429992

Description of the issue/feature this PR addresses:

<details>
    <summary>Click here to see - Current behavior before PR and Desired behavior after PR is merged:</summary>
    <b>Current behavior before PR </b><hr/>
    <img src="https://github.com/user-attachments/assets/55263397-6cc7-41c3-8825-0c00f8d515b8"/>
    <img src="https://github.com/user-attachments/assets/62cf2e26-c4a7-4a72-b814-e6a448ed9d08"/>
    <img src="https://github.com/user-attachments/assets/e5c2ea46-7b93-451e-9ab1-fd356e1d5c1a"/>
    <b>Desired behavior after PR is merged:</b><hr/>
    <img src="https://github.com/user-attachments/assets/b84788bf-c1cb-42a4-b381-66c85db8c09d">
    <img src="https://github.com/user-attachments/assets/f4fb0802-08f2-4413-a435-bdb58184c098"/>
</details>




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
