### PR TITLE
[IMP] account: manual payment method clean up

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -19,6 +19,7 @@ You could use this simplified accounting in case you work with an (external) acc
         'security/account_security.xml',
         'security/ir.model.access.csv',
         'data/account_data.xml',
+        'data/account_payment_method_line.xml',
         'data/digest_data.xml',
         'views/account_report.xml',
         'data/mail_template_data.xml',

--- a/addons/account/data/account_payment_method_line.xml
+++ b/addons/account/data/account_payment_method_line.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="account_payment_method_line_manual_in" model="account.payment.method.line">
+        <field name="name">Manual</field>
+        <field name="sequence">1</field>
+        <field name="payment_method_id" ref="account.account_payment_method_manual_in"/>
+    </record>
+    <record id="account_payment_method_line_manual_out" model="account.payment.method.line">
+        <field name="name">Manual</field>
+        <field name="sequence">1</field>
+        <field name="payment_method_id" ref="account.account_payment_method_manual_out"/>
+    </record>
+</odoo>

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -46,10 +46,10 @@ class AccountJournal(models.Model):
     _rec_names_search = ['name', 'code']
 
     def _default_inbound_payment_methods(self):
-        return self.env.ref('account.account_payment_method_manual_in')
+        return self.env['account.payment.method']
 
     def _default_outbound_payment_methods(self):
-        return self.env.ref('account.account_payment_method_manual_out')
+        return self.env['account.payment.method']
 
     def __get_bank_statements_available_sources(self):
         return [('undefined', _('Undefined Yet'))]

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -619,13 +619,15 @@ class ResPartner(models.Model):
     property_outbound_payment_method_line_id = fields.Many2one(
         comodel_name='account.payment.method.line',
         company_dependent=True,
-        domain=lambda self: [('payment_type', '=', 'outbound'), ('company_id', '=', self.env.company.id)],
+        check_company=True,
+        domain=lambda self: ['|', ('company_id', '=', self.env.company.id), ('code', '=', 'manual'), ('payment_type', '=', 'outbound')],
     )
 
     property_inbound_payment_method_line_id = fields.Many2one(
         comodel_name='account.payment.method.line',
         company_dependent=True,
-        domain=lambda self: [('payment_type', '=', 'inbound'), ('company_id', '=', self.env.company.id)],
+        check_company=True,
+        domain=lambda self: ['|', ('company_id', '=', self.env.company.id), ('code', '=', 'manual'), ('payment_type', '=', 'inbound')],
     )
 
     def _compute_bank_count(self):

--- a/addons/account/tests/test_account_move_date_algorithm.py
+++ b/addons/account/tests/test_account_move_date_algorithm.py
@@ -43,6 +43,7 @@ class TestAccountMoveDateAlgorithm(AccountTestInvoicingCommon):
             'partner_id': self.partner_a.id,
             'payment_type': 'inbound',
             'partner_type': 'customer',
+            'payment_method_line_id': self.inbound_payment_method_line.id,
             **kwargs,
             'date': date,
         })

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -646,12 +646,11 @@ class TestAccountMove(AccountTestInvoicingCommon):
         # make payment
         payment = self.env['account.payment'].create({
             'payment_type': 'inbound',
-            'payment_method_id': self.env.ref('account.account_payment_method_manual_in').id,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
             'partner_type': 'customer',
             'partner_id': self.partner_a.id,
             'amount': 1100,
             'date': move.date,
-            'journal_id': self.company_data['default_journal_bank'].id,
         })
         payment.action_post()
         (payment.move_id + move).line_ids.filtered(lambda x: x.account_id == self.company_data['default_account_receivable']).reconcile()

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1570,7 +1570,9 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         })
         action_register_payment = move.action_force_register_payment()  # should not raise an error on non-posted move
         self.assertTrue(action_register_payment)
-        wizard = self.env[action_register_payment['res_model']].with_context(action_register_payment['context']).create({})
+        wizard = self.env[action_register_payment['res_model']].with_context(action_register_payment['context']).create({
+            'payment_method_line_id': self.outbound_payment_method_line.id,
+        })
 
         action_create_payment = wizard.action_create_payments()
         payment = self.env[action_create_payment['res_model']].browse(action_create_payment['res_id'])
@@ -2044,6 +2046,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         # make payment
         self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
             'payment_date': invoice.date,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
         # check caba move
         partial_rec = invoice.mapped('line_ids.matched_debit_ids')
