### PR TITLE
[IMP] l10n_latam_check: Add checks table inside payment report

### DIFF
--- a/addons/l10n_latam_check/__manifest__.py
+++ b/addons/l10n_latam_check/__manifest__.py
@@ -53,6 +53,7 @@ There are 2 main Payment Methods additions:
         'security/security.xml',
         'views/account_payment_view.xml',
         'views/l10n_latam_check_view.xml',
+        'views/report_payment_receipt_templates.xml',
         'wizards/account_payment_register_views.xml',
     ],
     'installable': True,

--- a/addons/l10n_latam_check/views/report_payment_receipt_templates.xml
+++ b/addons/l10n_latam_check/views/report_payment_receipt_templates.xml
@@ -1,0 +1,41 @@
+<odoo>
+    <template inherit_id="account.report_payment_receipt_document" id="report_payment_receipt_document">
+        <xpath expr="//table[@name='invoices']" position="before">
+            <t t-set="check_ids" t-value="o._get_latam_checks()"/>
+            <t t-if="check_ids">
+                <table id="l10n_latam_check"  class="table table-sm">
+                        <thead>
+                            <tr>
+                                <th><span>Number</span></th>
+                                <th t-if="o.payment_method_code != 'own_checks'"><span>Bank</span></th>
+                                <th t-if="o.payment_method_code != 'own_checks'"><span>Issuer VAT</span></th>
+                                <th><span>Payment date</span></th>
+                                <th class="text-end"><span>Amount</span></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <t t-foreach="check_ids" t-as="check_id">
+                                <tr>
+                                    <td>
+                                        <span t-field='check_id.name'/>
+                                    </td>
+                                    <td t-if="o.payment_method_code != 'own_checks'">
+                                        <span t-field='check_id.bank_id.display_name'/>
+                                    </td>
+                                    <td t-if="o.payment_method_code != 'own_checks'">
+                                        <span t-field='check_id.issuer_vat'/>
+                                    </td>
+                                    <td>
+                                        <span t-field='check_id.payment_date'/>
+                                    </td>
+                                    <td class="text-end">
+                                        <span t-out="check_id.amount" t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"/>
+                                    </td>
+                                </tr>
+                            </t>
+                        </tbody>
+                </table>
+            </t>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR aims to improve PDF payments receipt report. Following the example of withholdings table, we added a new table with the information of the checks used to pay, such as check number, issuer VAT, payment date and check amount.
Current behavior before PR:
The PDF report contains only the amount paid and a table showing the withholdings related to the payment.
Desired behavior after PR is merged:
The payment receipt PDF includes additional payment information including the checks table.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
