### PR TITLE
[FIX] stock: no backorder when quality failed


### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -898,6 +898,10 @@ Please change the quantity done or the rounding precision of your unit of measur
         self.move_line_ids = move_lines_commands
         return True
 
+    def _is_manually_picked(self):
+        self.ensure_one()
+        return not self.scrapped and self.picked
+
     def _create_lot_ids_from_move_line_vals(self, vals_list, product_id, company_id=False):
         """ This method will search or create the lot_id from the lot_name and set it in the vals_list
         """

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1475,9 +1475,7 @@ class Picking(models.Model):
             for move in picking.move_ids:
                 if move.quantity:
                     has_quantity = True
-                if move.scrapped:
-                    continue
-                if move.picked:
+                if move._is_manually_picked():
                     has_pick = True
                 if has_quantity and has_pick:
                     break


### PR DESCRIPTION

Scenario:

- have 3 steps incoming shipments
- create a quality control check for one product
- create and confirm a PO for that product and another one
- fail the quality check, then validate the picking

Result: a backorder will be created for product that was not failed
Expected: no backorder is created

Why: when we fail a quantity, we set the move as "picked", then when
validating the picking, because of this move all move will be set as
picked.

Fix: add a new condition so a move that is picked and has a failed
quality check is not taken into account when deciding if we set all
moves as picked when the picking is validated.

Note: this commit only extract code from _traverse_path in another
method so it can be overrideable.

opw-4363773
