### PR TITLE
[FIX] mail, *: better avatar card style in dark theme

### DIFF
--- a/addons/hr/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
+++ b/addons/hr/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
@@ -5,7 +5,7 @@
             <attribute name="t-if">this.record.employee_id?.length</attribute>
         </xpath>
         <xpath expr="//span[hasclass('o_user_im_status')]" position="after">
-            <span t-elif="record.show_hr_icon_display" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center o_employee_presence_status">
+            <span t-elif="record.show_hr_icon_display" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center o_employee_presence_status bg-inherit">
                 <!-- Employee is present/connected and it is normal according to his work schedule  -->
                 <i t-if="record.hr_icon_display == 'presence_present'" class="fa fa-fw fa-circle text-success" title="Present" role="img" aria-label="Present"/>
                 <!-- Employee is not present/connected and it is normal according to his work schedule -->

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.dark.scss
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.dark.scss
@@ -1,0 +1,7 @@
+.o_avatar_card {
+    background-color: $gray-100;
+}
+
+.o_popover:has(.o_avatar_card) {
+    --popover-border-color: #{$gray-300};
+}

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.scss
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.scss
@@ -8,7 +8,6 @@
         bottom: -4px;
         right: -4px;
         border-radius: 2rem;
-        background-color: white;
         height: 18px;
         width: 18px;
     }

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.AvatarCardPopover">
-        <div class="o_avatar_card">
-            <div class="card-body">
-                <div class="d-flex align-items-start gap-2">
-                    <span class="o_avatar pt-1 position-relative o_card_avatar">
+        <div class="o_avatar_card rounded bg-inherit">
+            <div class="card-body rounded bg-inherit">
+                <div class="d-flex align-items-start gap-2 bg-inherit">
+                    <span class="o_avatar pt-1 position-relative o_card_avatar bg-inherit">
                         <img t-if="props.id"
                             t-attf-src="/web/image/res.users/{{props.id}}/avatar_128"
                             class="rounded"
                         />
-                        <span t-if="user.im_status" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center">
+                        <span t-if="user.im_status" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center bg-inherit">
                             <i t-if="user.im_status === 'online'" class="fa fa-fw fa-circle text-success" title="Online" role="img" aria-label="User is online"/>
                             <i t-elif="user.im_status === 'away'" class="fa fa-fw fa-circle text-warning" title="Idle" role="img" aria-label="User is idle"/>
                             <i t-elif="user.im_status === 'offline'" class="fa fa-fw fa-circle-o text-700" title="Offline" role="img" aria-label="User is offline"/>

--- a/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
+++ b/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
@@ -5,7 +5,7 @@
             <attribute name="t-attf-src" t-if="displayAvatar">/web/image/{{ props.recordModel }}/{{ props.id }}/avatar_128</attribute>
         </xpath>
         <xpath expr="//span[hasclass('o_card_avatar_im_status')]" position="replace">
-            <span t-if="record.user_id" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center o_user_im_status">
+            <span t-if="record.user_id" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center o_user_im_status bg-inherit">
                 <i t-if="record.im_status === 'online'" class="fa fa-fw fa-circle text-success" title="Online" role="img" aria-label="User is online"/>
                 <i t-elif="record.im_status === 'away'" class="fa fa-fw fa-circle text-warning" title="Idle" role="img" aria-label="User is idle"/>
                 <i t-elif="record.im_status === 'offline'" class="fa fa-fw fa-circle-o text-700" title="Offline" role="img" aria-label="User is offline"/>


### PR DESCRIPTION
- im status background was white in all themes, this is now the card color in all themes.
- avatar card color was too grey in dark theme, which made reading text content in card hard. This is now darker for better contrast.
- border is darker in dark theme too, so it's less harsh.
- borders in corners of avatar card were cut due to lack of rounded of card container. This commit adds `.rounded` to not cut corners.

Style in white theme is essentially unchanged.

Before / After
![Screenshot 2025-01-14 at 16 05 19](https://github.com/user-attachments/assets/8aa64798-afe6-4139-8a62-df7ded153b06) ![Screenshot 2025-01-14 at 16 05 31](https://github.com/user-attachments/assets/5feb590f-1a86-435c-a6dc-9cb1a53db708)
