### PR TITLE
[FIX] stock_account: Update lot_valuated from ProductProduct

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -150,6 +150,9 @@ class ProductProduct(models.Model):
     def write(self, vals):
         if 'standard_price' in vals and not self.env.context.get('disable_auto_svl'):
             self.filtered(lambda p: p.cost_method != 'fifo')._change_standard_price(vals['standard_price'])
+        if 'lot_valuated' in vals:
+            # lot_valuated must be updated from the ProductTemplate
+            self.product_tmpl_id.write({'lot_valuated': vals.pop('lot_valuated')})
         return super().write(vals)
 
     @api.onchange('standard_price')

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -634,3 +634,42 @@ class TestLotValuation(TestStockValuationCommon):
         quant.action_apply_inventory()
 
         self.assertEqual(lot.value_svl, 0)
+
+    def test_lot_valuated_update_from_product_product(self):
+        tmpl1 = self.product1.product_tmpl_id
+        tmpl1.categ_id.property_cost_method = 'average'
+        tmpl1.standard_price = 1
+        tmpl1.tracking = 'lot'
+        tmpl1.lot_valuated = False
+
+        lot = self.env['stock.lot'].create({
+            'product_id': self.product1.id,
+            'name': 'test',
+        })
+        quant = self.env['stock.quant'].create({
+            'product_id': self.product1.id,
+            'lot_id': lot.id,
+            'location_id': self.stock_location.id,
+            'inventory_quantity': 1
+        })
+        quant.action_apply_inventory()
+
+        self.assertEqual(self.product1.quantity_svl, 1)
+        self.assertEqual(self.product1.value_svl, 1)
+        self.assertEqual(lot.quantity_svl, 0)
+        self.assertEqual(lot.value_svl, 0)
+
+        self.product1.lot_valuated = True  # The update is done from the ProductProduct model
+        self.env.cr.flush()
+        self.assertEqual(lot.quantity_svl, 1)
+        self.assertEqual(lot.value_svl, 1)
+        self.assertEqual(self.product1.quantity_svl, 1)
+        self.assertEqual(self.product1.value_svl, 1)
+
+        self.product1.lot_valuated = False  # Check that
+        self.env.cr.flush()
+
+        self.assertEqual(self.product1.quantity_svl, 1)
+        self.assertEqual(self.product1.value_svl, 1)
+        self.assertEqual(lot.quantity_svl, 0)
+        self.assertEqual(lot.value_svl, 0)


### PR DESCRIPTION
The write logic for lot_valuated is handled on the ProductTemplate. When you change the value of 'lot_valuated', '_svl_empty_stock()' is called before the new value is set, and the code expects ProductTemplate.lot_valuated and ProductProduct.lot_valuated to not yet be updated. However, if you change 'lot_valuated' from the ProductProduct model, ProductProduct.lot_valuated will be updated before ProductTemplate.write() is called. Hence, in '_svl_empty_stock()', ProductTemplate.lot_valuated != ProductProduct.lot_valuated

This issue only happens in the 'write' context, so it should not cause too much issue.

To fix this issue, when lot_valuated is updated from ProductProduct, we call the ProductTemplate write instead.
---


https://github.com/user-attachments/assets/9d2f64a4-a7ad-4078-ad0b-0cc50270492b


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
