### PR TITLE
[IMP] core: speedup new_test_user and authenticate in tests

### DIFF
--- a/odoo/addons/test_http/tests/test_echo_reply.py
+++ b/odoo/addons/test_http/tests/test_echo_reply.py
@@ -91,9 +91,13 @@ class TestHttpEchoReplyJsonNoDB(TestHttpBase):
 
 @tagged('post_install', '-at_install')
 class TestHttpEchoReplyHttpWithDB(TestHttpBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.jackoneill = new_test_user(cls.env, 'jackoneill', context={'lang': 'en_US'})
+
     def setUp(self):
         super().setUp()
-        self.jackoneill = new_test_user(self.env, 'jackoneill', context={'lang': 'en_US'})
         self.authenticate('jackoneill', 'jackoneill')
 
     def test_echohttp0_get_qs_db(self):

--- a/odoo/addons/test_http/tests/test_greeting.py
+++ b/odoo/addons/test_http/tests/test_greeting.py
@@ -9,8 +9,12 @@ from .test_common import TestHttpBase
 
 @tagged('post_install', '-at_install')
 class TestHttpGreeting(TestHttpBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.jackoneill = new_test_user(cls.env, 'jackoneill', context={'lang': 'en_US'})
+
     def test_greeting0_matrix(self):
-        new_test_user(self.env, 'jackoneill', context={'lang': 'en_US'})
         test_matrix = [
             # path, database, login, expected_code, expected_re_pattern
             ('/test_http/greeting', False, None, 200, r"Tek'ma'te"),
@@ -55,7 +59,6 @@ class TestHttpGreeting(TestHttpBase):
         self.assertEqual(res.text, "Tek'ma'te")
 
     def test_greeting2_headers_db(self):
-        new_test_user(self.env, 'jackoneill', context={'lang': 'en_US'})
         self.authenticate('jackoneill', 'jackoneill')
         res = self.db_url_open('/test_http/greeting')
         self.assertEqual(res.status_code, 200)

--- a/odoo/addons/test_http/tests/test_models.py
+++ b/odoo/addons/test_http/tests/test_models.py
@@ -11,9 +11,13 @@ from .test_common import TestHttpBase
 
 @tagged('post_install', '-at_install')
 class TestHttpModels(TestHttpBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.jackoneill = new_test_user(cls.env, 'jackoneill', context={'lang': 'en_US'})
+
     def setUp(self):
         super().setUp()
-        self.jackoneill = new_test_user(self.env, 'jackoneill', context={'lang': 'en_US'})
         self.authenticate('jackoneill', 'jackoneill')
 
     def test_models0_galaxy_ok(self):


### PR DESCRIPTION
The /test_http test suite makes a heavy usage of both `new_test_user` and `authenticate`. Those two functions hash the password using very slow and computing intensive hash algorithms, which can take up to 1 full second on a slow laptop, everytime.

Those `new_test_user` are never commited, and will never be. They solely exist within the transaction of the test and are discarded once the test finished running. Also the cleartext version of the password is visible in the source code so there is no point strengenthing those.

In this work we patch the `CryptContext` instance for `res.users` to inject a very weak but very fast hash algorithm in front of the secure ones. This makes creating and authenticating new users much faster, which makes running the tests much faster too.

Running the `/test_http` test suite takes half the time with this patch.

Without this patch:

    Executed in   48,89 secs    fish           external
       usr time   31,23 secs  600,00 micros   31,23 secs
       sys time    0,83 secs  312,00 micros    0,83 secs

With this patch:

    Executed in   26,78 secs    fish           external
       usr time    8,15 secs   21,08 millis    8,13 secs
       sys time    0,89 secs    4,38 millis    0,89 secs