### PR TITLE
[FIX] loyalty: parse reward_product_domain as JSON

### DIFF
--- a/addons/pos_loyalty/models/loyalty_reward.py
+++ b/addons/pos_loyalty/models/loyalty_reward.py
@@ -44,7 +44,7 @@ class LoyaltyReward(models.Model):
         search_domain = [('program_id', 'in', config._get_program_ids().ids)]
         domains = self.search_read(search_domain, fields=['reward_product_domain'], load=False)
         for domain in filter(lambda d: d['reward_product_domain'] != "null", domains):
-            domain = ast.literal_eval(domain['reward_product_domain'])
+            domain = json.loads(domain['reward_product_domain'])
             for condition in self._parse_domain(domain).values():
                 field_name, _, _ = condition
                 fields.add(field_name)


### PR DESCRIPTION
Before this commit, `domain['reward_product_domain']` was being evaluated with `ast.literal_eval` while containing JSON-style booleans (`true/false`). That caused a `ValueError` because `true/false` are invalid in Python syntax.

With this commit, we now use `json.loads` to parse the domain string, which correctly handles JSON booleans without error.

opw-4458627

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
