### PR TITLE
[FIX] point_of_sale: fix preparation receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -77,6 +77,7 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
                 note: note,
                 pos_categ_id: product.pos_categ_ids[0]?.id ?? 0,
                 pos_categ_sequence: product.pos_categ_ids[0]?.sequence ?? 0,
+                display_name: product.display_name,
             };
 
             if (quantityDiff && orderline.skip_change === skipped) {

--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -36,7 +36,7 @@
                 <div t-foreach="changedlines" t-as="line" t-key="change_index">
                     <div t-attf-class="orderline #{line.isCombo ? 'mx-5 px-2' : 'mx-1'}">
                         <div class="d-flex medium">
-                            <span class="me-3" t-esc="line.quantity"/> <span class="product-name" t-esc="line.basic_name"/>
+                            <span class="me-3" t-esc="line.quantity"/> <span class="product-name" t-esc="line.display_name"/>
                         </div>
                         <div t-if="line.attribute_value_ids?.length" class="mx-5 fs-2">
                             <t t-foreach="line.attribute_value_ids" t-as="attribute" t-key="attribute.id">

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -379,3 +379,23 @@ registry.category("web_tour.tours").add("PoSPaymentSyncTour3", {
             ProductScreen.orderlinesHaveNoChange(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PreparationPrinterContent", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Product Test"),
+            Dialog.confirm("Add"),
+            ProductScreen.clickOrderButton(),
+            {
+                trigger:
+                    ".render-container .pos-receipt-body .product-name:contains('Product Test (Value 1)')",
+            },
+            {
+                trigger: ".render-container .pos-receipt-body .p-0:contains('Value 1')",
+            },
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -5,7 +5,7 @@ import odoo.tests
 from odoo.addons.point_of_sale.tests.common_setup_methods import setup_product_combo_items
 from odoo.addons.point_of_sale.tests.common import archive_products
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
-
+from odoo import Command
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestFrontendCommon(TestPointOfSaleHttpCommon):
@@ -340,3 +340,62 @@ class TestFrontend(TestFrontendCommon):
         assert_payment(1, 4.4)
         self.start_pos_tour('PoSPaymentSyncTour3')
         assert_payment(2, 6.6)
+
+    def test_preparation_printer_content(self):
+        self.env['pos.printer'].create({
+            'name': 'Printer',
+            'printer_type': 'epson_epos',
+            'epson_printer_ip': '0.0.0.0',
+            'product_categories_ids': [Command.set(self.env['pos.category'].search([]).ids)],
+        })
+
+        self.main_pos_config.write({
+            'is_order_printer' : True,
+            'printer_ids': [Command.set(self.env['pos.printer'].search([]).ids)],
+        })
+
+        self.product_test = self.env['product.product'].create({
+            'name': 'Product Test',
+            'available_in_pos': True,
+            'list_price': 10,
+            'pos_categ_ids': [(6, 0, [self.env['pos.category'].search([], limit=1).id])],
+            'taxes_id': False,
+        })
+
+        attribute = self.env['product.attribute'].create({
+            'name': 'Attribute 1',
+            'create_variant': 'no_variant',
+        })
+        attribute_value = self.env['product.attribute.value'].create({
+            'name': 'Value 1',
+            'attribute_id': attribute.id,
+        })
+        attribute_value_2 = self.env['product.attribute.value'].create({
+            'name': 'Value 2',
+            'attribute_id': attribute.id,
+        })
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': self.product_test.product_tmpl_id.id,
+            'attribute_id': attribute.id,
+            'value_ids': [(6, 0, [attribute_value.id, attribute_value_2.id])],
+        })
+
+        attribute_2 = self.env['product.attribute'].create({
+            'name': 'Attribute 1',
+            'create_variant': 'always',
+        })
+        attribute_2_value = self.env['product.attribute.value'].create({
+            'name': 'Value 1',
+            'attribute_id': attribute_2.id,
+        })
+        attribute_2_value_2 = self.env['product.attribute.value'].create({
+            'name': 'Value 2',
+            'attribute_id': attribute_2.id,
+        })
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': self.product_test.product_tmpl_id.id,
+            'attribute_id': attribute_2.id,
+            'value_ids': [(6, 0, [attribute_2_value.id, attribute_2_value_2.id])],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PreparationPrinterContent', login="pos_user")


### PR DESCRIPTION
Product variant with creation type "always" would not be printer on the preparation receipt.

Steps to reproduce:
-------------------
* Create a product and add a variant with creation type "always"
* Add a preparation printer to the point of sale
* Create a new order and add the product with the variant
* Validate the order and check the preparation receipt
> Observation: the product variant is not printed on the receipt

Why the fix:
------------
The product variant was not printed on the preparation receipt because the variant is added to the display name of the product and doesn't appear in the attribute list.

This fix also add the first test for the preparation receipt. This should be improved in the future to cover more cases.

opw-4450217