### PR TITLE
[FIX] project_purchase: include negative bills in project profitability

### DIFF
--- a/addons/project_purchase/models/project.py
+++ b/addons/project_purchase/models/project.py
@@ -172,7 +172,6 @@ class Project(models.Model):
             query = self.env['account.move.line'].sudo()._search([
                 ('move_id.move_type', 'in', ['in_invoice', 'in_refund']),
                 ('parent_state', 'in', ['draft', 'posted']),
-                ('price_subtotal', '>', 0),
                 ('id', 'not in', purchase_order_line_invoice_line_ids),
             ])
             query.add_where('account_move_line.analytic_distribution ? %s', [str(self.analytic_account_id.id)])


### PR DESCRIPTION
### Issue:

- The negative values in Vendor Bills are not being reflected in the Analytic Account linked to a project.
- the negative value does not reduce the project’s total cost in the Analytic Report cost calculations.

### Steps to reproduce:

1- Create a project and set an analytic account or use the "Renovations" project.
2- Create a vendor bill.
3- On the VB add two lines one with a positive Price and the other with a negative Price.
4- on `Analytic` of each line set the project to `Renovations` or the project you created.
5- Validate the vendor bill.
6- Go to the project app and click on the 3 dots of the project you choose and click on `Project Updates`.
7- Notice the total cost of the project is not reflecting the negative value of the vendor bill.

### Solution:

- The issue is caused by the condition ('price_subtotal', '>', 0) in the query for account.move.line.
- Removing this condition ensures both positive and negative price_subtotal values are included.

opw-[4416931](https://www.odoo.com/web#id=4416931&view_type=form&model=project.task)
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
