### PR TITLE
[FIX] account_peppol: remove peppol registration migration button

### DIFF
--- a/addons/account_peppol/i18n/account_peppol.pot
+++ b/addons/account_peppol/i18n/account_peppol.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0\n"
+"Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-13 10:27+0000\n"
-"PO-Revision-Date: 2024-08-13 10:27+0000\n"
+"POT-Creation-Date: 2025-01-15 15:33+0000\n"
+"PO-Revision-Date: 2025-01-15 15:33+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -140,13 +140,6 @@ msgstr ""
 #: code:addons/account_peppol/models/res_config_settings.py:0
 #, python-format
 msgid "Can't deregister with this status: %s"
-msgstr ""
-
-#. module: account_peppol
-#. odoo-python
-#: code:addons/account_peppol/models/res_config_settings.py:0
-#, python-format
-msgid "Can't migrate registration with this status: %s"
 msgstr ""
 
 #. module: account_peppol
@@ -800,6 +793,15 @@ msgstr ""
 #: code:addons/account_peppol/models/res_config_settings.py:0
 #, python-format
 msgid "The verification code should contain six digits."
+msgstr ""
+
+#. module: account_peppol
+#. odoo-python
+#: code:addons/account_peppol/models/res_config_settings.py:0
+#, python-format
+msgid ""
+"This feature is deprecated. Contact odoo support if you need a migration "
+"key."
 msgstr ""
 
 #. module: account_peppol

--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -296,15 +296,7 @@ class ResConfigSettings(models.TransientModel):
         The migration key is then displayed in Peppol settings.
         Currently, reopening after migrating away is not supported.
         """
-        self.ensure_one()
-
-        if self.account_peppol_proxy_state != 'active':
-            raise UserError(_(
-                "Can't migrate registration with this status: %s", self.account_peppol_proxy_state
-            ))
-
-        response = self._call_peppol_proxy(endpoint='/api/peppol/1/migrate_peppol_registration')
-        self.account_peppol_migration_key = response['migration_key']
+        raise UserError(_("This feature is deprecated. Contact odoo support if you need a migration key."))
 
     @handle_demo
     def button_deregister_peppol_participant(self):

--- a/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.js
+++ b/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.js
@@ -93,14 +93,6 @@ class PeppolSettingsButtons extends Component {
         });
     }
 
-    migrate() {
-        this.showConfirmation(
-            "This will migrate your Peppol registration away from Odoo. A migration key will be generated. \
-            If the other service does not support migration, consider deregistering instead.",
-            "button_migrate_peppol_registration"
-        )
-    }
-
     deregister() {
         if (this.ediMode === 'demo') {
             this._callConfigMethod("button_deregister_peppol_participant");

--- a/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.xml
+++ b/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.xml
@@ -15,14 +15,6 @@
                 <div class="mt-3">
                     <button type="button"
                             class="btn btn-secondary me-1"
-                            t-on-click="migrate"
-                            t-if="proxyState === 'active' and migrationPrepared === false and ediMode!='demo'">
-                            Migrate registration to another service
-                    </button>
-                </div>
-                <div class="mt-3">
-                    <button type="button"
-                            class="btn btn-secondary me-1"
                             t-on-click="deregister"
                             t-if="proxyState === 'active' and migrationPrepared === false">
                             <t t-out="deregisterUserButtonLabel"/>


### PR DESCRIPTION
Peppol migration creates more issues than it solves. A lot of users issue migration requests to move to another SMP but later discover that the SMP they wanted to migrate to does not support migration keys. This creates a state that we need to handle manually. Most SMP do not support migrating away and force users to deregister and reregister again on another one.

This commit adds a fix in stable for that issue by removing the button from the res_config_settings_buttons and adding a deprecated warning when the user tries to call the `button_migrate_peppol_registration` method.

task-4394408