### PR TITLE
[FIX] bunch of fix after fp feedback

### DIFF
--- a/addons/point_of_sale/models/pos_preset.py
+++ b/addons/point_of_sale/models/pos_preset.py
@@ -20,7 +20,7 @@ class PosPreset(models.Model):
     count_linked_config = fields.Integer(compute='_compute_count_linked_config')
 
     # Timing options
-    use_timing = fields.Boolean(string='Timing', default=False)
+    use_timing = fields.Boolean(string='Time Slots', default=False)
     resource_calendar_id = fields.Many2one('resource.calendar', 'Resource')
     attendance_ids = fields.One2many(related="resource_calendar_id.attendance_ids", string="Attendances", readonly=False)
     slots_per_interval = fields.Integer(string='Capacity', default=5)

--- a/addons/point_of_sale/static/src/app/components/popups/preset_slots_popup/preset_slots_popup.scss
+++ b/addons/point_of_sale/static/src/app/components/popups/preset_slots_popup/preset_slots_popup.scss
@@ -1,0 +1,3 @@
+.pos .preset-slot-button {
+    background-color: var(--bg, var(--btn-bg));
+}

--- a/addons/point_of_sale/static/src/app/components/popups/preset_slots_popup/preset_slots_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/preset_slots_popup/preset_slots_popup.xml
@@ -38,7 +38,7 @@
                                     <button t-foreach="entries[1]"
                                         t-as="slot"
                                         t-key="slot_index"
-                                        class="btn"
+                                        class="btn preset-slot-button"
                                         t-attf-class="{{getSlotColor(slot, preset)}}"
                                         t-on-click="() => this.confirm(slot, preset)">
                                             <span t-esc="slot.humain_readable" />

