### PR TITLE
[FIX] pos_mrp: line cost bom sharing product

### DIFF
--- a/addons/pos_mrp/models/pos_order.py
+++ b/addons/pos_mrp/models/pos_order.py
@@ -12,10 +12,10 @@ class PosOrderLine(models.Model):
         if not bom:
             return super()._get_stock_moves_to_consider(stock_moves, product)
         boms, components = bom.explode(product, self.qty)
+        #Get a flat list of all bom_line_ids
+        bom_line_ids = [item for x in boms for item in x[0].bom_line_ids.ids]
         ml_product_to_consider = (product.bom_ids and [comp[0].product_id.id for comp in components]) or [product.id]
-        if len(boms) > 1:
-            return stock_moves.filtered(lambda ml: ml.product_id.id in ml_product_to_consider and ml.bom_line_id)
-        return stock_moves.filtered(lambda ml: ml.product_id.id in ml_product_to_consider and (ml.bom_line_id in bom.bom_line_ids))
+        return stock_moves.filtered(lambda ml: ml.product_id.id in ml_product_to_consider and (ml.bom_line_id.id in bom_line_ids))
 
 class PosOrder(models.Model):
     _inherit = "pos.order"

--- a/addons/pos_mrp/tests/test_pos_mrp_flow.py
+++ b/addons/pos_mrp/tests/test_pos_mrp_flow.py
@@ -448,3 +448,113 @@ class TestPosMrp(TestPointOfSaleCommon):
             {'product_id': kit_1.id, 'total_cost': 15.0},
             {'product_id': kit_2.id, 'total_cost': 150.0},
         ])
+
+    def test_bom_nested_kit_order_total_cost_with_shared_component(self):
+        category = self.env['product.category'].create({
+            'name': 'Category for average cost',
+            'property_cost_method': 'average',
+        })
+
+        kit_1 = self.env['product.product'].create({
+            'name': 'Kit Product 1',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 30.0,
+            'categ_id': category.id,
+        })
+
+        kit_2 = self.env['product.product'].create({
+            'name': 'Kit Product 2',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 200.0,
+            'categ_id': category.id,
+        })
+
+        kit_3 = self.env['product.product'].create({
+            'name': 'Kit Product 3',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 200.0,
+            'categ_id': category.id,
+        })
+
+        shared_component_a = self.env['product.product'].create({
+            'name': 'Shared Comp A',
+            'type': 'product',
+            'available_in_pos': True,
+            'lst_price': 10.0,
+            'standard_price': 100,
+
+        })
+
+        bom_product_form = Form(self.env['mrp.bom'])
+        bom_product_form.product_id = kit_1
+        bom_product_form.product_tmpl_id = kit_1.product_tmpl_id
+        bom_product_form.product_qty = 1.0
+        bom_product_form.type = 'phantom'
+        with bom_product_form.bom_line_ids.new() as bom_line:
+            bom_line.product_id = shared_component_a
+            bom_line.product_qty = 1.0
+        self.bom_a = bom_product_form.save()
+
+        bom_product_form = Form(self.env['mrp.bom'])
+        bom_product_form.product_id = kit_2
+        bom_product_form.product_tmpl_id = kit_2.product_tmpl_id
+        bom_product_form.product_qty = 1.0
+        bom_product_form.type = 'phantom'
+        with bom_product_form.bom_line_ids.new() as bom_line:
+            bom_line.product_id = shared_component_a
+            bom_line.product_qty = 1.0
+        self.bom_b = bom_product_form.save()
+
+        bom_product_form = Form(self.env['mrp.bom'])
+        bom_product_form.product_id = kit_3
+        bom_product_form.product_tmpl_id = kit_3.product_tmpl_id
+        bom_product_form.product_qty = 1.0
+        bom_product_form.type = 'phantom'
+        with bom_product_form.bom_line_ids.new() as bom_line:
+            bom_line.product_id = kit_1
+            bom_line.product_qty = 1.0
+        self.bom_b = bom_product_form.save()
+
+
+        self.pos_config.open_ui()
+        order = self.env['pos.order'].create({
+            'session_id': self.pos_config.current_session_id.id,
+            'lines': [(0, 0, {
+                'name': kit_3.name,
+                'product_id': kit_3.id,
+                'price_unit': kit_3.lst_price,
+                'qty': 1,
+                'tax_ids': [[6, False, []]],
+                'price_subtotal': kit_3.lst_price,
+                'price_subtotal_incl': kit_3.lst_price,
+            }), (0, 0, {
+                'name': kit_2.name,
+                'product_id': kit_2.id,
+                'price_unit': kit_2.lst_price,
+                'qty': 1,
+                'tax_ids': [[6, False, []]],
+                'price_subtotal': kit_2.lst_price,
+                'price_subtotal_incl': kit_2.lst_price,
+            })],
+            'pricelist_id': self.pos_config.pricelist_id.id,
+            'amount_paid': kit_3.lst_price + kit_2.lst_price,
+            'amount_total': kit_3.lst_price + kit_2.lst_price,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'to_invoice': False,
+        })
+        payment_context = {"active_ids": order.ids, "active_id": order.id}
+        order_payment = self.PosMakePayment.with_context(**payment_context).create({
+            'amount': order.amount_total,
+            'payment_method_id': self.cash_payment_method.id
+        })
+        order_payment.with_context(**payment_context).check()
+        self.pos_config.current_session_id.action_pos_session_closing_control()
+        pos_order = self.env['pos.order'].search([], order='id desc', limit=1)
+        self.assertRecordValues(pos_order.lines, [
+            {'product_id': kit_3.id, 'total_cost': 100.0},
+            {'product_id': kit_2.id, 'total_cost': 100.0},
+        ])


### PR DESCRIPTION
When creating nested BoMs that share some common component, the cost of
the product was being calculated incorrectly

Steps to reproduce:
-------------------
* Set `All` category to use the costing method `AVCO` in the settings.
* Create a product Comp1 and set its cost to 100.
* Create Product P1 with a BoM that consumes 1 Comp1.
* Create Product P2 with a BoM that consumes 1 Comp1.
* Create Product P3 with a BoM that consumes 1 P1.
* Create a POS order with 1 P2, and 1 P3.
* Close the session and check the cost of the products in the order
> Observation: The cost for P3 is incorrect, it should be 100 but it is 200.

Why the fix:
------------
When selecting the stock moves line to consider for the cost of the PoS
order, we need to select the stock moves that are related to the
BoM lines of the original product. In the previous code we were only
relying on the product id, and this was causing the issue because some
products can have the same product id but used in different BoM lines.

opw-4201935