### PR TITLE
[MERGE] mail, various: improve sending flow (author, notified followers)

### DIFF
--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -195,7 +195,7 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                         'email_from': self.user_account_other.email_formatted,
                         'subject': _exp_subject,
                         'reply_to': formataddr((
-                            f'{move.company_id.name} {_exp_move_name}',
+                            self.user_account_other.name,
                             f'{self.alias_catchall}@{self.alias_domain}'
                         )),
                     },
@@ -206,7 +206,7 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                         'mail_server_id': self.mail_server_default,
                         'subject': _exp_subject,
                         'reply_to': formataddr((
-                            f'{move.company_id.name} {_exp_move_name}',
+                            self.user_account_other.name,
                             f'{self.alias_catchall}@{self.alias_domain}'
                         )),
                     },
@@ -276,7 +276,7 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                 'email_from': self.user_account_other.email_formatted,
                 'subject': f'{self.env.user.company_id.name} Invoice (Ref {test_move.name})',
                 'reply_to': formataddr((
-                    f'{test_move.company_id.name} {test_move.display_name}',
+                    self.user_account_other.name,
                     f'{self.alias_catchall}@{self.alias_domain}'
                 )),
             },
@@ -287,7 +287,7 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                 'mail_server_id': self.mail_server_default,
                 'subject': f'{self.env.user.company_id.name} Invoice (Ref {test_move.name})',
                 'reply_to': formataddr((
-                    f'{test_move.company_id.name} {test_move.display_name}',
+                    self.user_account_other.name,
                     f'{self.alias_catchall}@{self.alias_domain}'
                 )),
             },
@@ -363,7 +363,7 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                 'email_from': self.user_account_other.email_formatted,
                 'subject': f'SpanishSubject for {test_move.name}',  # translated version
                 'reply_to': formataddr((
-                    f'{test_move.company_id.name} {test_move.display_name}',
+                    self.user_account_other.name,
                     f'{self.alias_catchall}@{self.alias_domain}'
                 )),
             },
@@ -374,7 +374,7 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                 'mail_server_id': self.mail_server_default,
                 'subject': f'SpanishSubject for {test_move.name}',  # translated version
                 'reply_to': formataddr((
-                    f'{test_move.company_id.name} {test_move.display_name}',
+                    self.user_account_other.name,
                     f'{self.alias_catchall}@{self.alias_domain}'
                 )),
             },
@@ -435,7 +435,7 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                 'email_from': self.user_account_other.email_formatted,
                 'subject': f'{self.env.user.company_id.name} Invoice (Ref {test_move.name})',
                 'reply_to': formataddr((
-                    f'{test_move.company_id.name} {test_move.display_name}',
+                    self.user_account_other.name,
                     f'{self.alias_catchall}@{self.alias_domain}'
                 )),
             },
@@ -446,7 +446,7 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                 'mail_server_id': self.mail_server_default,
                 'subject': f'{self.env.user.company_id.name} Invoice (Ref {test_move.name})',
                 'reply_to': formataddr((
-                    f'{test_move.company_id.name} {test_move.display_name}',
+                    self.user_account_other.name,
                     f'{self.alias_catchall}@{self.alias_domain}'
                 )),
             },

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1932,13 +1932,13 @@ class CrmLead(models.Model):
                 _('Deadline: %s', self.date_deadline.strftime(get_lang(self.env).date_format)))
         return render_context
 
-    def _notify_get_reply_to(self, default=None):
+    def _notify_get_reply_to(self, default=None, author_id=False):
         # Override to set alias of lead and opportunities to their sales team if any
-        aliases = self.mapped('team_id').sudo()._notify_get_reply_to(default=default)
+        aliases = self.mapped('team_id').sudo()._notify_get_reply_to(default=default, author_id=author_id)
         res = {lead.id: aliases.get(lead.team_id.id) for lead in self}
         leftover = self.filtered(lambda rec: not rec.team_id)
         if leftover:
