### PR TITLE
[FIX] mail: command description cropped

### DIFF
--- a/addons/mail/static/src/components/composer_suggestion_view/composer_suggestion_view.xml
+++ b/addons/mail/static/src/components/composer_suggestion_view/composer_suggestion_view.xml
@@ -6,14 +6,14 @@
             <a class="o_ComposerSuggestionView dropdown-item d-flex w-100 py-2 px-4" t-att-class="{ 'active bg-300': composerSuggestionView.composerSuggestionListViewOwnerAsActiveSuggestionView }" t-attf-class="{{ className }}" href="#" t-att-title="composerSuggestionView.title" role="menuitem" t-on-click="composerSuggestionView.onClick" t-ref="root">
                 <t t-if="composerSuggestionView.suggestable.cannedResponse">
                     <strong class="o_ComposerSuggestionView_part1 flex-shrink-0 mw-100 pe-2 text-truncate"><t t-esc="composerSuggestionView.suggestable.cannedResponse.source"/></strong>
-                    <em class="o_ComposerSuggestionView_part2 text-600 text-truncate"><t t-esc="composerSuggestionView.suggestable.cannedResponse.substitution"/></em>
+                    <span class="o_ComposerSuggestionView_part2 text-600 text-truncate"><t t-esc="composerSuggestionView.suggestable.cannedResponse.substitution"/></span>
                 </t>
                 <t t-if="composerSuggestionView.suggestable.thread">
                     <strong class="o_ComposerSuggestionView_part1 flex-shrink-0 mw-100 pe-2 text-truncate"><t t-esc="composerSuggestionView.suggestable.thread.name"/></strong>
                 </t>
                 <t t-if="composerSuggestionView.suggestable.channelCommand">
                     <strong class="o_ComposerSuggestionView_part1 flex-shrink-0 mw-100 pe-2 text-truncate"><t t-esc="composerSuggestionView.suggestable.channelCommand.name"/></strong>
-                    <em class="o_ComposerSuggestionView_part2 text-600 text-truncate"><t t-esc="composerSuggestionView.suggestable.channelCommand.help"/></em>
+                    <span class="o_ComposerSuggestionView_part2 text-600 text-truncate"><t t-esc="composerSuggestionView.suggestable.channelCommand.help"/></span>
                 </t>
                 <t t-if="composerSuggestionView.suggestable.partner">
                     <t t-if="composerSuggestionView.personaImStatusIconView">
@@ -25,7 +25,7 @@
                     </t>
                     <strong class="o_ComposerSuggestionView_part1 flex-shrink-0 mw-100 pe-2 text-truncate"><t t-esc="composerSuggestionView.suggestable.partner.nameOrDisplayName"/></strong>
                     <t t-if="composerSuggestionView.suggestable.partner.email">
-                        <em class="o_ComposerSuggestionView_part2 text-600 text-truncate">(<t t-esc="composerSuggestionView.suggestable.partner.email"/>)</em>
+                        <span class="o_ComposerSuggestionView_part2 text-600 text-truncate">(<t t-esc="composerSuggestionView.suggestable.partner.email"/>)</span>
                     </t>
                 </t>
             </a>


### PR DESCRIPTION
Purpose of this commit:
The command descriptions currently use an italic font style due to being wrapped in the emphasis tag, causing the text to appear cropped at the end of the sentence. This commit resolves the issue by replacing the emphasis tag with a span tag.

task-4485553



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