@@ -2178,6 +2181,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         # make payment
         self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
             'payment_date': invoice.date,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
         # check caba move
         partial_rec = invoice.mapped('line_ids.matched_debit_ids')
@@ -2345,12 +2349,13 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             return move
 
         def create_payment(move, amount):
-            self.env['account.payment.register']\
-                .with_context(active_ids=move.ids, active_model='account.move')\
-                .create({
-                    'amount': amount,
-                })\
-                ._create_payments()
+            self.env['account.payment.register'].with_context(
+                active_ids=move.ids,
+                active_model='account.move',
+            ).create({
+                'amount': amount,
+                'payment_method_line_id': self.inbound_payment_method_line.id,
+            })._create_payments()
 
         def create_reverse(move, amount):
             move_reversal = self.env['account.move.reversal']\

--- a/addons/account/tests/test_account_move_in_refund.py
+++ b/addons/account/tests/test_account_move_in_refund.py
@@ -1075,8 +1075,12 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
         invoice = move_form.save()
         invoice.action_post()
         # make payment
-        self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+        self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice.ids,
+        ).create({
             'payment_date': invoice.date,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
         # check caba move
         partial_rec = invoice.mapped('line_ids.matched_credit_ids')
@@ -1209,8 +1213,12 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
         })
         invoice.action_post()
         # make payment
-        self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+        self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice.ids,
+        ).create({
             'payment_date': invoice.date,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
         # check caba move
         partial_rec = invoice.mapped('line_ids.matched_credit_ids')

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -3466,8 +3466,12 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         invoice = move_form.save()
         invoice.action_post()
         # make payment
-        self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+        self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice.ids,
+        ).create({
             'payment_date': invoice.date,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
         # check caba move
         partial_rec = invoice.mapped('line_ids.matched_credit_ids')
@@ -3600,8 +3604,12 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         })
         invoice.action_post()
         # make payment
-        self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+        self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice.ids,
+        ).create({
             'payment_date': invoice.date,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
         # check caba move
         partial_rec = invoice.mapped('line_ids.matched_credit_ids')
@@ -4006,8 +4014,12 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
 
                 self.env.company.currency_exchange_journal_id = new_exchange_journal
 
-                self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+                self.env['account.payment.register'].with_context(
+                    active_model='account.move',
+                    active_ids=invoice.ids,
+                ).create({
                     'payment_date': '2017-01-20',
+                    'payment_method_line_id': self.inbound_payment_method_line.id,
                 })._create_payments()
 
                 line_receivable = invoice.line_ids.filtered(lambda l: l.account_id.account_type == 'asset_receivable')

--- a/addons/account/tests/test_account_move_out_refund.py
+++ b/addons/account/tests/test_account_move_out_refund.py
@@ -1027,6 +1027,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
         # make payment
         self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
             'payment_date': invoice.date,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
         # check caba move
         partial_rec = invoice.mapped('line_ids.matched_debit_ids')
@@ -1159,8 +1160,12 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
         })
         invoice.action_post()
         # make payment
-        self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+        self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice.ids
+        ).create({
             'payment_date': invoice.date,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
         # check caba move
         partial_rec = invoice.mapped('line_ids.matched_debit_ids')

--- a/addons/account/tests/test_account_move_payments_widget.py
+++ b/addons/account/tests/test_account_move_payments_widget.py
@@ -160,10 +160,13 @@ class TestAccountMovePaymentsWidget(AccountTestInvoicingCommon):
         out_invoice.action_post()
 
         # Payment at exchange rate 2:1. 300 GOL -> 150 USD
-        payment = self.env['account.payment.register']\
-            .with_context(active_model='account.move', active_ids=out_invoice.ids)\
-            .create({'payment_date': '2017-01-01'})\
-            ._create_payments()
+        payment = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=out_invoice.ids
+        ).create({
+            'payment_date': '2017-01-01',
+            'payment_method_line_id': self.inbound_payment_method_line.id,
+        })._create_payments()
 
         expected_amounts = {payment.move_id.id: 300.0}
         # Get the exchange difference move.
@@ -192,10 +195,13 @@ class TestAccountMovePaymentsWidget(AccountTestInvoicingCommon):
         out_invoice.action_post()
 
         # Payment at exchange rate 3:1. 300 GOL -> 100 USD
-        payment = self.env['account.payment.register']\
-            .with_context(active_model='account.move', active_ids=out_invoice.ids)\
-            .create({'payment_date': '2016-01-01'})\
-            ._create_payments()
+        payment = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=out_invoice.ids,
+        ).create({
+            'payment_date': '2016-01-01',
+            'payment_method_line_id': self.inbound_payment_method_line.id,
+        })._create_payments()
 
         expected_amounts = {payment.move_id.id: 300.0}
         # Get the exchange difference move.

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -1801,14 +1801,15 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         })
         invoice.action_post()
 