-            res.update(super(CrmLead, leftover)._notify_get_reply_to(default=default))
+            res.update(super(CrmLead, leftover)._notify_get_reply_to(default=default, author_id=author_id))
         return res
 
     def _message_get_default_recipients(self):

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -551,13 +551,13 @@ class HrApplicant(models.Model):
             return self.env.ref('hr_recruitment.mt_applicant_stage_changed')
         return super()._track_subtype(init_values)
 
-    def _notify_get_reply_to(self, default=None):
+    def _notify_get_reply_to(self, default=None, author_id=False):
         """ Override to set alias of applicants to their job definition if any. """
-        aliases = self.mapped('job_id')._notify_get_reply_to(default=default)
+        aliases = self.mapped('job_id')._notify_get_reply_to(default=default, author_id=author_id)
         res = {app.id: aliases.get(app.job_id.id) for app in self}
         leftover = self.filtered(lambda rec: not rec.job_id)
         if leftover:
-            res.update(super(HrApplicant, leftover)._notify_get_reply_to(default=default))
+            res.update(super(HrApplicant, leftover)._notify_get_reply_to(default=default, author_id=author_id))
         return res
 
     def _get_customer_information(self):

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1182,6 +1182,7 @@ class MailMessage(models.Model):
     @api.model
     def _get_reply_to(self, values):
         """ Return a specific reply_to for the document """
+        author_id = values.get('author_id')
         model = values.get('model', self._context.get('default_model'))
         res_id = values.get('res_id', self._context.get('default_res_id')) or False
         email_from = values.get('email_from')
@@ -1191,7 +1192,7 @@ class MailMessage(models.Model):
             records = self.env[model].browse([res_id])
         else:
             records = self.env[model] if model else self.env['mail.thread']
-        return records.sudo()._notify_get_reply_to(default=email_from)[res_id]
+        return records.sudo()._notify_get_reply_to(default=email_from, author_id=author_id)[res_id]
 
     @api.model
     def _get_message_id(self, values):

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2411,7 +2411,7 @@ class MailThread(models.AbstractModel):
         if 'record_company_id' not in msg_values:
             msg_values['record_company_id'] = self._mail_get_companies(default=self.env.company)[self.id].id
         if 'reply_to' not in msg_values:
