### PR TITLE
[FIX] core: inherit translations better when upgrade

### DIFF
--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -1159,6 +1159,7 @@ class TestXMLTranslation(TransactionCase):
         terms_en = ('Bread and cheese', 'Knife and Fork', 'Knife <span invisible="1">and</span> Fork')
         view.with_env(env_en).write({'arch_db': archf % terms_en})
         terms_fr = ('Pain et fromage', 'Couteau et Fourchette', 'Couteau <span style="font-weight:bold" invisible="1">et</span> Fourchette')
+        terms_nl = ('Brood and kaas', 'Mes en Vork', 'Knife <span invisible="1">and</span> Fork')
 
         # check whether translations have been kept
         self.assertEqual(view.with_env(env_nolang).arch_db, archf % terms_en)
@@ -1167,9 +1168,10 @@ class TestXMLTranslation(TransactionCase):
         self.assertEqual(view.with_env(env_nl).arch_db, archf % terms_nl)
 
         # modify attributes in source term
-        terms_en = ('Bread and cheese', 'Knife and Fork', 'Knife <span readonly="1">and</span> Fork')
+        terms_en = ('Bread and cheese', 'Knife and Fork', 'Knife <span style="text-align: center;" readonly="1">and</span> Fork')
         view.with_env(env_en).write({'arch_db': archf % terms_en})
-        terms_fr = ('Pain et fromage', 'Couteau et Fourchette', 'Couteau <span style="font-weight:bold" readonly="1">et</span> Fourchette')
+        terms_fr = ('Pain et fromage', 'Couteau et Fourchette', 'Couteau <span style="text-align: center;" readonly="1">et</span> Fourchette')
+        terms_nl = ('Brood and kaas', 'Mes en Vork', 'Knife <span style="text-align: center;" readonly="1">and</span> Fork')
 
         # check whether translations have been kept
         self.assertEqual(view.with_env(env_nolang).arch_db, archf % terms_en)
@@ -1200,6 +1202,78 @@ class TestXMLTranslation(TransactionCase):
         self.assertEqual(view.with_env(env_nolang).arch_db, archf % terms_en)
         self.assertEqual(view.with_env(env_en).arch_db, archf % terms_en)
         self.assertEqual(view.with_env(env_fr).arch_db, archf % ('RandomRandom1', 'SomethingElse', 'AléatoireAléatoire3'))
