### PR TITLE
[IMP] hw_drivers: avoid handlers parent class registering

### DIFF
--- a/addons/hw_drivers/driver.py
+++ b/addons/hw_drivers/driver.py
@@ -8,13 +8,13 @@ from odoo.tools.lru import LRU
 
 
 class DriverMetaClass(type):
+    priority = -1
+
     def __new__(cls, clsname, bases, attrs):
         newclass = super(DriverMetaClass, cls).__new__(cls, clsname, bases, attrs)
-        if hasattr(newclass, 'priority'):
-            newclass.priority += 1
-        else:
-            newclass.priority = 0
-        drivers.append(newclass)
+        newclass.priority += 1
+        if clsname != 'Driver':
+            drivers.append(newclass)
         return newclass
 
 

--- a/addons/hw_drivers/interface.py
+++ b/addons/hw_drivers/interface.py
@@ -13,7 +13,8 @@ _logger = logging.getLogger(__name__)
 class InterfaceMetaClass(type):
     def __new__(cls, clsname, bases, attrs):
         new_interface = super(InterfaceMetaClass, cls).__new__(cls, clsname, bases, attrs)
-        interfaces[clsname] = new_interface
+        if clsname != 'Interface':
+            interfaces[clsname] = new_interface
         return new_interface
 
 


### PR DESCRIPTION
Interfaces/Drivers inherit from an `Interface`/`Driver` class. These parent classes should not be registered as an actual interface/driver.
This is now filterered at instanciation in order to avoid looping over useless elements later.
