### PR TITLE
[FIX] mail: full composer auto-save does not affect other composers

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -576,7 +576,7 @@ export class Composer extends Component {
                     );
                     const editorIsEmpty = !editor || !editor.innerText.replace(/^\s*$/gm, "");
                     if (!editorIsEmpty) {
-                        this.saveContent();
+                        this.saveContent({ editor });
                         this.restoreContent();
                     }
                 } else {
@@ -739,14 +739,14 @@ export class Composer extends Component {
         this.props.composer.isFocused = false;
     }
 
-    saveContent() {
+    /** @param {HTMLElement} [editor] if set, this is a save from full composer editor. */
+    saveContent({ editor = false } = {}) {
         const composer = toRaw(this.props.composer);
-        const editable = document.querySelector(".o_mail_composer_form_view .note-editable");
         const config = {};
-        if (editable) {
+        if (editor) {
             Object.assign(config, {
                 emailAddSignature: false,
-                text: editable.innerText.replace(/(\t|\n)+/g, "\n")
+                text: editor.innerText.replace(/(\t|\n)+/g, "\n"),
             });
         } else {
             Object.assign(config, {


### PR DESCRIPTION
Before this commit, when some conversations were open in chat windows and the full composer was open in a chatter, the content of full composer message composition could be duplicated in other conversation composers.

Steps to reproduce:
- open a discuss conversation in chat window
- open a form view with chatter
- quickly perform these actions in a 5 seconds window:
  - type something in composer of discuss chat window
  - clear content in composer of discuss chat window
  - open basic composer of chatter then type something
  - open the full composer
- wait about 5 seconds, then open a new browser tab with the same URL
=> the chat window of discuss conversation contains the full composer text content

This happens because when some content is typed in the non-full composer, the text content is regularly saved in local storage so that content is not lost on page reload.

The saving is debounced 5 seconds whenever the user types something.

The full composer must also be saved & restored in chatter, as this is also a frequent point of typing long messages and content may be lost without the save & restore feature.
The code to handling it was poorly written and forgot to assume there could be more than 1 composer open at once: whenever a save content in composer is in progress, it was simply checking whether a full composer is open, and if so it was simply saving the full composer content.

This explains the problem in the scenario above: when typing in discuss conversation in chat window, the save content is triggered after 5 seconds. The opening of full composer disrupts the discuss conversation composer content saving by not saving the discuss conversation composer but instead the full composer content in it.

This commit fixes the issue by enforcing debounce saving to save the content in the current composer. The full composer was never intended to be implied in the debounced save content, only the basic composer is. The full composer saving content works differently: whenever the full composer is closed in non-discard way the save of full composer in basic composer must happen.

Task-4485021

![Jan-16-2025 12-38-38](https://github.com/user-attachments/assets/1637bebe-e3e0-41f5-8cdf-24f3264b4318)
