### PR TITLE
[FIX] mail: no flicker on call video stream inset

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -9,6 +9,7 @@ import {
     onMounted,
     onPatched,
     onWillUnmount,
+    toRaw,
     useExternalListener,
     useRef,
     useState,
@@ -141,13 +142,15 @@ export class Call extends Component {
     /** @returns {CardData[]} */
     get visibleMainCards() {
         const activeSession = this.props.thread.activeRtcSession;
-        this.state.insetCard = undefined;
         if (!activeSession) {
+            this.state.insetCard = undefined;
             return this.visibleCards;
         }
         const type = activeSession.mainVideoStreamType;
         if (type === "screen" || activeSession.isScreenSharingOn) {
             this.setInset(activeSession, type === "camera" ? "screen" : "camera");
+        } else {
+            this.state.insetCard = undefined;
         }
         return [
             {
@@ -164,12 +167,18 @@ export class Call extends Component {
      * @param {String} [videoType]
      */
     setInset(session, videoType) {
-        this.state.insetCard = {
-            key: "session_" + session.id,
-            session,
-            type: videoType,
-            videoStream: session.getStream(videoType),
-        };
+        const key = "session_" + session.id;
+        if (toRaw(this.state).insetCard?.key === key) {
+            this.state.insetCard.type = videoType;
+            this.state.insetCard.videoStream = session.getStream(videoType);
+        } else {
+            this.state.insetCard = {
+                key,
+                session,
+                type: videoType,
+                videoStream: session.getStream(videoType),
+            };
+        }
     }
 
     get hasCallNotifications() {


### PR DESCRIPTION
Before this commit, during a discuss call while sharing screen and enabling camera, the inset card (= small video stream preview in bottom right of call view of the participant, either camera or screen-sharing depending on other stream being main active) was flickering.

This happens because each rendering of the call view re-renders the inset, which leads to the perceived flickers from stream being re-rendered.

The main cause of re-render comes from `setInset()` that is invoked whenever the `visibleMainCards` getter is called with inset, which is triggered on renderings like mouse-hovering on call view to display the call actions. Even when the inset card is unchanged, `setInset()` produces another object, which forces OWL to re-render the inset component.

This commit fixes the issue by having `setInset` reusing the inset data object if the inset to render refers to the same inset session.

Task-4484908