### PR TITLE
[FIX] stock_account: prevent lot valuation if quant without lot

### DIFF
--- a/addons/stock_account/i18n/stock_account.pot
+++ b/addons/stock_account/i18n/stock_account.pot
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-09-25 08:39+0000\n"
-"PO-Revision-Date: 2024-09-25 08:39+0000\n"
+"PO-Revision-Date: 2025-01-16 15:09+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -495,8 +495,8 @@ msgstr ""
 #. odoo-python
 #: code:addons/stock_account/models/product.py:0
 msgid ""
-"Lot %(lot)s has a negative quantity in stock. Correct this"
-"                         quantity before enabling lot valuation"
+"Lot %(lot)s has a negative quantity in stock.\n"
+"Correct this quantity before enabling/disabling lot valuation."
 msgstr ""
 
 #. module: stock_account
@@ -586,6 +586,14 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock_account.field_stock_valuation_layer__product_id
 #: model_terms:ir.ui.view,arch_db:stock_account.view_inventory_valuation_search
 msgid "Product"
+msgstr ""
+
+#. module: stock_account
+#. odoo-python
+#: code:addons/stock_account/models/product.py:0
+msgid ""
+"Product %(product)s has quantity in valued location %(location)s without any lot.\n"
+"Please assign lots to all your quantities before enabling lot valuation."
 msgstr ""
 
 #. module: stock_account

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -712,8 +712,26 @@ will update the cost of every lot/serial number in stock."),
                 lot_by_product[product][lot] += qty
         for product, location, lot, qty in neg_lots:
             if location._should_be_valued():
-                raise UserError(_("Lot %(lot)s has a negative quantity in stock. Correct this \
-                        quantity before enabling lot valuation", lot=lot))
+                raise UserError(_(
+                    "Lot %(lot)s has a negative quantity in stock.\n"
+                    "Correct this quantity before enabling/disabling lot valuation.",
+                    lot=lot.display_name
+                ))
+        lot_valuated_products = self.filtered("lot_valuated")
+        if lot_valuated_products:
+            no_lot_quants = self.env['stock.quant']._read_group([
+                ('product_id', 'in', lot_valuated_products.ids),
+                ('lot_id', '=', False),
+                ('quantity', '!=', 0),
+            ], ['product_id', 'location_id'])
+            for product, location in no_lot_quants:
+                if location._should_be_valued():
+                    raise UserError(_(
+                        "Product %(product)s has quantity in valued location %(location)s without any lot.\n"
+                        "Please assign lots to all your quantities before enabling lot valuation.",
+                        product=product.display_name,
+                        location=location.display_name
+                    ))
 
         for product in self:
             quantity_svl = products_orig_quantity_svl[product.id]

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -673,3 +673,22 @@ class TestLotValuation(TestStockValuationCommon):
         self.assertEqual(self.product1.value_svl, 1)
         self.assertEqual(lot.quantity_svl, 0)
         self.assertEqual(lot.value_svl, 0)
+
+    def test_no_lot_valuation_if_quant_without_lot(self):
+        """ Ensure that it is not possible to set lot_valuated to True
+        if there is valued quantities without lot in on hand.
+        This is because you can't validate a move without lot when lot valuation is enabled.
+        The user would hence be unable to use the quant without lot anyway.
+        """
+        self.product1.tracking = 'none'
+        self.product1.lot_valuated = False
+        quant = self.env['stock.quant'].create({
+            'product_id': self.product1.id,
+            'location_id': self.stock_location.id,
+            'inventory_quantity': 1
+        })
+        quant.action_apply_inventory()
+
+        self.product1.tracking = 'lot'
+        with self.assertRaises(UserError):
+            self.product1.lot_valuated = True


### PR DESCRIPTION
When Lot valuation is enabled on a product, it is not longer possible to create a move without lot. Hence, if you had a valued quantity without lot before enabling lot valuation, it was impossible to update or empty this quantity in any way. Leaving you with an unusable StockQuant. Furthermore, when enabling the lot valuation, no layer was created for the quants without lot, creating a permanent discrepancy between the stock and valuation. This discrepancy was still present even after disabling the lot valuation.

To fix this issue, we do not allow the lot valuation if there is a quant without lot in a valued location.
![image](https://github.com/user-attachments/assets/71dd7d28-9bba-4215-af2c-96daa8825825)


+ Fix negative lot error message

PREV:
![image](https://github.com/user-attachments/assets/42c7e297-8b1d-4a3c-acae-aed1954001e1)


NOW:
![image](https://github.com/user-attachments/assets/aa03b99a-a8b9-48e0-b7b8-a3d9286c4194)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
