### PR TITLE
[FIX] resource: fix duration days of working schedules

### DIFF
--- a/addons/resource/models/resource_calendar_attendance.py
+++ b/addons/resource/models/resource_calendar_attendance.py
@@ -73,7 +73,7 @@ class ResourceCalendarAttendance(models.Model):
         for attendance in self:
             attendance.duration_hours = (attendance.hour_to - attendance.hour_from) if attendance.day_period != 'lunch' else 0
 
-    @api.depends('day_period', 'duration_hours')
+    @api.depends('day_period', 'duration_hours', 'calendar_id.hours_per_day')
     def _compute_duration_days(self):
         for attendance in self:
             if attendance.day_period == 'lunch':


### PR DESCRIPTION
When creating a new working schedule, the duration (days) was not computed correctly. This was due to a missing field in the depends of the compute method.

This commits fixes the issue by adding the hours per day in the depens of the duration days compute method. That way, the duration days will be computed after that the hours per day are computed.

task-4457200