-            msg_values['reply_to'] = self._notify_get_reply_to(default=email_from)[self.id]
+            msg_values['reply_to'] = self._notify_get_reply_to(default=email_from, author_id=author_id)[self.id]
 
         msg_values.update(
             self._process_attachments_for_post(attachments, attachment_ids, msg_values)
@@ -2892,7 +2892,7 @@ class MailThread(models.AbstractModel):
             if 'record_company_id' not in msg_values:
                 msg_values['record_company_id'] = self._mail_get_companies(default=self.env.company)[self.id].id
         if 'reply_to' not in msg_values:
-            msg_values['reply_to'] = self._notify_get_reply_to(default=email_from)[self.id if self else False]
+            msg_values['reply_to'] = self._notify_get_reply_to(default=email_from, author_id=author_id)[self.id if self else False]
 
         msg_values.update(
             self._process_attachments_for_post(attachments, attachment_ids, msg_values)
@@ -2997,7 +2997,7 @@ class MailThread(models.AbstractModel):
             'email_add_signature': False,  # False as no notification -> no need to compute signature
             'message_id': generate_tracking_message_id('message-notify'),  # why? this is all but a notify
             'partner_ids': partner_ids,
-            'reply_to': self.env['mail.thread']._notify_get_reply_to(default=email_from)[False],
+            'reply_to': self.env['mail.thread']._notify_get_reply_to(default=email_from, author_id=author_id)[False],
         }
 
         values_list = [dict(base_message_values,

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -287,13 +287,13 @@ class Base(models.AbstractModel):
             }
         return res
 
-    def _notify_get_reply_to(self, default=None):
+    def _notify_get_reply_to(self, default=None, author_id=False):
         """ Returns the preferred reply-to email address when replying to a thread
         on documents. This method is a generic implementation available for
         all models as we could send an email through mail templates on models
         not inheriting from mail.thread.
 
-        Reply-to is formatted like "MyCompany MyDocument <reply.to@domain>".
+        Reply-to is formatted like '"Author Name" <reply.to@domain>".
         Heuristic it the following:
          * search for specific aliases as they always have priority; it is limited
            to aliases linked to documents (like project alias for task for example);
@@ -302,13 +302,11 @@ class Base(models.AbstractModel):
 
         This method can be used as a generic tools if self is a void recordset.
 
-        Override this method on a specific model to implement model-specific
-        behavior. Also consider inheriting from ``mail.thread``.
-        An example would be tasks taking their reply-to alias from their project.
-
         :param default: default email if no alias or catchall is found;
+        :param author_id: author to use in name part of formatted email;
+
         :return result: dictionary. Keys are record IDs and value is formatted
-          like an email "Company_name Document_name <reply_to@email>"/
+          like an email "Company_name Document_name <reply_to@email>"
         """
         _records = self
         model = _records._name if _records and _records._name != 'mail.thread' else False
@@ -354,12 +352,13 @@ class Base(models.AbstractModel):
         reply_to_formatted = dict.fromkeys(_res_ids, default)
         for res_id, record_reply_to in reply_to_email.items():
             reply_to_formatted[res_id] = self._notify_get_reply_to_formatted_email(
-                record_reply_to, doc_names.get(res_id) or '', company=record_ids_to_company[res_id],
+                record_reply_to, doc_names.get(res_id) or '',
+                author_id=author_id,
             )
 
         return reply_to_formatted
 
-    def _notify_get_reply_to_formatted_email(self, record_email, record_name, company=False):
+    def _notify_get_reply_to_formatted_email(self, record_email, record_name, author_id=False):
         """ Compute formatted email for reply_to and try to avoid refold issue
         with python that splits the reply-to over multiple lines. It is due to
         a bad management of quotes (missing quotes after refold). This appears
@@ -386,22 +385,18 @@ class Base(models.AbstractModel):
             _logger.warning('Notification email address for reply-to is longer than 68 characters. '
                 'This might create non-compliant folding in the email header in certain DKIM '
                 'verification tech stacks. It is advised to shorten it if possible. '
-                'Record name (if set): %s '
-                'Reply-To: %s ', record_name, record_email)
+                'Reply-To: %s ', record_email)
             return record_email
 
-        if not company:
-            if len(self) == 1:
-                company = self.sudo()._mail_get_companies(default=self.env.company)
-            else:
-                company = self.env.company
+        if author_id:
+            author_name = self.env['res.partner'].browse(author_id).name
+        else:
+            author_name = self.env.user.name
 
-        # try company.name + record_name, or record_name alone (or company.name alone)
-        name = f"{company.name} {record_name}" if record_name else company.name
-
-        formatted_email = tools.formataddr((name, record_email))
+        # try user.name alone, then company.name alone
+        formatted_email = tools.formataddr((author_name, record_email))
         if len(formatted_email) > length_limit:
-            formatted_email = tools.formataddr((record_name or company.name, record_email))
+            formatted_email = tools.formataddr((self.env.user.name, record_email))
         if len(formatted_email) > length_limit:
             formatted_email = record_email
         return formatted_email

--- a/addons/mail/tests/test_mail_message.py
+++ b/addons/mail/tests/test_mail_message.py
@@ -4,7 +4,7 @@ from odoo.addons.mail.tests import common
 from odoo.tests import new_test_user, tagged
 
 
-@tagged("-at_install", "post_install")
+@tagged("-at_install", "post_install", "mail_message")
 class TestMailMessage(common.MailCommon):
     def test_unlink_failure_message_notify_author(self):
         recipient = new_test_user(self.env, login="Bob", email="invalid_email_addr")

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -1125,7 +1125,10 @@ class MailComposeMessage(models.TransientModel):
         # is coming from reply_to field to render.
         if not self.reply_to_force_new:
             # compute alias-based reply-to in batch
-            reply_to_values = RecordsModel.browse(res_ids)._notify_get_reply_to(default=False)
+            reply_to_values = RecordsModel.browse(res_ids)._notify_get_reply_to_batch(
+                defaults=emails_from,
+                author_ids={res_id: self.author_id.id for res_id in res_ids},
+            )
         if self.reply_to_force_new:
             reply_to_values = self._render_field('reply_to', res_ids)
 

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -637,7 +637,7 @@ class MailComposeMessage(models.TransientModel):
         parameter. 'Reply-All' behavior triggers skipping followers. """
         self.filtered(lambda c: c.composition_mode != 'comment').notify_skip_followers = False
         self.filtered(
-            lambda c: c.composition_mode == 'comment' and c.composition_comment_option == 'reply_all'
+            lambda c: c.composition_mode == 'comment' and c.composition_comment_option == 'forward'
         ).notify_skip_followers = True
 
     @api.depends('composition_mode', 'model', 'res_ids', 'template_id')

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -42,10 +42,11 @@
                         <label for="partner_ids" string="To" invisible="composition_mode != 'comment' or subtype_is_log"/>
                         <div groups="base.group_user" invisible="composition_mode != 'comment' or subtype_is_log">
                             <widget invisible="not model or composition_mode == 'mass_mail' or composition_comment_option in ['reply_all', 'forward']" name="mail_composer_recipient_list" thread_model_field="model" thread_id_field="res_ids"/>
-                            <field name="partner_ids" widget="many2many_tags_email" placeholder="Add contacts to notify..."
+                            <field name="partner_ids" widget="many2many_tags_email" placeholder="Followers only"
                                 required="composition_comment_option == 'forward'"
                                 options="{'no_quick_create': True}" context="{'show_email':True, 'form_view_ref': 'base.view_partner_simple_form'}"/>
                         </div>
+                        <field name="notified_bcc" placeholder="Bcc"/>
                         <field name="subject" placeholder="Welcome to MyCompany!" required="True"/>
                     </group>
                     <field name="can_edit_body" invisible="1"/>

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1631,13 +1631,13 @@ class ProjectTask(models.Model):
 
         return groups
 
-    def _notify_get_reply_to(self, default=None):
+    def _notify_get_reply_to(self, default=None, author_id=False):
         # Override to set alias of tasks to their project if any
-        aliases = self.sudo().mapped('project_id')._notify_get_reply_to(default=default)
+        aliases = self.sudo().mapped('project_id')._notify_get_reply_to(default=default, author_id=author_id)
         res = {task.id: aliases.get(task.project_id.id) for task in self}
         leftover = self.filtered(lambda rec: not rec.project_id)
         if leftover:
-            res.update(super(ProjectTask, leftover)._notify_get_reply_to(default=default))
+            res.update(super(ProjectTask, leftover)._notify_get_reply_to(default=default, author_id=author_id))
         return res
 
     def _ensure_personal_stages(self):

--- a/addons/project/tests/test_project_mail_features.py
+++ b/addons/project/tests/test_project_mail_features.py
@@ -150,7 +150,7 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                         'partner_ids': self.partner_1 + self.partner_2,
                         'parent_id': self.env['mail.message'],
                         'reply_to': formataddr((
-                            f'{self.env.company.name} {self.project_followers.name}',
+                            self.user_portal.name,
                             self.project_followers_alias.alias_full_name
                         )),
                         'subject': f'Test from {self.user_portal.name}',
@@ -200,10 +200,6 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                 new_partner_customer = self.env['res.partner'].search([('email_normalized', '=', 'new.customer@test.agrolait.com')])
                 self.assertFalse(new_partner_customer)
 
-                expected_chatter_reply_to = formataddr(
-                    (f'{self.env.company.name} {self.project_followers.name}', self.project_followers_alias.alias_full_name)
-                )
-
                 self.assertIn('Please call me as soon as possible', task.description)
                 self.assertEqual(task.email_cc, f'"New Cc" <new.cc@test.agrolait.com>, {self.partner_2.email_formatted}')
                 self.assertEqual(task.name, f'Test from {author.email_formatted}')
@@ -240,7 +236,7 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                                 # deduced from 'To' and 'Cc' (recognized partners)
                                 'partner_ids': self.partner_1 + self.partner_2,
                                 'parent_id': self.env['mail.message'],
-                                'reply_to': expected_chatter_reply_to,
+                                'reply_to': formataddr((author.name, self.project_followers_alias.alias_full_name)),
                                 'subject': f'Test from {author.email_formatted}',
                                 'subtype_id': self.env.ref('project.mt_task_new'),
                             },
@@ -273,10 +269,7 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                                 # default recipients: partner_id
                                 'partner_ids': author,
                                 'parent_id': incoming_email,
-                                'reply_to': formataddr((
-                                    f'{self.env.company.name} {self.project_followers.name}',
-                                    self.project_followers_alias.alias_full_name
-                                )),
+                                'reply_to': formataddr((acknowledgement_author.name, self.project_followers_alias.alias_full_name)),
                                 'subject': f'Test Acknowledge {task.name}',
                                 # defined by _track_template
                                 'subtype_id': self.env.ref('mail.mt_note'),
@@ -371,7 +364,7 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                                 'parent_id': incoming_email,
                                 # coming from post
                                 'partner_ids': recipients,
-                                'reply_to': expected_chatter_reply_to,
+                                'reply_to': formataddr((self.user_projectuser.name, self.project_followers_alias.alias_full_name)),
                                 'subject': f'Re: {task.name}',
                                 'subtype_id': self.env.ref('mail.mt_comment'),
                             },