-        payment = self.env['account.payment.register']\
-            .with_context(active_model=invoice._name, active_ids=invoice.ids)\
-            .create({
-                'payment_date': '2016-01-01',
-                'amount': 90.0,
-                'currency_id': foreign_curr.id,
-            })\
-            ._create_payments()
+        payment = self.env['account.payment.register'].with_context(
+            active_model=invoice._name,
+            active_ids=invoice.ids,
+        ).create({
+            'payment_date': '2016-01-01',
+            'payment_method_line_id': self.inbound_payment_method_line.id,
+            'amount': 90.0,
+            'currency_id': foreign_curr.id,
+        })._create_payments()
 
         lines = (invoice + payment.move_id).line_ids\
             .filtered(lambda x: x.account_id.account_type == 'asset_receivable')
@@ -1943,6 +1944,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             'amount': 1907.17,
             'partner_id': self.partner_a.id,
             'currency_id': foreign_curr.id,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })
         pay1.action_post()
         pay1_liquidity_line = pay1.move_id.line_ids.filtered(lambda x: x.account_id.account_type != 'asset_receivable')
@@ -1961,6 +1963,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             'amount': 0.09,
             'partner_id': self.partner_a.id,
             'currency_id': foreign_curr.id,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })
         pay2.action_post()
         pay2_rec_line = pay2.move_id.line_ids.filtered(lambda x: x.account_id.account_type == 'asset_receivable')
@@ -2246,6 +2249,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             'amount': 1907.17,
             'partner_id': self.partner_a.id,
             'currency_id': foreign_curr.id,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })
         pay1.action_post()
         pay1_liquidity_line = pay1.move_id.line_ids.filtered(lambda x: x.account_id.account_type != 'asset_receivable')
@@ -2264,6 +2268,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             'amount': 0.09,
             'partner_id': self.partner_a.id,
             'currency_id': foreign_curr.id,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })
         pay2.action_post()
         pay2_rec_line = pay2.move_id.line_ids.filtered(lambda x: x.account_id.account_type == 'asset_receivable')
@@ -3671,14 +3676,15 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         })
         caba_inv.action_post()
 
-        self.env['account.payment.register']\
-            .with_context(active_model='account.move', active_ids=caba_inv.ids)\
-            .create({
-                'payment_date': '2017-01-01',
-                'currency_id': currency_id,
-                'amount': 110.0,
-            })\
-            ._create_payments()
+        self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=caba_inv.ids,
+        ).create({
+            'payment_date': '2017-01-01',
+            'payment_method_line_id': self.inbound_payment_method_line.id,
+            'currency_id': currency_id,
+            'amount': 110.0,
+        })._create_payments()
 
         receivable_line = caba_inv.line_ids.filtered(lambda x: x.account_id.account_type == 'asset_receivable')
         partial_rec = caba_inv.line_ids.matched_credit_ids
@@ -4608,8 +4614,12 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         })
         invoice.action_post()
 
-        self.env['account.payment.register'].with_context(active_ids=invoice.ids, active_model='account.move').create({
+        self.env['account.payment.register'].with_context(
+            active_ids=invoice.ids,
+            active_model='account.move',
+        ).create({
             'payment_date': invoice.date,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
 
         caba_move = self.env['account.move'].search([('tax_cash_basis_origin_move_id', '=', invoice.id)])
@@ -4681,7 +4691,12 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
 
         invoice.action_post()
 
-        pmt_wizard = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({})
+        pmt_wizard = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice.ids,
+        ).create({
+            'payment_method_line_id': self.inbound_payment_method_line.id,
+        })
         pmt_wizard._create_payments()
 
         caba_move = self.env['account.move'].search([('tax_cash_basis_origin_move_id', '=', invoice.id)])
@@ -4720,15 +4735,23 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         payment_date_1 = fields.Date.from_string('2017-01-01')
         payment_date_2 = fields.Date.from_string('2018-01-01')
 
-        pmt_wizard = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+        pmt_wizard = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice.ids,
+        ).create({
             'amount': 66.66,
             'payment_date': payment_date_1,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })
         pmt_wizard._create_payments()
 
-        pmt_wizard = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+        pmt_wizard = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice.ids,
+        ).create({
             'amount': 66.66,
             'payment_date': payment_date_2,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })
         pmt_wizard._create_payments()
 
@@ -4808,17 +4831,25 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         payment_date_1 = fields.Date.from_string('2017-01-01')
         payment_date_2 = fields.Date.from_string('2018-01-01')
 
-        pmt_wizard = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+        pmt_wizard = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice.ids,
+        ).create({
             'amount': 66.66,
             'currency_id': currency_id,
             'payment_date': payment_date_1,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })
         pmt_wizard._create_payments()
 
