### PR TITLE
[FIX] hw_posbox_homepage: allow windows access to update dialog

### DIFF
--- a/addons/hw_posbox_homepage/static/src/app/Homepage.js
+++ b/addons/hw_posbox_homepage/static/src/app/Homepage.js
@@ -106,7 +106,7 @@ export class Homepage extends Component {
 			</SingleData>
             <SingleData t-if="this.store.advanced" name="'Version'" value="this.data.version" icon="'fa-microchip'">
                 <t t-set-slot="button">
-                    <UpdateDialog t-if="this.store.isLinux" />
+                    <UpdateDialog />
                 </t>
             </SingleData>
             <SingleData t-if="this.store.advanced" name="'IP address'" value="this.data.ip" icon="'fa-globe'" />

--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/UpdateDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/UpdateDialog.js
@@ -27,6 +27,12 @@ export class UpdateDialog extends Component {
     }
 
     async getVersionInfo() {
+        if (!this.store.isLinux) {
+            this.state.odooIsUpToDate = true;
+            this.state.imageIsUpToDate = true;
+            this.state.initialization = false;
+            return
+        }
         try {
             const data = await this.store.rpc({
                 url: "/hw_posbox_homepage/version_info",
@@ -93,7 +99,7 @@ export class UpdateDialog extends Component {
                     <p>Currently fetching update data...</p>
                 </div>
 
-                <div class="mb-3">
+                <div class="mb-3" t-if="this.store.isLinux">
                     <h6>Operating System Update</h6>
                     <div t-if="this.state.imageIsUpToDate" class="text-success px-2 small">
                         Operating system is up to date
@@ -111,7 +117,7 @@ export class UpdateDialog extends Component {
                     </div>
                 </div>
 
-                <div class="mb-3">
+                <div class="mb-3" t-if="this.store.isLinux">
                     <h6>IoT Box Update</h6>
                     <div t-if="this.state.odooIsUpToDate" class="text-success px-2 small">
                         IoT Box is up to date.


### PR DESCRIPTION
Since odoo/odoo#191886, "download handlers" is available through "Update" page. As Windows IoT Boxes have no access to this page, the feature was unreachable. This commit fixes this behaviour by allowing access to Update page and disabling Linux specific tools on it.
