### PR TITLE
[FIX] l10n_fr_account: line 26 can't be a tag

### DIFF
--- a/addons/l10n_fr_account/data/tax_report_data.xml
+++ b/addons/l10n_fr_account/data/tax_report_data.xml
@@ -1294,14 +1294,14 @@
                 <field name="name">Determining the amount to be paid and/or VAT and/or TIC credits</field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
-                    <record id="tax_report_26" model="account.report.line">
+                    <record id="tax_report_26_external" model="account.report.line">
                         <field name="name">26 - Repayment of credit requested on form n°3519 attached</field>
-                        <field name="code">box_26</field>
+                        <field name="code">box_26_external</field>
                         <field name="expression_ids">
-                            <record id="tax_report_26_tag" model="account.report.expression">
+                            <record id="tax_report_26_external_tag" model="account.report.expression">
                                 <field name="label">balance</field>
-                                <field name="engine">tax_tags</field>
-                                <field name="formula">26</field>
+                                <field name="engine">external</field>
+                                <field name="formula">sum</field>
                             </record>
                         </field>
                     </record>
@@ -1324,7 +1324,7 @@
                             <record id="tax_report_27_formula" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">box_25.balance - box_26.balance - box_AA.balance</field>
+                                <field name="formula">box_25.balance - box_26_external.balance - box_AA.balance</field>
                                 <field name="subformula">if_above(EUR(0))</field>
                             </record>
                             <record id="tax_report_27_carryover" model="account.report.expression">


### PR DESCRIPTION
When we ask for a reimbursement for the VAT that is due from the state, we close the period, then we send the declarations, with the amount that is asked as reimbursement.
The issue is that we need this amount to be registered in the report of this period. 
But it is closed, so we can't post moves with the tag in it.
Let's transform it into an external value.

task-4328721




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