-        pmt_wizard = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+        pmt_wizard = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice.ids,
+        ).create({
             'amount': 66.66,
             'currency_id': currency_id,
             'payment_date': payment_date_2,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })
         pmt_wizard._create_payments()
 
@@ -4922,8 +4953,12 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         invoice.action_post()
 
         # make payment
-        self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+        self.env['account.payment.register'].with_context(
+            active_model='account.move', 
+            active_ids=invoice.ids,
+        ).create({
             'payment_date': invoice.date,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
 
         # check caba move
@@ -5049,6 +5084,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             'amount': 800.0,
             'currency_id': foreign_currency.id,
             'partner_id': self.partner_a.id,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })
         payment.action_post()
         # unlink the rate to simulate a custom rate on the payment
@@ -5087,9 +5123,15 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             {**move_vals, 'date': '2017-01-01', 'invoice_date': '2017-01-01'}
         )
         invoice_no_diff.action_post()
-        wizard_no_diff = self.env['account.payment.register']\
-            .with_context(active_model='account.move', active_ids=invoice_no_diff.ids)\
-            .create({**payment_vals, 'payment_date': '2017-01-01', 'amount': 3000})  # 3000 EUR = 1000 USD.
+        wizard_no_diff = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice_no_diff.ids,
+        ).create({
+            **payment_vals,
+            'payment_date': '2017-01-01',
+            'payment_method_line_id': self.inbound_payment_method_line.id,
+            'amount': 3000,
+        })  # 3000 EUR = 1000 USD.
         wizard_no_diff._create_payments()
 
         # Then check that an error is raised when trying to create a payment with an exchange difference.
@@ -5097,9 +5139,15 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             {**move_vals, 'date': '2016-01-01', 'invoice_date': '2016-01-01'}
         )
         invoice_diff.action_post()
-        wizard_diff = self.env['account.payment.register']\
-            .with_context(active_model='account.move', active_ids=invoice_diff.ids)\
-            .create({**payment_vals, 'payment_date': '2018-01-01', 'amount': 2000})  # 2000 EUR = 1000 USD.
+        wizard_diff = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice_diff.ids,
+        ).create({
+            **payment_vals,
+            'payment_date': '2018-01-01',
+            'payment_method_line_id': self.inbound_payment_method_line.id,
+            'amount': 2000,
+        })  # 2000 EUR = 1000 USD.
         with self.assertRaises(UserError):
             wizard_diff._create_payments()
 
@@ -5209,8 +5257,12 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         }])
         invoice.action_post()
 
-        self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+        self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice.ids,
+        ).create({
             'payment_date': invoice.date,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
 
         # Check the caba move lines.
@@ -5396,8 +5448,12 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         }])
         invoice.action_post()
 
-        self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+        self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice.ids,
+        ).create({
             'payment_date': invoice.date,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
 
         # Check the caba move lines.

--- a/addons/account/tests/test_account_partner.py
+++ b/addons/account/tests/test_account_partner.py
@@ -21,6 +21,7 @@ class TestAccountPartner(AccountTestInvoicingCommon):
             'partner_id': partner.id,
             'payment_type': 'inbound',
             'partner_type': 'customer',
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
         self.env.invalidate_all()
         self.assertEqual(partner.days_sales_outstanding, 0.0)

--- a/addons/account/tests/test_account_payment_method_line.py
+++ b/addons/account/tests/test_account_payment_method_line.py
@@ -108,8 +108,8 @@ class TestAccountPaymentMethodLine(AccountTestInvoicingCommon):
 
         # Test with two moves with different partners and different payment method lines
         self.assertRegisterPayment(
-            self.bank_journal_1,
-            None,  # We will get in the assertRegisterPayment the first payment method line of the journal
+            self.env['account.journal'],
+            self.inbound_payment_method_line_without_journal,
             self.move_partner_a + self.move_partner_b,
         )
 

--- a/addons/account/tests/test_early_payment_discount.py
+++ b/addons/account/tests/test_early_payment_discount.py
@@ -149,6 +149,7 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         active_ids = out_invoice_1.ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
             'payment_date': '2019-01-02',
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
 
         self.assertTrue(payments.is_reconciled)
@@ -182,6 +183,7 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         active_ids = inv.ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
             'payment_date': '2017-01-01',
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
 
         self.assertTrue(payments.is_reconciled)
@@ -215,10 +217,13 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         })
 
         invoice.action_post()
