### PR TITLE
[FIX] digest, various: fix URLs to new format

### DIFF
--- a/addons/account/models/digest.py
+++ b/addons/account/models/digest.py
@@ -35,5 +35,5 @@ class Digest(models.Model):
 
     def _compute_kpis_actions(self, company, user):
         res = super(Digest, self)._compute_kpis_actions(company, user)
-        res['kpi_account_total_revenue'] = 'account.action_move_out_invoice_type&menu_id=%s' % self.env.ref('account.menu_finance').id
+        res['kpi_account_total_revenue'] = 'account.action_move_out_invoice_type?menu_id=%s' % self.env.ref('account.menu_finance').id
         return res

--- a/addons/crm/models/digest.py
+++ b/addons/crm/models/digest.py
@@ -32,8 +32,8 @@ class Digest(models.Model):
 
     def _compute_kpis_actions(self, company, user):
         res = super(Digest, self)._compute_kpis_actions(company, user)
-        res['kpi_crm_lead_created'] = 'crm.crm_lead_action_pipeline&menu_id=%s' % self.env.ref('crm.crm_menu_root').id
-        res['kpi_crm_opportunities_won'] = 'crm.crm_lead_action_pipeline&menu_id=%s' % self.env.ref('crm.crm_menu_root').id
+        res['kpi_crm_lead_created'] = 'crm.crm_lead_action_pipeline?menu_id=%s' % self.env.ref('crm.crm_menu_root').id
+        res['kpi_crm_opportunities_won'] = 'crm.crm_lead_action_pipeline?menu_id=%s' % self.env.ref('crm.crm_menu_root').id
         if user.has_group('crm.group_use_lead'):
-            res['kpi_crm_lead_created'] = 'crm.crm_lead_all_leads&menu_id=%s' % self.env.ref('crm.crm_menu_root').id
+            res['kpi_crm_lead_created'] = 'crm.crm_lead_all_leads?menu_id=%s' % self.env.ref('crm.crm_menu_root').id
         return res

--- a/addons/hr_recruitment/models/digest.py
+++ b/addons/hr_recruitment/models/digest.py
@@ -22,5 +22,5 @@ class Digest(models.Model):
 
     def _compute_kpis_actions(self, company, user):
         res = super()._compute_kpis_actions(company, user)
-        res['kpi_hr_recruitment_new_colleagues'] = f"hr.open_view_employee_list_my&menu_id={self.env.ref('hr.menu_hr_root').id}"
+        res['kpi_hr_recruitment_new_colleagues'] = f"hr.open_view_employee_list_my?menu_id={self.env.ref('hr.menu_hr_root').id}"
         return res

--- a/addons/point_of_sale/models/digest.py
+++ b/addons/point_of_sale/models/digest.py
@@ -25,5 +25,5 @@ class Digest(models.Model):
 
     def _compute_kpis_actions(self, company, user):
         res = super(Digest, self)._compute_kpis_actions(company, user)
-        res['kpi_pos_total'] = 'point_of_sale.action_pos_sale_graph&menu_id=%s' % self.env.ref('point_of_sale.menu_point_root').id
+        res['kpi_pos_total'] = 'point_of_sale.action_pos_sale_graph?menu_id=%s' % self.env.ref('point_of_sale.menu_point_root').id
         return res

--- a/addons/project/models/digest_digest.py
+++ b/addons/project/models/digest_digest.py
@@ -23,5 +23,5 @@ class Digest(models.Model):
 
     def _compute_kpis_actions(self, company, user):
         res = super(Digest, self)._compute_kpis_actions(company, user)
-        res['kpi_project_task_opened'] = 'project.open_view_project_all&menu_id=%s' % self.env.ref('project.menu_main_pm').id
+        res['kpi_project_task_opened'] = 'project.open_view_project_all?menu_id=%s' % self.env.ref('project.menu_main_pm').id
         return res

--- a/addons/sale_management/models/digest.py
+++ b/addons/sale_management/models/digest.py
@@ -25,5 +25,5 @@ class Digest(models.Model):
 
     def _compute_kpis_actions(self, company, user):
         res = super(Digest, self)._compute_kpis_actions(company, user)
-        res['kpi_all_sale_total'] = 'sale.report_all_channels_sales_action&menu_id=%s' % self.env.ref('sale.sale_menu_root').id
+        res['kpi_all_sale_total'] = 'sale.report_all_channels_sales_action?menu_id=%s' % self.env.ref('sale.sale_menu_root').id
         return res

--- a/addons/website_sale/models/digest.py
+++ b/addons/website_sale/models/digest.py
@@ -24,5 +24,5 @@ class Digest(models.Model):
 
     def _compute_kpis_actions(self, company, user):
         res = super()._compute_kpis_actions(company, user)
-        res['kpi_website_sale_total'] = 'website.backend_dashboard&menu_id=%s' % self.env.ref('website.menu_website_configuration').id
+        res['kpi_website_sale_total'] = 'website.backend_dashboard?menu_id=%s' % self.env.ref('website.menu_website_configuration').id
         return res


### PR DESCRIPTION
Some URLs in the digest emails are currently broken due to an outdated URL format.

### Steps to reproduce

* Install `digest` and `crm` modules
* Go to Settings > Technical > Digest Emails
* Select the "Your Odoo Periodic Digest" digest and send it
* Check the sent email and click on any of the "Open Email" links

You should encounter an error indicating that the action does not exist.

Although the reproduction steps use the `crm` module as an example, this issue occurs with all the modules listed in the title.

### Cause

The "Open Report" URLs were not updated to account for the new URL format.

opw-4405288
opw-4502625