### PR TITLE
[FIX] mail: broken live call participant badge

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_participant_card.scss
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.scss
@@ -73,9 +73,8 @@
     margin: Min(5%, map-get($spacers, 2));
 }
 
-.o-discuss-CallParticipantCard-overlayBottom {
+.o-discuss-CallParticipantCard-overlayBottomName {
     background-color: rgba(0, 0, 0, 0.75);
-    max-width: 50%;
 }
 
 .o-discuss-CallParticipantCard-overlay-replayButton {

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -28,9 +28,9 @@
             </div>
             <t t-if="rtcSession">
                 <!-- overlay -->
-                <span class="o-discuss-CallParticipantCard-overlay o-discuss-CallParticipantCard-overlayBottom z-1 position-absolute bottom-0 start-0 d-flex overflow-hidden rounded-1">
-                    <span t-if="!props.minimized and !props.inset" class="px-1 text-truncate smaller opacity-75" t-esc="name"/>
-                    <small t-if="rtcSession.isScreenSharingOn and props.minimized and !isOfActiveCall" class="user-select-none o-minimized rounded-pill text-bg-danger d-flex align-items-center fw-bolder" title="live" aria-label="live">
+                <span class="o-discuss-CallParticipantCard-overlay z-1 position-absolute bottom-0 start-0 d-flex overflow-hidden rounded-1">
+                    <span t-if="!props.minimized and !props.inset" class="px-1 text-truncate smaller opacity-75 o-discuss-CallParticipantCard-overlayBottomName" t-esc="name"/>
+                    <small t-if="rtcSession.isScreenSharingOn and props.minimized and !isOfActiveCall" class="user-select-none o-minimized rounded text-bg-danger d-flex align-items-center fw-bolder p-1" title="live" aria-label="live">
                         LIVE
                     </small>
                 </span>
@@ -54,7 +54,7 @@
                     <span t-if="showServerState" class="d-flex flex-column justify-content-center me-1 p-2 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-title="rtc.state.serverState">
                         <i class="fa fa-exclamation-triangle text-warning"/>
                     </span>
-                    <span t-if="rtcSession.isScreenSharingOn and !props.minimized and !isOfActiveCall" class="user-select-none rounded-pill text-bg-danger d-flex align-items-center me-1 fw-bolder" title="live" aria-label="live">
+                    <span t-if="rtcSession.isScreenSharingOn and !props.minimized and !isOfActiveCall" class="user-select-none rounded text-bg-danger d-flex align-items-center me-1 fw-bolder p-1" title="live" aria-label="live">
                         LIVE
                     </span>
                 </div>


### PR DESCRIPTION
Before this commit the `LIVE` badge on the minimized call participant card had some styling issues. This was caused by missing padding on the related div tag and non-transparent background on the parent tag. This commit fixes the issue by introducing some padding and removing the css class that adds background opacity.

Before:
![Pasted image 20250113125543](https://github.com/user-attachments/assets/37573b8b-2ec1-4004-8171-3ff35655edc2)
![Pasted image 20250113152305](https://github.com/user-attachments/assets/2c7bda9c-23ec-4f09-b5ba-0afb9907e3ad)



After:
![image](https://github.com/user-attachments/assets/b2f6c159-7713-46d9-990a-817c6d4ec317)
![image](https://github.com/user-attachments/assets/f03e9072-85a1-4a11-bf4a-78aca68342c7)
