### PR TITLE
[IMP] product: Add tracking to field uom_id

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -113,7 +113,7 @@ class ProductTemplate(models.Model):
     purchase_ok = fields.Boolean('Purchase', default=True, compute='_compute_purchase_ok', store=True, readonly=False)
     uom_id = fields.Many2one(
         'uom.uom', 'Unit',
-        default=_get_default_uom_id, required=True,
+        default=_get_default_uom_id, required=True, tracking=True,
         help="Default unit of measure used for all stock operations.")
     uom_ids = fields.Many2many('uom.uom', string='Packagings', help="Packagings which can be used for sales")
     uom_name = fields.Char(string='Unit Name', related='uom_id.name', readonly=True)


### PR DESCRIPTION
Following this PR: https://github.com/odoo/odoo/pull/184131

It is now possible for users to change the UoM of the product.
This change has a lot of impact on the product data, hence tracking any modification of the UoM will help any potential investigation.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
