### PR TITLE
[FIX] Compute accrual days on allocations with multiple employees

### DIFF
--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -63,7 +63,7 @@ class TestAllocations(TestHrHolidaysCommon):
             'name': 'Bank Holiday',
             'holiday_type': 'employee',
             'employee_ids': [(4, self.employee.id), (4, self.employee_emp.id)],
-            'employee_id': self.employee.id,
+            'multi_employee': True,
             'holiday_status_id': self.leave_type.id,
             'number_of_days': 2,
             'allocation_type': 'regular',


### PR DESCRIPTION
Steps to reproduce Bug 1:
  1. Create an accrual plan.
  2. Check the box `Based on worked time`.
  3. Create a milestone. The configuration of the milestone is arbitrary. For example accrue 10 days yearly.
  4. Create an allocation.
  5. Set allocation start date 1 year before.
  6. Select accrual allocation.
  7. Choose the accrual plan defined above.
  8.  Set multiple employees on the allocation
  9. the number of allocated days will be 0.

Steps to reproduce Bug 2:
  1. Create an accrual plan and milestone identical to the above but don't check the box `Based on worked time`.
  2. Create an allocation.
  3. Set allocation start date 1 year before.
  4. Select accrual allocation.
  5. Choose the accrual plan defined above
  6. Set a single employee on the allocation
  7. the number of allocated days will be 10.
  8. Set 2 employees on the allocation instead of 1.
  9. the number of allocated days will still be 10.

Required Behavior:
  1. If the accrual plan isn't `based on worked time`, then the number of allocated days should be computed normally on the allocation with multiple employees. 
  2. If the accrual plan `is based on worked time`, then the number of allocated days is different for each employee and it should be set to 0 on the allocation with multiple employees.

task-4481698
