### PR TITLE
[FIX] project: Use company id data not company record

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -774,7 +774,7 @@ class Task(models.Model):
             if project.analytic_account_id:
                 vals['analytic_account_id'] = project.analytic_account_id.id
             if 'company_id' in default_fields and 'default_project_id' not in self.env.context:
-                vals['company_id'] = project.sudo().company_id
+                vals['company_id'] = project.sudo().company_id.id
         elif 'default_user_ids' not in self.env.context and 'user_ids' in default_fields:
             user_ids = vals.get('user_ids', [])
             user_ids.append(Command.link(self.env.user.id))


### PR DESCRIPTION
Steps:
- Install project_todo
- Create a second company
- Create a project
- Link the project to a company
- Setup a default value for task.project_id with your new project (1)
- Try to open project_todo

Actual result:
- Error due to company id
- can't adapt type 'res.company'

Expected result:
- No error
- Welcome task is created and project is opened

opw-4465277

Caused by https://github.com/odoo/odoo/pull/173625