### PR TITLE
[FIX] html_editor: delete backward on Android Chrome

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -18,7 +18,7 @@ import {
     nextLeaf,
     previousLeaf,
 } from "../utils/dom_info";
-import { getState, isFakeLineBreak, prepareUpdate } from "../utils/dom_state";
+import { getState, isFakeLineBreak, observeMutations, prepareUpdate } from "../utils/dom_state";
 import {
     childNodes,
     closestElement,
@@ -41,6 +41,7 @@ import {
 import { CTYPES } from "../utils/content_types";
 import { withSequence } from "@html_editor/utils/resource";
 import { compareListTypes } from "@html_editor/main/list/utils";
+import { hasTouch, isBrowserChrome } from "@web/core/browser/feature_detection";
 
 /**
  * @typedef {Object} RangeLike
@@ -85,6 +86,8 @@ export class DeletePlugin extends Plugin {
             withSequence(5, this.onBeforeInputInsertText.bind(this)),
             this.onBeforeInputDelete.bind(this),
         ],
+        input_handlers: (ev) => this.onAndroidChromeInput?.(ev),
+        selectionchange_handlers: withSequence(5, () => this.onAndroidChromeSelectionChange?.()),
         /** Overrides */
         delete_backward_overrides: withSequence(30, this.deleteBackwardUnmergeable.bind(this)),
         delete_backward_word_overrides: withSequence(20, this.deleteBackwardUnmergeable.bind(this)),
@@ -1158,8 +1161,11 @@ export class DeletePlugin extends Plugin {
         };
         const argsForDelete = handledInputTypes[ev.inputType];
         if (argsForDelete) {
-            ev.preventDefault();
             this.delete(...argsForDelete);
+            ev.preventDefault();
+            if (isBrowserChrome() && hasTouch()) {
+                this.preventDefaultDeleteAndroidChrome(ev);
+            }
         }
     }
 
@@ -1171,6 +1177,39 @@ export class DeletePlugin extends Plugin {
             }
             // Default behavior: insert text and trigger input event
         }
+    }
+
+    /**
+     * Beforeinput event of type deleteContentBackward cannot be default
+     * prevented in Android Chrome. So we need to revert:
+     * - eventual mutations between beforeinput and input events
+     * - eventual selection change after input event
+     *
+     * @param {InputEvent} beforeInputEvent
+     */
+    preventDefaultDeleteAndroidChrome(beforeInputEvent) {
+        const restoreDOM = this.dependencies.history.makeSavePoint();
+        this.onAndroidChromeInput = (ev) => {
+            if (ev.inputType !== beforeInputEvent.inputType) {
+                return;
+            }
+            // Revert DOM changes that occurred between beforeinput and input.
+            restoreDOM();
+
+            // Revert selection changes after input event, within the same tick.
+            // If further mutations occurred, consider selection change legit
+            // (e.g. dictionary input) and do not revert it.
+            const { restore: restoreSelection } = this.dependencies.selection.preserveSelection();
+            const observerOptions = { childList: true, subtree: true, characterData: true };
+            const getMutationRecords = observeMutations(this.editable, observerOptions);
+            this.onAndroidChromeSelectionChange = () => {
+                const shouldRevertSelectionChanges = !getMutationRecords().length;
+                if (shouldRevertSelectionChanges) {
+                    restoreSelection();
+                }
+            };
+            setTimeout(() => delete this.onAndroidChromeSelectionChange);
+        };
     }
 
     // ======== AD-HOC STUFF ========

--- a/addons/html_editor/static/src/utils/dom_state.js
+++ b/addons/html_editor/static/src/utils/dom_state.js
@@ -564,3 +564,21 @@ export function enforceWhitespace(el, offset, direction, rule) {
         );
     }
 }
