### PR TITLE
[FIX] invoice_report_document: use overflow-auto class for legal notes to esure it wont over lap with other sections.

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -234,7 +234,7 @@
                                     <div class="oe_structure"/>
                                 </t>
                             </div>
-                            <div id="payment_term" class="clearfix">
+                            <div id="payment_term" class="clearfix overflow-auto">
                                 <div class="justify-text">
                                     <p t-if="not is_html_empty(o.fiscal_position_id.note)" name="note" class="mb-2">
                                         <span t-field="o.fiscal_position_id.note"/>


### PR DESCRIPTION
Behaviour Before the Commit:

When an invoice pdf has more than 1 page and legal notes(multiline notes) section is the first thing on next page, wkhtmltopdf fails to handle page-break for legal notes text. First line of legal notes overwrites on the total amount section resulting in overflow of contents. It works fine if legal notes are not the first thing on page.

Behaviour After the Commit:

Legal notes(multiline notes) text does not overwrite on total payment summary anymore.

Fix:

Add 'overflow-auto' class to div with id='payment-term' and has clearfix class to ensure it handles overflow.

Steps to reproduce:

1. Create a multiline legal notes for any tax.
2. Open Customer-Invoices, create an invoice by adding multiple products with the tax which has multiline legal notes.
3. Make sure to add specific number of products/sections so that invoice expands to 2 pages.
4. Legal notes section must be the first thing on second page, otherwise it will not overwrite text.

Feel free to look at the ticket number 4416845 for detailed understanding of the bug.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
