### PR TITLE
[IMP] partner_autocomplete: additional info on partner update

### DIFF
--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -225,8 +225,20 @@ class ResPartner(models.Model):
         return partners
 
     def write(self, values):
+        additional_info = values.get("additional_info")
+        if additional_info:
+            template_values = json.loads(additional_info)
+            template_values["flavor_text"] = _(
+                "Partner enriched by Odoo Partner Autocomplete Service"
+            )
+            values["additional_info"] = False
         res = super(ResPartner, self).write(values)
         if len(self) == 1:
             self._update_autocomplete_data(values.get('vat', False))
-
+        if additional_info:
+            self.message_post_with_view(
+                "iap_mail.enrich_company",
+                values=template_values,
+                subtype_id=self.env.ref("mail.mt_note").id,
+            )
         return res


### PR DESCRIPTION
targeted versions: >=16

We can enrich an existing partner but only when we create it we get a message with the additional info. Until now, it remained hidden in the additional_info field. Now we can follow the same approach as when we create the contact and post it to the partner thread.

cc @Tecnativa TT52584


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
