### PR TITLE
[FIX] purchase: Fix taxes in the purchase order portal view

### DIFF
--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -348,7 +348,7 @@
                                         />
                                     </td>
                                     <td t-if="not update_dates and order.state in ['purchase', 'done']" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                                        <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.taxes_id))"/>
+                                        <span t-out="', '.join(map(lambda x: (x.name), line.taxes_id))"/>
                                     </td>
                                     <td class="text-end" t-if="not update_dates and order.state in ['purchase', 'done']">
                                         <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>


### PR DESCRIPTION
From saas-17.4, the "description" field on "account.tax" has been changed from Char to Html. However, the portal view for the purchase order does not correctly render HTML fields in the taxes column.

As a result, the taxes are displayed using only the "name" field in the portal purchase order view.

opw-4439126

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
