### PR TITLE
[FIX] web: remove error notification when loading an image

### DIFF
--- a/addons/web/static/src/views/fields/image/image_field.js
+++ b/addons/web/static/src/views/fields/image/image_field.js
@@ -106,9 +106,6 @@ export class ImageField extends Component {
     }
     onLoadFailed() {
         this.state.isValid = false;
-        this.notification.add(this.env._t("Could not display the selected image"), {
-            type: "danger",
-        });
     }
 }
 

--- a/addons/web/static/src/views/fields/image_url/image_url_field.js
+++ b/addons/web/static/src/views/fields/image_url/image_url_field.js
@@ -34,9 +34,6 @@ export class ImageUrlField extends Component {
 
     onLoadFailed() {
         this.state.src = this.constructor.fallbackSrc;
-        this.notification.add(this.env._t("Could not display the specified image url."), {
-            type: "info",
-        });
     }
 }
 


### PR DESCRIPTION
There is already a placeholder image displayed when an image fails to load.

opw-4419565