### PR TITLE
[FIX] mail : Correct Usability Of User Settings

### DIFF
--- a/addons/mail/models/res_users_settings.py
+++ b/addons/mail/models/res_users_settings.py
@@ -9,7 +9,7 @@ class ResUsersSettings(models.Model):
     _description = 'User Settings'
     _rec_name = 'user_id'
 
-    user_id = fields.Many2one('res.users', string="User", required=True, readonly=True, ondelete='cascade')
+    user_id = fields.Many2one('res.users', string="User", required=True, ondelete='cascade', domain=[("res_users_settings_id", "=", False)])
     is_discuss_sidebar_category_channel_open = fields.Boolean(string="Is discuss sidebar category channel open?", default=True)
     is_discuss_sidebar_category_chat_open = fields.Boolean(string="Is discuss sidebar category chat open?", default=True)
 

--- a/addons/mail/views/res_users_settings_views.xml
+++ b/addons/mail/views/res_users_settings_views.xml
@@ -21,7 +21,7 @@
             <form string="User Settings">
                 <sheet>
                     <div class="oe_title">
-                        <h1><field name="user_id"/></h1>
+                        <h1><field name="user_id" attrs="{'readonly': [('id', '!=', False)]}"/></h1>
                     </div>
                     <group name="discuss_user_settings">
                         <group string="Discuss sidebar">


### PR DESCRIPTION
Issue:
------
Case:  User Settings menu is basically used to handle created users but when clicking on the `New` button within the User Settings the form view corresponding to that model i.e; `res.users.settings` will be opened which is an inappropriate behavior.
Whenever a User is created that user will be reflected within that menu. There's no meaning of having `New` button when no user is created to handle.

Solution:
-----------
Some users do not have a user settings yet, so it is a perfectly valid use case to create one.
We should not artificially prevent acceptable behavior in technical/admin menus.

Steps to reproduce:
------------------------
1. Create a database in version 16.0.
2. Go to `User Settings`.
3. Click On `New` button. Try making changes and save.
4. An Invalid Field `User` error will Occur.

This is because there's a many2One field i.e; `user_id` within the tree and form views which is basically an existing user.
The `New` button will open a form view with no User which is a must. And will cause the Invalid field error when trying to save any change.

Ref:
https://github.com/odoo/odoo/blob/16.0/addons/mail/views/res_users_settings_views.xml#L24

Ref Screenshot:
![image](https://github.com/user-attachments/assets/24373b6e-2d67-42f7-9506-24faa3021e41)


Co-Authored By - @seb-odoo 