### PR TITLE
[IMP] mail: new message separator when all messages are new

### DIFF
--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -21,7 +21,9 @@
                         <t t-set="currentDay" t-value="msg.dateDay"/>
                     </t>
                     <div t-if="msg.threadAsFirstUnread?.eq(props.thread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bolder z-1 px-2">
-                        <hr class="flex-grow-1 border-danger opacity-100"/><span class="ps-2 pe-1 bg-danger o-text-white rounded text-uppercase">New</span>
+                        <t t-if="props.thread.selfMember.localNewMessageSeparator !== 0">
+                            <hr class="flex-grow-1 border-danger opacity-100"/><span class="ps-2 pe-1 bg-danger o-text-white rounded text-uppercase">New</span>
+                        </t>
                     </div>
                     <NotificationMessage t-if="msg.isNotification and !msg.notificationHidden" message="msg" thread="props.thread" registerMessageRef="registerMessageRef" />
                     <Message

--- a/addons/mail/static/src/discuss/core/common/channel_member_model.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_model.js
@@ -50,7 +50,7 @@ export class ChannelMember extends Record {
     });
     unreadSynced = Record.attr(true, {
         compute() {
-            return this.localNewMessageSeparator === this.new_message_separator;
+            return this.localMessageUnreadCounter === this.message_unread_counter;
         },
         onUpdate() {
             if (this.unreadSynced) {

--- a/addons/mail/static/src/discuss/core/common/thread_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_patch.js
@@ -54,6 +54,7 @@ const threadPatch = {
                 this.setScroll(scrollTop);
             }
             thread.scrollUnread = false;
+            this.env.bus.trigger("scrollUnreadChanged");
         } else {
             super.applyScrollContextually(...arguments);
         }

--- a/addons/mail/static/tests/core/new_message_separator.test.js
+++ b/addons/mail/static/tests/core/new_message_separator.test.js
@@ -7,7 +7,6 @@ import {
     listenStoreFetch,
     openDiscuss,
     openFormView,
-    scroll,
     setupChatHub,
     start,
     startServer,
@@ -16,7 +15,7 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
 import { click as hootClick, press, queryFirst } from "@odoo/hoot-dom";
-import { mockDate, tick } from "@odoo/hoot-mock";
+import { mockDate } from "@odoo/hoot-mock";
 import { Command, serverState, withUser } from "@web/../tests/web_test_helpers";
 
 import { rpc } from "@web/core/network/rpc";
@@ -61,26 +60,59 @@ test("keep new message separator when message is deleted", async () => {
     await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", { text: "message 1" });
 });
 
-test("separator is not shown if message is not yet loaded", async () => {
+test("new message separator is not shown if all messages are new", async () => {
     const pyEnv = await startServer();
-    const generalId = pyEnv["discuss.channel"].create({ name: "General" });
-    for (let i = 0; i < 60; i++) {
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const bobPartnerId = pyEnv["res.partner"].create({ name: "Bob" });
+    for (let i = 0; i < 5; i++) {
         pyEnv["mail.message"].create({
+            author_id: bobPartnerId,
             body: `message ${i}`,
             message_type: "comment",
             model: "discuss.channel",
-            author_id: serverState.partnerId,
-            res_id: generalId,
+            res_id: channelId,
         });
     }
     await start();
-    await openDiscuss(generalId);
-    await contains(".o-mail-Message", { count: 30 });
-    await scroll(".o-mail-Thread", 0);
-    await contains(".o-mail-Message", { text: "message 0" });
-    await tick(); // give enough time for the useVisible hook to register load more as hidden
-    await scroll(".o-mail-Thread", 0);
-    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", { text: "message 0" });
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message", { count: 5 });
+    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New" });
+});
+
+test("new message separator is shown after first mark as read, on receiving new message", async () => {
+    const pyEnv = await startServer();
+    const bobPartnerId = pyEnv["res.partner"].create({ name: "Bob" });
+    const bobUserId = pyEnv["res.users"].create({ name: "Bob", partner_id: bobPartnerId });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: bobPartnerId }),
+        ],
+        channel_type: "chat",
+    });
+    pyEnv["mail.message"].create({
+        author_id: bobPartnerId,
+        body: `Message 0`,
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message", { text: "Message 0" });
+    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New" });
+    await withUser(bobUserId, () =>
+        rpc("/mail/message/post", {
+            post_data: {
+                body: "Message 1",
+                message_type: "comment",
+                subtype_xmlid: "mail.mt_comment",
+            },
+            thread_id: channelId,
+            thread_model: "discuss.channel",
+        })
+    );
+    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", { text: "Message 1" });
+    await contains(".o-mail-Thread-newMessage hr + span", { text: "New" });
 });
 
 test("keep new message separator until user goes back to the thread", async () => {
@@ -93,17 +125,32 @@ test("keep new message separator until user goes back to the thread", async () =
             Command.create({ partner_id: serverState.partnerId }),
         ],
     });
-    pyEnv["mail.message"].create({
-        author_id: partnerId,
-        body: "hello",
-        message_type: "comment",
-        model: "discuss.channel",
-        res_id: channelId,
-    });
+    const messageIds = pyEnv["mail.message"].create([
+        {
+            author_id: partnerId,
+            body: "Message body 1",
+            message_type: "comment",
+            model: "discuss.channel",
+            res_id: channelId,
+        },
+        {
+            author_id: partnerId,
+            body: "Message body 2",
+            message_type: "comment",
+            model: "discuss.channel",
+            res_id: channelId,
+        },
+    ]);
+    // simulate that there is at least one read message in the channel
+    const [memberId] = pyEnv["discuss.channel.member"].search([
+        ["channel_id", "=", channelId],
+        ["partner_id", "=", serverState.partnerId],
+    ]);
+    pyEnv["discuss.channel.member"].write([memberId], { new_message_separator: messageIds[0] + 1 });
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Thread");
-    await contains(".o-mail-Message", { text: "hello" });
+    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", { text: "Message body 2" });
     await contains(".o-mail-Thread-newMessage hr + span", { text: "New" });
     await hootClick(document.body); // Force "focusin" back on the textarea
     await hootClick(".o-mail-Composer-input");
@@ -115,7 +162,7 @@ test("keep new message separator until user goes back to the thread", async () =
     await contains(".o-mail-Discuss-threadName", { value: "History" });
     await hootClick(".o-mail-DiscussSidebar-item:contains(test)");
     await contains(".o-mail-Discuss-threadName", { value: "test" });
-    await contains(".o-mail-Message", { text: "hello" });
+    await contains(".o-mail-Message", { text: "Message body 2" });
     await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New" });
 });
 
@@ -134,6 +181,17 @@ test("show new message separator on receiving new message when out of odoo focus
         channel_type: "channel",
         name: "General",
     });
+    const messageId = pyEnv["mail.message"].create({
+        body: "not empty",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    // simulate that there is at least one read message in the channel
+    const [memberId] = pyEnv["discuss.channel.member"].search([
+        ["channel_id", "=", channelId],
+        ["partner_id", "=", serverState.partnerId],
+    ]);
+    pyEnv["discuss.channel.member"].write([memberId], { new_message_separator: messageId + 1 });
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Thread");
@@ -246,6 +304,17 @@ test("show new message separator when message is received while chat window is c
         ],
         channel_type: "chat",
     });
+    const messageId = pyEnv["mail.message"].create({
+        body: "not empty",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    // simulate that there is at least one read message in the channel
+    const [memberId] = pyEnv["discuss.channel.member"].search([
+        ["channel_id", "=", channelId],
+        ["partner_id", "=", serverState.partnerId],
+    ]);
+    pyEnv["discuss.channel.member"].write([memberId], { new_message_separator: messageId + 1 });
     setupChatHub({ opened: [channelId] });
     listenStoreFetch("init_messaging");
     await start();
@@ -273,15 +342,30 @@ test("only show new message separator in its thread", async () => {
     const pyEnv = await startServer();
     const demoPartnerId = pyEnv["res.partner"].create({ name: "Demo" });
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
-    pyEnv["mail.message"].create({
-        author_id: demoPartnerId,
-        body: "@Mitchell Admin",
-        attachment_ids: [],
-        message_type: "comment",
-        model: "discuss.channel",
-        res_id: channelId,
-        needaction: true,
-    });
+    const messageIds = pyEnv["mail.message"].create([
+        {
+            author_id: demoPartnerId,
+            body: "Hello",
+            message_type: "comment",
+            model: "discuss.channel",
+            res_id: channelId,
+        },
+        {
+            author_id: demoPartnerId,
+            body: "@Mitchell Admin",
+            attachment_ids: [],
+            message_type: "comment",
+            model: "discuss.channel",
+            res_id: channelId,
+            needaction: true,
+        },
+    ]);
+    // simulate that there is at least one read message in the channel
+    const [memberId] = pyEnv["discuss.channel.member"].search([
+        ["channel_id", "=", channelId],
+        ["partner_id", "=", serverState.partnerId],
+    ]);
+    pyEnv["discuss.channel.member"].write([memberId], { new_message_separator: messageIds[0] + 1 });
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", { text: "@Mitchell Admin" });

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -314,7 +314,7 @@ test("mark channel as fetched when a new message is loaded", async () => {
     );
     await contains(".o-mail-Message");
     await waitForSteps(["rpc:channel_fetch"]);
-    await contains(".o-mail-Thread-newMessage hr + span", { text: "New" });
+    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", { text: "Hello!" });
     await focus(".o-mail-Composer-input");
     await waitForSteps(["rpc:mark_as_read"]);
 });

--- a/addons/mail/static/tests/thread/unread_messages_banner.test.js
+++ b/addons/mail/static/tests/thread/unread_messages_banner.test.js
@@ -28,9 +28,10 @@ defineMailModels();
 test("show unread messages banner when there are unread messages", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const bobPartnerId = pyEnv["res.partner"].create({ name: "Bob" });
     for (let i = 0; i < 30; ++i) {
         pyEnv["mail.message"].create({
-            author_id: serverState.partnerId,
+            author_id: bobPartnerId,
             body: `message ${i}`,
             model: "discuss.channel",
             res_id: channelId,
@@ -47,9 +48,10 @@ test("show unread messages banner when there are unread messages", async () => {
 test("mark thread as read from unread messages banner", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const bobPartnerId = pyEnv["res.partner"].create({ name: "Bob" });
     for (let i = 0; i < 30; ++i) {
         pyEnv["mail.message"].create({
-            author_id: serverState.partnerId,
+            author_id: bobPartnerId,
             body: `message ${i}`,
             model: "discuss.channel",
             res_id: channelId,
@@ -69,10 +71,11 @@ test("mark thread as read from unread messages banner", async () => {
 test("reset new message separator from unread messages banner", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const bobPartnerId = pyEnv["res.partner"].create({ name: "Bob" });
     let lastMessageId;
     for (let i = 0; i < 30; ++i) {
         lastMessageId = pyEnv["mail.message"].create({
-            author_id: serverState.partnerId,
+            author_id: bobPartnerId,
             body: `message ${i}`,
             model: "discuss.channel",
             res_id: channelId,
@@ -99,7 +102,7 @@ test("reset new message separator from unread messages banner", async () => {
         },
     ];
     await Promise.all([openDiscuss(channelId), waitNotifications(markAsReadNotification)]);
-    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", {
+    await contains(".o-mail-Message", {
         text: "message 0",
     });
     await click("span", {
@@ -112,9 +115,10 @@ test("reset new message separator from unread messages banner", async () => {
 test("remove banner when scrolling to bottom", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    const bobPartnerId = pyEnv["res.partner"].create({ name: "Bob" });
     for (let i = 0; i < 50; ++i) {
         pyEnv["mail.message"].create({
-            author_id: serverState.partnerId,
+            author_id: bobPartnerId,
             body: `message ${i}`,
             model: "discuss.channel",
             res_id: channelId,
@@ -140,8 +144,9 @@ test("remove banner when scrolling to bottom", async () => {
 test("remove banner when opening thread at the bottom", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    const bobPartnerId = pyEnv["res.partner"].create({ name: "Bob" });
     const messageId = pyEnv["mail.message"].create({
-        author_id: serverState.partnerId,
+        author_id: bobPartnerId,
         body: `Hello World`,
         model: "discuss.channel",
         res_id: channelId,
@@ -166,9 +171,10 @@ test("remove banner when opening thread at the bottom", async () => {
 test("keep banner after mark as unread when scrolling to bottom", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    const bobPartnerId = pyEnv["res.partner"].create({ name: "Bob" });
     for (let i = 0; i < 30; ++i) {
         pyEnv["mail.message"].create({
-            author_id: serverState.partnerId,
+            author_id: bobPartnerId,
             body: `message ${i}`,
             model: "discuss.channel",
             res_id: channelId,
@@ -184,18 +190,18 @@ test("keep banner after mark as unread when scrolling to bottom", async () => {
 
 test("sidebar and banner counters display same value", async () => {
     const pyEnv = await startServer();
-    const bobPatnerId = pyEnv["res.partner"].create({ name: "Bob" });
-    const bobUserId = pyEnv["res.users"].create({ name: "Bob", partner_id: bobPatnerId });
+    const bobPartnerId = pyEnv["res.partner"].create({ name: "Bob" });
+    const bobUserId = pyEnv["res.users"].create({ name: "Bob", partner_id: bobPartnerId });
     const channelId = pyEnv["discuss.channel"].create({
         channel_type: "chat",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ partner_id: bobPatnerId }),
+            Command.create({ partner_id: bobPartnerId }),
         ],
     });
     for (let i = 0; i < 30; ++i) {
         pyEnv["mail.message"].create({
-            author_id: serverState.partnerId,
+            author_id: bobPartnerId,
             body: `message ${i}`,
             model: "discuss.channel",
             res_id: channelId,


### PR DESCRIPTION
Before this commit, new message separator was displayed even if all the messages
 in a conversation were new. This commit changes that behavior.

 task-4448873
