### PR TITLE
[FIX] website_slides: fix test dependent on demo data

### DIFF
--- a/addons/website_slides/tests/test_attendee.py
+++ b/addons/website_slides/tests/test_attendee.py
@@ -603,7 +603,7 @@ class TestAttendeeCase(HttpCaseWithUserPortal):
             "Mail subject should have been translated into recipient's language"
         )
 
-    @users('demo', 'portal')
+    @users('user_emp', 'portal')
     def test_channel_visibility_on_website(self):
         """Check visibility of channels for Internal/Portal users."""
         visible_channel = self.env['slide.channel'].search([


### PR DESCRIPTION
The demo user is only accessible with demo data, which may not
work if demo data is not used.

Followup of https://github.com/odoo/odoo/pull/179915

Runbot-111710