### PR TITLE
[FIX] accounting: Setting reconcile false for Bank and Cash type accounts explicitly.

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -442,6 +442,8 @@ class AccountAccount(models.Model):
                 account.reconcile = False
             elif account.account_type in ('asset_receivable', 'liability_payable'):
                 account.reconcile = True
+            elif account.account_type == 'asset_cash':
+                account.reconcile = False
             # For other asset/liability accounts, don't do any change to account.reconcile.
 
     def _set_opening_debit(self):


### PR DESCRIPTION
Behavior Before the Commit:
Whenever you change the account type of a Cash and Bank account to a different type,
please ensure that the Reconcile option is set to True. However, if you later switch
the account type back to Cash and Bank, the Reconcile option will remain True and
will not automatically revert to False.
    
Fix: explicitly set reconcile to False for account_type 'Cash and Bank' in compute_reconcile
method.

Behavior After the commit:
Reconcile will be changed to false on changing the account type to Cash and Bank.

opw-4450088: https://www.odoo.com/odoo/my-support-tasks/4450088
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
