### PR TITLE
[FIX] account: cash basis journal for last payment

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -2865,6 +2865,7 @@ class AccountMoveLine(models.Model):
 
             caba_rounding_diff_label = _("Cash basis rounding difference")
             move_vals['date'] = max(move_vals['date'], move.date)
+            move_vals['journal_id'] = self.company_id.tax_cash_basis_journal_id.id
             for caba_treatment, line in move_values['to_process_lines']:
 
                 vals = {

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -4504,6 +4504,11 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             ]
         )
 
+        self.assertEqual(
+            invoice.line_ids.filtered(lambda x: x.account_id.account_type == 'asset_receivable').full_reconcile_id.exchange_move_id.journal_id.id,
+            self.env.company.tax_cash_basis_journal_id.id,
+        )
+
         self.assertTrue(
             invoice.line_ids.filtered(lambda x: x.account_id == self.cash_basis_transfer_account).full_reconcile_id,
             "The cash basis transition account line of the invoice should be fully reconciled with the CABA moves and the adjustment."


### PR DESCRIPTION
If you pay an invoice with multiple payments some roundings are made for the taxes. On the last payment, the error from those roundings are put on a move to make sure that the exact amount of the invoice is paid.

That move was put on the wrong journal. It was put in the 'Exchange Difference' journal instead of the 'Cash Basis Taxes'.

opw-4460696

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
