### PR TITLE
[FIX] payment_worldline: make API request not depend on locale variable

### DIFF
--- a/addons/payment_worldline/models/payment_provider.py
+++ b/addons/payment_worldline/models/payment_provider.py
@@ -1,16 +1,17 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
-import datetime
 import hashlib
 import hmac
 import logging
 import pprint
+from wsgiref.handlers import format_date_time
 
 import requests
 
 from odoo import _, fields, models
 from odoo.exceptions import ValidationError
+from odoo.fields import Datetime
 
 from odoo.addons.payment_worldline import const
 
@@ -65,8 +66,7 @@ class PaymentProvider(models.Model):
         api_url = self._worldline_get_api_url()
         url = f'{api_url}/v2/{self.worldline_pspid}/{endpoint}'
         content_type = 'application/json; charset=utf-8' if method == 'POST' else ''
-        tz = datetime.timezone(datetime.timedelta(hours=0), 'GMT')
-        dt = datetime.datetime.now(tz).strftime('%a, %d %b %Y %H:%M:%S %Z')  # Datetime in RFC1123.
+        dt = format_date_time(Datetime.now().timestamp())  # Datetime in locale-independent RFC1123
         signature = self._worldline_calculate_signature(
             method, endpoint, content_type, dt, idempotency_key=idempotency_key
         )


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Set locale variable `LC_TIME` to `be_FR.UTF-8` via command line;
2. do the same for `LC_ALL`;
3. start Odoo server;
4. attempt to make a payment via Worldline.

Example updating locale for a single shell session:
```bash
$ export LC_TIME=be_FR.UTF-8
$ export LC_ALL=$LC_TIME
$ ./odoo-bin
```

Issue
-----
Invalid API request: ACCESS_TO_MERCHANT_NOT_ALLOWED

Cause
-----
The date string sent to the Worldline API is formatted via the `datetime.strftime` method to be RFC 1123 compliant. The issue is that the result of this method is locale-dependent. If it's not set to `en_US.UTF-8`, it no longer adheres to the format expected by Worldline.

Solution
--------
Use the `format_date_time` method from the Python's standard `wsgiref` library. This method will always return a RFC 1123 compliant date string, regardless of locale setting.

opw-4472440