### PR TITLE
[IMP] account: Made account journal dashboard extensible

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -80,6 +80,18 @@ class AccountJournal(models.Model):
 
         (self - bank_cash_journals - sale_purchase_journals).kanban_dashboard_graph = False
 
+    def _transform_activity_dict(self, activity_data):
+        return {
+            'id': activity_data['id'],
+            'res_id': activity_data['res_id'],
+            'res_model': activity_data['res_model'],
+            'status': activity_data['status'],
+            'name': activity_data['summary'] or activity_data['act_type_name'],
+            'activity_category': activity_data['activity_category'],
+            'act_type_id': activity_data['act_type_id'],
+            'date': odoo_format_date(self.env, activity_data['date_deadline']),
+        }
+
     def _get_json_activity_data(self):
         today = fields.Date.context_today(self)
         activities = defaultdict(list)
@@ -92,6 +104,7 @@ class AccountJournal(models.Model):
                 activity.res_model,
                 activity.summary,
       CASE WHEN activity.date_deadline < %(today)s THEN 'late' ELSE 'future' END as status,
+                act_type.id as act_type_id,
                 %(act_type_name)s as act_type_name,
                 act_type.category as activity_category,
                 activity.date_deadline,
@@ -109,6 +122,7 @@ class AccountJournal(models.Model):
                 activity.res_model,
                 activity.summary,
       CASE WHEN activity.date_deadline < %(today)s THEN 'late' ELSE 'future' END as status,
+                act_type.id as act_type_id,
                 %(act_type_name)s as act_type_name,
                 act_type.category as activity_category,
                 activity.date_deadline,
@@ -125,18 +139,8 @@ class AccountJournal(models.Model):
             company_ids=self.env.companies.ids,
         )
         self.env.cr.execute(sql_query)
-        for activity in self.env.cr.dictfetchall():
-            act = {
-                'id': activity['id'],
-                'res_id': activity['res_id'],
-                'res_model': activity['res_model'],
-                'status': activity['status'],
-                'name': activity['summary'] or activity['act_type_name'],
-                'activity_category': activity['activity_category'],
-                'date': odoo_format_date(self.env, activity['date_deadline'])
-            }
-
-            activities[activity['journal_id']].append(act)
+        for activity_data in self.env.cr.dictfetchall():
+            activities[activity_data['journal_id']].append(self._transform_activity_dict(activity_data))
         for journal in self:
             journal.json_activity_data = json.dumps({'activities': activities[journal.id]})
 

--- a/addons/account/static/src/components/journal_dashboard_activity/journal_dashboard_activity.xml
+++ b/addons/account/static/src/components/journal_dashboard_activity/journal_dashboard_activity.xml
@@ -5,9 +5,9 @@
      <t t-name="account.JournalDashboardActivity">
         <t t-foreach="info.activities" t-as="activity" t-key="activity_index">
             <div class="row">
-                <div class="col o_mail_activity">
+                <div class="col-auto o_mail_activity">
                     <a href="#"
-                       t-att-class="(activity.status == 'late' ? 'text-danger ' : ' ') + (activity.activity_category == 'tax_report' ? 'o_open_vat_report' : 'see_activity')"
+                       t-attf-class="{{ activity.status == 'late' ? 'text-danger' : '' }}"
                        t-att-data-res-id="activity.res_id" t-att-data-id="activity.id" t-att-data-model="activity.res_model"
                        t-on-click.stop.prevent="() => this.openActivity(activity)">
                         <t t-out="activity.name"/>


### PR DESCRIPTION
This commit applies the necessary changes to make the json_activity_data field of account.journal extensible. The field computation needed to be extended in account_reports to make dashboard activities styling more dynamic. More details can be found in the enterprise PR: https://github.com/odoo/enterprise/pull/75871

task-4370133


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
