### PR TITLE
[FIX] hr_holidays: fix graphs in time off reporting by type

### DIFF
--- a/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_model.js
+++ b/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_model.js
@@ -69,5 +69,6 @@ export class HrHolidaysGraphModel extends GraphModel {
             }
             return processedDataPoints;
         }
+        return super._getProcessedDataPoints();
     }
 }

--- a/addons/hr_holidays/static/tests/tours/time_off_graph_view_tour.js
+++ b/addons/hr_holidays/static/tests/tours/time_off_graph_view_tour.js
@@ -1,0 +1,39 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+registry.category("web_tour.tours").add("time_off_graph_view_tour", {
+    url: "/odoo",
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Open Time Off app",
+            trigger: ".o_app[data-menu-xmlid='hr_holidays.menu_hr_holidays_root']",
+            run: "click",
+        },
+        {
+            content: "Open reporting menu",
+            trigger: ".o-dropdown[data-menu-xmlid='hr_holidays.menu_hr_holidays_report']",
+            run: "click",
+        },
+        {
+            content: "Open reporting by type",
+            trigger: ".o-dropdown-item[data-menu-xmlid='hr_holidays.menu_hr_holidays_summary_all']",
+            run: "click",
+        },
+        {
+            content: "Open bar chart view",
+            trigger: "button[data-mode='bar']",
+            run: "click",
+        },
+        {
+            content: "Open line chart view",
+            trigger: "button[data-mode='line']",
+            run: "click",
+        },
+        {
+            content: "Open pie chart view",
+            trigger: "button[data-mode='pie']",
+            run: "click",
+        }
+    ]
+});

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -28,3 +28,4 @@ from . import test_expiring_leaves
 from . import test_hr_departure_wizard
 from . import test_time_off_card_tour
 from . import test_hr_leave_type_tour
+from . import test_time_off_graph_view_tour

--- a/addons/hr_holidays/tests/test_time_off_graph_view_tour.py
+++ b/addons/hr_holidays/tests/test_time_off_graph_view_tour.py
@@ -1,0 +1,8 @@
+from odoo.tests import HttpCase, tagged, users
+
+@tagged('post_install', '-at_install')
+class TestTimeOffGraphViewTour(HttpCase):
+
+    @users('admin')
+    def test_time_off_graph_view_tour(self):
+        self.start_tour('/', 'time_off_graph_view_tour', login='admin')


### PR DESCRIPTION
The line and pie chart were crashing in the time off reporting by type. Steps to reproduce:
- Open time off > Reporting > By type
- Click on the line or pie chart view

This commit fixes the issue by processing the data points for the line and pie chart views.

task-4477518
