### PR TITLE
[FIX] auth_ldap: add email on new res.partner

### DIFF
--- a/addons/auth_ldap/models/res_company_ldap.py
+++ b/addons/auth_ldap/models/res_company_ldap.py
@@ -193,12 +193,14 @@ class CompanyLDAP(models.Model):
         :return: parameters for a new resource of model res_users
         :rtype: dict
         """
-
-        return {
+        data = {
             'name': tools.ustr(ldap_entry[1]['cn'][0]),
             'login': login,
             'company_id': conf['company'][0]
         }
+        if tools.single_email_re.match(login):
+            data['email'] = login
+        return data
 
     def _get_or_create_user(self, conf, login, ldap_entry):
         """


### PR DESCRIPTION
Before this commit, when a new res.user is created after signing in with auth_ldap, there was no email on the linked res.partner, which may cause issues in modules such as helpdesk, where partner email is used to find related tickets.

res.users created through the form view will trigger the onchange which sets the 'email' = 'login', which does not happen when creating a user directly through the ORM.

This commit adds 'email' as a key which is returned by the method _map_ldap_attributes, which is used to create new partners with the correct email associated with the res.user login.

opw-4378487



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