@@ -441,14 +434,17 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                                 # coming from incoming email
                                 'incoming_email_cc': f'"Another Cc" <another.cc@test.agrolait.com>, {self.partner_3.email}',
                                 # To: received email Msg-To - customer who replies + email Reply-To
-                                'incoming_email_to': ', '.join(external_partners.mapped('email_formatted') + [expected_chatter_reply_to]),
+                                'incoming_email_to': ', '.join(
+                                    external_partners.mapped('email_formatted') +
+                                    [formataddr((self.user_projectuser.name, self.project_followers_alias.alias_full_name))]
+                                ),
                                 'mail_server_id': self.env['ir.mail_server'],
                                 # notified: followers - already emailed, aka internal only
                                 'notified_partner_ids': internal_followers,
                                 'parent_id': incoming_email,
                                 # same reasoning as email_to/cc
                                 'partner_ids': external_partners + self.partner_3,
-                                'reply_to': expected_chatter_reply_to,
+                                'reply_to': formataddr((author.name, self.project_followers_alias.alias_full_name)),
                                 'subject': f'Re: Re: {task.name}',
                                 'subtype_id': self.env.ref('mail.mt_comment'),
                             },
@@ -507,9 +503,7 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                         # followers of 'new task' type
                         'partner_ids': (self.user_projectuser + self.user_projectmanager).partner_id,
                         'parent_id': self.env['mail.message'],
