### PR TITLE
[FIX] html_editor: scroll to selection if needed

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -23,6 +23,7 @@ import {
     normalizeDeepCursorPosition,
     normalizeFakeBR,
 } from "../utils/selection";
+import { scrollTo } from "@web/core/utils/scrolling";
 
 /**
  * @typedef { Object } EditorSelection
@@ -157,7 +158,13 @@ export class SelectionPlugin extends Plugin {
 
     setup() {
         this.resetSelection();
-        this.addDomListener(this.document, "selectionchange", this.updateActiveSelection);
+        this.addDomListener(this.document, "selectionchange", () => {
+            this.updateActiveSelection();
+            const selection = this.document.getSelection();
+            if (selection.isCollapsed && this.isSelectionInEditable(selection)) {
+                scrollTo(closestElement(selection.focusNode));
+            }
+        });
         this.addDomListener(this.editable, "mousedown", (ev) => {
             if (ev.detail >= 3) {
                 this.correctTripleClick = true;


### PR DESCRIPTION
**Problem**:
When the selection moves out of the viewport while typing, the user cannot see what they are typing.

**Solution**:
Automatically scroll to the selection if it moves out of the viewport.

**Steps to Reproduce**:
1. Open the editor.
2. Keep adding paragraphs by pressing Enter repeatedly.
3. When the selection goes out of the viewport, type some text.
   - The typed content is not visible.

opw-4356668

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
