### PR TITLE
[IMP] l10n_es_edi_tbai: allow setting reversed invoices in outgoing refunds

### DIFF
--- a/addons/l10n_es_edi_tbai_multi_refund/views/account_move_view.xml
+++ b/addons/l10n_es_edi_tbai_multi_refund/views/account_move_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <field name="l10n_es_tbai_refund_reason" position='after'>
-                <field name="l10n_es_tbai_reversed_ids" attrs="{'invisible': [('move_type', '!=', 'in_refund')]}" widget="many2many_tags"/>
+                <field name="l10n_es_tbai_reversed_ids" attrs="{'invisible': [('move_type', 'not in', ('in_refund', 'out_refund'))]}" widget="many2many_tags"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
When doing a refund for an outgoing invoice, sometimes the user will use Odoo's built-in refund features and the reversed_entry_id field will be filled appropriately. That's OK.

However, other times they will just create a new invoice from scratch. For example, when refunding one line for an invoice that had 100 lines, it's easier to create a new invoice with one line than to create a refund and delete 99 lines from it. In these cases, the user can't link it with the invoice it's refunding, resulting in an error for TicketBAI.

See https://github.com/odoo/odoo/pull/191303#discussion_r1910034083 for details.

@moduon MT-4966

cc @RicGR98 @gelojr

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
