### PR TITLE
[FIX] repair: show recycle lines in repair order report

### DIFF
--- a/addons/repair/i18n/repair.pot
+++ b/addons/repair/i18n/repair.pot
@@ -22,6 +22,11 @@ msgstr ""
 
 #. module: repair
 #: model_terms:ir.ui.view,arch_db:repair.report_repairorder
+msgid "(<i>Recycle</i>)"
+msgstr ""
+
+#. module: repair
+#: model_terms:ir.ui.view,arch_db:repair.report_repairorder
 msgid "(<i>Remove</i>)"
 msgstr ""
 

--- a/addons/repair/report/repair_templates_repair_order.xml
+++ b/addons/repair/report/repair_templates_repair_order.xml
@@ -52,6 +52,7 @@
                                 <td>
                                     <p t-if="line.repair_line_type == 'add'"><i>(Add)</i> <span t-field="line.product_id">Product A</span></p>
                                     <p t-if="line.repair_line_type == 'remove'">(<i>Remove</i>) <span t-field="line.product_id">Product B</span></p>
+                                    <p t-if="line.repair_line_type == 'recycle'">(<i>Recycle</i>) <span t-field="line.product_id">Product C</span></p>
                                 </td>
                                 <td class="text-end">
                                     <span t-field="line.product_uom_qty">5</span>

--- a/addons/repair/report/repair_templates_repair_order.xml
+++ b/addons/repair/report/repair_templates_repair_order.xml
@@ -52,7 +52,7 @@
                                 <td>
                                     <p t-if="line.repair_line_type == 'add'"><i>(Add)</i> <span t-field="line.product_id">Product A</span></p>
                                     <p t-if="line.repair_line_type == 'remove'">(<i>Remove</i>) <span t-field="line.product_id">Product B</span></p>
-                                    <p t-if="line.repair_line_type == 'recycle'">(<i>Recycle</i>) <span t-field="line.product_id">Product C</span></p>
+                                    <p t-if="line.repair_line_type == 'recycle'">(<i>Recycle</i>) <span t-field="line.product_id" data-oe-demo="Product C"/></p>
                                 </td>
                                 <td class="text-end">
                                     <span t-field="line.product_uom_qty">5</span>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The "Recycle" repair type wasn't integrated properly into the report template
Current behavior before PR:
Repair lines with "Recycle" type create empty lines on the repair order report
![grafik](https://github.com/user-attachments/assets/20ffc739-d14d-4f3b-adfe-73b36fa42938)
![grafik](https://github.com/user-attachments/assets/157bd99f-e1ff-4c3b-a89d-7b67284e336b)
Desired behavior after PR is merged:
Repair lines with "Recycle" type have their product description printed on the report


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
