### PR TITLE
[IMP] l10n_my_edi: Various improvements

### DIFF
--- a/addons/l10n_my_edi/data/neutralize.sql
+++ b/addons/l10n_my_edi/data/neutralize.sql
@@ -1,4 +1,6 @@
--- disable l10n_my_edi integration by archiving all proxy users.
+-- disable l10n_my_edi integration by archiving all proxy users; and reset the mode to pre-production.
 UPDATE account_edi_proxy_client_user
    SET active = FALSE
- WHERE proxy_type = 'l10n_my_edi'
+ WHERE proxy_type = 'l10n_my_edi';
+UPDATE res_company
+   SET l10n_my_edi_mode = 'test';

--- a/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
@@ -213,7 +213,7 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
 
         vals.append({
             'id_attrs': {'schemeID': 'TIN'},
-            'id': partner.vat,
+            'id': partner._l10n_my_edi_get_tin_for_myinvois(),
         })
 
         if partner.l10n_my_identification_type and partner.l10n_my_identification_number:
@@ -281,8 +281,8 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
                 self._l10n_my_edi_make_validation_error(constraints, 'phone_number_required', partner_type, partner.display_name)
 
             # We need to provide both l10n_my_identification_type and l10n_my_identification_number
-            if not partner.l10n_my_identification_type or not partner.l10n_my_identification_number:
-                self._l10n_my_edi_make_validation_error(constraints, 'required_id', partner_type, partner.display_name)
+            if not partner.commercial_partner_id.l10n_my_identification_type or not partner.commercial_partner_id.l10n_my_identification_number:
+                self._l10n_my_edi_make_validation_error(constraints, 'required_id', partner_type, partner.commercial_partner_id.display_name)
 
             if not partner.state_id:
                 self._l10n_my_edi_make_validation_error(constraints, 'no_state', partner_type, partner.display_name)
@@ -293,15 +293,16 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
             if not partner.street:
                 self._l10n_my_edi_make_validation_error(constraints, 'no_street', partner_type, partner.display_name)
 
-            if partner.sst_registration_number and len(partner.sst_registration_number.split(';')) > 2:
-                self._l10n_my_edi_make_validation_error(constraints, 'too_many_sst', partner_type, partner.display_name)
+            if partner.commercial_partner_id.sst_registration_number and len(partner.commercial_partner_id.sst_registration_number.split(';')) > 2:
+                self._l10n_my_edi_make_validation_error(constraints, 'too_many_sst', partner_type, partner.commercial_partner_id.display_name)
 
-        invoice_lines = invoice.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_note', 'line_section') and line.product_id)
-        for line in invoice_lines:
-            if not line.product_id.product_tmpl_id.l10n_my_edi_classification_code:
+        for line in invoice.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_note', 'line_section')):
+            if line.product_id and not line.product_id.product_tmpl_id.l10n_my_edi_classification_code:
                 self._l10n_my_edi_make_validation_error(constraints, 'class_code_required', line.product_id.id, line.product_id.display_name)
             if not line.tax_ids:
-                self._l10n_my_edi_make_validation_error(constraints, 'tax_ids_required', line.id, line.name)
+                self._l10n_my_edi_make_validation_error(constraints, 'tax_ids_required', line.id, line.display_name)
+            elif any(tax.l10n_my_tax_type == 'E' for tax in line.tax_ids) and not invoice.l10n_my_edi_exemption_reason:
+                self._l10n_my_edi_make_validation_error(constraints, 'tax_exemption_required', invoice.id, invoice.display_name)
 
         document_type_code, original_document = self._l10n_my_edi_get_document_type_code(invoice)
         if document_type_code != '01' and not original_document:
@@ -423,7 +424,7 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
         """
         if invoice.currency_id.name != "MYR":
             # I couldn't find any information on maximum precision, so we will use the currency format.
-            return self.env.ref('base.MYR').round(invoice.amount_total_signed / (invoice.amount_total or 1))
+            return self.env.ref('base.MYR').round(abs(invoice.amount_total_signed) / (invoice.amount_total or 1))
         return ''
 
     @api.model
@@ -476,6 +477,10 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
                 "The following product must have their item classification code set: %(product_name)s",
                 product_name=record_name
             ),
+            'class_code_required_line': _(
+                "The following line must have their item classification code set: %(line_name)s",
+                line_name=record_name
+            ),
             'adjustment_origin': _(
                 "You cannot send a debit / credit note for invoice %(invoice_number)s as it has not yet been sent to MyInvois.",
                 invoice_number=record_name
@@ -487,6 +492,10 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
             'tax_ids_required': _(
                 "You must set a tax on the line : %(line_name)s.\nIf taxes are not applicable, please set a 0%% tax with a tax type 'Not Applicable'.",
                 line_name=record_name
+            ),
+            'tax_exemption_required': _(
+                "You must set a Tax Exemption Reason on the invoice : %(invoice_name)s as some taxes have the type 'Tax exemption'.",
+                invoice_name=record_name
             ),
         }
 

--- a/addons/l10n_my_edi/models/account_move.py
+++ b/addons/l10n_my_edi/models/account_move.py
@@ -215,6 +215,10 @@ class AccountMove(models.Model):
         else:
             self._l10n_my_edi_set_status(result['status'])
 
+        # As done during submission flow, when the status becomes
+        if self.l10n_my_edi_state == 'valid':
+            self._update_validation_fields(result)
+
     def action_l10n_my_edi_reject_bill(self):
         self.ensure_one()
 
@@ -372,10 +376,7 @@ class AccountMove(models.Model):
                         elif result['status_reason']:
                             errors[move] = [result['status_reason']]
                 elif move.l10n_my_edi_state == 'valid':
-                    # We receive a timezone_aware datetime, but it should always be in UTC.
-                    # Odoo expect a timezone unaware datetime in UTC, so we can safely remove the info without any more work needed.
-                    utc_tz_aware_datetime = dateutil.parser.isoparse(status_info['valid_datetime'])
-                    move.l10n_my_edi_validation_time = utc_tz_aware_datetime.replace(tzinfo=None)
+                    move._update_validation_fields(status_info)
 
             if self._can_commit():
                 self._cr.commit()
@@ -486,6 +487,8 @@ class AccountMove(models.Model):
                         state=invoice_result['status'],
                         message=_('This invoice has been %(status)s for reason: %(reason)s', status=invoice_result['status'], reason=invoice_result['reason']) if invoice_result.get('reason') else None,
                     )
+                    if invoice.l10n_my_edi_state == 'valid':
+                        invoice._update_validation_fields(invoice_result)
                 submission_processed += 1
                 # Commit if we can, in case an issue arises later.
                 if self._can_commit():
@@ -545,6 +548,14 @@ class AccountMove(models.Model):
                 'document_uuid': self.l10n_my_edi_external_uuid,
             },
         )
+
+    def _update_validation_fields(self, validation_result):
+        """ Update a few important fields in self based on the data received when an invoice gets to the 'valid' state. """
+        self.ensure_one()
+        # We receive a timezone_aware datetime, but it should always be in UTC.
+        # Odoo expect a timezone unaware datetime in UTC, so we can safely remove the info without any more work needed.
+        utc_tz_aware_datetime = dateutil.parser.isoparse(validation_result['valid_datetime'])
+        self.l10n_my_edi_validation_time = utc_tz_aware_datetime.replace(tzinfo=None)
 
     # Other methods
 

--- a/addons/l10n_my_edi/models/product_template.py
+++ b/addons/l10n_my_edi/models/product_template.py
@@ -2,6 +2,81 @@
 
 from odoo import fields, models
 
+CLASSIFICATION_CODES_LIST = [
+    ("001", "(001) Breastfeeding equipment "),
+    ("002", "(002) Child care centres and kindergartens fees"),
+    ("003", "(003) Computer, smartphone or tablet"),
+    ("004", "(004) Consolidated e-Invoice "),
+    (
+        "005",
+        "(005) Construction materials (as specified under Fourth Schedule of the Lembaga Pembangunan Industri Pembinaan Malaysia Act 1994)",
+    ),
+    ("006", "(006) Disbursement"),
+    ("007", "(007) Donation"),
+    ("008", "(008) -Commerce - e-Invoice to buyer / purchaser"),
+    ("009", "(009) e-Commerce - Self-billed e-Invoice to seller, logistics, etc. "),
+    ("010", "(010) Education fees"),
+    ("011", "(011) Goods on consignment (Consignor)"),
+    ("012", "(012) Goods on consignment (Consignee)"),
+    ("013", "(013) Gym membership"),
+    ("014", "(014) Insurance - Education and medical benefits"),
+    ("015", "(015) Insurance - Takaful or life insurance"),
+    ("016", "(016) Interest and financing expenses"),
+    ("017", "(017) Internet subscription"),
+    ("018", "(018) Land and building"),
+    (
+        "019",
+        "(019) Medical examination for learning disabilities and early intervention or rehabilitation treatments of learning disabilities",
+    ),
+    ("020", "(020) Medical examination or vaccination expenses"),
+    ("021", "(021) Medical expenses for serious diseases"),
+    ("022", "(022) Others"),
+    (
+        "023",
+        "(023) Petroleum operations (as defined in Petroleum (Income Tax) Act 1967)",
+    ),
+    ("024", "(024) Private retirement scheme or deferred annuity scheme"),
+    ("025", "(025) Motor vehicle"),
+    (
+        "026",
+        "(026) Subscription of books / journals / magazines / newspapers / other similar publications",
+    ),
+    ("027", "(027) Reimbursement"),
+    ("028", "(028) Rental of motor vehicle"),
+    (
+        "029",
+        "(029) EV charging facilities (Installation, rental, sale / purchase or subscription fees) ",
+    ),
+    ("030", "(030) Repair and maintenance"),
+    ("031", "(031) Research and development"),
+    ("032", "(032) Foreign income"),
+    ("033", "(033) Self-billed - Betting and gaming"),
+    ("034", "(034) Self-billed - Importation of goods"),
+    ("035", "(035) Self-billed - Importation of services"),
+    ("036", "(036) Self-billed - Others"),
+    (
+        "037",
+        "(037) Self-billed - Monetary payment to agents, dealers or distributors",
+    ),
+    (
+        "038",
+        "(038) Fees related to sports equipment, facility rentals, competition registration, and training imposed by registered sports organizations under the Sports Development Act 1997",
+    ),
+    ("039", "(039) Supporting equipment for disabled person"),
+    ("040", "(040) Voluntary contribution to approved provident fund "),
+    ("041", "(041) Dental examination or treatment"),
+    ("042", "(042) Fertility treatment"),
+    (
+        "043",
+        "(043) Treatment and home care nursing, daycare centres and residential care centers",
+    ),
+    ("044", "(044) Vouchers, gift cards, loyalty points, etc"),
+    (
+        "045",
+        "(045) Self-billed - Non-monetary payment to agents, dealers or distributors",
+    ),
+]
+
 
 class ProductTemplate(models.Model):
     """
