### PR TITLE
[IMP] account_edi_ubl_cii,account_peppol: Peppol First amendments

### DIFF
--- a/addons/account/static/src/components/actionable_errors/actionable_errors.js
+++ b/addons/account/static/src/components/actionable_errors/actionable_errors.js
@@ -21,6 +21,11 @@ export class ActionableErrors extends Component {
     }
 
     async handleOnClick(errorData){
+        if (errorData.action?.view_mode) {
+            // view_mode is not handled JS side
+            errorData.action['views'] = [[false, errorData.action.view_mode]];
+            delete errorData.action['view_mode'];
+        }
         this.env.model.action.doAction(errorData.action);
     }
 

--- a/addons/account/wizard/account_move_send_wizard.py
+++ b/addons/account/wizard/account_move_send_wizard.py
@@ -158,6 +158,7 @@ class AccountMoveSendWizard(models.TransientModel):
                 for edi_key in self._get_default_extra_edis(wizard.move_id)
             }
 
+    @api.depends('move_id')
     def _compute_invoice_edi_format(self):
         for wizard in self:
             wizard.invoice_edi_format = self._get_default_invoice_edi_format(wizard.move_id)

--- a/addons/account_edi_proxy_client/i18n/account_edi_proxy_client.pot
+++ b/addons/account_edi_proxy_client/i18n/account_edi_proxy_client.pot
@@ -6,14 +6,22 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-25 08:39+0000\n"
-"PO-Revision-Date: 2024-09-25 08:39+0000\n"
+"POT-Creation-Date: 2025-01-20 14:49+0000\n"
+"PO-Revision-Date: 2025-01-20 14:49+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: account_edi_proxy_client
+#. odoo-python
+#: code:addons/account_edi_proxy_client/models/account_edi_proxy_user.py:0
+msgid ""
+"A user already exists with theses credentials on our server. Please check "
+"your information."
+msgstr ""
 
 #. module: account_edi_proxy_client
 #: model:ir.model,name:account_edi_proxy_client.model_account_edi_proxy_client_user

--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -170,6 +170,10 @@ class AccountEdiProxyClientUser(models.Model):
             except AccountEdiProxyError as e:
                 raise UserError(e.message)
             if 'error' in response:
