### PR TITLE
[FIX] pos_self_order: corrected price calculation for combo product lines

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -81,7 +81,7 @@ class PosSelfOrderController(http.Controller):
 
                 for i, pos_order_line in enumerate(line.combo_line_ids):
                     child_product = pos_order_line.product_id
-                    price_unit = float_round(pos_order_line.combo_id.base_price * factor, precision_digits=sale_price_digits)
+                    price_unit = float_round(pos_order_line.combo_line_id.combo_id.base_price * factor, precision_digits=sale_price_digits)
                     remaining_total -= price_unit
 
                     if i == len(line.combo_line_ids) - 1:


### PR DESCRIPTION
Issue:
=======
Combo product lines in the POS frontend displayed incorrect prices when order from self Order

Cause:
=======
The `price_unit` was being calculated without considering the `combo_line_id`. For example:
price_unit += pos_order_line.combo_price + price_extra_child`

Fix:
=====
The `combo_line_id` was included in the calculation to ensure accuracy: price_unit += pos_order_line.`combo_line_id`.combo_price + price_extra_child

Task-4464002


