### PR TITLE
[FIX] google_calendar: avoid sync failure on rescheduled all-day events

### DIFF
--- a/addons/google_calendar/utils/google_event.py
+++ b/addons/google_calendar/utils/google_event.py
@@ -193,9 +193,17 @@ class GoogleEvent(abc.Set):
         recurringEventId_value = re.match(r'(\w+_)', self.recurringEventId)
         if not id_value or not recurringEventId_value or id_value.group(1) != recurringEventId_value.group(1):
             return None
-        ID_RANGE = re.search(r'\w+_R\d+T\d+', self.recurringEventId).group()
-        TIMESTAMP = re.search(r'\d+T\d+Z', self.id).group()
-        return f"{ID_RANGE}_{TIMESTAMP}"
+        rec_pattern = re.search(r'(\w+_R\d+(?:T\d+)?(?:Z)?)', self.recurringEventId)
+        if not rec_pattern:
+            return None
+        id_range = rec_pattern.group()
+
+        ts_pattern = re.search(r'(\d{8}(?:T\d+Z?)?)$', self.id)
+        if not ts_pattern:
+            return None
+        timestamp = ts_pattern.group()
+
+        return f"{id_range}_{timestamp}"
 
     def cancelled(self):
         return self.filter(lambda e: e.status == 'cancelled')


### PR DESCRIPTION
Before this commit, syncing a Google Calendar that includes an all-day recurrent event—one of which is rescheduled—would fail entirely. This happened because `full_recurring_event_id` only handled events with a specific date-time format (`T...Z`), causing the regex to break for date-only IDs.

opw-4443780

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
