### PR TITLE
[FIX] resource : Avoid override the company_id

### DIFF
--- a/addons/resource/models/resource_calendar_leaves.py
+++ b/addons/resource/models/resource_calendar_leaves.py
@@ -58,7 +58,8 @@ class ResourceCalendarLeaves(models.Model):
     @api.depends('calendar_id')
     def _compute_company_id(self):
         for leave in self:
-            leave.company_id = leave.calendar_id.company_id or self.env.company
+            if not leave.company_id:
+                leave.company_id = leave.calendar_id.company_id or leave.resource_id.company_id or self.env.company
 
     @api.depends('date_from')
     def _compute_date_to(self):


### PR DESCRIPTION
In this FW-port https://github.com/odoo/enterprise/pull/74528 we are having a test failing when checking I found out that it is failing because demo data of payroll belgian localization as it is creating a public holiday which affects the working dates of the test 'test_move_backward_without_conflicts'.

This public holiday https://github.com/odoo/enterprise/blob/c16044ce583fd2caf9210ab2621e2bcd55be4421/l10n_be_hr_payroll/data/l10n_be_hr_payroll_demo.xml#L29-L35 should be only for the belgian company but since company_id field in 'resource.calendar.leaves' is readonly and computed so it is not protected while creation https://github.com/odoo/odoo/blob/0506eb85a3f6717117110bed53c4397e25672dc5/odoo/models.py#L4780-L4781 at some point it is getting changed to the main company id when computing the company_id in resource.calendar.leave since we don't have a calendar_id
https://github.com/odoo/odoo/blob/d8fa043f085ee1e1d11708e2bd1213b7ce3c9dd9/addons/resource/models/resource_calendar_leaves.py#L59-L61

To fix this while computing the company_id we are now checking if the company_id is not set as if it is already has a value we will not override it and we fallback on the resource_id.company_id before we get the self.env.company