### PR TITLE
[FIX] web: fix duplicate key error in user switch template

### DIFF
--- a/addons/web/static/src/core/user_switch/user_switch.xml
+++ b/addons/web/static/src/core/user_switch/user_switch.xml
@@ -6,7 +6,7 @@
                 <div class="oe_login_form o_user_switch user-select-none my-4" t-ref="root">
                     <p>Choose a user</p>
                     <div class="list-group my-3">
-                        <t t-foreach="state.users" t-as="user" t-key="user">
+                        <t t-foreach="state.users" t-as="user" t-key="user_index">
                             <button type="button" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" t-on-click="() => this.fillForm(user.login)">
                                 <span class="d-flex justify-content-begin align-items-center">
                                     <img class="o_avatar o_user_avatar rounded me-2" t-attf-src="{{getAvatarUrl(user)}}" t-att-alt="user.login"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
The user switch component fails in debug mode with the following error in the console log

> Error message:
> OwlError: Got duplicate key in t-foreach: [object Object]
>     at UserSwitch.template

This error happens because we are using the user object as a key ([object Object]), instead we should use the user_index 

**Current behavior before PR:**
1. Open a runbot
2. Log in and log out with admin account
3. Log in and log out with demo account
4. The user switch component appears on the login page
5. Adding ?debug=1 to the URL causes:
   - User switch component disappears
   - Console shows duplicate key error

**Desired behavior after PR is merged:**
- Having possibility to use switch user component in debug mode

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
