### PR TITLE
[IMP] product: improve layout of weight and volume fields with UOMs

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -364,14 +364,14 @@
                         <group>
                             <group name="weight" string="Logistics" invisible="type != 'consu'">
                                 <label for="volume"/>
-                                <div class="o_row">
+                                <div class="d-flex">
                                     <field name="volume" class="oe_inline"/>
-                                    <span><field name="volume_uom_name"/></span>
+                                    <field name="volume_uom_name"/>
                                 </div>
                                 <label for="weight"/>
-                                <div class="o_row">
+                                <div class="d-flex">
                                     <field name="weight" class="oe_inline"/>
-                                    <span><field name="weight_uom_name"/></span>
+                                    <field name="weight_uom_name"/>
                                 </div>
                             </group>
                             <group name="sales" string="Sales">


### PR DESCRIPTION
In This Commit:
---------------------------
- Refined the layout to align weight and volume fields with their respective unit of measures (UOMs), improving readability.

task-4475793
