### PR TITLE
[IMP] purchase_requisition: do not mangle lines of confirmed PO

### DIFF
--- a/addons/purchase_requisition/models/purchase.py
+++ b/addons/purchase_requisition/models/purchase.py
@@ -76,6 +76,9 @@ class PurchaseOrder(models.Model):
             self.date_order = fields.Datetime.now()
 
         # Create PO lines if necessary
+        # Do not clobber existing lines if the PO is already confirmed
+        if self.state != 'draft':
+            return
         order_lines = []
         for line in requisition.line_ids:
             # Compute name


### PR DESCRIPTION
The user could create a PO and forget to assign it to a blanket order. They can still do so after the fact, but doing so will mess with the existing lines of the order, which is undesirable if the order was confirmed.

This commit simply prevents the automatic creation of PO lines on change to the purchase agreement field unless the order is in draft status.

Task ID: [4461281](https://www.odoo.com/odoo/project/966/tasks/4461281)
