### PR TITLE
[FIX] html_editor: hide toolbar when selection is in non-contenteditable

### DIFF
--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -307,6 +307,7 @@ export class ToolbarPlugin extends Plugin {
     shouldBeVisible(selectionData) {
         const inEditable =
             selectionData.documentSelectionIsInEditable &&
+            selectionData.documentSelectionIsContenteditable &&
             !selectionData.documentSelectionIsProtected &&
             !selectionData.documentSelectionIsProtecting;
         if (!inEditable) {

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -1127,6 +1127,118 @@ describe("toolbar open and close on user interaction", () => {
             await expectElementCount(".o-we-toolbar", 1);
         });
     });
+
+    describe("contentEditable false", () => {
+        test("toolbar should not open when selection is inside of a contentEditable false elelement", async () => {
+            const { el } = await setupEditor(
+                `<div>t[es]t</div><div contenteditable="false">contenteditable false </div>`
+            );
+            await waitFor(".o-we-toolbar");
+            expect(".o-we-toolbar").toHaveCount(1);
+
+            setContent(
+                el,
+                `<div>test</div><div contenteditable="false">conte[ntedita]ble false </div>`
+            );
+            await tick(); // selectionChange
+
+            await animationFrame();
+            expect(".o-we-toolbar").toHaveCount(0);
+        });
+        test("toolbar should not open when selection only includes contentEditable false elelement", async () => {
+            const { el } = await setupEditor(
+                `<div>t[es]t</div><div contenteditable="false">contenteditable </div><div contenteditable="false">false </div>`
+            );
+            await waitFor(".o-we-toolbar");
+            expect(".o-we-toolbar").toHaveCount(1);
+
+            setContent(
+                el,
+                `<div>test</div>[<div contenteditable="false">contenteditable </div><div contenteditable="false">false </div>]`
+            );
+            await tick(); // selectionChange
+
+            await animationFrame();
+            expect(".o-we-toolbar").toHaveCount(0);
+        });
+        test("toolbar should not open when selection only includes contentEditable false elelement (2)", async () => {
+            const { el } = await setupEditor(
+                `<div>t[es]t</div>
+                <div>
+                    <t contenteditable="false">
+                        <div>
+                            <strong>Address block</strong>
+                            <div>Usually contains the address of the document's recipient.</div>
+                        </div>
+                    </t>
+                </div>`
+            );
+            await waitFor(".o-we-toolbar");
+            expect(".o-we-toolbar").toHaveCount(1);
+
+            setContent(
+                el,
+                `<div>test</div>
+                <div>
+                    [<t contenteditable="false">
+                        <div>
+                            <strong>Address block</strong>
+                            <div>Usually contains the address of the document's recipient.</div>
+                        </div>
+                    </t>]
+                </div>`
+            );
+            await tick(); // selectionChange
+
+            await animationFrame();
+            expect(".o-we-toolbar").toHaveCount(0);
+        });
+        test("toolbar should open when selection's anchor and focus nodes are content editable, even a contenteditable false element in the middle", async () => {
+            const { el } = await setupEditor(
+                `<p>t[]est<span contenteditable="false">contenteditable false </span>test</p>`
+            );
+            expect(".o-we-toolbar").toHaveCount(0);
+
+            setContent(
+                el,
+                `<p>t[est<span contenteditable="false">contenteditable false </span>te]st</p>`
+            );
+            await tick(); // selectionChange
+
+            await animationFrame();
+            expect(".o-we-toolbar").toHaveCount(1);
+        });
+        test("toolbar should open when anchor node is content editable, focus node is contenteditable false (not possible in practice)", async () => {
+            const { el } = await setupEditor(
+                `<p>t[]est<span contenteditable="false">contenteditable false </span>test</p>`
+            );
+            expect(".o-we-toolbar").toHaveCount(0);
+
+            setContent(
+                el,
+                `<p>t[est<span contenteditable="false">contente]ditable false </span>test</p>`
+            );
+            await tick(); // selectionChange
+
+            await animationFrame();
+            expect(".o-we-toolbar").toHaveCount(1);
+        });
+        test("toolbar should open when focus node is content editable, anchor node is contenteditable false (not possible in practice)", async () => {
+            const { el } = await setupEditor(
+                `<p>t[]est<span contenteditable="false">contenteditable false </span>test</p>`
+            );
+            expect(".o-we-toolbar").toHaveCount(0);
+
+            setContent(
+                el,
+                `<p>test<span contenteditable="false">contente[ditable false </span>te]st</p>`
+            );
+            await tick(); // selectionChange
+
+            await animationFrame();
+            expect(".o-we-toolbar").toHaveCount(1);
+        });
+    });
 });
 
 test.tags("desktop");


### PR DESCRIPTION
Before this commit:
The toolbar appeared even when selecting a contenteditable false element within the editable area. For instance, while editing a report, clicking on a non-editable element like a delivery slip would still show the toolbar.

After this commit:
The toolbar is hidden when the selection is within contenteditable false elements or consists only such elements. Exception: The toolbar remains visible for icons, as they are editable by the toolbar. Tests are added.

task-4309925




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
