### PR TITLE
[FIX] html_editor: powerbox scroll and hover when document in iframe

### DIFF
--- a/addons/html_editor/static/src/main/powerbox/powerbox.js
+++ b/addons/html_editor/static/src/main/powerbox/powerbox.js
@@ -1,4 +1,4 @@
-import { Component, onPatched, useExternalListener, useRef } from "@odoo/owl";
+import { Component, onPatched, useEffect, useExternalListener, useRef } from "@odoo/owl";
 
 /**
  * @todo @phoenix i think that most of the "control" code in this component
@@ -25,9 +25,21 @@ export class Powerbox extends Component {
         });
 
         this.mouseSelectionActive = false;
-        useExternalListener(this.props.document, "mousemove", () => {
-            this.mouseSelectionActive = true;
-        });
+        const onMouseMove = () => (this.mouseSelectionActive = true);
+        useExternalListener(this.props.document, "mousemove", onMouseMove);
+
+        // If necessary attach the same listener on the document on which
+        // the powerbox is mounted, serving the same purpose:
+        // do not trigger re-renderings when we are scrolling the powerbox
+        useEffect(
+            (ownDoc, propsDoc) => {
+                if (ownDoc && propsDoc && ownDoc !== propsDoc) {
+                    ownDoc.addEventListener("mousemove", onMouseMove);
+                    return () => ownDoc.removeEventListener("mousemove", onMouseMove);
+                }
+            },
+            () => [ref.el?.ownerDocument, this.props.document]
+        );
     }
 
     get commands() {

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -7,6 +7,7 @@ import {
     manuallyDispatchProgrammaticEvent,
     press,
     queryAllTexts,
+    scroll,
     waitFor,
 } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
@@ -711,6 +712,27 @@ test("select command with 'mouseenter'", async () => {
 
     await press("enter");
     expect(getContent(el)).toBe("<h3>ab[]</h3>");
+});
+
+test.tags("desktop");
+test("select command with 'mouseenter' after scroll -- doc in iframe", async () => {
+    const { editor } = await setupEditor("<p>ab[]</p>", { props: { iframe: true } });
+
+    // Hoot don't trigger a mousemove event at the start of an hover, if we don't hover
+    // another element before. So we need to do a first hover to set a previous element.
+    await hover("body"); // Hover on main document's body
+
+    await insertText(editor, "/");
+    await animationFrame();
+
+    await hover(".o-we-command-name:eq(1)");
+    await scroll(".o-we-powerbox", { y: 1000 }); // Scroll to bottom
+    await animationFrame();
+    await scroll(".o-we-powerbox", { y: 0 }); // Scroll back to top
+
+    await hover(".o-we-command-name:eq(3)");
+    await animationFrame();
+    expect(".active .o-we-command-name").toHaveText("4 columns");
 });
 
 test("click on a command", async () => {


### PR DESCRIPTION
Have the edited document in an iframe.
Spawn the Powerbox, Scroll the powerbox.

Without letting the mouse out of the powerbox, try to hover a command

Before this commit, this did not work. It was because of a piece of code that prevents selection of commands during scrolling, probably to avoid re-renders.

After this commit, this use case works as expected.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
