### PR TITLE
[FIX] account: Print & Send - Remove deadcode

### DIFF
--- a/addons/account/wizard/account_move_send_wizard.py
+++ b/addons/account/wizard/account_move_send_wizard.py
@@ -361,27 +361,15 @@ class AccountMoveSendWizard(models.TransientModel):
     # BUSINESS ACTIONS
     # -------------------------------------------------------------------------
 
-    @api.model
-    def _action_download(self, attachments):
-        """ Download the PDF attachment, or a zip of attachments if there are more than one. """
-        return {
-            'type': 'ir.actions.act_url',
-            'url': f'/account/download_invoice_attachments/{",".join(map(str, attachments.ids))}',
-            'close': True,
-        }
-
     def action_send_and_print(self, allow_fallback_pdf=False):
         """ Create invoice documents and send them."""
         self.ensure_one()
         if self.alerts:
             self._raise_danger_alerts(self.alerts)
         self._update_preferred_settings()
-        attachments = self._generate_and_send_invoices(
+        self._generate_and_send_invoices(
             self.move_id,
             **self._get_sending_settings(),
             allow_fallback_pdf=allow_fallback_pdf,
         )
-        if attachments and self.sending_methods and 'manual' in self.sending_methods:
-            return self._action_download(attachments)
-        else:
-            return {'type': 'ir.actions.act_window_close'}
+        return {'type': 'ir.actions.act_window_close'}


### PR DESCRIPTION
With previous commit [1], we aligned the Print & Send wizard's behavior to the one in the Sales app.
It's no longer possible to download directly from the wizard, therefore the code removed in this commit was never accessed.

[1]: https://github.com/odoo/odoo/commit/7ad7a1d976391e81eaa03be7076cc61f4a6cfcbe

task-no
