### PR TITLE
[IMP] base: remove default '--' sign

### DIFF
--- a/addons/account/data/mail_template_data.xml
+++ b/addons/account/data/mail_template_data.xml
@@ -58,7 +58,7 @@
         Do not hesitate to contact us if you have any questions.
         <t t-if="not is_html_empty(object.invoice_user_id.signature)">
             <br /><br />
-            <t t-out="object.invoice_user_id.signature or ''">--<br/>Mitchell Admin</t>
+            <div>--<br/><t t-out="object.invoice_user_id.signature or ''">Mitchell Admin</t></div>
         </t>
     </p>
 </div>
@@ -88,7 +88,7 @@
         Best regards,
         <t t-if="not is_html_empty(user.signature)">
             <br/><br/>
-            <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+            <div>--<br/><t t-out="user.signature or ''">Mitchell Admin</t></div>
         </t>
     </p>
 </div>
@@ -133,7 +133,7 @@
         Do not hesitate to contact us if you have any questions.
         <t t-if="not is_html_empty(object.invoice_user_id.signature)">
             <br /><br />
-            <t t-out="object.invoice_user_id.signature or ''">--<br/>Mitchell Admin</t>
+            <div>--<br/><t t-out="object.invoice_user_id.signature or ''">Mitchell Admin</t></div>
         </t>
     </p>
 </div>

--- a/addons/auth_signup/data/mail_template_data.xml
+++ b/addons/auth_signup/data/mail_template_data.xml
@@ -202,7 +202,7 @@
                         Thanks,<br/>
                         <t t-if="user.signature">
                             <br/>
-                            <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+                            <div>--<br/><t t-out="user.signature or ''">Mitchell Admin</t></div>
                         </t>
                     </div>
                 </td></tr>

--- a/addons/base_install_request/data/mail_template_data.xml
+++ b/addons/base_install_request/data/mail_template_data.xml
@@ -25,7 +25,7 @@
         Thanks,
         <t t-if="not is_html_empty(object.user_id.signature)">
             <br/><br/>
-            <t t-out="object.user_id.signature or ''">--<br/>Mitchell Admin</t>
+            <div>--<br/><t t-out="object.user_id.signature or ''">Mitchell Admin</t></div>
         </t>
         <br/><br/>
     </p>

--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -116,7 +116,7 @@
     Thank you,
     <t t-if="object.event_id.user_id.signature">
         <br />
-        <t t-out="object.event_id.user_id.signature or ''">--<br/>Mitchell Admin</t>
+        <div>--<br/><t t-out="object.event_id.user_id.signature or ''">Mitchell Admin</t></div>
     </t>
 </div>
             </field>
@@ -248,7 +248,7 @@
     Thank you,
     <t t-if="object.event_id.user_id.signature">
         <br />
-        <t t-out="object.event_id.user_id.signature or ''">--<br/>Mitchell Admin</t>
+        <div>--<br/><t t-out="object.event_id.user_id.signature or ''">Mitchell Admin</t></div>
     </t>
 </div>
             </field>
@@ -356,7 +356,7 @@
     Thank you,
     <t t-if="object.event_id.user_id.signature">
         <br />
-        <t t-out="object.event_id.user_id.signature or ''">--<br/>Mitchell Admin</t>
+        <div>--<br/><t t-out="object.event_id.user_id.signature or ''">Mitchell Admin</t></div>
     </t>
 </div>
             </field>
@@ -452,7 +452,7 @@
     </div>
     <t t-if="object.user_id.signature">
         <br />
-        <t t-out="object.user_id.signature or ''">--<br/>Mitchell Admin</t>
+        <div>--<br/><t t-out="object.user_id.signature or ''">Mitchell Admin</t></div>
     </t>
 </div>
             </field>

--- a/addons/gamification/data/mail_template_data.xml
+++ b/addons/gamification/data/mail_template_data.xml
@@ -363,7 +363,7 @@
         </tr>
         <tr>
             <td t-if="not user.share and user.active" style="padding:15px 20px 10px 20px;">
-                <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+                <div>--<br/><t t-out="user.signature or ''">Mitchell Admin</t></div>
             </td>
             <td t-else="" style="padding:15px 20px 10px 20px;">
                 <t t-out="user.company_id.name or ''"/>

