### PR TITLE
[FIX] l10n_es_edi_tbai_multi_refund: allow selecting customer refunds

### DIFF
--- a/addons/l10n_es_edi_tbai_multi_refund/i18n/l10n_es_edi_tbai_multi_refund.pot
+++ b/addons/l10n_es_edi_tbai_multi_refund/i18n/l10n_es_edi_tbai_multi_refund.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-02 09:47+0000\n"
-"PO-Revision-Date: 2025-01-02 09:47+0000\n"
+"POT-Creation-Date: 2025-01-17 12:42+0000\n"
+"PO-Revision-Date: 2025-01-17 12:42+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -32,6 +32,11 @@ msgstr ""
 #. module: l10n_es_edi_tbai_multi_refund
 #: model:ir.model,name:l10n_es_edi_tbai_multi_refund.model_account_move
 msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_es_edi_tbai_multi_refund
+#: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai_multi_refund.view_move_form
+msgid "Refunded Invoices"
 msgstr ""
 
 #. module: l10n_es_edi_tbai_multi_refund

--- a/addons/l10n_es_edi_tbai_multi_refund/views/account_move_view.xml
+++ b/addons/l10n_es_edi_tbai_multi_refund/views/account_move_view.xml
@@ -6,7 +6,8 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <field name="l10n_es_tbai_refund_reason" position='after'>
-                <field name="l10n_es_tbai_reversed_ids" attrs="{'invisible': [('move_type', 'not in', ('in_refund', 'out_refund'))]}" widget="many2many_tags"/>
+                <field name="l10n_es_tbai_reversed_ids" attrs="{'invisible': [('move_type', '!=', 'in_refund')]}" widget="many2many_tags"/>
+                <field name="l10n_es_tbai_reversed_ids" attrs="{'invisible': [('move_type', '!=', 'out_refund')]}" widget="many2many_tags" string="Refunded Invoices" domain="[('move_type', '=', 'out_invoice'), ('commercial_partner_id', '=', commercial_partner_id)]" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
In https://github.com/odoo/odoo/pull/193392 the reversed invoices field was exposed when reversing customer invoices.

However, the field domain forbids selection of customer invoices. Also, the field name was misleading.

![image](https://github.com/user-attachments/assets/520d0b47-a776-4354-a7d2-feaf986ad7d8)


This hotfix should make it possible to actually refund outgoing invoices.

@moduon MT-4966



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