@@ -16,78 +91,5 @@ class ProductTemplate(models.Model):
 
     l10n_my_edi_classification_code = fields.Selection(
         string="Malaysian classification code",
-        selection=[
-            ("001", "(001) Breastfeeding equipment "),
-            ("002", "(002) Child care centres and kindergartens fees"),
-            ("003", "(003) Computer, smartphone or tablet"),
-            ("004", "(004) Consolidated e-Invoice "),
-            (
-                "005",
-                "(005) Construction materials (as specified under Fourth Schedule of the Lembaga Pembangunan Industri Pembinaan Malaysia Act 1994)",
-            ),
-            ("006", "(006) Disbursement"),
-            ("007", "(007) Donation"),
-            ("008", "(008) -Commerce - e-Invoice to buyer / purchaser"),
-            ("009", "(009) e-Commerce - Self-billed e-Invoice to seller, logistics, etc. "),
-            ("010", "(010) Education fees"),
-            ("011", "(011) Goods on consignment (Consignor)"),
-            ("012", "(012) Goods on consignment (Consignee)"),
-            ("013", "(013) Gym membership"),
-            ("014", "(014) Insurance - Education and medical benefits"),
-            ("015", "(015) Insurance - Takaful or life insurance"),
-            ("016", "(016) Interest and financing expenses"),
-            ("017", "(017) Internet subscription"),
-            ("018", "(018) Land and building"),
-            (
-                "019",
-                "(019) Medical examination for learning disabilities and early intervention or rehabilitation treatments of learning disabilities",
-            ),
-            ("020", "(020) Medical examination or vaccination expenses"),
-            ("021", "(021) Medical expenses for serious diseases"),
-            ("022", "(022) Others"),
-            (
-                "023",
-                "(023) Petroleum operations (as defined in Petroleum (Income Tax) Act 1967)",
-            ),
-            ("024", "(024) Private retirement scheme or deferred annuity scheme"),
-            ("025", "(025) Motor vehicle"),
-            (
-                "026",
-                "(026) Subscription of books / journals / magazines / newspapers / other similar publications",
-            ),
-            ("027", "(027) Reimbursement"),
-            ("028", "(028) Rental of motor vehicle"),
-            (
-                "029",
-                "(029) EV charging facilities (Installation, rental, sale / purchase or subscription fees) ",
-            ),
-            ("030", "(030) Repair and maintenance"),
-            ("031", "(031) Research and development"),
-            ("032", "(032) Foreign income"),
-            ("033", "(033) Self-billed - Betting and gaming"),
-            ("034", "(034) Self-billed - Importation of goods"),
-            ("035", "(035) Self-billed - Importation of services"),
-            ("036", "(036) Self-billed - Others"),
-            (
-                "037",
-                "(037) Self-billed - Monetary payment to agents, dealers or distributors",
-            ),
-            (
-                "038",
-                "(038) Fees related to sports equipment, facility rentals, competition registration, and training imposed by registered sports organizations under the Sports Development Act 1997",
-            ),
-            ("039", "(039) Supporting equipment for disabled person"),
-            ("040", "(040) Voluntary contribution to approved provident fund "),
-            ("041", "(041) Dental examination or treatment"),
-            ("042", "(042) Fertility treatment"),
-            (
-                "043",
-                "(043) Treatment and home care nursing, daycare centres and residential care centers",
-            ),
-            ("044", "(044) Vouchers, gift cards, loyalty points, etc"),
-            (
-                "045",
-                "(045) Self-billed - Non-monetary payment to agents, dealers or distributors",
-            ),
-        ],
+        selection=CLASSIFICATION_CODES_LIST,
     )

--- a/addons/l10n_my_edi/models/res_partner.py
+++ b/addons/l10n_my_edi/models/res_partner.py
@@ -67,7 +67,7 @@ class ResPartner(models.Model):
     def action_validate_tin(self):
         """ Calling this action will reach our EDI proxy in order to validate the TIN against the provided identification information. """
         self.ensure_one()
-        if not self.vat or not self.l10n_my_identification_type or not self.l10n_my_identification_number:
+        if not self._l10n_my_edi_get_tin_for_myinvois() or not self.l10n_my_identification_type or not self.l10n_my_identification_number:
             raise UserError(_('In order to validate the TIN, you must provide the Identification type and number.'))
 
         # Sudo to allow a user without access to the proxy user to validate the ID if needed.
