### PR TITLE
[FIX] l10n_br_website_sale: b2b fields error

### DIFF
--- a/addons/l10n_br_website_sale/controllers/main.py
+++ b/addons/l10n_br_website_sale/controllers/main.py
@@ -10,7 +10,7 @@ class WebsiteSaleBr(WebsiteSale):
 
         if request.params.get('country_id'):
             country = request.env['res.country'].browse(int(request.params['country_id']))
-            if request.website.sudo().company_id.country_id.code == "BR" and country.code == "BR" and "vat" not in mandatory_fields:
+            if request.website.sudo().company_id.country_id.code == "BR" and country.code == "BR" and "vat" not in mandatory_fields and request.website._display_partner_b2b_fields():
                 mandatory_fields += ['vat']
             # Needed because the user could put brazil and then change to another country, we don't want the field to stay mandatory
             elif 'vat' in mandatory_fields and country.code != 'BR':


### PR DESCRIPTION
The b2b fields are still required in the portal form
even if the "Show b2b fields" is deactivated

Steps:

- From the website editor, on the checkout form,
  unselect the "Show b2b fields" setting
- Log out and go to ecommerce
- Add a product to card and checkout
- Fill the address form with a Brazilian address
-> Error: "Some required fields are empty."

With this commit, we add the field `vat` to the mandatory fields only if
the option "Show b2b" fields is activated.

opw-4403161
