### PR TITLE
[FIX] mail: redirect to record "nice" url from mail

### DIFF
--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -134,7 +134,12 @@ class MailController(http.Controller):
             url_params['view_id'] = view_id
         if cids:
             request.future_response.set_cookie('cids', '-'.join([str(cid) for cid in cids]))
-        url = f'/odoo/{model}/{res_id}?{url_encode(url_params)}'
+        
+        # @see commit c63d14a0485a553b74a8457aee158384e9ae6d3f
+        # @see router.js: heuristics to discrimate a model name from an action path
+        # is the presence of dots, or the prefix m- for models
+        model_in_url = model if "." in model else "m-" + model
+        url = f'/odoo/{model_in_url}/{res_id}?{url_encode(url_params)}'
         return request.redirect(url)
 
     @http.route('/mail/view', type='http', auth='public')


### PR DESCRIPTION
Commit c63d14a0485a553b74a8457aee158384e9ae6d3f introduced new nicer urls to get to Odoo. Commit 5776b574b3aba190c54b2e4974ce514d9b0bec2a adapted the /mail/view controller for it, allowing people clicking on a link to a record in a mail to be redirected to a nice new URL.

Although one case was missing: when the model doesn't contain dots, the string is considered an action's path. So, when opening a record from a mail, there was a crash in odoo because the action could not be found.

After this commit, there is no crash, and the record is opened correctly with a nice url.

see router.js: heuristics to discrimate a model name from an action path is the presence of dots, or the prefix m- for models

opw-4475237

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
