### PR TITLE
[FIX] core: disable typofix translations when upgrade

### DIFF
--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -1173,58 +1173,6 @@ class TestXMLTranslation(TransactionCase):
         self.assertEqual(view.with_env(env_fr).arch_db, archf % (terms_fr[0], terms_en[1], terms_en[2]))
         self.assertEqual(view.with_env(env_nl).arch_db, archf % (terms_nl[0], terms_en[1], terms_en[2]))
 
-    def test_sync_xml_inline_modifiers(self):
-        """ Check translations of 'arch' after xml tags changes in source terms
-            when source term had updated modifiers attributes
-        """
-        archf = '''<form class="row">
-    %s
-    <div class="s_table_of_content_vertical_navbar" data-name="Navbar" contenteditable="false">
-        <div class="s_table_of_content_navbar" style="top: 76px;"><a href="#table_of_content_heading_1672668075678_4" class="table_of_content_link">%s</a></div>
-    </div>
-    <div class="s_table_of_content_main" data-name="Content">
-        <section class="pb16">
-            <h1 data-anchor="true" id="table_of_content_heading_1672668075678_4">%s</h1>
-        </section>
-    </div>
-</form>'''
-        terms_en = ('Bread and cheese', 'Knive and Fork', 'Knive <span style="font-weight:bold">and</span> Fork')
-        terms_fr = ('Pain et fromage', 'Couteau et Fourchette', 'Couteau <span style="font-weight:bold">et</span> Fourchette')
-        terms_nl = ('Brood and kaas', 'Mes en Vork', 'Mes en Vork')
-        view = self.create_view(archf, terms_en, en_US=terms_en, fr_FR=terms_fr, nl_NL=terms_nl)
-
-        env_nolang = self.env(context={"install_mode": True})
-        env_en = self.env(context={'lang': 'en_US', "install_mode": True})
-        env_fr = self.env(context={'lang': 'fr_FR', "install_mode": True})
-        env_nl = self.env(context={'lang': 'nl_NL', "install_mode": True})
-
-        self.assertEqual(view.with_env(env_nolang).arch_db, archf % terms_en)
-        self.assertEqual(view.with_env(env_en).arch_db, archf % terms_en)
-        self.assertEqual(view.with_env(env_fr).arch_db, archf % terms_fr)
-        self.assertEqual(view.with_env(env_nl).arch_db, archf % terms_nl)
-
-        # modify attributes in source term
-        terms_en = ('Bread and cheese', 'Knife and Fork', 'Knife <span invisible="1">and</span> Fork')
-        view.with_env(env_en).write({'arch_db': archf % terms_en})
-        terms_fr = ('Pain et fromage', 'Couteau et Fourchette', 'Couteau <span style="font-weight:bold" invisible="1">et</span> Fourchette')
-
-        # check whether translations have been kept
-        self.assertEqual(view.with_env(env_nolang).arch_db, archf % terms_en)
-        self.assertEqual(view.with_env(env_en).arch_db, archf % terms_en)
-        self.assertEqual(view.with_env(env_fr).arch_db, archf % terms_fr)
-        self.assertEqual(view.with_env(env_nl).arch_db, archf % terms_nl)
-
-        # modify attributes in source term
-        terms_en = ('Bread and cheese', 'Knife and Fork', 'Knife <span readonly="1">and</span> Fork')
-        view.with_env(env_en).write({'arch_db': archf % terms_en})
-        terms_fr = ('Pain et fromage', 'Couteau et Fourchette', 'Couteau <span style="font-weight:bold" readonly="1">et</span> Fourchette')
-
-        # check whether translations have been kept
-        self.assertEqual(view.with_env(env_nolang).arch_db, archf % terms_en)
-        self.assertEqual(view.with_env(env_en).arch_db, archf % terms_en)
-        self.assertEqual(view.with_env(env_fr).arch_db, archf % terms_fr)
-        self.assertEqual(view.with_env(env_nl).arch_db, archf % terms_nl)
-
     def test_sync_xml_close_terms(self):
         """ Check translations of 'arch' after xml tags changes in source terms. """
         archf = '<form string="X">%s<div>%s</div>%s</form>'

--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -246,29 +246,29 @@ class BaseString(Field[str | typing.Literal[False]]):
             }
             from_lang_value = old_translations.pop(lang, old_translations['en_US'])
             translation_dictionary = self.get_translation_dictionary(from_lang_value, old_translations)
-            text2terms = defaultdict(list)
-            for term in new_terms:
-                if term_text := self.get_text_content(term):
-                    text2terms[term_text].append(term)
 
-            is_text = self.translate.is_text if hasattr(self.translate, 'is_text') else lambda term: True
-            term_adapter = self.translate.term_adapter if hasattr(self.translate, 'term_adapter') else None
-            for old_term in list(translation_dictionary.keys()):
-                if old_term not in new_terms:
+            if not records.env.context.get("install_mode"):
+                text2terms = defaultdict(list)
+                for term in new_terms:
+                    if term_text := self.get_text_content(term):
+                        text2terms[term_text].append(term)
+
+                is_text = self.translate.is_text if hasattr(self.translate, 'is_text') else lambda term: True
+                for old_term in list(translation_dictionary.keys()):
+                    if old_term in new_terms:
+                        continue
                     old_term_text = self.get_text_content(old_term)
                     matches = get_close_matches(old_term_text, text2terms, 1, 0.9)
