### PR TITLE
[IMP] account: account analytic plans

### DIFF
--- a/addons/account/models/account_analytic_plan.py
+++ b/addons/account/models/account_analytic_plan.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
+import re
 
-from odoo import fields, models, api
+from odoo import _, fields, models, api
 
 
 class AccountAnalyticApplicability(models.Model):
@@ -18,7 +19,7 @@ class AccountAnalyticApplicability(models.Model):
         },
     )
     account_prefix = fields.Char(
-        string='Financial Accounts Prefix',
+        string='Financial Accounts Prefixes',
         help="Prefix that defines which accounts from the financial accounting this applicability should apply on.",
     )
     product_categ_id = fields.Many2one(
@@ -29,6 +30,32 @@ class AccountAnalyticApplicability(models.Model):
         compute='_compute_display_account_prefix',
         help='Defines if the field account prefix should be displayed'
     )
+    account_prefix_placeholder = fields.Char(compute='_compute_prefix_placeholder')
+
+    @api.depends('account_prefix', 'business_domain')
+    def _compute_prefix_placeholder(self):
+        account_expense = self.env['account.account'].search([('account_type', '=', 'expense')], limit=1)
+        account_income = self.env['account.account'].search([('account_type', '=', 'income')], limit=1)
+
+        for applicability in self:
+            if applicability.business_domain == 'bill':
+                account = account_expense
+                account_prefixes = "60, 61, 62"
+            else:
+                account = account_income
+                account_prefixes = "40, 41, 42"
+
+            if account and account.code:
+                prefix_base = account.code[:2]
+                try:
+                    # Convert prefix_base to an integer for numerical manipulation
+                    prefix_num = int(prefix_base)
+                    account_prefixes = f"{prefix_num}, {prefix_num + 1}, {prefix_num + 2}"
+
+                except ValueError:
+                    pass
+
+            applicability.account_prefix_placeholder = _("e.g. %(prefix)s", prefix=account_prefixes)
 
     def _get_score(self, **kwargs):
         score = super(AccountAnalyticApplicability, self)._get_score(**kwargs)
@@ -37,7 +64,8 @@ class AccountAnalyticApplicability(models.Model):
         product = self.env['product.product'].browse(kwargs.get('product', None))
         account = self.env['account.account'].browse(kwargs.get('account', None))
         if self.account_prefix:
-            if account and account.code.startswith(self.account_prefix):
+            account_prefixes = tuple(prefix for prefix in re.split("[,;]", self.account_prefix.replace(" ", "")) if prefix)
+            if account and account.code.startswith(account_prefixes):
                 score += 1
             else:
                 return -1

--- a/addons/account/models/account_analytic_plan.py
+++ b/addons/account/models/account_analytic_plan.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import re
 
 from odoo import _, fields, models, api
@@ -61,8 +60,8 @@ class AccountAnalyticApplicability(models.Model):
         score = super(AccountAnalyticApplicability, self)._get_score(**kwargs)
         if score == -1:
             return -1
-        product = self.env['product.product'].browse(kwargs.get('product', None))
-        account = self.env['account.account'].browse(kwargs.get('account', None))
+        product = self.env['product.product'].browse(kwargs.get('product'))
+        account = self.env['account.account'].browse(kwargs.get('account'))
         if self.account_prefix:
             account_prefixes = tuple(prefix for prefix in re.split("[,;]", self.account_prefix.replace(" ", "")) if prefix)
             if account and account.code.startswith(account_prefixes):

--- a/addons/account/tests/test_account_analytic.py
+++ b/addons/account/tests/test_account_analytic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.analytic.tests.common import AnalyticCommon
 from odoo.tests import tagged, Form

--- a/addons/account/tests/test_account_analytic.py
+++ b/addons/account/tests/test_account_analytic.py
@@ -340,3 +340,66 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon, AnalyticCommon):
 
         invoice.invoice_line_ids.account_id = accounts_by_code.get('641000')
         self.assertEqual(invoice.invoice_line_ids.analytic_distribution, {str(self.analytic_account_4.id): 100})
+
+    def test_analytic_applicability_multiple_prefixes(self):
+        # This applicability should block all invoices with lines having account_code who starts with '40' or '41'
+        self.env['account.analytic.applicability'].create([
+            {
+                'business_domain': 'invoice',
+                'applicability': 'mandatory',
+                'analytic_plan_id': self.analytic_plan_2.id,
+                'company_id': self.env.company.id,
+                'account_prefix': '40, 41',
+            }
+        ])
+
+        account_analytic = self.env['account.analytic.account'].search([('plan_id', '=', self.analytic_plan_2.id)], limit=1)
+
+        account_invoice_1, account_invoice_2 = self.env['account.account'].create([
+            {
+                'code': '400300',
+                'name': 'My first invoice Account',
+            },
+            {
+                'code': '410300',
+                'name': 'My second invoice Account',
+            },
+        ])
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_b.id,
+            'date': '2017-01-01',
+            'invoice_date': '2017-01-01',
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 200.0,
+                    'account_id': account_invoice_1.id,
+                }),
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 200.0,
+                    'account_id': account_invoice_2.id,
+                })
+            ]
+        })
+
+        # This invoice should be blocked as there is no analytic plans on lines
+        with self.assertRaisesRegex(ValidationError, '100% analytic distribution.'):
+            invoice.with_context({'validate_analytic': True}).action_post()
+
+        invoice.line_ids.filtered(lambda line: line.account_id.code.startswith('40'))[0].write({
+            'analytic_distribution': {account_analytic.id: 100}
+        })
+
+        # This invoice should be blocked because one line is missing plans
+        with self.assertRaisesRegex(ValidationError, '100% analytic distribution.'):
+            invoice.with_context({'validate_analytic': True}).action_post()
+
+        invoice.line_ids.filtered(lambda line: line.account_id.code.startswith('41'))[0].write({
+            'analytic_distribution': {account_analytic.id: 100}
+        })
+
+        # This invoice should not be blocked, as all lines have plans
+        invoice.with_context({'validate_analytic': True}).action_post()

--- a/addons/account/views/account_analytic_plan_views.xml
+++ b/addons/account/views/account_analytic_plan_views.xml
@@ -9,7 +9,11 @@
                 <data>
                     <xpath expr="//field[@name='applicability_ids']//field[@name='business_domain']" position="after">
                         <field name="display_account_prefix" column_invisible="True"/>
-                        <field name="account_prefix" invisible="not display_account_prefix"/>
+                        <field name="account_prefix_placeholder" column_invisible="True"/>
+                        <field name="account_prefix"
+                               widget="char_with_placeholder_field"
+                               options="{'placeholder_field': 'account_prefix_placeholder'}"
+                               invisible="not display_account_prefix"/>
                         <field name="product_categ_id"/>
                     </xpath>
                 </data>


### PR DESCRIPTION
This commit allows the user to put multiple accounts prefix on a single analytic plan line.

So, if the user want to add the accounts 51000, 61000 and 71000, he can now add this: 51, 61, 71 in the same line.

task-4294662