### PR TITLE
[IMP] stock_account: stock valuation layer references to scraps

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -315,10 +315,10 @@ class StockMove(models.Model):
         for move in self:
             move.is_quantity_done_editable = move.product_id
 
-    @api.depends('picking_id', 'name', 'picking_id.name')
+    @api.depends('name', 'picking_id.name', 'scrap_id.name', 'scrapped')
     def _compute_reference(self):
         for move in self:
-            move.reference = move.picking_id.name if move.picking_id else move.name
+            move.reference = move.scrap_id.name if move.scrapped else move.picking_id.name or move.name
 
     @api.depends('move_line_ids')
     def _compute_move_lines_count(self):
@@ -2318,6 +2318,13 @@ Please change the quantity done or the rounding precision in your settings.""",
         """ Open the form view of the move's reference document, if one exists, otherwise open form view of self
         """
         self.ensure_one()
+        if self.scrapped:
+            return {
+                'res_model': 'stock.scrap',
+                'type': 'ir.actions.act_window',
+                'views': [[False, 'form']],
+                'res_id': self.scrap_id.id,
+            }
         source = self.picking_id
         if source and source.browse().has_access('read'):
             return {


### PR DESCRIPTION
When a scrap is created from a stock move, the description of the
valuation layer omits any mention of scrapping. This is unlike the
behaviour of creation of scrap from scratch, whose valuation layer
directly points at the reference of the scrap.

To fix this inconsistency, all scrap moves' references are now the
references of the scraps themselves rather than those of origin moves.
Stock valuation layer descriptions also carry the scrap reference, as
well as the scrap reasons (tags), if they exist.

Clicking on a scrap move's stock valuation layer leads to scrap form
view rather than stock move form view (previous behaviour for scraps
created from moves) or stock valuation form view (previous behaviour
for manually created scraps).

Task ID: [4457325](https://www.odoo.com/odoo/project/966/tasks/4457325)
