### PR TITLE
[FIX] base_automation: hide domain for on_change's

### DIFF
--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -38,7 +38,8 @@
 
                     <field name="filter_pre_domain" widget="domain" options="{'model': 'model_name', 'in_dialog': True}"
                            attrs="{'invisible': [('trigger', 'not in', ['on_write', 'on_create_or_write'])]}"/>
-                    <field name="filter_domain" widget="domain" options="{'model': 'model_name', 'in_dialog': True}"/>
+                    <field name="filter_domain" widget="domain" options="{'model': 'model_name', 'in_dialog': True}"
+                           attrs="{'invisible': [('trigger', 'in', ['on_change'])]}"/>
                     <field name="trg_date_id"
                         options="{'no_open': True, 'no_create': True}"
                         attrs="{'invisible': [('trigger', '!=', 'on_time')], 'required': [('trigger', '=', 'on_time')]}"/>


### PR DESCRIPTION
Before this commit, the base.automation form view displays the filter_domain field when on_change trigger type is selected but the code does not take into account the filter_domain value for this type of trigger.

After this commit, this field is simply hidden in that case.

Task: opw-4492554