### PR TITLE
[FIX] point_of_sale: prevent category labels from being cut

### DIFF
--- a/addons/point_of_sale/static/src/app/components/category_selector/category_selector.xml
+++ b/addons/point_of_sale/static/src/app/components/category_selector/category_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.CategorySelector">
-        <div t-attf-class="{{this.pos.config.show_category_images ? 'd-grid category-list' : 'd-grid product-list'}} gap-1 gap-lg-2 p-2">
+        <div t-attf-class="{{this.pos.config.show_category_images ? 'd-flex flex-wrap category-list' : 'd-grid product-list'}} gap-1 gap-lg-2 p-2">
             <t t-foreach="this.getCategoriesAndSub()" t-as="category" t-key="category.id">
                 <button t-on-click="() => this.pos.setSelectedCategory(category.id)"
                     t-attf-class="o_colorlist_item_color_{{!category.isSelected and !category.isChildren ? 'transparent_ border-none': ''}}{{category.color or 'none'}}"


### PR DESCRIPTION
With Commit[1] we aimed to apply a fix to prevent an horizontal scroll on the screen when the list of category is extremely long. While this solved the issue, it introduces a new one on category labels which were sometimes cut due to the size of the grid elements.

| saas-18.1 | This PR |
|--------|--------|
| <img alt="image" src="https://github.com/user-attachments/assets/d471ef51-502d-496c-8b84-7ec1e19d01af" /> | <img alt="image" src="https://github.com/user-attachments/assets/9870287e-17d1-47b3-a92c-8165f811a0e3" /> | 

It was also setting the same class twice inside a conditional, which was not useful.

With this commit, we apply a `d-flex flex-wrap` to solve both issues.

Commit[1]: df97b2966436cd104bd806cb66786824f66fa567

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
