### PR TITLE
[IMP] base: creating new res device log returns true

### DIFF
--- a/odoo/addons/base/models/res_device.py
+++ b/odoo/addons/base/models/res_device.py
@@ -85,10 +85,11 @@ class ResDeviceLog(models.Model):
             Passage through this method must leave a "trace" in the session.
 
             :param request: Request or WebsocketRequest object
+            :return: whether a device log was created
         """
         trace = request.session.update_trace(request)
         if not trace:
-            return
+            return False
 
         geoip = GeoIP(trace['ip_address'])
         user_id = request.session.uid
@@ -117,6 +118,7 @@ class ResDeviceLog(models.Model):
                 revoked=False,
             ))
         _logger.info("User %d inserts device log (%s)", user_id, session_identifier)
+        return True
 
     @api.autovacuum
     def _gc_device_log(self):


### PR DESCRIPTION
In case you want to inherit _update_device, and want to know whether or not a device was made, you need to first get the latest id, then call super(), and then compare the latest id with the previous value. This can simply be fixed by returning True and checking the return value.

Meant to simplify https://github.com/odoo/internal/pull/3299
