### PR TITLE
[IMP] im_livechat: add continue button when chat bot is done

### DIFF
--- a/addons/im_livechat/i18n/im_livechat.pot
+++ b/addons/im_livechat/i18n/im_livechat.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~18.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-24 15:31+0000\n"
-"PO-Revision-Date: 2024-12-24 15:31+0000\n"
+"POT-Creation-Date: 2025-01-15 08:33+0000\n"
+"PO-Revision-Date: 2025-01-15 08:33+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -455,12 +455,6 @@ msgid "Conversation"
 msgstr ""
 
 #. module: im_livechat
-#. odoo-javascript
-#: code:addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js:0
-msgid "Conversation ended..."
-msgstr ""
-
-#. module: im_livechat
 #. odoo-python
 #: code:addons/im_livechat/models/discuss_channel.py:0
 msgid "Conversation with %s"
@@ -756,6 +750,12 @@ msgstr ""
 #. module: im_livechat
 #: model:ir.model.fields.selection,name:im_livechat.selection__chatbot_script_step__step_type__free_input_multi
 msgid "Free Input (Multi-Line)"
+msgstr ""
+
+#. module: im_livechat
+#. odoo-javascript
+#: code:addons/im_livechat/static/src/embed/common/chat_window_patch.xml:0
+msgid "Give your feedback"
 msgstr ""
 
 #. module: im_livechat
@@ -1175,7 +1175,9 @@ msgstr ""
 
 #. module: im_livechat
 #: model:ir.model.fields,help:im_livechat.field_discuss_channel__livechat_active
-msgid "Livechat session is active until visitor leaves the conversation."
+msgid ""
+"Livechat session is active until visitor or operator leaves the "
+"conversation."
 msgstr ""
 
 #. module: im_livechat
@@ -1573,7 +1575,7 @@ msgstr ""
 
 #. module: im_livechat
 #. odoo-javascript
-#: code:addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js:0
+#: code:addons/im_livechat/static/src/embed/common/thread_model_patch.js:0
 msgid "Say something"
 msgstr ""
 
@@ -1622,7 +1624,7 @@ msgstr ""
 
 #. module: im_livechat
 #. odoo-javascript
-#: code:addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js:0
+#: code:addons/im_livechat/static/src/embed/common/thread_model_patch.js:0
 msgid "Select an option above"
 msgstr ""
 
@@ -1824,7 +1826,8 @@ msgstr ""
 
 #. module: im_livechat
 #. odoo-javascript
-#: code:addons/im_livechat/static/src/core/common/chat_window_patch.xml:0
+#: code:addons/im_livechat/static/src/core/common/thread_model_patch.js:0
+#: code:addons/im_livechat/static/src/embed/common/thread_model_patch.js:0
 msgid "This livechat conversation has ended"
 msgstr ""
 

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -45,7 +45,8 @@ class DiscussChannel(models.Model):
 
     def _field_store_repr(self, field_name):
         if field_name == "livechat_operator_id":
-            return Store.One("livechat_operator_id", ["user_livechat_username", "write_date"])
+            # sudo - res.partner: accessing livechat operator is allowed
+            return Store.One("livechat_operator_id", ["user_livechat_username", "write_date"], sudo=True)
         return super()._field_store_repr(field_name)
 
     def _to_store_defaults(self, for_current_user=True):

--- a/addons/im_livechat/static/src/core/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/core/common/chat_window_patch.xml
@@ -8,9 +8,11 @@
             </t>
         </xpath>
         <xpath expr="//Composer" position="replace">
-            <t t-if="thread.channel_type === 'livechat' and thread?.livechat_active === false">
-                <span class="bg-200 py-1 text-center fst-italic fw-bold text-muted">This livechat conversation has ended</span>
-            </t>
+            <div t-if="thread?.composerDisabled" class="bg-200 py-1 text-center d-flex fst-italic fw-bold text-muted" t-ref="composerDisabledContainer">
+                <span class="flex-grow-1"/>
+                <span t-esc="thread.composerDisabledText"/>
+                <span class="flex-grow-1"/>
+            </div>
             <t t-else="">$0</t>
         </xpath>
     </t>

--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -1,6 +1,7 @@
 import { Record } from "@mail/core/common/record";
 import { Thread } from "@mail/core/common/thread_model";
 
