### PR TITLE
[IMP] im_livechat, web: proper focus when using hotkeys on CloseConfirmation

### DIFF
--- a/addons/im_livechat/static/src/core/common/chat_window_patch.js
+++ b/addons/im_livechat/static/src/core/common/chat_window_patch.js
@@ -13,6 +13,7 @@ patch(ChatWindow.prototype, {
         this.CW_LIVECHAT_STEP = CW_LIVECHAT_STEP;
     },
     onCloseConfirmationDialog() {
+        this.props.chatWindow.autofocus++;
         this.props.chatWindow.actionsDisabled = false;
         this.props.chatWindow.livechatStep = CW_LIVECHAT_STEP.NONE;
     },

--- a/addons/im_livechat/static/src/core/common/close_confirmation.js
+++ b/addons/im_livechat/static/src/core/common/close_confirmation.js
@@ -6,7 +6,7 @@ export class CloseConfirmation extends Component {
     static props = ["onCloseConfirmationDialog", "onClickLeaveConversation"];
 
     setup() {
-        useAutofocus({ refName: "root" });
+        useAutofocus({ refName: "confirm" });
     }
 
     onKeydown(ev) {

--- a/addons/im_livechat/static/src/core/common/close_confirmation.xml
+++ b/addons/im_livechat/static/src/core/common/close_confirmation.xml
@@ -2,18 +2,13 @@
 <templates xml:space="preserve">
     <t t-name="im_livechat.CloseConfirmation">
         <div
-            class="o-livechat-CloseConfirmation z-1 position-absolute w-100 h-100 d-flex justify-content-center align-items-center"
-            t-on-keydown.capture.stop="onKeydown"
-            t-on-click.stop="() => this.props.onCloseConfirmationDialog()"
-            t-ref="root"
-            tabindex="1"
-        >
+            class="o-livechat-CloseConfirmation z-1 position-absolute w-100 h-100 d-flex justify-content-center align-items-center" t-on-click.stop="() => this.props.onCloseConfirmationDialog()">
             <div class="o-livechat-CloseConfirmation-dialog rounded bg-view bg-opacity-100 p-3 m-3 d-flex flex-column position-relative" t-ref="dialog">
                 <div class="position-absolute top-0 end-0 p-1 o-xsmaller">
                     <button class="o-livechat-CloseConfirmation-close btn-close" t-on-click.stop="() => this.props.onCloseConfirmationDialog()"/>
                 </div>
                 <span class="pt-2 pb-3">Leaving will end the livechat. Proceed leaving?</span>
-                <button class="o-livechat-CloseConfirmation-leave btn btn-danger p-2 gap-1" t-on-click.stop="() => this.props.onClickLeaveConversation()"><i class="fa fa-fw fa-sign-out"/>Yes, leave conversation</button>
+                <button class="o-livechat-CloseConfirmation-leave btn btn-danger p-2 gap-1" t-on-keydown.stop.prevent="onKeydown" t-on-click.stop="() => this.props.onClickLeaveConversation()" t-ref="confirm"><i class="fa fa-fw fa-sign-out"/>Yes, leave conversation</button>
             </div>
         </div>
     </t>

--- a/addons/web/static/src/core/utils/hooks.js
+++ b/addons/web/static/src/core/utils/hooks.js
@@ -47,10 +47,20 @@ export function useAutofocus({ refName, selectAll, mobile } = {}) {
     if (!mobile && isMobileOS()) {
         return ref;
     }
+    function isFocusable(el) {
+        if (!el) {
+            return;
+        }
+        if (!uiService.activeElement || uiService.activeElement.contains(el)) {
+            return true;
+        }
+        const rootNode = el.getRootNode();
+        return rootNode instanceof ShadowRoot && uiService.activeElement.contains(rootNode.host);
+    }
     // LEGACY
     useEffect(
         (el) => {
-            if (el && (!uiService.activeElement || uiService.activeElement.contains(el))) {
+            if (isFocusable(el)) {
                 el.focus();
                 if (["INPUT", "TEXTAREA"].includes(el.tagName) && el.type !== "number") {
                     el.selectionEnd = el.value.length;


### PR DESCRIPTION
Before this commit, the Enter hotkey did not work to confirm the CloseConfirmation in livechat. This happened because:
- The `keydown` event is currently captured by the chat window not the CloseConfirmation component because the focused element is not properly detected.
- `useAutofocus` doesn't detect the focus target element because it checks only for the main tree DOM root, not the shadow root.

This PR changes the `useAutofocus` to handle the shadow roots and puts the focus on the chat window composer on cancel so it's more effective in case the user needs to type or use Esc to reopen close confirmation.

