### PR TITLE
[FIX] html_editor: preserve p tag inside li when changing tag

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -22,7 +22,6 @@ import {
 import { closestElement, descendants, firstLeaf, lastLeaf } from "../utils/dom_traversal";
 import { FONT_SIZE_CLASSES, TEXT_STYLE_CLASSES } from "../utils/formatting";
 import { DIRECTIONS, childNodeIndex, nodeSize, rightPos } from "../utils/position";
-import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 import { convertList, getListMode } from "@html_editor/utils/list";
 
 /**
@@ -424,14 +423,8 @@ export class DomPlugin extends Plugin {
                     block.nodeName
                 )
             ) {
-                if (tagName === "P") {
-                    if (block.nodeName === "LI") {
-                        continue;
-                    } else if (block.parentNode.nodeName === "LI") {
-                        cursors.update(callbacksForCursorUpdate.unwrap(block));
-                        unwrapContents(block);
-                        continue;
-                    }
+                if (tagName === "P" && block.nodeName === "LI") {
+                    continue;
                 }
 
                 const newEl = setTagName(block, tagName);

--- a/addons/html_editor/static/src/main/list/list.scss
+++ b/addons/html_editor/static/src/main/list/list.scss
@@ -1,0 +1,3 @@
+li p {
+    margin-bottom: 0px;
+}

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -50,19 +50,27 @@ describe("to paragraph", () => {
         });
     });
 
-    test("should not add paragraph tag when selection is changed to normal in list", async () => {
+    test("should add paragraph tag when selection is changed to normal in list", async () => {
         await testEditor({
             contentBefore: "<ul><li><h1>[abcd]</h1></li></ul>",
             stepFunction: setTag("p"),
-            contentAfter: `<ul><li>[abcd]</li></ul>`,
+            contentAfter: `<ul><li><p>[abcd]</p></li></ul>`,
         });
     });
 
-    test("should not add paragraph tag when selection is changed to normal in list (2)", async () => {
+    test("should add paragraph tag when selection is changed to normal in list (2)", async () => {
         await testEditor({
             contentBefore: "<ul><li><h1>[ab<span>cd]</span></h1></li></ul>",
             stepFunction: setTag("p"),
-            contentAfter: `<ul><li>[ab<span>cd]</span></li></ul>`,
+            contentAfter: `<ul><li><p>[ab<span>cd]</span></p></li></ul>`,
+        });
+    });
+
+    test("should add paragraph tag when selection is changed to normal in list (3)", async () => {
+        await testEditor({
+            contentBefore: "<ul><li><h1>[ab<span>cd]</span></h1><h2>ef</h2></li></ul>",
+            stepFunction: setTag("p"),
+            contentAfter: `<ul><li><p>[ab<span>cd]</span></p><h2>ef</h2></li></ul>`,
         });
     });
 


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

When converting paragraph related elements (other than the `<p>` tag itself) to a `<p>` tag, the tag would be unwrapped.

Desired behavior after PR is merged:

The tag is now converted directly to a `<p>` tag without unwrapping it.

task-4488784

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
