### PR TITLE
[FIX] mail: properly truncate payload for push notifications

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -32,7 +32,7 @@ from odoo.tools import is_html_empty, html_escape, html2plaintext, parse_contact
 from odoo.tools.misc import clean_context, split_every
 
 from requests import Session
-from ..web_push import push_to_end_point, DeviceUnreachableError
+from ..web_push import push_to_end_point, DeviceUnreachableError, ENCRYPTION_BLOCK_OVERHEAD, ENCRYPTION_HEADER_SIZE, MAX_PAYLOAD_SIZE
 
 MAX_DIRECT_PUSH = 5
 
@@ -4430,19 +4430,74 @@ class MailThread(models.AbstractModel):
         return list(pids)
 
     def _truncate_payload(self, payload):
+        r"""Check the payload limit of ~3990 bytes to avoid 413 error return code.
+
+        See `_truncate_payload_get_max_payload_length` for the exact limit.
+
+        When sending a push notification, the entire encrypted json payload should be no more than 4096 bytes in length.
+        To ensure this, when possible, the body contents of the notification are truncated in such a way that the end
+        result will not exceed that limit.
+
+        Example Truncation:
+            We know there is an encryption overhead of 10 bytes, and a total limit of 50 bytes.
+            The payload is `{"messageId": "5291", "body": "A very long text"}`
+            So we have an effective payload length of (50 - 10) = 40.
+            Our full payload is 49 bytes, of which 16 bytes are text we are willing to truncate.
+            We must remove 9 bytes, such that the payload becomes effectively
+            `{"messageId": "5291", "body": "A very "}`
+
+        There are some considerations with this approach. Notably we must consider the full encoded length in bytes.
+        While we encode the payload in utf-8, it is actually transformed into json with `ensure_ascii=True` first.
+        This means this payload, as a python dictionary: {"body": "BØDY"}; Becomes {"body": "B\\u00d8DY"}.
+        Where `00d8` is the unicode codepoint for "Ø", and "\\u" is a json escape sequence.
+
+        In that case we must ensure that the truncated body does not suddenly contain invalid unicode escape sequences.
+        Similarly to how one should not cut an encoded string in the middle of a utf-8 character.
+
+        Example Unicode Truncation:
+            Assume {"body": "BØDY"} needs to be truncated of 3 bytes
+            It should not become {"body": "B\\u00d"}
+            Instead it should become {"body": "B"}
+
+        :param dict payload: Current payload to truncate.
+        :return: The truncated payload;
         """
-        Check the payload limit of 4096 bytes to avoid 413 error return code.
-        If the payload is too big, we trunc the body value.
-        :param dict payload: Current payload to trunc
-        :return: The truncate payload;
-        """
-        payload_length = len(str(payload).encode())
-        body = payload['options']['body']
+        payload_length = len(json.dumps(payload).encode())
+        # json.dumps defaults to translating unicode to hex codepoints (ensure_ascii=True)
+        # hence we need to check the length the body takes up in that format
+        # json string quotes are removed and the body is not encoded as it's already all ASCII
+        body = json.dumps(payload['options']['body'])[1:-1]
         body_length = len(body)
-        if payload_length > 4096:
-            body_max_length = 4096 - payload_length - body_length
-            payload['options']['body'] = body.encode()[:body_max_length].decode(errors="ignore")
+
+        max_length = self._truncate_payload_get_max_payload_length()
+        if payload_length > max_length:
+            body_max_length = max(0, max_length - payload_length + body_length)
+            # truncate to max length and try to loads again
+            # if there's any error, it will be a unicode error
+            # the error position gives us the start of the codepoint
+            # remove everything after that + the preceding escape marker (\u)
+            try:
+                # remove trailing '\' as the error for that is unhelpful
+                truncated_body = body[:body_max_length].rstrip('\\')
+                truncated_body = json.loads(f'"{truncated_body}"')
+            except json.decoder.JSONDecodeError as json_error:
+                truncated_body = json.loads(f'"{body[:json_error.pos - 2]}"')
+            payload['options']['body'] = truncated_body
         return payload
+
+    @staticmethod
+    def _truncate_payload_get_max_payload_length():
+        """Define the maximum length we want for the payload.
+
+        This limit is derived from:
+            - the maximum encrypted payload size we may send to web push servers.
+            - the header required using AES128GCM encryption.
+            - the overhead of encrypting one block. Payload will not exceed 1 block
+            as the point here is to keep everything within the default (and max) block size.
+        For details about encryption overhead sizes, see variable definition in web_push.
+        Currently all of these values are payload-independant.
+        """
+        return MAX_PAYLOAD_SIZE - ENCRYPTION_HEADER_SIZE - ENCRYPTION_BLOCK_OVERHEAD
 
     def _notify_thread_by_web_push(self, message, recipients_data, msg_vals=False, **kwargs):
         """ Method to send cloud notifications for every mention of a partner