--- a/addons/loyalty/data/mail_template_data.xml
+++ b/addons/loyalty/data/mail_template_data.xml
@@ -92,7 +92,7 @@
         Thank you,
         <t t-if="object._get_signature()">
             <br />
-            <t t-out="object._get_signature() or ''">--<br/>Mitchell Admin</t>
+            <div>--<br/><t t-out="object._get_signature() or ''">Mitchell Admin</t></div>
         </t>
     </td>
 </tr>

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3699,7 +3699,7 @@ class MailThread(models.AbstractModel):
         if author_user:
             email_add_signature = msg_vals.get('email_add_signature', message.email_add_signature)
             if email_add_signature:
-                signature = author_user.signature
+                signature = Markup('<div>-- <br/>%s</div>') % author_user.signature
 
         if force_email_company:
             company = force_email_company

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -539,9 +539,20 @@ export class Composer extends Component {
             // Reset signature when recovering an empty body.
             composer.emailAddSignature = true;
         }
+        let signature = this.store.self.signature;
+        if (signature) {
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(signature, 'text/html');
+            const divElement = document.createElement('div');
+            divElement.setAttribute('data-o-mail-quote', '1');
+            const br = document.createElement("br");
+            const textNode = document.createTextNode("-- ");
+            divElement.append(textNode, br, ...doc.body.childNodes);
+            signature = divElement.outerHTML;
+        }
         default_body = this.formatDefaultBodyForFullComposer(
             default_body,
-            this.props.composer.emailAddSignature ? markup(this.store.self.signature) : ""
+            this.props.composer.emailAddSignature ? markup(signature) : ""
         );
         const context = {
             default_attachment_ids: attachmentIds,

--- a/addons/project/data/mail_template_data.xml
+++ b/addons/project/data/mail_template_data.xml
@@ -18,7 +18,7 @@
     Best regards,
     <t t-if="user.signature">
         <br />
-        <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+        <div>--<br/><t t-out="user.signature or ''">Mitchell Admin</t></div>
     </t>
 </div>
         </field>

--- a/addons/project/data/mail_template_demo.xml
+++ b/addons/project/data/mail_template_demo.xml
@@ -14,7 +14,7 @@
     It is my pleasure to let you know that we have successfully completed the project "<strong t-out="object.name or ''">Renovations</strong>".
     <t t-if="user.signature">
         <br />
-        <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+        <div>--<br/><t t-out="user.signature or ''">Mitchell Admin</t></div>
     </t>
 </div>
 <br/><span style="margin: 0px 0px 0px 0px; font-size: 12px; opacity: 0.5; color: #454748;" groups="project.group_project_stages">You are receiving this email because your project has been moved to the stage <b t-out="object.stage_id.name or ''">Done</b></span>

--- a/addons/purchase/data/mail_template_data.xml
+++ b/addons/purchase/data/mail_template_data.xml
@@ -37,7 +37,7 @@
         Best regards,
         <t t-if="not is_html_empty(object.user_id.signature)">
             <br/><br/>
-            <t t-out="object.user_id.signature or ''">--<br/>Mitchell Admin</t>
+            <div>--<br/><t t-out="object.user_id.signature or ''">Mitchell Admin</t></div>
         </t>
     </p>
 </div></field>
@@ -75,7 +75,7 @@
         </t>
         <t t-if="not is_html_empty(object.user_id.signature)">
             <br/><br/>
-            <t t-out="object.user_id.signature or ''">--<br/>Mitchell Admin</t>
+            <div>--<br/><t t-out="object.user_id.signature or ''">Mitchell Admin</t></div>
         </t>
         <br/><br/>
     </p>
@@ -115,7 +115,7 @@
         Could you please confirm it will be delivered on time?
         <t t-if="not is_html_empty(object.user_id.signature)">
             <br/><br/>
-            <t t-out="object.user_id.signature or ''">--<br/>Mitchell Admin</t>
+            <div>--<br/><t t-out="object.user_id.signature or ''">Mitchell Admin</t></div>
         </t>
         <br/><br/>
     </p>

--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -44,7 +44,7 @@
         Do not hesitate to contact us if you have any questions.
         <t t-if="not is_html_empty(object.user_id.signature)">
             <br/><br/>
-            <t t-out="object.user_id.signature or ''">--<br/>Mitchell Admin</t>
+            <div>--<br/><t t-out="object.user_id.signature or ''">Mitchell Admin</t></div>
         </t>
         <br/><br/>
     </p>
@@ -78,7 +78,7 @@
         Do not hesitate to contact us if you have any questions.
         <t t-if="not is_html_empty(object.user_id.signature)">
             <br/><br/>
-            <t t-out="object.user_id.signature or ''">--<br/>Mitchell Admin</t>
+            <div>--<br/><t t-out="object.user_id.signature or ''">Mitchell Admin</t></div>
         </t>
         <br/><br/>
     </p>
@@ -138,7 +138,7 @@
         Do not hesitate to contact us if you have any questions.
         <t t-if="not is_html_empty(object.user_id.signature)">
             <br/><br/>
-            <t t-out="object.user_id.signature or ''">--<br/>Mitchell Admin</t>
+            <div>--<br/><t t-out="object.user_id.signature or ''">Mitchell Admin</t></div>
         </t>
         <br/><br/>
     </p>
@@ -392,7 +392,7 @@
         Do not hesitate to contact us if you have any questions.
         <t t-if="not is_html_empty(object.user_id.signature)">
             <br/><br/>
-            <t t-out="object.user_id.signature or ''">--<br/>Mitchell Admin</t>
+            <div>--<br/><t t-out="object.user_id.signature or ''">Mitchell Admin</t></div>
         </t>
         <br/><br/>
     </p>

--- a/addons/sale_gelato/data/mail_template_data.xml
+++ b/addons/sale_gelato/data/mail_template_data.xml
@@ -36,7 +36,7 @@
                     Thank you,
                     <t t-if="object.user_id.name">
                         <br />
-                        <t t-out="object.user_id.name or ''">--<br/>Mitchell Admin</t>
+                        <div>--<br/><t t-out="object.user_id.name or ''">Mitchell Admin</t></div>
                     </t>
                 </p>
             </div>

--- a/addons/stock/data/mail_template_data.xml
+++ b/addons/stock/data/mail_template_data.xml
@@ -36,7 +36,7 @@
         Thank you,
         <t t-if="user.signature">
             <br />
-            <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+            <div>--<br/><t t-out="user.signature or ''">Mitchell Admin</t></div>
         </t>
     </p>
 </div>

--- a/addons/website_event_track/data/mail_template_data.xml
+++ b/addons/website_event_track/data/mail_template_data.xml
@@ -23,7 +23,7 @@
     Thank you,
     <t t-if="user.signature">
         <br />
-        <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+        <div>--<br/><t t-out="user.signature or ''">Mitchell Admin</t></div>
     </t>
 </div></field>
         <field name="lang">{{ object.partner_id.lang }}</field>

--- a/addons/website_slides/data/mail_template_data.xml
+++ b/addons/website_slides/data/mail_template_data.xml
@@ -27,7 +27,7 @@
                         Enjoy this exclusive content!
                         <t t-if="user.signature">
                             <br />
-                            <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+                            <div>--<br/><t t-out="user.signature or ''">Mitchell Admin</t></div>
                         </t>
                     </p>
                 </div>
@@ -59,7 +59,7 @@
                         </div>
                         <t t-if="user.signature">
                             <br />
-                            <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+                            <div>--<br/><t t-out="user.signature or ''">Mitchell Admin</t></div>
                         </t>
                     </p>
                 </div>
@@ -92,7 +92,7 @@
                         Enjoy this exclusive content!
                         <t t-if="object.channel_id.user_id.signature">
                             <br />
-                            <t t-out="object.channel_id.user_id.signature or ''">--<br/>Mitchell Admin</t>
+                            <div>--<br/><t t-out="object.channel_id.user_id.signature or ''">Mitchell Admin</t></div>
                         </t>
                     </div>
                 </div>
@@ -127,7 +127,7 @@
                         </div>
                         <t t-if="user.signature">
                             <br />
-                            <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+                            <div>--<br/><t t-out="user.signature or ''">Mitchell Admin</t></div>
                         </t>
                     </p>
                 </div>

--- a/odoo/addons/base/data/res_users_data.xml
+++ b/odoo/addons/base/data/res_users_data.xml
@@ -7,8 +7,7 @@
             <field name="company_id" ref="main_company"/>
             <field name="company_ids" eval="[Command.link(ref('main_company'))]"/>
             <field name="email">odoobot@example.com</field>
-            <field name="signature"><![CDATA[<span>-- <br/>
-System</span>]]></field>
+            <field name="signature">System</field>
         </record>
 
         <!-- user 2 is the human admin user -->
@@ -19,8 +18,7 @@ System</span>]]></field>
             <field name="company_id" ref="main_company"/>
             <field name="company_ids" eval="[Command.link(ref('main_company'))]"/>
             <field name="groups_id" eval="[Command.set([])]"/>
