### PR TITLE
[FIX] l10_ch: make Swiss QRcode on invoice depend on the QRcode setting

### DIFF
--- a/addons/l10n_ch/models/account_invoice.py
+++ b/addons/l10n_ch/models/account_invoice.py
@@ -40,8 +40,11 @@ class AccountMove(models.Model):
     @api.depends('partner_id', 'currency_id')
     def _compute_l10n_ch_qr_is_valid(self):
         for move in self:
-            move.l10n_ch_is_qr_valid = move.move_type == 'out_invoice' \
-                                       and move.partner_bank_id._eligible_for_qr_code('ch_qr', move.partner_id, move.currency_id, raises_error=False)
+            move.l10n_ch_is_qr_valid = (
+                move.move_type == 'out_invoice'
+                and move.partner_bank_id._eligible_for_qr_code('ch_qr', move.partner_id, move.currency_id, raises_error=False)
+                and move.company_id.qr_code
+            )
 
     @api.depends('partner_bank_id.l10n_ch_isr_subscription_eur', 'partner_bank_id.l10n_ch_isr_subscription_chf')
     def _compute_l10n_ch_isr_subscription(self):


### PR DESCRIPTION
### Steps to reproduce:
- Install "l10n_ch" and switch to a Swiss company
- Create an invoice for a Swiss partner
- Send it
- The QR code appears in the generated PDF

### Cause:
The settings are not checked to display the QR code.

### Solution:
Check the settings.

Ticket link: https://www.odoo.com/odoo/69/tasks/4380520
opw-4380520