+                if response['error'] == 'A user already exists with this identification.':
+                    # Note: Peppol IAP errors weren't made properly with error code that are then translated on
+                    # Odoo side. We are for now forced to check the error message.
+                    raise UserError(_('A user already exists with theses credentials on our server. Please check your information.'))
                 raise UserError(response['error'])
 
         return self.create({

--- a/addons/account_edi_ubl_cii/i18n/account_edi_ubl_cii.pot
+++ b/addons/account_edi_ubl_cii/i18n/account_edi_ubl_cii.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-13 09:08+0000\n"
-"PO-Revision-Date: 2024-12-13 09:08+0000\n"
+"POT-Creation-Date: 2025-01-20 14:49+0000\n"
+"PO-Revision-Date: 2025-01-20 14:49+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -179,6 +179,12 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py:0
 msgid "Conditional cash/payment discount"
+msgstr ""
+
+#. module: account_edi_ubl_cii
+#. odoo-python
+#: code:addons/account_edi_ubl_cii/models/account_move_send.py:0
+msgid "Configure"
 msgstr ""
 
 #. module: account_edi_ubl_cii
@@ -525,6 +531,12 @@ msgid "Malta VAT - 9943"
 msgstr ""
 
 #. module: account_edi_ubl_cii
+#. odoo-python
+#: code:addons/account_edi_ubl_cii/models/account_move_send.py:0
+msgid "Missing partner(s) VAT or Peppol Address"
+msgstr ""
+
+#. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__9940
 msgid "Monaco VAT - 9940"
 msgstr ""
@@ -599,9 +611,7 @@ msgstr ""
 #. module: account_edi_ubl_cii
 #. odoo-python
 #: code:addons/account_edi_ubl_cii/models/account_move_send.py:0
-msgid ""
-"Please fill in Peppol EAS and Peppol Endpoint in your company form to "
-"generate a complete file."
+msgid "Please configure your company to generate a complete XML file."
 msgstr ""
 
 #. module: account_edi_ubl_cii
@@ -776,14 +786,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_ubl_cii
-#. odoo-python
-#: code:addons/account_edi_ubl_cii/models/account_move_send.py:0
-msgid ""
-"These partners are missing Peppol Address. Please check those in their "
-"Accounting tab. Otherwise, the generated files will be incomplete."
-msgstr ""
-
-#. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__9952
 msgid "Turkey VAT - 9952"
 msgstr ""
@@ -835,12 +837,6 @@ msgstr ""
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__9953
 msgid "Vatican VAT - 9953"
-msgstr ""
-
-#. module: account_edi_ubl_cii
-#. odoo-python
-#: code:addons/account_edi_ubl_cii/models/account_move_send.py:0
-msgid "View Company"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/models/account_move_send.py
+++ b/addons/account_edi_ubl_cii/models/account_move_send.py
@@ -30,9 +30,9 @@ class AccountMoveSend(models.AbstractModel):
             )
             if not_configured_company_partners:
                 alerts['account_edi_ubl_cii_configure_company'] = {
-                    'message': _("Please fill in Peppol EAS and Peppol Endpoint in your company form to generate a complete file."),
+                    'message': _("Please configure your company to generate a complete XML file."),
                     'level': 'info',
-                    'action_text': _("View Company"),
+                    'action_text': _("Configure"),
                     'action': not_configured_company_partners._get_records_action(),
                 }
             not_configured_partners = peppol_format_moves.partner_id.commercial_partner_id.filtered(
@@ -40,9 +40,7 @@ class AccountMoveSend(models.AbstractModel):
             )
             if not_configured_partners:
                 alerts['account_edi_ubl_cii_configure_partner'] = {
-                    'message': _("These partners are missing Peppol Address. "
-                                 "Please check those in their Accounting tab. "
-                                 "Otherwise, the generated files will be incomplete."),
+                    'message': _("Missing partner(s) VAT or Peppol Address"),
                     'level': 'info',
                     'action_text': _("View Partner(s)"),
                     'action': not_configured_partners._get_records_action(name=_("Check Partner(s)"))

--- a/addons/account_peppol/i18n/account_peppol.pot
+++ b/addons/account_peppol/i18n/account_peppol.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-23 10:41+0000\n"
-"PO-Revision-Date: 2024-12-23 10:41+0000\n"
+"POT-Creation-Date: 2025-01-20 16:19+0000\n"
+"PO-Revision-Date: 2025-01-20 16:19+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -86,7 +86,7 @@ msgstr ""
 
 #. module: account_peppol
 #. odoo-javascript
-#: code:addons/account_peppol/static/src/components/peppol_info/peppol_info.xml:0
+#: code:addons/account_peppol/static/src/components/peppol_info/peppol_info.js:0
 msgid "Activate"
 msgstr ""
 
@@ -408,6 +408,12 @@ msgid "Fully automated"
 msgstr ""
 
 #. module: account_peppol
+#. odoo-javascript
+#: code:addons/account_peppol/static/src/components/peppol_info/peppol_info.js:0
+msgid "Got it !"
+msgstr ""
+
+#. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.res_config_settings_view_form
 msgid "I want to migrate my existing Peppol connection to Odoo (optional):"
 msgstr ""
@@ -512,13 +518,13 @@ msgid "Mobile number"
 msgstr ""
 
 #. module: account_peppol
-#: model:ir.model.fields.selection,name:account_peppol.selection__res_company__account_peppol_proxy_state__not_registered
-msgid "Not registered"
+#: model:ir.model.fields.selection,name:account_peppol.selection__res_partner__peppol_verification_state__not_valid
+msgid "Not on Peppol"
 msgstr ""
 
 #. module: account_peppol
-#: model:ir.model.fields.selection,name:account_peppol.selection__res_partner__peppol_verification_state__not_valid
-msgid "Not valid"
+#: model:ir.model.fields.selection,name:account_peppol.selection__res_company__account_peppol_proxy_state__not_registered
+msgid "Not registered"
 msgstr ""
 
 #. module: account_peppol
@@ -746,12 +752,6 @@ msgstr ""
 #: model:ir.model.fields,help:account_peppol.field_res_company__account_peppol_contact_email
 #: model:ir.model.fields,help:account_peppol.field_res_config_settings__account_peppol_contact_email
 msgid "Primary contact email for Peppol-related communication"
-msgstr ""
-
-#. module: account_peppol
-#. odoo-javascript
-#: code:addons/account_peppol/static/src/components/peppol_info/peppol_info.js:0
-msgid "Print & Send"
 msgstr ""
 
 #. module: account_peppol
@@ -1015,6 +1015,13 @@ msgid "View Partner(s)"
 msgstr ""
 
 #. module: account_peppol
+#: code:addons/account_peppol/models/account_edi_proxy_user.py:0
+msgid ""
+"We could not find a user with this information on our server. Please check "
+"your information."
+msgstr ""
+
+#. module: account_peppol
 #. odoo-javascript
 #: code:addons/account_peppol/static/src/components/peppol_info/peppol_info.xml:0
 msgid "What is Peppol and why it's great ?"
@@ -1057,6 +1064,11 @@ msgstr ""
 #. module: account_peppol
 #: code:addons/account_peppol/tools/demo_utils.py:0
 msgid "You can now send invoices in demo mode."
+msgstr ""
+
+#. module: account_peppol
+#: code:addons/account_peppol/models/account_move_send.py:0
+msgid "You can send this invoice electronically via Peppol."
 msgstr ""
 
 #. module: account_peppol

--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -61,6 +61,7 @@ class AccountEdiProxyClientUser(models.Model):
                 # commit the above changes before raising below
                 if not modules.module.current_test:
                     self.env.cr.commit()
+                raise UserError(_('We could not find a user with this information on our server. Please check your information.'))
             raise UserError(e.message)
 
         if 'error' in response:

--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -30,16 +30,16 @@ class AccountMoveSend(models.AbstractModel):
                 'action_text': _("View Partner(s)"),
                 'action': invalid_partners._get_records_action(name=_("Check Partner(s)")),
             }
-            edi_modes = set(
-                peppol_moves.company_id.account_edi_proxy_client_ids \
-                    .filtered(lambda usr: usr.proxy_type == 'peppol') \
-                    .mapped('edi_mode')
-            )
-            if edi_modes.intersection({'test', 'demo'}):
-                alerts['account_peppol_demo_test_mode'] = {
-                    'message': _("Peppol is in testing/demo mode."),
-                    'level': 'info',
-                }
+        edi_modes = set(
+            peppol_moves.company_id.account_edi_proxy_client_ids \
+                .filtered(lambda usr: usr.proxy_type == 'peppol') \
+                .mapped('edi_mode')
+        )
+        if edi_modes.intersection({'test', 'demo'}):
+            alerts['account_peppol_demo_test_mode'] = {
+                'message': _("Peppol is in testing/demo mode."),
+                'level': 'info',
+            }
 
         # Check for not peppol partners that are on the network.
         not_peppol_moves = moves.filtered(lambda m: 'peppol' not in moves_data[m]['sending_methods'])

--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -1,6 +1,6 @@
 from base64 import b64encode
 
-from odoo import api, models, _
+from odoo import models, _
 from odoo.addons.account.models.company import PEPPOL_LIST
 from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
 
@@ -18,7 +18,10 @@ class AccountMoveSend(models.AbstractModel):
 
         def filter_peppol_state(moves, state):
             return peppol_partner(moves.filtered(
-                lambda m: peppol_partner(m).with_company(m.company_id).peppol_verification_state == state))
+                lambda m: self.env['res.partner']._get_peppol_verification_state(
+                    peppol_partner(m).peppol_endpoint,
+                    peppol_partner(m).peppol_eas,
+                    moves_data[m]['invoice_edi_format']) == state))
 
         alerts = super()._get_alerts(moves, moves_data)
         # Check for invalid peppol partners.
