### PR TITLE
[FIX] hw_posbox_homepage: duplicate Wi-Fi interface and Wi-Fi stability

### DIFF
--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -127,6 +127,8 @@ class Manager(Thread):
                 if iot_devices != previous_iot_devices:
                     previous_iot_devices = iot_devices.copy()
                     self.send_all_devices()
+                if platform.system() == 'Linux' and helpers.get_ip() != '10.11.12.1':
+                    wifi.reconnect(helpers.get_conf('wifi_ssid'), helpers.get_conf('wifi_password'))
                 time.sleep(3)
                 schedule and schedule.run_pending()
             except Exception:

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import netifaces
-import os
 import platform
 import subprocess
 import threading
@@ -11,6 +10,7 @@ import time
 
 from itertools import groupby
 from pathlib import Path
+
 from odoo import http
 from odoo.addons.hw_drivers.tools import helpers, wifi
 from odoo.addons.hw_drivers.main import iot_devices
@@ -100,7 +100,7 @@ class IotBoxOwlHomePage(http.Controller):
     @http.route('/hw_posbox_homepage/wifi_clear', auth='none', type='http', cors='*')
     def clear_wifi_configuration(self):
         helpers.update_conf({'wifi_ssid': '', 'wifi_password': ''})
-        wifi.disconnect(forget_network=True)
+        wifi.disconnect()
         return json.dumps({
             'status': 'success',
             'message': 'Successfully disconnected from wifi',
@@ -127,20 +127,17 @@ class IotBoxOwlHomePage(http.Controller):
         network_interfaces = []
         if platform.system() == 'Linux':
             ssid = wifi.get_current() or wifi.get_access_point_ssid()
-            interfaces = netifaces.interfaces()
-            for iface_id in interfaces:
-                if 'wlan' in iface_id or 'eth' in iface_id:
-                    is_wifi = 'wlan' in iface_id
-                    iface_obj = netifaces.ifaddresses(iface_id)
-                    ifconfigs = iface_obj.get(netifaces.AF_INET, [])
-                    for conf in ifconfigs:
-                        if conf.get('addr'):
-                            network_interfaces.append({
-                                'id': iface_id,
-                                'is_wifi': is_wifi,
-                                'ssid': ssid if is_wifi else None,
-                                'ip': conf.get('addr'),
-                            })
+            for iface_id in netifaces.interfaces():
+                if iface_id == 'lo':
+                    continue  # Skip loopback interface (127.0.0.1)
+
+                is_wifi = 'wlan' in iface_id
+                network_interfaces.extend([{
+                    'id': iface_id,
+                    'is_wifi': is_wifi,
+                    'ssid': ssid if is_wifi else None,
+                    'ip': conf.get('addr', 'No Internet'),
+                } for conf in netifaces.ifaddresses(iface_id).get(netifaces.AF_INET, [])])
 
         is_certificate_ok, certificate_details = helpers.get_certificate_status()
 
@@ -152,11 +149,11 @@ class IotBoxOwlHomePage(http.Controller):
         } for device in iot_devices.values()]
         device_type_key = lambda device: device['type']
         grouped_devices = {
-            device_type: list(devices) for device_type, devices in groupby(sorted(devices, key=device_type_key), device_type_key)
+            device_type: list(devices)
+            for device_type, devices in groupby(sorted(devices, key=device_type_key), device_type_key)
         }
 
