### PR TITLE
[FIX] account: ignore account type constraint on imports

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1220,7 +1220,13 @@ class AccountMoveLine(models.Model):
 
     @api.constrains('account_id', 'display_type')
     def _check_payable_receivable(self):
-        for line in self:
+        # Make it possible to bypass the constraint to allow importing already existing documents.
+        constraint_start_date = fields.Date.to_date(self.env['ir.config_parameter'].sudo().get_param(
+            'account.move.line.constraint_start_date',
+            '1970-01-01',
+        ))
+
+        for line in self.filtered(lambda aml: aml.date > constraint_start_date):
             account_type = line.account_id.account_type
             if line.move_id.is_sale_document(include_receipts=True):
                 if account_type == 'liability_payable':


### PR DESCRIPTION
The constraint on account types is too rigid when importing moves from an outside source. These moves represent historical data and should not prevent users from importing it into Odoo.

The solution is to ignore the constraint when a dedicated context key is present.

task-4465663

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