-        payments = self.env['account.payment.register']\
-            .with_context(active_model='account.move', active_ids=invoice.ids)\
-            .create({'payment_date': '2017-01-01'})\
-            ._create_payments()
+        payments = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice.ids,
+        ).create({
+            'payment_date': '2017-01-01',
+            'payment_method_line_id': self.inbound_payment_method_line.id,
+        })._create_payments()
 
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -242,6 +247,7 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         active_ids = inv_1500_10_percents_discount_tax_incl_15_percents_tax.ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
             'payment_date': '2017-01-01',
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
 
         self.assertTrue(payments.is_reconciled)
@@ -266,6 +272,7 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         active_ids = inv_1500_10_percents_discount_tax_incl_15_percents_tax.ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
             'payment_date': '2017-01-01',
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
 
         self.assertTrue(payments.is_reconciled)
@@ -293,7 +300,8 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         active_ids = inv_mixed_lines_discount_and_no_discount.ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
             'payment_date': '2017-01-01',
-            'group_payment': True
+            'group_payment': True,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
 
         self.assertTrue(payments.is_reconciled)
@@ -329,7 +337,9 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         (out_invoice_1 + out_invoice_2).action_post()
         active_ids = (out_invoice_1 + out_invoice_2).ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2019-01-01', 'group_payment': True
+            'payment_date': '2019-01-01',
+            'group_payment': True,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -362,7 +372,9 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         (out_invoice_1 + out_invoice_2).action_post()
         active_ids = (out_invoice_1 + out_invoice_2).ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2019-01-01', 'group_payment': True
+            'payment_date': '2019-01-01',
+            'group_payment': True,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -395,7 +407,9 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         (out_invoice_1 + out_invoice_2).action_post()
         active_ids = (out_invoice_1 + out_invoice_2).ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2019-01-01', 'group_payment': True
+            'payment_date': '2019-01-01',
+            'group_payment': True,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -428,7 +442,9 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         (out_invoice_1 + out_invoice_2).action_post()
         active_ids = (out_invoice_1 + out_invoice_2).ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2019-01-01', 'group_payment': True
+            'payment_date': '2019-01-01',
+            'group_payment': True,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -534,10 +550,13 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         })
         bill.action_post()
 
