### PR TITLE
[FIX] mail: draggable participant cards on mobile

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -205,6 +205,13 @@ export class CallParticipantCard extends Component {
         document.addEventListener("mousemove", onMousemove);
     }
 
+    onTouchMove(ev) {
+        if (!this.props.inset) {
+            return;
+        }
+        this.drag(ev);
+    }
+
     drag(ev) {
         this.state.drag = true;
         const insetEl = this.root.el;

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -15,7 +15,7 @@
             t-on-click="onClick"
             t-on-contextmenu="onContextMenu"
             t-on-mousedown="onMouseDown"
-            t-on-touchmove="(ev) => this.drag(ev)"
+            t-on-touchmove="onTouchMove"
             t-ref="root"
         >
             <!-- card -->


### PR DESCRIPTION
Before this commit, when dragging participant cards on mobile they will get dragged off screen.
1. Open discuss on mobile
2. Get into a call
3. Move the participant cards -> they will disappear

This happens because the `drag` function gets called without checking if the participant card is in the inset state (the state in which it can be moved around).
This commit fixes the issue by checking that the component is in that state before being able to drag it.

task-4491597