### PR TITLE
[FIX] account: do not affect base of tax without "is_base_affected"

### DIFF
--- a/addons/account/tests/test_taxes_computation.py
+++ b/addons/account/tests/test_taxes_computation.py
@@ -549,9 +549,36 @@ class TestTax(TestTaxCommon):
         # tax       price_incl      incl_base_amount    is_base_affected
         # ----------------------------------------------------------------
         # tax1                      T                   T
+        # tax2
+        # tax3                                          T
+        tax2.is_base_affected = False
+        tests.append(
+            self._prepare_taxes_computation_test(
+                tax1 + tax2 + tax3,
+                100.0,
+                {
+                    'total_included': 115.18,
+                    'total_excluded': 100.0,
+                    'taxes_data': (
+                        (100.0, 6.0),
+                        (100.0, 6.0),
+                        (106.0, 3.18),
+                    ),
+                },
+                {
+                    'rounding_method': 'round_globally',
+                    'excluded_special_modes': ['total_included'],
+                },
+            )
+        )
+
+        # tax       price_incl      incl_base_amount    is_base_affected
+        # ----------------------------------------------------------------
+        # tax1                      T                   T
         # tax2                      T                   T
         # tax3                                          T
         tax2.include_base_amount = True
+        tax2.is_base_affected = True
         tests.append(
             self._prepare_taxes_computation_test(
                 tax1 + tax2 + tax3,
@@ -633,7 +660,7 @@ class TestTax(TestTaxCommon):
                 {'rounding_method': 'round_globally'},
             ),
         ))
-        self._assert_tests(tests, mode='py')
+        self._assert_tests(tests)
 
     def test_division_taxes_for_l10n_br(self):
         tax1 = self.division_tax(5)

--- a/addons/l10n_in_edi/tests/test_edi_json.py
+++ b/addons/l10n_in_edi/tests/test_edi_json.py
@@ -225,14 +225,14 @@ class TestEdiJson(AccountTestInvoicingCommon):
                 {
                     "SlNo": "2", "PrdDesc": "product_with_cess", "IsServc": "N", "HsnCd": "222222", "Qty": 1.0,
                     "Unit": "UNT", "UnitPrice": 1000.0, "TotAmt": 1000.0, "Discount": 100.0, "AssAmt": 900.0,
-                    "GstRt": 12.0, "IgstAmt": 0.0, "CgstAmt": 56.8, "SgstAmt": 56.8, "CesRt": 5.0, "CesAmt": 45.0,
+                    "GstRt": 12.0, "IgstAmt": 0.0, "CgstAmt": 54.0, "SgstAmt": 54.0, "CesRt": 5.0, "CesAmt": 45.0,
                     "CesNonAdvlAmt": 1.59, "StateCesRt": 0.0, "StateCesAmt": 0.0, "StateCesNonAdvlAmt": 0.0,
-                    "OthChrg": 0.0, "TotItemVal": 1060.19
+                    "OthChrg": 0.0, "TotItemVal": 1054.59
                 }
             ],
             "ValDtls": {
-                "AssVal": 1800.0, "CgstVal": 79.3, "SgstVal": 79.3, "IgstVal": 0.0, "CesVal": 46.59,
-                "StCesVal": 0.0, "Discount": 0.0, "RndOffAmt": 0.0, "TotInvVal": 2005.19
+                "AssVal": 1800.0, "CgstVal": 76.5, "SgstVal": 76.5, "IgstVal": 0.0, "CesVal": 46.59,
+                "StCesVal": 0.0, "Discount": 0.0, "RndOffAmt": 0.0, "TotInvVal": 1999.59
             }
         }
         self.assertDictEqual(json_value, expected, "Indian EDI send json value is not matched")
