### PR TITLE
[FIX] web: handle sign buttons disability with loaded draw signatures

### DIFF
--- a/addons/web/static/src/core/signature/name_and_signature.js
+++ b/addons/web/static/src/core/signature/name_and_signature.js
@@ -89,7 +89,7 @@ export class NameAndSignature extends Component {
                     }
                     if (this.props.signature.signatureImage) {
                         this.clear();
-                        this.signaturePad.fromDataURL(this.props.signature.signatureImage);
+                        this.fromDataURL(this.props.signature.signatureImage);
                     }
                 }
             },
@@ -121,6 +121,15 @@ export class NameAndSignature extends Component {
     clear() {
         this.signaturePad.clear();
         this.props.signature.isSignatureEmpty = this.isSignatureEmpty;
+    }
+
+    /**
+    * Loads a signature image from a base64 dataURL and updates the empty state.
+    */
+    async fromDataURL() {
+        await this.signaturePad.fromDataURL(...arguments);
+        this.props.signature.isSignatureEmpty = this.isSignatureEmpty;
+        this.props.onSignatureChange(this.state.signMode);
     }
 
     /**

--- a/addons/web/static/tests/core/name_and_signature.test.js
+++ b/addons/web/static/tests/core/name_and_signature.test.js
@@ -95,6 +95,7 @@ test("test name_and_signature widget default signature", async function () {
     };
     const res = await mountWithCleanup(NameAndSignature, { props });
     expect(res.isSignatureEmpty).toBe(false);
+    expect(res.props.signature.isSignatureEmpty).toBe(false);
 });
 
 test("test name_and_signature widget update signmode with onSignatureChange prop", async function () {


### PR DESCRIPTION
Before this commit, although there is a signature loaded in the draw mode, the signature's isSignatureEmpty flag is true, which affects the logic that handles the sign buttons [enable/disable] state.
After this commit, the isSignatureEmpty is handled correctly and the sign buttons' disability logic is clear.

task-4466854
Related: https://github.com/odoo/enterprise/pull/77120

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