-        terminal_id = helpers.get_conf('six_payment_terminal')
-        six_terminal = terminal_id or 'Not Configured'
+        six_terminal = helpers.get_conf('six_payment_terminal') or 'Not Configured'
 
         return json.dumps({
             'db_uuid': helpers.get_conf('db_uuid'),

--- a/addons/hw_posbox_homepage/static/src/app/Homepage.js
+++ b/addons/hw_posbox_homepage/static/src/app/Homepage.js
@@ -112,7 +112,7 @@ export class Homepage extends Component {
     <div t-if="!this.state.loading" class="w-100 d-flex flex-column align-items-center justify-content-center background">
         <div class="bg-white p-4 rounded overflow-auto position-relative w-100 main-container">
             <div class="position-absolute end-0 top-0 mt-3 me-4 d-flex gap-1">
-                <IconButton onClick.bind="toggleAdvanced" icon="this.store.advanced ? 'fa-cog' : 'fa-cogs'" />
+                <IconButton t-if="!store.base.is_access_point_up" onClick.bind="toggleAdvanced" icon="this.store.advanced ? 'fa-cog' : 'fa-cogs'" />
                 <IconButton onClick.bind="restartOdooService" icon="'fa-power-off'" />
             </div>
             <div class="d-flex mb-4 flex-column align-items-center justify-content-center">
@@ -126,7 +126,7 @@ export class Homepage extends Component {
                     Please contact your account manager to take advantage of your IoT Box's full potential.
                 </small>
             </div>
-            <div t-if="store.advanced and !store.base.is_access_point_up" t-att-class="'alert ' + (state.data.is_certificate_ok === true ? 'alert-info' : 'alert-warning')" role="alert">
+            <div t-if="store.advanced" t-att-class="'alert ' + (state.data.is_certificate_ok === true ? 'alert-info' : 'alert-warning')" role="alert">
                 <p class="m-0 fw-bold">HTTPS Certificate</p>
                 <small>
                     <t t-if="state.data.is_certificate_ok === true">Status: </t>
@@ -145,7 +145,7 @@ export class Homepage extends Component {
 					<ServerDialog t-if="this.store.isLinux" />
 				</t>
 			</SingleData>
-            <SingleData t-if="store.advanced and !store.base.is_access_point_up" name="'Version'" value="state.data.version" icon="'fa-microchip'">
+            <SingleData t-if="store.advanced" name="'Version'" value="state.data.version" icon="'fa-microchip'">
                 <t t-set-slot="button">
                     <UpdateDialog t-if="this.store.isLinux" />
                 </t>
@@ -176,7 +176,7 @@ export class Homepage extends Component {
 
             <hr class="mt-5" />
             <FooterButtons />
-            <div class="d-flex justify-content-center gap-2 mt-2">
+            <div class="d-flex justify-content-center gap-2 mt-2" t-if="!store.base.is_access_point_up">
                 <a href="https://www.odoo.com/fr_FR/help" target="_blank" class="link-primary">Help</a>
                 <a href="https://www.odoo.com/documentation/master/applications/general/iot.html" target="_blank" class="link-primary">Documentation</a>
             </div>

--- a/addons/hw_posbox_homepage/static/src/app/status.js
+++ b/addons/hw_posbox_homepage/static/src/app/status.js
@@ -26,23 +26,27 @@ class StatusPage extends Component {
         }
     }
 
+    get accessPointSsid() {
+        return this.state.data.network_interfaces.filter(i => i.is_wifi)[0]?.ssid;
+    }
+
     static template = xml`
     <div t-if="!state.loading" class="container-fluid">
         <div class="text-center pt-5">
             <img class="odoo-logo" src="/web/static/img/logo2.png" alt="Odoo logo"/>
         </div>
         <div class="status-display-boxes">
-            <div t-if="state.data.pairing_code" class="status-display-box">
+            <div t-if="state.data.pairing_code and !state.data.is_access_point_up" class="status-display-box">
                 <h4 class="text-center mb-3">Pairing Code</h4>
                 <hr/>
                 <h4 t-out="state.data.pairing_code" class="text-center mb-3"/>
             </div>
-            <div t-if="state.data.is_access_point_up" class="status-display-box">
+            <div t-if="state.data.is_access_point_up and accessPointSsid" class="status-display-box">
                 <h4 class="text-center mb-3">No Internet Connection</h4>
                 <hr/>
                 <p class="mb-3">
                     Please connect your IoT Box to internet via an ethernet cable or connect to Wi-FI network<br/>
-                    <a class="alert-link" t-out="'IoTBox-' + (state.data.network_interfaces[0].ssid or state.data.mac.replace(':', ''))" /><br/>
+                    <a class="alert-link" t-out="accessPointSsid" /><br/>
                     to configure a Wi-Fi connection on the IoT Box
                 </p>
             </div>


### PR DESCRIPTION
- Sometimes, an issue could occur displaying twice the connected Wi-Fi network, but one with the IP address of the access point (fictive 10.11.12.1).
- Once we unplugged the ethernet cable, when no Wi-Fi network was configured, there was no reconnection process (start access point mode).

Task: 4403568