### PR TITLE
[IMP] website: warn when custom js not loaded

### DIFF
--- a/addons/web/static/src/module_loader.js
+++ b/addons/web/static/src/module_loader.js
@@ -170,7 +170,46 @@
             }
 
             domReady(() => {
-                // Empty body
+                    const customJSUnloaded = unloaded.some((module) =>
+                    module.includes("user_custom_javascript")
+                );
+
+                if (customJSUnloaded && (document.querySelector(".o_frontend_to_backend_edit_btn") || window.location.href.includes("/web/login"))) {
+                    if (document.querySelector(".custom-js-unloaded-popup")) {
+                        return; // Popup already displayed, do nothing
+                    }
+
+                    const overlay = document.createElement("div");
+                    overlay.className = "custom-js-unloaded-overlay position-fixed top-0 start-0 w-100 h-100";
+                    overlay.style.backgroundColor = "rgba(0, 0, 0, 0.5)";
+                    overlay.style.zIndex = "10000";
+
+                    const popup = document.createElement("div");
+                    popup.className =
+                        "custom-js-unloaded-popup position-fixed start-50 translate-middle bg-danger text-white p-3 rounded shadow";
+                    popup.style.top = "40%";
+                    popup.style.zIndex = "10001";
+                    popup.style.border = "2px solid black";
+
+                    const message = document.createElement("div");
+                    message.textContent =
+                        "Custom JavaScript code has been disabled. You may proceed, but some features may not work as expected.";
+                    popup.appendChild(message);
+
+                    const closeButton = document.createElement("button");
+                    closeButton.className = "btn btn-light mt-2";
+                    closeButton.textContent = "Close";
+                    closeButton.onclick = () => {
+                        overlay.remove();
+                        popup.remove();
+                    };
+                    popup.appendChild(closeButton);
+
+                    document.body.appendChild(overlay);
+                    document.body.appendChild(popup);
+                    return;
+                }
+
                 while (document.body.childNodes.length) {
                     document.body.childNodes[0].remove();
                 }


### PR DESCRIPTION
Alternative/supplement of https://github.com/odoo/upgrade/pull/6137

Display a proper warning to the editors of `website` and on the login page instead of an error that removes all content from the webpage and prevents users from accessing settings where they could possibly address the erroneous JavaScript.
![image](https://github.com/user-attachments/assets/26d9f0d7-210b-48ee-a824-13be6429356f)

Example of invalid JS code that locks you out:
```
var core = require('web.core');
```

The custom JS editor checks for simple syntax errors, but doesn't check for invalid imports (and possibly some other potential errors). This means that saving the above code will present all users that attempt to load `user_custom_javascript` with a blank page displaying errors:
![image](https://github.com/user-attachments/assets/7017554a-b3c8-4ce4-b107-d94fbfab93e0)


There is nothing else there, because the `document` is cleared in its entirety with `document.body.childNodes[0].remove();`. This effectively locks out admins from accessing the backend or even logging in. 

This issue was first observed post-upgrade, because the contents of the file with the code are not updated (for that, see the PR in `odoo/upgrade`. Upon closer investigation, it turned out that it's possible to reproduce it in standard too, by simply making the code import an unavailable library.

The design and implementation in general is obviously just a draft, mostly to showcase the idea. Moreover, the codebase in 16, 17 and 18 varies greatly and it is not possible to forward port this specific solution. My hope with this PR is that the relevant teams (looking at you @odoo/rd-framework-js :D) will share their expertise.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
