### PR TITLE
[FIX] mrp_subcontracting: remove duplicate detailed operation button

### DIFF
--- a/addons/mrp_subcontracting/views/stock_picking_views.xml
+++ b/addons/mrp_subcontracting/views/stock_picking_views.xml
@@ -10,14 +10,10 @@
                 <button name="action_record_components" class="oe_highlight" invisible="display_action_record_components != 'mandatory'" string="Record components" type="object" data-hotkey="shift+x"/>
                 <button name="action_record_components" invisible="display_action_record_components != 'facultative'" string="Record components" type="object" data-hotkey="shift+x"/>
             </xpath>
-            <xpath expr="//field[@name='move_ids_without_package']//list//button[@name='action_show_details']" position="after">
+            <xpath expr="//field[@name='move_ids_without_package']//list//button[@name='action_show_details']" position="before">
                 <field name="show_subcontracting_details_visible" column_invisible="True"/>
-                <button name="action_show_subcontract_details" string="Subcontracting" type="object" icon="fa-pencil"
+                <button name="action_show_subcontract_details" string="Subcontracting" type="object" icon="fa-pencil" width="0.1"
                     invisible="not show_subcontracting_details_visible"/>
-            </xpath>
-            <xpath expr="//field[@name='move_ids_without_package']//list" position="inside">
-                <field name="is_subcontract" column_invisible="True"/>
-                <button name="action_show_details" invisible="not is_subcontract" type="object" icon="fa-list" width="0.1" title="Details"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Issue:
===========
Currently, the 'Detailed Operation' button appears twice on each product move for subcontracting receipts.

Steps to Reproduce:
===========================
1. Create a Bill of Materials (BOM) with the type set to 'Subcontracting'.
2. Create a Purchase Order (PO) for the product associated with the BOM.
3. Navigate to the receipt for that PO.
4. Observe that the 'Detailed Operation' button appears twice for each move.

With this commit:
=====================

A duplicate detailed operation button was displayed in each product
move for subcontracting receipts due to code duplication,
leading to redundancy and confusion. This fix removes the
extra button to ensure a clear and intuitive UI.

task-4467313
