### PR TITLE
[FIX] web: tests: decrease test_unit_desktop suite timeout

### DIFF
--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -36,7 +36,7 @@ class WebSuite(odoo.tests.HttpCase):
     @odoo.tests.no_retry
     def test_unit_desktop(self):
         # Unit tests suite (desktop)
-        self.browser_js('/web/tests?headless&loglevel=2&preset=desktop&timeout=15000', "", "", login='admin', timeout=2000, success_signal="[HOOT] test suite succeeded", error_checker=unit_test_error_checker)
+        self.browser_js('/web/tests?headless&loglevel=2&preset=desktop&timeout=15000', "", "", login='admin', timeout=1800, success_signal="[HOOT] test suite succeeded", error_checker=unit_test_error_checker)
 
     @odoo.tests.no_retry
     def test_hoot(self):


### PR DESCRIPTION
This timeout has been recently increased [1] because builds sometimes reached it. It was indicating that something was wrong, but until we figured it out, the correct thing to do was to increase it.

PR [2] just fixed the underlying issue, which was coming from the update to from chrome 123 to chrome 126 on runbots. Indeed, as of chrome 124, the instruction to force a garbage collect after each test had to be slightly adapted.

Now that this is done, this suite generally lasts 20-22 minutes, so we can safely decrease the timeout to 30 minutes, which allows us to kill the test earlier when something's wrong, and which will indicate regressions (like memory leaks) faster.

[1] odoo/odoo#191456
[2] odoo/odoo#193332

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
