### PR TITLE
[FIX] point_of_sale: preset wrong time in back-end

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -172,7 +172,7 @@ export class Navbar extends Component {
                 await this.pos.selectPreset(this.pos.models["pos.preset"].get(data.presetId));
             }
 
-            order.preset_time = data.slot.sql_datetime;
+            order.setPresetDateTime(data.slot.sql_datetime);
             if (data.slot.datetime > DateTime.now()) {
                 this.pos.addPendingOrder([order.id]);
                 await this.pos.syncAllOrders();

--- a/addons/point_of_sale/static/src/app/components/popups/preset_slots_popup/preset_slots_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/preset_slots_popup/preset_slots_popup.js
@@ -2,6 +2,7 @@ import { Component, onWillStart, useState } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { Dialog } from "@web/core/dialog/dialog";
 import { _t } from "@web/core/l10n/translation";
+import { serializeDateTime } from "@web/core/l10n/dates";
 
 const { DateTime } = luxon;
 
@@ -51,7 +52,10 @@ export class PresetSlotsPopup extends Component {
 
     isSelected(time, preset) {
         const order = this.pos.getOrder();
-        return order.preset_time === time && order.preset_id?.id === preset.id;
+        return (
+            order.preset_time === serializeDateTime(DateTime.fromSQL(time)) &&
+            order.preset_id?.id === preset.id
+        );
     }
 
     getSlotsForDate(preset, date) {

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -1,7 +1,7 @@
 import { registry } from "@web/core/registry";
 import { Base } from "./related_models";
 import { _t } from "@web/core/l10n/translation";
-import { serializeDateTime } from "@web/core/l10n/dates";
+import { serializeDateTime, deserializeDateTime, parseDateTime } from "@web/core/l10n/dates";
 import { random5Chars, uuidv4, gte, lt } from "@point_of_sale/utils";
 import { floatIsZero, roundPrecision } from "@web/core/utils/numbers";
 import { roundCurrency } from "@point_of_sale/app/models/utils/currency";
@@ -9,7 +9,6 @@ import { computeComboItems } from "./utils/compute_combo_items";
 import { accountTaxHelpers } from "@account/helpers/account_tax";
 
 const formatCurrency = registry.subRegistries.formatters.content.monetary[1];
-const { DateTime } = luxon;
 
 export class PosOrder extends Base {
     static pythonModel = "pos.order";
@@ -108,7 +107,7 @@ export class PosOrder extends Base {
     }
 
     get presetTime() {
-        const dateTime = DateTime.fromSQL(this.preset_time);
+        const dateTime = deserializeDateTime(this.preset_time);
         return dateTime.isValid ? dateTime.toFormat("HH:mm") : false;
     }
 
@@ -119,6 +118,10 @@ export class PosOrder extends Base {
             (!this.preset_id?.needsName || this.partner_id?.name || this.floating_order_name) &&
             (!this.preset_id?.needsSlot || this.preset_time)
         );
+    }
+
+    setPresetDateTime(newTime) {
+        this.preset_time = newTime ? serializeDateTime(parseDateTime(newTime)) : false;
     }
 
     getEmailItems() {

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -10,7 +10,7 @@
                 class="buttonClass"/>
         </t>
         <button t-if="pos.config.use_presets and !props.showRemainingButtons"
-            class="btn btn-light btn-lg flex-shrink-0 border-0"
+            class="preset-button btn btn-light btn-lg flex-shrink-0 border-0"
             t-attf-class="{{`o_colorlist_item_color_${currentOrder.preset_id?.color}`}}"
             t-on-click="() => this.pos.selectPreset()">
             <span t-esc="currentOrder.preset_id?.name" />

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1876,9 +1876,9 @@ export class PosStore extends WithLazyGetterTrap {
 
             if (preset.use_timing && !order.preset_time) {
                 await this.syncPresetSlotAvaibility(preset);
-                order.preset_time = preset.nextSlot?.sql_datetime || false;
+                order.setPresetDateTime(preset.nextSlot?.sql_datetime || false);
             } else if (!preset.use_timing) {
-                order.preset_time = false;
+                order.setPresetDateTime(false);
             }
         }
     }

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -825,3 +825,18 @@ export function createProductFromFrontend(name, barcode, list_price, category) {
 export function editProductFromFrontend(name, barcode, list_price) {
     return productInputSteps(name, barcode, list_price);
 }
+
+export function selectPreset(name = "Eat In") {
+    return [
+        {
+            content: "select Tackout preset",
+            trigger: `.product-screen .pads .control-buttons .preset-button`,
+            run: "click",
+        },
+        {
+            content: "select preset",
+            trigger: `.modal button:contains(${name})`,
+            run: "click",
+        },
+    ];
+}

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -560,3 +560,20 @@ registry.category("web_tour.tours").add("FinishResidualOrder", {
             ReceiptScreen.clickNextOrder(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("RestaurantPresetTakeoutTour", {
+    steps: () =>
+        [
+            Chrome.freezeDateTime(1739370000000),
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("4"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola", true),
+            ProductScreen.selectPreset("Takeout"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Deco Addict"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+        ].flat(),
+});

--- a/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.js
+++ b/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.js
@@ -47,7 +47,7 @@ export class PresetInfoPopup extends Component {
         }
 
         if (this.preset.needsSlot && this.state.selectedSlot) {
-            this.selfOrder.currentOrder.preset_time = this.state.selectedSlot;
+            this.selfOrder.currentOrder.setPresetDateTime(this.state.selectedSlot);
         }
 
         this.props.callback(true);


### PR DESCRIPTION
Steps:
===
- Open Restaurant in POS system.
- Create an order with preset as `Takeout` and select desired time.
- validate it.
- open that order in backend.
- Observe the takeout date & time—it differs from the originally selected time.

Issue:
===
- The POS system stores the preset_time in local time directly to the database, but the backend consider it as UTC, leading to mismatched times when displayed.

Fix:
===
- The frontend now sets preset_time in UTC before saving, ensuring consistent time handling across the system.

Task: 4477402
Related: odoo/enterprise#77558  
