### PR TITLE
[FIX] hr_holidays: fix ambiguous column

### DIFF
--- a/addons/hr_holidays/models/res_users.py
+++ b/addons/hr_holidays/models/res_users.py
@@ -54,7 +54,7 @@ class User(models.Model):
                             AND hr_leave.state = 'validate'
                             AND hr_leave.active = 't'
                             AND res_users.active = 't'
-                            AND date_from <= %%s AND date_to >= %%s''' % field, (now, now))
+                            AND hr_leave.date_from <= %%s AND hr_leave.date_to >= %%s''' % field, (now, now))
         return [r[0] for r in self.env.cr.fetchall()]
 
     def _clean_leave_responsible_users(self):


### PR DESCRIPTION
Use fully qualified names as columns in related table can have a same name and this query could raise an error.

Like the one below error below was shown in 18.0
```
psycopg2.errors.AmbiguousColumn: column reference "state" is ambiguous
LINE 3:                             AND state = 'validate'
```
Note: error occured in 18.0 will be fixed in forward port, using fully qualified names was the purpose so made sense to start from 16.0 and fix for all versions after
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
