### PR TITLE
[FIX] pos_restaurant: split decimal orderline

### DIFF
--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
@@ -44,7 +44,10 @@ export class SplitBillScreen extends Component {
             } else {
                 this.qtyTracker[line.uuid] += 1;
             }
-
+            // We need this split for decimal quantities (e.g. 0.5 kg)
+            if (this.qtyTracker[line.uuid] > line.get_quantity()) {
+                this.qtyTracker[line.uuid] = line.get_quantity();
+            }
             this.priceTracker[line.uuid] =
                 (line.get_price_with_tax() / line.qty) * this.qtyTracker[line.uuid];
         }


### PR DESCRIPTION
Fixes an issue where splitting an order line with a decimal quantity (e.g., 2.5) would cause indefinite increments in the split bill screen. This adds a check to ensure the split quantity does not exceed the original order line quantity.

task-id: 4461861

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
