### PR TITLE
[IMP] web: pass the action context

### DIFF
--- a/addons/web/static/src/model/record.js
+++ b/addons/web/static/src/model/record.js
@@ -34,6 +34,7 @@ class _Record extends Component {
                 activeFields,
                 resId: this.props.info.resId,
                 mode: this.props.info.mode,
+                ...(this.props.info?.context && { context: this.props.info.context }),
             },
             hooks: {
                 onRecordSaved: this.props.info.onRecordSaved || (() => {}),
@@ -165,6 +166,7 @@ export class Record extends Component {
         "onRecordChanged?",
         "onRecordSaved?",
         "onWillSaveRecord?",
+        "context?"
     ];
     setup() {
         const { activeFields, fieldNames, fields, resModel } = this.props;


### PR DESCRIPTION
When the Kanban view is opened from the Gantt popover, the context is not being passed in the record.If the visibility of the field is based on the context, it will not work, as shown in the example below.

For example:
   When a task is opened from a specific project, the project name should not be displayed.
XML:
  `<field invisible="context.get('default_project_id', False)" name="project_id" options="{'no_open': True}"/>`

task-4444660