### PR TITLE
[FIX] hr: fix singleton record error

### DIFF
--- a/addons/hr/wizard/mail_activity_schedule.py
+++ b/addons/hr/wizard/mail_activity_schedule.py
@@ -14,7 +14,7 @@ class MailActivitySchedule(models.TransientModel):
     def _compute_plan_available_ids(self):
         todo = self.filtered(lambda s: s.res_model == 'hr.employee')
         for scheduler in todo:
-            base_domain = self._get_plan_available_base_domain()
+            base_domain = scheduler._get_plan_available_base_domain()
             if not scheduler.department_id:
                 final_domain = expression.AND([base_domain, [('department_id', '=', False)]])
             else:


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- The [_get_plan_available_base_domain()](https://github.com/odoo/odoo/blob/18.0/addons/mail/wizard/mail_activity_schedule.py#L330) method is built and `self.ensure_one()` is placed in it but it is called in `_compute_plan_available_ids()` with `self` which can have multiple records

### Current behavior before PR:
- The error `ValueError: Expected singleton: mail.activity.schedule(1, 2)` occurred

### Desired behavior after PR is merged:
- The problem has been fixed.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
