### PR TITLE
[IMP] mail: better call context menu

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_context_menu.js
+++ b/addons/mail/static/src/discuss/call/common/call_context_menu.js
@@ -24,6 +24,7 @@ export class CallContextMenu extends Component {
             uploadStats: {},
             producerStats: {},
             peerStats: {},
+            rangeVolume: this.volume,
         });
         onMounted(() => {
             if (!this.env.debug) {

--- a/addons/mail/static/src/discuss/call/common/call_context_menu.scss
+++ b/addons/mail/static/src/discuss/call/common/call_context_menu.scss
@@ -1,0 +1,33 @@
+.o-mail-CallContextMenu-volumeTooltip {
+    /* Visibility */
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 0s, opacity 0.2s ease-out;
+
+    /* Positioning */
+    position: absolute;
+    bottom: 150%;
+    left: calc(var(--progress) - 0.13 * (var(--progress)));
+    transform: translateX(calc(-50% + 8px));
+
+    /* Appearance */
+    background-color: #212529;
+    color: #F9FAFB;
+    padding: 4px 10px;
+
+    &::after {
+        content: "";
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        border-width: 6px;
+        border-style: solid;
+        border-color: #212529 transparent transparent transparent;
+    }
+}
+
+.form-range:hover + .o-mail-CallContextMenu-volumeTooltip {
+    visibility: visible;
+    opacity: 1;
+}

--- a/addons/mail/static/src/discuss/call/common/call_context_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_context_menu.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="discuss.CallContextMenu">
-        <div class="o-discuss-CallContextMenu d-flex flex-column p-3">
+        <div class="o-discuss-CallContextMenu d-flex flex-column p-3 bg-100 rounded">
             <div class="text-center pb-2 fw-bolder" t-out="props.rtcSession.name"/>
-            <input t-if="!isSelf" type="range" min="0.0" max="1" step="0.01" t-att-value="volume" t-on-change="onChangeVolume" class="form-range"/>
+            <div t-if="!isSelf" class="d-flex flex-row gap-2 align-items-center">
+                <i class="fa fa-fw fa-lg opacity-75" t-attf-class="{{state.rangeVolume > 0 ? 'fa-volume-up' : 'fa-volume-off'}}"/>
+                <div class="position-relative">
+                    <input type="range" min="0.0" max="1" step="0.01" class="form-range h-auto" t-att-value="volume" t-model="state.rangeVolume" t-on-change="onChangeVolume"/>
+                    <output t-esc="`${Math.round(state.rangeVolume * 200)}%`" class="o-mail-CallContextMenu-volumeTooltip fw-bold rounded" t-attf-style="--progress:{{state.rangeVolume * 100}}%;"/>
+                </div>
+            </div>
             <t t-if="env.debug and !isSelf and rtc.state.connectionType === rtcConnectionTypes.P2P">
                 <hr class="w-100 border-top"/>
                 <div><span class="fw-bolder">Connection type: </span><t t-out="rtc.state.connectionType"/></div>

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -4,6 +4,7 @@ import { CONNECTION_TYPES } from "@mail/discuss/call/common/rtc_service";
 import { useHover } from "@mail/utils/common/hooks";
 import { isEventHandled, markEventHandled } from "@web/core/utils/misc";
 import { browser } from "@web/core/browser/browser";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 import {
     Component,
@@ -28,11 +29,15 @@ export class CallParticipantCard extends Component {
         super.setup();
         this.contextMenuAnchorRef = useRef("contextMenuAnchor");
         this.root = useRef("root");
-        this.popover = usePopover(CallContextMenu);
+        this.popover = usePopover(CallContextMenu, {
+            arrow: false,
+            popoverClass: "border-secondary",
+        });
         this.rtc = useService("discuss.rtc");
         this.store = useService("mail.store");
         this.ui = useService("ui");
         this.rootHover = useHover("root");
+        this.isMobileOS = isMobileOS();
         this.state = useState({ drag: false, dragPos: undefined });
         onMounted(() => {
             if (!this.rtcSession) {
@@ -163,7 +168,6 @@ export class CallParticipantCard extends Component {
      * @param {Event} ev
      */
     onContextMenu(ev) {
-        ev.preventDefault();
         markEventHandled(ev, "CallParticipantCard.clickVolumeAnchor");
         if (this.popover.isOpen) {
             this.popover.close();

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.scss
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.scss
@@ -86,3 +86,18 @@
         background-color: $o-gray-800;
     }
 }
+
+.o-discuss-CallParticipantCard-contextButton {
+    margin: Min(5%, map-get($spacers, 2));
+    background-color: black;
+    aspect-ratio: 1;
+    color: #F9FAFB !important;
+
+    &:hover {
+        background-color: #4b4b4b;
+    }
+
+    &:active {
+        background-color: #707070 !important;
+    }
+}

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -13,7 +13,6 @@
             t-att-aria-label="name"
             t-attf-class="{{ props.className }}"
             t-on-click="onClick"
-            t-on-contextmenu="onContextMenu"
             t-on-mousedown="onMouseDown"
             t-on-touchmove="(ev) => this.drag(ev)"
             t-ref="root"
@@ -34,7 +33,10 @@
                         LIVE
                     </small>
                 </span>
-                <div class="o-discuss-CallParticipantCard-overlay position-absolute top-0 end-0 d-flex flex-row-reverse">
+                <button t-if="popover.isOpen or (isContextMenuAvailable and ((!isMobileOS and rootHover.isHover) or (isMobileOS and !props.minimized)))" t-on-click="onContextMenu" class="o-discuss-CallParticipantCard-contextButton btn btn-secondary btn-sm rounded-circle position-absolute border-0 top-0 end-0 smaller p-1" title="Participant options" t-ref="contextMenuAnchor">
+                    <i class="fa fa-chevron-down fa-fw"/>
+                </button>
+                <div class="o-discuss-CallParticipantCard-overlay position-absolute bottom-0 end-0 d-flex flex-row-reverse">
                     <span t-if="hasRaisingHand" class="d-flex flex-column justify-content-center me-1 rounded-circle bg-500" t-att-class="{'o-minimized p-1': props.minimized, 'p-2': !props.minimized }" title="raising hand" aria-label="raising hand">
                         <i class="fa fa-hand-paper-o"/>
                     </span>
@@ -58,9 +60,6 @@
                         LIVE
                     </span>
                 </div>
-
-                <!-- context menu -->
-                <i t-if="isContextMenuAvailable" class="position-absolute bottom-0 start-50" t-ref="contextMenuAnchor"/>
             </t>
         </div>
     </t>

--- a/addons/mail/static/src/discuss/call/common/settings_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/settings_model_patch.js
@@ -9,13 +9,13 @@ const SettingsPatch = {
     },
     getVolume(rtcSession) {
         return (
-            rtcSession.volume ||
+            rtcSession.volume ??
             this.volumes.find(
                 (volume) =>
                     (volume.persona.type === "partner" &&
                         volume.persona.id === rtcSession.partnerId) ||
                     (volume.persona.type === "guest" && volume.persona.id === rtcSession.guestId)
-            )?.volume ||
+            )?.volume ??
             0.5
         );
     },

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -577,7 +577,8 @@ test("Use saved volume settings", async () => {
     await openDiscuss(channelId);
     await click("[title='Start a Call']");
     await contains(".o-discuss-Call");
-    await triggerEvents(`.o-discuss-CallParticipantCard[title='${partnerName}']`, ["contextmenu"]);
+    await triggerEvents(`.o-discuss-CallParticipantCard[title='${partnerName}']`, ["mouseenter"]);
+    await click("button[title='Participant options']");
     await contains(".o-discuss-CallContextMenu");
     const rangeInput = queryFirst(".o-discuss-CallContextMenu input[type='range']");
     expect(rangeInput.value).toBe(expectedVolume.toString());


### PR DESCRIPTION
This commit fixes various issues with the context menu on the call participant:

- Before this commit it wasn't possible to set the volume of a user to 0 due to the use of the `||` operator in the getVolume function. This commit fixes the issue by using the correct `??` operator.
- Before this commit the volume slider in dark mode had the same background as the popover menu, making it difficult to see. This commit fixes the issue by making the slider darker than the background.
- A volume icon was added to better indicate the slider purpose.
- A volume percentage tooltip was added for more accurate use.
- A chevron button was added to the participant card for  better discoverability of the context menu.
