### PR TITLE
[FIX] core: JS tests / tours needing focus

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -905,6 +905,7 @@ class ChromeBrowser:
         self._websocket_send('Runtime.enable')
         self._logger.info('Chrome headless enable page notifications')
         self._websocket_send('Page.enable')
+        self._websocket_send('Emulation.setFocusEmulationEnabled', params={'enabled': True})
         emulated_device = {
             'mobile': False,
             'width': None,


### PR DESCRIPTION
Apparently in normal mode (and thus the new headless mode) Chrome does not focus the document. The `activeElement` is correctly set, but `document.hasFocus()` always returns `false` and per-element focus events are suppressed.

That makes tests testing or needing focus fail in the new headless mode as well as well as impossible (or at least frustrating) to `debug`.

Enabling "focus emulation", which corresponds to the "Emulate a focused page" UI option, seems to resolve the issue.

Fixes reliably failing tests

- `/im_livechat:ExternalTestSuite.test_external_livechat`
- `/account:TestUI.test_01_account_tax_groups_tour`
- `/account_accountant:TestBankRecWidget.test_tour_bank_rec_widget`
- `/web_editor:TestOdooEditor.test_odoo_editor_suite`

Backport of: odoo/odoo@0aaf98b77feaa15f5eb30e1c251f5765e8afbfa5
