### PR TITLE
[FIX] mail: fix call on embed livechat

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -12,6 +12,7 @@ import { registry } from "@web/core/registry";
 import { debounce } from "@web/core/utils/timing";
 import { loadBundle, loadJS } from "@web/core/assets";
 import { memoize } from "@web/core/utils/functions";
+import { url } from "@web/core/utils/urls";
 import { callActionsRegistry } from "./call_actions";
 
 /**
@@ -459,7 +460,11 @@ export class Rtc extends Record {
      * @param {boolean} [initialState.camera]
      */
     async toggleCall(channel, { audio = true, camera } = {}) {
-        await loadJS("/mail/static/lib/selfie_segmentation/selfie_segmentation.js");
+        await Promise.resolve(() =>
+            loadJS(url("/mail/static/lib/selfie_segmentation/selfie_segmentation.js")).catch(
+                () => {}
+            )
+        );
         if (this.state.hasPendingRequest) {
             return;
         }


### PR DESCRIPTION
__Current behavior before commit:__
Since [`9592bd1`][1] when the livechat is integrated on a third-party website, a visitor can not answer the call of an operator. This is because the script `selfie_segmentation.js` is being fetched from the third-party website domain instead of the Odoo database domain; resulting in the following error:
`AssetsLoadingError: The loading of
/mail/static/lib/selfie_segmentation/selfie_segmentation.js failed`

__Description of the fix:__
Use of the `url` function to prepend the correct domain name.

opw-4417974

[1]: https://github.com/odoo/odoo/commit/9592bd1