### PR TITLE
[FIX] stock: correct uom write comparison

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -1115,11 +1115,11 @@ class UomUom(models.Model):
 
     def write(self, values):
         # Users can not update the factor if open stock moves are based on it
-        keys_to_protect = {'factor', 'relative_factor', 'relative_uom_id', 'category_id'}
+        keys_to_protect = {'factor', 'relative_factor', 'relative_uom_id'}
         if any(key in values for key in keys_to_protect):
             changed = self.filtered(
-                lambda u: any(u[f] != values[f] if f in values else False
-                              for f in keys_to_protect))
+                lambda u: any(f in values and u[f] != values[f] for f in {'factor', 'relative_factor'}) or
+                          'relative_uom_id' in values and u.relative_uom_id.id != int(values['relative_uom_id']))
             if changed:
                 error_msg = _(
                     "You cannot change the ratio of this unit of measure"


### PR DESCRIPTION
Currently the write will check if uom.relative_uom_id != int, which will throw a UserWarning:

unsupported operand type(s) for "==": 'uom.uom()' == '8'

whenever `relative_uom_id` was written to. Although this error is only show via the log, it's best to not have it at all + we should probably properly enforce the check.

Also, remove `category_id` from the `keys_to_protect` since it was deleted anyways.

Followup to task: 4252043


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
