### PR TITLE
[FIX] website: fix image link alignment in the image gallery

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/002.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/002.scss
@@ -114,6 +114,14 @@
         }
 
         > .container-fluid {
+            // keep image with a link centered with "full" content width.
+            .carousel-item > a {
+                margin-right: auto;
+                margin-left: auto;
+            }
+        }
+
+        > .container-fluid {
             padding: 0;
         }
 


### PR DESCRIPTION
Steps to reproduce the issue:

- In Website edit mode, drag and drop an "Image Gallery" block onto the page.
- Select "Full" as the "Content Width" option for the "Image Gallery" block.
- Click on the image.
- Add a link to the image.
- Zoom the page to 50% using the browser tool.
- Bug: the image is aligned to the left instead of being centered.
- Remove the link: the image is correctly centered.

opw-4458747