### PR TITLE
[WIP][FIX] *: add aggregator for color field

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -28,7 +28,7 @@ class account_journal(models.Model):
     kanban_dashboard_graph = fields.Text(compute='_kanban_dashboard_graph')
     json_activity_data = fields.Text(compute='_get_json_activity_data')
     show_on_dashboard = fields.Boolean(string='Show journal on dashboard', help="Whether this journal should be displayed on the dashboard or not", default=True)
-    color = fields.Integer("Color Index", default=0)
+    color = fields.Integer("Color Index", default=0, aggregator='avg')
     current_statement_balance = fields.Monetary(compute='_compute_current_statement_balance') # technical field used to avoid computing the value multiple times
     has_statement_lines = fields.Boolean(compute='_compute_current_statement_balance') # technical field used to avoid computing the value multiple times
     entries_count = fields.Integer(compute='_compute_entries_count')

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -139,7 +139,7 @@ class Lead(models.Model):
     tag_ids = fields.Many2many(
         'crm.tag', 'crm_tag_rel', 'lead_id', 'tag_id', string='Tags',
         help="Classify and analyze your lead/opportunity categories like: Training, Service")
-    color = fields.Integer('Color Index', default=0)
+    color = fields.Integer('Color Index', default=0, aggregator='avg')
     # Revenues
     expected_revenue = fields.Monetary('Expected Revenue', currency_field='company_currency', tracking=True, default=0.0)
     prorated_revenue = fields.Monetary('Prorated Revenue', currency_field='company_currency', store=True, compute="_compute_prorated_revenue")

--- a/addons/hr/models/hr_department.py
+++ b/addons/hr/models/hr_department.py
@@ -28,7 +28,7 @@ class Department(models.Model):
     plan_ids = fields.One2many('mail.activity.plan', 'department_id')
     plans_count = fields.Integer(compute='_compute_plan_count')
     note = fields.Text('Note')
-    color = fields.Integer('Color Index')
+    color = fields.Integer('Color Index', aggregator='avg')
     parent_path = fields.Char(index=True)
     master_department_id = fields.Many2one(
         'hr.department', 'Master Department', compute='_compute_master_department_id', store=True)

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -140,7 +140,7 @@ class HrEmployeePrivate(models.Model):
         string='Tags')
     # misc
     notes = fields.Text('Notes', groups="hr.group_hr_user")
-    color = fields.Integer('Color Index', default=0)
+    color = fields.Integer('Color Index', default=0, aggregator='avg')
     barcode = fields.Char(string="Badge ID", help="ID used for employee identification.", groups="hr.group_hr_user", copy=False)
     pin = fields.Char(string="PIN", groups="hr.group_hr_user", copy=False,
         help="PIN used to Check In/Out in the Kiosk Mode of the Attendance application (if enabled in Configuration) and to change the cashier in the Point of Sale application.")

--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -40,7 +40,7 @@ class HrAttendance(models.Model):
     check_in = fields.Datetime(string="Check In", default=fields.Datetime.now, required=True, tracking=True)
     check_out = fields.Datetime(string="Check Out", tracking=True)
     worked_hours = fields.Float(string='Worked Hours', compute='_compute_worked_hours', store=True, readonly=True)
-    color = fields.Integer(compute='_compute_color')
+    color = fields.Integer(compute='_compute_color', aggregator='avg')
     overtime_hours = fields.Float(string="Over Time", compute='_compute_overtime_hours', store=True)
     in_latitude = fields.Float(string="Latitude", digits=(10, 7), readonly=True)
     in_longitude = fields.Float(string="Longitude", digits=(10, 7), readonly=True)

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -78,7 +78,7 @@ class Applicant(models.Model):
     day_open = fields.Float(compute='_compute_day', string="Days to Open", compute_sudo=True)
     day_close = fields.Float(compute='_compute_day', string="Days to Close", compute_sudo=True)
     delay_close = fields.Float(compute="_compute_delay", string='Delay to Close', readonly=True, aggregator="avg", help="Number of days to close", store=True)
