### PR TITLE
[FIX] core: http.route "methods" accepts any Iterable

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -201,7 +201,7 @@ class IrHttp(models.AbstractModel):
             for url, endpoint in cls._generate_routing_rules(mods, converters=cls._get_converters()):
                 routing = submap(endpoint.routing, ROUTING_KEYS)
                 if routing['methods'] is not None and 'OPTIONS' not in routing['methods']:
-                    routing['methods'] = routing['methods'] + ['OPTIONS']
+                    routing['methods'] = [*routing['methods'], 'OPTIONS']
                 rule = werkzeug.routing.Rule(url, endpoint=endpoint, **routing)
                 rule.merge_slashes = False
                 routing_map.add(rule)

--- a/odoo/addons/test_http/controllers.py
+++ b/odoo/addons/test_http/controllers.py
@@ -33,7 +33,7 @@ class TestHttp(http.Controller):
     # =====================================================
     # Greeting
     # =====================================================
-    @http.route(['/test_http/greeting', '/test_http/greeting-none'], type='http', auth='none')
+    @http.route(('/test_http/greeting', '/test_http/greeting-none'), type='http', auth='none')
     def greeting_none(self):
         return "Tek'ma'te"
 
@@ -130,7 +130,7 @@ class TestHttp(http.Controller):
     def cors_http(self):
         return "Hello"
 
-    @http.route('/test_http/cors_http_methods', type='http', auth='none', methods=['GET', 'PUT'], cors='*')
+    @http.route('/test_http/cors_http_methods', type='http', auth='none', methods=('GET', 'PUT'), cors='*')
     def cors_http_verbs(self, **kwargs):
         return "Hello"
 

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -718,7 +718,7 @@ def route(route=None, **routing):
         # Sanitize the routing
         assert routing.get('type', 'http') in _dispatchers.keys()
         if route:
-            routing['routes'] = route if isinstance(route, list) else [route]
+            routing['routes'] = [route] if isinstance(route, str) else route
         wrong = routing.pop('method', None)
         if wrong is not None:
             _logger.warning("%s defined with invalid routing parameter 'method', assuming 'methods'", fname)
@@ -1984,7 +1984,7 @@ class Application:
         for url, endpoint in _generate_routing_rules([''] + odoo.conf.server_wide_modules, nodb_only=True):
             routing = submap(endpoint.routing, ROUTING_KEYS)
             if routing['methods'] is not None and 'OPTIONS' not in routing['methods']:
-                routing['methods'] = routing['methods'] + ['OPTIONS']
+                routing['methods'] = [*routing['methods'], 'OPTIONS']
             rule = werkzeug.routing.Rule(url, endpoint=endpoint, **routing)
             rule.merge_slashes = False
             nodb_routing_map.add(rule)


### PR DESCRIPTION
The docstring of `@route` states that it accepts any iterable for the `methods` argument, but several places in the source code wrongly expected a list, and break if it is a tuple.
