### PR TITLE
[FIX] tests: use devtools emulated devices for Chrome viewport size

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -905,6 +905,14 @@ class ChromeBrowser:
         self._websocket_send('Runtime.enable')
         self._logger.info('Chrome headless enable page notifications')
         self._websocket_send('Page.enable')
+        emulated_device = {
+            'mobile': False,
+            'width': None,
+            'height': None,
+            'deviceScaleFactor': 1,
+        }
+        emulated_device['width'], emulated_device['height'] = [int(size) for size in self.window_size.split(",")]
+        self._websocket_request('Emulation.setDeviceMetricsOverride', params=emulated_device)
         if os.name == 'posix':
             self.sigxcpu_handler = signal.getsignal(signal.SIGXCPU)
             signal.signal(signal.SIGXCPU, self.signal_handler)
@@ -1012,7 +1020,6 @@ class ChromeBrowser:
             '--disable-translate': '',
             # required for tours that use Youtube autoplay conditions (namely website_slides' "course_tour")
             '--autoplay-policy': 'no-user-gesture-required',
-            '--window-size': self.window_size,
             '--remote-debugging-address': HOST,
             '--remote-debugging-port': str(self.remote_debugging_port),
             '--no-sandbox': '',


### PR DESCRIPTION
To run tours or unit tests, we instrument Chrome and run it headlessly.
One of the arguments passed while doing so is the "window size" it needs
to use to emulate desktop-like or mobile-like screen sizes.

Newer versions of Chrome sometimes introduce slight variation between
the Chrome's window size and its viewport size (due to changes in the
interface layout...). While often not a deal-breaker, Chrome 128 forces
a min-width for the window greater than the breakpoint we use for
smaller/mobile-like testing (e.g. 375px, which matches a small
smartphone).

This commit changes the way we instrument Chrome to use a specific size
by using the DevTools' Emulated Device (aka. "responsive mode"). It
allows to apply a very specific viewport's size independently of the
actual Chrome's window size, which makes it way more predictable than
before.

Note: this change is part of the preparation to support the "new"
headless mode, which becomes the default starting with Chrome 128.

Reference:
- https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setDeviceMetricsOverride