### PR TITLE
[FIX] stock: clean context before scrap validation

### DIFF
--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -5016,15 +5016,13 @@ class StockMove(TransactionCase):
         })
         warning_message = scrap.action_validate()
         self.assertEqual(warning_message.get('res_model', 'Wrong Model'), 'stock.warn.insufficient.qty.scrap')
-        insufficient_qty_wizard = self.env['stock.warn.insufficient.qty.scrap'].create({
-            'product_id': self.product.id,
-            'location_id': self.stock_location.id,
-            'scrap_id': scrap.id,
-            'quantity': 1,
-            'product_uom_name': self.product.uom_id.name
-        })
+        insufficient_qty_wizard = self.env['stock.warn.insufficient.qty.scrap']\
+            .with_context(warning_message['context']).create({})
         insufficient_qty_wizard.action_done()
         self.assertEqual(self.env['stock.quant']._gather(self.product, self.stock_location).quantity, -11)
+        self.assertEqual(scrap.scrap_qty, 1)
+        self.assertEqual(scrap.product_uom_id, self.uom_dozen)
+        self.assertEqual(scrap.state, 'done')
 
     def test_scrap_7_sn_warning(self):
         """ Check serial numbers are correctly double checked """

--- a/addons/stock/wizard/stock_warn_insufficient_qty.py
+++ b/addons/stock/wizard/stock_warn_insufficient_qty.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
+from odoo.tools.misc import clean_context
 
 
 class StockWarnInsufficientQty(models.AbstractModel):
@@ -42,7 +43,7 @@ class StockWarnInsufficientQtyScrap(models.TransientModel):
         return self.scrap_id.company_id
 
     def action_done(self):
-        return self.scrap_id.do_scrap()
+        return self.with_context(clean_context(self.env.context)).scrap_id.do_scrap()
 
     def action_cancel(self):
         # FIXME in master: we should not have created the scrap in a first place


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”:
    - UoM: g
- Go to inventory > operation > Scrap:
    - Create a new one: - product: P1 - UoM: KG - Quantity: 1

- Validate the scrap
- A wizard is triggered indicating insufficient stock quantity.
- validate it

Problem:
The quantity in the scrap is updated to 1000 kg, and the related move is created with a quantity of 1000 kg.

opw-4485849