@@ -77,7 +77,7 @@ class ResPartner(models.Model):
 
         response = proxy_user._l10n_my_edi_contact_proxy('api/l10n_my_edi/1/validate_tin', params={
             'identification_values': {
-                'tin': self.vat,
+                'tin': self._l10n_my_edi_get_tin_for_myinvois(),
                 'id_type': self.l10n_my_identification_type,
                 'id_val': self.l10n_my_identification_number,
             }
@@ -87,9 +87,18 @@ class ResPartner(models.Model):
             ref = response['error']['reference']
             # No need to rollback, we don't want to be blocking on that.
             if ref == 'document_tin_not_found':
-                self._message_log(body=_('MyInvois was not able to match the TIN with the provided identification number.'))
+                self._message_log(body=_('MyInvois was not able to match the TIN with the provided identification number.\nThis may happen when using generic TIN and will not prevent you from invoicing.'))
                 self.l10n_my_tin_validation_state = 'invalid'
             else:
                 self._message_log(body=_('An unexpected error occurred while validating the TIN. Please try again later.'))
         else:
             self.l10n_my_tin_validation_state = 'valid' if response.get('success') else 'invalid'
+
+    def _l10n_my_edi_get_tin_for_myinvois(self):
+        """ Helper to return the VAT number relevant to the situation. """
+        self.ensure_one()
+        return self.vat
+
+    @api.model
+    def _commercial_fields(self):
+        return super()._commercial_fields() + ['l10n_my_identification_type', 'l10n_my_identification_number']

--- a/addons/l10n_my_edi/views/res_partner_view.xml
+++ b/addons/l10n_my_edi/views/res_partner_view.xml
@@ -13,10 +13,10 @@
                     <group colspan="2">
                         <label for="l10n_my_identification_type" string="Identification"/>
                         <div class="d-flex gap-2">
-                            <field name="l10n_my_identification_type"/>
+                            <field name="l10n_my_identification_type"  readonly="parent_id"/>
                             <span class="d-flex gap-2 w-100">
-                                <field name="l10n_my_identification_number" placeholder="202001234568"/>
-                                <button class="oe_link oe_inline p-0" type="object" name="action_validate_tin" invisible="not l10n_my_edi_display_tin_warning or l10n_my_tin_validation_state">Validate</button>
+                                <field name="l10n_my_identification_number" placeholder="202001234568"  readonly="parent_id"/>
+                                <button class="oe_link oe_inline p-0" type="object" name="action_validate_tin" invisible="not l10n_my_edi_display_tin_warning or l10n_my_tin_validation_state or parent_id">Validate</button>
                                 <span class="text-success fa fa-check" title="Validation Successful" invisible="not l10n_my_edi_display_tin_warning or l10n_my_tin_validation_state != 'valid'"/>
                                 <span class="text-danger fa fa-close" title="Validation Failed" invisible="not l10n_my_edi_display_tin_warning or l10n_my_tin_validation_state != 'invalid'"/>
                             </span>

--- a/addons/l10n_my_edi_extended/__init__.py
+++ b/addons/l10n_my_edi_extended/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import models
+from . import wizard

--- a/addons/l10n_my_edi_extended/__manifest__.py
+++ b/addons/l10n_my_edi_extended/__manifest__.py
@@ -1,0 +1,22 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Malaysia - E-invoicing Extended Features',
+    'countries': ['my'],
+    'version': '1.0',
+    'category': 'Accounting/Localizations/EDI',
+    'icon': '/account/static/description/l10n.png',
+    "summary": "Extended features for the E-invoicing using MyInvois",
+    'description': """
+    This module improves the MyInvois E-invoicing feature by adding proper support for self billing, rendering the MyInvois
+    QR code in the invoice PDF file and allows better management of foreign customer TIN.
+    """,
+    'depends': ['l10n_my_edi'],
+    'data': [
+        'views/account_move_view.xml',
+        'views/report_invoice.xml',
+        'views/res_partner_view.xml',
+    ],
+    'installable': True,
+    'auto_install': ['l10n_my_edi'],
+    'license': 'LGPL-3'
+}

--- a/addons/l10n_my_edi_extended/models/__init__.py
+++ b/addons/l10n_my_edi_extended/models/__init__.py
@@ -1,0 +1,5 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import account_edi_xml_ubl_my
+from . import account_move
+from . import account_move_line
+from . import res_partner

--- a/addons/l10n_my_edi_extended/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi_extended/models/account_edi_xml_ubl_my.py
@@ -1,0 +1,74 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, api
+
+
+class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
+    _inherit = "account.edi.xml.ubl_myinvois_my"
+
+    def _export_invoice_vals(self, invoice):
+        # EXTENDS 'l10n_my_edi'
+        vals = super()._export_invoice_vals(invoice)
+
+        # For self billed documents (when sending in_xxx entries to the platform) the supplier and customer are unversed.
+        if vals['vals']['document_type_code'] in ('11', '12', '13'):
+            vals['vals']['accounting_supplier_party_vals']['party_vals'] = self._get_partner_party_vals(invoice.partner_id, role='supplier')
+            vals['vals']['accounting_customer_party_vals']['party_vals'] = self._get_partner_party_vals(invoice.company_id.partner_id, role='customer')
+            # /!\ For the company (regular invoices) it is the field on res.company that is used, and not the one on res.partner.
+            # In master the behavior will be aligned and the classification information will be retrieved in _get_partner_party_vals
+            vals['vals']['accounting_supplier_party_vals']['party_vals'].update({
+                'industry_classification_code_attrs': {'name': invoice.partner_id.commercial_partner_id.l10n_my_edi_industrial_classification.name},
+                'industry_classification_code': invoice.partner_id.commercial_partner_id.l10n_my_edi_industrial_classification.code,
+            })
+        return vals
+
+    def _get_delivery_vals_list(self, invoice):
+        # OVERRIDE 'l10n_my_edy'
+        customer = invoice.company_id.partner_id if invoice.is_purchase_document() else invoice.partner_id
+        return [{
+            'accounting_delivery_party_vals': self._l10n_my_edi_get_delivery_party_vals(customer),
+        }]
+
+    def _export_invoice_constraints(self, invoice, vals):
+        # EXTENDS 'l10n_my_edi'
+        constraints = super()._export_invoice_constraints(invoice, vals)
+        # The credit/debit note error would trigger for self billed invoice, we check if it's the case and remove it if needed.
+        document_type_code, original_document = self._l10n_my_edi_get_document_type_code(invoice)
+        if document_type_code == '11' and f"myinvois_{invoice.id}_adjustment_origin" in constraints:
+            del constraints[f'myinvois_{invoice.id}_adjustment_origin']
+        # The classification check was only looking at the product, we also want to validate lines without product
+        for line in invoice.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_note', 'line_section')):
+            # If there are no products, we still expect a classification to be manually set.
+            if not line.product_id and not line.l10n_my_edi_classification_code:
+                self._l10n_my_edi_make_validation_error(constraints, 'class_code_required_line', line.id, line.display_name)
+            # We allow invoicing a product with no classification when the classification has been manually provided.
+            if f"myinvois_{line.product_id.id}_class_code_required" in constraints and line.l10n_my_edi_classification_code:
+                del constraints[f"myinvois_{line.product_id.id}_class_code_required"]
+
+        return constraints
+
+    @api.model
+    def _l10n_my_edi_get_document_type_code(self, invoice):
+        """ Override the super method to include self billed documents. """
+        # OVERRIDE 'l10n_my_edy'
+        super()._l10n_my_edi_get_document_type_code(invoice)
+
+        if 'debit_origin_id' in self.env['account.move']._fields and invoice.debit_origin_id:
+            code = '03' if invoice.move_type == 'out_invoice' else '13'
+            return code, invoice.debit_origin_id
+        elif invoice.move_type in ('out_refund', 'in_refund'):
+            code = '02' if invoice.move_type == 'out_refund' else '12'
+            return code, invoice.reversed_entry_id
+        else:
+            code = '01' if invoice.move_type == 'out_invoice' else '11'
+            return code, None
+
+    def _get_invoice_line_item_vals(self, line, taxes_vals):
+        # EXTENDS 'l10n_my_edi' to use the new field
+        vals = super()._get_invoice_line_item_vals(line, taxes_vals)
+        # Replace the code to get it from the line instead
+        vals['commodity_classification_vals'] = [{
+            'item_classification_code': line.l10n_my_edi_classification_code,
+            'item_classification_attrs': {'listID': 'CLASS'},
+        }]
+        return vals

--- a/addons/l10n_my_edi_extended/models/account_move.py
+++ b/addons/l10n_my_edi_extended/models/account_move.py
@@ -1,0 +1,188 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import base64
+import time
+from collections import defaultdict
+
+import werkzeug
+
+from odoo import fields, models, api, _, SUPERUSER_ID
+from odoo.exceptions import UserError
+from odoo.tools import image_data_uri
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    # ------------------
+    # Fields declaration
+    # ------------------
+
+    l10n_my_edi_invoice_long_id = fields.Char(
+        string="MyInvois Long ID",
+        copy=False,
+        readonly=True,
+    )
+    l10n_my_invoice_need_edi = fields.Boolean(
+        compute='_compute_l10n_my_invoice_need_edi',
+        export_string_translation=False,
+    )
+
+    # --------------------------------
+    # Compute, inverse, search methods
+    # --------------------------------
+
+    @api.depends('move_type', 'state', 'country_code', 'company_id')
+    def _compute_l10n_my_invoice_need_edi(self):
+        for move in self:
+            # We return true for malaysian invoices which are not sent yet, sent but awaiting validation or valid.
+            move.l10n_my_invoice_need_edi = self.env['account.move.send']._l10n_my_edi_need_edi(move, ['in_progress', 'valid'])
+
+    def _get_name_invoice_report(self):
+        # EXTENDS 'account'
+        if self.l10n_my_edi_external_uuid:  # Meaning we are a myinvois invoice, meaning we need to embed the qr code.
+            # As we add the view in stable, we need to check that it exists.
+            if self.env.ref('l10n_my_edi_extended.report_invoice_document', raise_if_not_found=False):
+                return 'l10n_my_edi_extended.report_invoice_document'
+        return super()._get_name_invoice_report()
+
+    # --------------
+    # Action methods
+    # --------------
+
+    def action_invoice_sent(self):
+        """ The wizard should not be available for invoices sent to MyInvois but not yet validated.
+        This is because before validation the ID used for the QR code is not available and the user should NOT send the invoice yet.
+        """
+        self.ensure_one()
+
+        if self.l10n_my_edi_state == 'in_progress':
+            raise UserError(_('You cannot send invoices that are currently being validated.\nPlease wait for the validation to complete.'))
+
+        return super().action_invoice_sent()
+
+    # ----------------
+    # Business methods
+    # ----------------
+
+    def _update_validation_fields(self, validation_result):
+        """ Extended to update the long id as well. """
+        # EXTENDS 'l10n_my_edi'
+        super()._update_validation_fields(validation_result)
+        self.l10n_my_edi_invoice_long_id = validation_result['long_id']
+
+    def _generate_myinvois_qr_code(self):
+        """ Generate the qr code which should be embedded into the invoices PDF """
+        self.ensure_one()
+
+        if not self.l10n_my_edi_invoice_long_id:  # Only valid invoices have a long id
+            return None
+
+        # We need to add the portal url to the qr
+        proxy_user = self._l10n_my_edi_ensure_proxy_user()
+        if proxy_user.edi_mode == 'prod':
+            portal_url = "myinvois.hasil.gov.my"
+        else:
+            portal_url = "preprod.myinvois.hasil.gov.my"
+
+        try:
+            qr_code = self.env['ir.actions.report'].barcode(
+                barcode_type='QR',
+                width=128,
+                height=128,
+                humanreadable=1,
+                value=f'https://{portal_url}/{self.l10n_my_edi_external_uuid}/share/{self.l10n_my_edi_invoice_long_id}',
+            )
+        except (ValueError, AttributeError):
+            raise werkzeug.exceptions.HTTPException(description='Cannot convert into QR Code.')
+
+        return image_data_uri(base64.b64encode(qr_code))
+
+    def action_l10n_my_edi_send_invoice(self):
+        """ Create the xml file (if needed) to be sent to the platform.
+        This will replace what is done in send & print.
+        """
+        # Gather the moves that have to be sent and the xml for each of them.
+        moves, xml_contents = self._l10n_my_edi_prepare_moves_to_send()
+        # We then push the moves to myinvois.
+        self._l10n_my_edi_send_to_myinvois(moves, xml_contents)
+        # We need to see if the validation status is already available; otherwise it will be fetched via a cron.
+        self._l10n_my_edi_get_status(moves)
+        # Finally, we update the move attachments
+        for move, xml_content in xml_contents.items():
+            if xml_content:
+                self.env['ir.attachment'].with_user(SUPERUSER_ID).create({
+                    'name': f'{move.name.replace("/", "_")}_myinvois.xml',
+                    'raw': xml_content,
+                    'mimetype': 'application/xml',
+                    'res_model': move._name,
+                    'res_id': move.id,
+                    'res_field': 'l10n_my_edi_file',  # Binary field
+                })
+                move.invalidate_recordset(fnames=['l10n_my_edi_file_id', 'l10n_my_edi_file'])
+
+    def _l10n_my_edi_prepare_moves_to_send(self):
+        AccountMoveSend = self.env['account.move.send']
+        xml_contents = defaultdict(list)
+        moves = self.env['account.move']
+        for move in self:
+            if not move.l10n_my_invoice_need_edi or move.l10n_my_edi_state:
+                continue
+
+            moves |= move
+
+            if move.l10n_my_edi_file:
+                xml_content = base64.b64decode(move.l10n_my_edi_file).decode('utf-8')
+            else:
+                xml_content, errors = move._l10n_my_edi_generate_invoice_xml()
+                if errors:
+                    raise UserError(AccountMoveSend._format_error_text({
+                        'error_title': _('Error when generating MyInvois file:'),
+                        'errors': errors,
+                    }))
+                xml_content = xml_content.decode('utf-8')
+            xml_contents[move] = xml_content
+        return moves, xml_contents
+
+    def _l10n_my_edi_send_to_myinvois(self, moves, xml_contents):
+        AccountMoveSend = self.env['account.move.send']
+        if moves and xml_contents:
+            errors = moves._l10n_my_edi_submit_documents(xml_contents)
+
+            if errors:
+                for move in moves:
+                    move.message_post(body=AccountMoveSend._format_error_html({
+                        'error_title': _('Error when sending the invoices to the E-invoicing service.'),
+                        'errors': errors[move],
+                    }))
+
+            # At this point we will need to commit as we reached the api, and we could have a mix of failed and valid invoice.
+            if moves._can_commit():
+                self._cr.commit()
+
+            # We already logged the details on the invoice(s) and saved the api results. If we send a single invoice, we can safely raise now.
+            if errors and len(moves) == 1:
+                raise UserError(AccountMoveSend._format_error_text({
+                    'error_title': _('Error when sending the invoices to the E-invoicing service.'),
+                    'errors': errors[moves],
+                }))
+
+    def _l10n_my_edi_get_status(self, moves):
+        AccountMoveSend = self.env['account.move.send']
+        retry = 0
+        errors, any_in_progress = moves._l10n_my_edi_fetch_updated_statuses()
+        while any_in_progress and retry < 2:
+            time.sleep(1)  # We wait a second before retrying.
+            errors, any_in_progress = moves._l10n_my_edi_fetch_updated_statuses()
+            retry += 1
+        # While technically an in_progress status is not an error, it won't hurt much to display it as such.
+        # The "error" message in this case should be clear enough.
+        if errors:
+            for move in moves:
+                move.message_post(body=AccountMoveSend._format_error_html({
+                    'error_title': _('Error when sending the invoices to the E-invoicing service.'),
+                    'errors': errors[move],
+                }))
+        # We commit again if possible, to ensure that the invoice status is set in the database in case of errors later.
+        if self._can_commit():
+            self._cr.commit()

--- a/addons/l10n_my_edi_extended/models/account_move_line.py
+++ b/addons/l10n_my_edi_extended/models/account_move_line.py
@@ -1,0 +1,33 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, api
+from odoo.addons.l10n_my_edi.models.product_template import CLASSIFICATION_CODES_LIST
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    # ------------------
+    # Fields declaration
+    # ------------------
+
+    l10n_my_edi_classification_code = fields.Selection(
+        string="Malaysian classification code",
+        selection=CLASSIFICATION_CODES_LIST,
+        compute="_compute_l10n_my_edi_classification_code",
+        store=True,
+        readonly=False,
+        copy=False,
+    )
+
+    # --------------------------------
+    # Compute, inverse, search methods
+    # --------------------------------
+
+    @api.depends("product_id.product_tmpl_id")
+    def _compute_l10n_my_edi_classification_code(self):
+        """ Default to the product classification if any """
+        for line in self:
+            # We don't want to automatically update it on invoices that were sent to MyInvois
+            if not line.move_id.l10n_my_edi_external_uuid:
+                line.l10n_my_edi_classification_code = line.product_id.product_tmpl_id.l10n_my_edi_classification_code or line.l10n_my_edi_classification_code

--- a/addons/l10n_my_edi_extended/models/res_partner.py
+++ b/addons/l10n_my_edi_extended/models/res_partner.py
@@ -1,0 +1,53 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    # ------------------
+    # Fields declaration
+    # ------------------
+
+    # Note: When merging with the base module in master, the company's industrial classification should become a related to this field.
+    l10n_my_edi_industrial_classification = fields.Many2one(
+        comodel_name='l10n_my_edi.industry_classification',
+        string="Ind. Classification",
+        compute='_compute_l10n_my_edi_industrial_classification',
+        store=True,
+        readonly=False,
+    )
+    l10n_my_edi_malaysian_tin = fields.Char(
+        string="Malaysian TIN",
+        help="The value set in this field will be used as TIN for the customer/supplier.\n"
+             "If left empty, the Tax ID field will be used.",
+    )
+
+    # --------------------------------
+    # Compute, inverse, search methods
+    # --------------------------------
+
+    @api.depends('l10n_my_edi_malaysian_tin')
+    def _compute_l10n_my_tin_validation_state(self):
+        # EXTEND 'l10n_my_edi' to add the depends
+        super()._compute_l10n_my_tin_validation_state()
+
+    def _compute_l10n_my_edi_industrial_classification(self):
+        default_classification = self.env.ref('l10n_my_edi.class_00000', raise_if_not_found=False)
+        self.filtered(lambda p: not p.l10n_my_edi_industrial_classification).l10n_my_edi_industrial_classification = default_classification
+
+    # ----------------
+    # Business methods
+    # ----------------
+
+    def _l10n_my_edi_get_tin_for_myinvois(self):
+        # EXTEND 'l10n_my_edi'
+        # When l10n_my_edi_malaysian_tin is set, it will be used instead of the VAT.
+        # A user may want to keep the correct VAT on a foreign contact while also use myinvois with a malaysia TIN/Generic TIN
+        # Using the Tax ID field also causes issue when base_vat is enabled, which block setting foreign VAT numbers.
+        return self.l10n_my_edi_malaysian_tin or super()._l10n_my_edi_get_tin_for_myinvois()
+
+    @api.model
+    def _commercial_fields(self):
+        return super()._commercial_fields() + ['l10n_my_edi_industrial_classification', 'l10n_my_edi_malaysian_tin']

--- a/addons/l10n_my_edi_extended/tests/__init__.py
+++ b/addons/l10n_my_edi_extended/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import test_file_generation
+from . import test_new_submissions_flow

--- a/addons/l10n_my_edi_extended/tests/test_file_generation.py
+++ b/addons/l10n_my_edi_extended/tests/test_file_generation.py
@@ -1,0 +1,97 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from freezegun import freeze_time
+from lxml import etree
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.l10n_my_edi.tests.test_file_generation import NS_MAP
+from odoo.tests import tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class L10nMyEDITestFileGeneration(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref='my'):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        # TIN number is required
+        cls.company_data['company'].write({
+            'vat': 'C2584563200',
+            'l10n_my_edi_mode': 'test',
+            'l10n_my_edi_industrial_classification': cls.env['l10n_my_edi.industry_classification'].search([('code', '=', '01111')]).id,
+            'l10n_my_identification_type': 'BRN',
+            'l10n_my_identification_number': '202001234567',
+            'state_id': cls.env.ref('base.state_my_jhr').id,
+            'street': 'that one street, 5',
+            'city': 'Main city',
+            'phone': '+60123456789',
+        })
+        cls.partner_b.write({
+            'vat': '123456789',
+            'l10n_my_identification_type': 'BRN',
+            'l10n_my_identification_number': 'NA',
+            'country_id': cls.env.ref('base.us').id,
+            'state_id': cls.env.ref('base.state_us_1'),
+            'street': 'that other street, 3',
+            'city': 'Main city',
+            'phone': '+60123456785',
+            'l10n_my_edi_malaysian_tin': 'EI00000000020',
+            'l10n_my_edi_industrial_classification': cls.env.ref('l10n_my_edi.class_00000', raise_if_not_found=False).id,
+        })
+        cls.product_a.l10n_my_edi_classification_code = "001"
+
+        cls.purchase_tax = cls.env['account.tax'].create({
+            'name': 'tax_10',
+            'amount_type': 'percent',
+            'amount': 10,
+            'type_tax_use': 'purchase',
+            'country_id': cls.env.ref('base.my').id,
+        })
+
+    @freeze_time('2024-07-15 10:00:00')
+    def test_07_self_billing(self):
+        bill = self.init_invoice(
+            'in_invoice', partner=self.partner_b, products=self.product_a, taxes=self.purchase_tax,
+        )
+        bill.action_post()
+
+        file, errors = bill._l10n_my_edi_generate_invoice_xml()
+        self.assertFalse(errors)
+        self.assertTrue(file)
+
+        root = etree.fromstring(file)
+        # We assert that the supplier is the partner of the invoice, with all information present.
+        supplier_root = root.xpath('cac:AccountingSupplierParty/cac:Party', namespaces=NS_MAP)[0]
+        data_to_check = [
+            ('cac:PartyIdentification/cbc:ID[@schemeID="TIN"]', self.partner_b.commercial_partner_id.l10n_my_edi_malaysian_tin),  # We set the generic VAT in the new field, it should have been used.
+            ('cac:PartyIdentification/cbc:ID[@schemeID="BRN"]', self.partner_b.commercial_partner_id.l10n_my_identification_number),
+            ('cbc:IndustryClassificationCode', self.partner_b.commercial_partner_id.l10n_my_edi_industrial_classification.code),  # It should use the code on the partner.
+            ('cac:PartyName/cbc:Name', self.partner_b.name),
+        ]
+        for path, expected_value in data_to_check:
+            self._assert_node_values(supplier_root, path, expected_value)
+        # And that the customer is the company.
+        customer_root = root.xpath('cac:AccountingCustomerParty/cac:Party', namespaces=NS_MAP)[0]
+        data_to_check = [
+            ('cac:PartyIdentification/cbc:ID[@schemeID="TIN"]', self.company_data['company'].vat),  # We didn't set the new field as the company is malaysian, the vat should be in use.
+            ('cac:PartyIdentification/cbc:ID[@schemeID="BRN"]', self.company_data['company'].l10n_my_identification_number),
+            ('cac:PartyName/cbc:Name', self.company_data['company'].name),
+        ]
+        for path, expected_value in data_to_check:
+            self._assert_node_values(customer_root, path, expected_value)
+
+    def _assert_node_values(self, root, node_path, text, attributes=None):
+        node = root.xpath(node_path, namespaces=NS_MAP)
+
+        assert node, f'The requested node has not been found: {node_path}'
+
+        self.assertEqual(
+            node[0].text,
+            text,
+        )
+        if attributes:
+            for attribute, value in attributes.items():
+                self.assertEqual(
+                    node[0].attrib[attribute],
+                    value,
+                )

--- a/addons/l10n_my_edi_extended/tests/test_new_submissions_flow.py
+++ b/addons/l10n_my_edi_extended/tests/test_new_submissions_flow.py
@@ -1,5 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
@@ -15,7 +14,11 @@ CONTACT_PROXY_METHOD = 'odoo.addons.l10n_my_edi.models.account_edi_proxy_user.Ac
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
-class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
+class L10nMyEDITestNewSubmission(TestAccountMoveSendCommon):
+    """ The tests in this file are similar to the ones in test_submissions but use the new flow (outside of send & print)
+    to test the features of the EDI.
+    These will fully replace the old tests in master.
+    """
 
     @classmethod
     def setUpClass(cls, chart_template_ref='my'):
@@ -55,20 +58,16 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
         cls.proxy_user = cls.env['account_edi_proxy_client.user']._register_proxy_user(cls.company_data['company'], 'l10n_my_edi', 'demo')
         cls.proxy_user.edi_mode = 'test'
 
-        # This will allow to still use the send and print flow when testing, even if the new module is installed.
-        # It's best to keep the code tested even if we expect users to use the new flow.
-        cls.env['ir.config_parameter'].set_param('l10n_my_edi.disable.send_and_print.first', 'False')
+        cls.env['ir.config_parameter'].set_param('l10n_my_edi.disable.send_and_print.first', 'True')
 
-        cls.fakenow = datetime(2024, 7, 15, 10, 00, 00)
-        cls.startClassPatcher(freeze_time(cls.fakenow))
-
-    def test_01_basic_submission(self):
+    @freeze_time('2024-07-15 10:00:00')
+    def test_01_new_basic_submission(self):
         """
         This tests the most basic flow: an invoice is successfully sent to the MyInvois platform, and then pass validation.
         """
-        send_and_print = self.create_send_and_print(self.basic_invoice)
+        # Send to MyInvois
         with patch(CONTACT_PROXY_METHOD, new=self._test_01_mock):
-            send_and_print.action_send_and_print()
+            self.basic_invoice.action_l10n_my_edi_send_invoice()
 
         # Now that the invoice has been sent successfully, we assert that some info have been saved correctly.
         self.assertRecordValues(
@@ -76,6 +75,7 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
             [{
                 'l10n_my_edi_state': 'valid',
                 'l10n_my_edi_validation_time': datetime.strptime('2024-07-15 05:00:00', '%Y-%m-%d %H:%M:%S'),
+                'l10n_my_edi_invoice_long_id': '123-789-654',
                 'l10n_my_edi_submission_uid': '123456789',
                 'l10n_my_edi_external_uuid': '123458974513518',
             }]
@@ -84,31 +84,31 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
         # We will test the actual file in another test class, but we ensure it was generated as expected.
         self.assertTrue(self.basic_invoice.l10n_my_edi_file_id)
 
-    def test_02_failed_submission(self):
+    @freeze_time('2024-07-15 10:00:00')
+    def test_02_new_failed_submission(self):
         """
         This test will test a flow where the submission itself (not the documents inside) fails for any reason.
         A general error as such should be handled, but is not expected and should be treated as a bug on our side.
 
         As we submit a single invoice, we expect a UserError to be raised.
         """
-        send_and_print = self.create_send_and_print(self.basic_invoice)
         with patch(CONTACT_PROXY_METHOD, new=self._test_02_mock):
-            with self.assertRaises(UserError, msg='Server error; If the problem persists, please contact the Odoo support.'):
-                send_and_print.action_send_and_print()
+            with self.assertRaisesRegex(UserError, 'Server error; If the problem persists, please contact the Odoo support.'):
+                self.basic_invoice.action_l10n_my_edi_send_invoice()
 
-    def test_03_failed_document_submission(self):
+    @freeze_time('2024-07-15 10:00:00')
+    def test_03_new_failed_document_submission(self):
         """
         Unlike the previous test, this will test the use case where the submission is done correctly but the document
         itself is incorrect.
 
         This would be due to an incorrect supplier tin for example.
         """
-        send_and_print = self.create_send_and_print(self.basic_invoice)
         with patch(CONTACT_PROXY_METHOD, new=self._test_03_mock):
             # We want to assert that some values are saved during the commit, which won't happen during a test if we raise all the way.
             # So instead of doing an assertRaises, we will catch the error (ensuring that it does happen) then continue.
             try:
-                send_and_print.action_send_and_print()
+                self.basic_invoice.action_l10n_my_edi_send_invoice()
             except UserError:
                 pass  # We expect a user error to be raised here.
             else:
@@ -125,14 +125,14 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
             }]
         )
 