-                    if matches:
-                        closest_term = get_close_matches(old_term, text2terms[matches[0]], 1, 0)[0]
-                        if closest_term in translation_dictionary:
-                            continue
-                        old_is_text = is_text(old_term)
-                        closest_is_text = is_text(closest_term)
-                        if old_is_text or not closest_is_text:
-                            if not closest_is_text and records.env.context.get("install_mode") and lang == 'en_US' and term_adapter:
-                                adapter = term_adapter(closest_term)
-                                translation_dictionary[closest_term] = {k: adapter(v) for k, v in translation_dictionary.pop(old_term).items()}
-                            else:
-                                translation_dictionary[closest_term] = translation_dictionary.pop(old_term)
+                    if not matches:
+                        continue
+                    closest_term = get_close_matches(old_term, text2terms[matches[0]], 1, 0)[0]
+                    if closest_term in translation_dictionary:
+                        continue
+                    old_is_text = is_text(old_term)
+                    closest_is_text = is_text(closest_term)
+                    if old_is_text or not closest_is_text:
+                        translation_dictionary[closest_term] = translation_dictionary.pop(old_term)
+
             # pylint: disable=not-callable
             new_translations = {
                 l: self.translate(lambda term: translation_dictionary.get(term, {l: None})[l], cache_value)

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -305,46 +305,6 @@ def serialize_xml(node):
     return etree.tostring(node, method='xml', encoding='unicode')
 
 
-MODIFIER_ATTRS = {"invisible", "readonly", "required", "column_invisible", "attrs", "states"}
-def xml_term_adapter(term_en):
-    """
-    Returns an `adapter(term)` function that will ensure the modifiers are copied
-    from the base `term_en` to the translated `term` when the XML structure of
-    both terms match. `term_en` and any input `term` to the adapter must be valid
-    XML terms. Using the adapter only makes sense if `term_en` contains some tags
-    from TRANSLATED_ELEMENTS.
-    """
-    orig_node = parse_xml(f"<div>{term_en}</div>")
-
-    def same_struct_iter(left, right):
-        if left.tag != right.tag:
-            raise ValueError("Non matching struct")
-        yield left, right
-        left_iter = left.iterchildren()
-        right_iter = right.iterchildren()
-        for lc, rc in zip(left_iter, right_iter):
-            yield from same_struct_iter(lc, rc)
-        if next(left_iter, None) is not None or next(right_iter, None) is not None:
-            raise ValueError("Non matching struct")
-
-    def adapter(term):
-        new_node = parse_xml(f"<div>{term}</div>")
-        try:
-            for orig_n, new_n in same_struct_iter(orig_node, new_node):
-                removed_attrs = [k for k in new_n.attrib if k in MODIFIER_ATTRS and k not in orig_n.attrib]
-                for k in removed_attrs:
-                    del new_n.attrib[k]
-                keep_attrs = {k: v for k, v in orig_n.attrib.items() if k in MODIFIER_ATTRS}
-                new_n.attrib.update(keep_attrs)
-        except ValueError:  # non-matching structure
-            return term
-
-        # remove tags <div> and </div> from result
-        return serialize_xml(new_node)[5:-6]
-
-    return adapter
-
-
 _HTML_PARSER = etree.HTMLParser(encoding='utf8')
 
 def parse_html(text):
@@ -432,8 +392,6 @@ html_translate.term_converter = html_term_converter
 
 xml_translate.is_text = is_text
 html_translate.is_text = is_text
-
-xml_translate.term_adapter = xml_term_adapter
 
 
 


### PR DESCRIPTION
[FIX] core: disable typofix translations when upgrade

Before:
The typofix feature treats terms in the old and new values with similar text
content as the same term, migrating the translations of the old term to the new
term.

For example

The old value has the mapping:
`'Draft': 'Brouillon'`

The new value contains the term:
`'<span invisible="name or name_placeholder or quick_edit_mode">Draft</span>'`

Since the old term and the new has the same text content `'Draft'`, after write,
the new term will reuse the old translation of `'Draft'`. However, the translation
`'Brouillon'` is always visible unlike its en_US term

Since the old term and the new term share the same text content, `'Draft'`, after
`write`, the new term reuses the old translation of `'Draft'`. However, the
translation `'Brouillon'` is always visible, unlike its en_US counterpart.

This behavior is acceptable in non-upgrade mode because the user writes the
en_US value and is responsible for verifying translations afterward. However, it
is problematic during upgrades because users cannot easily identify which
records have changed and need to be rechecked.

After:
1. Revert 7cd56fc as it is no longer needed.
2. Disable typofix translations during upgrades.
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
