### PR TITLE
[FIX] point_of_sale: set opening amount to last session's closing balance

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1664,8 +1664,8 @@ class PosSession(models.Model):
         if cash_payment_method_ids:
             self.opening_notes = notes
             difference = cashbox_value - self.cash_register_balance_start
-            self.cash_register_balance_start = cashbox_value
             self._post_cash_details_message('Opening cash', self.cash_register_balance_start, difference, notes)
+            self.cash_register_balance_start = cashbox_value
         elif notes:
             message = _('Opening control message: ')
             message += notes


### PR DESCRIPTION
- Resolved issue where the "expected opening" amount in the POS session chatter incorrectly displayed the manually modified amount instead of the previous closing balance.
- Adjusted the sequence of setting `cash_register_balance_start` to maintain consistent chatter messages with accurate deltas.

task-id: 4471816

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