@@ -31,8 +34,8 @@ class AccountMoveSend(models.AbstractModel):
                 'action': invalid_partners._get_records_action(name=_("Check Partner(s)")),
             }
         edi_modes = set(
-            peppol_moves.company_id.account_edi_proxy_client_ids \
-                .filtered(lambda usr: usr.proxy_type == 'peppol') \
+            peppol_moves.company_id.account_edi_proxy_client_ids
+                .filtered(lambda usr: usr.proxy_type == 'peppol')
                 .mapped('edi_mode')
         )
         if edi_modes.intersection({'test', 'demo'}):
@@ -41,15 +44,8 @@ class AccountMoveSend(models.AbstractModel):
                 'level': 'info',
             }
 
-        # Check for not peppol partners that are on the network.
         not_peppol_moves = moves.filtered(lambda m: 'peppol' not in moves_data[m]['sending_methods'])
-        if peppol_not_selected_partners := filter_peppol_state(not_peppol_moves, 'valid'):
-            if len(peppol_not_selected_partners) == 1:
-                alerts['account_peppol_partner_want_peppol'] = {
-                    'message': _(
-                        "%s has requested electronic invoices reception on Peppol.",
-                         peppol_not_selected_partners.display_name
-                    ),
+        what_is_peppol_alert = {
                     'level': 'info',
                     'action_text': _("Why should you use it ?"),
                     'action': {
@@ -59,9 +55,30 @@ class AccountMoveSend(models.AbstractModel):
                         'target': 'new',
                         'context': {
                             'footer': False,
-                            'move_ids': moves.ids,
+                            'action_on_activate': self.action_what_is_peppol_activate(moves),
                         },
                     },
+                }
+        info_always_on_countries = {'BE'}
+        can_send = self.env['account_edi_proxy_client.user']._get_can_send_domain()
+        always_on_companies = moves.company_id.filtered(
+            lambda c: c.country_code in info_always_on_countries and c.account_peppol_proxy_state not in can_send
+        )
+        if always_on_companies:
+            alerts.pop('account_edi_ubl_cii_configure_company', False)
+            alerts['account_peppol_partner_want_peppol'] = {
+                'message': _("You can send this invoice electronically via Peppol."),
+                **what_is_peppol_alert,
+            }
+        elif peppol_not_selected_partners := filter_peppol_state(not_peppol_moves, 'valid'):
+            # Check for not peppol partners that are on the network.
+            if len(peppol_not_selected_partners) == 1:
+                alerts['account_peppol_partner_want_peppol'] = {
+                    'message': _(
+                        "%s has requested electronic invoices reception on Peppol.",
+                        peppol_not_selected_partners.display_name
+                    ),
+                    **what_is_peppol_alert,
                 }
         return alerts
 
@@ -99,12 +116,12 @@ class AccountMoveSend(models.AbstractModel):
         # EXTENDS 'account'
         if method == 'peppol':
             partner = move.partner_id.commercial_partner_id.with_company(move.company_id)
+            invoice_edi_format = partner.invoice_edi_format or 'ubl_bis3'  # we fallback to bis3 if partner is not set
             return all([
                 self._is_applicable_to_company(method, move.company_id),
-                partner.is_peppol_edi_format,
-                partner.peppol_verification_state == 'valid',
+                self.env['res.partner']._get_peppol_verification_state(partner.peppol_endpoint, partner.peppol_eas, invoice_edi_format) == 'valid',
                 move.company_id.account_peppol_proxy_state != 'rejected',
-                move._need_ubl_cii_xml(partner.invoice_edi_format)
+                move._need_ubl_cii_xml(invoice_edi_format)
                 or move.ubl_cii_xml_id and move.peppol_move_state not in ('processing', 'done'),
             ])
         else:
@@ -147,7 +164,7 @@ class AccountMoveSend(models.AbstractModel):
                     invoice_data['error'] = _('The partner is missing Peppol EAS and/or Endpoint identifier.')
                     continue
 
-                if partner.peppol_verification_state != 'valid':
+                if self.env['res.partner']._get_peppol_verification_state(partner.peppol_endpoint, partner.peppol_eas, invoice_data['invoice_edi_format']) != 'valid':
                     invoice.peppol_move_state = 'error'
                     invoice_data['error'] = _('Please verify partner configuration in partner settings.')
                     continue
@@ -194,3 +211,16 @@ class AccountMoveSend(models.AbstractModel):
 
         if self._can_commit():
             self._cr.commit()
+
+    def action_what_is_peppol_activate(self, moves):
+        companies = moves.company_id
+        can_send = self.env['account_edi_proxy_client.user']._get_can_send_domain()
+        if len(companies) == 1 and companies.account_peppol_proxy_state not in can_send:
+            action = self.env['peppol.registration']._action_open_peppol_form()
+            action['context'].update({
+                'active_model': "account.move",
+                'active_ids': moves.ids,
+            })
+            return action
+        else:
+            return moves.action_send_and_print()

--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -28,7 +28,7 @@ class ResPartner(models.Model):
     peppol_verification_state = fields.Selection(
         selection=[
             ('not_verified', 'Not verified yet'),
-            ('not_valid', 'Not valid'),  # does not exist on Peppol at all
+            ('not_valid', 'Not on Peppol'),  # does not exist on Peppol at all
             ('not_valid_format', 'Cannot receive this format'),  # registered on Peppol but cannot receive the selected document type
             ('valid', 'Valid'),
         ],

--- a/addons/account_peppol/static/src/components/peppol_info/peppol_info.js
+++ b/addons/account_peppol/static/src/components/peppol_info/peppol_info.js
@@ -1,8 +1,8 @@
 /** @odoo-module **/
 import { Component } from "@odoo/owl";
 import { registry } from "@web/core/registry";
-import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
+import {_t} from "@web/core/l10n/translation";
 import { standardActionServiceProps } from "@web/webclient/actions/action_service";
 
 
@@ -15,17 +15,23 @@ class WhatIsPeppol extends Component {
         this.actionService = useService("action");
     }
 
+    closeButtonLabel() {
+        if (this.props.action.context.action_on_activate.res_model === "peppol.registration") {
+            return _t("Activate")
+        } else {
+            return _t("Got it !")
+        }
+    }
+
     activate() {
+        const action = this.props.action.context.action_on_activate;
         this.actionService.doAction({
-            name: _t("Print & Send"),
-            type: "ir.actions.act_window",
-            res_model: "account.move.send.wizard",
-            views: [[false, "form"]],
-            target: "new",
-            context: {
-                active_model: "account.move",
-                active_ids: Object.values(this.props.action.context.move_ids),
-            },
+            name: action.name,
+            type: action.type,
+            res_model: action.res_model,
+            views: [[false, action.view_mode]],
+            target: action.target,
+            context: action.context,
         });
     }
 }

--- a/addons/account_peppol/static/src/components/peppol_info/peppol_info.xml
+++ b/addons/account_peppol/static/src/components/peppol_info/peppol_info.xml
@@ -31,7 +31,7 @@
                         </div>
                     </li>
                 </ul>
-                <button class="btn btn-lg btn-primary mt-5 w-100" t-on-click="activate">Activate</button>
+                <button class="btn btn-lg btn-primary mt-5 w-100" t-on-click="activate" t-out="closeButtonLabel()"/>
             </div>
         </div>
     </t>

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -91,17 +91,19 @@ def _mock_button_verify_partner_endpoint(func, self, *args, **kwargs):
     old_value = self.peppol_verification_state
     company = kwargs.get('company') or self.env.company
     endpoint, eas, edi_format = self.peppol_endpoint, self.peppol_eas, self.invoice_edi_format
-    if endpoint and eas and edi_format:
-        self.with_company(company).peppol_verification_state = 'valid'
+    state = _mock_get_peppol_verification_state(func, self, endpoint, eas, edi_format)
+    self.with_company(company).peppol_verification_state = state
+    self._log_verification_state_update(company, old_value, state)
+    if state == 'valid':
         self.with_company(company).invoice_sending_method = 'peppol'
-        self._log_verification_state_update(company, old_value, 'valid')
-    else:
-        self.with_company(company).peppol_verification_state = 'not_valid'
 
 
 def _mock_get_peppol_verification_state(func, self, *args, **kwargs):
     (endpoint, eas, format) = args
-    return 'valid' if endpoint and eas and format else False
+    if endpoint and eas:
+        return 'valid' if format in self._get_peppol_formats() else 'not_valid_format'
+    else:
+        return 'not_valid'
 
 
 def _mock_user_creation(func, self, *args, **kwargs):

--- a/addons/account_peppol/wizard/account_move_send_wizard.py
+++ b/addons/account_peppol/wizard/account_move_send_wizard.py
@@ -26,6 +26,16 @@ class AccountMoveSendWizard(models.TransientModel):
                     }
                 }
 
+    @api.depends('sending_methods')
+    def _compute_invoice_edi_format(self):
+        # EXTENDS 'account' - add default on bis3 if not set on partner's preferences and "by Peppol" is selected
+        super()._compute_invoice_edi_format()
+        for wizard in self:
+            if not wizard.invoice_edi_format and wizard.sending_methods and 'peppol' in wizard.sending_methods:
+                wizard.invoice_edi_format = 'ubl_bis3'
+            elif wizard.invoice_edi_format != self._get_default_invoice_edi_format(wizard.move_id) and wizard.sending_methods and 'peppol' not in wizard.sending_methods:
+                wizard.invoice_edi_format = None
+
     def action_send_and_print(self, allow_fallback_pdf=False):
         # EXTENDS 'account'
         self.ensure_one()


### PR DESCRIPTION
- Improvements of message of Peppol/BIS3 related warnings of the Print & Send wizards.
- Wording improvements for clarity.
- Make the "What is Peppol" modal more present. Change its flow: the "activate" buttons
now leads to the Peppol registration wizard if the company is not registered yet.

task-4478365