-    color = fields.Integer("Color Index", default=0)
+    color = fields.Integer("Color Index", default=0, aggregator='avg')
     emp_id = fields.Many2one('hr.employee', string="Employee", help="Employee linked to the applicant.", copy=False)
     emp_is_active = fields.Boolean(string="Employee Active", related='emp_id.active')
     user_email = fields.Char(related='user_id.email', string="User Email", readonly=True)

--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -47,7 +47,7 @@ class Job(models.Model):
     document_ids = fields.One2many('ir.attachment', compute='_compute_document_ids', string="Documents", readonly=True)
     documents_count = fields.Integer(compute='_compute_document_ids', string="Document Count")
     alias_id = fields.Many2one(help="Email alias for this job position. New emails will automatically create new applicants for this job position.")
-    color = fields.Integer("Color Index")
+    color = fields.Integer("Color Index", aggregator='avg')
     is_favorite = fields.Boolean(compute='_compute_is_favorite', inverse='_inverse_is_favorite')
     favorite_user_ids = fields.Many2many('res.users', 'job_favorite_user_rel', 'job_id', 'user_id', default=_get_default_favorite_user_ids)
     interviewer_ids = fields.Many2many('res.users', string='Interviewers', domain="[('share', '=', False), ('company_ids', 'in', company_id)]", help="The Interviewers set on the job position can see all Applicants in it. They have access to the information, the attachments, the meeting management and they can refuse him. You don't need to have Recruitment rights to be set as an interviewer.")

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -38,7 +38,7 @@ class MaintenanceEquipmentCategory(models.Model):
     company_id = fields.Many2one('res.company', string='Company',
         default=lambda self: self.env.company)
     technician_user_id = fields.Many2one('res.users', 'Responsible', tracking=True, default=lambda self: self.env.uid)
-    color = fields.Integer('Color Index')
+    color = fields.Integer('Color Index', aggregator='avg')
     note = fields.Html('Comments', translate=True)
     equipment_ids = fields.One2many('maintenance.equipment', 'category_id', string='Equipment', copy=False)
     equipment_count = fields.Integer(string="Equipment Count", compute='_compute_equipment_count')
@@ -160,7 +160,7 @@ class MaintenanceEquipment(models.Model):
     cost = fields.Float('Cost')
     note = fields.Html('Note')
     warranty_date = fields.Date('Warranty Expiration Date')
-    color = fields.Integer('Color Index')
+    color = fields.Integer('Color Index', aggregator='avg')
     scrap_date = fields.Date('Scrap Date')
     maintenance_ids = fields.One2many('maintenance.request', 'equipment_id')
 
@@ -237,7 +237,7 @@ class MaintenanceRequest(models.Model):
     stage_id = fields.Many2one('maintenance.stage', string='Stage', ondelete='restrict', tracking=True,
                                group_expand='_read_group_stage_ids', default=_default_stage, copy=False)
     priority = fields.Selection([('0', 'Very Low'), ('1', 'Low'), ('2', 'Normal'), ('3', 'High')], string='Priority')
-    color = fields.Integer('Color Index')
+    color = fields.Integer('Color Index', aggregator='avg')
     close_date = fields.Date('Close Date', help="Date the maintenance was finished. ")
     kanban_state = fields.Selection([('normal', 'In Progress'), ('blocked', 'Blocked'), ('done', 'Ready for next stage')],
                                     string='Kanban State', required=True, default='normal', tracking=True)
@@ -404,7 +404,7 @@ class MaintenanceTeam(models.Model):
     member_ids = fields.Many2many(
         'res.users', 'maintenance_team_users_rel', string="Team Members",
         domain="[('company_ids', 'in', company_id)]")
-    color = fields.Integer("Color Index", default=0)
+    color = fields.Integer("Color Index", default=0, aggregator='avg')
     request_ids = fields.One2many('maintenance.request', 'maintenance_team_id', copy=False)
     equipment_ids = fields.One2many('maintenance.equipment', 'maintenance_team_id', copy=False)
 

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -135,7 +135,7 @@ class MassMailing(models.Model):
         default='draft', required=True,
         copy=False, tracking=True,
         group_expand=True)
