### PR TITLE
[FIX] mrp: fix error unsupported operand type(s) for -: 'str' and 'datetime.timedelta'

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -870,7 +870,7 @@ class MrpProduction(models.Model):
         date_start_map = dict()
         if 'date_start' in vals:
             date_start_map = {
-                prod: vals['date_start'] - datetime.timedelta(days=prod.bom_id.produce_delay)
+                prod: fields.Datetime.to_datetime(vals['date_start']) - datetime.timedelta(days=prod.bom_id.produce_delay)
                 if prod.bom_id else vals['date_start']
                 for prod in self
             }


### PR DESCRIPTION
### Before this PR
Changing the date on production this error appears
`unsupported operand type(s) for -: 'str' and 'datetime.timedelta'`

### After this PR
No error

Error caused by this commit
https://github.com/odoo/odoo/commit/7c808beaf36853b4d9171ef0981d1ec9c4b73a44
by this pr https://github.com/odoo/odoo/pull/188389

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
