### PR TITLE
[FIX] website_links: ensure correct base URL for short links

### DIFF
--- a/addons/website_links/models/link_tracker.py
+++ b/addons/website_links/models/link_tracker.py
@@ -18,6 +18,8 @@ class LinkTracker(models.Model):
         }
 
     def _compute_short_url_host(self):
+        current_website = self.env['website'].get_current_website()
+        base_url = current_website.get_base_url() if current_website == self.env.company.website_id else self.env.company.get_base_url()
         for tracker in self:
             base_url = self.env['website'].get_current_website().get_base_url()
             tracker.short_url_host = urls.url_join(base_url, '/r/')

--- a/addons/website_links/tests/test_link_tracker.py
+++ b/addons/website_links/tests/test_link_tracker.py
@@ -1,0 +1,70 @@
+from odoo.tests import TransactionCase, tagged, users
+from odoo.addons.mail.tests.common import mail_new_test_user
+
+
+@tagged('post_install', '-at_install')
+class TestLinkTracker(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.company_1 =  cls.env.company
+
+        cls.company_2 = cls.env['res.company'].create({
+            'name': 'Company 2',
+        })
+
+        cls.website_1, cls.website_2 = cls.env['website'].create([
+            {
+                'name': 'website 1',
+                'domain': 'https://maincompany.odoo.com',
+                'company_id': cls.company_1.id
+            },
+            {
+                'name': 'Website 2',
+                'domain': 'https://secondarycompany.odoo.com',
+                'company_id': cls.company_2.id
+            }
+        ])
+
+        cls.company_1.write({'website_id': cls.website_1.id})
+
+        cls.test_user = mail_new_test_user(
+            cls.env,
+            login='test_user',
+            name='Test User',
+            company_id=cls.company_1.id,
+            company_ids=[(6, 0, [cls.company_1.id, cls.company_2.id])],
+            groups="website.group_website_designer"
+        )
+
+    @users('test_user')
+    def test_compute_short_url_host(self):
+        """Test _compute_short_url_host with multiple companies/websites
+            The short URL base should match the website domain of the company
+        """
+        link_1 = self.env['link.tracker'].create({
+            'url': 'https://www.1odoo.com',
+        })
+        self.assertTrue(link_1.short_url.startswith(self.website_1.domain),
+            "Short URL should use company 1 website domain")
+
+        # Switch to Company 2
+        self.env.user.company_id = self.company_2
+        link_2 = self.env['link.tracker'].create({
+            'url': 'https://www.2odoooo.com',
+        })
+        self.assertTrue(link_2.short_url.startswith(self.website_2.domain),
+            "Short URL should use company 2 website domain"
+        )
+
+        # Remove website from Company 2
+        # The short URL host should fallback to a default value
+        self.company_2.write({'website_id': False})
+        link_3 = self.env['link.tracker'].create({
+            'url': 'https://www.3ooddoooo.com'
+        })
+        self.assertTrue(
+            link_3.short_url_host,
+            "Short URL host should have a fallback value when no website is configured"
+        )


### PR DESCRIPTION
The base URL was being retrieved incorrectly in `_compute_short_url_host()` without considering the current company.
This caused the short URL to always use the domain of the company logged into the database, rather than the domain of the selected company.

This happens because the base URL was retrieved using `get_current_website()` from the `website` module, which does not consider the company context. As a result, the short URL adapts based on the domain of the last logged-in company, leading to inconsistent URLs.


Steps to reproduce:
1. Context: The database has two companies, Company A and Company B, each with their own custom domains, Domain A and Domain B.
2. Log in to the database using Domain A.
- Post a link via social marketing for Company A. The short URL will use Domain A.
3. Switch to the Company B.
- Post the same link via social marketing for Company B. The short URL will now incorrectly use Domain A instead of B. While the short URL still redirects to the correct content, the domain in the short URL is inconsistent and depends on the last logged-in domain.

OPW-4235176



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
