### PR TITLE
[FIX] mail: exit full screen on discuss call leave

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_action_list.js
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.js
@@ -49,6 +49,6 @@ export class CallActionList extends Component {
      * @param {MouseEvent} ev
      */
     async onClickToggleAudioCall(ev, { camera = false } = {}) {
-        await this.rtc.toggleCall(this.props.thread, { camera });
+        await this.rtc.toggleCall(this.props.thread, { camera, fullscreen: this.props.fullscreen });
     }
 }

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -457,9 +457,11 @@ export class Rtc extends Record {
      * @param {import("models").Thread} channel
      * @param {Object} [initialState={}]
      * @param {boolean} [initialState.audio]
+     * @param {{ exit: () => {} }} [initialState.fullscreen] if set, the call view is using fullscreen.
+     *   Providing fullscreen object allows to exit on call leave.
      * @param {boolean} [initialState.camera]
      */
-    async toggleCall(channel, { audio = true, camera } = {}) {
+    async toggleCall(channel, { audio = true, fullscreen, camera } = {}) {
         await Promise.resolve(() =>
             loadJS(url("/mail/static/lib/selfie_segmentation/selfie_segmentation.js")).catch(
                 () => {}
@@ -470,6 +472,7 @@ export class Rtc extends Record {
         }
         const isActiveCall = channel.eq(this.state.channel);
         if (this.state.channel) {
+            fullscreen?.exit();
             await this.leaveCall(this.state.channel);
         }
         if (!isActiveCall) {


### PR DESCRIPTION
Before this commit, leaving call while the call view is full screen would keep the fullscreen mode.

This commit fixes the issue by exiting the full screen when leaving the call.

Task-4476568