### PR TITLE
[FIX] account,web: harmonize documents' taxes header display

### DIFF
--- a/addons/account/views/bill_preview_template.xml
+++ b/addons/account/views/bill_preview_template.xml
@@ -65,7 +65,7 @@
                                             <th name="th_description" class="text-start"><span>Description</span></th>
                                             <th name="th_quantity" class="text-end"><span>Quantity</span></th>
                                             <th name="th_priceunit" class="text-end d-md-table-cell"><span>Unit Price</span></th>
-                                            <th name="th_taxes" class="text-start d-md-table-cell"><span>Taxes</span></th>
+                                            <th name="th_taxes" class="text-end d-md-table-cell"><span>Taxes</span></th>
                                             <th name="th_subtotal" class="text-end"><span>Amount</span></th>
                                         </tr>
                                     </thead>
@@ -80,7 +80,7 @@
                                             <td class="text-end d-md-table-cell">
                                                 <span class="text-nowrap">1,500.00</span>
                                             </td>
-                                            <td class="text-start d-md-table-cell">
+                                            <td class="text-end d-md-table-cell">
                                                 <span>Tax 0%</span>
                                             </td>
                                             <td class="text-end o_price_total">
@@ -97,7 +97,7 @@
                                             <td class="text-end d-md-table-cell">
                                                 <span class="text-nowrap">2,350.00</span>
                                             </td>
-                                            <td class="text-start d-md-table-cell">
+                                            <td class="text-end d-md-table-cell">
                                                 <span>Tax 0%</span>
                                             </td>
                                             <td class="text-end o_price_total">

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -113,7 +113,7 @@
                                     <th name="th_discount" t-if="display_discount" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                                         <span>Disc.%</span>
                                     </th>
-                                    <th name="th_taxes" t-attf-class="text-start {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"><span>Taxes</span></th>
+                                    <th name="th_taxes" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"><span>Taxes</span></th>
                                     <th name="th_subtotal" class="text-end">
                                         <span>Amount</span>
                                     </th>
@@ -142,7 +142,7 @@
                                                 <span class="text-nowrap" t-field="line.discount">0</span>
                                             </td>
                                             <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.tax_ids])"/>
-                                            <td name="td_taxes" t-attf-class="text-start {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }} {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
+                                            <td name="td_taxes" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }} {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
                                                 <span t-out="taxes" id="line_tax_ids">Tax 15%</span>
                                             </td>
                                             <td name="td_subtotal" class="text-end o_price_total">

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -146,7 +146,7 @@
                                    <th name="th_description" class="text-start"><span>Description</span></th>
                                    <th name="th_quantity" class="text-end"><span>Quantity</span></th>
                                    <th name="th_priceunit" class="text-end d-md-table-cell"><span>Unit Price</span></th>
-                                   <th name="th_taxes" class="text-start d-md-table-cell"><span>Taxes</span></th>
+                                   <th name="th_taxes" class="text-end d-md-table-cell"><span>Taxes</span></th>
                                    <th name="th_subtotal" class="text-end">
                                        <span>Amount</span>
                                    </th>
@@ -162,7 +162,7 @@
                                    <td class="text-end d-md-table-cell">
                                        <span class="text-nowrap">1,500.00</span>
                                    </td>
-                                   <td class="text-start d-md-table-cell">
+                                   <td class="text-end d-md-table-cell">
                                        <span id="line_tax_ids">Tax 15%</span>
                                    </td>
                                    <td class="text-end o_price_total">
@@ -178,7 +178,7 @@
                                    <td class="text-end d-md-table-cell">
                                        <span class="text-nowrap">2,350.00</span>
                                    </td>
-                                   <td class="text-start d-md-table-cell">
+                                   <td class="text-end d-md-table-cell">
                                        <span id="line_tax_ids">Tax 15%</span>
                                    </td>
                                    <td class="text-end o_price_total">


### PR DESCRIPTION
**Steps to reproduce:**

- In Sales app, create a new invoice with one product;
- Post the invoice without validating it;
- Print invoice without payment from action button.

**Issue:**
The taxes column's header is "start aligned" as its content and the other columns are "end aligned".

**Expected:**
Column headers should be harmonized and have a consistent display as per :
https://github.com/odoo/odoo/blob/4d9cf2e5103fcdc11be2fd574886afed6f300281/addons/sale/report/ir_actions_report_templates.xml#L79-L88

**Cause:**
The view sets the header alignement on start.


opw-4380680

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
