### PR TITLE
[FIX] tools: extract _t in template strings

### DIFF
--- a/addons/iap_mail/static/src/js/services/iap_notification_service.js
+++ b/addons/iap_mail/static/src/js/services/iap_notification_service.js
@@ -1,5 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { escape } from "@web/core/utils/strings";
 
 import { markup } from "@odoo/owl";
 
@@ -24,13 +25,10 @@ export const iapNotificationService = {
         }
 
         function displayCreditErrorNotification(params) {
-            // ℹ️ `_t` can only be inlined directly inside JS template literals
-            // after Babel has been updated to version 2.12.
-            const translatedText = _t("Buy more credits");
             const message = markup(`
             <a class='btn btn-link' href='${params.get_credits_url}' target='_blank'>
                 <i class='oi oi-arrow-right'></i>
-                ${translatedText}
+                ${escape(_t("Buy more credits"))}
             </a>`);
             notification.add(message, {
                 title: params.title,

--- a/addons/web/static/src/webclient/user_menu/user_menu_items.js
+++ b/addons/web/static/src/webclient/user_menu/user_menu_items.js
@@ -47,16 +47,13 @@ class ShortcutsFooterComponent extends Component {
 }
 
 function shortCutsItem(env) {
-    // ℹ️ `_t` can only be inlined directly inside JS template literals after
-    // Babel has been updated to version 2.12.
-    const translatedText = _t("Shortcuts");
     return {
         type: "item",
         id: "shortcuts",
         hide: env.isSmall,
         description: markup(
             `<div class="d-flex align-items-center justify-content-between">
-                <span>${escape(translatedText)}</span>
+                <span>${escape(_t("Shortcuts"))}</span>
                 <span class="fw-bold">${isMacOS() ? "CMD" : "CTRL"}+K</span>
             </div>`
         ),

--- a/addons/website_forum/static/src/interactions/website_forum.js
+++ b/addons/website_forum/static/src/interactions/website_forum.js
@@ -1,6 +1,6 @@
 import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
-
+import { htmlJoin } from "@mail/utils/common/html";
 import { markup } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { cookie } from "@web/core/browser/cookie";;
@@ -256,14 +256,16 @@ export class WebsiteForum extends Interaction {
             return;
         }
         const forumId = parseInt(this.el.ownerDocument.getElementById("wrapwrap").dataset.forum_id);
-        const additionalInfoWithForumID = forumId
-            ? markup(`<br/>
-                <a class="alert-link" href="/forum/${forumId}/faq">
-                    ${escape(_t("Read the guidelines to know how to gain karma."))}
-                </a>`)
-            : "";
-        const translatedText = _t("karma is required to perform this action. ");
-        const message = markup(`${karma} ${escape(translatedText)}${additionalInfoWithForumID}`);
+        let message = _t("%(score)s karma is required to perform this action.", { score: karma });
+        if (forumId) {
+            message = htmlJoin(
+                message,
+                _t("%(link_start)sRead the guidelines to know how to gain karma.%(link_end)s", {
+                    link_start: markup(`<br><a class="alert-link" href="/forum/${forumId}/faq">`),
+                    link_end: markup("</a>"),
+                })
+            );
+        }
         this.services.notification.add(message, {
             type: "warning",
             sticky: false,

--- a/odoo/addons/test_translation_import/i18n/fr.po
+++ b/odoo/addons/test_translation_import/i18n/fr.po
@@ -251,6 +251,12 @@ msgid "JS Export 26"
 msgstr ""
 
 #. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 27"
+msgstr ""
+
+#. module: test_translation_import
 #: model_terms:test.translation.import.model1,xml:test_translation_import.test_translation_import_model1_record1
 msgid "Knife"
 msgstr "Couteau"

--- a/odoo/addons/test_translation_import/i18n/fr_BE.po
+++ b/odoo/addons/test_translation_import/i18n/fr_BE.po
@@ -249,6 +249,12 @@ msgid "JS Export 26"
 msgstr ""
 
 #. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 27"
+msgstr ""
+
+#. module: test_translation_import
 #: model_terms:test.translation.import.model1,xml:test_translation_import.test_translation_import_model1_record1
 msgid "Knife"
 msgstr "Couteau, Belgium"

--- a/odoo/addons/test_translation_import/i18n/fr_CA.po
+++ b/odoo/addons/test_translation_import/i18n/fr_CA.po
@@ -249,6 +249,12 @@ msgid "JS Export 26"
 msgstr ""
 
 #. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 27"
+msgstr ""
+
+#. module: test_translation_import
 #: model_terms:test.translation.import.model1,xml:test_translation_import.test_translation_import_model1_record1
 msgid "Knife"
 msgstr "Couteau, Canada"

--- a/odoo/addons/test_translation_import/i18n/test_translation_import.pot
+++ b/odoo/addons/test_translation_import/i18n/test_translation_import.pot
@@ -249,6 +249,12 @@ msgid "JS Export 26"
 msgstr ""
 
 #. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 27"
+msgstr ""
+
+#. module: test_translation_import
 #: model_terms:test.translation.import.model1,xml:test_translation_import.test_translation_import_model1_record1
 msgid "Knife"
 msgstr ""

--- a/odoo/addons/test_translation_import/i18n/tlh.po
+++ b/odoo/addons/test_translation_import/i18n/tlh.po
@@ -249,6 +249,12 @@ msgid "JS Export 26"
 msgstr ""
 
 #. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 27"
+msgstr ""
+
+#. module: test_translation_import
 #: model_terms:test.translation.import.model1,xml:test_translation_import.test_translation_import_model1_record1
 msgid "Knife"
 msgstr ""

--- a/odoo/addons/test_translation_import/static/src/js/js_codefile.js
+++ b/odoo/addons/test_translation_import/static/src/js/js_codefile.js
@@ -46,5 +46,7 @@ export class TestTranslationExportModel {
         _t(dummyFunction`NO - JS Export 06 ${term}`);
 
         _t(dummyFunction("NO - JS Export 07"));
+
+        dummyFunction(`NO - JS Export 08${_t("JS Export 27")}NO - JS Export 09`);
     }
 }

--- a/odoo/tools/babel/python_extractor.py
+++ b/odoo/tools/babel/python_extractor.py
@@ -27,10 +27,10 @@ if TYPE_CHECKING:
     # The result of extracting terms, a 4-tuple containing:
     # (lineno: int, messages: str | tuple[str, ...], comments: list[str], context: str | None)
     #   - `lineno`: The line number of the extracted term(s)
+    #   - `funcname`: The translation function name
     #   - `messages`: The extracted term(s). A single one or multiple in case of e.g. `ngettext`
     #   - `comments`: The extracted translator comments for the term(s)
-    #   - `context`: The (optional) context key associated with the term(s)
-    _ExtractionResult: TypeAlias = tuple[int, str | tuple[str, ...], list[str], str | None]
+    _ExtractionResult: TypeAlias = tuple[int, str, str | tuple[str, ...], list[str]]
 
     # The possible options to pass to the extraction function
     class _PyOptions(TypedDict, total=False):


### PR DESCRIPTION
When using the `_t()` function in Javascript as variable part in a template string, the term inside didn't get extracted.

This commit adapts the extractor to support that and meanwhile fixes some small issues.

Related to https://github.com/odoo/enterprise/pull/80216