### PR TITLE
[IMP] l10n_in: cleanup unnecessary fields

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -30,7 +30,6 @@ class AccountMove(models.Model):
     l10n_in_shipping_bill_date = fields.Date('Shipping bill date')
     l10n_in_shipping_port_code_id = fields.Many2one('l10n_in.port.code', 'Port code')
     l10n_in_reseller_partner_id = fields.Many2one('res.partner', 'Reseller', domain=[('vat', '!=', False)], help="Only Registered Reseller")
-    l10n_in_journal_type = fields.Selection(string="Journal Type", related='journal_id.type')
     l10n_in_warning = fields.Json(compute="_compute_l10n_in_warning")
 
     @api.depends('partner_id', 'partner_id.l10n_in_gst_treatment', 'state')

--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -17,7 +17,7 @@
                     options="{'no_create': True, 'no_open': True}"
                     invisible="country_code != 'IN' or move_type == 'entry'"
                     readonly="state != 'draft'"
-                    required="country_code == 'IN' and move_type != 'entry' and l10n_in_journal_type in ('sale', 'purchase')"/>
+                    required="country_code == 'IN' and move_type != 'entry' and journal_id.type in ('sale', 'purchase')"/>
                 <field name="l10n_in_gst_treatment"
                     invisible="country_code != 'IN' or move_type == 'entry'"
                     readonly="state != 'draft'"


### PR DESCRIPTION
this commits removes the `l10n_in_journal_type` field because when the field was introduced in previous versions where orm didn't support the related fields in views. But now it does it's no longer required in the model

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
