### PR TITLE
[FIX] delivery: fix loc. selector maker position

### DIFF
--- a/addons/delivery/static/src/js/location_selector/map/map.js
+++ b/addons/delivery/static/src/js/location_selector/map/map.js
@@ -107,6 +107,8 @@ export class Map extends Component {
                     'delivery.locationSelector.map.marker',
                     { number: locations.indexOf(loc) + 1 },
                 ),
+                iconSize: [30, 40],
+                iconAnchor: [15, 40],
             };
 
             const marker = L.marker(


### PR DESCRIPTION
Before this commit, markers on the location selector map were misaligned. The misalignment was proportional to the zoom level, as the marker incorrectly used the top-left corner of the anchor as its reference.

This commit resolves the issue by defining the correct icon anchor position for markers.