--- a/addons/mail/web_push.py
+++ b/addons/mail/web_push.py
@@ -18,6 +18,18 @@ from .tools import jwt
 
 MAX_PAYLOAD_SIZE = 4096
 
+# size of the overhead of the header for all encryption blocks
+# +-----------+-----------------+---------------------------+------------------------+
+# | salt (16) | record_size (4) | sender_public_key.len (1) | sender_public_key (65) |
+# +-----------+-----------------+---------------------------+------------------------+
+# sender_public_key = 0x04 (1 byte) | X-coord (32 bytes) | Y-coord (32 bytes)
+# using SECP256R1 curve + X9.62 encoding + SEC1 uncompressed formatting
+ENCRYPTION_HEADER_SIZE = 16 + 4 + 1 + (1 + 32 + 32)
+
+# size of the overhead of encryption per encryption block
+# 1 padding delimiter (continue or final block) + 16-bytes in-message authentication tag from AEAD_AES_128_GCM
+ENCRYPTION_BLOCK_OVERHEAD = 1 + 16
+
 _logger = logger.getLogger(__name__)
 
 def _iv(base, counter):

--- a/addons/test_mail_full/tests/test_web_push.py
+++ b/addons/test_mail_full/tests/test_web_push.py
@@ -8,6 +8,7 @@ import odoo
 from odoo.tools.misc import mute_logger
 from odoo.addons.mail.models.partner_devices import InvalidVapidError
 from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.addons.mail.web_push import ENCRYPTION_BLOCK_OVERHEAD, ENCRYPTION_HEADER_SIZE
 from odoo.addons.sms.tests.common import SMSCommon
 from odoo.addons.test_mail.data.test_mail_data import MAIL_TEMPLATE
 from odoo.tests import tagged
@@ -373,3 +374,148 @@ class TestWebPushNotification(SMSCommon):
                 partner_id=self.user_email.partner_id.id,
                 vapid_public_key=self.vapid_public_key,
             )
