### PR TITLE
[FIX] account: avoid searching on account.root

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -6908,6 +6908,12 @@ msgid "Filter Multivat"
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_root.py:0
+msgid "Filter on the Account or its Display Name instead"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_analytic_line__general_account_id
 #: model_terms:ir.ui.view,arch_db:account.view_account_analytic_line_filter_inherit_account
 msgid "Financial Account"

--- a/addons/account/models/account_root.py
+++ b/addons/account/models/account_root.py
@@ -2,6 +2,7 @@
 from itertools import accumulate
 
 from odoo import api, fields, models
+from odoo.exceptions import UserError
 from odoo.tools import Query
 
 
@@ -25,7 +26,7 @@ class AccountRoot(models.Model):
                 return self.browse(sorted(ids))._as_query()
             case [('id', 'parent_of', ids)]:
                 return self.browse(sorted({s for _id in ids for s in accumulate(_id)}))._as_query()
-        raise NotImplementedError
+        raise UserError(self.env._("Filter on the Account or its Display Name instead"))
 
     @api.model
     def _from_account_code(self, code):


### PR DESCRIPTION
account.root is a technical model only meant to be used in the side panel and therefore only has a limited ORM functionality. Trying to search on anything else than the ID is not allowed, and rather useless since a domain on `root_id` and be replaced with a domain on the account (or it's display_name) directly.
Instead of:
* `[('root_id', 'ilike', prefix)]`, use `[('display_name', 'ilike', prefix)]`
* `[('account_id.root_id', 'ilike', prefix)]`, use `[('account_id', 'ilike', prefix)]`

This commit simply redirects the user to the alternate field.
