### PR TITLE
[FIX] mrp: allow finished lot production via quality checks

### DIFF
--- a/addons/mrp/models/stock_lot.py
+++ b/addons/mrp/models/stock_lot.py
@@ -12,6 +12,8 @@ class StockLot(models.Model):
         active_mo_id = self.env.context.get('active_mo_id')
         if active_mo_id:
             active_mo = self.env['mrp.production'].browse(active_mo_id)
-            if not active_mo.picking_type_id.use_create_components_lots:
+            component_product_ids = set(active_mo.move_raw_ids.product_id.ids)
+            product_ids = self.env.context.get('lot_product_ids')
+            if not active_mo.picking_type_id.use_create_components_lots and product_ids & component_product_ids:
                 raise UserError(_('You are not allowed to create or edit a lot or serial number for the components with the operation type "Manufacturing". To change this, go on the operation type and tick the box "Create New Lots/Serial Numbers for Components".'))
         return super()._check_create()

--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -149,7 +149,8 @@ class StockLot(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        self._check_create()
+        lot_product_ids =  {val.get('product_id') for val in vals_list} | {self.env.context.get('default_product_id')}
+        self.with_context(lot_product_ids=lot_product_ids)._check_create()
         return super(StockLot, self.with_context(mail_create_nosubscribe=True)).create(vals_list)
 
     def write(self, vals):


### PR DESCRIPTION
### Steps to reproduce:

- Create a storable product FP tracked by SN with a BOM:
    - 1 Operation: - instruction: Register Production type (per product)
    - 1 x Comp (storable product in stock)
- Create and confirm an MO for one unit of FP.
- Go to the shopfoor app > open the instruction of your operation
- Type a non-existing serial number in the search bar > Create "new_sn"
> This opens a form view of the stock.lot model
- Save and close the new stock.lot
> Invalid operation: You are not allowed to create or edit a lot or serial number for the components with the operation type
> "Manufacturing". To change this, go on the operation type and tick the box "Create New Lots/Serial Numbers for
> Components"

#### Expected behavior:

The invalid operation should not be raised as the "required" option concerns only componenets and not final products.

### Cause of the issue:

Creating a stock lot will first launch a call of the `_check_create`: https://github.com/odoo/odoo/blob/c25d71f14fa168807f07cd88bed805d15db8add5/addons/stock/models/stock_lot.py#L150-L153 However, since this check does not verifies that the product for which we create the lot is indeed related to a component of the MO it will raise the invalid operation even for final products: https://github.com/odoo/odoo/blob/c25d71f14fa168807f07cd88bed805d15db8add5/addons/mrp/models/stock_lot.py#L11-L17

### Issue 2:

Currently, the `quickCreate` ("Create *sn_name*") option of the lot field of te "register production" dialog calls a `name_create` that will set an error message in the logs as the product_id required field can not be provided neither in the vals or the context of the `name_create`.  You then fall back on the same form dialog than the "Create and edit".  The `quickCreate` option should therefore just be disabled.

Enterprise: https://github.com/odoo/enterprise/pull/77265

opw-4452747
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