-    def test_04_cancellation(self):
+    @freeze_time('2024-07-15 10:00:00')
+    def test_04_new_cancellation(self):
         """
         An invoice can be cancelled up to 72h after validation.
         Test the cancellation flow when it works well.
         """
-        send_and_print = self.create_send_and_print(self.basic_invoice)
         with patch(CONTACT_PROXY_METHOD, new=self._test_04_mock):
-            send_and_print.action_send_and_print()
+            self.basic_invoice.action_l10n_my_edi_send_invoice()
 
             # Open the wizard successfully, 72h did not pass
             action = self.basic_invoice.button_request_cancel()
@@ -149,14 +149,14 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
             }]
         )
 
-    def test_05_cancellation_failures(self):
+    @freeze_time('2024-07-15 10:00:00')
+    def test_05_new_cancellation_failures(self):
         """
         Tests two scenarios when cancellation fails.
         First on is trying to launch the wizard past the 72h mark, and then an actual cancellation error.
         """
-        send_and_print = self.create_send_and_print(self.basic_invoice)
         with patch(CONTACT_PROXY_METHOD, new=self._test_05_mock):
-            send_and_print.action_send_and_print()
+            self.basic_invoice.action_l10n_my_edi_send_invoice()
 
             self.basic_invoice.l10n_my_edi_validation_time = datetime.strptime('2024-07-12 10:00:00', '%Y-%m-%d %H:%M:%S')
 