-    color = fields.Integer(string='Color Index')
+    color = fields.Integer(string='Color Index', aggregator='avg')
     user_id = fields.Many2one(
         'res.users', string='Responsible',
         tracking=True,

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -34,7 +34,7 @@ class MrpWorkcenter(models.Model):
     sequence = fields.Integer(
         'Sequence', default=1, required=True,
         help="Gives the sequence order when displaying a list of work centers.")
-    color = fields.Integer('Color')
+    color = fields.Integer('Color', aggregator='avg')
     currency_id = fields.Many2one('res.currency', 'Currency', related='company_id.currency_id', readonly=True, required=True)
     costs_hour = fields.Float(string='Cost per hour', help='Hourly processing cost.', default=0.0)
     time_start = fields.Float('Setup Time')

--- a/addons/point_of_sale/models/pos_category.py
+++ b/addons/point_of_sale/models/pos_category.py
@@ -27,7 +27,7 @@ class PosCategory(models.Model):
     child_ids = fields.One2many('pos.category', 'parent_id', string='Children Categories')
     sequence = fields.Integer(help="Gives the sequence order when displaying a list of product categories.")
     image_128 = fields.Image("Image", max_width=128, max_height=128)
-    color = fields.Integer('Color', required=False, default=get_default_color)
+    color = fields.Integer('Color', required=False, default=get_default_color, aggregator='avg')
 
     # During loading of data, the image is not loaded so we expose a lighter
     # field to determine whether a pos.category has an image or not.

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -119,7 +119,7 @@ class ProductTemplate(models.Model):
     variant_seller_ids = fields.One2many('product.supplierinfo', 'product_tmpl_id')
 
     active = fields.Boolean('Active', default=True, help="If unchecked, it will allow you to hide the product without removing it.")
-    color = fields.Integer('Color Index')
+    color = fields.Integer('Color Index', aggregator='avg')
 
     is_product_variant = fields.Boolean(string='Is a product variant', compute='_compute_is_product_variant')
     attribute_line_ids = fields.One2many('product.template.attribute.line', 'product_tmpl_id', 'Product Attributes', copy=True)

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -109,7 +109,7 @@ class Project(models.Model):
     open_task_count = fields.Integer(compute='_compute_open_task_count', string="Open Task Count", export_string_translation=False)
     task_ids = fields.One2many('project.task', 'project_id', string='Tasks', export_string_translation=False,
                                domain=lambda self: [('is_closed', '=', False)])
-    color = fields.Integer(string='Color Index', export_string_translation=False)
+    color = fields.Integer(string='Color Index', export_string_translation=False, aggregator=False)
     user_id = fields.Many2one('res.users', string='Project Manager', default=lambda self: self.env.user, tracking=True)
     alias_id = fields.Many2one(help="Internal email associated with this project. Incoming emails are automatically synchronized "
                                     "with Tasks (or optionally Issues if the Issue Tracker module is installed).")

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -213,7 +213,7 @@ class Task(models.Model):
         domain="['|', ('company_id', '=?', company_id), ('company_id', '=', False)]", )
     email_cc = fields.Char(help='Email addresses that were in the CC of the incoming emails from this task and that are not currently linked to an existing customer.')
     company_id = fields.Many2one('res.company', string='Company', compute='_compute_company_id', store=True, readonly=False, recursive=True, copy=True, default=_default_company_id)
-    color = fields.Integer(string='Color Index', export_string_translation=False)
+    color = fields.Integer(string='Color Index', export_string_translation=False, aggregator='avg')
     rating_active = fields.Boolean(string='Project Rating Status', related="project_id.rating_active")
     attachment_ids = fields.One2many(
         'ir.attachment',

--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -119,7 +119,7 @@ class CrmTeam(models.Model):
         'crm.team.member', 'crm_team_id', string='Sales Team Members (incl. inactive)',
         context={'active_test': False})
     # UX options
-    color = fields.Integer(string='Color Index', help="The color of the channel")
+    color = fields.Integer(string='Color Index', help="The color of the channel", aggregator='avg')
     favorite_user_ids = fields.Many2many(
         'res.users', 'team_favorite_user_rel', 'team_id', 'user_id',
         string='Favorite Members', default=_get_default_favorite_user_ids)

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -45,7 +45,7 @@ class Survey(models.Model):
         string='Survey Type', required=True, default='custom')
     allowed_survey_types = fields.Json(string='Allowed survey types', compute="_compute_allowed_survey_types")
     title = fields.Char('Survey Title', required=True, translate=True)
