### PR TITLE
[IMP] stock_landed_costs: test landed costs are added to fifo products

### DIFF
--- a/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
+++ b/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
@@ -150,6 +150,7 @@ class TestStockValuationLCFIFO(TestStockValuationLCCommon):
         move1 = self._make_in_move(self.product1, 10, unit_cost=10, create_picking=True)
         move2 = self._make_in_move(self.product1, 10, unit_cost=20)
         lc = self._make_lc(move1, 100)
+        self.assertEqual(self.product1.standard_price, 15, 'Adding landed cost to FIFO should update standard price')
         move3 = self._make_out_move(self.product1, 1)
 
         self.assertEqual(self.product1.value_svl, 380)


### PR DESCRIPTION
# Leaving test out of original commit

[IMP] stock_landed_costs: test landed costs are added to fifo products

This Adding test that ensures that landed costs are correctly applied
to FIFO products, updating their cost appropriately, based on (ref.1)

(ref.1)
[IMP] stock_account: Set the AVCO value as standard price on product form
9cd316f038dc95051814ede9474f8f15f7d165df

Stems from a bug in the previous versions:
Reproduce
---
- Create a PRODUCT_CATEGORY with First In First Out (FIFO) and Automated Inventory Valuation
- Create a storable PRODUCT in the PRODUCT_CATEGORY
- Create storable COMPONENT with a vendor (ex. cost set to $5)
- Create a MO, manufacture the PRODUCT consuming the COMPONENT
- (Open the PRODUCT, observe: the cost is set to COMPONENT's cost OK (ex. $5))
- Add LANDED_COST (ex. $2 equally split) to the MO
BUG: In PRODUCT, cost isn't updated with LANDED_COST (ex. still $5 instead of $7)

opw-4370005


# legacy commit

Landed costs weren't being added to products using FIFO costing method, unlike products using average cost (AVCO). This fix ensures that landed costs are correctly applied to FIFO products, updating their cost appropriately, based on (ref.1).

Reproduce
---
- Create a PRODUCT_CATEGORY with First In First Out (FIFO) and Automated Inventory Valuation
- Create a storable PRODUCT in the PRODUCT_CATEGORY
- Create storable COMPONENT with a vendor (ex. cost set to $5)
- Create a MO, manufacture the PRODUCT consuming the COMPONENT
- (Open the PRODUCT, observe: the cost is set to COMPONENT's cost OK (ex. $5))
- Add LANDED_COST (ex. $2 equally split) to the MO BUG: In PRODUCT, cost isn't updated with LANDED_COST (ex. still $5 instead of $7)

References
---
(ref.1)
[IMP] stock_account: Set the AVCO value as standard price on product form https://github.com/odoo/odoo/commit/9cd316f038dc95051814ede9474f8f15f7d165df

opw-4370005
