### PR TITLE
[FIX] sale_loyalty: handle adding order & specific discounts

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -433,7 +433,10 @@ class SaleOrder(models.Model):
             else:
                 non_common_lines = discounted_lines - lines_to_discount
                 # Fixed prices are per tax
-                discounted_amounts = {line.tax_id.filtered(lambda t: t.amount_type != 'fixed'): abs(line.price_total) for line in lines}
+                discounted_amounts = defaultdict(int, {
+                    line.tax_id.filtered(lambda t: t.amount_type != 'fixed'): abs(line.price_total)
+                    for line in lines
+                })
                 for line in itertools.chain(non_common_lines, common_lines):
                     # For gift card and eWallet programs we have no tax but we can consume the amount completely
                     if lines.reward_id.program_id.is_payment_program:


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Create a promotion to apply a fixed discount to an order;
2. create a promotion to apply a fixed discount to a specific product;
3. create a order with a taxed product eligible for the 2nd discount;
4. apply the first promotion;
5. apply the second promotion.

Issue
-----
Traceback:
> KeyError: account.tax(1,)

Cause
-----
Commit db12319e8b3b changed the way taxes get handled for discounts on the order total. They no longer automatically get a tax applied to them.

This causes a problem in the `_discountable_specific` method, which builds a `dict` using taxes of discount lines as keys to calculate discountable amounts.

Because the existing reward doesn't have a tax, this dict only has an `account.tax()` key, leading to a `KeyError` when trying to get discountable amount associated with the product-specific reward's taxes.

Solution
--------
Change the `dict` to a `defaultdict` which returns `0` for non-existing keys.

opw-4419764