### PR TITLE
[IMP] iot_box_image: set version number automatically

### DIFF
--- a/addons/iot_box_image/build_image.sh
+++ b/addons/iot_box_image/build_image.sh
@@ -28,8 +28,7 @@ __base="$(basename ${__file} .sh)"
 MOUNT_POINT="${__dir}/root_mount"
 OVERWRITE_FILES_BEFORE_INIT_DIR="${__dir}/overwrite_before_init"
 OVERWRITE_FILES_AFTER_INIT_DIR="${__dir}/overwrite_after_init"
-VERSION=17.0
-VERSION_IOTBOX=24.10
+VERSION_IOTBOX="$(date '+%y.%m')"
 
 if [[ "${1:-}" == "-c" || "${1:-}" == "--cleanup" ]]; then
     echo "Cleaning up..."


### PR DESCRIPTION
Before this PR, the IoT box version (e.g 25.01
for an image built in January 2025) was changed
manually whenever a new image was released.
After this PR, the version string is generated
automatically based on the date at build time.
Also, an unused `VERSION` variable was removed
from the build script.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
