### PR TITLE
[IMP] hr_contract: improve constraints on running contracts

### DIFF
--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import ast
 from collections import defaultdict
 from pytz import timezone, UTC
 from datetime import date, datetime, time
@@ -316,6 +317,18 @@ class HrEmployee(models.Model):
                 'from_action_open_contract': True,
             }
             action['target'] = 'current'
+            return action
+
+        open_contracts = self.contract_ids.filtered(lambda c: c.state == 'open')
+        if len(open_contracts) > 1:
+            action.update({
+                'views': [(False, 'list'), (False, 'form')],
+                'context': {'search_default_running': True},
+                'domain': expression.AND([
+                    ast.literal_eval(action.get('domain', '[]')),
+                    [('id', 'in', self.contract_ids.ids)]
+                ]),
+            })
             return action
 
         target_contract = self.contract_id

--- a/addons/hr_holidays_contract/tests/test_multi_contract.py
+++ b/addons/hr_holidays_contract/tests/test_multi_contract.py
@@ -25,25 +25,6 @@ class TestHolidaysMultiContract(TestHolidayContract):
         with self.assertRaises(ValidationError):
             self.contract_cdi.date_start = datetime.strptime('2015-11-17', '%Y-%m-%d').date()
 
-    def test_create_contract_in_leave(self):
-        # test create contract such that a leave is across two contracts
-        start = datetime.strptime('2015-11-05 07:00:00', '%Y-%m-%d %H:%M:%S')
-        end = datetime.strptime('2015-12-15 18:00:00', '%Y-%m-%d %H:%M:%S')
-        self.contract_cdi.date_start = datetime.strptime('2015-12-30', '%Y-%m-%d').date()  # remove this contract to be able to create the leave
-        # begins during contract, ends after contract
-        leave = self.create_leave(start, end, name="Doctor Appointment", employee_id=self.jules_emp.id)
-        leave.action_approve()
-        # move contract in the middle of the leave
-        with self.assertRaises(ValidationError):
-            self.env['hr.contract'].create({
-                'date_start': datetime.strptime('2015-11-30', '%Y-%m-%d').date(),
-                'name': 'Contract for Richard',
-                'resource_calendar_id': self.calendar_40h.id,
-                'wage': 5000.0,
-                'employee_id': self.jules_emp.id,
-                'state': 'open',
-            })
-
     def test_leave_outside_contract(self):
         # Leave outside contract => should not raise
         start = datetime.strptime('2014-10-18 07:00:00', '%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
This PR refines the contract constraints by allowing multiple contracts to be in a running state simultaneously. An employee can have multiple active contracts only if the contracts are not flexible, planning-based, or attendance-based.

task-4374321

