### PR TITLE
[FIX] account: check for leap year when creating placeholder

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3503,7 +3503,8 @@ class AccountMove(models.Model):
         last_month = int(self.company_id.fiscalyear_last_month)
         is_staggered_year = last_month != 12 or last_day != 31
         if is_staggered_year:
-            if self.date > date(self.date.year, last_month, last_day):
+            # relativedelta accounts for invalid dates, e.g. Feb 29th on a non-leap year.
+            if self.date > date(self.date.year, last_month, 1) + relativedelta(day=last_day):
                 year_part = "%s-%s" % (self.date.strftime('%y'), (self.date + relativedelta(years=1)).strftime('%y'))
             else:
                 year_part = "%s-%s" % ((self.date + relativedelta(years=-1)).strftime('%y'), self.date.strftime('%y'))


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

If the customer sets their last fiscal day and month to February 29th, a ValueError may be raised when creating a placeholder name for account.move records if their dates are not in a leap year.

More precisely, a ValueError is thrown when creating the starting sequence of the placeholder name, as a new date object is created using the company's last fiscal day and month and the year of the account.move.

This commit adjusts the day of the created date to February 28th if the last fiscal day and month is set to February 29th and if the account.move year is not a leap year. This date was chosen since that's 365 days after February 29th.

### Current behaviour before PR:

If the company's last fiscal day and month is set to February 29th, creating a placeholder name for account.move records whose date is not in a leap year raises a ValueError.

Steps to reproduce:
1. Set the last fiscal day to February 29th.
2. Go to Accounting > Journal Entries (account.move).
3. Trigger the computation of the placeholder name for account.move() (edit journal_id, create record, edit date field...)
4. A ValueError exception is raised.

### Desired behaviour after PR is merged:

The placeholder name for account.move records is successful and less prone to errors.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
