### PR TITLE
[FIX] base: Test compute field before saving

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -17,7 +17,7 @@ from odoo import api, fields, models, tools, _, _lt, Command
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import pycompat, unique, OrderedSet, lazy_property
-from odoo.tools.safe_eval import safe_eval, datetime, dateutil, time
+from odoo.tools.safe_eval import safe_eval, test_python_expr, datetime, dateutil, time
 
 _logger = logging.getLogger(__name__)
 
@@ -607,6 +607,13 @@ class IrModelFields(models.Model):
                 models.check_pg_name(field.name)
             except ValidationError:
                 msg = _("Field names can only contain characters, digits and underscores (up to 63).")
+                raise ValidationError(msg)
+
+    @api.constrains('compute')
+    def _check_python_compute(self):
+        for action in self.filtered('compute'):
+            msg = test_python_expr(expr=action.compute.strip(), mode="exec")
+            if msg:
                 raise ValidationError(msg)
 
     _sql_constraints = [


### PR DESCRIPTION
Code:
```
for record in self:
  record.x_a = "Hello"
```

Steps:
- try to create a server action with the provided code
    - Fail as expected as code must use "write" instead of "="
- try to create a field with a compute using the provided code
    - New field, so compute seems triggered directly
    - Fail as expected as code must use "write" instead of "="
- try to create a field without the compute just the depends
    - Succeed
- update your new field to use the provided code
    - Succeed --> SHOULD FAIL
- open a record for the new field's model and change its depends field
    - Error

If nothing is specified, default value are used, so the new field is stored

Actual result:
- ValueError: forbidden opcode(s) in 'for record in self:\n  record.x_a = "Hello"': STORE_ATTR

Expected result:
- Error is provided when updating the compute as a ValidationError
- I cannot use invalid code in compute field (on create and on update)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
