### PR TITLE
[FIX] sale_pdf_quote_builder: multi compute

### DIFF
--- a/addons/sale_pdf_quote_builder/models/sale_order.py
+++ b/addons/sale_pdf_quote_builder/models/sale_order.py
@@ -33,10 +33,10 @@ class SaleOrder(models.Model):
     def _compute_available_product_document_ids(self):
         for order in self:
             order.available_product_document_ids = self.env['quotation.document'].search(
-                self.env['quotation.document']._check_company_domain(self.company_id),
+                self.env['quotation.document']._check_company_domain(order.company_id),
                 order='sequence',
             ).filtered(lambda doc:
-                self.sale_order_template_id in doc.quotation_template_ids
+                order.sale_order_template_id in doc.quotation_template_ids
                 or not doc.quotation_template_ids
             )
 


### PR DESCRIPTION
This fix addresses a minor issue with the
`_compute_available_product_document_ids` method of `sale.order`, which doesn't fully support multi-compute.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
