### PR TITLE
[IMP] point_of_sale: remove iot patch loop from build

### DIFF
--- a/addons/point_of_sale/tools/posbox/posbox_create_image.sh
+++ b/addons/point_of_sale/tools/posbox/posbox_create_image.sh
@@ -140,14 +140,6 @@ rm -rf "${CLONE_DIR}"
 rm -rf "${OVERWRITE_FILES_BEFORE_INIT_DIR}/usr"
 cp -a "${OVERWRITE_FILES_AFTER_INIT_DIR}"/* "${MOUNT_POINT}"
 
-find "${MOUNT_POINT}"/ -type f -name "*.iotpatch"|while read iotpatch; do
-    DIR=$(dirname "${iotpatch}")
-    BASE=$(basename "${iotpatch%.iotpatch}")
-    find "${DIR}" -type f -name "${BASE}" ! -name "*.iotpatch"|while read file; do
-        patch -f --verbose "${file}" < "${iotpatch}"
-    done
-done
-
 # cleanup
 umount -fv "${MOUNT_POINT}"/boot/
 umount -lv "${MOUNT_POINT}"/


### PR DESCRIPTION
In odoo/odoo#192449, we removed the only code patch we had on the IoT Box. We can then remove the patching logic.
