### PR TITLE
[FIX] pos_online_payment: access error if no customer when paying online

### DIFF
--- a/addons/pos_online_payment/controllers/payment_portal.py
+++ b/addons/pos_online_payment/controllers/payment_portal.py
@@ -96,7 +96,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
 
         user_sudo = request.env.user
         if not pos_order_sudo.partner_id:
-            user_sudo = request.env.ref('base.public_user')
+            user_sudo = pos_order_sudo.company_id._get_public_user()
         logged_in = not user_sudo._is_public()
         partner_sudo = pos_order_sudo.partner_id or self._get_partner_sudo(user_sudo)
         if not partner_sudo:
@@ -178,7 +178,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
         exit_route = request.httprequest.args.get('exit_route')
         user_sudo = request.env.user
         if not pos_order_sudo.partner_id:
-            user_sudo = request.env.ref('base.public_user')
+            user_sudo = pos_order_sudo.company_id._get_public_user()
         logged_in = not user_sudo._is_public()
         partner_sudo = pos_order_sudo.partner_id or self._get_partner_sudo(user_sudo)
         if not partner_sudo:

--- a/addons/website/models/res_company.py
+++ b/addons/website/models/res_company.py
@@ -39,19 +39,3 @@ class Company(models.Model):
     def google_map_link(self, zoom=8):
         partner = self.sudo().partner_id
         return partner and partner.google_map_link(zoom) or None
-
-    def _get_public_user(self):
-        self.ensure_one()
-        # We need sudo to be able to see public users from others companies too
-        public_users = self.env.ref('base.group_public').sudo().with_context(active_test=False).users
-        public_users_for_website = public_users.filtered(lambda user: user.company_id == self)
-
-        if public_users_for_website:
-            return public_users_for_website[0]
-        else:
-            return self.env.ref('base.public_user').sudo().copy({
-                'name': 'Public user for %s' % self.name,
-                'login': 'public-user@company-%s.com' % self.id,
-                'company_id': self.id,
-                'company_ids': [(6, 0, [self.id])],
-            })

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -426,3 +426,19 @@ class Company(models.Model):
             },
             'views': [[False, 'tree'], [False, 'kanban'], [False, 'form']],
         }
+
+    def _get_public_user(self):
+        self.ensure_one()
+        # We need sudo to be able to see public users from others companies too
+        public_users = self.env.ref('base.group_public').sudo().with_context(active_test=False).users
+        public_users_for_company = public_users.filtered(lambda user: user.company_id == self)
+
+        if public_users_for_company:
+            return public_users_for_company[0]
+        else:
+            return self.env.ref('base.public_user').sudo().copy({
+                'name': 'Public user for %s' % self.name,
+                'login': 'public-user@company-%s.com' % self.id,
+                'company_id': self.id,
+                'company_ids': [(6, 0, [self.id])],
+            })


### PR DESCRIPTION
* STEP TO REPRODUCE: Have 2 company (1 is Default San Francisco the other is VN company),Start enviroment in VN company -> config an online payment method with
Demo/Wire
Transfer -> Start session and create pos order with no customer then Validate -> Customer scan QR code using mobile (not logged in) -> 403 forbidden error, read the log said: Sorry, Public user for VN company (id=10) doesn't have 'read' access to: User (res.users)
* REASON: when request.env.ref('base.public_user') it will get public user from San Francisco company while the request user is Public User of VN company, the record rule prevent that
* SOLUTION: Fix by using method _get_public_user() in res.company, this
commit also move _get_public_user() from website to base module so other
modules can use it

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