+
+/**
+ * Call this function to start watching for mutations.
+ * Call the returned function to stop watching and get the mutation records.
+ *
+ * @returns {() => MutationRecord[]}
+ */
+export function observeMutations(target, observerOptions) {
+    const records = [];
+    const observerCallback = (mutations) => records.push(...mutations);
+    const observer = new MutationObserver(observerCallback);
+    observer.observe(target, observerOptions);
+    return () => {
+        observerCallback(observer.takeRecords());
+        observer.disconnect();
+        return records;
+    };
+}

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -1,10 +1,12 @@
-import { describe, expect, test } from "@odoo/hoot";
+import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
-import { microTick, press } from "@odoo/hoot-dom";
+import { manuallyDispatchProgrammaticEvent, microTick, press } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { deleteBackward, insertText, tripleClick, undo } from "../_helpers/user_actions";
-import { getContent } from "../_helpers/selection";
+import { getContent, setSelection } from "../_helpers/selection";
+import { patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { browser } from "@web/core/browser/browser";
 
 /**
  * content of the "deleteBackward" sub suite in editor.test.js
@@ -2085,6 +2087,80 @@ describe("Selection not collapsed", () => {
                         <div contenteditable="true"><p>[]<br></p></div>
                     </div>`),
             });
+        });
+    });
+
+    describe("Android Chrome", () => {
+        beforeEach(() => {
+            patchWithCleanup(browser.navigator, {
+                userAgent:
+                    "Mozilla/5.0 (Linux; Android 10; Pixel 3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Mobile Safari/537.36",
+            });
+        });
+
+        // This simulates the sequence of events that happens in Android Chrome
+        // when pressing backspace. Some random stuff might happen, and
+        // `extraAction` can be used to simulate that.
+        const backspaceAndroid = async (editor, { extraAction = null } = {}) => {
+            const dispatch = (type, eventInit) =>
+                manuallyDispatchProgrammaticEvent(editor.editable, type, eventInit);
+            const selection = editor.document.getSelection();
+            if (selection.isCollapsed) {
+                selection.modify("extend", "backward", "character");
+            }
+            await dispatch("keydown", { key: "Unidentified" });
+            await dispatch("beforeinput", { inputType: "deleteContentBackward" });
+            // beforeinput event is not default preventable
+            selection.getRangeAt(0).deleteContents();
+            extraAction?.();
+            await dispatch("input", { inputType: "deleteContentBackward" });
+            await dispatch("keyup", { key: "Unidentified" });
+        };
+
+        test.tags("mobile");
+        test("should merge paragraphs and put cursor between c and d", async () => {
+            const { editor, el } = await setupEditor("<p>abc</p><p>[]def</p>");
+            await backspaceAndroid(editor, {
+                extraAction: async () => {
+                    // Simulate what happens in Android Chrome for this particular
+                    // case: after input, the cursor is moved one character to the
+                    // right: <p>abcd[]ef</p>
+                    await microTick();
+                    const secondTextNode = el.querySelector("p").childNodes[1];
+                    setSelection({ anchorNode: secondTextNode, anchorOffset: 1 });
+                },
+            });
+            await tick(); // Wait for the selection change to be handled
+            expect(getContent(el)).toBe("<p>abc[]def</p>");
+        });
+
+        test.tags("mobile");
+        test("should revert random stuff done by chrome", async () => {
+            const { editor, el } = await setupEditor("<p>abc[]</p>");
+            await backspaceAndroid(editor, {
+                extraAction: () =>
+                    el.append(
+                        editor.document.createTextNode("random changes that should be reverted")
+                    ),
+            });
+            expect(getContent(el)).toBe("<p>ab[]</p>");
+        });
+
+        test.tags("mobile");
+        test("should not break Gboard dictionary input", async () => {
+            const { editor, el } = await setupEditor("<p>woonderf[]</p>");
+            // Roughly as observed on Android Chrome with Gboard:
+            // - selection change
+            // - input deleteContentBackward
+            // - input insertText
+            const selection = editor.document.getSelection();
+            for (let i = 0; i < 6; i++) {
+                selection.modify("extend", "backward", "character");
+            }
+            await backspaceAndroid(editor);
+            await insertText(editor, "nderful ");
+            await tick(); // Wait for the selection change to be handled
+            expect(getContent(el)).toBe("<p>wonderful []</p>");
         });
     });
 });


### PR DESCRIPTION
On Android Chrome, for some obscure reason (bug?) the beforeinput event of type deleteContentBackward cannot be default prevented. This leads to unpredictable behavior when deleting content, considering the editor handles the delete operation and assumes the default behavior is prevented.

The steps below illustrate one of the possible issues.

Steps 1:

a. Have the following html:
```
<h1><span style="font-size: 36px;">Welcome to the To-do app! </span></h1>
<p>
    <span style="font-size: 14px;">
        Use it to manage your work</span>
</p>
```

b. On Android Chrome, place the cursor at the beginning of the paragraph and press backspace on the device's virtual keyboard.

As a result, the paragraph is merged with the heading, but the characters "Use it to" disappear:
```
<h1>
    <span style="font-size: 36px;">Welcome to the To-do app!</span>
    <span style="font-size: 14px;">&nbsp;manage your work</span>
</h1>
```

This example was taken from the "Welcome Mitchell Admin" task in the To-do app, so it's easily testable.

Steps 2:

a. On Android Chrome, have two paragraphs with some text, and place the cursor at the beginning of the second paragraph. E.g.:
```
    <p>abc</p>
    <p>[]def</p>
```

b. Press backspace on the device's virtual keyboard.

As a result, the paragraphs are merged (as expected), but the cursor is placed in the wrong position, e.g.: `<p>abcd[]ef</p>`, whilst `<p>abc[]def</p>` was expected.

Since the default behavior cannot be prevented, this commit makes sure that eventual DOM mutations and selection changes occurred after the beforeinput event are reverted, aiming to achieve the same effect as preventing default.

task-4243933
