### PR TITLE
[FIX] stock: display correct description 3 step incoming

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -940,7 +940,7 @@ class StockMoveLine(models.Model):
             'product_id': self.product_id.id,
             'product_uom_qty': 0 if self.picking_id and self.picking_id.state != 'done' else self.quantity,
             'product_uom': self.product_uom_id.id,
-            'description_picking': self.description_picking,
+            'description_picking': self.description_picking or self.product_id.with_context(lang=self.env.context.get('lang'))._get_description(self.picking_type_id),
             'location_id': self.picking_id.location_id.id,
             'location_dest_id': self.picking_id.location_dest_id.id,
             'picked': self.picked,

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -255,6 +255,8 @@ class StockRule(models.Model):
             'propagate_cancel': self.propagate_cancel,
             'warehouse_id': self.warehouse_id.id,
             'procure_method': 'make_to_order',
+            'description_picking': move_to_copy.product_id.with_context(lang=move_to_copy._get_lang())._get_description(
+                self.picking_type_id) or move_to_copy.description_picking,
         }
         return new_move_vals
 

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -3656,3 +3656,26 @@ class TestAutoAssign(TestStockCommon):
         self.assertEqual(delivery_order_2.partner_id, partner_2)
         self.assertEqual(delivery_order_2.move_ids.mapped('product_id'), self.productA)
         self.assertEqual(delivery_order_2.move_ids.product_uom_qty, 1.0)
+
+    def test_description_picking_consistent_with_product_description(self):
+        """
+        Ensure the description_picking of a move matches the product template's
+        description in a multi-step reception process.
+        """
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        warehouse.reception_steps = 'two_steps'
+
+        self.productA.product_tmpl_id.description_picking = 'transfer'
+        receipt = self.env['stock.picking'].create({
+            'picking_type_id': self.picking_type_in,
+            'location_id': self.supplier_location,
+            'move_line_ids': [Command.create({
+                'product_id': self.productA.id,
+                'quantity': 1,
+                'description_picking': 'receipt',
+            })]
+        })
+        receipt.button_validate()
+
+        next_picking = receipt._get_next_transfers()
+        self.assertEqual(next_picking.move_ids.description_picking, 'transfer')


### PR DESCRIPTION
There is an inconsistency in the product description during 3-step incoming shipments.

How to reproduce the issue:

- Enable three-step incoming shipments.

- Create a product with a description for receipts (e.g., 'receipt') and a different description for internal transfers (e.g., 'transfer').

- Create a receipt with the product, validate it, and open the corresponding picking for the internal transfer.

The move_line description_picking is taken from the receipt description instead of the internal transfer description (it shows 'receipt' instead of 'transfer').

opw-4406582

PR with very similar issue: https://github.com/odoo/enterprise/pull/77283




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
