### PR TITLE
[FIX] web: buttonbox with only one item alignment on small screen

### DIFF
--- a/addons/web/static/src/views/form/button_box/button_box.scss
+++ b/addons/web/static/src/views/form/button_box/button_box.scss
@@ -176,9 +176,15 @@
     grid-template-columns: repeat(var(--button-box-per-row), minmax(0, 1fr));
     overflow: hidden;
     gap: var(--button-box-gap);
-    width: calc(100vw - var(--button-box-spacing) * 2) !important;
-    left: var(--button-box-spacing) !important;
-    right: var(--button-box-spacing) !important;
+
+    &:has(.o-dropdown-item:only-child) {
+        --button-box-per-row: 1;
+    }
+    &:not(:has(.o-dropdown-item:only-child)) {
+        width: calc(100vw - var(--button-box-spacing) * 2) !important;
+        left: var(--button-box-spacing) !important;
+        right: var(--button-box-spacing) !important;
+    }
 
     > span .o_field_widget, .o_stat_info, .o_stat_value {
         @include text-truncate;


### PR DESCRIPTION
On smaller screen, the statbuttons are grouped in a dropdown (the
"lightning" icon) and displayed in two columns.

But when only one button is present, it leaves a weird empty cell next
to it.

This commit fixes it by adding an exception in CSS when only one button
is present to remove the useless column and center it.

Note: this change doesn't affect the empty cell when an odd number of
buttons are displayed.

task-4491705
