### PR TITLE
[FIX] mail: command description cropped

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -124,7 +124,7 @@
         <strong class="px-2 py-1 align-self-center flex-shrink-0 text-truncate">
             <t t-esc="partner.name"/>
         </strong>
-        <em t-if="partner.email" class="text-600 text-truncate align-self-center">(<t t-esc="partner.email"/>)</em>
+        <span t-if="partner.email" class="text-600 text-truncate align-self-center">(<t t-esc="partner.email"/>)</span>
     </t>
 
     <t t-name="mail.Composer.suggestionThread">
@@ -137,17 +137,17 @@
         <strong class="px-2 py-1 align-self-center flex-shrink-0 text-truncate">
             <t t-esc="option.label"/>
         </strong>
-        <em class="text-600 text-truncate align-self-center">
+        <span class="text-600 text-truncate align-self-center">
             <t t-esc="option.help"/>
-        </em>
+        </span>
     </t>
 
     <t t-name="mail.Composer.suggestionCannedResponse">
         <strong class="px-2 py-1 align-self-center flex-shrink-0 text-truncate">
             <t t-esc="option.source"/>
         </strong>
-        <em class="text-600 text-truncate align-self-center">
+        <span class="text-600 text-truncate align-self-center">
             <t t-esc="option.label"/>
-        </em>
+        </span>
     </t>
 </templates>


### PR DESCRIPTION
Purpose of this commit:
The command descriptions (canned responses, channel command) currently use an italic font style due to being wrapped in the emphasis tag, causing the text to appear cropped at the end of the sentence. This commit resolves the issue by replacing the emphasis tag with a span tag.

task-4485553





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
