### PR TITLE
[FIX] pos_loyalty: fix issue with loyalty points

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -871,6 +871,9 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                 continue;
             }
             for (const program of programs) {
+                if (line.ignoreLoyaltyPoints({ program })) {
+                    continue;
+                }
                 // Skip lines for the current program's discounts.
                 if (isDiscount && rewardProgram.id === program.id) {
                     continue;

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -73,6 +73,7 @@ class SaleOrderLine(models.Model):
                 item['qty_invoiced'] = self._convert_qty(sale_line, item['qty_invoiced'], 's2p')
                 item['qty_to_invoice'] = self._convert_qty(sale_line, item['qty_to_invoice'], 's2p')
                 item['price_unit'] = sale_line_uom._compute_price(item['price_unit'], product_uom)
+                item['tax_id'] = sale_line.tax_id.id
                 results.append(item)
 
             elif sale_line.display_type == 'line_note':

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
@@ -193,7 +193,14 @@ odoo.define('pos_sale.SaleOrderManagementScreen', function (require) {
                         product: this.env.pos.db.get_product_by_id(line.product_id[0]),
                         description: line.product_id[1],
                         price: line.price_unit,
-                        tax_ids: orderFiscalPos ? undefined : line.tax_id,
+                            tax_ids:
+                                orderFiscalPos &&
+                                line.reward_id &&
+                                this.env.pos.reward_by_id[line.reward_id[0]] &&
+                                this.env.pos.reward_by_id[line.reward_id[0]].reward_type !==
+                                    "discount"
+                                    ? undefined
+                                    : line.tax_id,
                         price_automatically_set: true,
                         price_manually_set: false,
                         sale_order_origin_id: clickedOrder,


### PR DESCRIPTION
Lines from SO are taken into account when computing loyalty points leading to rewards being granted two times when importing an SO.

Taxes on discount rewards were also badly taken into account.

opw-4381890

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
