### PR TITLE
[FIX] account: prevent singleton error during journal entry reversal

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -969,7 +969,7 @@ class AccountPaymentRegister(models.TransientModel):
             'memo': self.communication,
             'journal_id': self.journal_id.id,
             'company_id': self.company_id.id,
-            'currency_id': self.currency_id.id,
+            'currency_id': self.currency_id.id or self.env.company.currency_id.id,
             'partner_id': self.partner_id.id,
             'partner_bank_id': self.partner_bank_id.id,
             'payment_method_line_id': self.payment_method_line_id.id,


### PR DESCRIPTION
Currently, an error was occurring when a user tried to reverse a journal entry.

Step to reproduce:
---
- Enabled payroll entries in Payroll > Configuration > Settings.
- Created a new employee and its corresponding contract in payroll.
- Computed the payslip, generated draft journal entries, and created a payment.
- In accounting check in payments by payslip, currency id will not get fetched.
- Make a reverse entry.

Traceback:
---
ValueError: Expected singleton: res.currency().

This is because at [1] does not have ``currency_id`` in self so it does not link any currency with account payment register

This commit will fix the above issue by providing default company currency when currency is not found in self.

[1] - https://github.com/odoo/odoo/blob/0583db332efdc884975da1a074c91981d2865c9d/addons/account/wizard/account_payment_register.py#L972

sentry-6207053954

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
