### PR TITLE
[IMP] web: allow kanban record selection

### DIFF
--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -191,7 +191,7 @@
             <field name="model_id" ref="model_account_account"/>
             <field name="groups_id" eval="[(4, ref('account.group_account_manager'))]"/>
             <field name="binding_model_id" ref="account.model_account_account" />
-            <field name="binding_view_types">form,list</field>
+            <field name="binding_view_types">form,list,kanban</field>
             <field name="state">code</field>
             <field name="code">
 if records:

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -402,7 +402,7 @@
             <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
             <field name="model_id" ref="account.model_account_payment"/>
             <field name="binding_model_id" ref="account.model_account_payment"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
             <field name="code">
                 records.action_post()
             </field>
@@ -437,7 +437,7 @@
                 'default_email_layout_xmlid': 'mail.mail_notification_light',
             }"/>
             <field name="binding_model_id" ref="model_account_payment"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
         </record>
     </data>
 </odoo>

--- a/addons/account/wizard/account_merge_wizard_views.xml
+++ b/addons/account/wizard/account_merge_wizard_views.xml
@@ -40,7 +40,7 @@
             <field name="res_model">account.merge.wizard</field>
             <field name="binding_model_id" ref="account.model_account_account"/>
             <field name="binding_type">action</field>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
             <field name="view_mode">form</field>
             <field name="view_id" eval="ref('account.account_merge_wizard_form')"/>
             <field name="target">new</field>

--- a/addons/account/wizard/account_move_reversal_view.xml
+++ b/addons/account/wizard/account_move_reversal_view.xml
@@ -33,7 +33,7 @@
             <field name="target">new</field>
             <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
             <field name="binding_model_id" ref="account.model_account_move" />
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
         </record>
     </data>
 </odoo>

--- a/addons/account/wizard/account_resequence_views.xml
+++ b/addons/account/wizard/account_resequence_views.xml
@@ -38,7 +38,7 @@
             <field name="target">new</field>
             <field name="groups_id" eval="[(6, 0, [ref('base.group_no_one')])]"/>
             <field name="binding_model_id" ref="account.model_account_move" />
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
         </record>
     </data>
 </odoo>

--- a/addons/account/wizard/account_validate_move_view.xml
+++ b/addons/account/wizard/account_validate_move_view.xml
@@ -62,7 +62,7 @@
             <field name="help">This wizard will validate all journal entries selected. Once journal entries are validated, you can not update them anymore.</field>
             <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
             <field name="binding_model_id" ref="account.model_account_move" />
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
         </record>
 
     </data>

--- a/addons/account_check_printing/data/account_check_printing_data.xml
+++ b/addons/account_check_printing/data/account_check_printing_data.xml
@@ -12,7 +12,7 @@
             <field name="name">Print Checks</field>
             <field name="model_id" ref="account.model_account_payment"/>
             <field name="binding_model_id" ref="account.model_account_payment" />
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
             <field name="groups_id" eval="[(4, ref('account.group_account_user'))]"/>
             <field name="state">code</field>
             <field name="code">

--- a/addons/account_debit_note/wizard/account_debit_note_view.xml
+++ b/addons/account_debit_note/wizard/account_debit_note_view.xml
@@ -34,7 +34,7 @@
             <field name="view_id" ref="view_account_debit_note"/>
             <field name="target">new</field>
             <field name="binding_model_id" ref="account.model_account_move" />
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
         </record>
     </data>
 </odoo>

--- a/addons/account_peppol/views/res_partner_views.xml
+++ b/addons/account_peppol/views/res_partner_views.xml
@@ -64,7 +64,7 @@
         <field name="name">Verify Peppol</field>
         <field name="model_id" ref="account_peppol.model_res_partner"/>
         <field name="binding_model_id" ref="base.model_res_partner"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">
             for record in records:

--- a/addons/auth_totp_mail/data/ir_action_data.xml
+++ b/addons/auth_totp_mail/data/ir_action_data.xml
@@ -5,7 +5,7 @@
         <field name="name">Invite to use two-factor authentication</field>
         <field name="model_id" ref="base.model_res_users"/>
         <field name="binding_model_id" ref="base.model_res_users"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">
             action = records.action_totp_invite()

--- a/addons/crm/static/tests/tours/create_crm_team_tour.js
+++ b/addons/crm/static/tests/tours/create_crm_team_tour.js
@@ -29,7 +29,7 @@ registry.category("web_tour.tours").add('create_crm_team_tour', {
 }, {
     trigger: 'div.modal-dialog tr:contains("Test Sales Manager") input.form-check-input:checked',
 }, {
-    trigger: '.o_list_selection_box:contains(2)',
+    trigger: '.o_selection_box:contains(2)',
 }, {
     trigger: 'button.o_select_button',
     run: "click",

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -673,7 +673,7 @@
     'default_composition_mode': 'mass_mail',
                 }</field>
             <field name="binding_model_id" ref="model_crm_lead"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
         </record>
 
         <!--
@@ -1241,7 +1241,7 @@
             <field name="target">new</field>
             <field name="context">{'default_res_model': 'crm.lead', 'default_res_ids': active_ids}</field>
             <field name="binding_model_id" ref="model_crm_lead"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
         </record>
 
 </odoo>

--- a/addons/crm/wizard/crm_lead_to_opportunity_mass_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_mass_views.xml
@@ -59,6 +59,6 @@
         <field name="target">new</field>
         <field name="context">{}</field>
         <field name="binding_model_id" ref="model_crm_lead"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
     </record>
 </odoo>

--- a/addons/crm/wizard/crm_merge_opportunities_views.xml
+++ b/addons/crm/wizard/crm_merge_opportunities_views.xml
@@ -37,7 +37,7 @@
             <field name="view_mode">form</field>
             <field name="target">new</field>
             <field name="binding_model_id" ref="model_crm_lead"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
         </record>
 
 </odoo>

--- a/addons/crm_sms/views/crm_lead_views.xml
+++ b/addons/crm_sms/views/crm_lead_views.xml
@@ -12,7 +12,7 @@
             'default_res_ids': active_ids
         }</field>
         <field name="binding_model_id" ref="crm.model_crm_lead"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
     </record>
     <record id="crm_lead_act_window_sms_composer_multi" model="ir.actions.act_window">
         <field name="name">Send SMS</field>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -591,7 +591,7 @@
         <field name="name">Mail to Driver</field>
         <field name="model_id" ref="fleet.model_fleet_vehicle"/>
         <field name="binding_model_id" ref="fleet.model_fleet_vehicle"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">action = records.action_send_email()</field>
     </record>

--- a/addons/hr/static/src/views/kanban_view.js
+++ b/addons/hr/static/src/views/kanban_view.js
@@ -1,0 +1,29 @@
+import { registry } from "@web/core/registry";
+
+import { kanbanView } from "@web/views/kanban/kanban_view";
+import { KanbanController } from "@web/views/kanban/kanban_controller";
+
+import { useArchiveEmployee } from "@hr/views/archive_employee_hook";
+
+export class EmployeeKanbanController extends KanbanController {
+    setup() {
+        super.setup();
+        this.archiveEmployee = useArchiveEmployee();
+    }
+
+    getStaticActionMenuItems() {
+        const menuItems = super.getStaticActionMenuItems();
+        const selectedRecords = this.model.root.selection;
+
+        menuItems.archive.callback = this.archiveEmployee.bind(
+            this,
+            selectedRecords.map(({ resId }) => resId)
+        );
+        return menuItems;
+    }
+}
+
+registry.category("views").add("hr_employee_kanban", {
+    ...kanbanView,
+    Controller: EmployeeKanbanController,
+});

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -508,7 +508,7 @@
         <field name="name">Approve Allocations</field>
         <field name="model_id" ref="hr_holidays.model_hr_leave_allocation"/>
         <field name="binding_model_id" ref="hr_holidays.model_hr_leave_allocation"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">
             if records:

--- a/addons/hr_presence/views/hr_employee_views.xml
+++ b/addons/hr_presence/views/hr_employee_views.xml
@@ -31,7 +31,7 @@
         <field name="value">presence_group_1</field>
         <field name="model_id" ref="hr.model_hr_employee"/>
         <field name="binding_model_id" ref="hr.model_hr_employee"/>
-        <field name="binding_view_types">form,list</field>
+        <field name="binding_view_types">form,list,kanban</field>
         <field name="state">code</field>
         <field name="code">
             action = records.action_set_present()
@@ -43,7 +43,7 @@
         <field name="value">presence_group_1</field>
         <field name="model_id" ref="hr.model_hr_employee"/>
         <field name="binding_model_id" ref="hr.model_hr_employee"/>
-        <field name="binding_view_types">form,list</field>
+        <field name="binding_view_types">form,list,kanban</field>
         <field name="state">code</field>
         <field name="code">
             action = records.action_set_absent()
@@ -55,7 +55,7 @@
         <field name="model_id" ref="hr.model_hr_employee"/>
         <field name="value">presence_group_2</field>
         <field name="binding_model_id" ref="hr.model_hr_employee"/>
-        <field name="binding_view_types">form,list</field>
+        <field name="binding_view_types">form,list,kanban</field>
         <field name="state">code</field>
         <field name="code">
             action = records.action_send_log()
@@ -67,7 +67,7 @@
         <field name="model_id" ref="hr.model_hr_employee"/>
         <field name="value">presence_group_2</field>
         <field name="binding_model_id" ref="hr.model_hr_employee"/>
-        <field name="binding_view_types">form,list</field>
+        <field name="binding_view_types">form,list,kanban</field>
         <field name="state">code</field>
         <field name="code">
             action = records.action_send_sms()
@@ -79,7 +79,7 @@
         <field name="model_id" ref="hr.model_hr_employee"/>
         <field name="value">presence_group_2</field>
         <field name="binding_model_id" ref="hr.model_hr_employee"/>
-        <field name="binding_view_types">form,list</field>
+        <field name="binding_view_types">form,list,kanban</field>
         <field name="state">code</field>
         <field name="code">
             action = records.action_open_leave_request()

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -594,7 +594,7 @@
         <field name="name">Send Email</field>
         <field name="model_id" ref="hr_recruitment.model_hr_applicant"/>
         <field name="binding_model_id" ref="hr_recruitment.model_hr_applicant"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">action = records.action_send_email()</field>
     </record>
@@ -603,7 +603,7 @@
         <field name="name">Refuse</field>
         <field name="model_id" ref="hr_recruitment.model_hr_applicant"/>
         <field name="binding_model_id" ref="hr_recruitment.model_hr_applicant"/>
-        <field name="binding_view_types">list,form</field>
+        <field name="binding_view_types">list,kanban,form</field>
         <field name="state">code</field>
         <field name="code">
 if records:

--- a/addons/hr_recruitment/views/hr_candidate_views.xml
+++ b/addons/hr_recruitment/views/hr_candidate_views.xml
@@ -199,7 +199,7 @@
         <field name="name">Send Email</field>
         <field name="model_id" ref="hr_recruitment.model_hr_candidate"/>
         <field name="binding_model_id" ref="hr_recruitment.model_hr_candidate"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">action = records.action_send_email()</field>
     </record>

--- a/addons/hr_recruitment_sms/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_sms/views/hr_applicant_views.xml
@@ -11,6 +11,6 @@
             'default_res_ids': active_ids,
         }</field>
         <field name="binding_model_id" ref="hr_recruitment.model_hr_applicant"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
     </record>
 </odoo>

--- a/addons/hr_recruitment_sms/views/hr_candidate_views.xml
+++ b/addons/hr_recruitment_sms/views/hr_candidate_views.xml
@@ -11,6 +11,6 @@
             'default_res_ids': active_ids,
         }</field>
         <field name="binding_model_id" ref="hr_recruitment.model_hr_candidate"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
     </record>
 </odoo>

--- a/addons/hr_skills/data/ir_actions_server_data.xml
+++ b/addons/hr_skills/data/ir_actions_server_data.xml
@@ -16,7 +16,7 @@ action['domain'] = [('department_id', '=', record.id)]
         <field name="name">Print Resume</field>
         <field name="model_id" ref="hr.model_hr_employee"/>
         <field name="binding_model_id" ref="hr.model_hr_employee"/>
-        <field name="binding_view_types">list,form</field>
+        <field name="binding_view_types">list,kanban,form</field>
         <field name="binding_type">report</field>
         <field name="state">code</field>
         <field name="code">

--- a/addons/hr_timesheet/views/hr_employee_views.xml
+++ b/addons/hr_timesheet/views/hr_employee_views.xml
@@ -42,7 +42,7 @@
         <field name="name">Delete</field>
         <field name="model_id" ref="hr.model_hr_employee"/>
         <field name="binding_model_id" ref="hr.model_hr_employee"/>
-        <field name="binding_view_types">form,list</field>
+        <field name="binding_view_types">form,list,kanban</field>
         <field name="state">code</field>
         <field name="code">action = records.action_unlink_wizard()</field>
     </record>

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -95,7 +95,15 @@ class IrAttachment extends models.Model {
         },
     ];
 }