@@ -289,14 +289,14 @@ class TestEdiJson(AccountTestInvoicingCommon):
                 {
                     "SlNo": "3", "PrdDesc": "product_with_cess", "IsServc": "N", "HsnCd": "222222", "Qty": 1.0,
                     "Unit": "UNT", "UnitPrice": 1000.0, "TotAmt": 1000.0, "Discount": 0.0, "AssAmt": 1000.0,
-                    "GstRt": 12.0, "IgstAmt": 0.0, "CgstAmt": 63.1, "SgstAmt": 63.1, "CesRt": 5.0, "CesAmt": 50.0,
+                    "GstRt": 12.0, "IgstAmt": 0.0, "CgstAmt": 60.0, "SgstAmt": 60.0, "CesRt": 5.0, "CesAmt": 50.0,
                     "CesNonAdvlAmt": 1.59, "StateCesRt": 0.0, "StateCesAmt": 0.0, "StateCesNonAdvlAmt": 0.0,
-                    "OthChrg": 0.0, "TotItemVal": 1177.79
+                    "OthChrg": 0.0, "TotItemVal": 1171.59
                 }
             ],
             "ValDtls": {
-                "AssVal": 1600.0, "CgstVal": 78.1, "SgstVal": 78.1, "IgstVal": 0.0, "CesVal": 51.59,
-                "StCesVal": 0.0, "Discount": 0.0, "RndOffAmt": 0.0, "TotInvVal": 1807.79
+                "AssVal": 1600.0, "CgstVal": 75.0, "SgstVal": 75.0, "IgstVal": 0.0, "CesVal": 51.59,
+                "StCesVal": 0.0, "Discount": 0.0, "RndOffAmt": 0.0, "TotInvVal": 1801.59
             },
         })
         self.assertDictEqual(json_value, expected, "Indian EDI with negative unit price sent json value is not matched")
@@ -354,8 +354,8 @@ class TestEdiJson(AccountTestInvoicingCommon):
         expected_copy_rounding.update({
             "DocDtls": {"Typ": "INV", "No": "INV/2019/00009", "Dt": "01/01/2019"},
             "ValDtls": {
-                "AssVal": 1800.0, "CgstVal": 79.3, "SgstVal": 79.3, "IgstVal": 0.0, "CesVal": 46.59,
-                "StCesVal": 0.0, "Discount": 0.0, "RndOffAmt": -0.19, "TotInvVal": 2005.00
+                "AssVal": 1800.0, "CgstVal": 76.5, "SgstVal": 76.5, "IgstVal": 0.0, "CesVal": 46.59,
+                "StCesVal": 0.0, "Discount": 0.0, "RndOffAmt": 0.41, "TotInvVal": 2000.00
             }})
         self.assertDictEqual(json_value, expected_copy_rounding, "Indian EDI with cash rounding sent json value is not matched")
 

--- a/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
+++ b/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
@@ -71,13 +71,13 @@ class TestEdiEwaybillJson(TestEdiJson):
             }
             ],
             "totalValue": 1800.0,
-            "cgstValue": 79.3,
-            "sgstValue": 79.3,
+            "cgstValue": 76.5,
+            "sgstValue": 76.5,
             "igstValue": 0.0,
             "cessValue": 45.0,
             "cessNonAdvolValue": 1.59,
             "otherValue": 0.0,
-            "totInvValue": 2005.19
+            "totInvValue": 1999.59
         }
         self.assertDictEqual(json_value, expected, "Indian EDI send json value is not matched")
 


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Create a first tax:
  * Tax Name: Tax1
  * Tax Computation: Percentage of Price
  * Tax Type: Sales
  * Amount: 20%
  * Label on Invoices: Tax1
  * Tax Group: Tax1
  * Affect Base of Subsequent Taxes: [Checked]
- Create a second tax:
  * Tax Name: Tax2
  * Tax Computation: Percentage of Price
  * Tax Type: Sales
  * Amount: 20%
  * Label on Invoices: Tax2
  * Tax Group: Tax2
  * Base Affected by Previous Taxes: [Not checked]
- Create an invoice
- Add an invoice line
- Add Tax1
- Add Tax2

**Issue:**
Base amount of Tax2 is affected by Tax1 when it should not.

opw-4450494




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
