### PR TITLE
[17.0][IMP] l10n_jp: Set 'round_globally' as the default tax rounding method

### DIFF
--- a/addons/l10n_jp/models/template_jp.py
+++ b/addons/l10n_jp/models/template_jp.py
@@ -40,5 +40,6 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_journal_early_pay_discount_gain_account_id': 'l10n_jp_425000',
                 'account_sale_tax_id': 'l10n_jp_tax_sale_exc_10',
                 'account_purchase_tax_id': 'l10n_jp_tax_purchase_exc_10',
+                'tax_calculation_rounding_method': 'round_globally',
             },
         }


### PR DESCRIPTION
Under Japan’s Qualified Invoice System, which took effect in October 2023, the consumption tax amount should be calculated and rounded based on the total invoice amount for each tax rate, rather than on an item-by-item basis.

See https://www.pwc.com/jp/en/taxnews/pdf/jtu-20221111-en.pdf

@qrtl

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
