### PR TITLE
[FIX] hr: fix archive banner z-index

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -69,7 +69,6 @@
                     <sheet>
                         <div name="button_box" class="oe_button_box">
                         </div>
-                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                         <field name="avatar_128" invisible="1"/>
                         <div class="row justify-content-between position-relative w-100 m-0 mb-2">
                             <div class="oe_title mw-75 ps-0 pe-2">
@@ -90,6 +89,7 @@
                                 <field name="hr_icon_display" class="d-flex align-items-end fs-6 o_employee_availability" invisible="not show_hr_icon_display or not id" widget="hr_presence_status"/>
                             </div>
                         </div>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                         <group>
                             <group>
                                 <field name="work_email" widget="email" placeholder="e.g. johndoe@example.com"/>


### PR DESCRIPTION
if an employee get archived the banner will appear behind the employee picture

Issue: the `--Ribbon-z-index: 1` var is removed from web/static because it overlap with something else

- move the widget after the div to have a higher z-index

Task: 4452394


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
