### PR TITLE
[IMP] base: add phonenumbers package.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -89,3 +89,4 @@ XlsxWriter==3.1.9 ; python_version >= '3.12'
 xlwt==1.3.0
 zeep==4.1.0 ; python_version < '3.11'  # (jammy)
 zeep==4.2.1 ; python_version >= '3.11'
+phonenumbers==8.12.39


### PR DESCRIPTION
This commit adds the `phonenumbers` package in the `requirements.txt`
file as it's needed in the VoIP module to get the country code of the
phone numbers the calls are made to.

Task-441692

Enterprise: https://github.com/odoo/enterprise/pull/77271