### PR TITLE
[IMP] fleet: keep odometers driver history

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -162,11 +162,14 @@ class FleetVehicle(models.Model):
                 record.odometer = 0
 
     def _set_odometer(self):
-        for record in self:
-            if record.odometer:
-                date = fields.Date.context_today(record)
-                data = {'value': record.odometer, 'date': date, 'vehicle_id': record.id}
-                self.env['fleet.vehicle.odometer'].create(data)
+        self.env['fleet.vehicle.odometer'].create([
+            {
+                'value': vehicle.odometer,
+                'date': fields.Date.context_today(vehicle),
+                'vehicle_id': vehicle.id,
+                'driver_id': vehicle.driver_id.id
+            } for vehicle in self if vehicle.odometer
+        ])
 
     def _compute_count_all(self):
         Odometer = self.env['fleet.vehicle.odometer']

--- a/addons/fleet/models/fleet_vehicle_odometer.py
+++ b/addons/fleet/models/fleet_vehicle_odometer.py
@@ -14,7 +14,13 @@ class FleetVehicleOdometer(models.Model):
     value = fields.Float('Odometer Value', aggregator="max")
     vehicle_id = fields.Many2one('fleet.vehicle', 'Vehicle', required=True)
     unit = fields.Selection(related='vehicle_id.odometer_unit', string="Unit", readonly=True)
-    driver_id = fields.Many2one(related="vehicle_id.driver_id", string="Driver", readonly=False)
+    driver_id = fields.Many2one('res.partner', string="Driver", compute='_compute_driver_id', readonly=False, store=True)
+
+    @api.depends('vehicle_id')
+    def _compute_driver_id(self):
+        for odometer in self:
+            if not odometer.driver_id:
+                odometer.driver_id = odometer.vehicle_id.driver_id
 
     @api.depends('vehicle_id', 'date')
     def _compute_vehicle_log_name(self):


### PR DESCRIPTION
This PR allows to have a different driver per odometer in order to keep an history of odometers with their driver. By default, when a new odometer is created, the current driver of the car is set.

task-3995630
