### PR TITLE
[FIX] point_of_sale: iOS downoad invoice popup

### DIFF
--- a/addons/point_of_sale/static/src/services/account_move_services.js
+++ b/addons/point_of_sale/static/src/services/account_move_services.js
@@ -1,0 +1,15 @@
+import { AccountMoveService } from "@account/services/account_move_service";
+import { isIosApp, isIOS } from "@web/core/browser/feature_detection";
+import { patch } from "@web/core/utils/patch";
+
+patch(AccountMoveService.prototype, {
+    async downloadPdf(accountMoveId) {
+        if (isIosApp() || isIOS()) {
+            return await this.action.doAction({
+                type: "ir.actions.act_url",
+                url: `/account/download_invoice_documents/${accountMoveId}/pdf`,
+            });
+        }
+        return super.downloadPdf(accountMoveId);
+    },
+});


### PR DESCRIPTION
When downloading an invoice from the POS on iOS the PoS would be
reloaded after closing the download popup.

Steps to reproduce:
-------------------
* Open PoS on iOS
* Make an order and invoice it
> Observation: After closing the invoice you are back on the product
screen

Why the fix:
------------
We open the download invoice popup in a new tab so that the PoS is not
reloaded after closing the popup.

opw-4471713