### PR TITLE
[FIX] hr_holidays: remove unnecessary code

### DIFF
--- a/addons/hr_holidays/static/src/persona_model_patch.js
+++ b/addons/hr_holidays/static/src/persona_model_patch.js
@@ -1,7 +1,6 @@
 import { Persona } from "@mail/core/common/persona_model";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
-import { user } from "@web/core/user";
 import { patch } from "@web/core/utils/patch";
 
 const { DateTime } = luxon;
@@ -23,19 +22,8 @@ patch(Persona.prototype, {
         if (!this.out_of_office_date_end) {
             return "";
         }
-        const currentDate = new Date();
         const date = deserializeDateTime(this.out_of_office_date_end);
-        // const options = { day: "numeric", month: "short" };
-        if (currentDate.getFullYear() !== date.year) {
-            // options.year = "numeric";
-        }
-        let localeCode = user.lang.replace(/_/g, "-");
-        if (localeCode === "sr@latin") {
-            localeCode = "sr-Latn-RS";
-        }
-        // const fdate = date.toLocaleString(DateTime.TIME_SHORT);
         const fdate = date.toLocaleString(DateTime.DATE_MED);
-        // const formattedDate = date.toLocaleDateString(localeCode, options);
         return _t("Out of office until %s", fdate);
     },
 });


### PR DESCRIPTION
Clean up `get outOfOfficeText` method by removing unused code and redundant conditions.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
