### PR TITLE
[FIX] account: edi format parent partner

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -640,10 +640,10 @@ class ResPartner(models.Model):
     @api.depends_context('company')
     def _compute_invoice_edi_format(self):
         for partner in self:
-            if partner.invoice_edi_format_store == 'none':
+            if partner.commercial_partner_id.invoice_edi_format_store == 'none':
                 partner.invoice_edi_format = False
             else:
-                partner.invoice_edi_format = partner.invoice_edi_format_store or partner._get_suggested_invoice_edi_format()
+                partner.invoice_edi_format = partner.commercial_partner_id.invoice_edi_format_store or partner.commercial_partner_id._get_suggested_invoice_edi_format()
 
     def _inverse_invoice_edi_format(self):
         for partner in self:


### PR DESCRIPTION
The invoice edi format should be take from the parent
of the partner instead of the partner himself.

Steps:

- Create an individual partner X and set an edi format
- Create a company partner Y and set a different edi format
- Make X child of Y
- Create an invoice for X, confirm and click on 'Send and print' button
-> The edi file is in the format set on X instead of the format set on Y

opw-4480527