-defineModels([Partner, IrAttachment]);
+
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+
+defineModels([Partner, IrAttachment, User]);
 
 let htmlEditor;
 beforeEach(() => {
@@ -802,12 +810,10 @@ test("Embed video by pasting video URL", async () => {
         },
     ];
 
-    onRpc("/html_editor/video_url/data", async () => {
-        return {
-            platform: "youtube",
-            embed_url: "//www.youtube.com/embed/qxb74CMR748?rel=0&autoplay=0",
-        };
-    });
+    onRpc("/html_editor/video_url/data", async () => ({
+        platform: "youtube",
+        embed_url: "//www.youtube.com/embed/qxb74CMR748?rel=0&autoplay=0",
+    }));
 
     await mountView({
         type: "form",
@@ -1268,12 +1274,8 @@ test("edit and save a html field in collaborative should keep the same wysiwyg",
             ' data-last-history-steps="12345"'
         );
     });
-    onRpc("/html_editor/get_ice_servers", () => {
-        return [];
-    });
-    onRpc("/html_editor/bus_broadcast", (params) => {
-        return { id: 10 };
-    });
+    onRpc("/html_editor/get_ice_servers", () => []);
+    onRpc("/html_editor/bus_broadcast", (params) => ({ id: 10 }));
 
     await mountView({
         type: "form",
@@ -1824,8 +1826,8 @@ describe("save image", () => {
 
         const imageRecord = IrAttachment._records[0];
         // Method to get the html of a cropped image.
-        const getImageContainerHTML = (src, isModified) => {
-            return `
+        const getImageContainerHTML = (src, isModified) =>
+            `
             <p>
                 <img
                     class="img img-fluid o_we_custom_image o_we_image_cropped${
@@ -1846,7 +1848,6 @@ describe("save image", () => {
         `
                 .replace(/(?:\s|(?:\r\n))+/g, " ")
                 .replace(/\s?(<|>)\s?/g, "$1");
-        };
         // Promise to resolve when we want the response of the modify_image RPC.
         const modifyImagePromise = new Deferred();
         let writeCount = 0;

--- a/addons/l10n_id/views/account_move_views.xml
+++ b/addons/l10n_id/views/account_move_views.xml
@@ -5,7 +5,7 @@
             <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
             <field name="model_id" ref="account.model_account_move"/>
             <field name="binding_model_id" ref="account.model_account_move"/>
-            <field name="binding_view_types">list,form</field>
+            <field name="binding_view_types">list,kanban,form</field>
             <field name="state">code</field>
             <field name="code">
                 if records:

--- a/addons/l10n_ke_edi_tremol/views/account_move_view.xml
+++ b/addons/l10n_ke_edi_tremol/views/account_move_view.xml
@@ -47,7 +47,7 @@
             <field name="name">Send to fiscal device</field>
             <field name="model_id" ref="account.model_account_move"/>
             <field name="binding_model_id" ref="account.model_account_move"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
             <field name="state">code</field>
             <field name="code">
                 action = records.l10n_ke_action_cu_post()

--- a/addons/l10n_my_edi_extended/views/account_move_view.xml
+++ b/addons/l10n_my_edi_extended/views/account_move_view.xml
@@ -56,7 +56,7 @@
         <field name="state">code</field>
         <field name="model_id" ref="model_account_move"/>
         <field name="binding_model_id" ref="model_account_move"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="code">
             if records:
                 action = records.action_l10n_my_edi_send_invoice()

--- a/addons/l10n_ph/views/account_move_views.xml
+++ b/addons/l10n_ph/views/account_move_views.xml
@@ -5,7 +5,7 @@
         <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
         <field name="model_id" ref="account.model_account_move"/>
         <field name="binding_model_id" ref="account.model_account_move"/>
-        <field name="binding_view_types">list,form</field>
+        <field name="binding_view_types">list,kanban,form</field>
         <field name="state">code</field>
         <field name="code">action = records.action_open_l10n_ph_2307_wizard()</field>
     </record>

--- a/addons/l10n_ro_edi/views/account_move_views.xml
+++ b/addons/l10n_ro_edi/views/account_move_views.xml
@@ -105,7 +105,7 @@
         <field name="name">Fetch E-Factura Status</field>
         <field name="model_id" ref="account.model_account_move"/>
         <field name="binding_model_id" ref="account.model_account_move"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">
             if records:

--- a/addons/l10n_vn_edi_viettel/views/account_move_views.xml
+++ b/addons/l10n_vn_edi_viettel/views/account_move_views.xml
@@ -72,7 +72,7 @@
         <field name="name">Send payment status to SInvoice</field>
         <field name="model_id" ref="account.model_account_move"/>
         <field name="binding_model_id" ref="account.model_account_move"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">
             if records:

--- a/addons/lunch/data/lunch_data.xml
+++ b/addons/lunch/data/lunch_data.xml
@@ -40,7 +40,7 @@
         <field name="name">Lunch: Receive meals</field>
         <field name="model_id" ref="model_lunch_order"/>
         <field name="binding_model_id" ref="model_lunch_order"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">records.action_confirm()</field>
     </record>
@@ -49,7 +49,7 @@
         <field name="name">Lunch: Cancel meals</field>
         <field name="model_id" ref="model_lunch_order"/>
         <field name="binding_model_id" ref="model_lunch_order"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">records.action_cancel()</field>
     </record>
@@ -58,7 +58,7 @@
         <field name="name">Lunch: Send notifications</field>
         <field name="model_id" ref="model_lunch_order"/>
         <field name="binding_model_id" ref="model_lunch_order"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">records.action_notify()</field>
     </record>

--- a/addons/mail/static/tests/widgets/activity_widget.test.js
+++ b/addons/mail/static/tests/widgets/activity_widget.test.js
@@ -253,7 +253,7 @@ test("list activity widget: batch selection from list", async (assert) => {
     // We select 2 among the 3 partners created above and click on the clock of one of them
     await click(".o_list_record_selector .o-checkbox", { target: matildeRow });
     await click(".o_list_record_selector .o-checkbox", { target: marioRow });
-    await contains(".o_list_selection_box", { text: "2 selected" });
+    await contains(".o_selection_box", { text: "2 selected" });
     await click(".o-mail-ActivityButton", { target: matildeRow });
     await contains(".o-mail-ActivityListPopover button", {
         text: "Schedule an activity on selected records",

--- a/addons/mail/views/res_partner_views.xml
+++ b/addons/mail/views/res_partner_views.xml
@@ -107,7 +107,7 @@
                 'default_reply_to_force_new': True,
             }</field>
             <field name="binding_model_id" ref="base.model_res_partner"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
         </record>
 
     </data>

--- a/addons/mail/wizard/mail_template_reset_views.xml
+++ b/addons/mail/wizard/mail_template_reset_views.xml
@@ -21,7 +21,7 @@
         <field name="name">Reset Mail Template</field>
         <field name="res_model">mail.template.reset</field>
         <field name="binding_model_id" ref="mail.model_mail_template"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
         <field name="context">{

--- a/addons/mass_mailing/wizard/mailing_list_merge_views.xml
+++ b/addons/mass_mailing/wizard/mailing_list_merge_views.xml
@@ -32,6 +32,6 @@
         <field name="view_mode">form</field>
         <field name="target">new</field>
         <field name="binding_model_id" ref="model_mailing_list"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
     </record>
 </odoo>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -94,7 +94,7 @@
             <field name="name">Split</field>
             <field name="model_id" ref="mrp.model_mrp_production"/>
             <field name="binding_model_id" ref="mrp.model_mrp_production"/>
-            <field name="binding_view_types">list,form</field>
+            <field name="binding_view_types">list,kanban,form</field>
             <field name="state">code</field>
             <field name="code">action = records.action_split()</field>
         </record>
@@ -103,7 +103,7 @@
             <field name="name">Labels</field>
             <field name="model_id" ref="mrp.model_mrp_production"/>
             <field name="binding_model_id" ref="mrp.model_mrp_production"/>
-            <field name="binding_view_types">list,form</field>
+            <field name="binding_view_types">list,kanban,form</field>
             <field name="binding_type">report</field>
             <field name="state">code</field>
             <field name="code">
@@ -149,7 +149,7 @@
             <field name="name">Plan based on Components Availability</field>
             <field name="model_id" ref="mrp.model_mrp_production"/>
             <field name="binding_model_id" ref="mrp.model_mrp_production"/>
-            <field name="binding_view_types">list,form</field>
+            <field name="binding_view_types">list,kanban,form</field>
             <field name="state">code</field>
             <field name="code">action = records.action_plan_with_components_availability()</field>
         </record>
@@ -158,7 +158,7 @@
             <field name="name">Merge</field>
             <field name="model_id" ref="mrp.model_mrp_production"/>
             <field name="binding_model_id" ref="mrp.model_mrp_production"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
             <field name="state">code</field>
             <field name="code">action = records.action_merge()</field>
         </record>
@@ -167,7 +167,7 @@
             <field name="name">Mark as Done</field>
             <field name="model_id" ref="mrp.model_mrp_production"/>
             <field name="binding_model_id" ref="mrp.model_mrp_production"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
             <field name="state">code</field>
             <field name="code">
             if records:
@@ -725,7 +725,7 @@
             <field name="name">Unreserve</field>
             <field name="model_id" ref="mrp.model_mrp_production"/>
             <field name="binding_model_id" ref="mrp.model_mrp_production"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
             <field name="state">code</field>
             <field name="code">
             if records:

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -497,7 +497,7 @@
         <field name="name">Start</field>
         <field name="model_id" ref="mrp.model_mrp_workorder"/>
         <field name="binding_model_id" ref="mrp.model_mrp_workorder"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">action = records.button_start(raise_on_invalid_state=True)</field>
     </record>
@@ -506,7 +506,7 @@
         <field name="name">Pause</field>
         <field name="model_id" ref="mrp.model_mrp_workorder"/>
         <field name="binding_model_id" ref="mrp.model_mrp_workorder"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">action = records.button_pending()</field>
     </record>

--- a/addons/mrp_account/views/product_views.xml
+++ b/addons/mrp_account/views/product_views.xml
@@ -81,7 +81,7 @@
             <field name="name">Compute Price from BoM</field>
             <field name="model_id" ref="product.model_product_template"/>
             <field name="binding_model_id" ref="product.model_product_template"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
             <field name="state">code</field>
             <field name="code">
             if records:
@@ -93,7 +93,7 @@
             <field name="name">Compute Price from BoM</field>
             <field name="model_id" ref="product.model_product_product"/>
             <field name="binding_model_id" ref="product.model_product_product"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
             <field name="state">code</field>
             <field name="code">
             if records:

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -454,7 +454,7 @@
         <field name="groups_id" eval="[(4, ref('point_of_sale.group_pos_user'))]"/>
         <field name="binding_model_id" ref="point_of_sale.model_pos_order" />
         <field name="state">code</field>
-        <field name="binding_view_types">list,form</field>
+        <field name="binding_view_types">list,kanban,form</field>
         <field name="code">
 if records:
     action = records.action_pos_order_cancel()
@@ -465,7 +465,7 @@ if records:
         <field name="name">Send Email</field>
         <field name="model_id" ref="point_of_sale.model_pos_order"/>
         <field name="binding_model_id" ref="point_of_sale.model_pos_order"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">
             if records:

--- a/addons/portal/__manifest__.py
+++ b/addons/portal/__manifest__.py
@@ -55,6 +55,7 @@ a dependency towards website editing and customization capabilities.""",
         ],
         "portal.assets_chatter_helpers": [
             "web/static/src/views/view_dialogs/form_view_dialog.js",
+            "web/static/src/views/view_dialogs/export_data_dialog.js",
             "web/static/src/core/debug/*",
             "web/static/src/core/commands/command_hook.js",
             "web/static/src/model/**/*",

--- a/addons/privacy_lookup/data/ir_actions_server_data.xml
+++ b/addons/privacy_lookup/data/ir_actions_server_data.xml
@@ -4,7 +4,7 @@
         <field name="name">Archive Selection</field>
         <field name="model_id" ref="privacy_lookup.model_privacy_lookup_wizard_line"/>
         <field name="binding_model_id" ref="privacy_lookup.model_privacy_lookup_wizard_line"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">
 records.action_archive_all()
@@ -15,7 +15,7 @@ records.action_archive_all()
         <field name="name">Delete Selection</field>
         <field name="model_id" ref="privacy_lookup.model_privacy_lookup_wizard_line"/>
         <field name="binding_model_id" ref="privacy_lookup.model_privacy_lookup_wizard_line"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">
 records.action_unlink_all()

--- a/addons/project/static/src/views/project_project_kanban/project_project_kanban_controller.js
+++ b/addons/project/static/src/views/project_project_kanban/project_project_kanban_controller.js
@@ -1,0 +1,20 @@
+import { KanbanController } from "@web/views/kanban/kanban_controller";
+import { onWillStart } from "@odoo/owl";
+import { user } from "@web/core/user";
+
+export class ProjectKanbanController extends KanbanController {
+    setup() {
+        super.setup();
+        onWillStart(async () => {
+            this.isProjectManager = await user.hasGroup('project.group_project_manager');
+        });
+    }
+
+    getStaticActionMenuItems() {
+        const actionMenuItems = super.getStaticActionMenuItems(...arguments);
+        if (!this.isProjectManager) {
+            ['duplicate', 'archive', 'unarchive'].forEach(item => delete actionMenuItems[item]);
+        }
+        return actionMenuItems;
+    }
+};

--- a/addons/project/views/project_project_stage_views.xml
+++ b/addons/project/views/project_project_stage_views.xml
@@ -123,7 +123,7 @@
         <field name="name">Delete</field>
         <field name="model_id" ref="project.model_project_project_stage"/>
         <field name="binding_model_id" ref="project.model_project_project_stage"/>
-        <field name="binding_view_types">form,list</field>
+        <field name="binding_view_types">form,list,kanban</field>
         <field name="state">code</field>
         <field name="code">action = records.unlink_wizard(stage_view=True)</field>
     </record>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -25,7 +25,7 @@
                 'default_composition_mode': 'mass_mail',
             }</field>
             <field name="binding_model_id" ref="project.model_project_project"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
         </record>
 
         <record id="edit_project" model="ir.ui.view">

--- a/addons/project/views/project_task_type_views.xml
+++ b/addons/project/views/project_task_type_views.xml
@@ -136,7 +136,7 @@
             <field name="name">Delete</field>
             <field name="model_id" ref="project.model_project_task_type"/>
             <field name="binding_model_id" ref="project.model_project_task_type"/>
-            <field name="binding_view_types">form,list</field>
+            <field name="binding_view_types">form,list,kanban</field>
             <field name="state">code</field>
             <field name="code">action = records.unlink_wizard(stage_view=True)</field>
         </record>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -310,7 +310,7 @@
                 'default_composition_mode': 'mass_mail',
             }</field>
             <field name="binding_model_id" ref="project.model_project_task"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
         </record>
 
         <record id="view_task_form2" model="ir.ui.view">
@@ -1238,7 +1238,7 @@
             <field name="target">new</field>
             <field name="context">{'default_res_model': 'project.task', 'default_res_ids': active_ids}</field>
             <field name="binding_model_id" ref="project.model_project_task"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
         </record>
 
         <record id="project_milestone_action_view_tasks" model="ir.actions.act_window">

--- a/addons/project_sms/views/project_project_views.xml
+++ b/addons/project_sms/views/project_project_views.xml
@@ -12,6 +12,6 @@
             'default_res_ids': active_ids,
         }</field>
         <field name="binding_model_id" ref="model_project_project"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
     </record>
 </odoo>

--- a/addons/project_sms/views/project_task_views.xml
+++ b/addons/project_sms/views/project_task_views.xml
@@ -11,6 +11,6 @@
             'default_res_ids': active_ids,
         }</field>
         <field name="binding_model_id" ref="model_project_task"/>
-        <field name="binding_view_types">list,form</field>
+        <field name="binding_view_types">list,kanban,form</field>
     </record>
 </odoo>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -886,7 +886,7 @@
         <field name="name">Confirm RFQ</field>
         <field name="model_id" ref="purchase.model_purchase_order"/>
         <field name="binding_model_id" ref="purchase.model_purchase_order"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">
 if records:
@@ -903,6 +903,6 @@ if isinstance(res, dict):
         <field name="target">new</field>
         <field name="context">{'default_res_model': 'purchase.order', 'default_res_ids': active_ids}</field>
         <field name="binding_model_id" ref="purchase.model_purchase_order"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
     </record>
 </odoo>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -1099,7 +1099,7 @@
         <field name="name">Mark Quotation as Sent</field>
         <field name="model_id" ref="sale.model_sale_order"/>
         <field name="binding_model_id" ref="sale.model_sale_order"/>
-        <field name="binding_view_types">form,list</field>
+        <field name="binding_view_types">form,list,kanban</field>
         <field name="state">code</field>
         <field name="code">action = records.action_quotation_sent()</field>
     </record>
@@ -1118,7 +1118,7 @@
         <field name="model_id" ref="sale.model_sale_order"/>
         <field name="sequence">1</field>
         <field name="binding_model_id" ref="sale.model_sale_order"/>
-        <field name="binding_view_types">list,form</field>
+        <field name="binding_view_types">list,kanban,form</field>
         <field name="state">code</field>
         <field name="code">
             if records:
@@ -1133,6 +1133,6 @@
         <field name="target">new</field>
         <field name="context">{'default_res_model': 'sale.order', 'default_res_ids': active_ids}</field>
         <field name="binding_model_id" ref="sale.model_sale_order"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
     </record>
 </odoo>

--- a/addons/sale/wizard/mass_cancel_orders_views.xml
+++ b/addons/sale/wizard/mass_cancel_orders_views.xml
@@ -40,7 +40,7 @@
         <field name="view_id" ref="mass_cancel_orders_view_form"/>
         <field name="target">new</field>
         <field name="binding_model_id" ref="model_sale_order"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
     </record>
 
 </odoo>

--- a/addons/sale/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale/wizard/sale_make_invoice_advance_views.xml
@@ -60,7 +60,7 @@
         <field name="view_mode">form</field>
         <field name="target">new</field>
         <field name="binding_model_id" ref="sale.model_sale_order"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
     </record>
 
 </odoo>

--- a/addons/sms/views/res_partner_views.xml
+++ b/addons/sms/views/res_partner_views.xml
@@ -37,7 +37,7 @@
             'default_res_ids': active_ids
         }</field>
         <field name="binding_model_id" ref="base.model_res_partner"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
     </record>
     <record id="res_partner_act_window_sms_composer_single" model="ir.actions.act_window">
         <field name="name">Send SMS</field>

--- a/addons/sms/views/sms_sms_views.xml
+++ b/addons/sms/views/sms_sms_views.xml
@@ -75,7 +75,7 @@
         <field name="name">Resend</field>
         <field name="model_id" ref="sms.model_sms_sms"/>
         <field name="binding_model_id" ref="sms.model_sms_sms"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">action = records.resend_failed()</field>
     </record>

--- a/addons/sms/wizard/sms_template_reset_views.xml
+++ b/addons/sms/wizard/sms_template_reset_views.xml
@@ -22,7 +22,7 @@
         <field name="name">Reset SMS Template</field>
         <field name="res_model">sms.template.reset</field>
         <field name="binding_model_id" ref="sms.model_sms_template"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
         <field name="context">{

--- a/addons/stock/static/src/views/stock_orderpoint_list_view.xml
+++ b/addons/stock/static/src/views/stock_orderpoint_list_view.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="stock.StockOrderpoint.listView" t-inherit="web.ListView">
-        <xpath expr="//t[@t-call='web.ListView.Selection']" position="after">
+        <xpath expr="//SelectionBox" position="after">
             <Dropdown>
                 <button class="btn btn-secondary">
                     <span class="o_dropdown_title">Replenish</span>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -435,7 +435,7 @@
             <field name="name">Validate</field>
             <field name="model_id" ref="stock.model_stock_picking"/>
             <field name="binding_model_id" ref="stock.model_stock_picking"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
             <field name="state">code</field>
             <field name="code">
             if records:
@@ -449,7 +449,7 @@
             <field name="name">Unreserve</field>
             <field name="model_id" ref="stock.model_stock_picking"/>
             <field name="binding_model_id" ref="stock.model_stock_picking"/>
-            <field name="binding_view_types">list,form</field>
+            <field name="binding_view_types">list,kanban,form</field>
             <field name="state">code</field>
             <field name="code">
             if records:
@@ -461,7 +461,7 @@
             <field name="name">Labels</field>
             <field name="model_id" ref="stock.model_stock_picking"/>
             <field name="binding_model_id" ref="stock.model_stock_picking"/>
-            <field name="binding_view_types">list,form</field>
+            <field name="binding_view_types">list,kanban,form</field>
             <field name="binding_type">report</field>
             <field name="state">code</field>
             <field name="code">
@@ -502,7 +502,7 @@
                 'default_composition_mode': 'mass_mail',
             }</field>
             <field name="binding_model_id" ref="stock.model_stock_picking"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
         </record>
 
         <record id="click_dashboard_graph" model="ir.actions.server">

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -467,7 +467,7 @@ in this location. That leads to a negative stock.
         <field name="name">Set to quantity on hand</field>
         <field name="model_id" ref="model_stock_quant"/>
         <field name="binding_model_id" ref="stock.model_stock_quant"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="groups_id" eval="[(4, ref('stock.group_stock_user'))]"/>
         <field name="code">
@@ -479,7 +479,7 @@ in this location. That leads to a negative stock.
         <field name="name">Set to 0</field>
         <field name="model_id" ref="model_stock_quant"/>
         <field name="binding_model_id" ref="stock.model_stock_quant"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="groups_id" eval="[(4, ref('stock.group_stock_manager'))]"/>
         <field name="code">

--- a/addons/stock_account/wizard/stock_valuation_layer_revaluation_views.xml
+++ b/addons/stock_account/wizard/stock_valuation_layer_revaluation_views.xml
@@ -7,7 +7,7 @@
         <field name="view_mode">form</field>
         <field name="binding_model_id" ref="stock_account.model_stock_valuation_layer"/>
         <!-- Not available in form view because clicking a layer only opens its form view if it's already an adjustment layer, the action would always fail with a UserError because the quantity is 0 -->
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="target">new</field>
     </record>
 

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -282,7 +282,7 @@
         <field name="name">Unreserve</field>
         <field name="model_id" ref="stock_picking_batch.model_stock_picking_batch"/>
         <field name="binding_model_id" ref="stock_picking_batch.model_stock_picking_batch"/>
-        <field name="binding_view_types">list,form</field>
+        <field name="binding_view_types">list,kanban,form</field>
         <field name="state">code</field>
         <field name="code">
         if records:

--- a/addons/stock_picking_batch/wizard/stock_add_to_wave_views.xml
+++ b/addons/stock_picking_batch/wizard/stock_add_to_wave_views.xml
@@ -28,6 +28,6 @@
         <field name="view_mode">form</field>
         <field name="target">new</field>
         <field name="binding_model_id" ref="stock.model_stock_picking"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
     </record>
 </odoo>

--- a/addons/stock_picking_batch/wizard/stock_picking_to_batch_views.xml
+++ b/addons/stock_picking_batch/wizard/stock_picking_to_batch_views.xml
@@ -32,7 +32,7 @@
         <field name="view_mode">form</field>
         <field name="target">new</field>
         <field name="binding_model_id" ref="model_stock_picking"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
     </record>
 
 </odoo>

--- a/addons/test_website/static/tests/tours/page_manager.js
+++ b/addons/test_website/static/tests/tours/page_manager.js
@@ -17,7 +17,7 @@ registry.category("web_tour.tours").add('test_website_page_manager', {
     run: "click",
 }, {
     content: "Check that there is only 2 records selected",
-    trigger: ".o_list_selection_box:contains(2):contains(selected)",
+    trigger: ".o_selection_box:contains(2):contains(selected)",
 }, {
     content: "Click on the 'Select all records' checkbox again to unselect all records and see the search bar",
     trigger: "thead .o_list_record_selector",

--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -1,4 +1,8 @@
-import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import {
+    deleteConfirmationMessage,
+    AlertDialog,
+    ConfirmationDialog,
+} from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { DataPoint } from "./datapoint";
 import { Record } from "./record";
@@ -198,6 +202,37 @@ export class DynamicList extends DataPoint {
 
     unarchive(isSelected) {
         return this.model.mutex.exec(() => this._toggleArchive(isSelected, false));
+    }
+
+    toggleArchiveWithConfirmation(archive, dialogProps = {}) {
+        const isSelected = this.isDomainSelected || this.selection.length > 0;
+        if (archive) {
+            const defaultProps = {
+                body: _t("Are you sure that you want to archive all the selected records?"),
+                cancel: () => {},
+                confirm: () => this.archive(isSelected),
+                confirmLabel: _t("Archive"),
+            };
+            this.model.dialog.add(ConfirmationDialog, { ...defaultProps, ...dialogProps });
+        } else {
+            this.unarchive(isSelected);
+        }
+    }
+
+    deleteRecordsWithConfirmation(dialogProps = {}, records) {
+        let body = deleteConfirmationMessage;
+        if (this.model.root.isDomainSelected || this.model.root.selection.length > 1) {
+            body = _t("Are you sure you want to delete these records?");
+        }
+        const defaultProps = {
+            body,
+            cancel: () => {},
+            cancelLabel: _t("No, keep it"),
+            confirm: () => this.deleteRecords(records),
+            confirmLabel: _t("Delete"),
+            title: _t("Bye-bye, record!"),
+        };
+        this.model.dialog.add(ConfirmationDialog, { ...defaultProps, ...dialogProps });
     }
 
     // -------------------------------------------------------------------------

--- a/addons/web/static/src/search/cog_menu/cog_menu.js
+++ b/addons/web/static/src/search/cog_menu/cog_menu.js
@@ -30,6 +30,7 @@ export class CogMenu extends ActionMenus {
         context: { type: ActionMenus.props.context, optional: true },
         resModel: { type: ActionMenus.props.resModel, optional: true },
         items: { ...ActionMenus.props.items, optional: true },
+        slots: { type: Object, optional: true },
     };
     static defaultProps = {
         ...ActionMenus.defaultProps,

--- a/addons/web/static/src/search/cog_menu/cog_menu.xml
+++ b/addons/web/static/src/search/cog_menu/cog_menu.xml
@@ -10,6 +10,7 @@
                     </button>
 
                     <t t-set-slot="content">
+                        <t t-slot="default"/>
                         <t t-if="state.printItems.length">
                             <Dropdown t-if="state.printItems.length > 1">
                                 <button>

--- a/addons/web/static/src/views/form/form_cog_menu/form_cog_menu.js
+++ b/addons/web/static/src/views/form/form_cog_menu/form_cog_menu.js
@@ -7,8 +7,4 @@ export class FormCogMenu extends CogMenu {
         ...CogMenu.components,
         StatusBarDropdownItems,
     };
-    static props = {
-        ...CogMenu.props,
-        slots: { type: Object, optional: true },
-    };
 }

--- a/addons/web/static/src/views/kanban/kanban_cog_menu.js
+++ b/addons/web/static/src/views/kanban/kanban_cog_menu.js
@@ -1,7 +1,7 @@
 import { CogMenu } from "../../search/cog_menu/cog_menu";
 
-export class ListCogMenu extends CogMenu {
-    static template = "web.ListCogMenu";
+export class KanbanCogMenu extends CogMenu {
+    static template = "web.KanbanCogMenu";
     static props = {
         ...CogMenu.props,
         hasSelectedRecords: { type: Number, optional: true },

--- a/addons/web/static/src/views/kanban/kanban_cog_menu.xml
+++ b/addons/web/static/src/views/kanban/kanban_cog_menu.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.FormCogMenu" t-inherit="web.CogMenu">
-        <xpath expr="//div[hasclass('o_cp_action_menus')]" position="attributes">
-            <attribute name="t-if">env.isSmall or hasItems</attribute>
-        </xpath>
+    <t t-name="web.KanbanCogMenu" t-inherit="web.CogMenu">
         <xpath expr="//t[@t-if='state.printItems.length']/Dropdown" position="before">
             <div role="separator" class="dropdown-divider"/>
         </xpath>

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -1,9 +1,6 @@
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
-import {
-    deleteConfirmationMessage,
-    ConfirmationDialog,
-} from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
+import { user } from "@web/core/user";
 import { useService } from "@web/core/utils/hooks";
 import { omit } from "@web/core/utils/objects";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
@@ -18,13 +15,22 @@ import { useModelWithSampleData } from "@web/model/model";
 import { standardViewProps } from "@web/views/standard_view_props";
 import { MultiRecordViewButton } from "@web/views/view_button/multi_record_view_button";
 import { useViewButtons } from "@web/views/view_button/view_button_hook";
+import { useExportRecords } from "@web/views/view_hook";
 import { addFieldDependencies, extractFieldsFromArchInfo } from "@web/model/relational_model/utils";
 import { KanbanCogMenu } from "./kanban_cog_menu";
 import { KanbanRenderer } from "./kanban_renderer";
 import { useProgressBar } from "./progress_bar_hook";
 import { SelectionBox } from "@web/views/view_components/selection_box";
 
-import { Component, reactive, useEffect, useRef, useState } from "@odoo/owl";
+import {
+    Component,
+    onWillStart,
+    reactive,
+    useEffect,
+    useRef,
+    useState,
+    useSubEnv,
+} from "@odoo/owl";
 
 const QUICK_CREATE_FIELD_TYPES = ["char", "boolean", "many2one", "selection", "many2many"];
 
@@ -188,6 +194,19 @@ export class KanbanController extends Component {
             },
             () => [this.model.root.selection?.length, this.model.root.isDomainSelected]
         );
+        onWillStart(async () => {
+            this.isExportEnable = await user.hasGroup("base.group_allow_export");
+        });
+        this.archiveEnabled =
+            "active" in this.props.fields
+                ? !this.props.fields.active.readonly
+                : "x_active" in this.props.fields
+                ? !this.props.fields.x_active.readonly
+                : false;
+        useSubEnv({ model: this.model });
+        this.exportRecords = useExportRecords(this.env, this.props.context, () =>
+            this.getExportableFields()
+        );
     }
 
     get display() {
@@ -304,6 +323,18 @@ export class KanbanController extends Component {
         return this.props.className;
     }
 
+    get archiveDialogProps() {
+        return {};
+    }
+
+    get deleteConfirmationDialogProps() {
+        return {};
+    }
+
+    getExportableFields() {
+        return Object.keys(this.model.root.config.activeFields).map((e) => this.props.fields[e]);
+    }
+
     async onSelectionChanged() {
         if (this.props.onSelectionChanged) {
             const resIds = await this.model.root.getResIds(true);
@@ -312,22 +343,55 @@ export class KanbanController extends Component {
     }
 
     getStaticActionMenuItems() {
-        return {};
-    }
-
-    async deleteRecord(record) {
-        this.dialog.add(ConfirmationDialog, {
-            title: _t("Bye-bye, record!"),
-            body: deleteConfirmationMessage,
-            confirm: () => this.model.root.deleteRecords([record]),
-            confirmLabel: _t("Delete"),
-            cancel: () => {},
-            cancelLabel: _t("No, keep it"),
-        });
+        return {
+            export: {
+                isAvailable: () => this.isExportEnable,
+                sequence: 10,
+                icon: "fa fa-upload",
+                description: _t("Export"),
+                callback: () => this.exportRecords(),
+            },
+            archive: {
+                isAvailable: () => this.archiveEnabled,
+                sequence: 20,
+                icon: "oi oi-archive",
+                description: _t("Archive"),
+                callback: () =>
+                    this.model.root.toggleArchiveWithConfirmation(true, this.archiveDialogProps),
+            },
+            unarchive: {
+                isAvailable: () => this.archiveEnabled,
+                sequence: 30,
+                icon: "oi oi-unarchive",
+                description: _t("Unarchive"),
+                callback: () => this.model.root.toggleArchiveWithConfirmation(false),
+            },
+            duplicate: {
+                isAvailable: () => this.props.archInfo.activeActions.duplicate,
+                sequence: 35,
+                icon: "fa fa-clone",
+                description: _t("Duplicate"),
+                callback: () => this.model.root.duplicateRecords(),
+            },
+            delete: {
+                isAvailable: () => this.props.archInfo.activeActions.delete,
+                sequence: 40,
+                icon: "fa fa-trash-o",
+                description: _t("Delete"),
+                callback: () =>
+                    this.model.root.deleteRecordsWithConfirmation(
+                        this.deleteConfirmationDialogProps
+                    ),
+            },
+        };
     }
 
     evalViewModifier(modifier) {
         return evaluateBooleanExpr(modifier, { context: this.props.context });
+    }
+
+    deleteRecord(record) {
+        this.model.root.deleteRecordsWithConfirmation({}, [record]);
     }
 
     async openRecord(record, { newWindow } = {}) {

--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -115,6 +115,8 @@
 
     --KanbanColumn__highlight-background: #{tint-color($o-action, 90%)};
     --KanbanColumn__highlight-border: #{$o-action};
+    --KanbanColumn__highlight-selected: #d1ecf1;
+    --KanbanColumn__highlight-selected-border: #{tint-color($o-action, 60%)};
 
     --o-view-nocontent-zindex: 1;
 

--- a/addons/web/static/src/views/kanban/kanban_controller.xml
+++ b/addons/web/static/src/views/kanban/kanban_controller.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
 
     <t t-name="web.KanbanView">
-        <div t-att-class="className" t-ref="root">
-            <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''" display="props.display">
+        <div t-attf-class="{{ className }} {{ hasSelectedRecords ? 'o_kanban_selection_active' : 'o_kanban_selection_available' }}" t-ref="root">
+            <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''" display="display">
                 <t t-set-slot="control-panel-create-button">
                     <t t-if="canCreate and props.showButtons">
                         <button type="button" class="btn btn-primary o-kanban-button-new" accesskey="c" t-on-click="() => this.createRecord()" data-bounce-button="">
@@ -30,14 +30,56 @@
                         />
                     </t>
                 </t>
+                <t t-set-slot="control-panel-selection-actions">
+                    <div t-if="hasSelectedRecords" class="o_selection_container d-flex gap-1 w-100 w-md-auto">
+                       <SelectionBox />
+                        <t t-if="!env.isSmall">
+                            <t t-foreach="headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
+                                <MultiRecordViewButton
+                                    t-if="button.display !== 'always'"
+                                    list="model.root"
+                                    className="button.className"
+                                    clickParams="button.clickParams"
+                                    defaultRank="'btn-secondary'"
+                                    domain="props.domain"
+                                    icon="button.icon"
+                                    string="button.string"
+                                    title="button.title"
+                                    attrs="button.attrs"
+                                />
+                            </t>
+                            <t t-if="props.info.actionMenus">
+                                <ActionMenus t-props="this.actionMenuProps"/>
+                            </t>
+                        </t>
+                    </div>
+                </t>
                 <t t-set-slot="control-panel-additional-actions">
-                    <CogMenu/>
+                    <CogMenu t-if="!hasSelectedRecords"/>
+                    <CogMenu t-elif="env.isSmall and (props.info.actionMenus or headerButtons.length)" t-props="this.actionMenuProps" hasSelectedRecords="hasSelectedRecords">
+                        <t t-foreach="headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
+                            <DropdownItem class="'o-dropdown-item-unstyled-button'">
+                                <MultiRecordViewButton
+                                    t-if="button.display !== 'always'"
+                                    list="model.root"
+                                    className="button.className"
+                                    clickParams="button.clickParams"
+                                    defaultRank="'btn-secondary'"
+                                    domain="props.domain"
+                                    icon="button.icon"
+                                    string="button.string"
+                                    title="button.title"
+                                    attrs="button.attrs"
+                                />
+                            </DropdownItem>
+                        </t>
+                    </CogMenu>
                 </t>
                 <t t-set-slot="layout-actions">
                     <SearchBar toggler="searchBarToggler"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">
-                    <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
+                    <t t-if="!hasSelectedRecords" t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
                 </t>
                 <t t-component="props.Renderer"
                     list="model.root"

--- a/addons/web/static/src/views/kanban/kanban_header.js
+++ b/addons/web/static/src/views/kanban/kanban_header.js
@@ -128,19 +128,6 @@ export class KanbanHeader extends Component {
     // Edition methods
     // ------------------------------------------------------------------------
 
-    archiveGroup() {
-        this.dialog.add(ConfirmationDialog, {
-            body: _t("Are you sure that you want to archive all the records from this column?"),
-            confirmLabel: _t("Archive All"),
-            confirm: () => this.group.list.archive(),
-            cancel: () => {},
-        });
-    }
-
-    unarchiveGroup() {
-        this.group.list.unarchive();
-    }
-
     deleteGroup() {
         this.dialog.add(ConfirmationDialog, {
             body: _t("Are you sure you want to delete this column?"),
@@ -181,19 +168,10 @@ export class KanbanHeader extends Component {
     // ------------------------------------------------------------------------
 
     get permissions() {
-        return ["canArchiveGroup", "canDeleteGroup", "canEditGroup", "canQuickCreate"].reduce(
-            (o, key) => {
-                Object.defineProperty(o, key, { get: () => this[key]() });
-                return o;
-            },
-            {}
-        );
-    }
-
-    canArchiveGroup() {
-        const { archiveGroup } = this.props.activeActions;
-        const hasActiveField = "active" in this.group.fields;
-        return archiveGroup && hasActiveField && this.group.groupByField.type !== "many2many";
+        return ["canDeleteGroup", "canEditGroup", "canQuickCreate"].reduce((o, key) => {
+            Object.defineProperty(o, key, { get: () => this[key]() });
+            return o;
+        }, {});
     }
 
     canDeleteGroup() {
@@ -251,30 +229,4 @@ kanbanHeaderConfigItems.add(
         class: "o_column_delete",
     },
     { sequence: 30 }
-);
-kanbanHeaderConfigItems.add(
-    "archive_group",
-    {
-        label: _t("Archive All"),
-        method: "archiveGroup",
-        isVisible: ({ permissions }) => permissions.canArchiveGroup,
-        class: ({ props }) => ({
-            o_column_archive_records: true,
-            disabled: props.list.model.useSampleModel,
-        }),
-    },
-    { sequence: 40 }
-);
-kanbanHeaderConfigItems.add(
-    "unarchive_group",
-    {
-        label: _t("Unarchive All"),
-        method: "unarchiveGroup",
-        isVisible: ({ permissions }) => permissions.canArchiveGroup,
-        class: ({ props }) => ({
-            o_column_unarchive_records: true,
-            disabled: props.list.model.useSampleModel,
-        }),
-    },
-    { sequence: 50 }
 );

--- a/addons/web/static/src/views/kanban/kanban_record.scss
+++ b/addons/web/static/src/views/kanban/kanban_record.scss
@@ -128,4 +128,40 @@
             background-color: $gray-100;
         }
     }
+
+    &.o_record_selected {
+        background-color: var(--KanbanColumn__highlight-selected);
+    }
+}
+
+.o_kanban_record:focus-visible, .o_kanban_selection_active .o_kanban_record:focus {
+    outline: none;
+    box-shadow: inset 0 0px 0px 3px var(--KanbanColumn__highlight-selected-border);
+}
+
+.o_kanban_ungrouped .o_kanban_record:focus-visible, .o_kanban_selection_active .o_kanban_ungrouped .o_kanban_record:focus {
+    @include media-breakpoint-up(md) {
+        outline: 3px solid var(--KanbanColumn__highlight-selected-border);
+        box-shadow: none;
+    }
+}
+
+.o_kanban_selection_available .o_kanban_record.o_record_selection_available {
+    background-color: rgba(0, 0, 0, 0.1) !important;
+    > *:not(.o_record_selection_tooltip) {
+        filter: brightness(0.9);
+    }
+    &:hover {
+        background-color: rgba(0, 0, 0, 0.5) !important;
+        > *:not(.o_record_selection_tooltip) {
+            filter: brightness(0.6);
+        }
+        .o_record_selection_tooltip {
+            display: block !important;
+            z-index: 1;
+            transform: translate(-50%, -50%);
+            background: white;
+            color: black;
+        }
+    }
 }

--- a/addons/web/static/src/views/kanban/kanban_record.xml
+++ b/addons/web/static/src/views/kanban/kanban_record.xml
@@ -7,7 +7,12 @@
             t-att-data-id="props.record.id"
             t-att-tabindex="props.record.model.useSampleModel ? -1 : 0"
             t-custom-click="onGlobalClick"
+            t-on-touchstart="onTouchStart"
+            t-on-touchmove="onTouchMoveOrCancel"
+            t-on-touchcancel="onTouchMoveOrCancel"
+            t-on-touchend="onTouchEnd"
             t-ref="root">
+                <span t-if="props.selectionAvailable" class="o_record_selection_tooltip d-none position-absolute p-2 rounded-3 start-50 top-50">Click to select</span>
                 <t t-call="{{ this.templates[this.constructor.KANBAN_CARD_ATTRIBUTE] }}" t-call-context="this.renderingContext"/>
                 <t t-call="{{ this.constructor.menuTemplate }}"/>
         </article>

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.KanbanRenderer">
-        <div class="o_kanban_renderer o_renderer d-flex"
+        <div class="o_kanban_renderer o_renderer d-flex user-select-none"
             t-attf-class="{{ props.list.isGrouped ? 'o_kanban_grouped align-content-stretch' : 'o_kanban_ungrouped align-content-start flex-wrap justify-content-start' }}"
             t-ref="root"
         >
@@ -45,12 +45,15 @@
                                     forceGlobalClick="props.forceGlobalClick"
                                     group="group"
                                     groupByField="props.list.groupByField"
+                                    getSelection.bind="getSelection"
+                                    toggleSelection.bind="toggleSelection"
                                     deleteRecord="props.deleteRecord"
                                     archiveRecord.bind="archiveRecord"
                                     openRecord="props.openRecord"
                                     readonly="props.readonly"
                                     record="record"
                                     progressBarState="props.progressBarState"
+                                    selectionAvailable="state.selectionAvailable"
                                 />
                             </t>
                             <t t-set="unloadedCount" t-value="getGroupUnloadedCount(group)" />
@@ -73,11 +76,14 @@
                         canResequence="!isProcessing(groupOrRecord.record.id) and canResequenceRecords"
                         forceGlobalClick="props.forceGlobalClick"
                         groupByField="props.list.groupByField"
+                        getSelection.bind="getSelection"
+                        toggleSelection.bind="toggleSelection"
                         deleteRecord="props.deleteRecord"
                         archiveRecord="(record, active) => this.archiveRecord(record, active)"
                         openRecord="props.openRecord"
                         readonly="props.readonly"
                         record="groupOrRecord.record"
+                        selectionAvailable="state.selectionAvailable"
                     />
                 </t>
             </t>

--- a/addons/web/static/src/views/list/export_all/export_all.js
+++ b/addons/web/static/src/views/list/export_all/export_all.js
@@ -32,7 +32,7 @@ export const exportAllItem = {
     Component: ExportAll,
     groupNumber: STATIC_ACTIONS_GROUP_NUMBER,
     isDisplayed: async (env) =>
-        env.config.viewType === "list" &&
+        ["kanban", "list"].includes(env.config.viewType) &&
         !env.model.root.selection.length &&
         (await user.hasGroup("base.group_allow_export")) &&
         exprToBoolean(env.config.viewArch.getAttribute("export_xlsx"), true),

--- a/addons/web/static/src/views/list/list_cog_menu.xml
+++ b/addons/web/static/src/views/list/list_cog_menu.xml
@@ -2,9 +2,6 @@
 <templates xml:space="preserve">
 
     <t t-name="web.ListCogMenu" t-inherit="web.CogMenu">
-        <xpath expr="//t[@t-if='state.printItems.length']" position="before">
-            <t t-slot="default"/>
-        </xpath>
         <xpath expr="//t[@t-if='state.printItems.length']/Dropdown" position="before">
             <div role="separator" class="dropdown-divider"/>
         </xpath>

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -62,8 +62,8 @@
                     </CogMenu>
                 </t>
                 <t t-set-slot="control-panel-selection-actions">
-                    <div t-if="hasSelectedRecords" class="o_list_selection_container m-1 m-md-0 d-flex gap-1">
-                        <t t-call="web.ListView.Selection"/>
+                    <div t-if="hasSelectedRecords" class="o_selection_container m-1 m-md-0 d-flex gap-1">
+                        <SelectionBox />
                         <t t-if="!env.isSmall">
                             <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
                                 <MultiRecordViewButton
@@ -113,33 +113,6 @@
                     Discard
                 </button>
             </t>
-        </div>
-    </t>
-
-    <t t-name="web.ListView.Selection">
-        <div class="o_list_selection_box list-group flex-row w-auto" t-att-class="{'m-1 gap-1': env.isSmall}" role="alert">
-            <span class="list-group-item active d-flex align-items-center pe-0 py-0 rounded-1 gap-1 flex-grow-1" t-att-class="{'shadow': env.isSmall}">
-                <span t-if="isDomainSelected">All <b t-esc="nbTotal"/> selected</span>
-                <t t-else="">
-                    <b t-esc="nbSelected"/> selected
-                    <button t-if="!env.isSmall and isPageSelected and (!model.root.isRecordCountTrustable or nbTotal > nbSelected)"
-                        class="o_list_select_domain btn btn-sm btn-info p-1 ms-2 me-n2 border-0 fw-normal"
-                        title="Select all records matching the search"
-                        t-on-click="onSelectDomain">
-                        <i class="oi oi-fw oi-arrow-right"/>
-                        Select all <span t-if="model.root.isRecordCountTrustable" t-esc="nbTotal"/>
-                    </button>
-                </t>
-                <button title="Unselect All" class="o_list_unselect_all btn btn-link ms-auto border-0" t-on-click="onUnselectAll">
-                    <i class="oi oi-close"/>
-                </button>
-            </span>
-            <button t-if="env.isSmall and !isDomainSelected and (!model.root.isRecordCountTrustable or nbTotal > nbSelected)"
-                class="o_list_select_domain btn btn-info shadow"
-                title="Select all records matching the search"
-                t-on-click="onSelectDomain">
-                All
-            </button>
         </div>
     </t>
 

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -1694,23 +1694,21 @@ export class ListRenderer extends Component {
         }
         const isRecordPresent = this.props.list.records.includes(this.lastCheckedRecord);
         if (this.shiftKeyMode && isRecordPresent) {
-            this.toggleRecordShiftSelection(record);
+            this.toggleRangeSelection(record);
         } else {
             record.toggleSelection();
         }
         this.lastCheckedRecord = record;
     }
 
-    toggleRecordShiftSelection(record) {
+    toggleRangeSelection(record) {
         const { records } = this.props.list;
         const recordIndex = records.indexOf(record);
         const lastCheckedRecordIndex = records.indexOf(this.lastCheckedRecord);
         const start = Math.min(recordIndex, lastCheckedRecordIndex);
         const end = Math.max(recordIndex, lastCheckedRecordIndex);
-        const { selected } = record;
-
         for (let i = start; i <= end; i++) {
-            records[i].toggleSelection(!selected);
+            records[i].toggleSelection(!record.selected);
         }
     }
 

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -571,18 +571,3 @@
         margin: auto 0;
     }
 }
-
-@include media-breakpoint-down(md) {
-    .o_web_client:has(.o_list_selection_container) .o_navbar {
-        opacity: 0.15;
-    }
-
-    .o_list_view .o_list_selection_container {
-        position: fixed;
-        top: 0;
-        left: 0;
-    }
-}
-.modal-footer .o_list_selection_box {
-    margin-bottom: 0rem !important;
-}

--- a/addons/web/static/src/views/view_components/selection_box.js
+++ b/addons/web/static/src/views/view_components/selection_box.js
@@ -1,0 +1,40 @@
+import { Component, useState } from "@odoo/owl";
+
+export class SelectionBox extends Component {
+    static components = {};
+    static template = "web.SelectionBox";
+    static props = {};
+    setup() {
+        this.root = useState(this.env.model.root);
+    }
+    get nbSelected() {
+        return this.selectedRecords.length;
+    }
+    get nbTotal() {
+        return this.root.isGrouped ? this.root.recordCount : this.root.count;
+    }
+    get isDomainSelected() {
+        return this.root.isDomainSelected;
+    }
+    get isPageSelected() {
+        return (
+            this.nbSelected === this.root.records.length &&
+            (!this.isRecordCountTrustable || this.nbTotal > this.selectedRecords.length)
+        );
+    }
+    get isRecordCountTrustable() {
+        return this.root.isRecordCountTrustable;
+    }
+    get selectedRecords() {
+        return this.root.selection;
+    }
+    onUnselectAll() {
+        this.selectedRecords.forEach((record) => {
+            record.toggleSelection(false);
+        });
+        this.root.selectDomain(false);
+    }
+    onSelectDomain() {
+        this.root.selectDomain(true);
+    }
+}

--- a/addons/web/static/src/views/view_components/selection_box.scss
+++ b/addons/web/static/src/views/view_components/selection_box.scss
@@ -1,0 +1,13 @@
+@include media-breakpoint-down(md) {
+    .o_web_client:has(.o_selection_container) .o_navbar {
+        opacity: 0.15;
+    }
+    .o_selection_container {
+        position: fixed;
+        top: 0;
+        left: 0;
+    }
+}
+.modal-footer .o_selection_box {
+    margin-bottom: 0 !important;
+}

--- a/addons/web/static/src/views/view_components/selection_box.xml
+++ b/addons/web/static/src/views/view_components/selection_box.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="web.SelectionBox">
+        <div class="o_selection_box list-group flex-row w-auto" t-att-class="{'m-1 gap-1': env.isSmall}" role="alert">
+            <span class="list-group-item active d-flex align-items-center pe-0 py-0 rounded-1 gap-1 flex-grow-1" t-att-class="{'shadow': env.isSmall}">
+                <span t-if="isDomainSelected">All <b t-esc="nbTotal"/> selected</span>
+                <t t-else="">
+                    <b t-esc="nbSelected"/> selected
+                    <button t-if="!env.isSmall and isPageSelected and (!isRecordCountTrustable or nbTotal > nbSelected)"
+                        class="o_select_domain btn btn-sm btn-info p-1 ms-2 me-n2 border-0 fw-normal"
+                        title="Select all records matching the search"
+                        t-on-click="onSelectDomain">
+                        <i class="oi oi-fw oi-arrow-right"/>
+                        Select all <span t-if="isRecordCountTrustable" t-esc="nbTotal"/>
+                    </button>
+                </t>
+                <button title="Unselect All" class="o_unselect_all btn btn-link ms-auto border-0" t-on-click="onUnselectAll">
+                    <i class="oi oi-close"/>
+                </button>
+            </span>
+            <button t-if="env.isSmall and !isDomainSelected and (!isRecordCountTrustable or nbTotal > nbSelected)"
+                class="o_select_domain btn btn-info shadow"
+                title="Select all records matching the search"
+                t-on-click="onSelectDomain">
+                All
+            </button>
+        </div>
+    </t>
+
+</templates>

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.js
@@ -254,7 +254,6 @@ export class ExportDataDialog extends Component {
     }
 
     async loadFields(id, preventLoad = false) {
-        let model = this.props.root.resModel;
         let parentField, parentParams;
         if (id) {
             if (this.expandedFields[id]) {
@@ -262,7 +261,6 @@ export class ExportDataDialog extends Component {
                 return this.expandedFields[id].fields;
             }
             parentField = this.knownFields[id];
-            model = parentField.params && parentField.params.model;
             parentParams = {
                 ...parentField.params,
                 parent_field_type: parentField.field_type,
@@ -274,11 +272,7 @@ export class ExportDataDialog extends Component {
         if (preventLoad) {
             return;
         }
-        const fields = await this.props.getExportedFields(
-            model,
-            this.state.isCompatible,
-            parentParams
-        );
+        const fields = await this.props.getExportedFields(this.state.isCompatible, parentParams);
         for (const field of fields) {
             field.parent = parentField;
             if (!this.knownFields[field.id]) {
@@ -394,9 +388,7 @@ export class ExportDataDialog extends Component {
         if (this.isDebug) {
             lookupResult = unique([
                 ...lookupResult,
-                ...Object.values(this.knownFields).filter((f) => {
-                    return f.id.includes(value);
-                }),
+                ...Object.values(this.knownFields).filter((f) => f.id.includes(value)),
             ]);
         }
         return lookupResult;

--- a/addons/web/static/tests/search/search_panel_desktop.test.js
+++ b/addons/web/static/tests/search/search_panel_desktop.test.js
@@ -181,7 +181,14 @@ class Category extends models.Model {
     ];
 }
 
-defineModels([Partner, Company, Category]);
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+
+defineModels([Partner, Company, Category, User]);
 
 defineActions([
     {

--- a/addons/web/static/tests/views/fields/boolean_favorite_field.test.js
+++ b/addons/web/static/tests/views/fields/boolean_favorite_field.test.js
@@ -9,6 +9,13 @@ import {
     onRpc,
 } from "@web/../tests/web_test_helpers";
 
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+
 class Partner extends models.Model {
     bar = fields.Boolean({ default: true });
 
@@ -21,7 +28,7 @@ class Partner extends models.Model {
     ];
 }
 
-defineModels([Partner]);
+defineModels([Partner, User]);
 
 test("FavoriteField in kanban view", async () => {
     await mountView({

--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -40,7 +40,13 @@ class Partner extends models.Model {
         },
     ];
 }
-defineModels([Partner]);
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+defineModels([Partner, User]);
 
 test("DatetimeField in form view", async () => {
     mockTimeZone(+2); // UTC+2

--- a/addons/web/static/tests/views/fields/float_toggle_field.test.js
+++ b/addons/web/static/tests/views/fields/float_toggle_field.test.js
@@ -16,7 +16,14 @@ class Partner extends models.Model {
     _records = [{ id: 1, float_field: 0.44444 }];
 }
 
-defineModels([Partner]);
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+
+defineModels([Partner, User]);
 
 test("basic flow in form view", async () => {
     onRpc("partner", "web_save", ({ args }) => {

--- a/addons/web/static/tests/views/fields/gauge_field.test.js
+++ b/addons/web/static/tests/views/fields/gauge_field.test.js
@@ -20,7 +20,14 @@ class Partner extends models.Model {
     ];
 }
 
-defineModels([Partner]);
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+
+defineModels([Partner, User]);
 
 setupChartJsForTests();
 

--- a/addons/web/static/tests/views/fields/html_field.test.js
+++ b/addons/web/static/tests/views/fields/html_field.test.js
@@ -21,7 +21,13 @@ class Partner extends models.Model {
     txt = fields.Html({ string: "txt", trim: true });
     _records = [{ id: 1, txt: RED_TEXT }];
 }
-defineModels([Partner]);
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+defineModels([Partner, User]);
 
 test("html fields are correctly rendered in form view (readonly)", async () => {
     await mountView({
@@ -164,12 +170,10 @@ test("field html translatable", async () => {
             { translation_type: "char", translation_show_source: true },
         ];
     });
-    onRpc("get_installed", () => {
-        return [
-            ["en_US", "English"],
-            ["fr_BE", "French (Belgium)"],
-        ];
-    });
+    onRpc("get_installed", () => [
+        ["en_US", "English"],
+        ["fr_BE", "French (Belgium)"],
+    ]);
     onRpc("update_field_translations", ({ args }) => {
         expect(args).toEqual(
             [

--- a/addons/web/static/tests/views/fields/image_url_field.test.js
+++ b/addons/web/static/tests/views/fields/image_url_field.test.js
@@ -33,7 +33,14 @@ class PartnerType extends models.Model {
     ];
 }
 
-defineModels([Partner, PartnerType]);
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+
+defineModels([Partner, PartnerType, User]);
 
 test("image fields are correctly rendered", async () => {
     await mountView({

--- a/addons/web/static/tests/views/fields/journal_dashboard_graph_field.test.js
+++ b/addons/web/static/tests/views/fields/journal_dashboard_graph_field.test.js
@@ -74,7 +74,13 @@ class Partner extends models.Model {
         },
     ];
 }
-defineModels([Partner]);
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+defineModels([Partner, User]);
 
 // Kanban
 // WOWL remove this helper and user the control panel instead

--- a/addons/web/static/tests/views/fields/many2one_barcode_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_barcode_field.test.js
@@ -70,7 +70,14 @@ class SaleOrderLine extends models.Model {
     });
 }
 
-defineModels([Product, SaleOrderLine]);
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+
+defineModels([Product, SaleOrderLine, User]);
 
 beforeEach(() => {
     mockUserAgent("android");

--- a/addons/web/static/tests/views/fields/priority_field.test.js
+++ b/addons/web/static/tests/views/fields/priority_field.test.js
@@ -35,7 +35,13 @@ class Partner extends models.Model {
         { id: 5, foo: "blop" },
     ];
 }
-defineModels([Partner]);
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+defineModels([Partner, User]);
 
 test("PriorityField when not set", async () => {
     await mountView({

--- a/addons/web/static/tests/views/fields/progress_bar_field.test.js
+++ b/addons/web/static/tests/views/fields/progress_bar_field.test.js
@@ -33,7 +33,13 @@ class Partner extends models.Model {
         },
     ];
 }
-defineModels([Partner]);
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+defineModels([Partner, User]);
 
 test("ProgressBarField: max_value should update", async () => {
     expect.assertions(3);

--- a/addons/web/static/tests/views/fields/properties_field.test.js
+++ b/addons/web/static/tests/views/fields/properties_field.test.js
@@ -275,6 +275,10 @@ class User extends models.Model {
             name: "Eve",
         },
     ];
+
+    has_group() {
+        return true;
+    }
 }
 
 defineModels([Partner, ResCompany, User]);
@@ -528,12 +532,10 @@ test("properties: selection", async () => {
         "Selection"
     );
 
-    const getOptions = () => {
-        return queryAll(".o_property_field_popover .o_field_property_selection_option");
-    };
-    const getOptionsValues = () => {
-        return queryAllValues(".o_property_field_popover .o_field_property_selection_option input");
-    };
+    const getOptions = () =>
+        queryAll(".o_property_field_popover .o_field_property_selection_option");
+    const getOptionsValues = () =>
+        queryAllValues(".o_property_field_popover .o_field_property_selection_option input");
 
     // Create a new selection option
     await click(".o_field_property_selection .fa-plus");
@@ -590,13 +592,12 @@ test("properties: selection", async () => {
         message: "Should have added a new option at the correct spot",
     });
 
-    const getOptionDraggableElement = (index) => {
-        return queryFirst(
+    const getOptionDraggableElement = (index) =>
+        queryFirst(
             `.o_field_property_selection_option:nth-child(${
                 index + 1
             }) .o_field_property_selection_drag`
         );
-    };
 
     await contains(getOptionDraggableElement(0)).dragAndDrop(getOptionDraggableElement(2));
     expect(getOptionsValues()).toEqual(["C", "New option 2", "A", "New option"]);
@@ -2082,11 +2083,8 @@ test("properties: separators move properties", async () => {
     await makePropertiesGroupView([false, true, true, false, true, true, false]);
 
     // return true if the given separator is folded
-    const foldState = (separatorName) => {
-        return !queryFirst(
-            `div[property-name='${separatorName}'] .o_field_property_label .fa-caret-down`
-        );
-    };
+    const foldState = (separatorName) =>
+        !queryFirst(`div[property-name='${separatorName}'] .o_field_property_label .fa-caret-down`);
 
     const assertFolded = (values) => {
         expect(values.length).toBe(4);
@@ -2267,9 +2265,8 @@ test("properties: separators drag and drop", async () => {
         ],
     ]);
 
-    const getPropertyHandleElement = (propertyName) => {
-        return queryFirst(`*[property-name='${propertyName}'] .oi-draggable`);
-    };
+    const getPropertyHandleElement = (propertyName) =>
+        queryFirst(`*[property-name='${propertyName}'] .oi-draggable`);
 
     // if we move properties inside the same column, do not generate the group
     await contains(getPropertyHandleElement("property_1"), { visible: false }).dragAndDrop(

--- a/addons/web/static/tests/views/fields/selection_field.test.js
+++ b/addons/web/static/tests/views/fields/selection_field.test.js
@@ -65,7 +65,13 @@ class Product extends models.Model {
         },
     ];
 }
-defineModels([Partner, Product]);
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+defineModels([Partner, Product, User]);
 
 test("SelectionField in a list view", async () => {
     Partner._records.forEach((r) => (r.color = "red"));

--- a/addons/web/static/tests/views/fields/state_selection_field.test.js
+++ b/addons/web/static/tests/views/fields/state_selection_field.test.js
@@ -24,7 +24,14 @@ class Partner extends models.Model {
     ];
 }
 
-defineModels([Partner]);
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+
+defineModels([Partner, User]);
 
 test("StateSelectionField in form view", async () => {
     await mountView({

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -226,7 +226,14 @@ class Currency extends models.Model {
     ];
 }
 
-defineModels([Partner, Product, Category, Currency, IrAttachment]);
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+
+defineModels([Partner, Product, Category, Currency, IrAttachment, User]);
 
 beforeEach(() => {
     patchWithCleanup(AnimatedNumber, { enableAnimations: false });
@@ -8831,7 +8838,7 @@ test("column progressbars with an active filter are working with load more", asy
     ]);
 });
 
-test.skip("column progressbars on archiving records update counter", async () => {
+test("column progressbars on archiving records update counter", async () => {
     // add active field on partner model and make all records active
     Partner._fields.active = fields.Boolean({ default: true });
 
@@ -8850,6 +8857,7 @@ test.skip("column progressbars on archiving records update counter", async () =>
                 </templates>
             </kanban>`,
         groupBy: ["bar"],
+        loadActionMenus: true,
     });
 
     expect(getKanbanCounters()).toEqual(["-4", "36"]);
@@ -8858,9 +8866,15 @@ test.skip("column progressbars on archiving records update counter", async () =>
     });
 
     // archive all records of the second columns
-    const clickColumnAction = await toggleKanbanColumnActions(1);
-    await clickColumnAction("Archive All");
-    await contains(".o_dialog footer .btn-primary").click(); // confirm
+    await keyDown("alt");
+    await animationFrame();
+    await contains(".o_kanban_group:nth-of-type(2) .o_kanban_record:nth-of-type(1)").click();
+    await keyUp("alt");
+    await contains(".o_kanban_group:nth-of-type(2) .o_kanban_record:nth-of-type(2)").click();
+    await contains(".o_kanban_group:nth-of-type(2) .o_kanban_record:nth-of-type(3)").click();
+    await contains(".o_cp_action_menus button").click();
+    await contains(".o_menu_item:contains(Archive)").click();
+    await contains(".modal-footer .btn-primary").click();
 
     expect(getKanbanCounters()).toEqual(["-4", "0"]);
     expect(queryAll(".progress-bar", { root: getKanbanColumn(1) })).toHaveCount(0, {
@@ -8881,7 +8895,7 @@ test.skip("column progressbars on archiving records update counter", async () =>
     ]);
 });
 
-test.skip("kanban with progressbars: correctly update env when archiving records", async () => {
+test("kanban with progressbars: correctly update env when archiving records", async () => {
     // add active field on partner model and make all records active
     Partner._fields.active = fields.Boolean({ default: true });
 
@@ -8900,14 +8914,19 @@ test.skip("kanban with progressbars: correctly update env when archiving records
                 </templates>
             </kanban>`,
         groupBy: ["bar"],
+        loadActionMenus: true,
     });
 
     expect(getKanbanRecordTexts()).toEqual(["4", "1", "2", "3"]);
 
     // archive all records of the first column
-    const clickColumnAction = await toggleKanbanColumnActions(0);
-    await clickColumnAction("Archive All");
-    await contains(".o_dialog footer .btn-primary").click(); // confirm
+    await keyDown("alt");
+    await animationFrame();
+    await contains(".o_kanban_group:nth-of-type(1) .o_kanban_record:nth-of-type(1)").click();
+    await keyUp("alt");
+    await contains(".o_cp_action_menus button").click();
+    await contains(".o_menu_item:contains(Archive)").click();
+    await contains(".modal-footer .btn-primary").click();
 
     expect(getKanbanRecordTexts()).toEqual(["1", "2", "3"]);
     expect.verifySteps([
@@ -9441,7 +9460,7 @@ test("progress bar with aggregates: activate bars (grouped by date)", async () =
     expect(getKanbanCounters()).toEqual(["15"]);
 });
 
-test.skip("progress bar with aggregates: Archive All in a column", async () => {
+test("progress bar with aggregates: Archive all in a column", async () => {
     Partner._fields.active = fields.Boolean({ default: true });
     Partner._records = [
         { foo: "yop", bar: true, int_field: 1, active: true },
@@ -9465,24 +9484,27 @@ test.skip("progress bar with aggregates: Archive All in a column", async () => {
                 </t></templates>
             </kanban>`,
         groupBy: ["bar"],
+        loadActionMenus: true,
     });
 
     expect(getKanbanColumnTooltips(1)).toEqual(["2 yop", "1 gnap", "1 blip"]);
     expect(getKanbanCounters()).toEqual(["268", "15"]);
-
-    const clickColumnAction = await toggleKanbanColumnActions(1);
-    await clickColumnAction("Archive All");
-
+    await keyDown("alt");
+    await animationFrame();
+    await contains(".o_kanban_group:nth-of-type(2) .o_kanban_record:nth-of-type(1)").click();
+    await keyUp("alt");
+    await contains(".o_kanban_group:nth-of-type(2) .o_kanban_record:nth-of-type(2)").click();
+    await contains(".o_kanban_group:nth-of-type(2) .o_kanban_record:nth-of-type(3)").click();
+    await contains(".o_kanban_group:nth-of-type(2) .o_kanban_record:nth-of-type(4)").click();
+    await contains(".o_cp_action_menus button").click();
+    await contains(".o_menu_item:contains(Archive)").click();
     expect(".o_dialog").toHaveCount(1);
     def = new Deferred();
-    await contains(".o_dialog footer .btn-primary").click();
-
+    await contains(".modal-footer .btn-primary").click();
     expect(getKanbanColumnTooltips(1)).toEqual(["2 yop", "1 gnap", "1 blip"]);
     expect(getKanbanCounters()).toEqual(["268", "15"]);
-
     def.resolve();
     await animationFrame();
-
     expect(getKanbanColumnTooltips(1)).toEqual([]);
     expect(getKanbanCounters()).toEqual(["268", "0"]);
 });

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -1060,6 +1060,7 @@ test("pager, ungrouped, with count limit reached", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
 
     await contains(".o_pager_limit").click();
@@ -1094,6 +1095,7 @@ test("pager, ungrouped, with count limit reached, click next", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
 
     await contains(".o_pager_next").click();
@@ -1154,6 +1156,7 @@ test("pager, ungrouped, with count limit reached, click next (2)", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
 
     await contains(".o_pager_next").click();
@@ -1226,6 +1229,7 @@ test("pager, ungrouped, with count limit reached, click previous", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
 
     await contains(".o_pager_previous").click();
@@ -1290,6 +1294,7 @@ test("pager, ungrouped, with count limit reached, edit pager", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
 
     await contains("span.o_pager_value").click();
@@ -1337,6 +1342,7 @@ test("count_limit attrs set in arch", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
 
     await contains(".o_pager_limit").click();
@@ -1548,6 +1554,7 @@ test("kanban with an action id as on_create attrs", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_search_read",
+        "has_group",
         "doAction some.action",
         "web_search_read",
     ]);
@@ -1787,6 +1794,7 @@ test("quick create record without quick_create_view", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group", // initial web_read_group
+        "has_group",
         "web_search_read", // initial search_read (first column)
         "web_search_read", // initial search_read (second column)
         "onchange", // quick create
@@ -1854,6 +1862,7 @@ test("quick create record with quick_create_view", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group", // initial web_read_group
+        "has_group",
         "web_search_read", // initial search_read (first column)
         "web_search_read", // initial search_read (second column)
         "get_views", // form view in quick create
@@ -2094,6 +2103,7 @@ test("quick create record in grouped on m2o (no quick_create_view)", async () =>
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group", // initial web_read_group
+        "has_group",
         "web_search_read", // initial search_read (first column)
         "web_search_read", // initial search_read (second column)
         "onchange", // quick create
@@ -2160,6 +2170,7 @@ test("quick create record in grouped on m2o (with quick_create_view)", async () 
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group", // initial web_read_group
+        "has_group",
         "web_search_read", // initial search_read (first column)
         "web_search_read", // initial search_read (second column)
         "get_views", // form view in quick create
@@ -2205,6 +2216,7 @@ test("quick create record in grouped on m2m (no quick_create_view)", async () =>
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group", // initial web_read_group
+        "has_group",
         "web_search_read", // initial search_read (first column)
         "web_search_read", // initial search_read (second column)
         "onchange", // quick create
@@ -2252,6 +2264,7 @@ test("quick create record in grouped on m2m in the None column", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group", // initial web_read_group
+        "has_group",
         "web_search_read", // initial search_read (first column)
         "web_search_read", // initial search_read (second column)
         "web_search_read", // read records when unfolding 'None'
@@ -2305,6 +2318,7 @@ test("quick create record in grouped on m2m (field not in template)", async () =
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group", // initial web_read_group
+        "has_group",
         "web_search_read", // initial search_read (first column)
         "web_search_read", // initial search_read (second column)
         "get_views", // get form view
@@ -2364,6 +2378,7 @@ test("quick create record in grouped on m2m (field in the form view)", async () 
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group", // initial web_read_group
+        "has_group",
         "web_search_read", // initial search_read (first column)
         "web_search_read", // initial search_read (second column)
         "get_views", // get form view
@@ -2397,6 +2412,7 @@ test("quick create record validation: stays open when invalid", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
     ]);
@@ -2466,6 +2482,7 @@ test("quick create record with default values and onchanges", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group", // initial web_read_group
+        "has_group",
         "web_search_read", // initial search_read (first column)
         "web_search_read", // initial search_read (second column)
         "get_views", // form view in quick create
@@ -2545,6 +2562,7 @@ test("quick create record with onchange of field marked readonly", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group", // initial web_read_group
+        "has_group",
         "web_search_read", // initial search_read (first column)
         "web_search_read", // initial search_read (second column)
     ]);
@@ -4186,6 +4204,7 @@ test("many2many_tags in kanban views", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
 
     // Checks that second records has only one tag as one should be hidden (color 0)
@@ -4350,6 +4369,7 @@ test("o2m loaded in only one batch", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_read_group",
@@ -4384,6 +4404,7 @@ test("kanban with many2many, load and reload", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_read_group",
@@ -4422,6 +4443,7 @@ test("kanban with reference field", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_read_group",
@@ -5557,6 +5579,7 @@ test("delete a column in grouped on m2o", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "unlink",
@@ -6329,6 +6352,7 @@ test("nocontent helper after adding a record (kanban with progressbar)", async (
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "onchange",
         "name_create",
         "web_read",
@@ -7022,6 +7046,7 @@ test("empty grouped kanban with sample data and many2many_tags", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group",
+        "has_group",
     ]);
 });
 
@@ -7485,6 +7510,7 @@ test("button executes action and reloads", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
     expect("button.a1").toHaveCount(4);
     expect("button.a1:first").not.toHaveAttribute("disabled");
@@ -8484,6 +8510,7 @@ test("column progressbars properly work", async () => {
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
     ]);
@@ -8581,6 +8608,7 @@ test('column progressbars: "false" bar is clickable', async () => {
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_search_read",
@@ -8630,6 +8658,7 @@ test('column progressbars: "false" bar with sum_field', async () => {
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_read_group",
@@ -8664,6 +8693,7 @@ test("column progressbars should not crash in non grouped views", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
 });
 
@@ -8701,6 +8731,7 @@ test("column progressbars: creating a new column should create a new progressbar
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "name_create",
@@ -8744,6 +8775,7 @@ test("column progressbars on quick create properly update counter", async () => 
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "onchange",
@@ -8785,6 +8817,7 @@ test("column progressbars are working with load more", async () => {
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_search_read",
@@ -8830,6 +8863,7 @@ test("column progressbars with an active filter are working with load more", asy
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "read_progress_bar",
@@ -8886,6 +8920,7 @@ test("column progressbars on archiving records update counter", async () => {
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "action_archive",
@@ -8935,6 +8970,7 @@ test("kanban with progressbars: correctly update env when archiving records", as
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "action_archive",
@@ -8971,6 +9007,7 @@ test("RPCs when (re)loading kanban view progressbars", async () => {
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         // reload
@@ -9016,6 +9053,7 @@ test("RPCs when (de)activating kanban view progressbar filters", async () => {
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_read_group domain []",
         "web_search_read",
         "web_search_read",
@@ -9090,6 +9128,7 @@ test("drag & drop records grouped by m2o with progressbar", async () => {
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_search_read",
@@ -9152,6 +9191,7 @@ test("d&d records grouped by date with progressbar with aggregates", async () =>
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_save",
@@ -9190,6 +9230,7 @@ test("progress bar subgroup count recompute", async () => {
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_search_read",
@@ -9232,6 +9273,7 @@ test("progress bar recompute after d&d to and from other column", async () => {
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_save",
@@ -9274,6 +9316,7 @@ test("progress bar recompute after filter selection", async () => {
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
     ]);
@@ -9327,6 +9370,7 @@ test("progress bar recompute after filter selection (aggregates)", async () => {
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
     ]);
@@ -9580,6 +9624,7 @@ test("column progressbars on quick create with quick_create_view", async () => {
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "get_views",
@@ -9650,6 +9695,7 @@ test("progressbars and active filter with quick_create_view", async () => {
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_read_group",
@@ -10603,6 +10649,7 @@ test("progressbar filter state is kept unchanged when domain is updated (records
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_search_read",
@@ -10688,6 +10735,7 @@ test("progressbar filter state is kept unchanged when domain is updated (emptyin
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_search_read",
@@ -10762,6 +10810,7 @@ test("filtered column counters when dropping in non-matching record", async () =
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_search_read",
@@ -10807,6 +10856,7 @@ test("filtered column is reloaded when dragging out its last record", async () =
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
     ]);
@@ -10896,6 +10946,7 @@ test("action/type attributes on kanban arch, type='object'", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
     await contains(".o_kanban_record p").click();
     expect.verifySteps(["doActionButton type object name a1", "web_search_read"]);
@@ -10929,6 +10980,7 @@ test("action/type attributes on kanban arch, type='action'", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
     await contains(".o_kanban_record p").click();
     expect.verifySteps(["doActionButton type action name a1", "web_search_read"]);
@@ -11248,6 +11300,7 @@ test("basic rendering with 2 groupbys", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
     ]);
@@ -11285,6 +11338,7 @@ test("basic rendering with a date groupby with a granularity", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
     ]);
@@ -11549,6 +11603,7 @@ test("Color '200' (gray) can be used twice (for false value and another value) i
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_search_read",
@@ -11642,6 +11697,7 @@ test("update field on which progress bars are computed", async () => {
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_search_read",
@@ -12001,6 +12057,7 @@ test("fieldDependencies support for fields: dependence on a relational field", a
         "/web/webclient/load_menus",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
 });
 
@@ -12142,6 +12199,7 @@ test("drag record to folded column, with progressbars", async () => {
         "get_views",
         "read_progress_bar",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_save",
@@ -12203,6 +12261,7 @@ test("quick create record in grouped kanban in a form view dialog", async () => 
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group", // initial web_read_group
+        "has_group",
         "web_search_read", // initial search_read (first column)
         "web_search_read", // initial search_read (second column)
         "onchange", // quick create
@@ -12426,6 +12485,7 @@ test("d&d records grouped by m2o with m2o displayed in records", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
     ]);
@@ -12545,6 +12605,7 @@ test("rerenders only once after resequencing records", async () => {
         "/web/webclient/load_menus",
         "get_views",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "web_save",
@@ -12622,7 +12683,13 @@ test("scroll on group unfold and progressbar click", async () => {
         groupBy: ["product_id"],
     });
 
-    expect.verifySteps(["get_views", "read_progress_bar", "web_read_group", "web_search_read"]);
+    expect.verifySteps([
+        "get_views",
+        "read_progress_bar",
+        "web_read_group",
+        "has_group",
+        "web_search_read",
+    ]);
     queryOne(".o_content").scrollTo = (params) => {
         expect.step("scrolled");
         expect(params.top).toBe(0);

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -4980,9 +4980,7 @@ test(`custom delete confirmation dialog`, async () => {
     class CautiousController extends listView.Controller {
         get deleteConfirmationDialogProps() {
             const props = super.deleteConfirmationDialogProps;
-            props.body = markup(
-                `<span class="text-danger">These are the consequences</span><br/>${props.body}`
-            );
+            props.body = markup(`<span class="text-danger">These are the consequences</span>`);
             return props;
         }
     }
@@ -5002,7 +5000,7 @@ test(`custom delete confirmation dialog`, async () => {
 
     await toggleActionMenu();
     await toggleMenuItem("Delete");
-    expect(`.modal:contains(you sure) .text-danger:contains(consequences)`).toHaveCount(1, {
+    expect(`.modal .text-danger:contains(consequences)`).toHaveCount(1, {
         message: "confirmation dialog should have markup and more",
     });
 

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -284,19 +284,19 @@ test(`select record range with shift click`, async () => {
         arch: `<list><field name="foo"/><field name="int_field"/></list>`,
     });
     await contains(`.o_data_row .o_list_record_selector input`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(0);
-    expect(`.o_list_selection_box`).toHaveText("1\nselected");
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(0);
+    expect(`.o_selection_box`).toHaveText("1\nselected");
     expect(`.o_data_row .o_list_record_selector input:checked`).toHaveCount(1);
 
     // shift click the 4th record to have 0-1-2-3 toggled
     await contains(`.o_data_row .o_list_record_selector input:eq(3)`).click({ shiftKey: true });
-    expect(`.o_list_selection_box`).toHaveText("4\nselected");
+    expect(`.o_selection_box`).toHaveText("4\nselected");
     expect(`.o_data_row .o_list_record_selector input:checked`).toHaveCount(4);
 
     // shift click the 3rd record to untoggle 2-3
     await contains(`.o_data_row .o_list_record_selector input:eq(2)`).click({ shiftKey: true });
-    expect(`.o_list_selection_box`).toHaveText("2\nselected");
+    expect(`.o_selection_box`).toHaveText("2\nselected");
     expect(`.o_data_row.o_data_row_selected`).toHaveCount(2);
 
     // shift click the 1st record to untoggle 0-1
@@ -919,21 +919,21 @@ test(`list view: action button in controlPanel basic rendering on desktop`, asyn
         `,
     });
     expect(`.o_control_panel_actions button[name=x]`).toHaveCount(0);
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(0);
     expect(`.o_control_panel_actions button[name="y"]`).toHaveCount(0);
 
     await contains(`.o_data_row .o_list_record_selector input[type="checkbox"]`).click();
     expect(`.o_control_panel_actions button[name=x]`).toHaveCount(1);
     expect(`.o_control_panel_actions button[name=x]`).toHaveClass("btn btn-secondary plaf");
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
     expect(queryFirst(`.o_control_panel_actions button[name=x]`).previousElementSibling).toBe(
-        queryFirst(`.o_control_panel_actions .o_list_selection_box`)
+        queryFirst(`.o_control_panel_actions .o_selection_box`)
     );
     expect(`.o_control_panel_actions button[name=y]`).toHaveCount(0);
 
     await contains(`.o_data_row .o_list_record_selector input[type="checkbox"]`).click();
     expect(`.o_control_panel_actions button[name=x]`).toHaveCount(0);
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(0);
     expect(`.o_control_panel_actions button[name="y"]`).toHaveCount(0);
 });
 
@@ -1292,7 +1292,7 @@ test(`list view: action button executes action on click with domain selected: co
         `,
     });
     await clickRecordSelector();
-    await contains(`.o_list_select_domain`).click();
+    await contains(`.o_select_domain`).click();
     expect.verifySteps([]);
 
     await clickControlPanelAction("x");
@@ -3612,28 +3612,28 @@ test(`selection box is properly displayed (single page)`, async () => {
         arch: `<list><field name="foo"/><field name="bar"/></list>`,
     });
     expect(`.o_data_row`).toHaveCount(4);
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(0);
 
     // select a record
     await contains(`.o_data_row .o_list_record_selector input`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(0);
-    expect(`.o_list_selection_box`).toHaveText("1\nselected");
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(0);
+    expect(`.o_selection_box`).toHaveText("1\nselected");
 
     // select all records of first page
     await contains(`thead .o_list_record_selector input`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(0);
-    expect(`.o_list_selection_box`).toHaveText("4\nselected");
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(0);
+    expect(`.o_selection_box`).toHaveText("4\nselected");
 
     // unselect a record
     await contains(`.o_data_row .o_list_record_selector input:eq(1)`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(0);
-    expect(`.o_list_selection_box`).toHaveText("3\nselected");
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(0);
+    expect(`.o_selection_box`).toHaveText("3\nselected");
 
-    await contains(`.o_list_unselect_all`).click();
-    expect(`.o_list_selection_box`).toHaveCount(0, {
+    await contains(`.o_unselect_all`).click();
+    expect(`.o_selection_box`).toHaveCount(0, {
         message: "selection options are no longer visible",
     });
     expect(`.o_data_row .o_list_record_selector input:checked`).toHaveCount(0, {
@@ -3649,27 +3649,27 @@ test(`selection box is properly displayed (multi pages) on desktop`, async () =>
         arch: `<list limit="3"><field name="foo"/><field name="bar"/></list>`,
     });
     expect(`.o_data_row`).toHaveCount(3);
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(0);
 
     // select a record
     await contains(`.o_data_row .o_list_record_selector input`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(0);
-    expect(`.o_list_selection_box`).toHaveText("1\nselected");
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(0);
+    expect(`.o_selection_box`).toHaveText("1\nselected");
 
     // select all records of first page
     await contains(`thead .o_list_record_selector input`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(1);
-    expect(`.o_list_selection_box`).toHaveText("3\nselected\n Select all 4");
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(1);
+    expect(`.o_selection_box`).toHaveText("3\nselected\n Select all 4");
 
     // select all domain
-    await contains(`.o_list_selection_box .o_list_select_domain`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
-    expect(`.o_list_selection_box`).toHaveText("All 4 selected");
+    await contains(`.o_selection_box .o_select_domain`).click();
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
+    expect(`.o_selection_box`).toHaveText("All 4 selected");
 
-    await contains(`.o_list_unselect_all`).click();
-    expect(`.o_list_selection_box`).toHaveCount(0, {
+    await contains(`.o_unselect_all`).click();
+    expect(`.o_selection_box`).toHaveCount(0, {
         message: "selection options are no longer visible",
     });
 });
@@ -3689,16 +3689,16 @@ test("selection box is properly displayed (multi pages) on mobile", async () => 
     });
 
     expect(".o_data_row").toHaveCount(3);
-    expect(".o_list_selection_box").toHaveCount(0);
+    expect(".o_selection_box").toHaveCount(0);
 
     // select a record
     await contains(".o_data_row:nth-child(1)").drag();
     await animationFrame();
 
-    expect(".o_list_selection_box").toHaveCount(1);
-    expect(".o_list_selection_box .o_list_select_domain").toHaveCount(1);
-    expect(".o_list_selection_box").toHaveText("1\nselected\nAll");
-    expect(".o_list_selection_box").toHaveCount(1);
+    expect(".o_selection_box").toHaveCount(1);
+    expect(".o_selection_box .o_select_domain").toHaveCount(1);
+    expect(".o_selection_box").toHaveText("1\nselected\nAll");
+    expect(".o_selection_box").toHaveCount(1);
     expect("div.o_control_panel .o_cp_action_menus").toHaveCount(1);
 
     await toggleActionMenu();
@@ -3709,16 +3709,16 @@ test("selection box is properly displayed (multi pages) on mobile", async () => 
     await contains(".o_data_row:nth-child(3)").drag();
     await animationFrame();
 
-    expect(".o_list_selection_box").toHaveCount(1);
-    expect(".o_list_selection_box .o_list_select_domain").toHaveCount(1);
-    expect(".o_list_selection_box").toHaveText("3\nselected\nAll");
+    expect(".o_selection_box").toHaveCount(1);
+    expect(".o_selection_box .o_select_domain").toHaveCount(1);
+    expect(".o_selection_box").toHaveText("3\nselected\nAll");
 
-    expect(".o_list_select_domain").toHaveCount(1);
+    expect(".o_select_domain").toHaveCount(1);
 
     // select all domain
-    await contains(".o_list_selection_box .o_list_select_domain").click();
-    expect(".o_list_selection_box").toHaveCount(1);
-    expect(".o_list_selection_box").toHaveText("All 4 selected");
+    await contains(".o_selection_box .o_select_domain").click();
+    expect(".o_selection_box").toHaveCount(1);
+    expect(".o_selection_box").toHaveText("All 4 selected");
 });
 
 test.tags("desktop");
@@ -3730,30 +3730,30 @@ test(`selection box is properly displayed (group list)`, async () => {
         groupBy: ["foo"],
     });
     expect(`.o_group_header`).toHaveCount(3);
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(0);
 
     // open first group
     await contains(`.o_group_header`).click();
 
     // select a record
     await contains(`.o_data_row .o_list_record_selector input`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(0);
-    expect(`.o_list_selection_box`).toHaveText("1\nselected");
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(0);
+    expect(`.o_selection_box`).toHaveText("1\nselected");
 
     // select all records of first page
     await contains(`thead .o_list_record_selector input`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(1);
-    expect(`.o_list_selection_box`).toHaveText("2\nselected\n Select all 4");
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(1);
+    expect(`.o_selection_box`).toHaveText("2\nselected\n Select all 4");
 
     // select all domain
-    await contains(`.o_list_selection_box .o_list_select_domain`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
-    expect(`.o_list_selection_box`).toHaveText("All 4 selected");
+    await contains(`.o_selection_box .o_select_domain`).click();
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
+    expect(`.o_selection_box`).toHaveText("All 4 selected");
 
-    await contains(`.o_list_unselect_all`).click();
-    expect(`.o_list_selection_box`).toHaveCount(0, {
+    await contains(`.o_unselect_all`).click();
+    expect(`.o_selection_box`).toHaveCount(0, {
         message: "selection options are no longer visible",
     });
 });
@@ -3769,29 +3769,29 @@ test(`selection box: grouped list, all groups folded`, async () => {
     expect(`.o_group_header`).toHaveCount(3);
     expect(`.o_data_row`).toHaveCount(0);
     expect(`.o_searchview`).toHaveCount(1);
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(0);
     expect(`.o_control_panel_breadcrumbs_actions .o_cp_action_menus`).toHaveCount(1);
 
     // click on the checkbox in the thead
     await contains(`thead .o_list_record_selector input`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
     expect(`.o_control_panel_breadcrumbs_actions .o_cp_action_menus`).toHaveCount(0);
     expect(`.o_searchview`).toHaveCount(0);
-    expect(`.o_list_selection_box`).toHaveText("All 4 selected");
+    expect(`.o_selection_box`).toHaveText("All 4 selected");
 
     // remove selection by clicking on the cross in the selection box
-    await contains(`.o_list_unselect_all`).click();
-    expect(`.o_list_selection_box`).toHaveCount(0);
+    await contains(`.o_unselect_all`).click();
+    expect(`.o_selection_box`).toHaveCount(0);
 
     // click again on the checkbox in the thead
     await contains(`thead .o_list_record_selector input`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
-    expect(`.o_list_selection_box`).toHaveText("All 4 selected");
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
+    expect(`.o_selection_box`).toHaveText("All 4 selected");
 
     // remove selection by clicking on the checkbox in the thead
     await contains(`thead .o_list_record_selector input`).click();
     expect(`.o_searchview`).toHaveCount(1);
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(0);
 });
 
 test.tags("desktop");
@@ -3804,7 +3804,7 @@ test(`selection box in grouped list, multi pages`, async () => {
     });
 
     expect(".o_group_header").toHaveCount(2);
-    expect(".o_list_selection_box").toHaveCount(0);
+    expect(".o_selection_box").toHaveCount(0);
     expect(".o_pager_value").toHaveText("1-2");
     expect(".o_pager_limit").toHaveText("4");
 
@@ -3812,16 +3812,16 @@ test(`selection box in grouped list, multi pages`, async () => {
     await contains(".o_group_header").click();
     expect(".o_data_row").toHaveCount(1);
     await contains("thead .o_list_record_selector input").click();
-    expect(".o_control_panel_actions .o_list_selection_box").toHaveCount(1);
-    expect(".o_list_selection_box .o_list_select_domain").toHaveCount(1);
-    expect(queryOne(".o_list_selection_box").innerText.replace(/\s+/g, " ").trim()).toBe(
+    expect(".o_control_panel_actions .o_selection_box").toHaveCount(1);
+    expect(".o_selection_box .o_select_domain").toHaveCount(1);
+    expect(queryOne(".o_selection_box").innerText.replace(/\s+/g, " ").trim()).toBe(
         "1 selected Select all" // we don't know the total count, so we don't display it
     );
 
     // select all domain
-    await contains(".o_list_selection_box .o_list_select_domain").click();
-    expect(".o_control_panel_actions .o_list_selection_box").toHaveCount(1);
-    expect(".o_list_selection_box").toHaveText("All 4 selected");
+    await contains(".o_selection_box .o_select_domain").click();
+    expect(".o_control_panel_actions .o_selection_box").toHaveCount(1);
+    expect(".o_selection_box").toHaveText("All 4 selected");
 });
 
 test.tags("desktop");
@@ -3835,11 +3835,11 @@ test(`selection box: grouped list, select domain, open group`, async () => {
 
     expect(".o_group_header").toHaveCount(3);
     expect(".o_data_row").toHaveCount(0);
-    expect(".o_control_panel_actions .o_list_selection_box").toHaveCount(0);
+    expect(".o_control_panel_actions .o_selection_box").toHaveCount(0);
 
     // select all domain by ticking the thead checkbox
     await contains(`thead .o_list_record_selector input`).click();
-    expect(`.o_list_selection_box`).toHaveText("All 4 selected");
+    expect(`.o_selection_box`).toHaveText("All 4 selected");
 
     // open first group
     await contains(".o_group_header").click();
@@ -3863,23 +3863,23 @@ test(`selection box: grouped list, select domain, use pager (inside group)`, asy
 
     expect(".o_group_header").toHaveCount(2);
     expect(".o_data_row").toHaveCount(0);
-    expect(".o_control_panel_actions .o_list_selection_box").toHaveCount(0);
+    expect(".o_control_panel_actions .o_selection_box").toHaveCount(0);
 
     // open second group and select all domain
     await contains(queryAll(".o_group_header")[1]).click();
     await contains("thead .o_list_record_selector input").click();
-    await contains(".o_list_selection_box .o_list_select_domain").click();
+    await contains(".o_selection_box .o_select_domain").click();
     expect(".o_data_row").toHaveCount(2);
     expect(".o_group_header .o_pager_value").toHaveText("1-2");
     expect(".o_group_header .o_pager_limit").toHaveText("3");
-    expect(".o_control_panel_actions .o_list_selection_box").toHaveCount(1);
-    expect(".o_list_selection_box").toHaveText("All 4 selected");
+    expect(".o_control_panel_actions .o_selection_box").toHaveCount(1);
+    expect(".o_selection_box").toHaveText("All 4 selected");
 
     // click pager next in the opened group
     await contains(".o_group_header .o_pager_next").click();
     expect(".o_data_row").toHaveCount(1);
     expect(".o_data_row .o_list_record_selector input:checked").toHaveCount(1);
-    expect(".o_list_selection_box").toHaveText("All 4 selected");
+    expect(".o_selection_box").toHaveText("All 4 selected");
 });
 
 test.tags("desktop");
@@ -3893,17 +3893,17 @@ test(`selection box: grouped list, select domain, use main pager`, async () => {
 
     expect(".o_group_header").toHaveCount(2);
     expect(".o_data_row").toHaveCount(0);
-    expect(".o_control_panel_actions .o_list_selection_box").toHaveCount(0);
+    expect(".o_control_panel_actions .o_selection_box").toHaveCount(0);
 
     // select all domain by ticking the thead checkbox
     await contains(`thead .o_list_record_selector input`).click();
-    expect(`.o_list_selection_box`).toHaveText("All 4 selected");
+    expect(`.o_selection_box`).toHaveText("All 4 selected");
 
     // go to second page
     await contains(".o_pager_next").click();
     expect(".o_group_header").toHaveCount(1);
     expect(".o_data_row").toHaveCount(0);
-    expect(`.o_list_selection_box`).toHaveText("All 4 selected");
+    expect(`.o_selection_box`).toHaveText("All 4 selected");
 
     // open a group
     await contains(".o_group_header").click();
@@ -3915,7 +3915,7 @@ test(`selection box: grouped list, select domain, use main pager`, async () => {
     await contains(".o_pager_next").click();
     expect(".o_data_row").toHaveCount(1);
     expect(".o_data_row .o_list_record_selector input:checked").toHaveCount(1);
-    expect(`.o_list_selection_box`).toHaveText("All 4 selected");
+    expect(`.o_selection_box`).toHaveText("All 4 selected");
 });
 
 test.tags("desktop");
@@ -3929,17 +3929,17 @@ test(`selection box: grouped list, select domain, reduce limit`, async () => {
 
     expect(".o_group_header").toHaveCount(3);
     expect(".o_data_row").toHaveCount(0);
-    expect(".o_control_panel_actions .o_list_selection_box").toHaveCount(0);
+    expect(".o_control_panel_actions .o_selection_box").toHaveCount(0);
 
     // select all domain by ticking the thead checkbox
     await contains(`thead .o_list_record_selector input`).click();
-    expect(`.o_list_selection_box`).toHaveText("All 4 selected");
+    expect(`.o_selection_box`).toHaveText("All 4 selected");
 
     // reduce limit to 2
     await contains(".o_pager_value").click();
     await contains("input.o_pager_value").edit("1-2");
     expect(".o_group_header").toHaveCount(2);
-    expect(`.o_list_selection_box`).toHaveText("All 4 selected");
+    expect(`.o_selection_box`).toHaveText("All 4 selected");
 });
 
 test.tags("desktop");
@@ -3959,16 +3959,16 @@ test(`selection box is displayed as first action button`, async () => {
         `,
     });
     expect(`.o_data_row`).toHaveCount(4);
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(0);
 
     // select a record
     await contains(`.o_data_row:eq(0) .o_list_record_selector input`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
     const firstElement = queryFirst(`.o_control_panel_actions > div`).firstElementChild;
-    expect(firstElement).toBe(queryFirst(`.o_control_panel_actions .o_list_selection_box`), {
+    expect(firstElement).toBe(queryFirst(`.o_control_panel_actions .o_selection_box`), {
         message: "last element should selection box",
     });
-    expect(`.o_list_selection_box`).toHaveText("1\nselected");
+    expect(`.o_selection_box`).toHaveText("1\nselected");
 });
 
 test.tags("desktop");
@@ -3979,26 +3979,24 @@ test(`selection box: select domain, then untick a record`, async () => {
         arch: `<list limit="2"><field name="foo"/><field name="bar"/></list>`,
     });
     expect(`.o_data_row`).toHaveCount(2);
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(0);
 
     // select all records of first page
     await contains(`thead .o_list_record_selector input`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(1);
-    expect(queryOne(".o_list_selection_box").innerText.replace(/\s+/g, " ").trim()).toBe(
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(1);
+    expect(queryOne(".o_selection_box").innerText.replace(/\s+/g, " ").trim()).toBe(
         "2 selected Select all 4"
     );
 
     // select domain
-    await contains(`.o_list_selection_box .o_list_select_domain`).click();
-    expect(`.o_list_selection_box`).toHaveText("All 4 selected");
+    await contains(`.o_selection_box .o_select_domain`).click();
+    expect(`.o_selection_box`).toHaveText("All 4 selected");
 
     // untick a record
     await contains(`.o_data_row .o_list_record_selector input`).click();
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(0);
-    expect(queryOne(`.o_list_selection_box`).innerText.replace(/\s+/g, " ").trim()).toBe(
-        "1 selected"
-    );
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(0);
+    expect(queryOne(`.o_selection_box`).innerText.replace(/\s+/g, " ").trim()).toBe("1 selected");
     expect(`thead .o_list_record_selector input`).not.toBeChecked();
 });
 
@@ -4010,13 +4008,13 @@ test(`selection box is not removed after multi record edition`, async () => {
         arch: `<list multi_edit="1"><field name="foo"/><field name="bar"/></list>`,
     });
     expect(`.o_data_row`).toHaveCount(4, { message: "there should be 4 records" });
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0, {
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(0, {
         message: "list selection box should not be displayed",
     });
 
     // select all records
     await contains(`.o_list_record_selector input`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1, {
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1, {
         message: "list selection box should be displayed",
     });
     expect(`.o_data_row .o_list_record_selector input:checked`).toHaveCount(4, {
@@ -4027,7 +4025,7 @@ test(`selection box is not removed after multi record edition`, async () => {
     await contains(`.o_data_row .o_data_cell`).click();
     await contains(`.o_data_row [name=foo] input`).edit("legion");
     await contains(`.modal-dialog button.btn-primary`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1, {
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1, {
         message: "list selection box should still be displayed",
     });
     expect(`.o_data_row .o_list_record_selector input:checked`).toHaveCount(4, {
@@ -4047,7 +4045,7 @@ test(`selection is reset on reload`, async () => {
             </list>
         `,
     });
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(0);
     expect(`tfoot .o_list_number`).toHaveText("32", {
         message: "total should be 32 (no record selected)",
     });
@@ -4057,7 +4055,7 @@ test(`selection is reset on reload`, async () => {
     expect(`tbody .o_list_record_selector input:eq(0)`).toBeChecked({
         message: "first row should be selected",
     });
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
     expect(`tfoot .o_list_number`).toHaveText("10", {
         message: "total should be 10 (first record selected)",
     });
@@ -4067,7 +4065,7 @@ test(`selection is reset on reload`, async () => {
     expect(`tbody .o_list_record_selector input:eq(0)`).not.toBeChecked({
         message: "first row should be selected",
     });
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(0);
     expect(`tfoot .o_list_number`).toHaveText("32", {
         message: "total should be 10 (first record selected)",
     });
@@ -4088,13 +4086,13 @@ test(`selection is kept on render without reload`, async () => {
         actionMenus: {},
     });
     expect(`div.o_control_panel .o_cp_action_menus`).toHaveCount(1);
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(0);
 
     // open blip grouping and check all lines
     await contains(`.o_group_header:contains(blip (2))`).click();
     await contains(`.o_data_row input`).click();
     expect(`div.o_control_panel .o_cp_action_menus`).toHaveCount(1);
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
 
     // open yop grouping and verify blip are still checked
     await contains(`.o_group_header:contains(yop (1))`).click();
@@ -4102,7 +4100,7 @@ test(`selection is kept on render without reload`, async () => {
         message: "opening a grouping does not uncheck others",
     });
     expect(`div.o_control_panel .o_cp_action_menus`).toHaveCount(1);
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
 
     // close and open blip grouping and verify blip are unchecked
     await contains(`.o_group_header:contains(blip (2))`).click();
@@ -4111,7 +4109,7 @@ test(`selection is kept on render without reload`, async () => {
         message: "opening and closing a grouping uncheck its elements",
     });
     expect(`div.o_control_panel .o_cp_action_menus`).toHaveCount(1);
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(0);
 });
 
 test.tags("desktop");
@@ -4126,13 +4124,13 @@ test(`select a record in list grouped by date with granularity`, async () => {
         actionMenus: {},
     });
     expect(`.o_group_header`).toHaveCount(2);
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(0);
 
     await contains(`.o_group_header`).click();
     expect(`.o_data_row`).toHaveCount(1);
 
     await contains(`.o_data_row .o_list_record_selector`).click();
-    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
+    expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
 });
 
 test.tags("desktop");
@@ -4171,7 +4169,7 @@ test(`aggregates are computed correctly on desktop`, async () => {
     expect(queryAllTexts(`tfoot td`)).toEqual(["", "", "32", "1.50"]);
 
     // Let's update the view to dislay NO records
-    await contains(`.o_list_unselect_all`).click();
+    await contains(`.o_unselect_all`).click();
     await toggleSearchBarMenu();
     await toggleMenuItem("My Filter");
     expect(queryAllTexts(`tfoot td`)).toEqual(["", "", "", ""]);
@@ -5066,9 +5064,9 @@ test(`delete all records matching the domain`, async () => {
 
     await contains(`thead .o_list_record_selector input`).click();
     expect(`div.o_control_panel .o_cp_action_menus`).toHaveCount(1);
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(1);
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(1);
 
-    await contains(`.o_list_selection_box .o_list_select_domain`).click();
+    await contains(`.o_selection_box .o_select_domain`).click();
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await toggleMenuItem("Delete");
     expect(`.modal`).toHaveCount(1, { message: "a confirm modal should be displayed" });
@@ -5109,9 +5107,9 @@ test(`delete all records matching the domain (limit reached)`, async () => {
 
     await contains(`thead .o_list_record_selector input`).click();
     expect(`div.o_control_panel .o_cp_action_menus`).toHaveCount(1);
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(1);
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(1);
 
-    await contains(`.o_list_selection_box .o_list_select_domain`).click();
+    await contains(`.o_selection_box .o_select_domain`).click();
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await toggleMenuItem("Delete");
     expect(`.modal`).toHaveCount(1, { message: "a confirm modal should be displayed" });
@@ -5232,9 +5230,9 @@ test(`archive all records matching the domain`, async () => {
 
     await contains(`thead .o_list_record_selector input`).click();
     expect(`div.o_control_panel .o_cp_action_menus`).toHaveCount(1);
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(1);
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(1);
 
-    await contains(`.o_list_selection_box .o_list_select_domain`).click();
+    await contains(`.o_selection_box .o_select_domain`).click();
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await toggleMenuItem("Archive");
     expect(`.modal`).toHaveCount(1, { message: "a confirm modal should be displayed" });
@@ -5277,9 +5275,9 @@ test(`archive all records matching the domain (limit reached)`, async () => {
 
     await contains(`thead .o_list_record_selector input`).click();
     expect(`div.o_control_panel .o_cp_action_menus`).toHaveCount(1);
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(1);
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(1);
 
-    await contains(`.o_list_selection_box .o_list_select_domain`).click();
+    await contains(`.o_selection_box .o_select_domain`).click();
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await toggleMenuItem("Archive");
     expect(`.modal`).toHaveCount(1, { message: "a confirm modal should be displayed" });
@@ -8843,14 +8841,14 @@ test(`execute ActionMenus actions with correct params (multi pages)`, async () =
     // select all records
     await contains(`thead .o_list_record_selector input`).click();
     expect(`.o_list_record_selector input:checked`).toHaveCount(3);
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(1);
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(1);
     expect(`div.o_control_panel .o_cp_action_menus`).toHaveCount(1);
 
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await toggleMenuItem("Custom Action");
 
     // select all domain
-    await contains(`.o_list_selection_box .o_list_select_domain`).click();
+    await contains(`.o_selection_box .o_select_domain`).click();
     expect(`.o_list_record_selector input:checked`).toHaveCount(3);
 
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
@@ -8860,13 +8858,13 @@ test(`execute ActionMenus actions with correct params (multi pages)`, async () =
     await contains(`thead .o_list_record_selector input`).click();
     await toggleSearchBarMenu();
     await toggleMenuItem("bar");
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(0);
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(0);
 
     // select all domain
     await contains(`thead .o_list_record_selector input`).click();
-    await contains(`.o_list_selection_box .o_list_select_domain`).click();
+    await contains(`.o_selection_box .o_select_domain`).click();
     expect(`.o_list_record_selector input:checked`).toHaveCount(3);
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(0);
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(0);
 
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await toggleMenuItem("Custom Action");
@@ -10536,7 +10534,7 @@ test(`editable list view: multi edition`, async () => {
         message: "no field should be editable anymore",
     });
     // discard selection
-    await contains(`.o_list_unselect_all`).click();
+    await contains(`.o_unselect_all`).click();
     expect(`.o_list_record_selector input:checked`).toHaveCount(0, {
         message: "no record should be selected anymore",
     });
@@ -11104,7 +11102,7 @@ test(`editable list view: multi edition when the domain is selected`, async () =
 
     // select all records, and then select all domain
     await contains(`.o_list_record_selector input`).click();
-    await contains(`.o_list_selection_box .o_list_select_domain`).click();
+    await contains(`.o_selection_box .o_select_domain`).click();
 
     // edit a field
     await contains(`.o_data_row .o_data_cell:eq(1)`).click();
@@ -14176,11 +14174,11 @@ test(`optional fields do not disappear even after listview reload`, async () => 
     expect(`th[data-name=m2o]`).toHaveCount(1);
 
     await contains(`tbody .o_list_record_selector input`).click();
-    expect(`.o_list_selection_box`).toHaveCount(1);
+    expect(`.o_selection_box`).toHaveCount(1);
 
     await contains(`.o_pager_value`).click();
     await contains(`input.o_pager_value`).edit("1-4");
-    expect(`.o_list_selection_box`).toHaveCount(0);
+    expect(`.o_selection_box`).toHaveCount(0);
     expect(`th`).toHaveCount(5, {
         message:
             "should have 5 th 1 for selector, 3 for columns, 1 for optional columns ever after listview reload",
@@ -17326,14 +17324,14 @@ test.tags("desktop")("select records range with shift click on several page", as
     await contains(`.o_data_row .o_list_record_selector input:eq(0)`).click();
     expect(`.o_data_row:eq(0) .o_list_record_selector input`).toBeChecked();
 
-    expect(`.o_list_selection_box .o_list_select_domain`).toHaveCount(0);
-    expect(`.o_list_selection_box`).toHaveText("1\nselected");
+    expect(`.o_selection_box .o_select_domain`).toHaveCount(0);
+    expect(`.o_selection_box`).toHaveText("1\nselected");
     expect(`.o_data_row .o_list_record_selector input:checked`).toHaveCount(1);
     // click the pager next button
     await contains(".o_pager_next").click();
     // shift click the first record of the second page
     await contains(`.o_data_row .o_list_record_selector input`).click({ shiftKey: true });
-    expect(`.o_list_selection_box`).toHaveText("1\nselected\n Select all 4");
+    expect(`.o_selection_box`).toHaveText("1\nselected\n Select all 4");
 });
 
 test("open record, with invalid record in list", async () => {
@@ -17422,24 +17420,24 @@ test("selection is properly displayed (single page) on mobile", async () => {
     });
 
     expect(".o_data_row").toHaveCount(4);
-    expect(".o_list_selection_box").toHaveCount(0);
+    expect(".o_selection_box").toHaveCount(0);
     expect(".o_control_panel .fa-search").toHaveCount(1);
 
     // select a record
     await contains(".o_data_row:nth-child(1)").drag();
-    expect(".o_list_selection_box").toHaveCount(1);
-    expect(".o_list_selection_box .o_list_select_domain").toHaveCount(1);
+    expect(".o_selection_box").toHaveCount(1);
+    expect(".o_selection_box .o_select_domain").toHaveCount(1);
     expect(".o_control_panel .o_cp_searchview").toHaveCount(0);
-    expect(queryFirst(".o_list_selection_box")).toHaveText("1\nselected\nAll");
+    expect(queryFirst(".o_selection_box")).toHaveText("1\nselected\nAll");
 
     // unselect a record
     await contains(".o_data_row:nth-child(1)").drag();
-    expect(".o_list_selection_box .o_list_select_domain").toHaveCount(0);
+    expect(".o_selection_box .o_select_domain").toHaveCount(0);
 
     // select 2 records
     await contains(".o_data_row:nth-child(1)").drag();
     await contains(".o_data_row:nth-child(2)").drag();
-    expect(queryFirst(".o_list_selection_box")).toHaveText("2\nselected\nAll");
+    expect(queryFirst(".o_selection_box")).toHaveText("2\nselected\nAll");
 
     expect("div.o_control_panel .o_cp_action_menus").toHaveCount(1);
 
@@ -17448,7 +17446,7 @@ test("selection is properly displayed (single page) on mobile", async () => {
 
     // unselect all
     await unselectAllRecords();
-    expect(".o_list_selection_box").toHaveCount(0);
+    expect(".o_selection_box").toHaveCount(0);
     expect(".o_control_panel .fa-search").toHaveCount(1);
 });
 

--- a/addons/web/static/tests/views/view_dialogs/export_data_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/export_data_dialog.test.js
@@ -50,7 +50,7 @@ class Partner extends models.Model {
         { id: 3, foo: "piou piou", display_name: "Jack O'Neill", bar: true },
     ];
 }
-class Users extends models.Model {
+class User extends models.Model {
     _name = "res.users";
     has_group() {
         return true;
@@ -67,7 +67,7 @@ class IrExportsLine extends models.Model {
     name = fields.Char();
     export_id = fields.Many2one({ relation: "ir.exports" });
 }
-defineModels([Partner, Users, IrExports, IrExportsLine]);
+defineModels([Partner, User, IrExports, IrExportsLine]);
 
 const fetchedFields = {
     root: [
@@ -639,14 +639,14 @@ test("ExportDialog: export all records of the domain", async () => {
             }
         },
     });
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "xls", label: "Excel" }];
-    });
-    onRpc("/web/export/get_fields", async (request) =>  {
+    onRpc("/web/export/formats", () => [{ tag: "xls", label: "Excel" }]);
+    onRpc("/web/export/get_fields", async (request) => {
         const { params } = await request.json();
         if (isDomainSelected) {
             const expectedDomain = params.parent_field ? [] : [["bar", "!=", "glou"]];
-            expect(params.domain).toEqual(expectedDomain, {message: "Domain is only applied on the root model"});
+            expect(params.domain).toEqual(expectedDomain, {
+                message: "Domain is only applied on the root model",
+            });
             expect.step("get export fields route called with correct domain");
         }
         return fetchedFields.root;

--- a/addons/web/static/tests/views/view_dialogs/export_data_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/export_data_dialog.test.js
@@ -168,15 +168,11 @@ const fetchedFields = {
 };
 
 test("Export dialog UI test", async () => {
-    onRpc("/web/export/formats", () => {
-        return [
-            { tag: "csv", label: "CSV" },
-            { tag: "xls", label: "Excel" },
-        ];
-    });
-    onRpc("/web/export/get_fields", () => {
-        return fetchedFields.root;
-    });
+    onRpc("/web/export/formats", () => [
+        { tag: "csv", label: "CSV" },
+        { tag: "xls", label: "Excel" },
+    ]);
+    onRpc("/web/export/get_fields", () => fetchedFields.root);
 
     await mountView({
         type: "list",
@@ -209,26 +205,22 @@ test("Export dialog UI test", async () => {
 });
 
 test("Export dialog: interacting with export templates", async () => {
-    onRpc("/web/export/formats", () => {
-        return [
-            { tag: "csv", label: "CSV" },
-            { tag: "xls", label: "Excel" },
-        ];
-    });
-    onRpc("/web/export/get_fields", () => {
-        return [
-            ...fetchedFields.root,
-            {
-                children: false,
-                field_type: "string",
-                id: "third_field",
-                relation_field: null,
-                required: false,
-                string: "Third field selected",
-                value: "third_field",
-            },
-        ];
-    });
+    onRpc("/web/export/formats", () => [
+        { tag: "csv", label: "CSV" },
+        { tag: "xls", label: "Excel" },
+    ]);
+    onRpc("/web/export/get_fields", () => [
+        ...fetchedFields.root,
+        {
+            children: false,
+            field_type: "string",
+            id: "third_field",
+            relation_field: null,
+            required: false,
+            string: "Third field selected",
+            value: "third_field",
+        },
+    ]);
     onRpc("/web/export/namelist", async (request) => {
         const { params } = await request.json();
         if (params.export_id === 1) {
@@ -332,12 +324,8 @@ test("Export dialog: interacting with export templates", async () => {
 test("Export dialog: interacting with export templates in debug", async () => {
     serverState.debug = true;
 
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "csv", label: "CSV" }];
-    });
-    onRpc("/web/export/get_fields", () => {
-        return [...fetchedFields.root];
-    });
+    onRpc("/web/export/formats", () => [{ tag: "csv", label: "CSV" }]);
+    onRpc("/web/export/get_fields", () => [...fetchedFields.root]);
     onRpc("/web/export/namelist", async (request) => {
         const { params } = await request.json();
         if (params.export_id === 1) {
@@ -369,9 +357,7 @@ test("Export dialog: interacting with export templates in debug", async () => {
 
 test.tags("desktop");
 test("Export dialog: interacting with available fields", async () => {
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "csv", label: "CSV" }];
-    });
+    onRpc("/web/export/formats", () => [{ tag: "csv", label: "CSV" }]);
     onRpc("/web/export/get_fields", async (request) => {
         const { params } = await request.json();
         if (!params.parent_field) {
@@ -458,16 +444,12 @@ test("Export dialog: compatible and export type options", async () => {
             expect(JSON.parse(options.data.data)["import_compat"]).toBe(true);
         },
     });
-    onRpc("/web/export/formats", () => {
-        return [
-            { tag: "csv", label: "CSV" },
-            { tag: "xls", label: "Excel" },
-            { tag: "wow", label: "WOW" },
-        ];
-    });
-    onRpc("/web/export/get_fields", () => {
-        return fetchedFields.root;
-    });
+    onRpc("/web/export/formats", () => [
+        { tag: "csv", label: "CSV" },
+        { tag: "xls", label: "Excel" },
+        { tag: "wow", label: "WOW" },
+    ]);
+    onRpc("/web/export/get_fields", () => fetchedFields.root);
 
     await mountView({
         type: "list",
@@ -495,9 +477,7 @@ test("toggling import compatibility after adding an expanded field", async () =>
             expect(JSON.parse(options.data.data)["import_compat"]).toBe(true);
         },
     });
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "csv", label: "CSV" }];
-    });
+    onRpc("/web/export/formats", () => [{ tag: "csv", label: "CSV" }]);
     onRpc("/web/export/get_fields", async (request) => {
         const { params } = await request.json();
         if (!params.parent_field) {
@@ -525,9 +505,7 @@ test("toggling import compatibility after adding an expanded field", async () =>
 });
 
 test("Export dialog: many2many fields are extendable", async () => {
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "csv", label: "CSV" }];
-    });
+    onRpc("/web/export/formats", () => [{ tag: "csv", label: "CSV" }]);
     onRpc("/web/export/get_fields", async (request) => {
         const { params } = await request.json();
         if (!params.parent_field) {
@@ -557,9 +535,7 @@ test("Export dialog: many2many fields are extendable", async () => {
 test("Export dialog: export list with 'exportable: false'", async () => {
     Partner._fields.not_exportable = fields.Char({ string: "Not exportable", exportable: false });
     Partner._fields.exportable = fields.Char();
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "csv", label: "CSV" }];
-    });
+    onRpc("/web/export/formats", () => [{ tag: "csv", label: "CSV" }]);
     onRpc("/web/export/get_fields", async (request) => {
         const { params } = await request.json();
         if (!params.parent_field) {
@@ -599,9 +575,7 @@ test("Export dialog: export list with 'exportable: false'", async () => {
 
 test.tags("desktop");
 test("Export dialog: sortable on desktop", async () => {
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "csv", label: "CSV" }];
-    });
+    onRpc("/web/export/formats", () => [{ tag: "csv", label: "CSV" }]);
     onRpc("/web/export/get_fields", async (request) => {
         const { params } = await request.json();
         if (!params.parent_field) {
@@ -627,9 +601,7 @@ test("Export dialog: sortable on desktop", async () => {
 
 test.tags("mobile");
 test("Export dialog: non-sortable on mobile", async () => {
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "csv", label: "CSV" }];
-    });
+    onRpc("/web/export/formats", () => [{ tag: "csv", label: "CSV" }]);
     onRpc("/web/export/get_fields", async (request) => {
         const { params } = await request.json();
         if (!params.parent_field) {
@@ -698,7 +670,7 @@ test("ExportDialog: export all records of the domain", async () => {
     await contains(".o_form_button_cancel").click();
 
     isDomainSelected = true;
-    await contains(".o_list_select_domain").click();
+    await contains(".o_select_domain").click();
     await contains(".o_control_panel .o_cp_action_menus .dropdown-toggle").click();
     await contains(".dropdown-menu span:contains(Export)").click();
     await contains(".o_select_button").click();
@@ -742,12 +714,8 @@ test("Direct export list", async () => {
             });
         },
     });
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "xls", label: "Excel" }];
-    });
-    onRpc("/web/export/get_fields", () => {
-        return fetchedFields.root;
-    });
+    onRpc("/web/export/formats", () => [{ tag: "xls", label: "Excel" }]);
+    onRpc("/web/export/get_fields", () => fetchedFields.root);
 
     await mountView({
         type: "list",
@@ -770,12 +738,8 @@ test("Direct export grouped list", async () => {
             expect(JSON.parse(options.data.data).groupby).toEqual(["foo", "bar"]);
         },
     });
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "xls", label: "Excel" }];
-    });
-    onRpc("/web/export/get_fields", () => {
-        return fetchedFields.root;
-    });
+    onRpc("/web/export/formats", () => [{ tag: "xls", label: "Excel" }]);
+    onRpc("/web/export/get_fields", () => fetchedFields.root);
 
     await mountView({
         type: "list",
@@ -802,12 +766,8 @@ test("Direct export list take optional fields into account on desktop", async ()
             ]);
         },
     });
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "xls", label: "Excel" }];
-    });
-    onRpc("/web/export/get_fields", () => {
-        return fetchedFields.root;
-    });
+    onRpc("/web/export/formats", () => [{ tag: "xls", label: "Excel" }]);
+    onRpc("/web/export/get_fields", () => fetchedFields.root);
 
     await mountView({
         type: "list",
@@ -837,12 +797,8 @@ test("Direct export list take optional fields into account on mobile", async () 
             ]);
         },
     });
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "xls", label: "Excel" }];
-    });
-    onRpc("/web/export/get_fields", () => {
-        return fetchedFields.root;
-    });
+    onRpc("/web/export/formats", () => [{ tag: "xls", label: "Excel" }]);
+    onRpc("/web/export/get_fields", () => fetchedFields.root);
 
     await mountView({
         type: "list",
@@ -865,12 +821,8 @@ test("Direct export list take optional fields into account on mobile", async () 
 
 test.tags("desktop");
 test("Export dialog with duplicated fields on desktop", async () => {
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "csv", label: "CSV" }];
-    });
-    onRpc("/web/export/get_fields", () => {
-        return fetchedFields.root;
-    });
+    onRpc("/web/export/formats", () => [{ tag: "csv", label: "CSV" }]);
+    onRpc("/web/export/get_fields", () => fetchedFields.root);
 
     await mountView({
         type: "list",
@@ -894,12 +846,8 @@ test("Export dialog with duplicated fields on desktop", async () => {
 
 test.tags("mobile");
 test("Export dialog with duplicated fields on mobile", async () => {
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "csv", label: "CSV" }];
-    });
-    onRpc("/web/export/get_fields", () => {
-        return fetchedFields.root;
-    });
+    onRpc("/web/export/formats", () => [{ tag: "csv", label: "CSV" }]);
+    onRpc("/web/export/get_fields", () => fetchedFields.root);
 
     await mountView({
         type: "list",
@@ -922,9 +870,7 @@ test("Export dialog with duplicated fields on mobile", async () => {
 });
 
 test("Export dialog: export list contains field with 'default_export: true'", async () => {
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "csv", label: "CSV" }];
-    });
+    onRpc("/web/export/formats", () => [{ tag: "csv", label: "CSV" }]);
     onRpc("/web/export/get_fields", async (request) => {
         const { params } = await request.json();
         if (!params.parent_field) {
@@ -958,9 +904,7 @@ test("Export dialog: export list contains field with 'default_export: true'", as
 });
 
 test("Export dialog: search subfields", async () => {
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "csv", label: "CSV" }];
-    });
+    onRpc("/web/export/formats", () => [{ tag: "csv", label: "CSV" }]);
     onRpc("/web/export/get_fields", async (request) => {
         const { params } = await request.json();
         if (!params.parent_field) {
@@ -993,9 +937,7 @@ test("Export dialog: search subfields", async () => {
 });
 
 test("Export dialog: expand subfields after search", async () => {
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "csv", label: "CSV" }];
-    });
+    onRpc("/web/export/formats", () => [{ tag: "csv", label: "CSV" }]);
     onRpc("/web/export/get_fields", async (request) => {
         const { params } = await request.json();
         if (!params.parent_field) {
@@ -1036,9 +978,7 @@ test("Export dialog: expand subfields after search", async () => {
 test("Export dialog: search in debug", async () => {
     serverState.debug = true;
 
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "csv", label: "CSV" }];
-    });
+    onRpc("/web/export/formats", () => [{ tag: "csv", label: "CSV" }]);
     onRpc("/web/export/get_fields", async (request) => {
         const { params } = await request.json();
         if (!params.parent_field) {
@@ -1071,12 +1011,8 @@ test("Export dialog: disable button during export", async () => {
     patchWithCleanup(download, {
         _download: () => (def = new Deferred()),
     });
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "xls", label: "Excel" }];
-    });
-    onRpc("/web/export/get_fields", () => {
-        return fetchedFields.root;
-    });
+    onRpc("/web/export/formats", () => [{ tag: "xls", label: "Excel" }]);
+    onRpc("/web/export/get_fields", () => fetchedFields.root);
 
     await mountView({
         type: "list",
@@ -1095,12 +1031,8 @@ test("Export dialog: disable button during export", async () => {
 });
 
 test("Export dialog: no column_invisible fields in default export list", async () => {
-    onRpc("/web/export/formats", () => {
-        return [{ tag: "xls", label: "Excel" }];
-    });
-    onRpc("/web/export/get_fields", () => {
-        return fetchedFields.root;
-    });
+    onRpc("/web/export/formats", () => [{ tag: "xls", label: "Excel" }]);
+    onRpc("/web/export/get_fields", () => fetchedFields.root);
 
     await mountView({
         type: "list",

--- a/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
@@ -671,7 +671,7 @@ test("SelectCreateDialog calls on_selected with every record matching the domain
     await animationFrame();
 
     await contains("thead .o_list_record_selector input").click();
-    await contains(".o_list_selection_box .o_list_select_domain").click();
+    await contains(".o_selection_box .o_select_domain").click();
     await clickModalButton({ text: "Select" });
 });
 
@@ -695,7 +695,7 @@ test("SelectCreateDialog calls on_selected with every record matching without se
     await animationFrame();
 
     await contains("thead .o_list_record_selector input").click();
-    await contains(".o_list_selection_box").click();
+    await contains(".o_selection_box").click();
     await clickModalButton({ text: "Select", index: 1 });
 });
 

--- a/addons/web/static/tests/webclient/actions/concurrency.test.js
+++ b/addons/web/static/tests/webclient/actions/concurrency.test.js
@@ -165,8 +165,8 @@ test("handle switching view and switching back on slow network", async () => {
         "/web/action/load",
         "get_views",
         "web_search_read",
-        "web_search_read",
         "has_group",
+        "web_search_read",
         "web_search_read",
     ]);
 
@@ -232,10 +232,10 @@ test("execute a new action while loading a lazy-loaded controller", async () => 
         "get_views",
         "web_read",
         "web_search_read",
+        "has_group",
         "/web/action/load",
         "get_views",
         "web_search_read",
-        "has_group",
     ]);
 
     // unblock the switch to Kanban in action 4
@@ -390,6 +390,7 @@ test("execute a new action while loading views", async () => {
         "/web/action/load",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
 });
 
@@ -701,9 +702,7 @@ test("local state, global state, and race conditions", async () => {
             this.id = id++;
             expect.step(this.props.state || "no state");
             useSetupAction({
-                getLocalState: () => {
-                    return { fromId: this.id };
-                },
+                getLocalState: () => ({ fromId: this.id }),
             });
             onWillStart(() => def);
         }

--- a/addons/web/static/tests/webclient/actions/error_handling.test.js
+++ b/addons/web/static/tests/webclient/actions/error_handling.test.js
@@ -154,6 +154,7 @@ test("connection lost when opening form view from kanban", async () => {
         "/web/action/load",
         "get_views",
         "web_search_read",
+        "has_group",
         "/web/dataset/call_kw/partner/web_read", // from mockFetch
         "/web/dataset/call_kw/partner/web_search_read", // from mockFetch
     ]);
@@ -199,6 +200,7 @@ test("connection lost when coming back to kanban from form", async () => {
         "/web/action/load",
         "get_views",
         "web_search_read",
+        "has_group",
         "web_read",
         "/web/dataset/call_kw/partner/web_search_read", // from mockFetch
     ]);
@@ -257,6 +259,7 @@ test("error on onMounted", async () => {
         "/web/action/load",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
 
     await contains(".o_kanban_record").click();

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -658,6 +658,7 @@ describe(`new urls`, () => {
             "/web/action/load",
             "get_views",
             "web_search_read",
+            "has_group",
             "Update the state without updating URL, nextState: actionStack,action",
         ]);
     });
@@ -768,6 +769,7 @@ describe(`new urls`, () => {
             "/web/action/load",
             "get_views",
             "web_search_read",
+            "has_group",
             "Update the state without updating URL, nextState: actionStack,action,view_type",
         ]);
     });
@@ -954,6 +956,7 @@ describe(`new urls`, () => {
             "/web/action/load",
             "get_views",
             "web_search_read",
+            "has_group",
             "pushState http://example.com/odoo/action-1",
         ]);
     });
@@ -1573,6 +1576,7 @@ describe(`legacy urls`, () => {
             "/web/action/load",
             "get_views",
             "web_search_read",
+            "has_group",
         ]);
     });
 
@@ -1666,6 +1670,7 @@ describe(`legacy urls`, () => {
             "/web/action/load",
             "get_views",
             "web_search_read",
+            "has_group",
         ]);
     });
 
@@ -1786,6 +1791,7 @@ describe(`legacy urls`, () => {
             "/web/action/load",
             "get_views",
             "web_search_read",
+            "has_group",
         ]);
     });
 

--- a/addons/web/static/tests/webclient/actions/new_window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/new_window_action.test.js
@@ -50,7 +50,14 @@ class Partner extends models.Model {
     };
 }
 
-defineModels([Partner]);
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+
+defineModels([Partner, User]);
 
 defineActions([
     {

--- a/addons/web/static/tests/webclient/actions/push_state.test.js
+++ b/addons/web/static/tests/webclient/actions/push_state.test.js
@@ -145,7 +145,14 @@ class Pony extends models.Model {
     };
 }
 
-defineModels([Partner, Pony]);
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+
+defineModels([Partner, Pony, User]);
 
 class TestClientAction extends Component {
     static template = xml`

--- a/addons/web/static/tests/webclient/actions/server_action.test.js
+++ b/addons/web/static/tests/webclient/actions/server_action.test.js
@@ -41,7 +41,14 @@ class Partner extends models.Model {
     };
 }
 
-defineModels([Partner]);
+class User extends models.Model {
+    _name = "res.users";
+    has_group() {
+        return true;
+    }
+}
+
+defineModels([Partner, User]);
 
 test("can execute server actions from db ID", async () => {
     defineActions([
@@ -57,9 +64,10 @@ test("can execute server actions from db ID", async () => {
             views: [[1, "kanban"]],
         },
     ]);
-    onRpc("/web/action/run", async () => {
-        return 1; // execute action 1
-    });
+    onRpc(
+        "/web/action/run",
+        async () => 1 // execute action 1
+    );
     stepAllNetworkCalls();
 
     await mountWithCleanup(WebClient);
@@ -74,6 +82,7 @@ test("can execute server actions from db ID", async () => {
         "/web/action/load",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
 });
 
@@ -92,9 +101,7 @@ test("handle server actions returning false", async function (assert) {
             views: [[false, "form"]],
         },
     ]);
-    onRpc("/web/action/run", async () => {
-        return false;
-    });
+    onRpc("/web/action/run", async () => false);
     stepAllNetworkCalls();
     await mountWithCleanup(WebClient);
     // execute an action in target="new"
@@ -128,15 +135,13 @@ test("action with html help returned by a server action", async () => {
             type: "ir.actions.server",
         },
     ]);
-    onRpc("/web/action/run", async () => {
-        return {
-            res_model: "partner",
-            type: "ir.actions.act_window",
-            views: [[false, "kanban"]],
-            help: "<p>I am not a helper</p>",
-            domain: [[0, "=", 1]],
-        };
-    });
+    onRpc("/web/action/run", async () => ({
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        views: [[false, "kanban"]],
+        help: "<p>I am not a helper</p>",
+        domain: [[0, "=", 1]],
+    }));
 
     await mountWithCleanup(WebClient);
     await getService("action").doAction(2);

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -220,6 +220,7 @@ test("can execute act_window actions from db ID", async () => {
         "/web/action/load",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
 });
 
@@ -384,6 +385,7 @@ test("switching into a view with mode=edit lands in edit mode", async () => {
         "/web/action/load",
         "get_views",
         "web_read_group",
+        "has_group",
         "web_search_read",
         "web_search_read",
         "onchange",
@@ -1157,6 +1159,7 @@ test("execute smart button and fails on desktop", async () => {
         "/web/action/load",
         "get_views",
         "web_search_read",
+        "has_group",
         "web_read",
     ]);
     expect.verifyErrors(["Oups"]);
@@ -1188,6 +1191,7 @@ test("execute smart button and fails on mobile", async () => {
         "/web/action/load",
         "get_views",
         "web_search_read",
+        "has_group",
         "web_read",
     ]);
     expect.verifyErrors(["Oups"]);
@@ -2526,7 +2530,7 @@ test("action and get_views rpcs are cached", async () => {
 
     await getService("action").doAction(1);
     expect(".o_kanban_view").toHaveCount(1);
-    expect.verifySteps(["/web/action/load", "get_views", "web_search_read"]);
+    expect.verifySteps(["/web/action/load", "get_views", "web_search_read", "has_group"]);
 
     await getService("action").doAction(1);
     expect(".o_kanban_view").toHaveCount(1);
@@ -2559,7 +2563,7 @@ test("get_views rpcs are cached (different context.active_id)", async () => {
         context: { active_id: 33 },
     });
     expect(".o_kanban_view").toHaveCount(1);
-    expect.verifySteps(["get_views", "web_search_read"]);
+    expect.verifySteps(["get_views", "web_search_read", "has_group"]);
 
     await getService("action").doAction({
         name: "Partner",

--- a/addons/web/views/partner_view.xml
+++ b/addons/web/views/partner_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Download (vCard)</field>
         <field name="model_id" ref="model_res_partner"/>
         <field name="binding_model_id" ref="model_res_partner"/>
-        <field name="binding_view_types">form,list</field>
+        <field name="binding_view_types">form,list,kanban</field>
         <field name="state">code</field>
         <field name="code">
             action = {

--- a/addons/website_livechat/views/website_visitor_views.xml
+++ b/addons/website_livechat/views/website_visitor_views.xml
@@ -134,7 +134,7 @@
         <field name="name">Send Chat Requests</field>
         <field name="model_id" ref="model_website_visitor"/>
         <field name="binding_model_id" ref="model_website_visitor"/>
-        <field name="binding_view_types">list</field>
+        <field name="binding_view_types">list,kanban</field>
         <field name="state">code</field>
         <field name="code">
             if records:

--- a/odoo/addons/base/views/ir_ui_view_views.xml
+++ b/odoo/addons/base/views/ir_ui_view_views.xml
@@ -142,7 +142,7 @@
             <field name="view_mode">form</field>
             <field name="target">new</field>
             <field name="binding_model_id" ref="model_ir_ui_view"/>
-            <field name="binding_view_types">form,list</field>
+            <field name="binding_view_types">form,list,kanban</field>
         </record>
 
         <!-- View customizations -->

--- a/odoo/addons/base/wizard/base_partner_merge_views.xml
+++ b/odoo/addons/base/wizard/base_partner_merge_views.xml
@@ -106,6 +106,6 @@
             <field name="view_mode">form</field>
             <field name="target">new</field>
             <field name="binding_model_id" ref="base.model_res_partner"/>
-            <field name="binding_view_types">list</field>
+            <field name="binding_view_types">list,kanban</field>
         </record>
 </odoo>


### PR DESCRIPTION
This commit brings selection feature parity in Kanban compared to the similar List view. It is now possible to select some records, by using the alt+click on a card. Once the selection mode is enabled, it is possible to select more cards by clicking on them directly.
