### PR TITLE
[FIX] account_edi_ubl_cii: retrieve product wrong company

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -800,6 +800,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             default_code=self._find_value('./cac:Item/cac:SellersItemIdentification/cbc:ID', tree),
             name=self._find_value('./cac:Item/cbc:Name', tree),
             barcode=self._find_value("./cac:Item/cac:StandardItemIdentification/cbc:ID[@schemeID='0160']", tree),
+            company=invoice_line.company_id
         )
         # Description
         description_node = tree.find('./{*}Item/{*}Description')


### PR DESCRIPTION
When receiving an ubl file by mail, we need to ensure
that the company from where we retrieve the product is the same as
the invoice company, otherwise we end up with an UserError ("Incompatible companies on records").

Steps:

- Have 2 company (X being id == 1 and Y being id == 2)
- Create a product "Locations et leasing opérationnel" with X setas
  company_id
- Create an alias on company Y vendor bills journals
- Sent the `bis3_bill_example.xml` located in `addons/account_edi_ubl_cii/tests/test_files/`
  to the email alias
- Open the created bill
-> Error in the chatter: "Error importing attachment ... as invoice
   (decoder=_import_invoice_ubl_cii)

opw-4444747
