### PR TITLE
[IMP] point_of_sale: revert send mail server action

### DIFF
--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -460,4 +460,16 @@ if records:
     action = records.action_pos_order_cancel()
         </field>
     </record>
+
+    <record id="model_pos_order_send_mail" model="ir.actions.server">
+        <field name="name">Send Email</field>
+        <field name="model_id" ref="point_of_sale.model_pos_order"/>
+        <field name="binding_model_id" ref="point_of_sale.model_pos_order"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">
+            if records:
+                action = records.with_context(hide_default_template=True).action_send_mail()
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Before this commit:
==========
- The Send Mail server action was removed in the SM cleanup PR while improving the mail template flow. This improvement broke down the email marketing flow from PoS.

After this commit:
==========
- Send Mail server action reverted to do email marketing from PoS.

task-4464312