### PR TITLE
[FIX] point_of_sale: auto apply fiscal position

### DIFF
--- a/addons/point_of_sale/models/account_fiscal_position.py
+++ b/addons/point_of_sale/models/account_fiscal_position.py
@@ -8,7 +8,8 @@ class AccountFiscalPosition(models.Model):
     @api.model
     def _load_pos_data_domain(self, data):
         fp_ids = [preset['fiscal_position_id'] for preset in data['pos.preset']]
-        return [('id', 'in', data['pos.config'][0]['fiscal_position_ids'] + fp_ids)]
+        partner_fp_ids = list({partner['fiscal_position_id'] for partner in data['res.partner'] if partner['fiscal_position_id']}) if 'res.partner' in data.keys() else []
+        return [('id', 'in', data['pos.config'][0]['fiscal_position_ids'] + fp_ids + partner_fp_ids)]
 
     @api.model
     def _load_pos_data_fields(self, config_id):

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -837,9 +837,9 @@ export class PosOrder extends Base {
         );
 
         if (newPartner) {
-            newPartnerFiscalPosition = newPartner.property_account_position_id
+            newPartnerFiscalPosition = newPartner.fiscal_position_id
                 ? this.models["account.fiscal.position"].find(
-                      (position) => position.id === newPartner.property_account_position_id?.id
+                      (position) => position.id === newPartner.fiscal_position_id?.id
                   )
                 : defaultFiscalPosition;
             newPartnerPricelist =

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -41,7 +41,7 @@ export class ControlButtons extends Component {
                 item: "none",
             },
         ];
-        for (const fiscalPos of this.pos.models["account.fiscal.position"].getAll()) {
+        for (const fiscalPos of this.pos.models["pos.config"].getFirst().fiscal_position_ids) {
             fiscalPosList.push({
                 id: fiscalPos.id,
                 label: fiscalPos.name,


### PR DESCRIPTION
Before this commit the auto apply of a fiscal position wasn't implemented in pos.

This commit implements the auto apply of a fiscal position by using the _get_fiscal_position method from account fiscal position to get the fiscal position of each customer. In order to keep the fiscal positions applied to the customers not selectable by the cashier, only the fiscal positions selected in the pos settings are shown in the fiscal position action menu.

Task-4318016
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
