### PR TITLE
[FIX] web: typo in mobile form view test

### DIFF
--- a/addons/web/static/tests/mobile/views/form_view_tests.js
+++ b/addons/web/static/tests/mobile/views/form_view_tests.js
@@ -410,7 +410,7 @@ QUnit.module("Mobile Views", ({ beforeEach }) => {
 
             window.scrollTo({ top: 265, left: 0 });
             assert.strictEqual(window.scrollY, 265, "Should have scrolled 265 px vertically");
-            assert.strictEqual(window.screenLeft, 0, "Should be 0 px from left as it is");
+            assert.strictEqual(window.scrollX, 0, "Should be 0 px from left as it is");
 
             // click on m2o field
             await click(fixture, ".o_field_many2one input");
@@ -428,7 +428,7 @@ QUnit.module("Mobile Views", ({ beforeEach }) => {
                 265,
                 "Should have scrolled back to 265 px vertically"
             );
-            assert.strictEqual(window.screenLeft, 0, "Should be 0 px from left as it is");
+            assert.strictEqual(window.scrollX, 0, "Should be 0 px from left as it is");
         }
     );
 


### PR DESCRIPTION
This commit fixes a typo in two mobile form view's tests where "screenLeft" was used instead of "scrollX".

Note: this was detected while testing for the new Chrome's headless mode set by default on Chrome 128+.
