### PR TITLE
[FIX] core: falsy evaluation of db_replica_host

### DIFF
--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -66,7 +66,7 @@ def report_configuration():
     _logger.info('database: %s@%s:%s', user, host, port)
     replica_host = config['db_replica_host']
     replica_port = config['db_replica_port']
-    if replica_host is not False or replica_port:
+    if replica_host or replica_port:
         _logger.info('replica database: %s@%s:%s', user, replica_host or 'default', replica_port or 'default')
     if sys.version_info[:2] > odoo.MAX_PY_VERSION:
         _logger.warning("Python %s is not officially supported, please use Python %s instead",

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -101,12 +101,12 @@ class PerfFilter(logging.Filter):
             perf_t0 = threading.current_thread().perf_t0
             remaining_time = tools.real_time() - perf_t0 - query_time
             record.perf_info = '%s %s %s' % self.format_perf(query_count, query_time, remaining_time)
-            if tools.config['db_replica_host'] is not False:
+            if tools.config['db_replica_host']:
                 cursor_mode = threading.current_thread().cursor_mode
                 record.perf_info = f'{record.perf_info} {self.format_cursor_mode(cursor_mode)}'
             delattr(threading.current_thread(), "query_count")
         else:
-            if tools.config['db_replica_host'] is not False:
+            if tools.config['db_replica_host']:
                 record.perf_info = "- - - -"
             record.perf_info = "- - -"
         return True

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -187,7 +187,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
         self.db_name = db_name
         self._db: Connection = odoo.sql_db.db_connect(db_name, readonly=False)
         self._db_readonly: Connection | None = None
-        if config['db_replica_host'] is not False or config['test_enable']:  # by default, only use readonly pool if we have a db_replica_host defined. Allows to have an empty replica host for testing
+        if config['db_replica_host'] or config['test_enable']:  # by default, only use readonly pool if we have a db_replica_host defined. Allows to have an empty replica host for testing
             self._db_readonly = odoo.sql_db.db_connect(db_name, readonly=True)
 
         # cursor for test mode; None means "normal" mode


### PR DESCRIPTION
Following the configuration refactor[1], the falsy evaluation of db_replica_host was wrong. The default is now an empty string.

This lead to situations where a readonly cursor was wrongfully used.

[1] https://github.com/odoo/odoo/commit/b1f7be518e2075c546bcedc0f4ba6dd62dff3c8f




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