+
+    def test_sync_xml_upgrade(self):
+        # text term and xml term with the same text content, text term is removed, xml term is changed
+        archf = '<form>%s<div>%s</div></form>'
+        terms_en = ('Draft', '<span invisible="1">Draft</span>')
+        terms_fr = ('Brouillon', '<span invisible="1">Brouillon</span>')
+        view = self.create_view(archf, terms_en, en_US=terms_en, fr_FR=terms_fr)
+
+        archf = '<form><div>%s</div></form>'
+        terms_en = ('<span invisible="0">Draft</span>')
+        terms_fr = ('<span invisible="0">Brouillon</span>')
+        view.with_context(install_mode=True).write({'arch_db': archf % terms_en})
+
+        self.assertEqual(view.arch_db, archf % terms_en)
+        self.assertEqual(view.with_context(lang='fr_FR').arch_db, archf % terms_fr)
+        
+        # change the order of the text term and the xml term and redo the previous test
+        archf = '<form>%s<div>%s</div></form>'
+        terms_en = ('<span invisible="1">Draft</span>', 'Draft')
+        terms_fr = ('<span invisible="1">Brouillon</span>', 'Brouillon')
+        view = self.create_view(archf, terms_en, en_US=terms_en, fr_FR=terms_fr)
+
+        archf = '<form><div>%s</div></form>'
+        terms_en = ('<span invisible="0">Draft</span>')
+        terms_fr = ('<span invisible="0">Brouillon</span>')
+        view.with_context(install_mode=True).write({'arch_db': archf % terms_en})
+
+        self.assertEqual(view.arch_db, archf % terms_en)
+        self.assertEqual(view.with_context(lang='fr_FR').arch_db, archf % terms_fr)
+
+        # xml terms with same text context but different structure, one is removed, another is changed
+        archf = '<form>%s<div>%s</div></form>'
+        terms_en = ('<i>Draft</i>', '<span invisible="1">Draft</span>')
+        terms_fr = ('<i>Brouillon</i>', '<span invisible="1">Brouillon</span>')
+        view = self.create_view(archf, terms_en, en_US=terms_en, fr_FR=terms_fr)
+
+        archf = '<form><div>%s</div></form>'
+        terms_en = ('<span invisible="2">Draft</span>')
+        terms_fr = ('<span invisible="2">Brouillon</span>')
+        view.with_context(install_mode=True).write({'arch_db': archf % terms_en})
+
+        self.assertEqual(view.arch_db, archf % terms_en)
+        self.assertEqual(view.with_context(lang='fr_FR').arch_db, archf % terms_fr)
+
+        # terms with same text context but different structure, both are removed
+        archf = '<form>%s<div>%s</div></form>'
+        terms_en = ('<i>Draft</i>', '<span invisible="1">Draft</span>')
+        terms_fr = ('<i>Brouillon</i>', '<span invisible="1">Brouillon</span>')
+        view = self.create_view(archf, terms_en, en_US=terms_en, fr_FR=terms_fr)
+
+        archf = '<form><div title="%s"/>%s</form>'
+        terms_en = ('Draft', 'Draft')
+        terms_fr = ('Draft', 'Draft')  # ('Brouillon', 'Brouillon') would be better
+        view.with_context(install_mode=True).write({'arch_db': archf % terms_en})
+
+        self.assertEqual(view.arch_db, archf % terms_en)
+        self.assertEqual(view.with_context(lang='fr_FR').arch_db, archf % terms_fr)
+
+        # text term and xml text term with the same text content, both are removed
+        archf = '<form>%s<div>%s</div></form>'
+        terms_en = ('Draft', '<span invisible="1">Draft</span>')
+        terms_fr = ('Brouillon', '<span invisible="1">Brouillon</span>')
+        view = self.create_view(archf, terms_en, en_US=terms_en, fr_FR=terms_fr)
+
+        archf = '<form><div>%s</div></form>'
+        terms_en = ('<i>Draft</i>')
+        terms_fr = ('<i>Draft</i>')  # '<i>Brouillon</i> would be better
+        view.with_context(install_mode=True).write({'arch_db': archf % terms_en})
+
+        self.assertEqual(view.arch_db, archf % terms_en)
+        self.assertEqual(view.with_context(lang='fr_FR').arch_db, archf % terms_fr)
+
 
     def test_cache_consistency(self):
         view = self.env["ir.ui.view"].create({

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1870,6 +1870,8 @@ class _String(Field):
                         if old_is_text or not closest_is_text:
                             if not closest_is_text and records.env.context.get("install_mode") and lang == 'en_US' and term_adapter:
                                 adapter = term_adapter(closest_term)
+                                if adapter(old_term) is None:  # old term and closest_term have different structures
+                                    continue
                                 translation_dictionary[closest_term] = {k: adapter(v) for k, v in translation_dictionary.pop(old_term).items()}
                             else:
                                 translation_dictionary[closest_term] = translation_dictionary.pop(old_term)

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -315,15 +315,13 @@ def xml_term_adapter(term_en):
     orig_node = parse_xml(f"<div>{term_en}</div>")
 
     def same_struct_iter(left, right):
-        if left.tag != right.tag:
+        if left.tag != right.tag or len(left) != len(right):
             raise ValueError("Non matching struct")
         yield left, right
         left_iter = left.iterchildren()
         right_iter = right.iterchildren()
         for lc, rc in zip(left_iter, right_iter):
             yield from same_struct_iter(lc, rc)
-        if next(left_iter, None) is not None or next(right_iter, None) is not None:
-            raise ValueError("Non matching struct")
 
     def adapter(term):
         new_node = parse_xml(f"<div>{term}</div>")
@@ -332,10 +330,10 @@ def xml_term_adapter(term_en):
                 removed_attrs = [k for k in new_n.attrib if k in MODIFIER_ATTRS and k not in orig_n.attrib]
                 for k in removed_attrs:
                     del new_n.attrib[k]
-                keep_attrs = {k: v for k, v in orig_n.attrib.items() if k in MODIFIER_ATTRS}
+                keep_attrs = {k: v for k, v in orig_n.attrib.items()}
                 new_n.attrib.update(keep_attrs)
         except ValueError:  # non-matching structure
-            return term
+            return None
 
         # remove tags <div> and </div> from result
         return serialize_xml(new_node)[5:-6]


### PR DESCRIPTION
# Before:
The typofix feature treats terms in the old and new values with similar text
content as the same term, migrating the translations of the old term to the new
term.

For example

The old value has the mapping:
`'Draft': 'Brouillon'`

The new value contains the term:
`'<span invisible="name or name_placeholder or quick_edit_mode">Draft</span>'`

Since the old term and the new term share the same text content, `'Draft'`, after
`write`, the new term reuses the old translation of 'Draft'. However, the
translation `'Brouillon'` is always visible, unlike its en_US counterpart.

This behavior is acceptable in non-upgrade mode because the user writes the
en_US value and is responsible for verifying translations afterward. However, it
is problematic during upgrades because users cannot easily identify which
records have changed and need to be rechecked.

# After:
The translation inheritance behavior can be described as below
Translations can be inherited after `write` from old terms to new terms which
share the very close text contents
1. when `write` in production mode, text contents for translation terms are more
   important than the HTML/XML structures of them, and the old term translations
   should be remained as much as possible. Because
    * the writing user is responsible to recheck all translations after `write`.
    * it is easier for the writing user to copy technical HTML/XML structures
      than translate text contents for a language they may not know.
    * the feature can also be used as typofix when the only small diff is the
      text content
2. when `write` in upgrade time, the HTML/XML structure is more important than
   the text content, and the new term structure should be remained as much as
   possible. Because
    * HTML/XML structures might be changed a lot after upgrade, which may
      contain behavior relevant diff (e.g. `invisible`), even if text contents
      are not changed.
    * users have no idea which records' values are changed during upgrade and
      are hard to recheck their translations.
    * new terms are highly likely to be correctly translated in the latest po
      files which will be imported during upgrade.
    * the typofix feature can still be remained when the only small diff is the
      text content

Based on the above feature analysis, we use the below new strategy
1. translations can be inherited only if the old source term and the new source
   term share the same HTML/XML structure
2. translations can be inherited only if the old translation term and the new
   source term share the same HTML/XML structure
3. when translations are inherited, MODIFIER_ATTRS will be synchronized with 
   the new source term, other attributes will be copied from the source term if 
   available.