-        payment = self.env['account.payment.register']\
-            .with_context(active_model='account.move', active_ids=bill.ids)\
-            .create({'payment_date': '2019-01-01'})\
-            ._create_payments()
+        payment = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=bill.ids,
+        ).create({
+            'payment_date': '2019-01-01',
+            'payment_method_line_id': self.inbound_payment_method_line.id,
+        })._create_payments()
 
         self.assertRecordValues(payment.move_id.line_ids.sorted('balance'), [
             # pylint: disable=bad-whitespace
@@ -801,7 +820,9 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         active_ids = (out_invoice_1 + out_invoice_2).ids
 
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2019-01-01', 'group_payment': False
+            'payment_date': '2019-01-01',
+            'group_payment': False,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
         self.assertTrue(all(payments.mapped('is_reconciled')))
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -841,7 +862,9 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         active_ids = (out_invoice_1 + out_invoice_2).ids
 
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2019-01-01', 'group_payment': False
+            'payment_date': '2019-01-01',
+            'group_payment': False,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
         self.assertTrue(all(payments.mapped('is_reconciled')))
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -1092,10 +1115,13 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         invoice.action_post()
 
         # Payment.
-        payment = self.env['account.payment.register']\
-            .with_context(active_model='account.move', active_ids=invoice.ids)\
-            .create({'payment_date': '2017-01-01'})\
-            ._create_payments()
+        payment = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice.ids,
+        ).create({
+            'payment_date': '2017-01-01',
+            'payment_method_line_id': self.inbound_payment_method_line.id,
+        })._create_payments()
 
         self.assertRecordValues(payment.move_id.line_ids.sorted('amount_currency'), [
             # Invoice's total:

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -181,8 +181,8 @@
                         <field name="reconciled_invoices_type" invisible="1"/>
                         <field name="company_id" invisible="1"/>
                         <field name="paired_internal_transfer_payment_id" invisible="1"/>
-                        <field name="available_journal_ids" invisible="1"/>
                         <field name="currency_id" invisible="1"/>
+                        <field name="journal_id" invisible="1"/>
 
                         <div class="oe_button_box" name="button_box">
                             <!-- Invoice stat button -->
@@ -270,15 +270,10 @@
                                 <field name="memo" string="Memo"/>
                             </group>
                             <group name="group2">
-                                <field name="journal_id"
-                                       domain="[('id', 'in', available_journal_ids)]"
-                                       readonly="state != 'draft'"/>
                                 <field name="payment_method_line_id"
-                                       context="{'hide_payment_journal_id': 1}"
                                        options="{'no_create': True, 'no_open': True}"
                                        required="1"
                                        readonly="state != 'draft'"/>
-
                                 <field name="partner_bank_id" string="Customer Bank Account"
                                       context="{'default_partner_id': partner_id, 'display_account_trust': True}"
                                         invisible="not show_partner_bank_account or partner_type != 'customer' or payment_type == 'inbound'"

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -26,6 +26,7 @@
                     <field name="currency_id" invisible="1" />
                     <field name="custom_user_amount" invisible="1" />
                     <field name="custom_user_currency_id" invisible="1" />
+                    <field name="journal_id" invisible="1"/>
 
                     <field name="show_partner_bank_account" invisible="1"/>
                     <field name="require_partner_bank_account" invisible="1"/>
@@ -56,10 +57,35 @@
                     </div>
                     <group>
                         <group name="group1">
-                            <field name="journal_id" options="{'no_open': True, 'no_create': True}" required="1"/>
+                            <label for="amount"/>
+                            <div name="amount_div" class="o_row">
+                                <field name="amount"
+                                 force_save="1"
+                                 readonly="not can_edit_wizard or can_group_payments and not group_payment"/>
+                                <field name="currency_id"
+                                       required="1"
+                                       options="{'no_create': True, 'no_open': True}"
+                                       invisible="not can_edit_wizard or can_group_payments and not group_payment"
+                                       groups="base.group_multi_currency"/>
+                            </div>
+                            <field
+                                name="installments_switch_html"
+                                string=""
+                                widget="account_payment_register_html"
+                                invisible="not installments_switch_html"
+                            />
+                            <field name="payment_date"/>
+                            <field name="communication"
+                                   invisible="not can_edit_wizard or (can_group_payments and not group_payment)"/>
+                        </group>
+                        <field name="qr_code" invisible="1"/>
+                        <div invisible="not qr_code" colspan="2" class="text-center">
+                            <field name="qr_code"/>
+                        </div>
+                        <group name="group2">
                             <field name="payment_method_line_id"
-                                   context="{'hide_payment_journal_id': 1}"
-                                   required="1"  options="{'no_create': True, 'no_open': True}"/>
+                                   required="1"  options="{'no_create': True, 'no_open': True}"
+                                   invisible="not can_edit_payment_method_line"/>
                             <field name="partner_bank_id"
                                    invisible="not show_partner_bank_account or not can_edit_wizard or (can_group_payments and not group_payment)"
                                    readonly="payment_type == 'inbound'"
@@ -103,32 +129,6 @@
                                 </div>
                             </div>
                         </group>
-                        <group name="group2">
-                            <label for="amount"/>
-                            <div name="amount_div" class="o_row">
-                                <field name="amount"
-                                 force_save="1"
-                                 readonly="not can_edit_wizard or can_group_payments and not group_payment"/>
-                                <field name="currency_id"
-                                       required="1"
-                                       options="{'no_create': True, 'no_open': True}"
-                                       invisible="not can_edit_wizard or can_group_payments and not group_payment"
-                                       groups="base.group_multi_currency"/>
-                            </div>
-                            <field
-                                name="installments_switch_html"
-                                string=""
-                                widget="account_payment_register_html"
-                                invisible="not installments_switch_html"
-                            />
-                            <field name="payment_date"/>
-                            <field name="communication"
-                                   invisible="not can_edit_wizard or (can_group_payments and not group_payment)"/>
-                        </group>
-                        <field name="qr_code" invisible="1"/>
-                        <div invisible="not qr_code" colspan="2" class="text-center">
-                            <field name="qr_code"/>
-                        </div>
                     </group>
                     <footer>
                         <button string="Create Payments" name="action_create_payments" type="object" class="oe_highlight" data-hotkey="q" invisible="total_payments_amount == 1"/>

--- a/addons/hr_expense/tests/common.py
+++ b/addons/hr_expense/tests/common.py
@@ -84,6 +84,14 @@ class TestExpenseCommon(AccountTestInvoicingCommon):
             'code': '610010',
             'name': 'Expense Account 1'
         })
+        # create expense outstanding account
+        cls.expense_outstanding_account = cls.env['account.account'].create({
+            'name': "Expense Outstanding Account",
+            'code': 'EXPO00',
+            'reconcile': True,
+            'account_type': 'asset_current',
+        })
+        cls.env.company.expense_outstanding_account_id = cls.expense_outstanding_account
 
     @classmethod
     def create_expenses(cls, values=None):

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -124,7 +124,7 @@ class TestExpenses(TestExpenseCommon):
         default_account_payable_id = self.company_data['default_account_payable'].id
         product_b_account_id = self.product_b.property_account_expense_id.id
         product_c_account_id = self.product_c.property_account_expense_id.id
-        company_payment_account_id = self.outbound_payment_method_line.payment_account_id.id
+        company_payment_account_id = self.expense_outstanding_account.id
         # One payment per expense
         self.assertRecordValues(all_expenses.account_move_id.line_ids.sorted(lambda line: (line.move_id, line)), [
             # own_account expense 1 move

--- a/addons/l10n_ar_withholding/tests/test_withholding_ar_ri.py
+++ b/addons/l10n_ar_withholding/tests/test_withholding_ar_ri.py
@@ -108,7 +108,9 @@ class TestL10nArWithholdingArRi(TestAr):
         return invoice
 
     def new_payment_register(self, move_ids, taxes):
-        wizard = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=move_ids.ids).create({'payment_date': '2023-01-01'})
+        wizard = (self.env['account.payment.register']
+            .with_context(active_model='account.move', active_ids=move_ids.ids)
+            .create({'payment_date': '2023-01-01', 'payment_method_line_id': self.inbound_payment_method_line.id}))
         wizard.l10n_ar_withholding_ids = [Command.clear()] + [Command.create({'tax_id': x['id'], 'base_amount': x['base_amount'], 'amount': 0}) for x in taxes]
         wizard.l10n_ar_withholding_ids._compute_amount()
         return wizard
@@ -201,6 +203,7 @@ class TestL10nArWithholdingArRi(TestAr):
         taxes = [{'id': self.tax_wth_test_1.id, 'base_amount': 5}, {'id': self.tax_wth_test_2.id, 'base_amount': 6.05}]
         wizard = self.new_payment_register(moves, [])
         wizard.currency_id = self.other_currency.id
+        wizard.payment_method_line_id = self.inbound_payment_method_line
         wizard.amount = 6.05
         wizard.l10n_ar_withholding_ids = [Command.clear()] + [Command.create({'tax_id': x['id'], 'base_amount': x['base_amount'], 'amount': 0}) for x in taxes]
         wizard.l10n_ar_withholding_ids._compute_amount()
@@ -300,6 +303,7 @@ class TestL10nArWithholdingArRi(TestAr):
             'payment_date': '2023-01-01',
             'currency_id': self.company_data['currency'].id,
             'l10n_ar_withholding_ids': [Command.create({'tax_id': self.tax_wth_test_1.id, 'base_amount': sum(in_invoice_wht.mapped('amount_untaxed')), 'amount': 0})],
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })
         wizard.l10n_ar_withholding_ids._compute_amount()
         action = wizard.action_create_payments()
