### PR TITLE
[IMP] core: TransactionCase.enter_test_mode context

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -725,21 +725,6 @@ class AccountTestInvoicingCommon(ProductCommon):
         '''
         return etree.fromstring(xml_tree_str)
 
-    @contextmanager
-    def enter_test_mode(self):
-        """
-        Make so that all new cursors opened on this database registry
-        reuse the one currently used by the test.
-
-        Useful for printing PDFs inside a TransactionCase test when
-        using a HttpCase is not possible/desirable.
-        """
-        self.env.registry.enter_test_mode(self.env.cr)
-        try:
-            yield
-        finally:
-            self.env.registry.leave_test_mode()
-
 
 class AccountTestMockOnlineSyncCommon(HttpCase):
     def start_tour(self, url_path, tour_name, step_delay=None, **kwargs):

--- a/addons/website/tests/test_res_users.py
+++ b/addons/website/tests/test_res_users.py
@@ -51,22 +51,21 @@ class TestWebsiteResUsers(TransactionCase):
 
     def test_same_website_message(self):
         # Use a test cursor because retrying() does commit.
-        self.env.registry.enter_test_mode(self.env.cr)
-        self.addCleanup(self.env.registry.leave_test_mode)
-        env = self.env(context={'lang': 'en_US'}, cr=self.env.registry.cursor())
+        with self.enter_registry_test_mode():
+            env = self.env(context={'lang': 'en_US'}, cr=self.env.registry.cursor())
 
-        def create_user_pou():
-            return new_test_user(env, login='Pou', website_id=self.website_1.id, groups='base.group_portal')
+            def create_user_pou():
+                return new_test_user(env, login='Pou', website_id=self.website_1.id, groups='base.group_portal')
 
-        # First user creation works.
-        create_user_pou()
+            # First user creation works.
+            create_user_pou()
 
-        # Second user creation fails with ValidationError instead of
-        # IntegrityError. Do not use self.assertRaises as it would try
-        # to create and rollback to a savepoint that is removed by the
-        # rollback in retrying().
-        with TestCase.assertRaises(self, ValidationError), mute_logger('odoo.sql_db'):
-            retrying(create_user_pou, env)
+            # Second user creation fails with ValidationError instead of
+            # IntegrityError. Do not use self.assertRaises as it would try
+            # to create and rollback to a savepoint that is removed by the
+            # rollback in retrying().
+            with TestCase.assertRaises(self, ValidationError), mute_logger('odoo.sql_db'):
+                retrying(create_user_pou, env)
 
     def _create_user_via_website(self, website, login):
         # We need a fake request to _signup_create_user.


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Sometimes it is needed to `enter_test_mode` just for a block of code. We add a simple context handler for that case.

Current behavior before PR:
Manual entering and registering a handler to leave test mode each time.

Desired behavior after PR is merged:
Context manager for test mode.
If all tests need it, we can still use the old method.

odoo/enterprise#77004



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
