### PR TITLE
[FIX] point_of_sale: fix closing session popup

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
@@ -201,10 +201,16 @@ export class ClosePosPopup extends Component {
             const bankPaymentMethodDiffPairs = this.props.other_payment_methods
                 .filter((pm) => pm.type == "bank")
                 .map((pm) => [pm.id, this.getDifference(pm.id)]);
-            const response = await this.pos.data.call("pos.session", "close_session_from_ui", [
-                this.pos.session.id,
-                bankPaymentMethodDiffPairs,
-            ]);
+            const response = await this.pos.data.call(
+                "pos.session",
+                "close_session_from_ui",
+                [this.pos.session.id, bankPaymentMethodDiffPairs],
+                {
+                    context: {
+                        login_number: odoo.login_number,
+                    },
+                }
+            );
             if (!response.successful) {
                 return this.handleClosingError(response);
             }


### PR DESCRIPTION
Fix issue that was always displaying popup "The session is being closed by another user. The page will be reloaded." each time you close a session. Now the `login_number` is correctly send in the context and can then be used inside `close_session_from_ui` correctly.

task-id: 4485659

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