@@ -335,6 +339,7 @@ class TestL10nArWithholdingArRi(TestAr):
             'payment_date': '2023-01-01',
             'currency_id': self.other_currency.id,
             'l10n_ar_withholding_ids': [Command.create({'tax_id': self.tax_wth_test_1.id, 'base_amount': sum(in_invoice_wht.mapped('amount_untaxed')), 'amount': 0})],
+            'payment_method_line_id': self.inbound_payment_method_line.id,
         })
         wizard.l10n_ar_withholding_ids._compute_amount()
         action = wizard.action_create_payments()

--- a/addons/l10n_hu_edi/tests/test_invoice_xml.py
+++ b/addons/l10n_hu_edi/tests/test_invoice_xml.py
@@ -85,7 +85,12 @@ class L10nHuEdiTestInvoiceXml(L10nHuEdiTestCommon):
 
         # Pay advance invoice on 2024-01-15.
         with freeze_time('2024-01-15'):
-            self.env['account.payment.register'].with_context(active_ids=advance_invoice.ids, active_model='account.move').create({})._create_payments()
+            self.env['account.payment.register'].with_context(
+                active_ids=advance_invoice.ids,
+                active_model='account.move'
+            ).create({
+                'payment_method_line_id': self.inbound_payment_method_line.id
+            })._create_payments()
 
         # Issue final invoice on 2024-02-01. The XML should report 2024-01-15 as the date of advance payment.
         with freeze_time('2024-02-01'):

