### PR TITLE
[FIX] account: domestic currency comp exist

### DIFF
--- a/addons/account/models/res_currency.py
+++ b/addons/account/models/res_currency.py
@@ -103,7 +103,9 @@ class ResCurrency(models.Model):
         domestic_currency_companies = companies.filtered(lambda x: x.currency_id == main_company.currency_id)
         other_companies = companies - domestic_currency_companies
 
-        table_builders = [self._get_table_builder_domestic_currency(domestic_currency_companies, use_cta_rates)]
+        table_builders = []
+        if domestic_currency_companies:
+            table_builders += [self._get_table_builder_domestic_currency(domestic_currency_companies, use_cta_rates)]
 
         last_date_to = None
         for period_key, date_from, date_to in date_periods:


### PR DESCRIPTION
We are not gonna find a value for domestic_currency_companies everytime, sometime they simply don't exist. In that case, we should check that they exist before we call _get_table_builder_domestic_currency.

otherwise syntax of this query: https://github.com/odoo/odoo/blob/18.0/addons/account/models/res_currency.py#L157 is gonna be wrong.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
