### PR TITLE
[FIX] hw_drivers: checkout script path

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -171,7 +171,7 @@ def check_git_branch():
                     subprocess.run(git + ['remote', 'set-branches', 'origin', db_branch], check=True)
                     _logger.info("Updating odoo folder to the branch %s", db_branch)
                     subprocess.run(
-                        ['/home/pi/odoo/addons/point_of_sale/tools/posbox/configuration/posbox_update.sh'], check=True
+                        ['/home/pi/odoo/addons/iot_box_image/configuration/checkout.sh'], check=True
                     )
             except subprocess.CalledProcessError:
                 _logger.exception("Failed to update the code with git.")


### PR DESCRIPTION
Forward-porting [this PR](https://github.com/odoo/odoo/pull/191928) resulted in setting path for checkout script to old path.
The path is now set to the new location (in `iot_box_image` module).