-    color = fields.Integer('Color Index', default=0)
+    color = fields.Integer('Color Index', default=0, aggregator='avg')
     description = fields.Html(
         "Description", translate=True, sanitize=True, sanitize_overridable=True,
         help="The description will be displayed on the home page of the survey. You can use this to give the purpose and guidelines to your candidates before they start it.")

--- a/addons/utm/models/utm_campaign.py
+++ b/addons/utm/models/utm_campaign.py
@@ -26,7 +26,7 @@ class UtmCampaign(models.Model):
         'tag_id', 'campaign_id', string='Tags')
 
     is_auto_campaign = fields.Boolean(default=False, string="Automatically Generated Campaign", help="Allows us to filter relevant Campaigns")
-    color = fields.Integer(string='Color Index')
+    color = fields.Integer(string='Color Index', aggregator='avg')
 
     _sql_constraints = [
         ('unique_name', 'UNIQUE(name)', 'The name must be unique'),

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -30,7 +30,7 @@ class Track(models.Model):
     company_id = fields.Many2one('res.company', related='event_id.company_id')
     tag_ids = fields.Many2many('event.track.tag', string='Tags')
     description = fields.Html(translate=html_translate, sanitize_attributes=False, sanitize_form=False)
-    color = fields.Integer('Agenda Color')
+    color = fields.Integer('Agenda Color', aggregator='avg')
     priority = fields.Selection([
         ('0', 'Low'), ('1', 'Medium'),
         ('2', 'High'), ('3', 'Highest')],

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -322,7 +322,7 @@ class Channel(models.Model):
         string="Course type", default="training", required=True)
     sequence = fields.Integer(default=10)
     user_id = fields.Many2one('res.users', string='Responsible', default=lambda self: self.env.uid)
-    color = fields.Integer('Color Index', default=0, help='Used to decorate kanban view')
+    color = fields.Integer('Color Index', default=0, help='Used to decorate kanban view', aggregator='avg')
     tag_ids = fields.Many2many(
         'slide.channel.tag', 'slide_channel_tag_rel', 'channel_id', 'tag_id',
         string='Tags', help='Used to categorize and filter displayed channels/courses')

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -286,7 +286,7 @@ class Partner(models.Model):
         selection=[('person', 'Individual'), ('company', 'Company')],
         compute='_compute_company_type', inverse='_write_company_type')
     company_id = fields.Many2one('res.company', 'Company', index=True)
-    color = fields.Integer(string='Color Index', default=0)
+    color = fields.Integer(string='Color Index', default=0, aggregator='avg')
     user_ids = fields.One2many('res.users', 'partner_id', string='Users', auto_join=True)
     partner_share = fields.Boolean(
         'Share Partner', compute='_compute_partner_share', store=True,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

 -  following this commit odoo/odoo@5ef08123,  from this [line](https://github.com/odoo/odoo/commit/5ef08123#diff-50c2c0143f95bd9826d9c06cef493589092f92c6bf47eb22d3500991157ab349R669) , now kanban view calls `webReadGroup` with explicit aggregator field, this causes issue when we apply groupby on `color index` field in kanban mode.
 -   As default aggregator of Interger field is 'sum' and when `color` field goes for aggregation, it return a sum of color index, which when converted into domain, fetches 0 result, as color value is evaluated against aggregated value which exceeds limit of 11.
 - example of damain formed `domain : [["color", "=", 33]]` ( here there are 3 records with color index 11)

Current behavior before PR:
- If aggreagted values becomes > 11, no result is shown in UI (kanban mode)
![image](https://github.com/user-attachments/assets/7aab8e99-7254-4f60-b31f-563bf4639ab0)

Desired behavior after PR is merged:
- records are properly grouped 
![image](https://github.com/user-attachments/assets/49e43a84-a7cb-4e91-97e6-3ba6946d68bb)

**STEPS TO REPRODUCE THE ISSUE:**

-> Go to project 
-> Then select same color for two or three project with higher color index
-> Group by "Color Index"

opw-4425778
co-author: hink

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
