### PR TITLE
[FIX] mail: users appearing as offline

### DIFF
--- a/addons/bus/static/src/im_status_service.js
+++ b/addons/bus/static/src/im_status_service.js
@@ -58,6 +58,7 @@ export const imStatusService = {
             }
             startAwayTimeout();
         });
+        return { updateBusPresence };
     },
 };
 

--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -84,7 +84,13 @@ export class Persona extends Record {
     /** @type {number} */
     userId;
     /** @type {ImStatus} */
-    im_status;
+    im_status = Record.attr(null, {
+        onUpdate() {
+            if (this.eq(this.store.self) && this.im_status === "offline") {
+                this.store.env.services.im_status.updateBusPresence();
+            }
+        },
+    });
     /** @type {'email' | 'inbox'} */
     notification_preference;
     isAdmin = false;

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -766,7 +766,7 @@ export class Store extends BaseStore {
 Store.register();
 
 export const storeService = {
-    dependencies: ["bus_service", "ui"],
+    dependencies: ["bus_service", "im_status", "ui"],
     /**
      * @param {import("@web/env").OdooEnv} env
      * @param {Partial<import("services").Services>} services


### PR DESCRIPTION
When a user disconnects, a message is sent on the bus. If another device is active, he will correct the user status. However, it can happen that this message is lost. For instance, when the bus table is cleared while the user is disconnected. Other parts of the code will update the user status, but the status will never be corrected.

This PR react to the user status changes to solve this issue.

opw-4484966

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
