### PR TITLE
[FIX] base_import_module: fix ir_model_data xmlid for cloc_exclude

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -141,14 +141,17 @@ class IrModule(models.Model):
                     elif ext == '.xml':
                         convert_xml_import(self.env, module, fp, idref, mode, noupdate)
                         if filename in exclude_list:
-                            self.env['ir.model.data'].create([{
-                                'name': f"{module}_{key}",
-                                'model': self.env['ir.model.data']._xmlid_lookup(f"{module}.{key}")[0],
-                                'module': "__cloc_exclude__",
-                                'res_id': value,
-                            } for key, value in idref.items() if not self.env.ref(
-                                f"__cloc_exclude__.{module}_{key}", raise_if_not_found=False
-                            )])
+                            for key, value in idref.items():
+                                xml_id = f"{module}.{key}" if '.' not in key else key
+                                name = xml_id.replace('.', '_')
+                                if self.env.ref(f"__cloc_exclude__.{name}", raise_if_not_found=False):
+                                    continue
+                                self.env['ir.model.data'].create([{
+                                    'name': name,
+                                    'model': self.env['ir.model.data']._xmlid_lookup(xml_id)[0],
+                                    'module': "__cloc_exclude__",
+                                    'res_id': value,
+                                }])
 
         path_static = opj(path, 'static')
         IrAttachment = self.env['ir.attachment']

--- a/addons/base_import_module/tests/test_cloc.py
+++ b/addons/base_import_module/tests/test_cloc.py
@@ -27,6 +27,9 @@ VALID_XML_2 = """<?xml version="1.0" encoding="UTF-8"?>
             </div>
         </t>
     </template>
+    <record id="base.view_company_form" model="ir.ui.view">
+        <field name="active" eval="True"/>
+    </record>
 </odoo>
 """
 


### PR DESCRIPTION
The cloc_exclude entry of the manifest was activated for data modules*, and it works for records with a new id. But it fails for records with external ids from another module, as it tries to lookup for a record with an xmlid like `new_module.external_module.id`, which is not a valid xmlid.

This commit fixes the issue by first checking if the record to exclude from cloc is from another module or not, before creating the ir_model_data entry.

*https://github.com/odoo/odoo/commit/a47de680de149a60dd479c4c0b14f2c1bf5afcbe

opw-4472893