### PR TITLE
[IMP] hw_drivers: minor syntax and readability improvements

### DIFF
--- a/addons/hw_drivers/connection_manager.py
+++ b/addons/hw_drivers/connection_manager.py
@@ -23,7 +23,7 @@ class ConnectionManager(Thread):
     daemon = True
 
     def __init__(self):
-        super(ConnectionManager, self).__init__()
+        super().__init__()
         self.pairing_code = False
         self.pairing_uuid = False
         self.pairing_code_expired = False

--- a/addons/hw_drivers/connection_manager.py
+++ b/addons/hw_drivers/connection_manager.py
@@ -20,6 +20,8 @@ MAXIMUM_NUMBER_OF_CODES = 3
 
 
 class ConnectionManager(Thread):
+    daemon = True
+
     def __init__(self):
         super(ConnectionManager, self).__init__()
         self.pairing_code = False
@@ -104,5 +106,4 @@ class ConnectionManager(Thread):
 
 
 connection_manager = ConnectionManager()
-connection_manager.daemon = True
 connection_manager.start()

--- a/addons/hw_drivers/driver.py
+++ b/addons/hw_drivers/driver.py
@@ -10,13 +10,12 @@ from odoo.tools.lru import LRU
 
 
 class Driver(Thread):
-    """
-    Hook to register the driver into the drivers list
-    """
+    """Hook to register the driver into the drivers list"""
     connection_type = ''
+    daemon = True
 
     def __init__(self, identifier, device):
-        super(Driver, self).__init__()
+        super().__init__()
         self.dev = device
         self.device_identifier = identifier
         self.device_name = ''

--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -24,7 +24,7 @@ class DisplayDriver(Driver):
     connection_type = 'display'
 
     def __init__(self, identifier, device):
-        super(DisplayDriver, self).__init__(identifier, device)
+        super().__init__(identifier, device)
         self.device_type = 'display'
         self.device_connection = 'hdmi'
         self.device_name = device['name']

--- a/addons/hw_drivers/iot_handlers/drivers/KeyboardUSBDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/KeyboardUSBDriver_L.py
@@ -47,7 +47,7 @@ class KeyboardUSBDriver(Driver):
             os.environ['XAUTHORITY'] = "/run/lightdm/pi/xauthority"
             KeyboardUSBDriver.display = xlib.XOpenDisplay(bytes(":0.0", "utf-8"))
 
-        super(KeyboardUSBDriver, self).__init__(identifier, device)
+        super().__init__(identifier, device)
         self.device_connection = 'direct'
         self.device_name = self._set_name()
 

--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
@@ -68,7 +68,7 @@ class PrinterDriver(Driver):
     connection_type = 'printer'
 
     def __init__(self, identifier, device):
-        super(PrinterDriver, self).__init__(identifier, device)
+        super().__init__(identifier, device)
         self.device_type = 'printer'
         self.device_connection = device['device-class'].lower()
         self.device_name = device['device-make-and-model']

--- a/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py
@@ -65,7 +65,7 @@ class SerialDriver(Driver):
         :type device: str
         """
 
-        super(SerialDriver, self).__init__(identifier, device)
+        super().__init__(identifier, device)
         self._actions.update({
             'get_status': self._push_status,
         })

--- a/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py
@@ -94,7 +94,7 @@ class ScaleDriver(SerialDriver):
     last_sent_value = None
 
     def __init__(self, identifier, device):
-        super(ScaleDriver, self).__init__(identifier, device)
+        super().__init__(identifier, device)
         self.device_type = 'scale'
         self._set_actions()
         self._is_reading = True

--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -22,6 +22,7 @@ iot_devices = {}
 
 
 class Manager(Thread):
+    daemon = True
     ws_channel = ""
 
     @helpers.require_db
@@ -94,14 +95,8 @@ class Manager(Thread):
         helpers.download_iot_handlers()
         helpers.load_iot_handlers()
 
-        # Start the interfaces
         for interface in interfaces.values():
-            try:
-                i = interface()
-                i.daemon = True
-                i.start()
-            except Exception:
-                _logger.exception("Interface %s could not be started", str(interface))
+            interface().start()
 
         # Set scheduled actions
         schedule.every().day.at("00:00").do(helpers.get_certificate_status)
@@ -129,5 +124,4 @@ class Manager(Thread):
                 _logger.exception("Manager loop unexpected error")
 
 manager = Manager()
-manager.daemon = True
 manager.start()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- Interfaces/Drivers `daemon` variable was set to `True` in the `run()` method of the manager thread (`main.py`).
  As all Interfaces/Drivers are daemon threads, we directly defined it in the parent Interface/Driver class.
  In addition, Interface start exception handling has been moved to the interface class itself.
- Some Driver/Interface super calls were still using python2 syntax: `super(ClassName, self)`. 
  Those calls were updated to `super()` following the standard Python3 syntax.

Enterprise PR: [https://github.com/odoo/enterprise/pull/77049](https://github.com/odoo/enterprise/pull/77049)
Task: 4477917