### PR TITLE
[FIX] certificate: show an error if the private key cannot be loaded

### DIFF
--- a/addons/certificate/models/key.py
+++ b/addons/certificate/models/key.py
@@ -135,9 +135,13 @@ class Key(models.Model):
         if self.public:
             raise UserError(_("Make sure to use a private key to sign documents."))
 
+        pem_key = self.with_context(bin_size=False).pem_key
+        if self.loading_error:
+            raise UserError(self.name + " - " + self.loading_error)
+
         return self._sign_with_key(
             message,
-            self.with_context(bin_size=False).pem_key,
+            pem_key,
             pwd=None,
             hashing_algorithm=hashing_algorithm,
             formatting=formatting


### PR DESCRIPTION
When the private key has an issue if we attempt to sing an invoice we may get a traceback in the frontend. We can instead show an error and include the key that's failing.

Example traceback if the key is invalid:
```
  File "/home/odoo/src/odoo/18.0/addons/certificate/models/key.py", line 206, in _sign_with_key
    private_key = serialization.load_pem_private_key(base64.b64decode(pem_key), pwd)
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/base64.py", line 83, in b64decode
    s = _bytes_from_decode_data(s)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/base64.py", line 45, in _bytes_from_decode_data
    raise TypeError("argument should be a bytes-like object or ASCII "
TypeError: argument should be a bytes-like object or ASCII string, not 'bool'
```

Steps to reproduce:
1. Install l10n_sa_edi
3. Alter the key in a way that makes it fail to load, e.g. upload a garbage text file as a key (note the error in the warning)
2. Make an invoice to ARAMCO partner
4. Click in the `Process now` link at the top of the invoice

We get the traceback.

This issue was seen during upgrades due to improper migration of SA keys (already solved). Still the UX here is suboptimal. This patch proposes to show an error that can help users understand the issue. We already show the error in the keys management interface, but the user working in invoices may be unaware of the issue with the key.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
