### PR TITLE
[FIX] website: prevent crash with empty links in the mega menu

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -829,10 +829,14 @@ publicWidget.registry.MegaMenuDropdown = publicWidget.Widget.extend({
         const megaMenuEls = this.el.querySelectorAll(".o_mega_menu");
         let matchingLink = null;
         megaMenuEls.forEach((megaMenuEl, position) => {
-            const linkEls = Array.from(megaMenuEl.querySelectorAll(`a:not([href="#"])`));
+            const linkEls = Array.from(megaMenuEl.querySelectorAll(`a[href]:not([href="#"])`));
             matchingLink = linkEls.find((linkEl) => {
-                const url = new URL(linkEl.href);
-                return `${url.origin}${url.pathname}` === currentHrefWithoutHash;
+                try {
+                    const url = new URL(linkEl.href);
+                    return `${url.origin}${url.pathname}` === currentHrefWithoutHash;
+                } catch {
+                    return false;
+                }
             });
             if (matchingLink) {
                 const megaMenuToggleEl = megaMenuEl


### PR DESCRIPTION
Steps to reproduce:

- Open the "Menu Editor" dialog.
- Add a "Mega Menu Item".
- Save the "Menu Editor" dialog.
- Enter "Edit Mode".
- Open the "Mega Menu".
- Select "Images Subtitles" as the "Mega Menu" template option.
- Click on the largest image on the right side of the "Mega Menu".
- Click the "Create Link" button in the image options.
- Leave the input URL empty for this new link.
- Save the page.
- A link without an "href" attribute is now present in the "Mega Menu".
- Edit the browser URL to redirect to a page that is not present in the menu; for example, add "/test" to the current URL. It does not matter whether the page exists or not.
- Bug: A traceback occurs.

The bug occurred because the function "_updateActiveMenuLinks" (introduced by this commit [1]) called "new URL" on an empty string, as it attempted to process a link without an href attribute.

[1]: https://github.com/odoo/odoo/commit/5be12800a59e912997fff39cec57ab70914f2485

opw-4480958