### PR TITLE
[IMP] account_reports: dynamic expressions system

### DIFF
--- a/addons/l10n_es/data/mod111.xml
+++ b/addons/l10n_es/data/mod111.xml
@@ -43,7 +43,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">domain</field>
                                         <field name="formula" eval="['|', '|', '|', ('tax_tag_ids', '=', '+mod111[02]'), ('tax_tag_ids', '=', '+mod111[03]'), ('tax_tag_ids', '=', '-mod111[02]'), ('tax_tag_ids', '=', '-mod111[03]')]"/>
-                                        <field name="subformula">count_rows</field>
+                                        <field name="subformula">count_rows(id)</field>
                                         <field name="figure_type">integer</field>
                                     </record>
                                 </field>
@@ -94,7 +94,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">domain</field>
                                         <field name="formula" eval="['|', '|', '|', ('tax_tag_ids', '=', '+mod111[05]'), ('tax_tag_ids', '=', '+mod111[06]'), ('tax_tag_ids', '=', '-mod111[05]'), ('tax_tag_ids', '=', '-mod111[06]')]"/>
-                                        <field name="subformula">count_rows</field>
+                                        <field name="subformula">count_rows(id)</field>
                                         <field name="figure_type">integer</field>
                                     </record>
                                 </field>
@@ -153,7 +153,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">domain</field>
                                         <field name="formula" eval="['|', '|', '|', ('tax_tag_ids', '=', '+mod111[08]'), ('tax_tag_ids', '=', '+mod111[09]'), ('tax_tag_ids', '=', '-mod111[08]'), ('tax_tag_ids', '=', '-mod111[09]')]"/>
-                                        <field name="subformula">count_rows</field>
+                                        <field name="subformula">count_rows(id)</field>
                                         <field name="figure_type">integer</field>
                                     </record>
                                 </field>
@@ -204,7 +204,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">domain</field>
                                         <field name="formula" eval="['|', '|', '|', ('tax_tag_ids', '=', '+mod111[11]'), ('tax_tag_ids', '=', '+mod111[12]'), ('tax_tag_ids', '=', '-mod111[11]'), ('tax_tag_ids', '=', '-mod111[12]')]"/>
-                                        <field name="subformula">count_rows</field>
+                                        <field name="subformula">count_rows(id)</field>
                                         <field name="figure_type">integer</field>
                                     </record>
                                 </field>

--- a/addons/l10n_es/data/mod115.xml
+++ b/addons/l10n_es/data/mod115.xml
@@ -38,7 +38,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">domain</field>
                                 <field name="formula" eval="['|', '|', '|', ('tax_tag_ids', '=', '+mod115[02]'), ('tax_tag_ids', '=', '+mod115[03]'), ('tax_tag_ids', '=', '-mod115[02]'), ('tax_tag_ids', '=', '-mod115[03]')]"/>
-                                <field name="subformula">count_rows</field>
+                                <field name="subformula">count_rows(id)</field>
                                 <field name="figure_type">integer</field>
                             </record>
                         </field>

--- a/addons/l10n_es/data/mod130.xml
+++ b/addons/l10n_es/data/mod130.xml
@@ -38,7 +38,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">domain</field>
                                     <field name="formula" eval="[('account_id.internal_group', '=', 'income'), '|', ('partner_id.industry_id', '=', False), ('partner_id.industry_id.name', '!=', 'Agriculture')]"/>
-                                    <field name="subformula">-sum</field>
+                                    <field name="subformula">-sum(balance)</field>
                                     <field name="date_scope">from_fiscalyear</field>
                                 </record>
                             </field>
@@ -54,7 +54,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">domain</field>
                                     <field name="formula" eval="[('account_id.internal_group', '=', 'expense'), '|', ('partner_id.industry_id', '=', False), ('partner_id.industry_id.name', '!=', 'Agriculture')]"/>
-                                    <field name="subformula">sum</field>
+                                    <field name="subformula">sum(balance)</field>
                                     <field name="date_scope">from_fiscalyear</field>
                                 </record>
                             </field>
@@ -120,7 +120,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">domain</field>
                                     <field name="formula" eval="[('tax_tag_ids', '=', '-mod130[06]'), '|', ('partner_id.industry_id', '=', False), ('partner_id.industry_id.name', '!=', 'Agriculture')]"/>
-                                    <field name="subformula">sum</field>
+                                    <field name="subformula">sum(balance)</field>
                                     <field name="date_scope">from_fiscalyear</field>
                                 </record>
                             </field>
@@ -156,7 +156,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">domain</field>
                                     <field name="formula" eval="[('account_id.internal_group', '=', 'income'), ('partner_id.industry_id.name', '=', 'Agriculture')]"/>
-                                    <field name="subformula">-sum</field>
+                                    <field name="subformula">-sum(balance)</field>
                                     <field name="date_scope">from_fiscalyear</field>
                                 </record>
                             </field>
@@ -197,7 +197,7 @@
                                     <field name="label">balance</field>
                                     <field name="engine">domain</field>
                                     <field name="formula" eval="[('tax_tag_ids', '=', '-mod130[06]'), ('partner_id.industry_id.name', '=', 'Agriculture')]"/>
-                                    <field name="subformula">sum</field>
+                                    <field name="subformula">sum(balance)</field>
                                     <field name="date_scope">from_fiscalyear</field>
                                 </record>
                             </field>


### PR DESCRIPTION
A change to the expressions has been made.

Same as before, the label targets the name and the subformula targets the engine output.
But now, the subformula can target a field on the model account_move_line.

Example for the engine domain, if we want to target the field balance we just set `balance` the aggregation is bu default sum.
If we want to target the field debit we do the same we just set `debit` yey.

We can explicitly set the aggregation function for instance instead of just setting balance, we can set the subforumla to `sum(balance)`.
The subformula pattern is as follow: `sign aggregation_function(field)` examples: `-sum_if_pos(debit)` or `move_name` or `-balance` or `count(id)` ...

This enables us to dynamically, from the interface, add columns and expressions to fill these with the values we want and add some flexibility to these reports.
This is only working for reports using engines.

task-4345514

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