-            <field name="signature"><![CDATA[<span>-- <br/>
-Administrator</span>]]></field>
+            <field name="signature">Administrator</field>
         </record>
 
         <record id="user_admin_settings" model="res.users.settings" forcecreate="0">

--- a/odoo/addons/base/data/res_users_demo.xml
+++ b/odoo/addons/base/data/res_users_demo.xml
@@ -36,7 +36,7 @@
             <field name="partner_id" ref="base.partner_demo"/>
             <field name="login">demo</field>
             <field name="password">demo</field>
-            <field name="signature" type="html"><span>-- <br/>+Mr Demo</span></field>
+            <field name="signature">Mr Demo</field>
             <field name="company_id" ref="main_company"/>
             <field name="groups_id" eval="[Command.set([ref('base.group_user'), ref('base.group_partner_manager'), ref('base.group_allow_export')])]"/>
             <field name="image_1920" type="base64" file="base/static/img/user_demo-image.png"/>
@@ -66,7 +66,7 @@
         </record>
 
         <record id="base.user_admin" model="res.users">
-            <field name="signature" type="html"><span>-- <br/>Mitchell Admin</span></field>
+            <field name="signature">Mitchell Admin</field>
         </record>
 
         <!-- Portal : partner and user -->
@@ -86,7 +86,7 @@
             <field name="partner_id" ref="partner_demo_portal"/>
             <field name="login">portal</field>
             <field name="password">portal</field>
