### PR TITLE
[FIX] 16.0 l10n_es_edi_tbai prevent ZeroDivisionError

### DIFF
--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -369,7 +369,7 @@ class AccountEdiFormat(models.Model):
             invoice_lines.append({
                 'line': line,
                 'discount': discount * refund_sign,
-                'unit_price': (line.balance + discount) / line.quantity * refund_sign,
+                'unit_price': (line.balance + discount) / line.quantity * refund_sign if line.quantity else 0.0,
                 'total': total,
                 'description': regex_sub(r'[^0-9a-zA-Z ]', '', line.name or '')[:250]
             })


### PR DESCRIPTION
[FIX] l10n_es_edi_tbai prevent ZeroDivisionError when invoice line quantity is zero

Current behavior before PR:

If any invoice line quantity is zero, ZeroDivisionError: float division by zero is raised when trying to post the account edi document to the tax agency.

Desired behavior after PR is merged:

No error is raised and the account edi document related to the invoice is sent to the tax agency.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
