### PR TITLE
[FIX] point_of_sale: respect PoS note order

### DIFF
--- a/addons/point_of_sale/models/pos_note.py
+++ b/addons/point_of_sale/models/pos_note.py
@@ -7,6 +7,7 @@ class PosNote(models.Model):
     _name = 'pos.note'
     _description = 'PoS Note'
     _inherit = ['pos.load.mixin']
+    _order = "sequence"
 
     name = fields.Char(required=True)
     sequence = fields.Integer('Sequence', default=1)


### PR DESCRIPTION
Before this commit, the PoS notes were not displayed in the correct order in the PoS interface, despite the existence of a `sequence` field that allowed users to define their desired order.

opw-4473463

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
