### PR TITLE
[FIX] spreadsheet_edition: drop sorting if field is not a measure

### DIFF
--- a/addons/spreadsheet/static/src/pivot/odoo_pivot.js
+++ b/addons/spreadsheet/static/src/pivot/odoo_pivot.js
@@ -504,6 +504,15 @@ export class OdooPivotRuntimeDefinition extends PivotRuntimeDefinition {
         this._model = definition.model;
         /** @type {SortedColumn} */
         this._sortedColumn = definition.sortedColumn;
+
+        // Ensure that the sorted column is a measure
+        // and if not, drop it.
+        // This situation can happen because of a bug in a previous version
+        const measureNames = definition.measures.map((field) => field.fieldName);
+        if (definition.sortedColumn && !measureNames.includes(definition.sortedColumn.measure)) {
+            this._sortedColumn = undefined;
+        }
+
         for (const dimension of this.columns.concat(this.rows)) {
             if (
                 (dimension.type === "date" || dimension.type === "datetime") &&

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -1491,6 +1491,34 @@ test("field matching is removed when filter is deleted", async function () {
     expect(model.getters.getPivot(pivotId).getDomainWithGlobalFilters()).toEqual([]);
 });
 
+test("ignore sorted column if not part of measures", async () => {
+    const spreadsheetData = {
+        pivots: {
+            1: {
+                type: "ODOO",
+                columns: [],
+                domain: [],
+                measures: [{ id: "probability:sum", fieldName: "probability", aggregator: "sum" }],
+                model: "partner",
+                rows: [{ fieldName: "bar" }],
+                sortedColumn: {
+                    measure: "foo",
+                    order: "asc",
+                    groupId: [[], [1]],
+                },
+                name: "A pivot",
+                context: {},
+                fieldMatching: {},
+                formulaId: "1",
+            },
+        },
+    };
+    const model = await createModelWithDataSource({ spreadsheetData });
+    setCellContent(model, "A1", "=PIVOT(1)");
+    await waitForDataLoaded(model);
+    expect(model.getters.getPivot(1).definition.sortedColumn).toBe(undefined);
+});
+
 test("Load pivot spreadsheet with models that cannot be accessed", async function () {
     let hasAccessRights = true;
     const { model } = await createSpreadsheetWithPivot({


### PR DESCRIPTION
Steps: Go to a pivot view with:

- either a predefined sort on the action/filter.
- sort by a measure then uncheck the measure.

We can't keep the sorting because the sorting is done client-side. If the field is not part of the measures, we don't have the data to sort...

Task: 4467262

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
