### PR TITLE
[FIX] stock: make the table take the whole width

### DIFF
--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -222,7 +222,7 @@
                         </group>
                     </group>
                     <group string="Rules" >
-                        <field name="rule_ids" nolabel="1" context="{'default_company_id': company_id, 'form_view_ref':'stock.view_route_rule_form'}">
+                        <field name="rule_ids" colspan="2" nolabel="1" context="{'default_company_id': company_id, 'form_view_ref':'stock.view_route_rule_form'}">
                             <list>
                                 <field name="sequence" widget="handle"/>
                                 <field name="action"/>


### PR DESCRIPTION
Commit 239e75b1385fa0 removes `colspan="2"` to guess it from the `nolabel` attribute. This is not working because of the `string=` attribute in the `group` tag that makes the DOM having two elements instead of only one. The rule in

https://github.com/odoo/odoo/blob/0ba664bace1e6bbb256bd98570866df19d35f401/addons/web/static/src/views/form/form_controller.scss#L474

is not applied.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
