### PR TITLE
[FIX] website_blog: fix blog page breadcrumb with long text

### DIFF
--- a/addons/website_blog/static/src/scss/website_blog.scss
+++ b/addons/website_blog/static/src/scss/website_blog.scss
@@ -137,6 +137,22 @@ $o-wblog-loader-size: 50px;
         }
     }
 
+    #o_wblog_post_content, .blog_header {
+        > nav.breadcrumb {
+            .breadcrumb-item:not(.active) {
+                flex-shrink: 0;
+            }
+            @include media-breakpoint-down(md) {
+                flex-wrap: wrap !important;
+
+                .breadcrumb-item {
+                    flex-shrink: 1 !important;
+                    @include text-truncate();
+                }
+            }
+        }
+    }
+
     #o_wblog_post_comments {
         .o_portal_chatter > hr {
             display: none;


### PR DESCRIPTION
Steps to reproduce:

- Go to the "/blog/astronomy-2/what-if-they-let-you-run-the-hubble-5" page.
- Click on the "Mobile Preview" button.
- Bug: The breadcrumb is broken.

In stable versions, we fixed this in the least intrusive way possible to avoid making significant layout changes to existing databases.

**BEFORE:**
<kbd>![2025-01-14_09-44](https://github.com/user-attachments/assets/ee8ef4f9-eac4-48fd-857f-e28ccc58ae75)</kbd>

**AFTER:**
<kbd>![2025-01-14_09-53](https://github.com/user-attachments/assets/66ae36f9-2149-43ce-99d5-5d49a6605853)</kbd>

In master version, in mobile view, we replaced the breadcrumb with a "< All Blogs" button to return to the blogs list, similar to what is done in "website_sale" and "website_event".

opw-4457408
