### PR TITLE
[REF] account: "Amount" field name changed to "Subtotal"

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1144,7 +1144,7 @@
                                                optional="show"/>
                                         <field name="price_subtotal"
                                                column_invisible="parent.move_type not in ['in_invoice', 'in_refund', 'in_receipt'] and parent.company_price_include == 'tax_included'"
-                                               string="Amount"/>
+                                               string="Subtotal"/>
                                         <field name="price_total"
                                                column_invisible="parent.move_type in ['in_invoice', 'in_refund', 'in_receipt'] or parent.company_price_include == 'tax_excluded'"
                                                string="Amount"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
"Amount" is in price_subtotal and price_total

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
