### PR TITLE
[FIX] web_editor: editing link should not convert to telephone url

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
@@ -123,7 +123,11 @@ export function deduceURLfromText(text, link) {
    // Check for telephone url.
    match = label.match(PHONE_REGEX);
    if (match) {
-        return (match[1] ? match[0] : "tel:" + match[0]).replace(/\s+/g, "");
+        if (match[1]) {
+            return match[0].replace(/\s+/g, "");
+        } else if (link?.href.startsWith("tel:")) {
+            return ("tel:" + match[0]).replace(/\s+/g, "");
+        }
    }
    return null;
 }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/link.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/link.test.js
@@ -241,6 +241,35 @@ describe('Link', () => {
                     contentAfter: '<p><a href="#">a<br>[]b</a></p>',
                 });
             });
+            it('should not convert to telephone url while inserting digits inside link', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p><a href="#">[]</a></p>',
+                    stepFunction: async editor => {
+                        await insertText(editor, '1');
+                        await insertText(editor, '2');
+                        await insertText(editor, '3');
+                    },
+                    contentAfter: '<p><a href="#">123[]</a></p>',
+                });
+            });
+            it('should update url if existing url is telephone url while inserting', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p><a href="tel:123">123[]</a></p>',
+                    stepFunction: async editor => {
+                        await insertText(editor, '4');
+                    },
+                    contentAfter: '<p><a href="tel:1234">1234[]</a></p>',
+                });
+            });
+            it('should convert url to telephone url if label starts with tel protocol', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p><a href="#">tel://[]</a></p>',
+                    stepFunction: async editor => {
+                        await insertText(editor, '1');
+                    },
+                    contentAfter: '<p><a href="tel://1">tel://1[]</a></p>',
+                });
+            });
         });
         describe('range not collapsed', () => {
             // This succeeds, but why would the cursor stay inside the link

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -264,6 +264,10 @@ export class Link extends Component {
             // Text begins with a known protocol, accept it as valid URL.
             return text;
         } else {
+            const match = text.match(PHONE_REGEX);
+            if (match) {
+                return ("tel:" + match[0]).replace(/\s+/g, "");
+            }
             return deduceURLfromText(text, this.linkEl) || '';
         }
     }


### PR DESCRIPTION
**Behavior before PR:**

When user edits link and inserts 3 or more digits, link url gets converted to telephone url. This happens because in sanitize.js `deduceURLfromText` method converts url to telephone url if label matches the regex.

**Behavior after PR:**

Now, inserting 3 or more digits will not convert existing url to telephone url directly. If current link is telephone url or
label starts with `"tel:"` prefix then url will get converted to telephone url if label matches the `PHONE_REGEX`.

task-4173806


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
