### PR TITLE
[FIX] web: close confirmation dialog on confirm inside button-called action view

### DIFF
--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js
@@ -14,7 +14,7 @@ export class ConfirmationDialog extends Component {
     }
     async _cancel() {
         if (this.isConfirmedOrCancelled) {
-            return;
+            return this.props.close();
         }
         this.isConfirmedOrCancelled = true;
         this.disableButtons();


### PR DESCRIPTION
**Description**
Before this commit, when calling an action from a button inside e.g. a form view header and this action contained a dialog confirmation button, after confirming, the dialog would not close when the confirm action opens a view in `current` window.

After this commit, when opening the confirmation dialog from such action, the view opens and the dialog is closed properly after confirming.

Impacted versions: 16.0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
