### PR TITLE
[FIX] account: fix fiscalyear last day in name sequence

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3503,6 +3503,8 @@ class AccountMove(models.Model):
         last_month = int(self.company_id.fiscalyear_last_month)
         is_staggered_year = last_month != 12 or last_day != 31
         if is_staggered_year:
+            max_last_day = calendar.monthrange(self.date.year, last_month)[1]
+            last_day = min(last_day, max_last_day)
             if self.date > date(self.date.year, last_month, last_day):
                 year_part = "%s-%s" % (self.date.strftime('%y'), (self.date + relativedelta(years=1)).strftime('%y'))
             else:


### PR DESCRIPTION
When computing an invoice name placeholder dynamically the sequence used depends on the fiscal year end date but it does not account for february 29 on non-leap years, which is a [valid](https://github.com/odoo/odoo/blob/893b253644159a70d1916e3eaf25d1c8af4e92c3/addons/account/models/company.py#L294-L298) date. Here an adjustment for the day is added to safely compare a date with the fiscalyear end.


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
