### PR TITLE
[IMP] point_of_sale: ui improvements

### DIFF
--- a/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
+++ b/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
@@ -26,11 +26,11 @@
                         </div>
                     </div>
                     <div t-if="order.internal_note"
-                        class="internal-note-container d-flex gap-2">
+                        class="internal-note-container d-flex gap-2 flex-wrap">
                         <t t-foreach="order.internal_note.split('\n') or []" t-as="note"
                             t-key="note_index">
                             <li t-if="note.trim() !== ''" t-esc="note"
-                                class="internal-note badge mt-1 p-2 rounded-pill bg-info text-info bg-opacity-25"
+                                class="internal-note badge rounded text-bg-info"
                                 style="font-size: 0.85rem;"/>
                         </t>
                     </div>

--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.Orderline">
         <li t-if="line.order_id" class="orderline position-relative d-flex align-items-center lh-sm cursor-pointer"
-            t-attf-class="{{ line.combo_parent_id?.getFullProductName() ? 'orderline-combo fst-italic' : '' }}"
+            t-attf-class="{{ line.combo_parent_id?.getFullProductName() ? 'orderline-combo fst-italic ms-4 border-start' : '' }}"
             t-att-class="{'selected' : line.isSelected() and this.props.mode === 'display', ...line.getDisplayClasses(), ...(props.class || [])}">
             <div class="product-order"></div>
             <div t-if="props.showImage and line.product_id.getImageUrl()" class="o_line_container d-flex align-items-center justify-content-center">
@@ -15,7 +15,13 @@
                             <t t-esc="line.getQuantityStr().unitPart"/>
                             <small t-if="line.getQuantityStr().decimalPart" class="fw-normal text-muted" t-esc="line.getQuantityStr().decimalPart"/>
                         </span>
-                        <span class="text-wrap" t-esc="line.getFullProductName()"/>
+                        <span class="text-wrap d-inline">
+                            <t t-esc="line.orderDisplayProductName.name" />
+                            <br/>
+                            <small class="attribute-line fst-italic ms-2" t-if="line.orderDisplayProductName.attributeString">
+                                <t t-esc="line.orderDisplayProductName.attributeString" />
+                            </small>
+                        </span>
                         <t t-slot="product-name" />
                     </div>
                     <div t-if="!props.basic_receipt" t-esc="line.getPriceString()" class="product-price price fw-bolder"/>
@@ -32,12 +38,17 @@
                         <i class="fa fa-sticky-note me-1" role="img" aria-label="Customer Note" title="Customer Note"/>
                         <t t-esc="line.customer_note" />
                     </li>
-                    <div t-if="this.props.mode === 'display'" class="internal-note-container d-flex gap-2">
+                    <div t-if="this.props.mode === 'display'" class="internal-note-container d-flex gap-2 flex-wrap">
                         <t t-foreach="line.note?.split?.('\n') or []" t-as="note" t-key="note_index">
-                            <li t-if="note.trim() !== ''" t-esc="note" class="internal-note badge mt-2 p-2 rounded-pill bg-info text-info bg-opacity-25" style="font-size: 0.85rem;" />
+                            <li t-if="note.trim() !== ''" t-esc="note" class="internal-note badge rounded text-bg-info" style="font-size: 0.85rem;" />
                         </t>
                     </div>
-                    <li t-foreach="line.packLotLines or []" t-as="lot" t-key="lot_index" t-esc="lot" />
+                    <div class="mt-1 d-flex gap-2 align-items-center">
+                        <t t-slot="pack-lot-icon" />
+                        <div class="fst-italic">
+                            <li t-foreach="line.packLotLines or []" t-as="lot" t-key="lot_index" t-esc="lot" />
+                        </div>
+                    </div>
                     <t t-slot="default" />
                 </ul>
             </div>

--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.scss
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.scss
@@ -45,7 +45,7 @@
     }
 
     > .qty {
-        min-width: 3rem;
+        min-width: 2rem;
     }
 }
 

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -1,5 +1,5 @@
 import { registry } from "@web/core/registry";
-import { constructFullProductName, uuidv4 } from "@point_of_sale/utils";
+import { constructFullProductName, uuidv4, constructAttributeString } from "@point_of_sale/utils";
 import { Base } from "./related_models";
 import { parseFloat } from "@web/views/fields/parsers";
 import { formatFloat, roundDecimals, roundPrecision, floatIsZero } from "@web/core/utils/numbers";
