### PR TITLE
[FIX] base: fix warning message for company check

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4319,7 +4319,7 @@ class BaseModel(metaclass=MetaModel):
                     _logger.warning(_(
                         "Skipping a company check for model %(model_name)s. Its fields %(field_names)s are set as company-dependent, "
                         "but the model doesn't have a `company_id` or `company_ids` field!",
-                        model_name=self.model_name, field_names=regular_fields
+                        model_name=self._name, field_names=regular_fields
                     ))
                     continue
                 for name in regular_fields:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In the company check warning message, self.model_name was used instead of self._name. 

Current behavior before PR:
model_name is not an attribute of the class BaseModel, which causes an AttributeError when the warning message is triggered.

Desired behavior after PR is merged:
Warning message correctly logged without having an error.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
