### PR TITLE
[FIX] website_sale_collect: add check on delivery radio existing

### DIFF
--- a/addons/website_sale_collect/static/src/js/checkout.js
+++ b/addons/website_sale_collect/static/src/js/checkout.js
@@ -46,6 +46,10 @@ publicWidget.registry.WebsiteSaleCheckout.include({
      * @override method from `@website_sale/js/checkout`
      */
     _canEnableMainButton() {
+        if (this.dmRadios.length === 0) {  // If there are no delivery methods.
+            return this._super.apply(this, arguments);  // Skip override.
+        }
+        // TODO: move logic below to `_isDeliveryMethodReady` override on master
         const checkedRadio = this.el.querySelector('input[name="o_delivery_radio"]:checked');
         const deliveryContainer = this._getDeliveryMethodContainer(checkedRadio);
         const hasWarning = (


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Go to eCommerce;
2. add only services to cart;
3. go to checkout;
4. on payment page, go back to Delivery page;
5. add a second address if needed;
6. change selected address.

Issue
-----
> Uncaught Promise > Cannot read properties of null

Cause
-----
The query selector in `_canEnabledMainButton` assumes a radio input is always present on this step, but this is only the case when deliverable products were added to the cart.

Solution
--------
Skip the remainder of the method if the delivery radio wasn't found.

opw-4365246
opw-4422905