@@ -721,6 +721,12 @@ export class PosOrderline extends Base {
     }
     getFullProductName() {
         return this.full_product_name || this.product_id.display_name;
+    }
+    get orderDisplayProductName() {
+        return {
+            name: this.product_id?.name,
+            attributeString: constructAttributeString(this),
+        };
     }
     isSelected() {
         return this.order_id?.uiState?.selected_orderline_uuid === this.uuid;

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -16,7 +16,7 @@
             <span t-esc="currentOrder.preset_id?.name" />
         </button>
         <button class="btn btn-secondary btn-lg flex-shrink-0 ms-auto more-btn" t-if="!props.showRemainingButtons and !ui.isSmall and props.onClickMore" t-on-click="props.onClickMore">
-            <i class="fa fa-ellipsis-v" aria-hidden="true" />
+            <i class="fa fa-fw fa-ellipsis-v" aria-hidden="true" />
         </button>
         <!-- All these buttons will only be displayed in a dialog -->
         <t t-if="props.showRemainingButtons">

--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
@@ -4,7 +4,7 @@
 		<OrderDisplay order="currentOrder" t-slot-scope="scope">
 			<t t-set="line" t-value="scope.line" />
 			<Orderline line="line" t-on-click="(event) => this.clickLine(event, line)">
-				<t t-set-slot="product-name">
+				<t t-set-slot="pack-lot-icon">
 					<i t-if="line.getProduct()?.product_tmpl_id?.isTracked()"
 						t-on-click.stop="() => this.editPackLotLines(line)" role="img"
 						t-attf-class="{{ line.hasValidProductLot() ? 'text-success' : 'text-danger'}} fa fa-list line-lot-icon ms-1"

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.scss
@@ -19,6 +19,10 @@
     color: $o-action;
 }
 