@@ -173,17 +173,17 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
             wizard.button_request_update()
             self.assertEqual(self.basic_invoice.message_ids[0].preview, 'You do not have the permission to update this invoice.')
 
-    def test_06_invalid_reset(self):
+    @freeze_time('2024-07-15 10:00:00')
+    def test_06_new_invalid_reset(self):
         """
         Test that an invalid invoice can be reset, and that after reset the edi related fields are correctly reset beside the hash and retry time.
         Also test that the invoice can be sent again after correction.
         """
-        send_and_print = self.create_send_and_print(self.basic_invoice)
         with patch(CONTACT_PROXY_METHOD, new=self._test_06_mock):
             # We want to assert that some values are saved during the commit, which won't happen during a test if we raise all the way.
             # So instead of doing an assertRaises, we will catch the error (ensuring that it does happen) then continue.
             try:
-                send_and_print.action_send_and_print()
+                self.basic_invoice.action_l10n_my_edi_send_invoice()
             except UserError:
                 pass  # We expect a user error to be raised here.
             else:
@@ -208,8 +208,7 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
             # ... we change whatever
             self.basic_invoice.action_post()
 
-            send_and_print = self.create_send_and_print(self.basic_invoice)
-            send_and_print.action_send_and_print()
+            self.basic_invoice.action_l10n_my_edi_send_invoice()
 
             self.assertRecordValues(
                 self.basic_invoice,
@@ -218,15 +217,15 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
                 }]
             )
 
