### PR TITLE
[FIX] pos_mercado_pago: undefined payment_method on MP callback

### DIFF
--- a/addons/pos_mercado_pago/static/src/app/payment_mercado_pago.js
+++ b/addons/pos_mercado_pago/static/src/app/payment_mercado_pago.js
@@ -44,12 +44,12 @@ export class PaymentMercadoPago extends PaymentInterface {
     }
 
     async get_payment(payment_id) {
-        const line = this.pos.get_order().selected_paymentline;
+        const line = this.pos.get_order().get_selected_paymentline();
         // mp_get_payment_status will call the Mercado Pago api
         return await this.env.services.orm.silent.call(
             "pos.payment.method",
             "mp_get_payment_status",
-            [[line.payment_method.id], payment_id]
+            [[line.payment_method_id.id], payment_id]
         );
     }
 


### PR DESCRIPTION
Before this commit:
Once receveiving Mercado Pago callback, a JS traceback would occur:
```js
TypeError: Cannot read properties of undefined (reading 'payment_method')
at Proxy.get_payment
```

opw-4349957