-                        'reply_to': formataddr((
-                            f'{self.env.company.name} {self.project_followers.name}',
-                            self.project_followers_alias.alias_full_name
+                        'reply_to': formataddr((self.user_projectmanager.name, self.project_followers_alias.alias_full_name
                         )),
                         'subject': test_task.name,
                         'subtype_id': self.env.ref('mail.mt_note'),

--- a/addons/test_mail/models/mail_test_ticket.py
+++ b/addons/test_mail/models/mail_test_ticket.py
@@ -148,13 +148,13 @@ class MailTestTicketMc(models.Model):
                 values['company_id'] = ticket.company_id.id
         return email_keys_to_values
 
-    def _notify_get_reply_to(self, default=None):
+    def _notify_get_reply_to(self, default=None, author_id=False):
         # Override to use alias of the parent container
-        aliases = self.sudo().mapped('container_id')._notify_get_reply_to(default=default)
+        aliases = self.sudo().mapped('container_id')._notify_get_reply_to(default=default, author_id=author_id)
         res = {ticket.id: aliases.get(ticket.container_id.id) for ticket in self}
         leftover = self.filtered(lambda rec: not rec.container_id)
         if leftover:
-            res.update(super()._notify_get_reply_to(default=default))
+            res.update(super()._notify_get_reply_to(default=default, author_id=author_id))
         return res
 
 

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -2912,7 +2912,7 @@ class TestComposerResultsMass(TestMailComposer):
                 composer = composer_form.save()
 
                 # ensure some parameters used afterwards
-                author = self.env.user.partner_id
+                author = self.partner_employee
                 self.assertEqual(composer.author_id, author,
                                  'Author is not synchronized, as template email_from does not match existing partner')
                 self.assertEqual(composer.email_from, self.template.email_from)
@@ -2980,7 +2980,7 @@ class TestComposerResultsMass(TestMailComposer):
                                             'email_from': self.partner_employee_2.email_formatted,
                                             'mail_server_id': self.mail_server_domain,
                                             'reply_to': formataddr((
-                                                f'{self.env.user.company_id.name} {record.name}',
+                                                author.name,
                                                 f'{self.alias_catchall}@{self.alias_domain}'
                                             )),
                                             'subject': exp_subject,
@@ -3398,7 +3398,7 @@ class TestComposerResultsMass(TestMailComposer):
                     # single email event if email field is multi-email
                     'email_from': formataddr((self.user_employee.name, 'email.from.1@test.mycompany.com')),
                     'reply_to': formataddr((
-                        f'{self.env.user.company_id.name} {record.name}',
+                        self.partner_employee.name,
                         f'{self.alias_catchall}@{self.alias_domain}'
                     )),
                     'subject': f'TemplateSubject {record.name}',
@@ -3407,7 +3407,7 @@ class TestComposerResultsMass(TestMailComposer):
                     # currently holding multi-email 'email_from'
                     'email_from': self.partner_employee.email_formatted,
                     'reply_to': formataddr((
-                        f'{self.env.user.company_id.name} {record.name}',
+                        self.partner_employee.name,
                         f'{self.alias_catchall}@{self.alias_domain}'
                     )),
                 },

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -1682,10 +1682,10 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
                     'subtype_id': self.env.ref('mail.mt_comment').id,
                 })
                 _mail, message = composer._action_send_mail()
