### PR TITLE
[FIX] mail: livechat from visitor stays open in mobile

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -161,7 +161,6 @@ class LivechatController(http.Controller):
                     operator, ["avatar_128", "user_livechat_username"]
                 ),
                 "name": channel_vals["name"],
-                "open_chat_window": True,
                 "scrollUnread": False,
                 "channel_type": "livechat",
                 "chatbot": chatbot_data,
@@ -189,7 +188,6 @@ class LivechatController(http.Controller):
                 channel,
                 extra_fields={
                     "isLoaded": not chatbot_script,
-                    "open_chat_window": True,
                     "scrollUnread": False,
                 },
             )

--- a/addons/im_livechat/static/tests/chat_window_patch.test.js
+++ b/addons/im_livechat/static/tests/chat_window_patch.test.js
@@ -9,6 +9,30 @@ import { rpc } from "@web/core/network/rpc";
 describe.current.tags("desktop");
 defineLivechatModels();
 
+test.tags("mobile");
+test("can fold livechat chat windows in mobile", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Visitor" });
+    pyEnv["res.users"].create([{ partner_id: partnerId }]);
+    pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({
+                unpin_dt: false,
+                partner_id: serverState.partnerId,
+            }),
+            Command.create({ partner_id: partnerId }),
+        ],
+        channel_type: "livechat",
+    });
+    await start();
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await click(".o-mail-NotificationItem", { text: "Visitor" });
+    await click(".o-mail-ChatWindow-command[title*='Fold']", {
+        parent: [".o-mail-ChatWindow", { text: "Visitor" }],
+    });
+    await contains(".o-mail-ChatBubble");
+});
+
 test("closing a chat window with no message from admin side unpins it", async () => {
     const pyEnv = await startServer();
     const [partnerId_1, partnerId_2] = pyEnv["res.partner"].create([

--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -8,6 +8,7 @@ import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { ChatBubble } from "./chat_bubble";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 export class ChatHub extends Component {
     static components = { ChatBubble, ChatWindow, Dropdown };
@@ -48,6 +49,10 @@ export class ChatHub extends Component {
         });
     }
 
+    get isMobileOS() {
+        return isMobileOS();
+    }
+
     onResize() {
         this.chatHub.onRecompute();
     }
@@ -70,7 +75,7 @@ export class ChatHub extends Component {
     }
 
     get isShown() {
-        return !this.ui.isSmall;
+        return true;
     }
 
     expand() {

--- a/addons/mail/static/src/core/common/chat_hub.scss
+++ b/addons/mail/static/src/core/common/chat_hub.scss
@@ -12,7 +12,7 @@
 }
 
 .o-mail-ChatHub-bubbleBtn {
-    padding: 0;
+    padding: 0 !important;
     border: none !important;
     border-radius: 50%;
     box-shadow: $box-shadow-sm;

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -8,14 +8,14 @@
                 <ChatWindow chatWindow="cw" right="env.embedLivechat ? chatHub.WINDOW_GAP : (chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (chatHub.opened.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2))"/>
             </t>
         </t>
-        <div t-if="isShown" class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto', 'o-liftUp': busMonitoring.hasConnectionIssues }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
+        <div class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto', 'o-liftUp': busMonitoring.hasConnectionIssues }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
             <div class="d-flex flex-column align-content-start justify-content-end align-items-center gap-1">
                 <t t-if="store.chatHub.compact">
                     <t t-call="mail.ChatHub.compactButton"/>
                 </t>
                 <t t-else="">
                     <Dropdown t-if="(chatHub.opened.length + chatHub.folded.length) gt 0" state="options" position="'top-end'" menuClass="'o-mail-ChatHub-optionsMenu o-mail-ChatHub-menu d-flex flex-column bg-view shadow-sm m-0 p-0 mb-1'">
-                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-view mt-1" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !options.isOpen, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"/>
+                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-view mt-1" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !options.isOpen and !isMobileOS, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"/>
                         <t t-set-slot="content">
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.compact = true"><i class="fa fa-fw fa-eye-slash ms-1"></i>Hide all conversations</button>
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close ms-1"></i>Close all conversations</button>

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -143,7 +143,7 @@ export class ChatWindow extends Component {
 
     toggleFold() {
         const chatWindow = toRaw(this.props.chatWindow);
-        if (this.ui.isSmall || this.state.actionsMenuOpened) {
+        if (this.state.actionsMenuOpened) {
             return;
         }
         chatWindow.fold();

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -9,7 +9,7 @@ export const threadActionsRegistry = registry.category("mail.thread/actions");
 threadActionsRegistry
     .add("fold-chat-window", {
         condition(component) {
-            return !component.ui.isSmall && component.props.chatWindow;
+            return component.props.chatWindow;
         },
         icon: "fa fa-fw fa-minus",
         name(component) {
@@ -103,6 +103,9 @@ function transformAction(component, id, action) {
         },
         /** Condition to display this action. */
         get condition() {
+            if (action.condition === undefined) {
+                return true;
+            }
             return action.condition(component);
         },
         /** Condition to disable the button of this action (but still display it). */


### PR DESCRIPTION
Before this commit, when using livechat by visitor in mobile, any page reload would remove access to the livechat.

Steps to reproduce:
- access to website with livechat installed on mobile
- click on livechat button (bubble icon in bottom right)
- send a message
- reload the page

=> the livechat is not open, not even as a chat bubble.

This prevents visitor from access the livechat again, except if user finds a workaround to open the same page in non-mobile mode (e.g. landscape mode or disabling high-dpi).

This happens because livechat relies on discuss chat hub, and there's some code to prevent server-side synchronisation of chat windows and bubbles in mobile. As a reminder, conversation in mobile are shown as fullscreen chat windows.
This code was preventing the opening of chat window on livechat for visitor, leading to prevention of continuing to live chat on the device.

This commit fixes by adding fold action to chat windows in mobile, thus allowing to have chat bubbles in mobile. This fixes allow to show chat windows as bubbles to livechat visitors, which is the primary fix of these changes.

opw-4423556
opw-4488830

18.0 version: https://github.com/odoo/odoo/pull/194363