### PR TITLE
[IMP] hr: ignore work_phone update from address_id when manually updated

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -186,6 +186,8 @@ class HrEmployee(models.Model):
     message_has_error = fields.Boolean(groups="hr.group_hr_user")
     message_has_error_counter = fields.Integer(groups="hr.group_hr_user")
     message_attachment_count = fields.Integer(groups="hr.group_hr_user")
+    address_id = fields.Many2one(tracking=True)
+    work_phone = fields.Char(tracking=True)
 
     _barcode_uniq = models.Constraint(
         'unique (barcode)',

--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -203,14 +203,11 @@ class HrEmployeeBase(models.AbstractModel):
         for employee in self.filtered('job_id'):
             employee.job_title = employee.job_id.name
 
-    @api.depends('address_id')
+    @api.depends('address_id.phone')
     def _compute_phones(self):
         for employee in self:
-            if employee.address_id and employee.address_id.phone:
-                employee.work_phone = employee.address_id.phone
-            else:
-                employee.work_phone = False
-
+            employee.work_phone = employee.address_id.phone
+    
     @api.depends('work_contact_id', 'work_contact_id.phone', 'work_contact_id.email')
     def _compute_work_contact_details(self):
         for employee in self:


### PR DESCRIPTION
The `hr.employee.base` model needed to track whether its `work_phone` field had been manually updated to ensure that updates are ignored if the field was manually modified. Updates should be allowed again if a new `address_id` is set."

task-3823390

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