-                if option == 'reply_all':
+                if option == 'forward':
                     self.assertEqual(
                         message.notified_partner_ids, self.partner_admin,
-                        'Either reply_all is broken, either notify_skip_followers parameter is broken')
+                        'Either forward is broken, either notify_skip_followers parameter is broken')
                 else:
                     self.assertEqual(message.notified_partner_ids, self.partner_employee_2 + self.partner_admin,
                                         'classic notify: followers + recipients - author')

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -1041,6 +1041,7 @@ class TestComposerInternals(TestMailComposer):
                                                     'test.cc.2@test.example.com'])
                     ])
                 )
+                self.assertEqual(self.test_record.message_partner_ids, self.partner_employee_2)
 
                 batch = bool(batch_mode)
                 test_records = self.test_records if batch else self.test_record
@@ -1062,6 +1063,10 @@ class TestComposerInternals(TestMailComposer):
                 })
 
                 # creation values are taken
+                if composition_mode == 'comment' and not batch_mode:
+                    self.assertEqual(composer.notified_bcc, self.partner_employee_2.name)
+                else:
+                    self.assertFalse(composer.notified_bcc)
                 self.assertEqual(composer.partner_ids, base_recipients)
                 self.assertEqual(composer.reply_to, 'my_reply_to@test.example.com')
                 self.assertFalse(composer.reply_to_force_new)

