### PR TITLE
[BW][FIX] core: disable typofix translations during upgrades

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1819,18 +1819,24 @@ class _String(Field):
                 if term_text:
                     text2terms[term_text].append(term)
 
+            is_text = self.translate.is_text if hasattr(self.translate, 'is_text') else lambda term: True
+            term_adapter = self.translate.term_adapter if hasattr(self.translate, 'term_adapter') else None
             for old_term in list(translation_dictionary.keys()):
                 if old_term not in new_terms:
                     old_term_text = self.get_text_content(old_term)
                     matches = get_close_matches(old_term_text, text2terms, 1, 0.9)
                     if matches:
                         closest_term = get_close_matches(old_term, text2terms[matches[0]], 1, 0)[0]
-                        if closest_term in translation_dictionary:
-                            continue
-                        old_is_text = old_term == self.get_text_content(old_term)
-                        closest_is_text = closest_term == self.get_text_content(closest_term)
+                        old_is_text = is_text(old_term)
+                        closest_is_text = is_text(closest_term)
                         if old_is_text or not closest_is_text:
-                            translation_dictionary[closest_term] = translation_dictionary.pop(old_term)
+                            if not closest_is_text and records.env.context.get("install_mode") and lang == 'en_US' and term_adapter:
+                                adapter = term_adapter(closest_term)
+                                if adapter(old_term) is None:  # old term and closest_term have different structures
+                                     continue
+                                translation_dictionary[closest_term] = {k: adapter(v) for k, v in translation_dictionary.pop(old_term).items()}
+                            else:
+                                translation_dictionary[closest_term] = translation_dictionary.pop(old_term)
             # pylint: disable=not-callable
             new_translations = {
                 l: self.translate(lambda term: translation_dictionary.get(term, {l: None})[l], cache_value)

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -292,6 +292,47 @@ def parse_xml(text):
 def serialize_xml(node):
     return etree.tostring(node, method='xml', encoding='unicode')
 
+
+MODIFIER_ATTRS = {"invisible", "readonly", "required", "column_invisible", "attrs", "states"}
+def xml_term_adapter(term_en):
+    """
+    Returns an `adapter(term)` function that will ensure the modifiers are copied
+    from the base `term_en` to the translated `term` when the XML structure of
+    both terms match. `term_en` and any input `term` to the adapter must be valid
+    XML terms. Using the adapter only makes sense if `term_en` contains some tags
+    from TRANSLATED_ELEMENTS.
+    """
+    orig_node = parse_xml(f"<div>{term_en}</div>")
+
+    def same_struct_iter(left, right):
+        if left.tag != right.tag or len(left) != len(right):
+            raise ValueError("Non matching struct")
+        yield left, right
+        left_iter = left.iterchildren()
+        right_iter = right.iterchildren()
+        for lc, rc in zip(left_iter, right_iter):
+            yield from same_struct_iter(lc, rc)
+        if next(left_iter, None) is not None or next(right_iter, None) is not None:
+            raise ValueError("Non matching struct")
+
+    def adapter(term):
+        new_node = parse_xml(f"<div>{term}</div>")
+        try:
+            for orig_n, new_n in same_struct_iter(orig_node, new_node):
+                removed_attrs = [k for k in new_n.attrib if k in MODIFIER_ATTRS and k not in orig_n.attrib]
+                for k in removed_attrs:
+                    del new_n.attrib[k]
+                keep_attrs = {k: v for k, v in orig_n.attrib.items()}
+                new_n.attrib.update(keep_attrs)
+        except ValueError:  # non-matching structure
+            return None
+
+        # remove tags <div> and </div> from result
+        return serialize_xml(new_node)[5:-6]
+
+    return adapter
+
+
 _HTML_PARSER = etree.HTMLParser(encoding='utf8')
 
 def parse_html(text):
@@ -367,11 +408,20 @@ def get_text_content(term):
     content = html.fromstring(term).text_content()
     return " ".join(content.split())
 
+def is_text(term):
+    """ Return whether the term has only text. """
+    return len(html.fromstring(f"<_>{term}</_>")) == 0
+
 xml_translate.get_text_content = get_text_content
 html_translate.get_text_content = get_text_content
 
 xml_translate.term_converter = xml_term_converter
 html_translate.term_converter = html_term_converter
+
+xml_translate.is_text = is_text
+html_translate.is_text = is_text
+
+xml_translate.term_adapter = xml_term_adapter
 
 def translate_sql_constraint(cr, key, lang):
     cr.execute("""


### PR DESCRIPTION
Before:
The typofix feature treats terms in the old and new values with similar text
content as the same term, migrating the translations of the old term to the new
term.

For example

The old value has the mapping:
'Draft': 'Brouillon'

The new value contains the term:
'<span invisible="name or name_placeholder or quick_edit_mode">Draft</span>'

Since the old term and the new term share the same text content, 'Draft', after
`write`, the new term reuses the old translation of 'Draft'. However, the
translation 'Brouillon' is always visible, unlike its en_US counterpart.

This behavior is acceptable in non-upgrade mode because the user writes the
en_US value and is responsible for verifying translations afterward. However, it
is problematic during upgrades because users cannot easily identify which
records have changed and need to be rechecked.

After:
The translation inheritance behavior can be described as below
Translations can be inherited after `write` from old terms to new terms which
share the very close text contents
1. when `write` in production mode, text contents for translation terms are more
   important than the HTML/XML structures of them, and the old term translations
   should be remained as much as possible. Because
    * the writing user is responsible to recheck all translations after `write`.
    * it is easier for the writing user to copy technical HTML/XML structures
      than translate text contents for a language they may not know.
    * the feature can also be used as typofix when the only small diff is the
      text content
2. when `write` in upgrade time, the HTML/XML structure is more important than
   the text content, and the new term structure should be remained as much as
   possible. Because
    * HTML/XML structures might be changed a lot after upgrade, which may
      contain behavior relevant diff (e.g. `invisible`), even if text contents
      are not changed.
    * users have no idea which records' values are changed during upgrade and
      are hard to recheck their translations.
    * new terms are highly likely to be correctly translated in the latest po
      files which will be imported during upgrade.
    * the typofix feature can still be remained when the only small diff is the
      text content

Based on the above feature analysis, we use the below new strategy
1. translations can be inherited only if the old source term and the new source
   term share the same HTML/XML structure
2. translations can be inherited only if the old translation term and the new
   source term share the same HTML/XML structure
3. when translations are inherited, MODIFIER_ATTRS will be synchronized with
   the new source term, other attributes will be copied from the source term if
   available.

Backward-Port-Of: #194181
Backward-Port-Of: #150152

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
