### PR TITLE
[FIX] sale_pdf_quote_builder: use correct datetime format

### DIFF
--- a/addons/sale_pdf_quote_builder/models/ir_actions_report.py
+++ b/addons/sale_pdf_quote_builder/models/ir_actions_report.py
@@ -173,7 +173,7 @@ class IrActionsReport(models.Model):
                 elif field_type_ == 'date':
                     formatted_value_ = format_date(self.env, value_)
                 elif field_type_ == 'datetime':
-                    formatted_value_ = format_datetime(self.env, value_, tz=tz)
+                    formatted_value_ = format_datetime(self.env, value_, tz=tz, dt_format=False)
                 elif field_type_ == 'selection' and value_:
                     formatted_value_ = dict(field_._description_selection(self.env))[value_]
                 elif field_type_ in {'one2many', 'many2one', 'many2many'}:


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Create a new quotation template;
2. add a header which uses the `date_order` field;
3. configure the mapping from this form field to the record field;
4. print the quotation template.

Issue
-----
The datetime is formatted as "Jan 16, 2025, 5:59:26 PM", which is different from how dates are formatted, or how datetimes are usually formatted elsewhere in Odoo.

Additionally, it may also be too long to fit in the form field.

Cause
-----
The `format_datetime` function is used without a `dt_format` specified, falling back on the default `'medium'`: https://github.com/odoo/odoo/blob/cbd5531697954ec62d79e0eec2c00bd61cd8b0e4/odoo/tools/misc.py#L1399

Solution
--------
In order to get the format defined for the relevant locale in Odoo, `dt_format=False` should be specified in the `format_datetime` call: https://github.com/odoo/odoo/blob/cbd5531697954ec62d79e0eec2c00bd61cd8b0e4/odoo/tools/misc.py#L1427-L1430

opw-4414688