--- a/addons/test_mail/tests/test_mail_flow.py
+++ b/addons/test_mail/tests/test_mail_flow.py
@@ -242,9 +242,6 @@ class TestMailFlow(MailCommon, TestRecipients):
 
         external_partners = partner_sylvie + partner_pay + partner_accounting + self.customer_portal_zboing + self.partner_portal
         internal_partners = self.partner_employee + self.partner_employee_2
-        expected_chatter_reply_to = formataddr(
-            (f'{self.env.company.name} {lead.name}', f'{self.alias_catchall}@{self.alias_domain}')
-        )
         self.assertMailNotifications(
             responsible_answer,
             [
@@ -265,7 +262,9 @@ class TestMailFlow(MailCommon, TestRecipients):
                         'parent_id': incoming_email,
                         # matches posted message
                         'partner_ids': partner_sylvie + partner_pay + partner_accounting + self.customer_portal_zboing,
-                        'reply_to': expected_chatter_reply_to,
+                        'reply_to': formataddr((
+                            self.partner_employee.name, f'{self.alias_catchall}@{self.alias_domain}'
+                        )),
                         'subtype_id': self.env.ref('mail.mt_comment'),
                     },
                     'notif': [
@@ -322,13 +321,20 @@ class TestMailFlow(MailCommon, TestRecipients):
                         # Cc: received email CC - an email still not partnerized (invoicing) and customer_zboing
                         'incoming_email_cc': f'{self.test_emails[3]}, {self.test_emails[4]}',
                         # To: received email Msg-To - customer who replies + email Reply-To
-                        'incoming_email_to': ', '.join((external_partners - partner_sylvie - self.customer_zboing).mapped('email_formatted') + [expected_chatter_reply_to]),
+                        'incoming_email_to':
+                            ', '.join((external_partners - partner_sylvie - self.customer_zboing).mapped('email_formatted') +
+                            [formataddr((
+                                self.partner_employee.name, f'{self.alias_catchall}@{self.alias_domain}'
+                            ))]),
                         'mail_server_id': self.env['ir.mail_server'],
                         # notified: followers - already mailed, aka internal only
                         'notified_partner_ids': internal_partners,
                         'parent_id': incoming_email,
                         # same reasoning as email_to/cc
                         'partner_ids': external_partners - partner_sylvie,
+                        'reply_to': formataddr((
+                            partner_sylvie.name, f'{self.alias_catchall}@{self.alias_domain}'
+                        )),
                         'subject': f'Re: Re: {lead.name}',
                         'subtype_id': self.env.ref('mail.mt_comment'),
                     },

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -1609,10 +1609,6 @@ class TestMailgateway(MailGatewayCommon):
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')
     def test_message_process_reply_to_new_thread(self):
         """ Test replies not being considered as replies but use destination information instead (aka, mass post + specific reply to using aliases) """
-        # shorten company name to prevent 68 character formatting from
-        # triggering and making the assert missmatch.
-        # See _notify_get_reply_to_formatted_email method
-        self.user_employee.company_id.name = "Forced"
         first_record = self.env['mail.test.simple'].with_user(self.user_employee).create({'name': 'Replies to Record'})
         record_msg = first_record.message_post(
             subject='Discussion',
@@ -1621,8 +1617,7 @@ class TestMailgateway(MailGatewayCommon):
         )
         self.assertEqual(
             record_msg.reply_to,
-            formataddr((f'{self.user_employee.company_id.name} {first_record.name}',
-                        f'{self.alias_catchall}@{self.alias_domain}'))
+            formataddr((self.partner_employee.name, f'{self.alias_catchall}@{self.alias_domain}'))
         )
         mail_msg = first_record.message_post(
             subject='Replies to Record',

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -1024,7 +1024,10 @@ class TestNoThread(MailCommon, TestRecipients):
                 with self.assertPostNotifications([{
                         'content': 'Hello Paulo',
                         'email_values': {
-                            'reply_to': self.company_admin.catchall_formatted,
+                            'reply_to': tools.mail.formataddr((
+                                self.partner_employee.name,
+                                self.company_admin.catchall_email,
+                            )),
                         },
                         'message_type': 'user_notification',
                         'notif': [{
@@ -1111,7 +1114,10 @@ class TestNoThread(MailCommon, TestRecipients):
         with self.assertPostNotifications([{
                 'content': 'Hello Paulo',
                 'email_values': {
-                    'reply_to': self.company_admin.catchall_formatted,
+                    'reply_to': tools.mail.formataddr((
+                        self.partner_employee.name,
+                        self.company_admin.catchall_email,
+                    )),
                     'subject': 'Test Notify',
                 },
                 'message_type': 'user_notification',

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -418,7 +418,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, _test_template = self._create_test_records()
         customer = self.env['res.partner'].browse(self.customer.ids)
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
-        with self.assertQueryCount(admin=9, employee=9):  # tm 8/8
+        with self.assertQueryCount(admin=15, employee=15):  # tm 14/14
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -494,7 +494,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=35, employee=35):
+        with self.assertQueryCount(admin=34, employee=34):
             composer._action_send_mail()
 
         # notifications
@@ -518,7 +518,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=44, employee=44):
+        with self.assertQueryCount(admin=43, employee=43):
             composer._action_send_mail()
 
         # notifications
@@ -539,7 +539,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_template.write({'attachment_ids': [(5, 0)]})
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=13, employee=13):  # tm 12/12
+        with self.assertQueryCount(admin=15, employee=15):  # tm 14/14
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -569,7 +569,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=13, employee=13):  # tm 12/12
+        with self.assertQueryCount(admin=15, employee=15):  # tm 14/14
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -766,16 +766,13 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         with self.assertQueryCount(admin=1, employee=1):
             test_records = self.env['mail.test.container'].browse(test_records_sudo.ids)
             reply_to = test_records._notify_get_reply_to(
-                default=self.env.user.email_formatted
+                default=self.env.user.email_formatted,
             )
 
         for record in test_records:
             self.assertEqual(
                 reply_to[record.id],
-                formataddr((
-                    f"{record.env.company.name} {record.name}",
-                    f"{record.alias_name}@{self.alias_domain}"
-                ))
+                formataddr((self.env.user.name, f"{record.alias_name}@{self.alias_domain}"))
             )
 
 
@@ -836,7 +833,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             'mail_message_id': message.id,
             'recipient_ids': [(4, pid) for pid in self.partners.ids],
         })
-        with self.assertQueryCount(admin=8, employee=8):
+        with self.assertQueryCount(admin=9, employee=9):
             self.env['mail.mail'].sudo().browse(mail.ids).send()
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
@@ -875,7 +872,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             unlinked_mails |= set(records.ids)
         unlinked_mails = set()
 
-        with self.assertQueryCount(admin=30, employee=30), \
+        with self.assertQueryCount(admin=31, employee=31), \
              patch.object(type(self.env['mail.mail']), 'unlink', _patched_unlink):
             self.env['mail.mail'].sudo().browse(mails.ids).send()
 


### PR DESCRIPTION
Rationale

Improve post and discussion flows to look more like classic email flows.
Notable make explicit recipients, who is going to be notified, who
are authors and replies going to land, ...

Specifications: Bcc in composer

When being in monorecord comment mode, compute 'Bcc' as being the
followers about to be notified of the message. This is done using
the same heuristics as mail.thread, aka calling '_get_recipients_data'
using the record, message_type, message_subtype. That way followers
are correctly computed. Remove partners being in partner_ids, as they
are already in explicit 'To' recipients.

Specifications: author name in Reply-To

New reply-to form should be '"Author Name" <notification@domain.com>'.
Remove computation based on record name, company, ... Customers expect
to reply to people, not on records.

Part of Task-4273479: [mail] Email-like recipients