### PR TITLE
[FIX] point_of_sale: resolve download furniture shop scenario issue

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1716,7 +1716,7 @@ class PosSession(models.Model):
             message += _('Opening control message: ')
             message += notes
         if message:
-            self.message_post(body=plaintext2html(message))
+            self.message_post(body=plaintext2html(message), email_from=self.env.user.email or "admin@example.com")
 
     def action_view_order(self):
         return {


### PR DESCRIPTION
Steps to reproduce:
--------------------------
- Start db without demo data.
- Click on furniture shop.

Issue:
--------
- There will be a TB while loading the furniture scenario.

Cause:
---------
- The user used in demo data doesn't have an email and it tries to post message in chatter.

Fix:
-----
- We have assigned a demo email to the user to avoid TB and also have the logs in chatter.

Task: 4486094
