### PR TITLE
[FIX] stock_account: run fifo with standard price

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -203,25 +203,26 @@ class ProductProduct(models.Model):
             'unit_cost': self.standard_price,
             'quantity': quantity,
         }
-        fifo_vals = self._run_fifo(abs(quantity), company)
-        vals['remaining_qty'] = fifo_vals.get('remaining_qty')
-        # In case of AVCO, fix rounding issue of standard price when needed.
-        if self.product_tmpl_id.cost_method == 'average' and not float_is_zero(self.quantity_svl, precision_rounding=self.uom_id.rounding):
-            rounding_error = currency.round(
-                (self.standard_price * self.quantity_svl - self.value_svl) * abs(quantity / self.quantity_svl)
-            )
-            if rounding_error:
-                # If it is bigger than the (smallest number of the currency * quantity) / 2,
-                # then it isn't a rounding error but a stock valuation error, we shouldn't fix it under the hood ...
-                if abs(rounding_error) <= max((abs(quantity) * currency.rounding) / 2, currency.rounding):
-                    vals['value'] += rounding_error
-                    vals['rounding_adjustment'] = '\nRounding Adjustment: %s%s %s' % (
-                        '+' if rounding_error > 0 else '',
-                        float_repr(rounding_error, precision_digits=currency.decimal_places),
-                        currency.symbol
-                    )
-        if self.product_tmpl_id.cost_method == 'fifo':
-            vals.update(fifo_vals)
+        if self.product_tmpl_id.cost_method in ('average', 'fifo'):
+            fifo_vals = self._run_fifo(abs(quantity), company)
+            vals['remaining_qty'] = fifo_vals.get('remaining_qty')
+            # In case of AVCO, fix rounding issue of standard price when needed.
+            if self.product_tmpl_id.cost_method == 'average' and not float_is_zero(self.quantity_svl, precision_rounding=self.uom_id.rounding):
+                rounding_error = currency.round(
+                    (self.standard_price * self.quantity_svl - self.value_svl) * abs(quantity / self.quantity_svl)
+                )
+                if rounding_error:
+                    # If it is bigger than the (smallest number of the currency * quantity) / 2,
+                    # then it isn't a rounding error but a stock valuation error, we shouldn't fix it under the hood ...
+                    if abs(rounding_error) <= max((abs(quantity) * currency.rounding) / 2, currency.rounding):
+                        vals['value'] += rounding_error
+                        vals['rounding_adjustment'] = '\nRounding Adjustment: %s%s %s' % (
+                            '+' if rounding_error > 0 else '',
+                            float_repr(rounding_error, precision_digits=currency.decimal_places),
+                            currency.symbol
+                        )
+            if self.product_tmpl_id.cost_method == 'fifo':
+                vals.update(fifo_vals)
         return vals
 
     def _change_standard_price(self, new_price):


### PR DESCRIPTION
When a delivery transfer is made, a stock valuation row is created, the problem encountered is within the ‘_prepare_out_svl_vals’ method, even if the valuation method is set to ‘standard price’ it still starts the ‘_run_fifo’ method by scaling the remaining quantities from the unwanted stock valuation row. 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
