### PR TITLE
[FIX] purchase: Prevent chatter logs for insignificant changes to Untaxed Amount

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -39,7 +39,8 @@ class PurchaseOrder(models.Model):
                 amount_untaxed = sum(order_lines.mapped('price_subtotal'))
                 amount_tax = sum(order_lines.mapped('price_tax'))
 
-            order.amount_untaxed = amount_untaxed
+            if order.currency_id.compare_amounts(order.amount_untaxed, amount_untaxed):
+                order.amount_untaxed = amount_untaxed
             order.amount_tax = amount_tax
             order.amount_total = order.amount_untaxed + order.amount_tax
 


### PR DESCRIPTION
The `amount_untaxed` field, which is tracked,
encounters floating-point precision issues during recomputation. When a value like `261,462.02` is assigned,
the field may become 261,`462.0200000002` due to floating-point imprecision. Although the value is stored correctly in the database (as `261,462.02`), the tracked change is logged in the chatter, causing unnecessary noise.

I couldn’t identify a clear or universal solution to this issue due to the inherent nature of floating-point arithmetic and its limitations. So what I did is checking if the new value is different than the old one then update the field.

Steps to reproduce:
1. Create a PO
2. Add a product with price 261,462.02
3. Save
4. Change the expected arrival date
5. Save See the chatter.
take a loot at the chatter.
![image](https://github.com/user-attachments/assets/a19ce09a-f02a-45a7-a02a-d044a4c1cc40)

opw-4315116



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
