### PR TITLE
[FIX] web: uniformize width of buttons in control panel

### DIFF
--- a/addons/web/static/src/scss/primary_variables.scss
+++ b/addons/web/static/src/scss/primary_variables.scss
@@ -235,6 +235,7 @@ $o-border-radius-lg: o-to-rem(6px) !default;
 
 // touch
 $o-touch-btn-padding: 7px 14px !default;
+$o-touch-btn-with-icon-padding: 7px 10px !default;
 
 // == Buttons
 // Map of customized values for each button. If a button's design is defined

--- a/addons/web/static/src/search/cog_menu/cog_menu.xml
+++ b/addons/web/static/src/search/cog_menu/cog_menu.xml
@@ -6,7 +6,7 @@
             <div class="lh-1">
                 <Dropdown menuClass="'lh-base'" beforeOpen.bind="loadPrintItems">
                     <button class="d-print-none btn" t-att-class="env.isSmall ? 'btn-secondary' : 'lh-sm p-0 border-0'" data-hotkey="u" data-tooltip="Actions">
-                        <i class="fa fa-cog"/>
+                        <i class="fa fa-fw fa-cog"/>
                     </button>
 
                     <t t-set-slot="content">

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -129,7 +129,7 @@
     <t t-name="web.embeddedActionsDropdown">
         <Dropdown menuClass="'o_embedded_actions_dropdown_menu'">
             <button class="btn btn-secondary">
-                <i class="fa fa-sliders"/>
+                <i class="fa fa-fw fa-sliders"/>
             </button>
             <t t-set-slot="content">
                 <t t-foreach="state.embeddedInfos.embeddedActions" t-as="action" t-key="action.id">

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -94,7 +94,7 @@
                     <t t-if="env.config.viewSwitcherEntries?.length > 1">
                         <div t-if="env.isSmall" class="o_cp_switch_buttons btn-group d-print-none">
                             <Dropdown>
-                                <button class="btn btn-secondary o-dropdown-caret">
+                                <button class="btn btn-secondary">
                                     <t t-set="activeView" t-value="env.config.viewSwitcherEntries.find((view) => view.active)"/>
                                     <i class="oi-fw" t-att-class="activeView.icon"/>
                                 </button>

--- a/addons/web/static/src/views/form/button_box/button_box.xml
+++ b/addons/web/static/src/views/form/button_box/button_box.xml
@@ -8,7 +8,7 @@
             <Dropdown position="!env.isSmall ? 'bottom-end' : ''" menuClass="'o-form-buttonbox p-0 border-0 ' + (!env.isSmall ? 'o_dropdown_more' : 'o-form-buttonbox-small')">
                 <button class="o_button_more btn d-flex justify-content-center align-items-center" t-att-class="!env.isSmall ? 'o-dropdown-caret btn-outline-secondary' : 'btn-secondary'">
                     <span t-if="!env.isSmall">More</span>
-                    <i t-else="" class="fa fa-bolt lh-base" aria-hidden="true"/>
+                    <i t-else="" class="fa fa-fw fa-bolt lh-base" aria-hidden="true"/>
                 </button>
                 <t t-set-slot="content">
                     <DropdownItem t-foreach="additionalButtons" t-as="button" t-key="button_value" class="'d-flex flex-column p-0'">

--- a/addons/web/static/src/webclient/webclient.scss
+++ b/addons/web/static/src/webclient/webclient.scss
@@ -147,6 +147,10 @@ kbd {
           padding: $o-touch-btn-padding;
       }
 
+      &:has(.fa-fw:only-child, .oi-fw:only-child) {
+          padding: $o-touch-btn-with-icon-padding;
+      }
+
       &.fa {
           font-size: 1.3em;
           padding: 2px 10px;


### PR DESCRIPTION
On smaller screen, the ControlPanel's buttons for CogMenu, Buttonbox,
Knowledge, Search don't have a consistent width.

This commit fixes it by giving those buttons' icon a fixed width,
independently of the character's size and adjusting the horizontal
padding for this use case.

task-4492690