-            <field name="signature"><![CDATA[<span>-- <br/>Mr Demo Portal</span>]]></field>
+            <field name="signature">Mr Demo Portal</field>
             <field name="groups_id" eval="[Command.clear()]"/><!-- Avoid auto-including this user in any default group -->
         </record>
 

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -557,7 +557,7 @@ class ResUsers(models.Model):
     @api.depends('name')
     def _compute_signature(self):
         for user in self.filtered(lambda user: user.name and is_html_empty(user.signature)):
-            user.signature = Markup('<p>--<br />%s</p>') % user['name']
+            user.signature = Markup('<p>%s</p>') % user['name']
 
     @api.depends('groups_id')
     def _compute_share(self):

--- a/odoo/cli/templates/l10n_payroll/data/l10n_{{code}}_hr_payroll_demo.xml.template
+++ b/odoo/cli/templates/l10n_payroll/data/l10n_{{code}}_hr_payroll_demo.xml.template
@@ -53,7 +53,7 @@
         <field name="partner_id" ref="l10n_{{code}}_hr_payroll.res_partner_antonina"/>
         <field name="login">antoninakaczmarczyk@example.com</field>
         <field name="password">antoninakaczmarczyk</field>
-        <field name="signature" type="html"><span>--<br/>+A. Kaczmarczyk</span></field>
+        <field name="signature">A. Kaczmarczyk</field>
         <field name="company_ids" eval="[(4, ref('l10n_{{code}}_hr_payroll.res_company_{{code}}'))]"/>
         <field name="company_id" ref="l10n_{{code}}_hr_payroll.res_company_{{code}}"/>
         <field name="groups_id" eval="[(6,0,[ref('base.group_user')])]"/>


### PR DESCRIPTION
1) Hide the '--' separator added before user signatures, similar to Gmail, to prevent accidental edits or formatting issues, except for 'Send Message' and 'Composer' actions.
2) Add '--' before signature while mail is sent.
3) Replace 'read more/less' with 'ellipsis' akin to Gmail in the chatter.
4) Adapt the mail templates for above functionality.

Task-4485719