+import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
 patch(Thread.prototype, {
@@ -44,5 +45,15 @@ patch(Thread.prototype, {
 
     get isChatChannel() {
         return this.channel_type === "livechat" || super.isChatChannel;
+    },
+
+    get composerDisabled() {
+        return this.channel_type === "livechat" && this.livechat_active === false;
+    },
+
+    get composerDisabledText() {
+        return this.channel_type === "livechat" && this.livechat_active === false
+            ? _t("This livechat conversation has ended")
+            : null;
     },
 });

--- a/addons/im_livechat/static/src/core/public_web/discuss_patch.xml
+++ b/addons/im_livechat/static/src/core/public_web/discuss_patch.xml
@@ -2,9 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Discuss" t-inherit-mode="extension">
         <xpath expr="//Composer" position="replace">
-            <t t-if="thread.channel_type === 'livechat' and thread?.livechat_active === false">
-                <span class="bg-200 py-2 mt-3 text-center fst-italic d-flex-inline justify-content-center fw-bold text-muted">This livechat conversation has ended</span>
-            </t>
+            <span t-if="thread?.composerDisabled" class="bg-200 py-1 text-center fst-italic fw-bold text-muted" t-esc="thread.composerDisabledText"/>
             <t t-else="">$0</t>
         </xpath>
     </t>

--- a/addons/im_livechat/static/src/embed/common/chat_window_patch.js
+++ b/addons/im_livechat/static/src/embed/common/chat_window_patch.js
@@ -1,3 +1,4 @@
+import { CW_LIVECHAT_STEP } from "@im_livechat/core/common/chat_window_model_patch";
 import { FeedbackPanel } from "@im_livechat/embed/common/feedback_panel/feedback_panel";
 
 import { ChatWindow } from "@mail/core/common/chat_window";
@@ -16,5 +17,16 @@ patch(ChatWindow.prototype, {
     async onClickNewSession() {
         await this.close();
         await this.livechatService.open();
+    },
+    onClickFeedback() {
+        this.props.chatWindow.livechatStep = CW_LIVECHAT_STEP.CONFIRM_CLOSE; // Skip the confirmation step.
+        this.close();
+    },
+    get showGiveFeedbackBtn() {
+        const thread = this.props.chatWindow.thread;
+        if (thread?.channel_type !== "livechat") {
+            return false;
+        }
+        return thread.chatbot?.completed || thread.livechat_active === false;
     },
 });

--- a/addons/im_livechat/static/src/embed/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/chat_window_patch.xml
@@ -13,11 +13,11 @@
         <xpath expr="//*[hasclass('o-mail-ChatWindow-header')]" position="attributes">
             <attribute name="t-attf-style" add="color: {{ livechatService.options.title_color }}; background-color: {{ livechatService.options.header_background_color }} !important;" separator=" "/>
         </xpath>
-        <xpath expr="//Composer" position="replace">
-            <t t-if="chatbotService.inputEnabled">$0</t>
-            <t t-else="">
-                <span class="bg-200 py-1 text-center fst-italic" t-esc="chatbotService.inputDisabledText"/>
-            </t>
+        <xpath expr="//*[@t-ref='composerDisabledContainer']" position="inside">
+            <button t-if="showGiveFeedbackBtn" class="btn btn-link p-0" title="Give your feedback" t-on-click="() => this.onClickFeedback()"><i class="oi oi-arrow-right"/></button>
+        </xpath>
+        <xpath expr="//*[@t-ref='composerDisabledContainer']" position="attributes">
+            <attribute name="t-attf-class" add="{{ showGiveFeedbackBtn ? 'px-2' : '' }}" separator=" "/>
         </xpath>
     </t>
 </templates>

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
@@ -4,7 +4,6 @@ import { rpc } from "@web/core/network/rpc";
 import { EventBus, reactive } from "@odoo/owl";
 
 import { browser } from "@web/core/browser/browser";
-import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 const STEP_DELAY = 500;
@@ -111,34 +110,6 @@ export class ChatBotService {
 
     get canRestart() {
         return this.chatbot?.completed && !this.chatbot.currentStep?.operatorFound;
-    }
-
-    get inputEnabled() {
-        if (!this.chatbot || this.chatbot.currentStep?.operatorFound) {
-            return true;
-        }
-        return (
-            !this.chatbot.currentStep?.completed &&
-            !this.isTyping &&
-            this.chatbot.currentStep?.expectAnswer &&
-            this.chatbot.currentStep?.answers.length === 0
-        );
-    }
-
-    get inputDisabledText() {
-        if (this.inputEnabled) {
-            return "";
-        }
-        if (this.chatbot.completed) {
-            return _t("Conversation ended...");
-        }
-        if (
-            this.chatbot.currentStep?.type === "question_selection" &&
-            !this.chatbot.currentStep.completed
-        ) {
-            return _t("Select an option above");
-        }
-        return _t("Say something");
     }
 
     get chatbot() {

--- a/addons/im_livechat/static/src/embed/common/message_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/message_model_patch.js
@@ -20,8 +20,7 @@ const messagePatch = {
     canReplyTo(thread) {
         return (
             super.canReplyTo(thread) &&
-            (thread?.channel_type !== "livechat" ||
-                this.store.env.services["im_livechat.chatbot"].inputEnabled)
+            (thread?.channel_type !== "livechat" || !thread.composerDisabled)
         );
     },
 };

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -4,6 +4,7 @@ import "@mail/discuss/core/common/thread_model_patch";
 
 import { patch } from "@web/core/utils/patch";
 import { SESSION_STATE } from "./livechat_service";
+import { _t } from "@web/core/l10n/translation";
 
 patch(Thread.prototype, {
     setup() {
@@ -93,5 +94,32 @@ patch(Thread.prototype, {
             return false;
         }
         return super.showUnreadBanner;
+    },
+
+    get composerDisabled() {
+        const step = this.chatbot?.currentStep;
+        return (
+            super.composerDisabled ||
+            (step &&
+                !step.operatorFound &&
+                (step.completed || !step.expectAnswer || step.answers.length > 0))
+        );
+    },
+
+    get composerDisabledText() {
+        const text = super.composerDisabledText;
+        if (text || !this.chatbot) {
+            return text;
+        }
+        if (this.chatbot.completed) {
+            return _t("This livechat conversation has ended");
+        }
+        if (
+            this.chatbot.currentStep?.type === "question_selection" &&
+            !this.chatbot.currentStep.completed
+        ) {
+            return _t("Select an option above");
+        }
+        return _t("Say something");
     },
 });

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_continue.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_continue.js
@@ -1,0 +1,25 @@
+import { registry } from "@web/core/registry";
+
+const messagesContain = (text) => `.o-livechat-root:shadow .o-mail-Message:contains("${text}")`;
+
+registry.category("web_tour.tours").add("website_livechat.chatbot_continue_tour", {
+    steps: () => [
+        {
+            trigger: messagesContain("Hello, what can I do for you?"),
+        },
+        {
+            trigger: ".o-livechat-root:shadow li:contains(No, thank you for your time.)",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow span:contains(This livechat conversation has ended)",
+        },
+        {
+            trigger: ".o-livechat-root:shadow button[title='Give your feedback']",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow *:contains(Did we correctly answer your question?)",
+        },
+    ],
+});

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -325,3 +325,35 @@ class TestLivechatChatbotUI(TestGetOperatorCommon, TestWebsiteLivechatCommon, Ch
             ]
         )
         self.start_tour("/", "website_livechat.question_selection_overlapping_answers")
+
+    def test_chatbot_continue_after_completion(self):
+        chatbot_script = self.env["chatbot.script"].create({"title": "Continue Bot"})
+        question_step = self.env["chatbot.script.step"].create(
+            {
+                "chatbot_script_id": chatbot_script.id,
+                "message": "Hello, what can I do for you?",
+                "step_type": "question_selection",
+            },
+        )
+        self.env["chatbot.script.answer"].create(
+            {
+                "name": "No, thank you for your time.",
+                "script_step_id": question_step.id,
+            }
+        )
+        livechat_channel = self.env["im_livechat.channel"].create(
+            {
+                "name": "Continue after completion channel",
+                "rule_ids": [
+                    Command.create(
+                        {
+                            "regex_url": "/",
+                            "chatbot_script_id": chatbot_script.id,
+                            "action": "auto_popup",
+                        }
+                    )
+                ],
+            }
+        )
+        self.env.ref("website.default_website").channel_id = livechat_channel.id
+        self.start_tour("/", "website_livechat.chatbot_continue_tour")


### PR DESCRIPTION

When the chat bot is completed, the visitor is in a dead-end. He
can either restart the script, or close the chat window. This PR
adds a continue button to reach the feedback panel.

task-4433028