### PR TITLE
[IMP] website: add a validation step for 301 302 redirects

### DIFF
--- a/addons/website/models/website_rewrite.py
+++ b/addons/website/models/website_rewrite.py
@@ -58,6 +58,7 @@ class WebsiteRewrite(models.Model):
     url_from = fields.Char('URL from', index=True)
     route_id = fields.Many2one('website.route')
     url_to = fields.Char("URL to")
+    url_from_is_controller = fields.Boolean(compute='_compute_url_from_is_controller', store=False)
     redirect_type = fields.Selection([
         ('404', '404 Not Found'),
         ('301', '301 Moved permanently'),
@@ -153,3 +154,14 @@ class WebsiteRewrite(models.Model):
 
     def refresh_routes(self):
         self.env['website.route']._refresh()
+
+    def _compute_url_from_is_controller(self):
+        """
+        Compute if the URL from is a controller/page or not.
+        Summary of how urls are served:
+            1. Controllers
+            2. Pages
+            3. Redirection
+        """
+        for rewrite in self:
+            rewrite.url_from_is_controller = bool(self.env['ir.http'].routing_map().bind('').test(rewrite.url_from))

--- a/addons/website/views/website_rewrite.xml
+++ b/addons/website/views/website_rewrite.xml
@@ -11,6 +11,11 @@
                                 invisible="redirect_type != '308'"/>
                     </header>
                     <sheet>
+                        <div class="alert alert-warning" role="alert"
+                             invisible="not (url_from_is_controller and redirect_type in ['301','302'])">
+                            This redirection is ineffective because the 'URL from' is currently in use.
+                            If you want to rename it, you should use action '308 Redirect / Rewrite' instead.
+                        </div>
                         <group>
                             <group>
                                 <field name="name"/>
@@ -34,7 +39,8 @@
             <field name="name">website.rewrite.list</field>
             <field name="model">website.rewrite</field>
             <field name="arch" type="xml">
-                <list string="Website rewrites">
+                <list string="Website rewrites"
+                      decoration-warning="url_from_is_controller and redirect_type in ['301','302']">
                     <field name="sequence" widget="handle" />
                     <field name="redirect_type"/>
                     <field name="name"/>

--- a/addons/website/views/website_rewrite.xml
+++ b/addons/website/views/website_rewrite.xml
@@ -67,8 +67,7 @@
             id="menu_website_rewrite"
             action="action_website_rewrite_list"
             parent="menu_website_global_configuration"
-            sequence="30"
-            groups="base.group_no_one"/>
+            sequence="30"/>
 
         <record id="view_rewrite_search" model="ir.ui.view">
             <field name="name">website.rewrite.search</field>


### PR DESCRIPTION
This PR introduces a validation step for 301 and 302 redirects and 
modifies the visibility of the 'Redirects' menu item under website 
'Configuration'.

301 and 302 redirects from dynamic pages don't work, and that is normal.
Here is the way urls are served at the moment:
            1. Controllers
            2. Pages
            3. Redirection

However, before this commit, nothing informed the user from setting a
dynamic page as the 'URL from' of a 301/302 redirect, which resulted in
no effect on the redirect.

After this commit,a warning is displayed in such cases.
Instead of raising a ValidationError that would prevent the user from
saving the record, we chose to display a warning in the form and
highlight ineffective records in the tree view.

The computed field also handles the following edge case: When the user
creates a redirect with a 'from URL' that points to a controller view of
a module that isn't installed, the redirect will initially work.
However, once the module is installed, the redirect will no longer
function properly. In this case, a warning will still appear after
installation, which would not have happened with a validation error as
we do for other redirects.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
