### PR TITLE
[FIX] website_sale: make product variant chatter consistent w/ template

### DIFF
--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -7,6 +7,7 @@ from odoo.exceptions import ValidationError
 
 class Product(models.Model):
     _inherit = "product.product"
+    _mail_post_access = 'read'
 
     website_id = fields.Many2one(related='product_tmpl_id.website_id', readonly=False)
 


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Have a user with only access to "Sales User: Own Documents Only";
2. open a product variant page;
3. add a comment in the chatter.

Issue
-----
Access Error

Cause
-----
Commit 35a07975deb0 added `_mail_post_access = 'read'` to the `product.template` model. This allows users with read-only access to still comment on `product.template` records.

This was not done for product variants, leading to an inconsistency where an internal user can comment on product templates, but not variants.

Solution
--------
Add `_mail_post_access = 'read'` to `product.product` as well.

opw-4189326