### PR TITLE
[IMP] project: Change domains for using in, not '!='

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -41,7 +41,7 @@ class AccountAnalyticLine(models.Model):
         domain = [('allow_timesheets', '=', True)]
         if not self.user_has_groups('hr_timesheet.group_timesheet_manager'):
             return expression.AND([domain,
-                ['|', ('privacy_visibility', '!=', 'followers'), ('message_partner_ids', 'in', [self.env.user.partner_id.id])]
+                ['|', ('privacy_visibility', 'in', ['employees', 'portal']), ('message_partner_ids', 'in', [self.env.user.partner_id.id])]
             ])
         return domain
 

--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -56,7 +56,7 @@
                 ('user_id', '=', user.id),
                 ('project_id', '!=', False),
                 '|', '|',
-                    ('project_id.privacy_visibility', '!=', 'followers'),
+                    ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
                     ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                     ('task_id.message_partner_ids', 'in', [user.partner_id.id])
             ]</field>
@@ -69,7 +69,7 @@
             <field name="domain_force">[
                 ('project_id', '!=', False),
                 '|',
-                    ('project_id.privacy_visibility', '!=', 'followers'),
+                    ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
                     ('project_id.message_partner_ids', 'in', [user.partner_id.id])
             ]</field>
             <field name="groups" eval="[(4, ref('hr_timesheet.group_hr_timesheet_approver'))]" />
@@ -98,7 +98,7 @@
             <field name="domain_force">[
                 ('user_id', '=', user.id),
                 '|', '|',
-                    ('project_id.privacy_visibility', '!=', 'followers'),
+                    ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
                     ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                     ('task_id.message_partner_ids', 'in', [user.partner_id.id])
             ]</field>
@@ -110,7 +110,7 @@
             <field name="model_id" ref="model_timesheets_analysis_report"/>
             <field name="domain_force">[
                 '|',
-                    ('project_id.privacy_visibility', '!=', 'followers'),
+                    ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
                     ('project_id.message_partner_ids', 'in', [user.partner_id.id])
             ]</field>
             <field name="groups" eval="[(4, ref('group_hr_timesheet_approver'))]"/>

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -72,7 +72,7 @@
         <field name="name">Project: employees: following required for follower-only projects</field>
         <field name="model_id" ref="model_project_project"/>
         <field name="domain_force">['|',
-                                        ('privacy_visibility', '!=', 'followers'),
+                                        ('privacy_visibility', 'in', ['employees', 'portal']),
                                         ('message_partner_ids', 'in', [user.partner_id.id])
                                     ]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
@@ -92,7 +92,7 @@
                 '&amp;',
                     ('project_id', '!=', False),
                     '|',
-                        ('project_id.privacy_visibility', '!=', 'followers'),
+                        ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
                         ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                 '|',
                     ('message_partner_ids', 'in', [user.partner_id.id]),
@@ -152,7 +152,7 @@
         <field name="name">Project: See private tasks</field>
         <field name="model_id" ref="project.model_project_task"/>
         <field name="domain_force">[
-            ('project_id.privacy_visibility', '!=', 'followers'),
+            ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
             '|', '|', ('project_id', '!=', False),
                       ('parent_id', '!=', False),
                  ('user_ids', 'in', user.id),
@@ -229,7 +229,7 @@
         <field name="model_id" ref="model_project_update"/>
         <field name="domain_force">[
         '|',
-            ('project_id.privacy_visibility', '!=', 'followers'),
+            ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
             '|',
                 ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                 '|',
@@ -244,7 +244,7 @@
         <field name="model_id" ref="model_report_project_task_user"/>
         <field name="domain_force">[
         '|',
-            ('project_id.privacy_visibility', '!=', 'followers'),
+            ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
             '|',
                 ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                 '|',
@@ -273,7 +273,7 @@
         <field name="model_id" ref="model_project_task_burndown_chart_report"/>
         <field name="domain_force">[
         '|',
-            ('project_id.privacy_visibility', '!=', 'followers'),
+            ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
             '|',
                 ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                 ('user_ids', 'in', user.id),
@@ -299,7 +299,7 @@
         <field name="model_id" ref="model_project_milestone"/>
         <field name="domain_force">[
         '|',
-            ('project_id.privacy_visibility', '!=', 'followers'),
+            ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
             '|',
                 ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                 ('project_id.user_id', '=', user.id),

--- a/addons/project_todo/security/project_todo_security.xml
+++ b/addons/project_todo/security/project_todo_security.xml
@@ -30,7 +30,7 @@
                 '&amp;',
                     ('project_id', '!=', False),
                     '|',
-                        ('project_id.privacy_visibility', '!=', 'followers'),
+                        ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
                         ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                 '|',
                     ('message_partner_ids', 'in', [user.partner_id.id]),


### PR DESCRIPTION
Description of the issue/feature this PR addresses: we cannot extend privacy_visibility to use other configurations, like checking by group, department or something different.

Current behavior before PR: if we add a new project_visibility option, it works as employees

Desired behavior after PR is merged: We are allowed to add extra visibilities




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
