### PR TITLE
[FIX] web: context should be applied before order

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -134,6 +134,9 @@ class Base(models.AbstractModel):
 
                 co_records = self[field_name]
 
+                if 'context' in field_spec:
+                    co_records = co_records.with_context(**field_spec['context'])
+
                 if 'order' in field_spec and field_spec['order']:
                     co_records = co_records.search([('id', 'in', co_records.ids)], order=field_spec['order'])
                     order_key = {
@@ -144,9 +147,6 @@ class Base(models.AbstractModel):
                         # filter out inaccessible corecords in case of "cache pollution"
                         values[field_name] = [id_ for id_ in values[field_name] if id_ in order_key]
                         values[field_name] = sorted(values[field_name], key=order_key.__getitem__)
-
-                if 'context' in field_spec:
-                    co_records = co_records.with_context(**field_spec['context'])
 
                 if 'fields' in field_spec:
                     if field_spec.get('limit') is not None:


### PR DESCRIPTION
Otherwise, if we use a context, it is not applied when filtering

Description of the issue/feature this PR addresses:  if you create a One2Many field with context={'active_test': 1} and you use the default_order on the tree view, the context is not applied.

Current behavior before PR: Contexts are not applied

Desired behavior after PR is merged: Context is applied.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
