### PR TITLE
[FIX] web: no *_view_ref propagation after m2o opening

### DIFF
--- a/addons/web/static/src/views/fields/many2one/many2one_field.js
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.js
@@ -176,6 +176,14 @@ export class Many2OneField extends Component {
         const action = await this.orm.call(this.relation, "get_formview_action", [[this.resId]], {
             context: this.context,
         });
+        // filter out *_view_ref keys from next action context
+        const refinedContext = {};
+        for (const key in action.context) {
+            if (!key.endsWith("_view_ref")) {
+                refinedContext[key] = action.context[key];
+            }
+        }
+        action.context = refinedContext;
         await this.action.doAction(action);
     }
     async openDialog(resId) {


### PR DESCRIPTION
Scenario:

- install hr_expense
- in settings enable "Google Images" and fill dummy parameters
- create an expanse for category "[FOOD] Meals"
- follow the internal link to the product
- click on gear icon > Get Pictures from Google Images

Result: error because there is no field 'product_variant_count' on the 'product.fetch.image.wizard' model

Expected result: no error

Why: the form_view_ref of the category field is kept after opening the product.product window action, so when opening the form view for the model product.fetch.image.wizard we will erroneously use the product.product view which causes an error.

Fix: WIP

opw-4358190