### PR TITLE
[FIX] stock: placeholder in count sheet

### DIFF
--- a/addons/stock/report/report_stockinventory.xml
+++ b/addons/stock/report/report_stockinventory.xml
@@ -33,8 +33,8 @@
                                     <tr t-foreach="docs.filtered(lambda quant: quant.location_id.id == location.id)" t-as="line">
                                         <td groups="stock.group_stock_multi_locations"></td>
                                         <td><span t-field="line.product_id">Laptop</span></td>
-                                        <td groups="stock.group_production_lot"><span t-field="line.lot_id">4</span></td>
-                                        <td groups="stock.group_tracking_lot"><span t-field="line.package_id">98</span></td>
+                                        <td groups="stock.group_production_lot"><span t-field="line.lot_id"/></td>
+                                        <td groups="stock.group_tracking_lot"><span t-field="line.package_id"/></td>
                                         <td class="text-end"><span t-field="line.available_quantity">2</span> <span t-field="line.product_uom_id" groups="uom.group_uom">Units</span></td>
                                         <td class="text-end"><span t-field="line.quantity">5</span> <span t-field="line.product_uom_id" groups="uom.group_uom">Units</span></td>
                                         <td class="text-end">


### PR DESCRIPTION
Since commit 567b8d676b3b6dc747df4d9bf10e7a91b4cb61bb It used to insert a placeholder when the data is not there but we won't on real report

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
