### PR TITLE
[FIX] mail: no autofocus on composer on mobile

### DIFF
--- a/addons/mail/static/src/core/web/thread_service_patch.js
+++ b/addons/mail/static/src/core/web/thread_service_patch.js
@@ -7,6 +7,7 @@ import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 import { Record } from "@mail/core/common/record";
 import { assignDefined, compareDatetime } from "@mail/utils/common/misc";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 let nextId = 1;
 
@@ -249,7 +250,7 @@ patch(ThreadService.prototype, {
                 }
             )
         );
-        if (autofocus) {
+        if (autofocus && !isMobileOS()) {
             chatWindow.autofocus++;
         }
         if (thread) {


### PR DESCRIPTION
Before this commit, when opening a channel on mobile the composer gets automatically focused.
This is not a problem on desktop, but when on mobile it triggers the opening of the system keyboard, occupying half the screen and requiring a "back" command to close it.

This happens because the function that opens the chat window will put focus on the composer.
This commit fixes the issue by only focusing the composer when not on mobile.

task-4115728