### PR TITLE
[FIX] point_of_sale: display correct stock quantity for product variants

### DIFF
--- a/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.js
+++ b/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.js
@@ -16,7 +16,7 @@ export class ProductInfoBanner extends Component {
 
     setup() {
         this.pos = usePos();
-        this.fetchStock = useTrackedAsync((p) => this.pos.getProductInfo(p, 1));
+        this.fetchStock = useTrackedAsync((p) => this.pos.getProductInfo(p, 1), { keepLast: true });
         this.ui = useState(useService("ui"));
         this.state = useState({
             other_warehouses: [],


### PR DESCRIPTION
Currently, for products with variants, the quantities on hand displayed in the product configurator can be incorrect.

### Steps to reproduce

* Install `point_of_sale`.
* Start the furniture shop POS session.
* Click on the Conference Chair; the steel legs are selected by default, and the system displays quantities on hand as 30.
* Switch to aluminum legs; the quantity remains 30.
* Switch back to steel legs.

You should see that the quantity on hand is now 26. This is the actual, correct quantity for steel legs. The originally displayed value of 30 was already incorrect for those legs.

### Cause

The issue arises from how the product's quantities on hand are fetched and updated:

- The `useEffect` hook is used to fetch quantities on hand whenever the product changes.
- However, the function used to retrieve these quantities (`fetchStock`) is wrapped with `useTrackedAsync`, which internally utilizes `useAsyncLockedMethod`.
- The `useAsyncLockedMethod` hook ensures that two calls to `fetchStock` cannot run simultaneously; if `fetchStock` is called while another call is still in progress, the subsequent call is ignored.

This behavior causes the problem. In the product attribute component, the `useEffect` hook is triggered twice in rapid succession when switching attributes. Since the second `fetchStock` call happens before the first completes, it is discarded due to the locking mechanism. As a result, the product changes twice, but the stock fetching process is executed only once, causing a mismatch between the selected product variant and its displayed quantities on hand.

### Fix

The `useTrackedAsync` utility was updated to allow specifying the locking mechanism. Specifically, it now supports an option to keep the last call instead of the first. This change ensures that even when multiple `fetchStock` calls are triggered in quick succession, the most recent call is executed, maintaining synchronization between the product variant and the displayed stock quantities.

opw-4421070