### PR TITLE
[FIX] sale_stock: valuation when same prod on different

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -342,8 +342,11 @@ class AccountMoveLine(models.Model):
             else:
                 qty_invoiced -= line.product_uom_id._compute_quantity(line.quantity, line.product_id.uom_id)
         value_invoiced -= sum(reversal_cogs.mapped('balance'))
+        product = self.product_id.with_company(self.company_id)
 
-        product = self.product_id.with_company(self.company_id).with_context(value_invoiced=value_invoiced)
+        so_lines = stock_moves.sale_line_id.order_id.order_line.filtered(lambda l: l.product_id == self.product_id)
+        if len(posted_cogs) <= 1 or len(so_lines) == 1:
+            product = product.with_context(value_invoiced=value_invoiced)
         average_price_unit = product._compute_average_price(qty_invoiced, qty_to_invoice, stock_moves, is_returned=is_line_reversing)
         price_unit = self.product_id.uom_id.with_company(self.company_id)._compute_price(average_price_unit, self.product_uom_id)
 


### PR DESCRIPTION
In case two sale order lines share the same product in automated inventory valuation, the system will make an incorrect valuation

Steps to reproduce:
- Enable Anglo-Saxon accounting.
- Create a storable product [TEST], with category set to automated valuation - FIFO.
- Create a purchase order with 2 lines
  1. Product [TEST], quantity 10, price unit 100
  2. Product [TEST], quantity 30, price unit 300
- Receive the product
- Create a sales order with 2 lines:
  1. Product [TEST], quantity 10, price unit 100
  2. Product [TEST], quantity 30, price unit 300
- Validate the delivery.
- Create an invoice from the SO, edit the second line quantity 30 -> 10, and validate
- Create a second invoice for the remaining 15 units from line 2, and validate it.

Issue In the second invoice, CoGs line is incorrect: it should have been 15 × 300 = 4500 but is instead 6500.

This occurs because when looking for [TEST] Cogs lines, we retrieve the two cogs line from invoices 1. So we will consider the invoice quantity of both lines (25), but we try to consume the svl of the second sale order line

opw-4358491

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
