### PR TITLE
[FIX] account,point_of_sale: iOS downoad invoice popup

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5171,11 +5171,11 @@ class AccountMove(models.Model):
 
         return report_action
 
-    def action_invoice_download_pdf(self):
+    def action_invoice_download_pdf(self, target = "download"):
         return {
             'type': 'ir.actions.act_url',
             'url': f'/account/download_invoice_documents/{",".join(map(str, self.ids))}/pdf',
-            'target': 'download',
+            'target': target,
         }
 
     def preview_invoice(self):

--- a/addons/account/static/src/services/account_move_service.js
+++ b/addons/account/static/src/services/account_move_service.js
@@ -28,11 +28,11 @@ export class AccountMoveService {
         return false;
     }
 
-    async downloadPdf(accountMoveId) {
+    async downloadPdf(accountMoveId, target = "download") {
         const downloadAction = await this.orm.call(
             "account.move",
             "action_invoice_download_pdf",
-            [accountMoveId]
+            [accountMoveId, target]
         );
         await this.action.doAction(downloadAction);
     }

--- a/addons/point_of_sale/static/src/overrides/services/account_move_services.js
+++ b/addons/point_of_sale/static/src/overrides/services/account_move_services.js
@@ -1,0 +1,12 @@
+import { AccountMoveService } from "@account/services/account_move_service";
+import { isIosApp, isIOS } from "@web/core/browser/feature_detection";
+import { patch } from "@web/core/utils/patch";
+
+patch(AccountMoveService.prototype, {
+    async downloadPdf(accountMoveId, target = "download") {
+        if (isIosApp() || isIOS()) {
+            return super.downloadPdf(accountMoveId, "_blank");
+        }
+        super.downloadPdf(accountMoveId, target);
+    },
+});


### PR DESCRIPTION
When downloading an invoice from the POS on iOS the PoS would be
reloaded after closing the download popup.

Steps to reproduce:
-------------------
* Open PoS on iOS
* Make an order and invoice it
> Observation: After closing the invoice you are back on the product
screen

Why the fix:
------------
We open the download invoice popup in a new tab so that the PoS is not
reloaded after closing the popup.

opw-4471713