### PR TITLE
[PERF] stock: writing the same value shouldn't be considered an update

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -369,7 +369,11 @@ class StockMoveLine(models.Model):
         updates = {}
         for key, model in triggers:
             if key in vals:
-                updates[key] = vals[key] if isinstance(vals[key], models.BaseModel) else self.env[model].browse(vals[key])
+                key_record = vals[key] if isinstance(vals[key], models.BaseModel) else self.env[model].browse(vals[key])
+                for ml in self:
+                    if ml[key] != key_record:  # Writing the same value is not considered an update
+                        updates[key] = key_record
+                        break
 
         if 'result_package_id' in updates:
             for ml in self.filtered(lambda ml: ml.package_level_id):


### PR DESCRIPTION
Writing on a stock.move.line can be costly operation as several things are performed during in the write method.

This commits filters the updates that are not "real", meaning they are re-writing the same value.

opw-4027721

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
