### PR TITLE
[FIX] web: don't apply domain to subfields in export dialog

### DIFF
--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -529,7 +529,7 @@ export class ListController extends Component {
     }
 
     async getExportedFields(model, import_compat, parentParams) {
-        let domain = this.model.root.domain;
+        let domain = parentParams ? [] : this.model.root.domain;
         if (!this.isDomainSelected) {
             const resIds = await this.getSelectedResIds();
             const ids = resIds.length > 0 && resIds;

--- a/addons/web/static/tests/views/view_dialogs/export_data_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/export_data_dialog.test.js
@@ -670,7 +670,13 @@ test("ExportDialog: export all records of the domain", async () => {
     onRpc("/web/export/formats", () => {
         return [{ tag: "xls", label: "Excel" }];
     });
-    onRpc("/web/export/get_fields", () => {
+    onRpc("/web/export/get_fields", async (request) =>  {
+        const { params } = await request.json();
+        if (isDomainSelected) {
+            const expectedDomain = params.parent_field ? [] : [["bar", "!=", "glou"]];
+            expect(params.domain).toEqual(expectedDomain, {message: "Domain is only applied on the root model"});
+            expect.step("get export fields route called with correct domain");
+        }
         return fetchedFields.root;
     });
 
@@ -696,9 +702,15 @@ test("ExportDialog: export all records of the domain", async () => {
     await contains(".o_control_panel .o_cp_action_menus .dropdown-toggle").click();
     await contains(".dropdown-menu span:contains(Export)").click();
     await contains(".o_select_button").click();
+
+    const firstField = ".o_left_field_panel .o_export_tree_item:first-child ";
+    await contains(firstField).click();
+
     expect.verifySteps([
         "download called with correct params when only one record is selected",
+        "get export fields route called with correct domain",
         "download called with correct params when all records are selected",
+        "get export fields route called with correct domain",
     ]);
 });
 


### PR DESCRIPTION
**Steps to reproduce**
1. Have Stock and Sales installed.
2. Go to the Sales list view of products, have more than 1 page of products.
3. Select all the products on the current page by checking the checkbox
on the first line. After that, click on "Select all" to select all
products.
4. Actions > Export
5. Select "Products" (`product_variant_ids`) and then "Products/Stock Quant"
(`stock_quant_ids`).
`ValueError: Invalid field stock.quant.sale_ok in leaf ('sale_ok', '=', True)`

**Change**
Only use the domain of the list view to filter fields when the export dialog
is opened. The domain should only be used for that and not when `getExportFields`
is called when clicking on one of the children fields of the root model.

opw-4408457