### PR TITLE
[FIX] discuss: prevent traceback with sessions missing a channelMember

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
@@ -60,11 +60,12 @@ export class DiscussSidebarCallParticipants extends Component {
     get sessions() {
         const sessions = [...this.props.thread.rtcSessions];
         return sessions.sort((s1, s2) => {
-            const persona1 = s1.channelMember.persona;
-            const persona2 = s2.channelMember.persona;
+            const persona1 = s1.channelMember?.persona;
+            const persona2 = s2.channelMember?.persona;
             return (
                 persona1?.name?.localeCompare(persona2?.name) ||
-                s1.channelMember.id - s2.channelMember.id
+                s1.channelMember?.id - s2.channelMember?.id ||
+                s1.id - s2.id
             );
         });
     }


### PR DESCRIPTION
Since [1], the session getter for the sidebar cards assumes that channelMember is always defined on rtcSessions, this could cause tracebacks.

[1]: https://github.com/odoo/odoo/pull/190050

