### PR TITLE
[FIX] hw_drivers: ensure lib directory before iterdir

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -397,17 +397,17 @@ def load_certificate():
 
 
 def delete_iot_handlers():
-    """
-    Delete all the drivers and interfaces
-    This is needed to avoid conflicts
-    with the newly downloaded drivers
+    """Delete all drivers, interfaces and libs if any.
+    This is needed to avoid conflicts with the newly downloaded drivers.
     """
     try:
-        for directory in ['drivers', 'interfaces', 'lib']:
-            iot_handlers = file_path(f'hw_drivers/iot_handlers/{directory}')
-            for file in Path(iot_handlers).iterdir():
-                if file.is_file():
-                    unlink_file(f"odoo/addons/hw_drivers/iot_handlers/{directory}/{file.name}")
+        iot_handlers = Path(file_path(f'hw_drivers/iot_handlers'))
+        filenames = [
+            f"odoo/addons/hw_drivers/iot_handlers/{file.relative_to(iot_handlers)}"
+            for file in iot_handlers.glob('**/*')
+            if file.is_file()
+        ]
+        unlink_file(*filenames)
         _logger.info("Deleted old IoT handlers")
     except OSError:
         _logger.exception('Failed to delete old IoT handlers')
@@ -491,11 +491,12 @@ def read_file_first_line(filename):
             return f.readline().strip('\n')
 
 
-def unlink_file(filename):
+def unlink_file(*filenames):
     with writable():
-        path = path_file(filename)
-        if path.exists():
-            path.unlink()
+        for filename in filenames:
+            path = path_file(filename)
+            if path.exists():
+                path.unlink()
 
 
 def write_file(filename, text, mode='w'):


### PR DESCRIPTION
We now also delete `lib/` directory before deleting/downloading new IoT handlers.
In community, this directory does not exist, resulting in Path error while trying to `iterdir()` on it.
We now look for files recursively inside `iot_handlers/`, and provide the list to the updated method `unlink_file` that now accepts multiple arguments to avoid excessively switching between rw/ro  filesystem modes.
