### PR TITLE
[IMP] hr_holidays: parallelize some rpcs

### DIFF
--- a/addons/hr_holidays/static/src/dashboard/time_off_dashboard.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_dashboard.js
@@ -24,16 +24,14 @@ export class TimeOffDashboard extends Component {
         });
 
         onWillStart(async () => {
-            await this.loadDashboardData();
-            const context = this.getContext();
-            this.hasAccrualAllocation = await this.orm.call(
-                "hr.leave.type",
-                "has_accrual_allocation",
-                [],
-                {
-                    context: context,
-                }
-            );
+            const promises = [
+                this.orm.call("hr.leave.type", "has_accrual_allocation", [], {
+                    context: this.getContext(),
+                }),
+                this.loadDashboardData(),
+            ];
+            const [hasAccrualAllocation] = await Promise.all(promises);
+            this.hasAccrualAllocation = hasAccrualAllocation;
         });
     }
 
@@ -50,22 +48,18 @@ export class TimeOffDashboard extends Component {
         if (date) {
             this.state.date = date;
         }
-        this.state.holidays = await this.orm.call(
-            "hr.leave.type",
-            "get_allocation_data_request",
-            [this.state.date, false],
-            {
-                context: context,
-            }
-        );
-        this.state.allocationRequests = await this.orm.call(
-            "hr.employee",
-            "get_allocation_requests_amount",
-            [],
-            {
-                context: context,
-            }
-        );
+        const promises = [
+            this.orm.call(
+                "hr.leave.type",
+                "get_allocation_data_request",
+                [this.state.date, false],
+                { context }
+            ),
+            this.orm.call("hr.employee", "get_allocation_requests_amount", [], { context }),
+        ];
+        const [holidays, allocationRequests] = await Promise.all(promises);
+        this.state.holidays = holidays;
+        this.state.allocationRequests = allocationRequests;
     }
 
     async newAllocationRequest() {


### PR DESCRIPTION
Loading data sequentially is much slower than doing it in parallel, if thecalls are independant. This commit make the time off dashboard loading faster. This is only a simple change, but it already helps. Ideally, we would want to batch the requests together, but this would require more work.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
