### PR TITLE
[FIX] account: fallback on the currency_rate when calculating the rate

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -963,7 +963,7 @@ class AccountMoveLine(models.Model):
                 include_caba_tags=line.move_id.always_tax_exigible,
                 fixed_multiplicator=sign,
             )
-            rate = line.amount_currency / line.balance if line.balance else 1
+            rate = line.amount_currency / line.balance if line.balance else line.currency_rate
             line.compute_all_tax_dirty = True
             line.compute_all_tax = {
                 frozendict({

--- a/addons/account/tests/test_invoice_taxes.py
+++ b/addons/account/tests/test_invoice_taxes.py
@@ -716,6 +716,41 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             'balance': 686.54,
         }])
 
+    def test_tax_calculation_multi_currency_100_included_tax(self):
+        self.env['res.currency.rate'].create({
+            'name': '2018-01-01',
+            'rate': 0.273748,
+            'currency_id': self.currency_data['currency'].id,
+            'company_id': self.env.company.id,
+        })
+        self.currency_data['currency'].rounding = 0.01
+
+        tax = self.env['account.tax'].create({
+            'name': 'tax_100',
+            'amount_type': 'division',
+            'amount': 100,
+            'price_include': True,
+        })
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_date': '2018-01-01',
+            'date': '2018-01-01',
+            'invoice_line_ids': [(0, 0, {
+                'name': 'xxxx',
+                'quantity': 1,
+                'price_unit': 100.00,
+                'tax_ids': [(6, 0, tax.ids)],
+            })]
+        })
+
+        self.assertRecordValues(invoice.line_ids.filtered('tax_line_id'), [{
+            'tax_base_amount': 0.0,
+            'balance': -365.3,    # 100 * (1 / 0.273748)
+        }])
+
     def test_fixed_tax_with_zero_price(self):
         fixed_tax = self.env['account.tax'].create({
             'name': 'Test 5 fixed',


### PR DESCRIPTION
### Steps to reproduce:
- In Accounting create a new tax like this: -Tax computation: percentage of price tax included -Amount: 100% -Included in Price: Ticked
- Create a new Customer Invoice in another currency
- Use the 100% tax
- Go in the tab "Journal Entries"
- The amounts were not converted

### Cause:
The rate is calculated like this : `rate = line.amount_currency / line.balance if line.balance else 1` But with this specific tax `amount_currency` and `balance` are 0 so the rate defaults to 1 thus not converting.

### Solution:
Fallback on the rate of the line.

opw-4443522