### PR TITLE
[FIX] sale_expense: call the write expense approval function in tests

### DIFF
--- a/addons/sale_expense/tests/test_reinvoice.py
+++ b/addons/sale_expense/tests/test_reinvoice.py
@@ -454,7 +454,7 @@ class TestReInvoice(TestExpenseCommon, TestSaleCommon):
             ],
         })
 
-        expense_sheet._do_approve()
+        expense_sheet.action_approve_expense_sheets()
         expense_sheet.action_sheet_move_create()
 
         self.assertRecordValues(sale_order.order_line, [
@@ -552,7 +552,7 @@ class TestReInvoice(TestExpenseCommon, TestSaleCommon):
             ],
         })
 
-        expense_sheet._do_approve()
+        expense_sheet.action_approve_expense_sheets()
         expense_sheet.action_sheet_move_create()
 
         self.assertRecordValues(sale_order.order_line, [


### PR DESCRIPTION
This fixes an mistake in this forward-port: https://github.com/odoo/odoo/pull/193036 Only 17.0 is impacted; further forward-ports will directly be done right.
