### PR TITLE
[IMP] mail: better call context menu

### DIFF
--- a/addons/mail/static/src/core/common/user_settings_service.js
+++ b/addons/mail/static/src/core/common/user_settings_service.js
@@ -78,9 +78,9 @@ export class UserSettings {
 
     getVolume(rtcSession) {
         return (
-            rtcSession.volume ||
-            this.partnerVolumes.get(rtcSession.partnerId) ||
-            this.guestVolumes.get(rtcSession.guestId) ||
+            rtcSession.volume ??
+            this.partnerVolumes.get(rtcSession.partnerId) ??
+            this.guestVolumes.get(rtcSession.guestId) ??
             0.5
         );
     }

--- a/addons/mail/static/src/discuss/call/common/call_context_menu.dark.scss
+++ b/addons/mail/static/src/discuss/call/common/call_context_menu.dark.scss
@@ -1,0 +1,8 @@
+.popover .form-range {
+    &::-moz-range-track {
+        background: darken($popover-bg, 10%);
+    }
+    &::-webkit-slider-runnable-track {
+        background: darken($popover-bg, 10%);
+    }
+}

--- a/addons/mail/static/src/discuss/call/common/call_context_menu.js
+++ b/addons/mail/static/src/discuss/call/common/call_context_menu.js
@@ -24,6 +24,7 @@ export class CallContextMenu extends Component {
             downloadStats: {},
             uploadStats: {},
             producerStats: {},
+            rangeVolume: this.volume,
         });
         onMounted(() => {
             if (!this.env.debug) {

--- a/addons/mail/static/src/discuss/call/common/call_context_menu.scss
+++ b/addons/mail/static/src/discuss/call/common/call_context_menu.scss
@@ -1,0 +1,35 @@
+.volume-tooltip {
+    /* Visibility */
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 0s, opacity 0.2s ease-out;
+    
+    /* Positioning */
+    position: absolute;
+    bottom: 150%;
+    left: calc(var(--progress) - 0.13 * (var(--progress)));
+    transform: translateX(calc(-50% + 8px));
+    z-index: 1;
+
+    /* Appearance */
+    background-color: #212529;
+    color: #F9FAFB;
+    padding: 4px 10px;
+    border-radius: 8px;
+    
+    &::after {
+        content: "";
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        border-width: 6px;
+        border-style: solid;
+        border-color: #212529 transparent transparent transparent;
+    }
+}
+
+.form-range:hover + .volume-tooltip {
+    visibility: visible;
+    opacity: 1;
+}

--- a/addons/mail/static/src/discuss/call/common/call_context_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_context_menu.xml
@@ -2,7 +2,13 @@
 <templates xml:space="preserve">
     <t t-name="discuss.CallContextMenu">
         <div class="d-flex flex-column p-3">
-            <input t-if="!isSelf" type="range" min="0.0" max="1" step="0.01" t-att-value="volume" t-on-change="onChangeVolume" class="form-range"/>
+            <div t-if="!isSelf" class="d-flex flex-row gap-2 align-items-center">
+                <i class="fa fa-lg fa-volume-up"/>
+                <div class="position-relative">
+                    <input type="range" min="0.0" max="1" step="0.01" class="form-range h-auto" t-att-value="volume" t-model="state.rangeVolume" t-on-change="onChangeVolume"/>
+                    <output t-esc="`${Math.round(state.rangeVolume * 200)}%`" class="volume-tooltip fw-bold" t-attf-style="--progress:{{state.rangeVolume * 100}}%;"/>
+                </div>
+            </div>
             <t t-if="env.debug and !isSelf and rtc.state.connectionType === rtcConnectionTypes.P2P">
                 <hr class="w-100 border-top"/>
                 <div><span class="fw-bolder">Connection type: </span><t t-out="rtc.state.connectionType"/></div>

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.scss
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.scss
@@ -85,3 +85,10 @@
         background-color: $o-gray-800;
     }
 }
+
+.o-discuss-CallParticipantCard-contextButton {
+    width: 30px;
+    height: 30px;
+    left: 90%;
+    top: 70%;
+}

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -31,6 +31,7 @@
                         draggable="false"
                 />
             </div>
+            <button t-if="rootHover.isHover and isContextMenuAvailable and props.minimized" t-on-click="onContextMenu" class="btn btn-secondary btn-sm rounded-circle position-absolute translate-middle o-discuss-CallParticipantCard-contextButton"><i class="fa fa-chevron-down" /></button>
             <t t-if="rtcSession">
                 <!-- overlay -->
                 <span class="o-discuss-CallParticipantCard-overlay o-discuss-CallParticipantCard-overlayBottom z-index-1 position-absolute bottom-0 start-0 d-flex overflow-hidden">


### PR DESCRIPTION
This commit fixes various issues with the context menu on the call participant:
- Before this commit it wasn't possible to set the volume of a user to 0 due to the use of the `||` operator in the `getVolume` function. This commit fixes the issue by using the correct `??` operator.
- Before this commit the volume slider in dark mode had the same background as the popover menu, making it difficult to see. This commit fixes the issue by making the slider darker than the background.
- A volume icon was added to better indicate the slider purpose.
- A volume percentage tooltip was added for more accurate use.
- A chevron button was added to the minimized participant card for better discoverability of the context menu.

Before:
![image (3)](https://github.com/user-attachments/assets/fc56e89a-3524-4476-94b4-59595d69a640)

After:
![Pasted image 20250113113653](https://github.com/user-attachments/assets/50f439cc-93c7-45e9-a9a5-54db69c987f6)

task-4467222
