### PR TITLE
[FIX] point_of_sale: fix `getPortalURL()`

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
@@ -65,6 +65,6 @@ export class OrderReceipt extends Component {
         return this.order.lines.some((line) => line.taxGroupLabels);
     }
     getPortalURL() {
-        return `${this.props.data.base_url}/pos/ticket`;
+        return `${this.order.session._base_url}/pos/ticket`;
     }
 }


### PR DESCRIPTION
access the url through `order.session._base_url` rather than the `props`
