### PR TITLE
16.0 fix cannot drop search block in dutch bvr

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -384,6 +384,7 @@
                 &.o_snippet_install {
                     .btn.o_install_btn {
                         @include o-position-absolute($top: 10px);
+                        @include text-truncate();
                     }
 
                     &:not(:hover) .btn.o_install_btn {

--- a/addons/website/i18n/nl.po
+++ b/addons/website/i18n/nl.po
@@ -238,11 +238,6 @@ msgid "+1 555-555-5556"
 msgstr "+1 555-555-5556"
 
 #. module: website
-#: model_terms:ir.ui.view,arch_db:website.searchbar_input_snippet_options
-msgid ", .s_searchbar_input"
-msgstr ", .s_zoekbalk_input"
-
-#. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_website_form_options
 msgid ", .s_website_form"
 msgstr ", .s_website_form"

--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -221,11 +221,6 @@ msgid "+1 555-555-5556"
 msgstr ""
 
 #. module: website
-#: model_terms:ir.ui.view,arch_db:website.searchbar_input_snippet_options
-msgid ", .s_searchbar_input"
-msgstr ""
-
-#. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_website_form_options
 msgid ", .s_website_form"
 msgstr ""

--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -128,6 +128,17 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
         if (contentAdditionEl) {
             // Necessary to be able to drop "inner blocks" next to an image link.
             contentAdditionEl.dataset.dropNear += ", .row > div:not(.o_grid_item_image) > a";
+            // TODO remove in master
+            // The class is added again here even though it has already been
+            // added by the "searchbar_input_snippet_options" template. We are
+            // doing it again because it was mistakenly translated into Dutch.
+            contentAdditionEl.dataset.selector += ", .s_searchbar_input";
+            contentAdditionEl.dataset.dropNear += ", .s_searchbar_input";
+        }
+        // TODO remove in master
+        const snippetSaveOptionEl = $html.find("[data-js='SnippetSave']")[0];
+        if (snippetSaveOptionEl) {
+            snippetSaveOptionEl.dataset.selector += ", .s_searchbar_input";
         }
     },
     /**

--- a/addons/website/static/src/snippets/s_embed_code/000.scss
+++ b/addons/website/static/src/snippets/s_embed_code/000.scss
@@ -2,3 +2,8 @@
 .editor_enable .s_embed_code {
     min-height: $o-font-size-base;
 }
+
+.s_embed_code .s_embed_code_embedded .bg-light.o_default_snippet_text {
+    background-color: lightcyan !important;
+    color: black;
+}

--- a/addons/website/views/snippets/s_searchbar.xml
+++ b/addons/website/views/snippets/s_searchbar.xml
@@ -55,7 +55,7 @@
             </div>
         </div>
     </xpath>
-    <xpath expr="//*[@t-set='so_content_addition_selector']" position="inside">, .s_searchbar_input</xpath>
+    <xpath expr="//*[@t-set='so_content_addition_selector']" position="inside" t-translation="off">, .s_searchbar_input</xpath>
 </template>
 
 <record id="website.s_searchbar_000_js" model="ir.asset">

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -19,7 +19,7 @@
 
 <template id="s_website_form_options" inherit_id="website.snippet_options">
     <!-- Extend drop locations to columns -->
-    <xpath expr="//t[@t-set='so_content_addition_selector']" position="inside">, .s_website_form</xpath>
+    <xpath expr="//t[@t-set='so_content_addition_selector']" position="inside" t-translation="off">, .s_website_form</xpath>
 
     <xpath expr="//div" position="after">
         <!-- Form -->

--- a/addons/website_event/views/event_snippets.xml
+++ b/addons/website_event/views/event_snippets.xml
@@ -9,7 +9,7 @@
 </template>
 
 <template id="snippet_options" inherit_id="website.snippet_options">
-    <xpath expr="//*[@t-set='so_content_addition_selector']" position="inside">, .s_speaker_bio</xpath>
+    <xpath expr="//*[@t-set='so_content_addition_selector']" position="inside" t-translation="off">, .s_speaker_bio</xpath>
 </template>
 
 <template id="event_searchbar_input_snippet_options" inherit_id="website.searchbar_input_snippet_options" name="event search bar snippet options">

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -184,7 +184,7 @@ database, without the s_newsletter_list class. See fixNewsletterListClass.
 </template>
 
 <template id="newsletter_subscribe_options" name="Newsletter Subscribe Options" inherit_id="website.snippet_options">
-    <xpath expr="//*[@t-set='so_snippet_addition_selector']" position="inside">, .o_newsletter_popup</xpath>
+    <xpath expr="//*[@t-set='so_snippet_addition_selector']" position="inside" t-translation="off">, .o_newsletter_popup</xpath>
     <xpath expr="//div[1]" position="before">
         <div data-js="NewsletterLayout" data-selector=".s_newsletter_block">
             <we-select string="Template"


### PR DESCRIPTION
Since the class `s_searchbar_input` was translated into Dutch by a
translator on Transifex.
<sub>See screenshot of the Website `nl.po` file </sub>↓
<kbd>![image](https://github.com/user-attachments/assets/053f084b-30cf-42d3-9c13-7387b777b88f)</kbd>

It is no longer possible to drop the searchbar
block onto a webpage when Odoo's language is set to Dutch.

In this PR, we add `t-translation="off"` in the xpath that adds
this class to the list of droppable element selectors, so it won't be
translated anymore. We also do the same for other xpath-ed classes that
don’t have `t-translation="off"`, to prevent the same issue elsewhere.

Since the class is already translated in the existing databases, in
stable versions, we add the class a second time to the list of droppable
element selectors. This second class won't be translated, which will fix
the issue for Dutch users.

[opw-4461785](https://www.odoo.com/web#id=4461785&cids=1&menu_id=4720&action=333&active_id=1695&model=project.task&view_type=form)

-----------
Note: This PR also fix 2 minor bugs:
- The text on the button to install a block overflows when translated into certain languages that make it longer.
<kbd>![image](https://github.com/user-attachments/assets/0532c186-c081-4e95-a853-1873e50005ff)</kbd>
- The `Embed code` block "Click on Edit..." message is not visible on dark background.
<kbd>![image](https://github.com/user-attachments/assets/16510ffb-7a2e-4eaa-b5f7-40f0e9d9a943)</kbd>