### PR TITLE
[FIX] account: hide purchase tab on product template

### DIFF
--- a/addons/account/views/product_view.xml
+++ b/addons/account/views/product_view.xml
@@ -49,9 +49,6 @@
             <field name="priority">5</field>
             <field name="inherit_id" ref="product.product_template_form_view"/>
             <field name="arch" type="xml">
-                <xpath expr="//page[@name='purchase']" position="attributes">
-                    <attribute name="invisible" remove="1" separator="or"/>
-                </xpath>
                 <xpath expr="//field[@name='company_id']" position="after">
                     <field name="fiscal_country_codes" invisible="1"/>
                 </xpath>


### PR DESCRIPTION
Before the refactoring of uom, it was possible to define `uom_po_id`, the uom for purchase that was used for vendor bills. This was the only setting to define in Purchase tab if the Purchase app was not installed.

Since the commit removed this field, the tab became useless and should be removed.

*https://github.com/odoo/odoo/commit/d3fa388cf7c41984b5f7cbc2a81fec3e27a00325