### PR TITLE
[FIX] bus: samesite and proxy_mode

### DIFF
--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -865,7 +865,11 @@ class WebsocketConnectionHandler:
             return
         headers = request.httprequest.headers
         origin_url = urlparse(headers.get('origin'))
-        if origin_url.netloc != headers.get('host') or origin_url.scheme != request.httprequest.scheme:
+        if odoo.tools.config['proxy_mode']:
+            different_scheme = headers["X-Forwarded-Proto"] != request.httprequest.scheme
+        else:
+            different_scheme = origin_url.scheme != request.httprequest.scheme
+        if origin_url.netloc != headers.get('host') or different_scheme:
             session = root.session_store.new()
             session.update(get_default_session(), db=request.session.db)
             root.session_store.save(session)


### PR DESCRIPTION
When Odoo is behind and inverse proxy an the web client sends a wss request it could be forwarded as https, resulting in the missbehavior of the apps when the bus_service is used: https://github.com/odoo/odoo/blob/16.0/addons/bus/static/src/services/bus_service.js#L95

cc @Tecnativa TT52638 TT54556

fyi @josep-tecnativa @yajo @pedrobaeza 

Description of the issue/feature this PR addresses:

The presence service for the messaging client stops working correctly

Current behavior before PR:

There's no guest/user presence refreshing as those connections get downgraded

Desired behavior after PR is merged:

Everything works again :)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
