### PR TITLE
[FIX] core: fix typofix translation

### DIFF
--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -997,6 +997,20 @@ class TestXMLTranslation(TransactionCase):
         self.assertEqual(view.with_env(env_fr).arch_db, archf % terms_fr)
         self.assertEqual(view.with_env(env_nl).arch_db, archf % terms_nl)
 
+    def test_sync_xml_attribute(self):
+        """ check translations with attribute can be cleaned up after write """
+        self.env['res.lang']._activate_lang('fr_FR')
+        archf = '<form><i title="%s"/></form>'
+        terms_en = ('Fork',)
+        terms_fr = ('Fourchetta',)
+        view = self.create_view(archf, terms_en, en_US=terms_en, fr_FR=terms_fr)
+
+        terms_en = ('Cheese',)
+        view.write({'arch_db': archf % terms_en})
+
+        self.assertEqual(view.arch_db, archf % terms_en)
+        self.assertEqual(view.with_context(lang='fr_FR').arch_db, archf % terms_en)
+
     def test_sync_text_to_xml(self):
         """ Check translations of 'arch' after xml tags changes in source terms. """
         archf = '<form string="X">%s</form>'

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1815,7 +1815,9 @@ class _String(Field):
             translation_dictionary = self.get_translation_dictionary(from_lang_value, old_translations)
             text2terms = defaultdict(list)
             for term in new_terms:
-                text2terms[self.get_text_content(term)].append(term)
+                term_text = self.get_text_content(term)
+                if term_text:
+                    text2terms[term_text].append(term)
 
             for old_term in list(translation_dictionary.keys()):
                 if old_term not in new_terms:


### PR DESCRIPTION
The get_text_content is not powerful enough to extract translated attributes. As a result, get_text_content will return empty string '' for terms whose translated contents are only in attributes. When the result is used to build the mapping text2terms, users will get strange result after write.

opw-4147913

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
