### PR TITLE
[FIX] point_of_sale: assign lot_id on quants when applicable

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -300,6 +300,7 @@ class StockMove(models.Model):
                                 else:
                                     ml_vals.update({
                                         'lot_name': existing_lot.name,
+                                        'lot_id': existing_lot.id,
                                     })
                         else:
                             ml_vals.update({'lot_name': lot.lot_name})

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2230,7 +2230,9 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         })
         order_payment.with_context(payment_context).check()
         self.pos_config.current_session_id.action_pos_session_closing_control()
-        self.assertEqual(order.picking_ids.move_line_ids_without_package.lot_id.name, '1001')
+        order_lot_id = order.picking_ids.move_line_ids_without_package.lot_id
+        self.assertEqual(order_lot_id.name, '1001')
+        self.assertTrue(all([quant.lot_id == order_lot_id for quant in self.env['stock.quant'].search([('product_id', '=', self.product2.id)])]))
 
     def test_product_combo_creation(self):
         """We check that combo products are created without taxes."""


### PR DESCRIPTION
Currently, when buying a product in pos and using a new lot id, the quantities do not reflect this lot id.

Steps to reproduce:
-------------------
* Create a product:
  * Storable
  * Available in POS
  * Tracked by lots
* Open shop session
* Select the product just created
* Enter anything as the lot number
* Finalize order
* Close session
* In the back-end, navigate to the product page
* Select the smart button **On hand**
> Observation: The lot is not reflected

Why the fix:
------------
When the session in closed, `stock.lot` are created but not reflected on the inventory quantity updates.

We can add the `lot_id` when creating move lines as where we mention it, it will always have a related existing lot as per: https://github.com/odoo/odoo/blob/ba21b59d1234d13b5d4460facd60c586648048b8/addons/point_of_sale/models/stock_picking.py#L290

opw-4359435