### PR TITLE
[FIX] mail: rename mail template to avoid duplicate names

### DIFF
--- a/addons/auth_signup/data/mail_template_data.xml
+++ b/addons/auth_signup/data/mail_template_data.xml
@@ -152,7 +152,7 @@
 
         <!-- Email template for new users that used a signup token -->
         <record id="mail_template_user_signup_account_created" model="mail.template">
-            <field name="name">Settings: New User Invite</field>
+            <field name="name">Settings: New Portal Sign Up</field>
             <field name="model_id" ref="base.model_res_users"/>
             <field name="subject">Welcome to {{ object.company_id.name }}!</field>
             <field name="email_from">{{ (object.company_id.email_formatted or user.email_formatted) }}</field>

--- a/addons/auth_signup/i18n/auth_signup.pot
+++ b/addons/auth_signup/i18n/auth_signup.pot
@@ -610,6 +610,10 @@ msgstr ""
 
 #. module: auth_signup
 #: model:mail.template,name:auth_signup.mail_template_user_signup_account_created
+msgid "Settings: New Portal Sign Up"
+msgstr ""
+
+#. module: auth_signup
 #: model:mail.template,name:auth_signup.set_password_email
 msgid "Settings: New User Invite"
 msgstr ""


### PR DESCRIPTION
Currently, there are two mail templates named "Settings: New User Invite" in the records. To avoid duplication, we will rename the template used to welcome portal users who register as internal users to "Settings: New Portal Sign Up".

Follow up of #188391

Task-4481862

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
