### PR TITLE
[FIX] im_livechat: hotkeys don't work on close confirmation

### DIFF
--- a/addons/im_livechat/static/src/embed/common/chat_window_patch.js
+++ b/addons/im_livechat/static/src/embed/common/chat_window_patch.js
@@ -30,6 +30,7 @@ patch(ChatWindow.prototype, {
     },
 
     onCloseConfirmationDialog() {
+        this.contentRef.el.querySelector(".o-mail-Composer-input").focus();
         this.state.actionsDisabled = false;
         this.livechatState.showCloseConfirmation = false;
     },

--- a/addons/im_livechat/static/src/embed/common/close_confirmation.js
+++ b/addons/im_livechat/static/src/embed/common/close_confirmation.js
@@ -1,12 +1,12 @@
-import { Component } from "@odoo/owl";
-import { useAutofocus } from "@web/core/utils/hooks";
+import { Component, onMounted, useRef } from "@odoo/owl";
 
 export class CloseConfirmation extends Component {
     static template = "im_livechat.CloseConfirmation";
     static props = ["onCloseConfirmationDialog", "onClickLeaveConversation"];
 
     setup() {
-        useAutofocus({ refName: "root" });
+        this.root = useRef("root");
+        onMounted(() => this.root.el.focus());
     }
 
     onKeydown(ev) {

--- a/addons/im_livechat/static/src/embed/common/close_confirmation.xml
+++ b/addons/im_livechat/static/src/embed/common/close_confirmation.xml
@@ -3,7 +3,7 @@
     <t t-name="im_livechat.CloseConfirmation">
         <div
             class="o-livechat-CloseConfirmation z-1 bg-black-50 position-absolute w-100 h-100 d-flex justify-content-center align-items-center"
-            t-on-keydown.capture.stop="onKeydown"
+            t-on-keydown.stop="onKeydown"
             t-on-click.stop="() => this.props.onCloseConfirmationDialog()"
             t-ref="root"
             tabindex="1"


### PR DESCRIPTION
Before this commit, the Escape and Enter hotkeys did not work to cancel and confirm the `CloseConfirmation` in livechat. This happened because:
- The `keydown' event is not captured without the focused element.
- `useAutofocus` doesn't detect the element properly because the active element in the ui service is set by the main tree DOM root, not the shadow root. This PR makes sure that the close confirmation element is focusable on mounting and also puts the focus on the chat window composer on cancel so it's more effective in case the user needs to type or use Esc to reopen close confirmation.