-    def test_07_pending_submission(self):
+    @freeze_time('2024-07-15 10:00:00')
+    def test_07_new_pending_submission(self):
         """
         Test the case of a submission status being unavailable at the time of submission.
         No errors should be raised, and it should be handled by the cron later on.
         """
         self.get_submission_status_count = 0  # Needed for the mock; we get it twice. Once during submission and once from the cron.
-        send_and_print = self.create_send_and_print(self.basic_invoice)
         with patch(CONTACT_PROXY_METHOD, new=self._test_07_mock):
-            send_and_print.action_send_and_print()
+            self.basic_invoice.action_l10n_my_edi_send_invoice()
 
             self.assertRecordValues(
                 self.basic_invoice,
@@ -241,9 +240,17 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
             self.env['account.move']._cron_l10n_my_edi_synchronize_myinvois()
 
             # The update should be reflected on the move.
-            self.assertEqual(self.basic_invoice.l10n_my_edi_state, 'valid')
+            self.assertRecordValues(
+                self.basic_invoice,
+                [{
+                    'l10n_my_edi_state': 'valid',
+                    'l10n_my_edi_validation_time': datetime.strptime('2024-07-15 05:00:00', '%Y-%m-%d %H:%M:%S'),
+                    'l10n_my_edi_invoice_long_id': '123-789-654',
+                }]
+            )
 
-    def test_08_mass_submission(self):
+    @freeze_time('2024-07-15 10:00:00')
+    def test_08_new_mass_submission(self):
         """ This test will ensure that invoices are split as expected if there are more than SUBMISSION_MAX_SIZE at once. """
         # For performance purposes we will not create 100 invoices here, but instead patch SUBMISSION_MAX_SIZE to make batches of two invoices.
         self.submission_count = 0
@@ -261,19 +268,18 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
         self.submission_invoice.action_post()
         self.submission_invoice |= self.basic_invoice
 
-        send_and_print = self.create_send_and_print(self.submission_invoice)
         with patch(CONTACT_PROXY_METHOD, new=self._test_08_mock), \
              patch('odoo.addons.l10n_my_edi.models.account_move.SUBMISSION_MAX_SIZE', 2):
-            send_and_print.action_send_and_print()
+            self.submission_invoice.action_l10n_my_edi_send_invoice()
 
         # we have 10 invoices, with a max size of 2 we expect 5 different submissions.
         self.assertEqual(self.submission_count, 5)
 
-    def test_09_fetch_status(self):
+    @freeze_time('2024-07-15 10:00:00')
+    def test_09_new_fetch_status(self):
         """ After pushing an invoice, we can optionally fetch the status manually if needed. """
-        send_and_print = self.create_send_and_print(self.basic_invoice)
         with patch(CONTACT_PROXY_METHOD, new=self._test_09_mock):
-            send_and_print.action_send_and_print()
+            self.basic_invoice.action_l10n_my_edi_send_invoice()
 
             self.assertRecordValues(
                 self.basic_invoice,
@@ -290,45 +296,16 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
             # The update should be reflected on the move.
             self.assertEqual(self.basic_invoice.l10n_my_edi_state, 'valid')
 
-    def test_10_reject_bill(self):
-        """
-        An invoice can be cancelled up to 72h after validation.
-        Test the cancellation flow when it works well.
-        """
-        bill = self.init_invoice(
-            'in_invoice', products=self.product_a
-        )
-        bill.action_post()
-
-        # Technically this would have been done at import
-        bill.l10n_my_edi_state = 'valid'
-
-        with patch(CONTACT_PROXY_METHOD, new=self._test_10_mock):
-            action = bill.action_l10n_my_edi_reject_bill()
-            wizard = self.env[action['res_model']].with_context(action['context']).create({
-                'reason': 'Discount not applied',
-            })
-            # Cancel the invoice
-            wizard.button_request_update()
-
-        self.assertRecordValues(  # Did not change, not until the supplier cancel.
-            bill,
-            [{
-                'l10n_my_edi_state': 'rejected',
-                'state': 'posted',
-            }]
-        )
-
-    def test_11_full_rejection_flow_invoice(self):
+    @freeze_time('2024-07-15 10:00:00')
+    def test_10_new_full_rejection_flow_invoice(self):
         """
         We issue an invoice to our customer with the wrong address.
         The customer reject it for that reason.
         We receive the updated status later on, and cancel the invoice to issue a new one later.
         """
-        send_and_print = self.create_send_and_print(self.basic_invoice)
-        with patch(CONTACT_PROXY_METHOD, new=self._test_11_mock):
+        with patch(CONTACT_PROXY_METHOD, new=self._test_10_mock):
             # Issue the invoice, and get a valid status.
-            send_and_print.action_send_and_print()
+            self.basic_invoice.action_l10n_my_edi_send_invoice()
             # Update the status, and receive a rejection request.
             self.basic_invoice.action_l10n_my_edi_update_status()
             self.assertEqual(self.basic_invoice.l10n_my_edi_state, 'rejected')
@@ -340,6 +317,15 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
             # Cancel the invoice
             wizard.button_request_update()
             self.assertEqual(self.basic_invoice.l10n_my_edi_state, 'cancelled')
+
+    @freeze_time('2024-07-15 10:00:00')
+    def test_11_qr_code_generation(self):
+        """ Basic test that ensure that a valid invoice can generate a QR code. """
+        with patch(CONTACT_PROXY_METHOD, new=self._test_11_mock):
+            self.basic_invoice.action_l10n_my_edi_send_invoice()
+
+        qr_data_uri = self.basic_invoice._generate_myinvois_qr_code()
+        self.assertTrue(qr_data_uri)
 
     # -------------------------------------------------------------------------
     # Patched methods
@@ -362,7 +348,7 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
                     '123458974513518': {
                         'status': 'valid',
                         'reason': '',
-                        'long_id': '',
+                        'long_id': '123-789-654',
                         'valid_datetime': '2024-07-15T05:00:00Z',
                     }
                 },
@@ -536,7 +522,7 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
                     '123458974513518': {
                         'status': 'valid',
                         'reason': '',
-                        'long_id': '',
+                        'long_id': '123-789-654',
                         'valid_datetime': '2024-07-15T05:00:00Z',
                     }
                 },