--- a/addons/l10n_latam_check/tests/test_own_checks.py
+++ b/addons/l10n_latam_check/tests/test_own_checks.py
@@ -13,7 +13,6 @@ class TestOwnChecks(L10nLatamCheckTest):
 
         with Form(self.env['account.payment'].with_context(default_payment_type='outbound')) as payment_form:
             payment_form.partner_id = self.partner_a
-            payment_form.journal_id = self.bank_journal
             payment_form.payment_method_line_id = self.bank_journal._get_available_payment_method_lines(
                 'outbound').filtered(lambda x: x.code == 'own_checks')[0]
             payment_form.memo = 'Deferred check'
@@ -45,7 +44,6 @@ class TestOwnChecks(L10nLatamCheckTest):
 
         with Form(self.env['account.payment'].with_context(default_payment_type='outbound')) as payment_form:
             payment_form.partner_id = self.partner_a
-            payment_form.journal_id = self.bank_journal
             payment_form.payment_method_line_id = self.bank_journal._get_available_payment_method_lines(
                 'outbound').filtered(lambda x: x.code == 'own_checks')[0]
 

--- a/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -378,10 +378,12 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
         bill.action_post()
 
         # Register a payment creating the CABA journal entry on the fly and reconcile it with the tax line.
-        self.env['account.payment.register']\
-            .with_context(active_ids=bill.ids, active_model='account.move')\
-            .create({})\
-            ._create_payments()
+        self.env['account.payment.register'].with_context(
+            active_ids=bill.ids,
+            active_model='account.move',
+        ).create({
+            'payment_method_line_id': self.inbound_payment_method_line.id,
+        })._create_payments()
 
         partial_rec = bill.mapped('line_ids.matched_debit_ids')
         caba_move = self.env['account.move'].search([('tax_cash_basis_rec_id', '=', partial_rec.id)])

--- a/addons/spreadsheet_account/tests/test_residual_amount.py
+++ b/addons/spreadsheet_account/tests/test_residual_amount.py
@@ -66,6 +66,7 @@ class SpreadsheetAccountingFunctionsTest(AccountTestInvoicingCommon):
             'partner_type': 'customer',
             'partner_id': cls.partner_a.id,
             'date': '2022-02-10',
+            'payment_method_line_id': cls.inbound_payment_method_line.id,
         })
 
         cls.payment_move_23 = cls.env['account.payment'].create({
@@ -74,6 +75,7 @@ class SpreadsheetAccountingFunctionsTest(AccountTestInvoicingCommon):
             'partner_type': 'customer',
             'partner_id': cls.partner_a.id,
             'date': '2023-02-10',
+            'payment_method_line_id': cls.outbound_payment_method_line.id,
         })
 
         # Post the move and payment and reconcile them


### PR DESCRIPTION
**Before**

[Journals]
- inbound/outbound manual payment lines were generated for all journals

[Pay wizard / Payment form view / Batch payment form] 
- journal could be chosen and was mandatory and would decide what payment method lines were shown

**Now**

[General] 
- only one set of inbound/outbound 'Manual' payment method lines are generated, not linked to any journals

[Pay wizard / Payment form view / Batch payment form] 
- journal field is removed, now all payment method lines available are shown with their corresponding journal
- default payment method chosen is the new 'Manual' payment method line
- field positioning is readjusted

https://github.com/odoo/enterprise/pull/78405
task-4460456