### PR TITLE
[FIX] website: translate model form labels

### DIFF
--- a/addons/website/models/website_form.py
+++ b/addons/website/models/website_form.py
@@ -23,7 +23,7 @@ class IrModel(models.Model):
 
     website_form_access = fields.Boolean('Allowed to use in forms', help='Enable the form builder feature for this model.')
     website_form_default_field_id = fields.Many2one('ir.model.fields', 'Field for custom form data', domain="[('model', '=', model), ('ttype', '=', 'text')]", help="Specify the field which will contain meta and custom form fields datas.")
-    website_form_label = fields.Char("Label for form action", help="Form action label. Ex: crm.lead could be 'Send an e-mail' and project.issue could be 'Create an Issue'.")
+    website_form_label = fields.Char("Label for form action", help="Form action label. Ex: crm.lead could be 'Send an e-mail' and project.issue could be 'Create an Issue'.", translate=True)
     website_form_key = fields.Char(help='Used in FormBuilder Registry')
 
     def _get_form_writable_fields(self, property_origins=None):


### PR DESCRIPTION
When `website` is installed, models have a `website_form_label` field that is used when an instance of that model can be created through a website form. It will show in the "Action" dropdown list on the "Form" component.

However, that field was not translatable and thus always shown in English. This commit fixes that by making it translatable.

[opw-4421055](https://www.odoo.com/odoo/project.task/4421055)