### PR TITLE
[FIX] hr_attendance: negative overtime for flexible employee

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -354,7 +354,7 @@ class HrAttendance(models.Model):
                             local_check_out = pytz.utc.localize(attendance.check_out)
                             work_duration += (local_check_out - local_check_in).total_seconds() / 3600.0
                         # In case of fully flexible employee, no overtime is computed
-                        if not emp.is_fully_flexible and work_duration > emp.resource_id.calendar_id.hours_per_day:
+                        if not emp.is_fully_flexible:
                             overtime_duration = work_duration - emp.resource_id.calendar_id.hours_per_day
                             overtime_duration_real = overtime_duration
 

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -507,12 +507,13 @@ class TestHrAttendanceOvertime(TransactionCase):
         })
         self.assertEqual(attendance.overtime_hours, 0, 'There should be no overtime for the flexible resource.')
 
-        # 2) 12:00 - 18:00 should contain 0 hours of overtime
+        # 2) 12:00 - 18:00 should contain -2 hours of overtime
+        # as we expect the employee to work 8 hours per day
         attendance.write({
             'check_in': datetime(2023, 1, 3, 12, 0),
             'check_out': datetime(2023, 1, 3, 18, 0)
         })
-        self.assertEqual(attendance.overtime_hours, 0, 'There should be no overtime for the flexible resource.')
+        self.assertAlmostEqual(attendance.overtime_hours, -2, 2, 'There should be -2 hours of overtime for the flexible resource.')
 
         # 3) 10:00 - 22:00 should contain 4 hours of overtime
         attendance.write({


### PR DESCRIPTION
Steps to reproduce:
1. Set a flexible working schedule with 40h / week and 8h / day for an employee
2. Record an attendance for the employee
3. Go to reporting, the expected hours is the same as the worked hours

Expected behavior:
The expected hours should be what was set in the schedule, which is 8 hours

Explanation:
The calculation of expected hours is based on the difference between overtime hours and worked hours. This is done to ensure the overtimes are always computed correctly. However if the overtime duration is negative, it is not taken into account in `_update_overtime`. This commit allows negative amounts for overtime hours.

opw-4388707


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
