### PR TITLE
[FIX] stock_account: fix standard_price on _svl_replenish_stock

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -96,6 +96,7 @@ will update the cost of every lot/serial number in stock."),
             in_stock_valuation_layers = SVL.create(in_svl_vals_list)
             if product_template.valuation == 'real_time':
                 move_vals_list += Product._svl_replenish_stock_am(in_stock_valuation_layers)
+            products._update_lots_standard_price()
 
         # Check access right
         if move_vals_list and not self.env['stock.valuation.layer'].has_access('read'):
@@ -632,6 +633,14 @@ will update the cost of every lot/serial number in stock."),
         to_reconcile_account_move_lines += new_account_move.line_ids.filtered(lambda l: not l.reconciled and l.account_id == accounts['stock_output'] and l.account_id.reconcile)
         return to_reconcile_account_move_lines.reconcile()
 
+    def _update_lots_standard_price(self):
+        grouped_lots = self.env['stock.lot']._read_group(
+            [('product_id', 'in', self.ids), ('product_id.lot_valuated', '=', True)],
+            ['product_id'], ['id:recordset']
+        )
+        for product, lots in grouped_lots:
+            lots.with_context(disable_auto_svl=True).write({"standard_price": product.standard_price})
+
     @api.model
     def _svl_empty_stock(self, description, product_category=None, product_template=None):
         impacted_product_ids = []
@@ -1046,6 +1055,7 @@ class ProductCategory(models.Model):
             in_stock_valuation_layers = SVL.sudo().create(in_svl_vals_list)
             if product_category.property_valuation == 'real_time':
                 move_vals_list += Product._svl_replenish_stock_am(in_stock_valuation_layers)
+            products._update_lots_standard_price()
 
         # Check access right
         if move_vals_list and not self.env['stock.valuation.layer'].has_access('read'):

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -592,3 +592,45 @@ class TestLotValuation(TestStockValuationCommon):
         self.product1.lot_valuated = True
         self.product1.product_tmpl_id.tracking = 'none'
         self.assertFalse(self.product1.product_tmpl_id.lot_valuated)
+
+    def test_lot_valuation_lot_product_price_diff(self):
+        """
+        This test ensure that when the product.standard_price and the lot.standard_price differ,
+        no discrepancy is created when setting lot_valuated to True.
+        When lot_valuated is set to True, the lot.standard_price is updated to match with the product.standard_price
+        """
+        self.product1.categ_id.property_cost_method = 'average'
+        self.product1.lot_valuated = False
+        self.product1.standard_price = 1
+
+        lot = self.env['stock.lot'].create({
+            'product_id': self.product1.id,
+            'name': 'LOT-WITH-COST',
+            'standard_price': 2,
+        })
+        lot2 = self.env['stock.lot'].create({
+            'product_id': self.product1.id,
+            'name': 'LOT-NO-COST',
+        })
+        quant = self.env['stock.quant'].create({
+            'product_id': self.product1.id,
+            'lot_id': lot.id,
+            'location_id': self.stock_location.id,
+            'inventory_quantity': 10,
+        })
+        quant.action_apply_inventory()
+
+        self.assertEqual(self.product1.value_svl, 10)  # 10 units with product standard_price = $1
+        self.assertEqual(lot.standard_price, 2)
+        self.assertEqual(lot2.standard_price, 0)
+
+        self.product1.lot_valuated = True
+
+        self.assertEqual(lot2.standard_price, 1)
+        self.assertEqual(lot.standard_price, 1)  # lot.standard_price was updated
+        self.assertEqual(lot.value_svl, 10)
+
+        quant.inventory_quantity = 0
+        quant.action_apply_inventory()
+
+        self.assertEqual(lot.value_svl, 0)


### PR DESCRIPTION
## How to reproduce:
- Create product P, tracked by lot, cost_method = 'standard', standard_price = 1
- Create quant with lot L1, 10 units on hand
- Set L1 standard_price = 2
- Set lot_valuated to True => lot value_svl is $10 for 10 units (product.standard_price * quantity)
- Set L1 quantity to 0 => lot value_svl is $-10 for 0 units

## Issue
When the svl is replenished for the lot, the product.standard_price is used. However, the lot.standard_price is not updated; hence, when the stock is emptied, and the lot.standard_price is used, a discrepancy is created.

## Solution
When the svl is replenished, we u se the product.standard_price and update the lot.standard_price

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
