### PR TITLE
[FIX] mail: correctly restart scheduled message cron

### DIFF
--- a/addons/mail/models/mail_scheduled_message.py
+++ b/addons/mail/models/mail_scheduled_message.py
@@ -250,7 +250,7 @@ class ScheduledMessage(models.Model):
 
         # restart cron if needed
         if self.search_count(domain, limit=1):
-            self.env('mail.ir_cron_post_scheduled_message')._trigger()
+            self.env.ref('mail.ir_cron_post_scheduled_message')._trigger()
 
     def _to_store(self, store: Store):
         for scheduled_message in self:


### PR DESCRIPTION
Before this commit, `mail.ir_cron_post_scheduled_message` fails with a traceback when there are a lot of scheduled messages to be sent.

Steps to reproduce
-----
1. Create a scheduled message from the chatter full composer
2. Duplicate it 50+ times
3. Run the scheduled action "Mail: Post scheduled messages"
4. Traceback occurs
```
File "/home/odoo/src/odoo/odoo/api.py", line 553, in __new__
assert isinstance(cr, BaseCursor)
^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

Cause
-----
This commit (df18d5257cef737f3e1d245a8b85769e1fe1a032) introduced this cron which posts past-due scheduled messages with a default `limit=50`. If there are more messages than the limit, the cron is triggered again. However, there is a typo when restarting the cron that incorrectly calls `env`.

Solution
-----
Change the line to use `env.ref()` to correctly access the xml_id and restart the cron.

opw-4474171
