### PR TITLE
[FIX] mail: multiple action_unfollow on livechat leave

### DIFF
--- a/addons/im_livechat/static/src/core/common/chat_window_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/chat_window_model_patch.js
@@ -13,16 +13,20 @@ const chatWindowPatch = {
         super.setup(...arguments);
         this.livechatStep = CW_LIVECHAT_STEP.NONE;
     },
-    close(...args) {
+    close(options = {}) {
         if (this.thread?.channel_type !== "livechat") {
-            return super.close(...args);
+            return super.close(...arguments);
+        }
+        if (options.force) {
+            this.livechatStep = CW_LIVECHAT_STEP.NONE;
+            return super.close(...arguments);
         }
         const isSelfVisitor = this.thread.livechatVisitorMember?.persona?.eq(this.store.self);
         switch (this.livechatStep) {
             case CW_LIVECHAT_STEP.NONE: {
                 if (this.thread.isTransient) {
                     this.thread.delete();
-                    super.close(...args);
+                    super.close(...arguments);
                     break;
                 }
                 if (!this.thread.livechat_active) {
@@ -30,7 +34,7 @@ const chatWindowPatch = {
                         this.livechatStep = CW_LIVECHAT_STEP.FEEDBACK;
                         this.open({ focus: true, notifyState: this.thread?.state !== "open" });
                     } else {
-                        super.close(...args);
+                        super.close(...arguments);
                     }
                     break;
                 }
@@ -48,31 +52,18 @@ const chatWindowPatch = {
                     this.livechatStep = CW_LIVECHAT_STEP.FEEDBACK;
                 } else {
                     this.livechatStep = CW_LIVECHAT_STEP.NONE;
-                    super.close(...args);
+                    super.close(...arguments);
                 }
                 break;
             }
             case CW_LIVECHAT_STEP.FEEDBACK: {
-                super.close(...args);
+                super.close(...arguments);
                 break;
             }
         }
         if (this.livechatStep !== CW_LIVECHAT_STEP.CONFIRM_CLOSE) {
             this.store.env.services["im_livechat.livechat"]?.leave();
             this.store.env.services["im_livechat.chatbot"]?.stop();
-        }
-    },
-    _onClose() {
-        if (
-            this.thread?.channel_type === "livechat" &&
-            this.thread.livechatVisitorMember?.persona?.notEq(this.store.self)
-        ) {
-            const thread = this.thread; // save ref before delete
-            super._onClose();
-            this.delete();
-            thread.leaveChannel({ force: true });
-        } else {
-            super._onClose();
         }
     },
 };

--- a/addons/im_livechat/static/src/core/public_web/chat_window_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/chat_window_model_patch.js
@@ -1,0 +1,20 @@
+import { ChatWindow } from "@mail/core/common/chat_window_model";
+import { patch } from "@web/core/utils/patch";
+
+patch(ChatWindow.prototype, {
+    _onClose(options = {}) {
+        if (
+            this.thread?.channel_type === "livechat" &&
+            this.thread.livechatVisitorMember?.persona?.notEq(this.store.self)
+        ) {
+            const thread = this.thread; // save ref before delete
+            super._onClose();
+            this.delete();
+            if (options.notifyState) {
+                thread.leaveChannel({ force: true });
+            }
+        } else {
+            super._onClose();
+        }
+    },
+});

--- a/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
@@ -76,6 +76,6 @@ patch(Thread.prototype, {
         if (this.channel_type === "livechat" && this.channel_member_ids.length <= 2 && !force) {
             await this.askLeaveConfirmation(_t("Leaving will end the livechat. Proceed leaving?"));
         }
-        super.leave();
+        super.leaveChannel(...arguments);
     },
 });

--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -34,18 +34,19 @@ export class ChatWindow extends Record {
     }
 
     close(options = {}) {
-        const { escape = false, notifyState = true } = options;
+        const { escape = false } = options;
+        options.notifyState ??= true;
         const chatHub = this.store.chatHub;
         const indexAsOpened = chatHub.opened.findIndex((w) => w.eq(this));
         this.store.chatHub.opened.delete(this);
         this.store.chatHub.folded.delete(this);
-        if (notifyState) {
+        if (options.notifyState) {
             this.store.chatHub.save();
         }
         if (escape && indexAsOpened !== -1 && chatHub.opened.length > 0) {
             chatHub.opened[indexAsOpened === 0 ? 0 : indexAsOpened - 1].focus();
         }
-        this._onClose();
+        this._onClose(options);
         this.delete();
     }
 

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -685,6 +685,11 @@ export class Thread extends Record {
         return cw;
     }
 
+    closeChatWindow(options = {}) {
+        const chatWindow = this.store.ChatWindow.get({ thread: this });
+        chatWindow?.close({ notifyState: false, ...options });
+    }
+
     pin() {
         if (this.model !== "discuss.channel" || this.store.self.type !== "partner") {
             return;

--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -21,10 +21,6 @@ const threadPatch = {
     get recipientsFullyLoaded() {
         return this.recipientsCount === this.recipients.length;
     },
-    closeChatWindow() {
-        const chatWindow = this.store.ChatWindow.get({ thread: this });
-        chatWindow?.close({ notifyState: false });
-    },
     computeIsDisplayed() {
         if (this.store.discuss.isActive && !this.store.env.services.ui.isSmall) {
             return this.eq(this.store.discuss.thread);

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -95,7 +95,7 @@ export class DiscussCoreCommon {
      * @param {{ notifId: number}} metadata
      */
     _handleNotificationChannelDelete(thread, metadata) {
-        thread.closeChatWindow();
+        thread.closeChatWindow({ force: true });
         thread.messages.splice(0, thread.messages.length);
         thread.delete();
     }


### PR DESCRIPTION
Before this PR, leaving a livechat channel from the Discuss app would trigger multiple `action_unfollow` actions:
- One initiated by the Discuss app.
- Another triggered by the `channel/leave` notification.

This PR resolves the issue by ensuring that the `channel/leave` notification does not redundantly trigger an `action_unfollow`.

Task-4488437

Additionally, this commit addresses minor code structure issues.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
