### PR TITLE
[FIX] mail: prevent IndexError when data is empty

### DIFF
--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -526,7 +526,10 @@ GROUP BY fol.id%s%s""" % (
         for follower in self:
             data = follower._read_format(
                 [field for field in fields if field not in ["partner", "thread"]], load=False
-            )[0]
+            )
+            if not data:
+                continue
+            data = data[0]
             if "partner" in fields:
                 data["partner"] = Store.one(follower.partner_id, fields=fields["partner"])
             if "thread" in fields:


### PR DESCRIPTION
Currently, an exception is raised when `_read_format`,  returned an empty list due to MissingError encountered - [1]. This issue was caused by attempting to access the first element `(data[0])` without checking if the list was empty.

error:  `IndexError: list index out of range.`

This commit resolves the issue by properly handling empty lists and skipping further processing in such cases.

[1] - https://github.com/odoo/odoo/blob/2a79d7d06d77d808cab00440bdac3c1e05c7bc1b/odoo/models.py#L4033
[2] - https://github.com/odoo/odoo/blob/2a79d7d06d77d808cab00440bdac3c1e05c7bc1b/addons/mail/models/mail_followers.py#L527

sentry-6021917973

