### PR TITLE
[FIX] website: add missing run methods in media dialog tour

### DIFF
--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -74,14 +74,17 @@ registerWebsitePreviewTour("website_media_dialog_external_library", {
     {
         content: "Click on the first illustration image",
         trigger: ".o_select_media_dialog .o_we_attachment_highlight",
+        run: "click",
     },
     {
         content: "Select the image",
-        trigger: "iframe .s_text_image img",
+        trigger: ":iframe .s_text_image img",
+        run: "click",
     },
     {
         content: "Try to crop the image",
         trigger: "#oe_snippets .o_we_customize_panel .o_we_user_value_widget[data-crop='true']",
+        run: "click",
     },
     {
         content: "Observe the crop is denied for illustration image",


### PR DESCRIPTION
This PR adds the missing run methods in the media dialog tour steps **merged** in [commit](https://github.com/odoo/odoo/commit/bee295f). The run methods are necessary to execute the tour steps Without these methods, the tour steps were not executed properly, and the functionality was not tested as intended.

task-4246644