@@ -609,15 +595,6 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
 
     def _test_10_mock(self, endpoint, params):
         """ Basic mocked method that simulate what the proxy would return depending on the endpoint. """
-        if endpoint == 'api/l10n_my_edi/1/update_status':
-            return {
-                'success': True,
-            }
-        else:
-            raise UserError('Unexpected endpoint called during a test: %s with params %s.' % (endpoint, params))
-
-    def _test_11_mock(self, endpoint, params):
-        """ Basic mocked method that simulate what the proxy would return depending on the endpoint. """
         if endpoint == 'api/l10n_my_edi/1/submit_invoices':
             return {
                 'submission_uid': '123456789',
@@ -649,6 +626,32 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
         elif endpoint == 'api/l10n_my_edi/1/update_status':
             return {
                 'success': True,
+            }
+        else:
+            raise UserError('Unexpected endpoint called during a test: %s with params %s.' % (endpoint, params))
+
+    def _test_11_mock(self, endpoint, params):
+        """ Basic mocked method that simulate what the proxy would return depending on the endpoint. """
+        if endpoint == 'api/l10n_my_edi/1/submit_invoices':
+            return {
+                'submission_uid': '123456789',
+                'documents': [{
+                    'move_id': params['documents'][0]['move_id'],
+                    'uuid': '123458974513518',
+                    'success': True,
+                }]
+            }
+        elif endpoint == 'api/l10n_my_edi/1/get_submission_statuses':
+            return {
+                'statuses': {
+                    '123458974513518': {
+                        'status': 'valid',
+                        'reason': '',
+                        'long_id': '123-789-654',
+                        'valid_datetime': '2024-07-15T05:00:00Z',
+                    }
+                },
+                'document_count': 1,
             }
         else:
             raise UserError('Unexpected endpoint called during a test: %s with params %s.' % (endpoint, params))

--- a/addons/l10n_my_edi_extended/views/account_move_view.xml
+++ b/addons/l10n_my_edi_extended/views/account_move_view.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_move_form_inherit_l10n_my_myinvois_extended" model="ir.ui.view">
+        <field name="name">account.move.form.inherit.l10n_my_myinvois_extended</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="l10n_my_edi.view_move_form_inherit_l10n_my_myinvois"/>
+        <field name="arch" type="xml">
+            <!-- Hide the original send & print button, as it is difficult to update its invisible condition -->
+            <button name="action_invoice_sent" class="oe_highlight" position="attributes">
+                <attribute name="invisible" add="l10n_my_invoice_need_edi" separator=" or "/>
+            </button>
+            <!-- Instead, we display our own buttons so that we can write the invisible properly for our use case. -->
+            <xpath expr="//button[@name='action_invoice_sent' and not(@class)]" position="after">
+                <button name="action_invoice_sent"
+                        type="object"
+                        string="Send &amp; Print"
+                        invisible="(not l10n_my_invoice_need_edi or l10n_my_edi_state != 'valid') or (state != 'posted' or is_being_sent or invoice_pdf_report_id or move_type not in ('out_invoice', 'out_refund'))"
+                        class="oe_highlight"
+                        data-hotkey="y"/>
+                <button name="action_invoice_sent"
+                        type="object"
+                        string="Send &amp; Print"
+                        invisible="(not l10n_my_invoice_need_edi or l10n_my_edi_state == 'valid') or (state != 'posted' or is_being_sent or invoice_pdf_report_id or move_type not in ('out_invoice', 'out_refund'))"
+                        data-hotkey="y"/>
+            </xpath>
+            <!-- We want the CTA to be primary only on invoices, and secondary on vendor bills. -->
+            <button name="action_invoice_sent" position="before">
+                <button name="action_l10n_my_edi_send_invoice" string="Send To MyInvois" type="object"
+                        groups="account.group_account_invoice"
+                        class="oe_highlight"
+                        invisible="not l10n_my_invoice_need_edi or l10n_my_edi_state or move_type not in ('out_invoice', 'out_refund')"/>
+            </button>
+            <button name="action_register_payment" position="after">
+                <button name="action_l10n_my_edi_send_invoice" string="Send To MyInvois" type="object"
+                        groups="account.group_account_invoice"
+                        invisible="not l10n_my_invoice_need_edi or l10n_my_edi_state or move_type not in ('in_invoice', 'in_refund')"/>
+            </button>
+            <!-- The rejection button is only intended for received bills, as we don't support that at the moment, and we now send bills, it will be confusing to keep it. -->
+            <button name="action_l10n_my_edi_reject_bill" position="replace">
+            </button>
+            <field name="l10n_my_edi_display_tax_exemption_reason" position="after">
+                    <field name="l10n_my_invoice_need_edi" invisible="1"/>
+            </field>
+            <!-- Add the classification code to the invoice lines -->
+            <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='name']" position="after">
+                <field name="l10n_my_edi_classification_code" optional="hide"/>
+            </xpath>
+            <field name="l10n_my_edi_external_uuid" position="after">
+                <field name="l10n_my_edi_invoice_long_id" invisible="not l10n_my_edi_external_uuid"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="invoice_send_to_myinvois" model="ir.actions.server">
+        <field name="name">Send To MyInvois</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="model_account_move"/>
+        <field name="binding_model_id" ref="model_account_move"/>
+        <field name="binding_view_types">list</field>
+        <field name="code">
+            if records:
+                action = records.action_l10n_my_edi_send_invoice()
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_my_edi_extended/views/report_invoice.xml
+++ b/addons/l10n_my_edi_extended/views/report_invoice.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_invoice_document" inherit_id="account.report_invoice_document" primary="True">
+        <div id="qrcode" position="after">
+            <div id="myinvois_qrcode" class="d-flex mb-3 avoid-page-break-inside" t-if="o.l10n_my_edi_external_uuid">
+                <div class="qrcode me-3" id="myinvois_qrcode_image">
+                    <t t-set="qr_code_url" t-value="o._generate_myinvois_qr_code()"/>
+                    <p t-if="qr_code_url" class="position-relative mb-0">
+                        <img t-att-src="qr_code_url"/>
+                        <img src="/account/static/src/img/Odoo_logo_O.svg"
+                             id="qrcode_odoo_logo"
+                             class="top-50 start-50 position-absolute bg-white border border-white border-3 rounded-circle"
+                        />
+                    </p>
+                </div>
+                <div class="d-inline text-muted lh-sm fst-italic" id="qrcode_info" t-if="qr_code_url">
+                    <p>Scan this QR Code to<br/>access your invoice
+                    </p>
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <!-- Workaround for Studio reports, see odoo/odoo#60660 -->
+    <template id="report_invoice" inherit_id="account.report_invoice">
+        <xpath expr='//t[@t-call="account.report_invoice_document"]' position="after">
+            <t t-elif="o._get_name_invoice_report() == 'l10n_my_edi_extended.report_invoice_document'"
+               t-call="l10n_my_edi_extended.report_invoice_document"
+               t-lang="lang"/>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/l10n_my_edi_extended/views/res_partner_view.xml
+++ b/addons/l10n_my_edi_extended/views/res_partner_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_partner_form_inherit_l10n_my_myinvois_extended" model="ir.ui.view">
+        <field name="name">res.partner.form.inherit.l10n_my_myinvois_extended</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="l10n_my_edi.view_partner_form_inherit_l10n_my_myinvois"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='l10n_my_edi']/group" position="inside">
+                <field name="l10n_my_edi_industrial_classification" readonly="parent_id"/>
+                <field name="l10n_my_edi_malaysian_tin" placeholder="EI00000000020" readonly="parent_id"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_my_edi_extended/wizard/__init__.py
+++ b/addons/l10n_my_edi_extended/wizard/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import account_move_send

