### PR TITLE
[FIX] account_peppol: Fix the messaged displayed on Peppol error

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -200,7 +200,7 @@ class AccountEdiProxyClientUser(models.Model):
                         # this rare edge case can happen if the participant is not active on the proxy side
                         # in this case we can't get information about the invoices
                         edi_user_moves.peppol_move_state = 'error'
-                        log_message = _("Peppol error: %s", content['message'])
+                        log_message = _("Peppol error: %s", content.get('display_message', content['message']))
                         edi_user_moves._message_log_batch(bodies={move.id: log_message for move in edi_user_moves})
                         break
 
@@ -212,7 +212,7 @@ class AccountEdiProxyClientUser(models.Model):
                             continue
 
                         move.peppol_move_state = 'error'
-                        move._message_log(body=_("Peppol error: %s", content['error']['message']))
+                        move._message_log(body=_("Peppol error: %s", content['error'].get('display_message', content['message'])))
                         continue
 
                     move.peppol_move_state = content['state']


### PR DESCRIPTION
When an error occurs on IAP side for Peppol we display the content of `message` while we have a more friendly-user text stored in `display_message`. Use the latter when logging in Odoo.

See: https://github.com/odoo/iap-apps/blob/5dde71627dfd6c6168935346bece0018d4701ce3/iap_services/peppol_proxy/exceptions.py#L14
task-no
