### PR TITLE
[FIX] web_editor: prevent adding empty `p` when deleting an image

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2009,8 +2009,11 @@ export class Wysiwyg extends Component {
             if (!this.lastMediaClicked) {
                 return;
             }
+            const anchorNode = this.lastMediaClicked.parentElement;
+            const anchorOffset = Array.from(anchorNode.childNodes).indexOf(this.lastMediaClicked);
             $(this.lastMediaClicked).remove();
             this.lastMediaClicked = undefined;
+            setSelection(anchorNode, anchorOffset, anchorNode, anchorOffset);
             this.odooEditor.toolbarHide();
         });
         $toolbar.find('#fa-resize div').click(e => {

--- a/addons/web_editor/static/tests/html_field_tests.js
+++ b/addons/web_editor/static/tests/html_field_tests.js
@@ -1304,6 +1304,65 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         const isRotated = isElementRotated(img);
         assert.notOk(isRotated, "The image should not be rotated");
     });
+
+    QUnit.module("Image Delete");
+
+    QUnit.test("Image should delete without making any element", async (assert) => {
+        assert.expect(3);
+        serverData.models.partner.records.push({
+            id: 1,
+            txt: `<p class="content"><br></p><p class="content"><img></p>`,
+        });
+        let htmlField;
+        const wysiwygPromise = makeDeferred();
+        patchWithCleanup(HtmlField.prototype, {
+            async startWysiwyg() {
+                await super.startWysiwyg(...arguments);
+                htmlField = this;
+                wysiwygPromise.resolve();
+            },
+            // To prevent saving when calling onWillUnmount
+            async commitChanges() { },
+        });
+
+        await makeView({
+            type: "form",
+            resId: 1,
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="txt" widget="html"/>
+                </form>`,
+        });
+        await wysiwygPromise;
+        const editor = htmlField.wysiwyg.odooEditor;
+        const paragraph = editor.editable.querySelectorAll(".content")[1];
+        setSelection(paragraph, 0, paragraph, 0);
+        await nextTick();
+
+        const img = editor.editable.querySelector("img");
+        setSelection(paragraph, 1, paragraph, 2);
+        await nextTick();
+
+        // Trigger mouseup manually to run `_updateEditorUI`.
+        const mouseUpEvent = new MouseEvent("mouseup", {
+            view: window,
+            bubbles: true,
+            cancelable: true,
+        });
+        img.dispatchEvent(mouseUpEvent);
+        await nextTick();
+        document.querySelector("#image-delete").click();
+        await nextTick();
+        assert.equal(
+            editor.editable.innerHTML,
+            '<p class="content"><br></p><p class="content oe-hint oe-command-temporary-hint" placeholder="Type &quot;/&quot; for commands"></p>'
+        );
+        const selection = document.getSelection();
+        assert.equal(selection.anchorNode, paragraph);
+        assert.equal(selection.anchorOffset, 0);
+    });
 });
 
 export const mediaDialogServices = {


### PR DESCRIPTION
**Problem**:
When an image inside a `<p>` tag (e.g., `<p><img></p>`) is deleted using the toolbar delete button, the selection is not properly restored, leaving an empty `<p>` in the DOM and the selection in the editor root.

**Solution**:
Restore the selection to the correct position after deleting the image to avoid leaving an empty `<p>`.

**Steps to Reproduce**:
1. Open an empty editor and add an image.
2. Delete the image using the toolbar delete button.
3. Inspect the DOM:
   - An empty `<p>` remains, and the selection is in the editor root.

opw-4472173

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
