### PR TITLE
[FIX] point_of_sale: correctly connect loaded many2one fields

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -279,9 +279,9 @@ export class PaymentScreen extends Component {
 
             // 2. Invoice.
             if (this.shouldDownloadInvoice() && this.currentOrder.is_to_invoice()) {
-                if (this.currentOrder.account_move) {
+                if (this.currentOrder.raw.account_move) {
                     await this.report.doAction("account.account_invoices", [
-                        this.currentOrder.account_move,
+                        this.currentOrder.raw.account_move,
                     ]);
                 } else {
                     throw {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -953,7 +953,7 @@ export class PosStore extends Reactive {
      * @returns {name: string, id: int, role: string}
      */
     get_cashier() {
-        this.user.role = this.user._raw.role;
+        this.user.role = this.user.raw.role;
         return this.user;
     }
     get_cashier_user_id() {

--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -231,14 +231,14 @@ patch(PaymentScreen.prototype, {
         }
 
         if (isInvoiceRequested) {
-            if (!this.currentOrder.account_move) {
+            if (!this.currentOrder.raw.account_move) {
                 this.dialog.add(AlertDialog, {
                     title: _t("Invoice could not be generated"),
                     body: _t("The invoice could not be generated."),
                 });
             } else {
                 await this.report.doAction("account.account_invoices", [
-                    this.currentOrder.account_move,
+                    this.currentOrder.raw.account_move,
                 ]);
             }
         }


### PR DESCRIPTION
Before this commit, if a many2one field was loaded with its data, it would not get connected. For example, in the Chilean localization, the account_move is loaded when capturing an order, but it would not get linked, causing an error.

opw-4479284

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
