### PR TITLE
[IMP] stock: hide XLSX export action in quant list view for moves

### DIFF
--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -160,7 +160,7 @@
         <field name="model">stock.quant</field>
         <field eval="10" name="priority"/>
         <field name="arch" type="xml">
-            <tree>
+            <tree export_xlsx="0">
                 <field name="product_id" column_invisible="context.get('single_product', False)"/>
                 <field name="location_id" column_invisible="context.get('hide_location', False)"/>
                 <field name="lot_id" groups="stock.group_production_lot"
@@ -186,6 +186,7 @@
                 <attribute name="js_class">inventory_report_list</attribute>
                 <attribute name="create">0</attribute>
                 <attribute name="delete">0</attribute>
+                <attribute name="export_xlsx">1</attribute>
             </xpath>
             <xpath expr="//field[@name='product_id']" position="before">
                 <header>


### PR DESCRIPTION
The cogwheel dropdown menu is unwanted and only contains the 'Export All' button, which is disabled with an attribute. This commit extends the existing base tree view for this specific use to avoid interfering with other views that use/extend it.

Task ID: [4471980](https://www.odoo.com/odoo/project/966/tasks/4471980)
