### PR TITLE
[IMP] hr_work_entry: make work entry type not updatable

### DIFF
--- a/addons/hr_work_entry/data/hr_work_entry_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data noupdate="0">
+    <data noupdate="1">
 
         <!-- Work Entry Type -->
         <record id="work_entry_type_attendance" model="hr.work.entry.type">

--- a/addons/hr_work_entry_contract/data/hr_work_entry_data.xml
+++ b/addons/hr_work_entry_contract/data/hr_work_entry_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data noupdate="0">
+    <data noupdate="1">
 
         <!-- Work Entry Type -->
          <record id="work_entry_type_leave" model="hr.work.entry.type">
@@ -44,8 +44,7 @@
             <field name="is_leave">True</field>
             <field name="color">5</field>
         </record>
-    </data>
-    <data noupdate="1">
+
         <record id="hr_work_entry.work_entry_type_attendance" model="hr.work.entry.type">
             <field name="is_leave">False</field>
         </record>


### PR DESCRIPTION
Work entry type data should not be updatable as it shoud not be erased at each migration/upgrade.

This commits fixes this by changing all work entry type data to noupdate true.

task-4479965
