### PR TITLE
[FIX] pos_mercado_pago: wrong attribute was chosen

### DIFF
--- a/addons/pos_mercado_pago/static/src/app/pos_store.js
+++ b/addons/pos_mercado_pago/static/src/app/pos_store.js
@@ -11,7 +11,7 @@ patch(PosStore.prototype, {
                 const pendingLine = this.getPendingPaymentLine("mercado_pago");
 
                 if (pendingLine) {
-                    pendingLine.payment_method.payment_terminal.handleMercadoPagoWebhook();
+                    pendingLine.payment_method_id.payment_terminal.handleMercadoPagoWebhook();
                 }
             }
         });


### PR DESCRIPTION
Before this commit:
Nothing would happen after a mercado pago webhook notification received.

Since 17.4, `payment_method` attribute have been changed to `payment_method_id`. Thus it was returning `undefined` and silently fail to update the line

After this commit:
Call `handleMercadoPagoWebhook` on notification received as intended

opw-4349957