### PR TITLE
[FIX] account: no stream if file not PDF-convertible with Original Bills

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -9301,6 +9301,13 @@ msgstr ""
 #. odoo-python
 #: code:addons/account/models/ir_actions_report.py:0
 #, python-format
+msgid "No original purchase document can be converted to PDF."
+msgstr ""
+
+#. module: account
+#. odoo-python
+#: code:addons/account/models/ir_actions_report.py:0
+#, python-format
 msgid ""
 "No original purchase document could be found for any of the selected "
 "purchase documents."

--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -38,10 +38,12 @@ class IrActionsReport(models.Model):
                             "There was an error when trying to add the banner to the original PDF.\n"
                             "Please make sure the source file is valid."
                         ))
-                collected_streams[invoice.id] = {
-                    'stream': stream,
-                    'attachment': attachment,
-                }
+                    collected_streams[invoice.id] = {
+                        'stream': stream,
+                        'attachment': attachment,
+                    }
+        if not collected_streams:
+            raise UserError(_("No original purchase document can be converted to PDF."))
         return collected_streams
 
     def _is_invoice_report(self, report_ref):


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Create a bill by uploading a XML (e.g. an EDI xml)
- Go to the bills list view
- Select the created bill
- Click on "Print > Original Bills"

**Issue:**
A PDF is generated but it is not possible to open it as it contains nothing.

**Cause:**
A previous fix has been made to handle image-type attachments by converting them to a pdf stream.
https://github.com/odoo/odoo/commit/41c79f66cfb5cdb558110d32842198157932397e 
However, it is just returning None if the attachment is not a PDF or an image file.

**Solution:**
Do not add a file if it could not be converted to a PDF stream and return an UserError if no stream can be returned.

opw-4439034



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
