### PR TITLE
[IMP] im_livechat: cleanup RTC session before we find an operator

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -247,6 +247,9 @@ class ImLivechatChannel(models.Model):
         """
         if not self.available_operator_ids:
             return False
+        # FIXME: remove inactive call sessions so operators no longer in call are available
+        # sudo: required to use garbage collecting function.
+        self.env["discuss.channel.rtc.session"].sudo()._gc_inactive_sessions()
         self.env.cr.execute("""
             WITH operator_rtc_session AS (
                 SELECT COUNT(DISTINCT s.id) as nbr, member.partner_id as partner_id


### PR DESCRIPTION
Before this PR, operators could be stuck inside a "ghost call," meaning that they had incorrectly closed RTC sessions. This is an issue with the fact that "in call" operators cannot be assigned a new live chat.

This PR cleanup rtc session before trying to find an operator

task-4440897, task-4453597

