### PR TITLE
[FIX] web_editor: website editor unresponsive issue

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3988,7 +3988,12 @@ export class OdooEditor extends EventTarget {
             };
             while (ZERO_WIDTH_CHARS.includes(adjacentCharacter) && hasSelectionChanged(previousSelection)) {
                 const selection = this.document.getSelection();
-                previousSelection = {...selection};
+                previousSelection = {
+                    anchorNode: selection.anchorNode,
+                    anchorOffset: selection.anchorOffset,
+                    focusNode: selection.focusNode,
+                    focusOffset: selection.focusOffset,
+                };
                 selection.modify(
                     ev.shiftKey ? 'extend' : 'move',
                     side === 'previous' ? 'backward' : 'forward',


### PR DESCRIPTION
Steps to Reproduce:

* Go to Website --> Edit Mode.
* Drag and drop the form snippet.
* Click inside the submit button such that the entire label "Submit" is
  selected.
* Press the right arrow key.
* The website will become unresponsive.


**Changes made:**

Assign `previousSelection` with the following properties:
 `anchorNode: selection.anchorNode`
 `anchorOffset: selection.anchorOffset`
 `focusNode: selection.focusNode`
 `focusOffset: selection.focusOffset`

**Reason:**

The original code attempted to spread the Selection object into previousSelection using **{...selection}**, which is incorrect since **the Selection object is not iterable**. As a result, `previousSelection` was never updated correctly, potentially causing the while loop to run indefinitely.

This fix manually extracts key properties—anchorNode, anchorOffset, focusNode, and focusOffset—from the Selection object and stores them in a plain object. This ensures that previousSelection updates properly, allowing the `hasSelectionChanged` function to function as expected.

By implementing this change, we prevent infinite loops and ensure accurate selection tracking, improving the stability and functionality of the text editor.

task-4471656