### PR TITLE
[IMP] web: showing module_loader errors

### DIFF
--- a/addons/mrp_subcontracting/views/subcontracting_portal_templates.xml
+++ b/addons/mrp_subcontracting/views/subcontracting_portal_templates.xml
@@ -95,7 +95,6 @@
                 </script>
                 <base target="_parent"/>
                 <t t-call-assets="mrp_subcontracting.webclient"/>
-                <t t-call="web.conditional_assets_tests"/>
             </t>
             <t t-set="head" t-value="head_subcontracting_portal + (head or '')"/>
             <t t-set="body_classname" t-value="'o_web_client o_subcontracting_portal'"/>

--- a/addons/web/static/src/module_loader.js
+++ b/addons/web/static/src/module_loader.js
@@ -145,68 +145,33 @@
                 return;
             }
 
-            function domReady(cb) {
-                if (document.readyState === "complete") {
-                    cb();
-                } else {
-                    document.addEventListener("DOMContentLoaded", cb);
+            const style = document.createElement("style");
+            style.textContent = `
+                body::before {
+                    font-weight: bold;
+                    content: "An error occurred while loading javascript modules, you may find more information in the devtools console";
+                    position: fixed;
+                    left: 0;
+                    bottom: 0;
+                    z-index: 100000000000;
+                    background-color: #C00;
+                    color: #DDD;
                 }
-            }
+            `;
 
-            function list(heading, names) {
-                const frag = document.createDocumentFragment();
-                if (!names || !names.length) {
-                    return frag;
-                }
-                frag.textContent = heading;
-                const ul = document.createElement("ul");
-                for (const el of names) {
-                    const li = document.createElement("li");
-                    li.textContent = el;
-                    ul.append(li);
-                }
-                frag.appendChild(ul);
-                return frag;
+            document.head.appendChild(style);
+            if (failed.length) {
+                console.error("The following modules failed to load because of an error:", failed)
             }
-
-            domReady(() => {
-                // Empty body
-                while (document.body.childNodes.length) {
-                    document.body.childNodes[0].remove();
-                }
-                const container = document.createElement("div");
-                container.className =
-                    "o_module_error position-fixed w-100 h-100 d-flex align-items-center flex-column bg-white overflow-auto modal";
-                container.style.zIndex = "10000";
-                const alert = document.createElement("div");
-                alert.className = "alert alert-danger o_error_detail fw-bold m-auto";
-                container.appendChild(alert);
-                alert.appendChild(
-                    list(
-                        "The following modules failed to load because of an error, you may find more information in the devtools console:",
-                        failed
-                    )
-                );
-                alert.appendChild(
-                    list(
-                        "The following modules could not be loaded because they form a dependency cycle:",
-                        cycle && [cycle]
-                    )
-                );
-                alert.appendChild(
-                    list(
-                        "The following modules are needed by other modules but have not been defined, they may not be present in the correct asset bundle:",
-                        missing
-                    )
-                );
-                alert.appendChild(
-                    list(
-                        "The following modules could not be loaded because they have unmet dependencies, this is a secondary error which is likely caused by one of the above problems:",
-                        unloaded
-                    )
-                );
-                document.body.appendChild(container);
-            });
+            if (missing) {
+                console.error("The following modules are needed by other modules but have not been defined, they may not be present in the correct asset bundle:", missing);
+            }
+            if (cycle) {
+                console.error("The following modules could not be loaded because they form a dependency cycle:", cycle);
+            }
+            if (unloaded) {
+                console.error("The following modules could not be loaded because they have unmet dependencies, this is a secondary error which is likely caused by one of the above problems:", unloaded);
+            }
         }
     }
 


### PR DESCRIPTION
Before this commit, the module_loader was showing error by empty the DOM and then adding his element with the errors. The issue is, if you have an error because of custom script or after an upgrade, then you were lockout because the DOM with empty and you cannot go fix the script.

After this commit, a shorter message will be shown in the bottom-left of the screen. This message will invite the user to check the devtool to have more details about the error.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
