### PR TITLE
[IMP] point_of_sale: improve price clarity in cards

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.ProductInfoPopup">
-        <Dialog title="props.productTemplate.display_name">
+        <Dialog title="props.productTemplate.display_name + ' | ' + env.utils.formatCurrency(props.info.productInfo.all_prices.price_with_tax)">
             <div class="section-inventory mt-3 mb-4 pb-4 border-bottom text-start" t-if="props.info?.productInfo?.warehouses?.length > 0">
                 <h3 class="section-title">
                     Inventory

--- a/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml
+++ b/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml
@@ -12,8 +12,13 @@
                     <i t-else="" class="fa fa-fw fa-spin fa-circle-o-notch" aria-hidden="true" />
                 </div>
             </div>
-            <div class="h4"><t t-esc="this.env.utils.formatCurrency(state.price_with_tax)"/></div>
-            <div class="h4">VAT: <t t-esc="state.tax_name || 0" /> (= <t t-esc="this.env.utils.formatCurrency(state.tax_amount)" />)</div>
+            <div class="h4">
+                <t t-esc="this.env.utils.formatCurrency(state.price_with_tax)"/>
+                <small class="text-muted mx-2">
+                    VAT: <t t-esc="state.tax_name || 0" />
+                    (= <t t-esc="this.env.utils.formatCurrency(state.tax_amount)" />)
+                </small>
+            </div>
             <AccordionItem t-if="state.other_warehouses?.length > 0">
                 <t t-set-slot="header">
                     Inventory


### PR DESCRIPTION
- Improve product price inside `product_info_popup` and `prodcut_info_banner`.

task-id: 4477205

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
