### PR TITLE
[FIX] stock: allow creation of lotless quant with quantity

### DIFF
--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -1171,6 +1171,23 @@ class StockQuant(TransactionCase):
                 'lot_id': lot_a.id,
             })
 
+    def test_set_on_hand_quantity_tracked_product(self):
+        """
+        Checks that you can update the on hand quantity of a tracked product
+        on a quant without a set lot.
+        """
+        quant_without_lot = self.env['stock.quant'].create({
+            'product_id': self.product_lot.id,
+            'location_id': self.stock_location.id,
+            'lot_id': False,
+        })
+        quant_without_lot.with_context({'inventory_mode': True}).inventory_quantity_auto_apply = 10.0
+        self.assertRecordValues(quant_without_lot, [{
+            'product_id': self.product_lot.id,
+            'quantity': 10.0,
+            'lot_id': False,
+        }])
+
 
 class StockQuantRemovalStrategy(TransactionCase):
     def setUp(self):


### PR DESCRIPTION
### Steps to reproduce:

- Create a storable product tracked by lot/serial
- Click on "On Hand"
- Create a new line with 10 "On Hand Quantity" WITHOUT lot/serial
- Go back to the product: The "On Hand" quantity is still at 0.
- Click back to the "On Hand": the quantity of the line is back to 0.

### Cause of the issue:

When a new line is created and the "On Hand Quantity" is edited from the `view_stock_quant_tree` view, we actually performs a create of the stock.quant followed by a write on the `inventory_quantity_auto_apply`. At this point the 'quantity' field of the new quant is not set and the `action_apply_inventory` of the `inventory_quantity_auto_apply` is expected to create and validate a move line in order to update our quant quantities here:
https://github.com/odoo/odoo/blob/e041e890b91e5bc515e1827683f073781788f253/addons/stock/models/stock_quant.py#L230-L235 However, this steps will never be performed as we return the call before the `_apply_invetory` because our quant is set without lots: https://github.com/odoo/odoo/blob/e041e890b91e5bc515e1827683f073781788f253/addons/stock/models/stock_quant.py#L447-L449 https://github.com/odoo/odoo/blob/e041e890b91e5bc515e1827683f073781788f253/addons/stock/models/stock_quant.py#L465-L477

### Fix:

Since the return value of the `action_apply_inventory` is only expected to be used in the `view_stock_quant_tree_editable` (Inventory adjustment ) where it is not possible to set the `inventory_quantity_auto_apply` inventory, we skip this return in case the calls has been performed from setting the `inventory_quantity_auto_apply` and proceed with the `_apply_inventory`.

opw-4428050
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
