### PR TITLE
[FIX] web: adapt query counters

### DIFF
--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -37,8 +37,8 @@ class TestPerfSessionInfo(common.HttpCase):
     def test_load_web_menus_perf(self):
         self.env.registry.clear_all_caches()
         self.env.invalidate_all()
-        # cold orm/fields cache (only web: 10, all module: 38; without demo: 40)
-        with self.assertQueryCount(40):
+        # cold orm/fields cache (only web: 10, all module: 38 (+3 if not has group account.group_account_readonly); without demo: 40)
+        with self.assertQueryCount(41):
             self.env['ir.ui.menu'].load_web_menus(False)
 
         # cold fields cache - warm orm cache (only web: 0, all module: 1)
@@ -49,8 +49,8 @@ class TestPerfSessionInfo(common.HttpCase):
     def test_load_menus_perf(self):
         self.env.registry.clear_all_caches()
         self.env.invalidate_all()
-        # cold orm/fields cache (only web: 10, all module: 38; without demo: 40)
-        with self.assertQueryCount(40):
+        # cold orm/fields cache (only web: 10, all module: 38 (+3 if not has group account.group_account_readonly); without demo: 40)
+        with self.assertQueryCount(41):
             self.env['ir.ui.menu'].load_menus(False)
 
         # cold fields cache - warm orm cache (only web: 0, all module: 1)
@@ -61,8 +61,8 @@ class TestPerfSessionInfo(common.HttpCase):
     def test_visible_menu_ids(self):
         self.env.registry.clear_all_caches()
         self.env.invalidate_all()
-        # cold ormcache (only web: 5, all module: 14)
-        with self.assertQueryCount(14):
+        # cold ormcache (only web: 5, all module: 14 (+3 if not has group account.group_account_readonly))
+        with self.assertQueryCount(17):
             self.env['ir.ui.menu']._visible_menu_ids()
 
         # cold fields cache - warm orm cache (only web: 0, all module: 0)


### PR DESCRIPTION
Following the changes in the related enterprise PR, query counters must be adapted.
Some overrides in accounting modules causes the query counter to go up.

Runbot Error: 109492
