### PR TITLE
[FIX] hr_*: allow editing unapproved allocation requests

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -121,9 +121,27 @@
                             </div>
                             <div name="duration_display">
                                 <field name="number_of_days_display" nolabel="1" style="width: 5rem;"
-                                    attrs="{'readonly': ['|', '|', ('type_request_unit', '=', 'hour'), ('state', 'not in', ('draft', 'confirm')), ('allocation_type', '=', 'accrual')], 'invisible': [('type_request_unit', '=', 'hour')]}"/>
+                                    attrs="{'readonly': [
+                                    '|', 
+                                        '|',
+                                            '&amp;',
+                                            ('is_officer', '!=', True),
+                                            ('state', 'not in', ('draft', 'confirm')),
+                                        ('type_request_unit', '=', 'hour'),
+                                    ('allocation_type', '=', 'accrual')
+                                    ], 
+                                    'invisible': [('type_request_unit', '=', 'hour')]}"/>
                                 <field name="number_of_hours_display" nolabel="1" style="width: 5rem;"
-                                    attrs="{'readonly': ['|', '|', ('type_request_unit', '!=', 'hour'), ('state', 'not in', ('draft', 'confirm')), ('allocation_type', '=', 'accrual')], 'invisible': [('type_request_unit', '!=', 'hour')]}"/>
+                                    attrs="{'readonly': [
+                                    '|', 
+                                        '|',
+                                            '&amp;',
+                                            ('is_officer', '!=', True),
+                                            ('state', 'not in', ('draft', 'confirm')),
+                                        ('type_request_unit', '!=', 'hour'),
+                                    ('allocation_type', '=', 'accrual')
+                                    ], 
+                                    'invisible': [('type_request_unit', '!=', 'hour')]}"/>
                                 <span class="ml8" attrs="{'invisible': [('type_request_unit', '=', 'hour')]}">Days</span>
                                 <span class="ml8" attrs="{'invisible': [('type_request_unit', '!=', 'hour')]}">Hours</span>
                             </div>

--- a/addons/hr_holidays_attendance/i18n/hr_holidays_attendance.pot
+++ b/addons/hr_holidays_attendance/i18n/hr_holidays_attendance.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-06 13:31+0000\n"
-"PO-Revision-Date: 2024-02-06 13:31+0000\n"
+"POT-Creation-Date: 2025-02-03 09:16+0000\n"
+"PO-Revision-Date: 2025-02-03 09:16+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -102,6 +102,15 @@ msgid ""
 msgstr ""
 
 #. module: hr_holidays_attendance
+#. odoo-python
+#: code:addons/hr_holidays_attendance/models/hr_leave_allocation.py:0
+#, python-format
+msgid ""
+"Only an Officer or Administrator is allowed to edit the allocation duration "
+"in this status."
+msgstr ""
+
+#. module: hr_holidays_attendance
 #: model:ir.model.fields,field_description:hr_holidays_attendance.field_hr_leave__overtime_deductible
 #: model:ir.model.fields,field_description:hr_holidays_attendance.field_hr_leave_allocation__overtime_deductible
 msgid "Overtime Deductible"
@@ -143,7 +152,6 @@ msgstr ""
 #. module: hr_holidays_attendance
 #. odoo-python
 #: code:addons/hr_holidays_attendance/models/hr_leave.py:0
-#: code:addons/hr_holidays_attendance/models/hr_leave.py:0
 #, python-format
 msgid "The employee does not have enough extra hours to request this leave."
 msgstr ""
@@ -184,7 +192,6 @@ msgstr ""
 
 #. module: hr_holidays_attendance
 #. odoo-python
-#: code:addons/hr_holidays_attendance/models/hr_leave.py:0
 #: code:addons/hr_holidays_attendance/models/hr_leave.py:0
 #, python-format
 msgid "You do not have enough extra hours to request this leave"

--- a/addons/hr_holidays_attendance/models/hr_leave_allocation.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_allocation.py
@@ -52,7 +52,9 @@ class HolidaysAllocation(models.Model):
         res = super().write(vals)
         if 'number_of_days' not in vals:
             return res
-        for allocation in self.filtered('overtime_id'):
+        if not self.env.user.has_group("hr_holidays.group_hr_holidays_user") and any(allocation.state not in ('draft', 'confirm') for allocation in self):
+            raise ValidationError(_('Only an Officer or Administrator is allowed to edit the allocation duration in this status.'))
+        for allocation in self.sudo().filtered('overtime_id'):
             employee = allocation.employee_id
             duration = allocation.number_of_hours_display
             overtime_duration = allocation.overtime_id.sudo().duration


### PR DESCRIPTION
The base.group_user did not have the access right to read overtime_id, which is necessary for filtering allocations that do not have a null overtime_id. The access right was granted to base.group_user only when the allocation state is either draft or confirm.

task-4452360

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