+
+    @patch.object(
+        odoo.addons.mail.models.mail_thread.Session, 'post', return_value=SimpleNamespace(status_code=201, text='Ok')
+    )
+    @patch.object(
+        odoo.addons.mail.models.mail_thread, 'push_to_end_point',
+        wraps=odoo.addons.mail.web_push.push_to_end_point,
+    )
+    def test_push_notifications_truncate_payload(self, thread_push_mock, session_post_mock):
+        """Ensure that when we send large bodies with various character types,
+        the final encrypted data (post-encryption) never exceeds 4096 bytes.
+
+        This test checks the behavior for the current size limits and encryption overhead.
+        See below test for a more illustrative example.
+        See MailThread._truncate_payload for a more thorough explanation.
+
+        Test scenarios include:
+        - ASCII characters (X)
+        - UTF-8 characters (Ø), at various offsets
+        """
+        # compute the size of an empty notification with these parameters
+        # this could change based on the id of record_simple for example
+        # but is otherwise constant for any notification sent with the same parameters
+        self.record_simple.with_user(self.user_email).message_notify(
+            partner_ids=self.user_inbox.partner_id.ids,
+            body='',
+            subject='Test Payload',
+            record_name=self.record_simple._name,
+        )
+        base_payload_size = len(thread_push_mock.call_args.kwargs['payload'].encode())
+        effective_payload_size_limit = self.env['mail.thread']._truncate_payload_get_max_payload_length()
+        # this is just a sanity check that the value makes sense, feel free to update as needed
+        self.assertEqual(effective_payload_size_limit, 3993, "Payload limit should come out to 3990.")
+        body_size_limit = effective_payload_size_limit - base_payload_size
+        encryption_overhead = ENCRYPTION_HEADER_SIZE + ENCRYPTION_BLOCK_OVERHEAD
+
+        test_cases = [
+            # (description, body)
+            ('empty string', '', 0, 0),
+            ('1-byte ASCII characters (below limit)', 'X' * (body_size_limit - 1), body_size_limit - 1, body_size_limit - 1),
+            ('1-byte ASCII characters (at limit)', 'X' * body_size_limit, body_size_limit, body_size_limit),
+            ('1-byte ASCII characters (past limit)', 'X' * (body_size_limit + 1), body_size_limit, body_size_limit),
+            ('1-byte ASCII characters (way past limit)', 'X' * 5000, body_size_limit, body_size_limit),
+        ] + [  # \u00d8 check that it can be cut anywhere by offsetting the string by 1 byte each time
+            (
+                f'2-bytes UTF-8 characters (near limit + {offset}-byte offset)',
+                ('+' * offset) + ('Ø' * (body_size_limit // 6)),
+                offset + ((body_size_limit - offset) // 6),  # length truncated to nearest full character (\u00f8)
+                offset * 1 + ((body_size_limit - offset) // 6) * 6,
+            )
+            for offset in range(0, 8)
+        ]
+
+        for description, body, expected_body_length, expected_body_size in test_cases:
+            with self.subTest(description):
+                self.record_simple.with_user(self.user_email).message_notify(
+                    partner_ids=self.user_inbox.partner_id.ids,
+                    body=body,
+                    subject='Test Payload',
+                    record_name=self.record_simple._name,
+                )
+
+                encrypted_payload = session_post_mock.call_args.kwargs['data']
+                payload_before_encryption = thread_push_mock.call_args.kwargs['payload']
+                self.assertLessEqual(
+                    len(encrypted_payload), 4096, 'Final encrypted payload should not exceed 4096 bytes'
+                )
+                self.assertEqual(
+                    len(json.loads(payload_before_encryption)['options']['body']), expected_body_length
+                )
+                self.assertEqual(
+                    len(encrypted_payload),
+                    base_payload_size + expected_body_size + encryption_overhead,
+                    'Encrypted size should be exactly the base payload size + body size + encryption overhead.'
+                )
+
+    @patch.object(
+        odoo.addons.mail.models.mail_thread.Session, 'post', return_value=SimpleNamespace(status_code=201, text='Ok')
+    )
+    @patch.object(
+        odoo.addons.mail.models.mail_thread, 'push_to_end_point',
+        wraps=odoo.addons.mail.web_push.push_to_end_point,
+    )
+    @patch.object(
+        odoo.addons.mail.web_push, '_encrypt_payload',
+        wraps=odoo.addons.mail.web_push._encrypt_payload,
+    )
+    def test_push_notifications_truncate_payload_mocked_size_limit(self, web_push_encrypt_payload_mock, thread_push_mock, session_post_mock):
+        """Illustrative test for text contents truncation.
+
+        We want to ensure we truncate utf-8 values properly based on maximum payload size.
+        Here max payload size is mocked, so that we can test on the same body each time to ease reading.
+
+        See MailThread._truncate_payload for a more thorough explanation.
+        """
+        self.record_simple.with_user(self.user_email).message_notify(
+            partner_ids=self.user_inbox.partner_id.ids,
+            body="",
+            subject='Test Payload',
+            record_name=self.record_simple._name,
+        )
+        base_payload = thread_push_mock.call_args.kwargs['payload'].encode()
+        base_payload_size = len(base_payload)
+        encryption_overhead = ENCRYPTION_HEADER_SIZE + ENCRYPTION_BLOCK_OVERHEAD
+
+        body = "BØDY"
+        body_json = json.dumps(body)[1:-1]
+        for size_limit, expected_body in [
+            (base_payload_size + len(body_json), "BØDY"),
+            (base_payload_size + len(body_json) - 1, "BØD"),
+            (base_payload_size + len(body_json) - 2, "BØ"),
+        ] + [  # truncating anywhere in \u00d8 (Ø) should truncate to the nearest full character (B)
+            (base_payload_size + len(body_json) - n, "B")
+            for n in range(3, 9)
+        ] + [
+            (base_payload_size + len(body_json) - 9, ""),
+            (base_payload_size + len(body_json) - 10, ""),  # should still work even if it would still be too big after truncate
+        ]:
+            with self.subTest(size_limit=size_limit), patch.object(
+                odoo.addons.mail.models.mail_thread.MailThread, '_truncate_payload_get_max_payload_length',
+                return_value=size_limit,
+            ):
+                self.record_simple.with_user(self.user_email).message_notify(
+                    partner_ids=self.user_inbox.partner_id.ids,
+                    body=body,
+                    subject='Test Payload',
+                    record_name=self.record_simple._name,
+                )
+                payload_at_push = thread_push_mock.call_args.kwargs['payload']
+                payload_before_encrypt = web_push_encrypt_payload_mock.call_args.args[0]
+                encrypted_payload = session_post_mock.call_args.kwargs['data']
+                self.assertEqual(payload_before_encrypt.decode(), payload_at_push, "Payload should not change between encryption and push call.")
+                self.assertEqual(len(payload_before_encrypt), len(payload_at_push), "Encoded body should be same size as decoded.")
+                self.assertEqual(
+                    len(encrypted_payload), len(payload_before_encrypt) + encryption_overhead,
+                    'Final encrypted payload should just be the size of the unencrypted payload + the size of encryption overhead.'
+                )
+                self.assertEqual(
+                    json.loads(payload_at_push)['options']['body'], expected_body
+                )
+                if not expected_body:
+                    self.assertEqual(
+                        payload_before_encrypt, base_payload,
+                        "Only the contents of the body should be truncated, not the rest of the payload."
+                    )


### PR DESCRIPTION
web push payloads currently get their body truncated when the payload comes out
to more than 4096 bytes. However this only keeps the plaintext payload under
that limit, not accounting for encryption.

As we need the payload to be 4096 bytes at most *after encryption*
the threshold for body truncation is reduced to around 3990 bytes to account for
the fixed overhead of encryption as laid out in the added constants and getters
so that they can be adjusted as needed.

Additionally there were some issues with the logic for truncation:
- Checking character length against byte length for the comparison, which led to
potentially a lot more truncated text than necessary.
- Truncation being done with the assumption the text would be encoded in utf-8
when it is actually transformed to json unicode escape sequences
(see ensure_ascii argument in json.dumps) again making the truncation inaccurate.
- The calculation of body_max_length was incorrect, as it allowed for negative
values which sometimes resulted in an empty body.

Steps to reproduce:

1. Activate desktop notifications.
2. Fastest way will be to send to an account A (with activated notis),
a message through discuss from an account B.
3. Additionally this affects the current flow too:
  3.1 When we try to notify a user following a heldesk team.
  3.2 We create an alias and set this to that current team.
  3.3 We simulate an email to that heldesk team, eg vip-support@test.com

opw-3939019