### PR TITLE
[FIX] {test_}base_automation: compute trigger_field_ids from default_filter_domain

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -327,7 +327,7 @@ class BaseAutomation(models.Model):
         for automation in self:
             field = (
                 automation._get_trigger_specific_field()
-                if automation.trigger not in TIME_TRIGGERS
+                if automation.trigger not in ["on_create_or_write", *TIME_TRIGGERS]
                 else False
             )
             if not field:
@@ -487,6 +487,8 @@ class BaseAutomation(models.Model):
     def _get_trigger_specific_field(self):
         self.ensure_one()
         match self.trigger:
+            case 'on_create_or_write':
+                return self._get_filter_domain_fields()
             case 'on_stage_set':
                 domain = [('ttype', '=', 'many2one'), ('name', 'in', ['stage_id', 'x_studio_stage_id'])]
             case 'on_tag_set':

--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -1199,6 +1199,28 @@ class TestCompute(common.TransactionCase):
         automation = automation_form.save()
         self.assertEqual(automation.filter_pre_domain, False)
 
+    def test_automation_form_view_with_default_values_in_context(self):
+        # Use case where default model, trigger and filter_domain in context
+        context = {
+            'default_name': 'Test Automation',
+            'default_model_id': self.env.ref('test_base_automation.model_base_automation_lead_test').id,
+            'default_trigger': 'on_create_or_write',
+            'default_filter_domain': repr([('state', '=', 'draft')]),
+        }
+        # Create form should be pre-filled with the default values
+        automation = self.env['base.automation'].with_context(context)
+        default_trigger_field_ids = [self.env.ref('test_base_automation.field_base_automation_lead_test__state').id]
+        automation_form = Form(automation, view='base_automation.view_base_automation_form')
+        self.assertEqual(automation_form.name, context.get('default_name'))
+        self.assertEqual(automation_form.model_id.id, context.get('default_model_id'))
+        self.assertEqual(automation_form.trigger, context.get('default_trigger'))
+        self.assertEqual(automation_form.trigger_field_ids.ids, default_trigger_field_ids,
+            'trigger_field_ids should match the fields in the default filter domain.')
+
+        automation_form.trigger = 'on_stage_set'
+        self.assertNotEqual(automation_form.trigger_field_ids.ids, default_trigger_field_ids,
+            'When user changes trigger, the trigger_field_ids field should be updated')
+
     def test_inversion(self):
         """ If a stored field B depends on A, an update to the trigger for A
         should trigger the recomputaton of A, then B.


### PR DESCRIPTION
Before this commit, 'trigger_field_ids' were already computed from the
filter_domain, but using a default_filter_domain didn't work due to the
'_onchange_trigger' method emptying 'trigger_field_ids' in the case of
on_create_or_write.

After this commit, we made '_onchange_trigger' take into account
the filter_domain for this case.

This addition fixes a window action from Documents to Automation Rules.

see odoo/odoo#193206
see odoo/enterprise#75719
task-4481308
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
