### PR TITLE
[IMP] odoo: add config for cron connection time

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -462,8 +462,7 @@ class ThreadedServer(CommonServer):
         # same time. This is known as the thundering herd effect.
 
         from odoo.addons.base.models.ir_cron import ir_cron
-        conn = odoo.sql_db.db_connect('postgres')
-        with conn.cursor() as cr:
+        def _run_cron(cr):
             pg_conn = cr._cnx
             # LISTEN / NOTIFY doesn't work in recovery mode
             cr.execute("SELECT pg_is_in_recovery()")
@@ -473,8 +472,8 @@ class ThreadedServer(CommonServer):
             else:
                 _logger.warning("PG cluster in recovery mode, cron trigger not activated")
             cr.commit()
-
-            while True:
+            alive_time = time.monotonic()
+            while config['limit_time_worker_cron'] <= 0 or (time.monotonic() - alive_time) <= config['limit_time_worker_cron']:
                 select.select([pg_conn], [], [], SLEEP_INTERVAL + number)
                 time.sleep(number / 100)
                 pg_conn.poll()
@@ -490,6 +489,11 @@ class ThreadedServer(CommonServer):
                         except Exception:
                             _logger.warning('cron%d encountered an Exception:', number, exc_info=True)
                         thread.start_time = None
+        while True:
+            conn = odoo.sql_db.db_connect('postgres')
+            with conn.cursor() as cr:
+                _run_cron(cr)
+            _logger.info('cron%d max age (%ss) reached, releasing connection.', number, config['limit_time_worker_cron'])
 
     def cron_spawn(self):
         """ Start the above runner function in a daemon thread.
@@ -1173,6 +1177,7 @@ class WorkerCron(Worker):
 
     def __init__(self, multi):
         super(WorkerCron, self).__init__(multi)
+        self.alive_time = time.monotonic()
         # process_work() below process a single database per call.
         # The variable db_index is keeping track of the next database to
         # process.
@@ -1194,6 +1199,13 @@ class WorkerCron(Worker):
             except select.error as e:
                 if e.args[0] != errno.EINTR:
                     raise
+
+    def check_limits(self):
+        super().check_limits()
+
+        if config['limit_time_worker_cron'] > 0 and (time.monotonic() - self.alive_time) > config['limit_time_worker_cron']:
+            _logger.info('WorkerCron (%s) max age (%ss) reached.', self.pid, config['limit_time_worker_cron'])
+            self.alive = False
 
     def _db_list(self):
         if config['db_name']:

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -314,6 +314,10 @@ class configmanager(object):
         group.add_option("--max-cron-threads", dest="max_cron_threads", my_default=2,
                          help="Maximum number of threads processing concurrently cron jobs (default 2).",
                          type="int")
+        group.add_option("--limit-time-worker-cron", dest="limit_time_worker_cron", my_default=0,
+                         help="Maximum time a cron thread/worker stays alive before it is restarted. "
+                              "Set to 0 to disable. (default: 0)",
+                         type="int")
         group.add_option("--unaccent", dest="unaccent", my_default=False, action="store_true",
                          help="Try to enable the unaccent extension when creating new databases.")
         group.add_option("--geoip-db", dest="geoip_database", my_default='/usr/share/GeoIP/GeoLite2-City.mmdb',
@@ -457,7 +461,8 @@ class configmanager(object):
                 'db_maxconn', 'import_partial', 'addons_path', 'upgrade_path',
                 'syslog', 'without_demo', 'screencasts', 'screenshots',
                 'dbfilter', 'log_level', 'log_db',
-                'log_db_level', 'geoip_database', 'dev_mode', 'shell_interface'
+                'log_db_level', 'geoip_database', 'dev_mode', 'shell_interface',
+                'limit_time_worker_cron',
         ]
 
         for arg in keys:


### PR DESCRIPTION
Adds a configuration that can be used to mitigate PostgreSQL
transactional errors with long-living connections and the
`LISTEN/NOTIFY`[^1] functionality by re-establishing the database
connection periodically.

In the case that a connection outlives the transaction wraparound[^2]
mechanism of postgres, the `LISTEN/NOTIFY` internal queue might contain
references to transactions that have already been deleted by the
system's (or a manual) `VACUUM`[^3] as it has its own transaction
validity mechanisms (roughly comparing transaction ids).

This can be reproduced by:
 - Triggering a wraparound _AND_ cleaning of pg_xact between the cron's
   `LISTEN` + `COMMIT` and its recyling.
 - Having done at least one `NOTIFY` during that time period (?).
 - Try to `LISTEN` to the same channel on the same database (transcation
   id must be < than the first connection's transaction id).

The following is an example error message:
```
ERROR database odoo.service.server: Worker (3194772) Exception occurred, exiting...
Traceback (most recent call last):
  File "/home/user/odoo/service/server.py", line 1089, in run
    self.start()
  File "/home/user/odoo/service/server.py", line 1235, in start
    self.dbcursor.commit()
  File "/home/user/odoo/sql_db.py", line 480, in commit
    result = self._cnx.commit()
             ^^^^^^^^^^^^^^^^^^
psycopg2.errors.UndefinedFile: could not access status of transaction 1194816979
DETAIL:  Could not open file "pg_xact/0473": No such file or directory.
```

[LISTEN/NOTIFY code](https://github.com/postgres/postgres/blob/REL_16_STABLE/src/backend/commands/async.c)

[Connection being kept](https://github.com/postgres/postgres/blob/REL_16_STABLE/src/backend/commands/async.c#L2167-L2191)

[See more](https://www.postgresql.org/message-id/flat/VE1PR03MB531295B1BDCFE422441B15FD92499%40VE1PR03MB5312.eurprd03.prod.outlook.com#7e36d1fdca921b5292e92c7017984ffa)

[^1]: https://www.postgresql.org/docs/current/sql-notify.html
[^2]: https://www.postgresql.org/docs/current/routine-vacuuming.html#VACUUM-FOR-WRAPAROUND
[^3]: https://www.postgresql.org/docs/17/sql-vacuum.html