### PR TITLE
[FIX] point_of_sale: order might be undefined on pending payment

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1388,7 +1388,7 @@ export class PosStore extends Reactive {
      * @param {str} terminalName
      */
     getPendingPaymentLine(terminalName) {
-        return this.get_order().payment_ids.find(
+        return this.get_order()?.payment_ids.find(
             (paymentLine) =>
                 paymentLine.payment_method_id.use_payment_terminal === terminalName &&
                 !paymentLine.is_done()


### PR DESCRIPTION
Using a payment method which rely on websocket (viva wallet, adyen, mercado pago, etc.) trigger a callback on all browser session of a given PoS session. If a browser session happen to not have any current session, a JS traceback will pop:
```js
TypeError: Cannot read properties of undefined (reading 'payment_ids')
```
due to the webscoket listener checking if there is on-going order using the payment method

opw-4374450

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
