### PR TITLE
[FIX] core: add_index needs a savepoint

### DIFF
--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -695,8 +695,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
                     method = 'btree'
                     where = f'{column_expression} IS NOT NULL' if index == 'btree_not_null' else ''
                 try:
-                    with cr.savepoint(flush=False):
-                        sql.create_index(cr, indexname, tablename, [expression], method, where)
+                    sql.create_index(cr, indexname, tablename, [expression], method, where)
                 except psycopg2.OperationalError:
                     _schema.error("Unable to add index for %s", self)
 


### PR DESCRIPTION
When there is a failure when adding an index, the ORM supposes a rollback is done in `add_index`, so the next SQL statement will fail because the current transaction is aborted.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
