### PR TITLE
[FIX] hr_recruitment: fix candidate/application link and constraint

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -347,7 +347,7 @@ class Applicant(models.Model):
         ], ['ids:array_agg(id)'], groupby=['res_id'])
         attachments_by_candidate = {e['res_id']: e['ids'] for e in attachments_result}
         for applicant in applicants:
-            if applicant.company_id != applicant.candidate_id.company_id:
+            if applicant.candidate_id.company_id and applicant.company_id != applicant.candidate_id.company_id:
                 raise ValidationError(_("You cannot create an applicant in a different company than the candidate"))
             candidate_id = applicant.candidate_id.id
             if candidate_id not in attachments_by_candidate:
@@ -591,23 +591,21 @@ class Applicant(models.Model):
         self = self.with_context(default_user_id=False, mail_notify_author=True)  # Allows sending stage updates to the author
         stage = False
         candidate_defaults = {}
+        partner_name, email_from_normalized = tools.parse_contact_from_email(msg.get('from'))
+        candidate_domain = [
+            ("email_from", "=", email_from_normalized),
+        ]
         if custom_values and 'job_id' in custom_values:
             job = self.env['hr.job'].browse(custom_values['job_id'])
             stage = job._get_first_stage()
             candidate_defaults['company_id'] = job.company_id.id
+            candidate_domain = expression.AND([candidate_domain, [("company_id", "in", [job.company_id.id, False])]])
 
-        partner_name, email_from_normalized = tools.parse_contact_from_email(msg.get('from'))
-        candidate = self.env["hr.candidate"].search(
-            [
-                ("email_from", "=", email_from_normalized),
-            ],
-            limit=1,
-        ) or self.env["hr.candidate"].create(
-            {
+        candidate = self.env["hr.candidate"].search(candidate_domain, limit=1)\
+            or self.env["hr.candidate"].create({
                 "partner_name": partner_name or email_from_normalized,
                 **candidate_defaults,
-            }
-        )
+            })
 
         defaults = {
             'candidate_id': candidate.id,


### PR DESCRIPTION
Before this commit, the creation of an applicant though `message_new`, It would check for existing candidates but not for the company; however, if the company is different, an error would be raised upon applicant creation and prevent it.

This commit adds the company to the candidate check to avoid raising the constraint, and adjusts the said constraint so that it allows linking to candidates with no company set.