### PR TITLE
[FIX] account: no frequent accounts

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -565,9 +565,13 @@ class AccountAccount(models.Model):
 
     @api.model
     def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        if not name and self._context.get('partner_id') and self._context.get('move_type'):
-            return self._order_accounts_by_frequency_for_partner(
-                            self.env.company.id, self._context.get('partner_id'), self._context.get('move_type'))
+        if (
+            not name
+            and (partner := self._context.get('partner_id'))
+            and (move_type := self._context.get('move_type'))
+            and (ordered_accounts := self._order_accounts_by_frequency_for_partner(self.env.company.id, partner, move_type))
+        ):
+            return ordered_accounts
         domain = domain or []
         if name:
             if operator in ('=', '!='):


### PR DESCRIPTION
The name search on the account field (account.account on account move line) looks for frequently used accounts for the partner. When no search text is provided, the name search suggests accounts that were previously used. When there are no frequent accounts, the name search returns nothing.

To reproduce

- create a vendor bill
- select a partner that has never been billed
- add a line
- click the account many2one field dropdown

Since no account options are available, the dropdown flashes open and quickly disappears.