--- a/addons/point_of_sale/static/src/app/components/popups/selection_popup/selection_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/selection_popup/selection_popup.js
@@ -10,6 +10,7 @@ export class SelectionPopup extends Component {
         list: { type: Array, optional: true },
         getPayload: Function,
         close: Function,
+        size: { type: String, optional: true },
     };
     static defaultProps = {
         title: _t("Select"),
@@ -44,5 +45,8 @@ export class SelectionPopup extends Component {
     confirm() {
         this.props.getPayload(this.computePayload());
         this.props.close();
+    }
+    get size() {
+        return this.props.size || "lg";
     }
 }

--- a/addons/point_of_sale/static/src/app/components/popups/selection_popup/selection_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/selection_popup/selection_popup.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.SelectionPopup">
-        <Dialog title="props.title" footer="false" contentClass="'pb-5'" bodyClass="'d-flex flex-column gap-2 border-bottom'">
+        <Dialog title="props.title" footer="false" size="this.size" contentClass="'pb-5'" bodyClass="'d-flex flex-column gap-2 border-bottom'">
             <button t-foreach="props.list" t-as="item" t-key="item.id"
                     class="selection-item d-flex align-items-center justify-content-between btn btn-lg btn-outline-secondary w-100 p-3 text-start"
                     t-att-class="{ 'selected active': item.isSelected }"

--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
@@ -21,7 +21,8 @@
                     t-esc="props.name" />
                 <h1 t-if="props.productCartQty"
                     t-out="props.productCartQty"
-                    class="product-cart-qty position-absolute bottom-0 end-0 fw-bolder mb-0 px-1 text-muted" />
+                    class="product-cart-qty position-absolute bottom-0 end-0 fw-bolder mb-0 px-1 text-muted bg-white bg-opacity-50"
+                    t-att-class="{'text-danger': props.productCartQty &lt; 0}"/>
             </div>
         </article>
     </t>

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -108,6 +108,13 @@ export class PosOrder extends Base {
         this.setPricelist(preset.pricelist_id);
         this.fiscal_position_id = preset.fiscal_position_id;
         this.preset_id = preset;
+        if (preset.is_return) {
+            for (const line of this.lines) {
+                if (line.getQuantity() > 0) {
+                    line.setQuantity(-line.getQuantity());
+                }
+            }
+        }
     }
 
     /**

--- a/addons/point_of_sale/static/src/app/models/pos_preset.js
+++ b/addons/point_of_sale/static/src/app/models/pos_preset.js
@@ -69,6 +69,42 @@ export class PosPreset extends Base {
         return this.uiState.availabilities;
     }
 
+    get actualPreset() {
+        const now = DateTime.now();
+        const dayOfWeek = now.weekday - 1;
+        const attToday = this.attendance_ids.filter((a) => a.dayofweek == dayOfWeek);
+        if (attToday.length === 0) {
+            return false;
+        }
+        for (const attendance of attToday) {
+            const dateOpening = DateTime.fromObject({
+                year: now.year,
+                month: now.month,
+                day: now.day,
+                hour: Math.floor(attendance.hour_from),
+                minute: (attendance.hour_from % 1) * 60,
+            });
+            const dateClosing = DateTime.fromObject({
+                year: now.year,
+                month: now.month,
+                day: now.day,
+                hour: Math.floor(attendance.hour_to),
+                minute: (attendance.hour_to % 1) * 60,
+            });
+            if (dateOpening > now) {
+                return false;
+            }
+            let start = dateOpening;
+            while (start >= dateOpening && start <= dateClosing) {
+                if (now > start && now < start.plus({ minutes: this.interval_time })) {
+                    return { start: start, end: start.plus({ minutes: this.interval_time }) };
+                }
+                start = start.plus({ minutes: this.interval_time });
+            }
+        }
+        return false;
+    }
+
     generateSlots() {
         const usage = this.slotsUsage;
         const interval = this.interval_time;

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -756,6 +756,25 @@ export class TicketScreen extends Component {
             await this.pos.data.read("pos.order", Array.from(new Set(idsNotInCacheOrOutdated)));
         }
     }
+    //#endregion
+    getPresetTimeColor(order) {
+        const slot = order.preset_id.actualPreset;
+        const presetTime = DateTime.fromSQL(order.preset_time);
+        if (!slot) {
+            if (presetTime < DateTime.now()) {
+                return "bg-danger text-white";
+            } else {
+                return "bg-light text-dark";
+            }
+        }
+        if (slot.start <= presetTime && presetTime < slot.end) {
+            return "bg-warning text-dark";
+        } else if (presetTime < slot.start) {
+            return "bg-danger text-white";
+        } else {
+            return "bg-light text-dark";
+        }
+    }
 }
 
 registry.category("pos_screens").add("TicketScreen", TicketScreen);

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -53,6 +53,9 @@
                                                     <t t-esc="order.preset_id?.name"></t>
                                                 </div>
                                             </td>
+                                            <td class="align-middle">
+                                                <div t-if="order.presetTime" t-attf-class="fs-6 badge rounded {{this.getPresetTimeColor(order)}}"><t t-esc="order.presetTime"/></div>
+                                            </td>
                                             <td t-if="showCardholderName()">
                                                 <div><t t-esc="getCardholderName(order)"></t></div>
                                             </td>

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1894,6 +1894,7 @@ export class PosStore extends WithLazyGetterTrap {
             preset = await makeAwaitable(this.dialog, SelectionPopup, {
                 title: _t("Select preset"),
                 list: selectionList,
+                size: "md",
             });
         }
 
@@ -1907,7 +1908,7 @@ export class PosStore extends WithLazyGetterTrap {
 
             order.setPreset(preset);
             if (preset.identification === "name" && !order.floating_order_name && !order.table_id) {
-                order.floating_order_name = order.getPartner().name;
+                order.floating_order_name = order.getPartner()?.name;
                 if (!order.floating_order_name) {
                     this.editFloatingOrderName(order);
                 }

--- a/addons/point_of_sale/views/pos_preset_view.xml
+++ b/addons/point_of_sale/views/pos_preset_view.xml
@@ -23,14 +23,14 @@
                         </button>
                     </div>
                     <field name="image_128" widget="image" class="oe_avatar"/>
-                    <div class="oe_title mb-2">
+                    <div class="oe_title">
                         <label for="name"/>
                         <h1><field name="name" placeholder="e.g. Cash" class="oe_inline"/></h1>
                     </div>
-                    <group name="Presets">
+                    <group class="w-100" name="Presets">
                         <group>
-                            <field name="pricelist_id"/>
-                            <field name="fiscal_position_id"/>
+                            <field name="pricelist_id" placeholder="Default"/>
+                            <field name="fiscal_position_id" placeholder="Default"/>
                             <field name="use_timing" />
                             <field name="resource_calendar_id" invisible="not use_timing" />
                             <label for="slot_params" string="Capacity" invisible="not use_timing" />
@@ -42,7 +42,11 @@
                         </group>
                         <group>
                             <field name="identification"/>
-                            <field name="is_return" />
+                            <label for="return" string="Return mode"/>
+                            <div>
+                                <field id="return" name="is_return" class="oe_inline"/>
+                                <span invisible="not is_return or pricelist_id" class="oe_inline ps-2 text-info">Tip: add a return pricelist (i.e. 0€)</span>
+                            </div>
                             <field name="color" widget="color_picker"/>
                         </group>
                     </group>


### PR DESCRIPTION
This commit consists of:

Preset form
    - realingment
    - add tip in case of return mode without pricelist
    - add placeholder on pricelist and fp
    - Rename timing to time slots

Preset selection popup
    - reduce modal size

Slot selection popup
    - reput css rule to make slot button red if full, green if still available and future and secondary if past.

When clicking on a preset which is a return preset, the quantities already in the cart becomes negatives

Change bg-color and opacity of the quantity in cart span on the product_cards

Add time slot in the ticket screen:
    - white if future preset
    - orange if current preset
    - red if past preset

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
