### PR TITLE
[FIX] mail: broken live call participant badge

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_participant_card.scss
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.scss
@@ -71,11 +71,6 @@
     margin: Min(5%, map-get($spacers, 2));
 }
 
-.o-discuss-CallParticipantCard-overlayBottom {
-    background-color: rgba(0, 0, 0, 0.75);
-    max-width: 50%;
-}
-
 .o-discuss-CallParticipantCard-overlay-replayButton {
     background-color: $o-gray-900;
     &:hover {

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -33,9 +33,9 @@
             </div>
             <t t-if="rtcSession">
                 <!-- overlay -->
-                <span class="o-discuss-CallParticipantCard-overlay o-discuss-CallParticipantCard-overlayBottom z-index-1 position-absolute bottom-0 start-0 d-flex overflow-hidden">
+                <span class="o-discuss-CallParticipantCard-overlay z-index-1 position-absolute bottom-0 start-0 d-flex overflow-hidden">
                     <span t-if="!props.minimized and !props.inset" class="p-1 rounded-1 text-truncate" t-esc="name"/>
-                    <small t-if="rtcSession.isScreenSharingOn and props.minimized and !isOfActiveCall" class="user-select-none o-minimized rounded-pill text-bg-danger d-flex align-items-center fw-bolder" title="live" aria-label="live">
+                    <small t-if="rtcSession.isScreenSharingOn and props.minimized and !isOfActiveCall" class="user-select-none o-minimized rounded-pill text-bg-danger d-flex align-items-center fw-bolder px-2 py-1" title="live" aria-label="live">
                         LIVE
                     </small>
                 </span>
@@ -59,7 +59,7 @@
                     <span t-if="showServerState" class="d-flex flex-column justify-content-center me-1 p-2 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-title="rtc.state.serverState">
                         <i class="fa fa-exclamation-triangle text-warning"/>
                     </span>
-                    <span t-if="rtcSession.isScreenSharingOn and !props.minimized and !isOfActiveCall" class="user-select-none rounded-pill text-bg-danger d-flex align-items-center me-1 fw-bolder" title="live" aria-label="live">
+                    <span t-if="rtcSession.isScreenSharingOn and !props.minimized and !isOfActiveCall" class="user-select-none rounded-pill text-bg-danger d-flex align-items-center me-1 fw-bolder px-2 py-1" title="live" aria-label="live">
                         LIVE
                     </span>
                 </div>


### PR DESCRIPTION
Before this commit the `LIVE` badge on the minimized call participant card had some styling issues.
This was caused by missing padding on the related div tag and non-transparent background on the parent tag.
This commit fixes the issue by introducing some padding and removing the css class that adds background opacity.
This commit also removes the now unused css class.

Before:
![Pasted image 20250113125543](https://github.com/user-attachments/assets/f5d36bb9-9b48-45a9-a170-6cb4323f9b9f)
![Pasted image 20250113152305](https://github.com/user-attachments/assets/3260d7a7-ef7c-40a0-9e80-3cb60a871cd1)

After:
![Pasted image 20250113160155](https://github.com/user-attachments/assets/a87bbc52-581e-47dc-838b-a144c8936329)
![Pasted image 20250113160208](https://github.com/user-attachments/assets/b65c022b-8223-4e84-9a06-17201f8680f0)
