### PR TITLE
[IMP] core: add handy static methods to the Html field

### DIFF
--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -14,7 +14,7 @@ from psycopg2.extras import Json as PsycopgJson
 
 from odoo.exceptions import UserError
 from odoo.netsvc import COLOR_PATTERN, DEFAULT, GREEN, RED, ColoredFormatter
-from odoo.tools import SQL, html_normalize, html_sanitize, sql
+from odoo.tools import SQL, html_normalize, html_sanitize, html2plaintext, is_html_empty, plaintext2html, sql
 from odoo.tools.misc import SENTINEL, Sentinel
 from odoo.tools.sql import pattern_to_translated_trigram_pattern, pg_varchar, value_to_translated_trigram_pattern
 from odoo.tools.translate import html_translate
@@ -582,3 +582,8 @@ class Html(BaseString):
     def get_trans_terms(self, value):
         # ensure the translation terms are stringified, otherwise we can break the PO file
         return list(map(str, super().get_trans_terms(value)))
+
+    escape = staticmethod(markup_escape)
+    is_empty = staticmethod(is_html_empty)
+    to_plaintext = staticmethod(html2plaintext)
+    from_plaintext = staticmethod(plaintext2html)

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -12,6 +12,7 @@ import time
 import email.utils
 from email.utils import getaddresses as orig_getaddresses
 from urllib.parse import urlparse
+from typing import Literal
 import html as htmllib
 
 import idna
@@ -474,13 +475,13 @@ def validate_url(url):
     return url
 
 
-def is_html_empty(html_content):
+def is_html_empty(html_content: str | markupsafe.Markup | Literal[False] | None) -> bool:
     """Check if a html content is empty. If there are only formatting tags with style
     attributes or a void content  return True. Famous use case if a
     '<p style="..."><br></p>' added by some web editor.
 
-    :param str html_content: html content, coming from example from an HTML field
-    :returns: bool, True if no content found or if containing only void formatting tags
+    :param html_content: html content, coming from example from an HTML field
+    :returns: True if no content found or if containing only void formatting tags
     """
     if not html_content:
         return True
@@ -522,7 +523,12 @@ def create_link(url, label):
     return f'<a href="{url}" target="_blank" rel="noreferrer noopener">{label}</a>'
 
 
-def html2plaintext(html, body_id=None, encoding='utf-8', include_references=True):
+def html2plaintext(
+    html: str | markupsafe.Markup | Literal[False] | None,
+    body_id: str | None = None,
+    encoding: str = 'utf-8',
+    include_references: bool = True
+) -> str:
     """ From an HTML text, convert the HTML to plain text.
     If @param body_id is provided then this is the tag where the
     body (not necessarily <body>) starts.
@@ -596,7 +602,7 @@ def html2plaintext(html, body_id=None, encoding='utf-8', include_references=True
 
     return html.strip()
 
-def plaintext2html(text, container_tag=None):
+def plaintext2html(text: str, container_tag: str | None = None) -> markupsafe.Markup:
     r"""Convert plaintext into html. Content of the text is escaped to manage
     html entities, using :func:`~odoo.tools.misc.html_escape`.
 
@@ -605,10 +611,9 @@ def plaintext2html(text, container_tag=None):
     - convert url into clickable link
     - 2 or more consecutive ``<br/>`` are considered as paragraph breaks
 
-    :param str text: plaintext to convert
-    :param str container_tag: container of the html; by default the content is
+    :param text: plaintext to convert
+    :param container_tag: container of the html; by default the content is
         embedded into a ``<div>``
-    :rtype: markupsafe.Markup
     """
     assert isinstance(text, str)
     text = misc.html_escape(text)


### PR DESCRIPTION
In the same spirit than other handy static methods on fields, like:

* fields.Float.is_zero
* fields.Float.compare
* fields.Float.round
* fields.Date.context_today
* fields.Date.to_date
* fields.Datetime.context_timestamp
* fields.Datetime.to_datetime
* ...

This commit introduces the following static methods on the Html field:

* Html.escape
* Html.is_empty
* Html.to_plaintext
* Html.from_plaintext

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
