### PR TITLE
[FIX] web_editor: adapt `border-style` value based on border widths

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -445,6 +445,8 @@ function classToStyle($editable, cssRules) {
                 style = `${key}:${value};${style}`;
             }
         };
+
+        style = correctBorderAttributes(style);
         if (_.isEmpty(style)) {
             writes.push(() => { node.removeAttribute('style'); });
         } else {
@@ -1702,6 +1704,56 @@ function _normalizeStyle(style) {
     element.parentElement.insertBefore(wrapper, element);
     wrapper.append(element);
     return wrapper;
+}
+
+/**
+ * Corrects the `border-style` attribute in the provided inline style string.
+ * This is specifically for Outlook, which displays borders even when their widths are set to 0px.
+ * If all border widths are 0, the function updates `border-style` to `none`.
+ *
+ * @param {string} style - The inline style string to correct.
+ * @returns {string} - The corrected inline style string.
+ */
+function correctBorderAttributes(style) {
+    const stylesObject = style
+        .replace(/\s+/g, "")
+        .split(";")
+        .reduce((styles, styleString) => {
+            const [attribute, value] = styleString.split(":").map((str) => str.trim());
+            if (attribute) {
+                styles[attribute] = value;
+            }
+            return styles;
+        }, {});
+
+    const BORDER_WIDTHS_ATTRIBUTES = [
+        "border-bottom-width",
+        "border-left-width",
+        "border-right-width",
+        "border-top-width",
+    ];
+
+    const isBorderStyleApplied = BORDER_WIDTHS_ATTRIBUTES.some(
+        (attribute) => attribute in stylesObject
+    );
+
+    if (!isBorderStyleApplied) {
+        return style;
+    }
+
+    const totalBorderWidth = BORDER_WIDTHS_ATTRIBUTES.reduce((totalWidth, attribute) => {
+        const widthValue = stylesObject[attribute] || "0px";
+        const numericWidth = parseFloat(widthValue.replace("px", "")) || 0;
+        return totalWidth + numericWidth;
+    }, 0);
+
+    if (totalBorderWidth === 0) {
+        stylesObject["border-style"] = "none";
+    }
+
+    return Object.entries(stylesObject)
+        .map(([attribute, value]) => `${attribute}:${value}`)
+        .join(";");
 }
 
 export default {

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -1066,6 +1066,52 @@ QUnit.module('convert_inline', {}, function () {
 
         $styleSheet.remove();
     });
+
+    QUnit.test('Correct border attributes for outlook', async function (assert) {
+        assert.expect(2);
+
+        const $styleSheet = $('<style type="text/css" title="test-stylesheet"/>');
+        document.head.appendChild($styleSheet[0])
+        const styleSheet = [...document.styleSheets].find(sheet => sheet.title === 'test-stylesheet');
+
+        styleSheet.insertRule(`
+            .test-border-zero {
+                border-bottom-width: 0px;
+                border-left-width: 0px;
+                border-right-width: 0px;
+                border-top-width: 0px;
+                border-style: solid;
+            }
+        `, 0);
+
+        styleSheet.insertRule(`
+            .test-border-one {
+                border-bottom-width: 1px;
+                border-left-width: 1px;
+                border-right-width: 1px;
+                border-top-width: 1px;
+                border-style: solid;
+            }
+        `, 1);
+
+        let $editable = $(`<div><div class="test-border-zero"></div></div>`);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        assert.strictEqual($editable.html(),
+            `<div class="test-border-zero" style="border-style:none;box-sizing:border-box;border-top-width:0px;border-right-width:0px;border-left-width:0px;border-bottom-width:0px"></div>`,
+            "Should change border-style to none",
+        );
+
+        $editable = $(`<div><div class="test-border-one"></div></div>`);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        assert.strictEqual($editable.html(),
+            `<div class="test-border-one" style="border-style:solid;box-sizing:border-box;border-top-width:1px;border-right-width:1px;border-left-width:1px;border-bottom-width:1px"></div>`,
+            "Should keep border style solid"
+        );
+
+        styleSheet.deleteRule(0);
+        styleSheet.deleteRule(0);
+        $styleSheet.remove();
+    });
 });
 
 });


### PR DESCRIPTION
[FIX] web_editor: adapt `border-style` value based on border widths

**Problem**:  
Outlook always displays the border of an element if `border-style` is set  
to `solid`, even when all border widths are 0.  

**Solution**:  
Change `border-style` to `none` if all border widths are 0.  

**Steps to Reproduce**:  
1. Open the "Event: Registration Confirmation" email template in the web editor.  
2. Add a character and save the template.  
3. Check the saved `body_html`.  
   -> All table elements will have `border-style: solid;` added as inline styling,  
      causing borders to appear in Outlook.  

opw-4211794

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
