### PR TITLE
[FIX] base: prevent error on duplicating multiple records

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -1079,9 +1079,11 @@ class IrActionsServer(models.Model):
 
     def copy_data(self, default=None):
         default = default or {}
+        vals_list = super().copy_data(default=default)
         if not default.get('name'):
-            default['name'] = _('%s (copy)', self.name)
-        return super().copy_data(default=default)
+            for vals in vals_list:
+                vals['name'] = _('%s (copy)', vals.get('name', ''))
+        return vals_list
 
 class IrActionsTodo(models.Model):
     """


### PR DESCRIPTION
This error occurs when attempting to duplicate two actions in ``Server Actions``.

Steps to reproduce:
---
- Search ``Server Actions``
- Select any two Actions and ``Duplicate``

Traceback:
---
``ValueError: Expected singleton: ir.actions.server(606, 701)``

After this commit:
---
We are now able to duplicate multiple records.

sentry-6218495006

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