+.ticket-screen .delete-column {
+    width: 30px;
+}
+
 @include media-breakpoint-down(sm) {
     .screen-full-width {
         flex-direction: column;

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -62,7 +62,7 @@
                                             <td class="align-middle">
                                                 <div class="fw-bolder"><t t-esc="getTotal(order)"></t></div>
                                             </td>
-                                            <td class="align-middle">
+                                            <td class="align-middle text-end">
                                                 <t t-set="status" t-value="getStatus(order)" />
                                                 <div t-attf-class="badge rounded fs-6 text-bg-{{
                                                     status === 'Ongoing' || status === 'Payment'
@@ -74,7 +74,7 @@
                                                     <t t-esc="status"></t>
                                                 </div>
                                             </td>
-                                            <td class="text-end" name="delete-column">
+                                            <td class="text-end delete-column" name="delete-column">
                                                 <button t-if="!shouldHideDeleteButton(order) and this.pos.cashier._role !== 'minimal'" t-on-click.stop="() => this.pos.onDeleteOrder(order)" class="btn btn-link btn-lg text-danger">
                                                     <i class="fa fa-trash" aria-hidden="true"/>
                                                 </button>

--- a/addons/point_of_sale/static/src/scss/pos_variables_extra.scss
+++ b/addons/point_of_sale/static/src/scss/pos_variables_extra.scss
@@ -1,3 +1,3 @@
-$left-pane-width: 500px !default;
+$left-pane-width: 450px !default;
 $left-pane-width-tablet: 400px !default;
 $navbar-height: 61px !default;

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -31,7 +31,7 @@ export function deduceUrl(url) {
     return url;
 }
 
-export function constructFullProductName(line) {
+export function constructAttributeString(line) {
     let attributeString = "";
 
     if (line.attribute_value_ids && line.attribute_value_ids.length > 0) {
@@ -50,10 +50,16 @@ export function constructFullProductName(line) {
         }
 
         attributeString = attributeString.slice(0, -2);
-        attributeString = ` (${attributeString})`;
     }
 
-    return `${line?.product_id?.name}${attributeString}`;
+    return attributeString;
+}
+
+export function constructFullProductName(line) {
+    const attributeString = constructAttributeString(line);
+    return attributeString
+        ? `${line?.product_id?.name} (${attributeString})`
+        : `${line?.product_id?.name}`;
 }
 /**
  * Returns a random 5 digits alphanumeric code

--- a/addons/point_of_sale/static/tests/generic_helpers/order_widget_util.js
+++ b/addons/point_of_sale/static/tests/generic_helpers/order_widget_util.js
@@ -29,6 +29,7 @@ export function hasLine({
     discount,
     oldPrice,
     priceNoDiscount,
+    attributeLine,
 } = {}) {
     let trigger = `.order-container .orderline${withClass}`;
     if (withoutClass) {
@@ -58,6 +59,9 @@ export function hasLine({
     }
     if (priceNoDiscount) {
         trigger += `:has(.info-list:contains("${priceNoDiscount}"))`;
+    }
+    if (attributeLine) {
+        trigger += `:has(.attribute-line:contains("${attributeLine}"))`;
     }
     const args = JSON.stringify(arguments[0]);
     return [

--- a/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
@@ -37,9 +37,10 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
 
             // Check that the product has been added to the order with correct attributes and price
             ProductScreen.selectedOrderlineHas(
-                "Configurable Chair (Fabrics: Other: Custom Fabric, Metal, Red)",
+                "Configurable Chair",
                 "1",
-                "11.0"
+                "11.0",
+                "Fabrics: Other: Custom Fabric, Metal, Red"
             ),
 
             // Orderlines with the same attributes should be merged
@@ -50,9 +51,10 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
             ProductConfigurator.fillCustomAttribute("Custom Fabric"),
             Dialog.confirm(),
             ProductScreen.selectedOrderlineHas(
-                "Configurable Chair (Fabrics: Other: Custom Fabric, Metal, Red)",
+                "Configurable Chair",
                 "2",
-                "22.0"
+                "22.0",
+                "Fabrics: Other: Custom Fabric, Metal, Red"
             ),
 
             // Orderlines with different attributes shouldn't be merged
@@ -62,9 +64,10 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
             ProductConfigurator.pickRadio("Leather"),
             Dialog.confirm(),
             ProductScreen.selectedOrderlineHas(
-                "Configurable Chair (Leather, Metal, Blue)",
+                "Configurable Chair",
                 "1",
-                "10.0"
+                "10.0",
+                "Leather, Metal, Blue"
             ),
 
             // Inactive variant attributes should not be displayed
@@ -84,10 +87,10 @@ registry.category("web_tour.tours").add("PosProductWithDynamicAttributes", {
             ProductScreen.clickDisplayedProduct("Dynamic Product"),
             ProductConfigurator.pickRadio("Test 1"),
             Dialog.confirm(),
-            ProductScreen.selectedOrderlineHas("Dynamic Product (Test 1)", "1", "1.15"),
+            ProductScreen.selectedOrderlineHas("Dynamic Product", "1", "1.15", "Test 1"),
             ProductScreen.clickDisplayedProduct("Dynamic Product"),
             ProductConfigurator.pickRadio("Test 2"),
             Dialog.confirm(),
-            ProductScreen.selectedOrderlineHas("Dynamic Product (Test 2)", "1", "12.65"),
+            ProductScreen.selectedOrderlineHas("Dynamic Product", "1", "12.65", "Test 2"),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -287,10 +287,10 @@ registry.category("web_tour.tours").add("limitedProductPricelistLoading", {
             ProductScreen.selectedOrderlineHas("Test Product 1", "1", "80.0"),
 
             scan_barcode("0100201"),
-            ProductScreen.selectedOrderlineHas("Test Product 2 (White)", "1", "100.0"),
+            ProductScreen.selectedOrderlineHas("Test Product 2", "1", "100.0", "White"),
 
             scan_barcode("0100202"),
-            ProductScreen.selectedOrderlineHas("Test Product 2 (Red)", "1", "120.0"),
+            ProductScreen.selectedOrderlineHas("Test Product 2", "1", "120.0", "Red"),
 
             scan_barcode("0100300"),
             ProductScreen.selectedOrderlineHas("Test Product 3", "1", "50.0"),

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -419,13 +419,14 @@ export function isShown() {
         },
     ];
 }
-export function selectedOrderlineHas(productName, quantity, price) {
+export function selectedOrderlineHas(productName, quantity, price, attributeLine = "") {
     return inLeftSide(
         Order.hasLine({
             withClass: ".selected",
             productName,
             quantity,
             price,
+            attributeLine,
         })
     );
 }


### PR DESCRIPTION
In this commit:
===
- Added the fa-fw class to the expand controls menu button for icon sizing.
- Reduced the size of the left pane to 10% for better screen utilization.
- Displayed product attribute names below the product name in the cart.
- Right-aligned the status in the ticket screen for improved layout consistency.

task-4486420

