### PR TITLE
[FIX] rpc: re-raise exceptions for http.py

### DIFF
--- a/addons/auth_totp/tests/test_totp.py
+++ b/addons/auth_totp/tests/test_totp.py
@@ -7,8 +7,6 @@ from passlib.totp import TOTP
 
 from odoo import http
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
-from odoo.exceptions import AccessDenied
-from odoo.service import common as auth, model
 from odoo.tests import tagged, get_db_name
 from odoo.tools import mute_logger
 
@@ -64,7 +62,7 @@ class TestTOTP(TestTOTPCommon, HttpCaseWithUserDemo):
             'Trying to fake the auth type should not work'
         )
         uid = self.user_demo.id
-        with self.assertRaisesRegex(Fault, r'Access Denied'):
+        with self.assertRaisesRegex(Fault, r'Access Denied'), mute_logger('odoo.http'):
             self.xmlrpc_object.execute_kw(
                 get_db_name(), uid, 'demo',
                 'res.users', 'read', [uid, ['login']]

--- a/odoo/addons/base/controllers/rpc.py
+++ b/odoo/addons/base/controllers/rpc.py
@@ -137,7 +137,11 @@ class RPC(Controller):
         try:
             response = self._xmlrpc(service)
         except Exception as error:
-            response = xmlrpc_handle_exception_string(error)
+            error.error_response = Response(
+                response=xmlrpc_handle_exception_string(error),
+                mimetype='text/xml',
+            )
+            raise
         return Response(response=response, mimetype='text/xml')
 
     @route("/xmlrpc/2/<service>", auth="none", methods=["POST"], csrf=False, save_session=False)
@@ -146,7 +150,11 @@ class RPC(Controller):
         try:
             response = self._xmlrpc(service)
         except Exception as error:
-            response = xmlrpc_handle_exception_int(error)
+            error.error_response = Response(
+                response=xmlrpc_handle_exception_int(error),
+                mimetype='text/xml',
+            )
+            raise
         return Response(response=response, mimetype='text/xml')
 
     @route('/jsonrpc', type='json', auth="none", save_session=False)

--- a/odoo/addons/test_rpc/tests/test_error.py
+++ b/odoo/addons/test_rpc/tests/test_error.py
@@ -20,7 +20,7 @@ class TestError(common.HttpCase):
         """ Create: mandatory field not provided """
         self.rpc("test_rpc.model_b", "create", {"name": "B1"})
         try:
-            with mute_logger("odoo.sql_db"):
+            with mute_logger("odoo.sql_db", "odoo.http"):
                 self.rpc("test_rpc.model_b", "create", {})
             raise
         except Exception as e:
@@ -40,7 +40,7 @@ class TestError(common.HttpCase):
         self.rpc("test_rpc.model_a", "create", {"name": "A1", "field_b1": b1, "field_b2": b2})
 
         try:
-            with mute_logger("odoo.sql_db"):
+            with mute_logger("odoo.sql_db", "odoo.http"):
                 self.rpc("test_rpc.model_b", "unlink", b1)
             raise
         except Exception as e:
@@ -54,7 +54,7 @@ class TestError(common.HttpCase):
 
         # Unlink b2 => ON DELETE RESTRICT constraint raises
         try:
-            with mute_logger("odoo.sql_db"):
+            with mute_logger("odoo.sql_db", "odoo.http"):
                 self.rpc("test_rpc.model_b", "unlink", b2)
             raise
         except Exception as e:

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1654,7 +1654,8 @@ class Request:
             except Exception as exc:
                 if isinstance(exc, HTTPException) and exc.code is None:
                     raise  # bubble up to odoo.http.Application.__call__
-                exc.error_response = self.registry['ir.http']._handle_error(exc)
+                if not hasattr(exc, 'error_response'):
+                    exc.error_response = self.registry['ir.http']._handle_error(exc)
                 raise
 
     def _serve_ir_http(self):


### PR DESCRIPTION
For my friends at tech support

Exceptions in RPC are handled and a Response is returned directly. It is a different behaviour than jsonrpc where the exception is raised and the dispatcher wraps it is a Response after logging the exception. The xmlrpc code should also raise an exception so that it can be handled in http.py. Adding here a way to detect if a Response was already generated for an exception in the exception handler of HTTP.

Related: #193208