### PR TITLE
[IMP] account: allow only file drop

### DIFF
--- a/addons/account/static/src/components/bills_upload/bills_upload.js
+++ b/addons/account/static/src/components/bills_upload/bills_upload.js
@@ -209,6 +209,12 @@ export class AccountMoveUploadListRenderer extends ListRenderer {
         super.setup();
         this.dropzoneState = useState({ visible: false });
     }
+
+    onDragStart(ev) {
+        if (ev.dataTransfer.types.includes("Files")) {
+            this.dropzoneState.visible = true;
+        }
+    }
 }
 
 export class AccountMoveListController extends ListController {
@@ -250,6 +256,12 @@ export class AccountMoveUploadKanbanRenderer extends KanbanRenderer {
         this.dropzoneState = useState({
             visible: false,
         });
+    }
+
+    onDragStart(ev) {
+        if (ev.dataTransfer.types.includes("Files")) {
+            this.dropzoneState.visible = true;
+        }
     }
 }
 
@@ -312,6 +324,12 @@ export class DashboardKanbanRecord extends KanbanRecord {
             hideZone: () => { this.dropzoneState.visible = false; },
         }
     }
+
+    onDragStart(ev) {
+        if (ev.dataTransfer.types.includes("Files")) {
+            this.dropzoneState.visible = true;
+        }
+    }
 }
 
 export class DashboardKanbanRenderer extends KanbanRenderer {
@@ -328,12 +346,17 @@ export class DashboardKanbanRenderer extends KanbanRenderer {
         });
     }
     kanbanDragEnter(e) {
-        this.env.dashboardState.isDragging = true;
+        if (e.dataTransfer.types.includes("Files")) {
+            this.env.dashboardState.isDragging = true;
+        } else {
+            this.disableDragging();
+        }
     }
     kanbanDragLeave(e) {
         const mouseX = e.clientX, mouseY = e.clientY;
         const {x, y, width, height} = this.rootRef.el.getBoundingClientRect();
-        if (!(mouseX > x && mouseX <= x + width && mouseY > y && mouseY <= y + height)) {
+        const mouseInsideKanbanRenderer = mouseX > x && mouseX <= x + width && mouseY > y && mouseY <= y + height;
+        if (!mouseInsideKanbanRenderer || !e.dataTransfer.types.includes("Files")) {
             // if the mouse position is outside the kanban renderer, all cards should hide their dropzones.
             this.disableDragging();
         } else {

--- a/addons/account/static/src/components/bills_upload/bills_upload.xml
+++ b/addons/account/static/src/components/bills_upload/bills_upload.xml
@@ -50,7 +50,7 @@
                 hideZone="() => dropzoneState.visible = false"/>
         </xpath>
         <xpath expr="//div[@t-ref='root']" position="attributes">
-            <attribute name="t-on-dragenter.stop.prevent">() => dropzoneState.visible = true</attribute>
+            <attribute name="t-on-dragenter.stop.prevent">onDragStart</attribute>
         </xpath>
         <t t-call="web.ActionHelper" position="replace">
             <t t-if="showNoContentHelper">
@@ -130,7 +130,7 @@
                 hideZone="() => dropzoneState.visible = false"/>
         </xpath>
         <xpath expr="//div[@t-ref='root']" position="attributes">
-            <attribute name="t-on-dragenter.stop.prevent">() => dropzoneState.visible = true</attribute>
+            <attribute name="t-on-dragenter.stop.prevent">onDragStart</attribute>
         </xpath>
     </t>
 
@@ -173,7 +173,7 @@
             t-att-data-id="props.canResequence and props.record.id"
             t-att-tabindex="props.record.model.useSampleModel ? -1 : 0"
             t-on-click="onGlobalClick"
-            t-on-dragenter.stop.prevent="() => dropzoneState.visible = true"
+            t-on-dragenter.stop.prevent="onDragStart"
             t-ref="root">
             <AccountFileUploader t-if="allowDrop" record="props.record">
                 <t t-set-slot="default">


### PR DESCRIPTION
This commit change a bit the behaviour of drag & drop feature in multiple account view. The main goal is to avoid users to drag and drop text in files drop zones. So now, if a user is dragging a text, we hide the files drop zones.

Linked:https://github.com/odoo/enterprise/pull/76565

opw-4366605