--- a/addons/l10n_my_edi_extended/wizard/account_move_send.py
+++ b/addons/l10n_my_edi_extended/wizard/account_move_send.py
@@ -1,0 +1,20 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+from odoo.tools import str2bool
+
+
+class AccountMoveSend(models.TransientModel):
+    _inherit = 'account.move.send'
+
+    @api.depends('move_ids')
+    def _compute_l10n_my_edi_enable(self):
+        """ Override to disable the usage of MyInvois in the Send & Print wizard.
+        It is not fully compatible with the QR flow and thus, we intend to send the file to MyInvois separately.
+        """
+        super()._compute_l10n_my_edi_enable()
+        for wizard in self:
+            # In master, the send & print sending flow will be fully removed and this won't be needed anymore.
+            # For now, this is kept so that runbot won't fail the base module tests, which we still want to run atm.
+            disabled = str2bool(self.env['ir.config_parameter'].sudo().get_param('l10n_my_edi.disable.send_and_print.first', 'True'))
+            wizard.l10n_my_edi_enable = not disabled and wizard.l10n_my_edi_enable

--- a/addons/l10n_my_ubl_pint/models/res_partner.py
+++ b/addons/l10n_my_ubl_pint/models/res_partner.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class ResPartner(models.Model):
@@ -27,3 +27,7 @@ class ResPartner(models.Model):
         for partner in self:
             if partner.country_code == 'MY':
                 partner.ubl_cii_format = 'pint_my'
+
+    @api.model
+    def _commercial_fields(self):
+        return super()._commercial_fields() + ['sst_registration_number', 'ttx_registration_number']

--- a/addons/l10n_my_ubl_pint/views/res_partner_view.xml
+++ b/addons/l10n_my_ubl_pint/views/res_partner_view.xml
@@ -6,8 +6,8 @@
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='vat']" position="after">
-                <field name="sst_registration_number" invisible="'MY' not in fiscal_country_codes" placeholder="A01-2345-67891012"/>
-                <field name="ttx_registration_number" invisible="'MY' not in fiscal_country_codes" placeholder="123-4567-89012345"/>
+                <field name="sst_registration_number" invisible="'MY' not in fiscal_country_codes" placeholder="A01-2345-67891012" readonly="parent_id"/>
+                <field name="ttx_registration_number" invisible="'MY' not in fiscal_country_codes" placeholder="123-4567-89012345" readonly="parent_id"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Brings various needed improvements to the module, either in place or
via a new extended module.

- Neutralization resets to pre-production
- Better handling of errors when generating the file by using the commercial partner
as expected.
- Align all the flows which update the invoice status to ensure that the data is
consistent.
- Improve validation for some special cases (lines without products, tax exemption)
- Add a new field for Malaysian TIN, mostly for foreign entities.
Will be used by default in all flows for MyInvois, with fallback on the Tax ID if empty.
- Classification code on invoice line, making the use of products optional.
- Rework the views for all fields related to ID on res.partner to align with other similar
fields. They will be Readonly on res.partner with a parent id, but displays the value of
the commercial partner.
- Industrial classification on the partner.
- "Full" support of self billing.
- Reworked flow to send to MyInvois BEFORE send & print. Which adds support for the
QR code generation, and new field to store the QR code long ID.
- Send & Print can no longer be used to send invoices to MyInvois after the new
module is installed

Task-4363294

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
