### PR TITLE
[FIX] l10n_in_pos: tax visibilty in reciept

### DIFF
--- a/addons/l10n_in_pos/static/src/overrides/components/pos_receipt.js
+++ b/addons/l10n_in_pos/static/src/overrides/components/pos_receipt.js
@@ -1,0 +1,23 @@
+import { patch } from "@web/core/utils/patch";
+import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
+
+patch(OrderReceipt.prototype, {
+    getTaxDetails(taxGroups) {
+        if (this.props.data.headerData.company.country_id?.code !== "IN") {
+            return super.getTaxDetails(taxGroups);
+        }
+        return this.props.data.tax_details.map((tax_group) => {
+            let tax_name = tax_group.name;
+            if (this.props.data.taxTotals.same_tax_base && this.props.data.tax_details.length > 2) {
+                tax_name += " on " + this.props.formatCurrency(tax_group.base);
+            }
+            return {
+                ...taxGroups,
+                id: tax_group.id,
+                tax_name: tax_name,
+                group_label: tax_group.tax_group_id.pos_receipt_label,
+                tax_amount_currency: tax_group.amount,
+            };
+        });
+    },
+});

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
@@ -28,4 +28,19 @@ export class OrderReceipt extends Component {
     getPortalURL() {
         return `${this.props.data.base_url}/pos/ticket`;
     }
+
+    getTaxDetails(taxGroups) {
+        return taxGroups.map((tax_group) => {
+            let tax_name = tax_group.group_name;
+            if (!this.props.data.taxTotals.same_tax_base) {
+                tax_name += " on " + this.props.formatCurrency(tax_group.base_amount);
+            }
+            return {
+                id: tax_group.id,
+                tax_name: tax_name,
+                group_label: tax_group.group_label,
+                tax_amount_currency: tax_group.tax_amount_currency,
+            };
+        });
+    }
 }

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -24,17 +24,13 @@
                             <span t-esc="props.formatCurrency(subtotal.base_amount_currency)" class="ms-auto"/>
                         </div>
 
-                        <div t-foreach="subtotal.tax_groups" t-as="tax_group" t-key="tax_group.id" class="d-flex">
+                        <div t-foreach="getTaxDetails(subtotal.tax_groups)" t-as="tax_group" t-key="tax_group.id" class="d-flex">
                             <t t-if="showTaxGroupLabels">
                                 <span t-if="tax_group.group_label" t-out="tax_group.group_label" class="me-2"/>
                                 <span t-else="" class="me-2" style="visibility: hidden;">A</span>
                             </t>
                             <span>
-                                <span t-esc="tax_group.group_name"/>
-                                <t t-if="!taxTotals.same_tax_base">
-                                    on
-                                    <span t-esc="props.formatCurrency(tax_group.base_amount_currency)"/>
-                                </t>
+                                <span t-esc="tax_group.tax_name"/>
                             </span>
                             <span t-esc="props.formatCurrency(tax_group.tax_amount_currency)" class="ms-auto"/>
                         </div>


### PR DESCRIPTION
Before this commit:
====
- Previously, only the tax type was displayed on receipts and the tax percentage was missing for Indian localisation.

Following this commit:
====
- The tax percentage is now displayed alongside the tax type on receipts, improving transparency and accuracy.

task-4464136
