### PR TITLE
[IMP] website: hide address bar on iOS small screens

### DIFF
--- a/addons/website/static/src/js/content/website_root.js
+++ b/addons/website/static/src/js/content/website_root.js
@@ -5,6 +5,7 @@ import { rpc } from "@web/core/network/rpc";
 import publicRootData from '@web/legacy/js/public/public_root';
 import "@website/libs/zoomodoo/zoomodoo";
 import { pick } from "@web/core/utils/objects";
+import { isIOS } from "@web/core/browser/feature_detection";
 
 import { markup } from "@odoo/owl";
 
@@ -37,7 +38,10 @@ export const WebsiteRoot = publicRootData.PublicRoot.extend({
     start: function () {
         // Enable magnify on zommable img
         this.$('.zoomable img[data-zoom]').zoomOdoo();
-
+        // On iOS devices with small screens, this hides the address bar by scrolling the window slightly.
+        if (this.env.isSmall && isIOS()) {
+            window.scrollTo(0, 1);
+        }
         return this._super.apply(this, arguments);
     },
 


### PR DESCRIPTION
Purpose:
On iOS, the address bar doesn't minimize when scrolling, which can be distracting and reduce the available screen space for content. This commit addresses this issue to enhance the user experience.

Spec:
When the user begins to scroll, the address bar should minimize to provide more screen real estate for the content and reduce distractions.

On iOS devices, particularly on small screens, the address bar (or URL bar) does not automatically minimize when the user starts scrolling. This can reduce the available screen space for displaying content and can be distracting.

By using `window.scrollTo(0, 1)`, the browser is forced to scroll down by 1 pixel, which can trigger the address bar to minimize, thereby providing more screen real estate for the web content. This is a common workaround to enhance the user experience on iOS devices by ensuring that the address bar does not take up unnecessary space.

task-4177998