### PR TITLE
[FIX] web: form compiler: correctly detect anchors to same form

### DIFF
--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -522,9 +522,7 @@ export class FormCompiler extends ViewCompiler {
     compileNotebook(el, params) {
         const noteBookId = this.noteBookId++;
         const noteBook = createElement("Notebook");
-        const pageAnchors = [...document.querySelectorAll("[href^=\\#]")]
-            .map((a) => CSS.escape(a.getAttribute("href").substring(1)))
-            .filter((a) => a.length);
+        const pageAnchors = [];
         const noteBookAnchors = {};
 
         if (el.hasAttribute("class")) {

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -1626,6 +1626,33 @@ test(`notebook page is changing when an anchor is clicked from another page`, as
     expect(`#anchor2`).toBeVisible();
 });
 
+test(`have a link to an id in the DOM, and open a form view with a node with that id`, async () => {
+    await mountWithCleanup(`
+        <div>
+            <a class="my_link" href="#my_special_id">My link</a>
+        </div>
+    `);
+    expect(".my_link").toHaveAttribute("href", "#my_special_id");
+
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `
+            <form>
+                <notebook>
+                    <page string="A page">
+                        <div id="my_special_id">Something</div>
+                    </page>
+                </notebook>
+            </form>
+        `,
+        resId: 1,
+    });
+
+    expect(".o_form_view").toHaveCount(1);
+    expect("#my_special_id").toHaveCount(1);
+});
+
 test(`invisible attrs on group are re-evaluated on field change`, async () => {
     await mountView({
         resModel: "partner",


### PR DESCRIPTION
Before this commit, the form compiler did a search in the whole DOM, when compiling a form, to find anchors, for which the target node would be in the form being compiled. The point of this was to automatically open the notebook tab when an anchor is click for an element that is hidden in a non active tab.

However, looking in the DOM makes no sense. It's very likely that the found element won't be there anymore when the view we compile will be put in the DOM, and moreover the compilation is done only once, so if we come back later on on the same form, we'll still use the information of the anchor we found the first time, which is ever less likely to be again in the DOM.

This was actually a code mistake, as what we aimed to do was to find anchors **in the form**, pointing to elements hidden in the notebook, but definitely not **in the dom**.

This mistake produces a crash: go to "Timesheet / Configuration / Settings" and try to open the "Internal" project in the time off section => traceback.

This commit removes the look up in the document. The feature of automatically opening the tab already partially works, but we won't fix it, and we'll even drop it in master.

opw~4457605

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
