### PR TITLE
[FIX] web_tour: restore tour_automatic unit tests

### DIFF
--- a/addons/web_tour/__manifest__.py
+++ b/addons/web_tour/__manifest__.py
@@ -27,8 +27,7 @@ Odoo Web tours.
             'web/static/lib/hoot-dom/**/*',
         ],
         'web.assets_unit_tests': [
-            # TODO: PIPU/JUM must be reactivated when Script timeout exceeded due to Hoot is fixed.
-            # 'web_tour/static/tests/tour_automatic.test.js',
+            'web_tour/static/tests/tour_automatic.test.js',
             'web_tour/static/tests/tour_interactive.test.js',
             'web_tour/static/tests/tour_recorder.test.js',
         ],

--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -5,7 +5,6 @@ import { Macro } from "@web/core/macro";
 import { browser } from "@web/core/browser/browser";
 import { setupEventActions } from "@web/../lib/hoot-dom/helpers/events";
 import * as hoot from "@odoo/hoot-dom";
-import { patch } from "@web/core/utils/patch";
 
 export class TourAutomatic {
     mode = "auto";
@@ -36,78 +35,83 @@ export class TourAutomatic {
         setupEventActions(document.createElement("div"));
         const macroSteps = this.steps
             .filter((step) => step.index >= this.currentIndex)
-            .flatMap((step) => {
-                return [
-                    {
-                        action: async () => {
-                            if (this.debugMode) {
-                                console.groupCollapsed(step.describeMe);
-                                console.log(step.stringify);
+            .flatMap((step) => [
+                {
+                    action: async () => {
+                        if (this.debugMode) {
+                            console.groupCollapsed(step.describeMe);
+                            console.log(step.stringify);
+                        } else {
+                            console.log(step.describeMe);
+                        }
+                        if (step.break && this.debugMode) {
+                            // eslint-disable-next-line no-debugger
+                            debugger;
+                        }
+                        // This delay is important for making the current set of tour tests pass.
+                        // IMPROVEMENT: Find a way to remove this delay.
+                        await new Promise((resolve) => requestAnimationFrame(resolve));
+                        if (this.config.stepDelay > 0) {
+                            await hoot.delay(this.config.stepDelay);
+                        }
+                    },
+                },
+                {
+                    initialDelay: () => (this.previousStepIsJustACheck ? 0 : null),
+                    trigger: step.trigger ? () => step.findTrigger() : null,
+                    timeout: (step.timeout || 10000) + this.config.stepDelay,
+                    action: async () => {
+                        if (this.checkForUndeterminisms) {
+                            await step.checkForUndeterminisms();
+                        }
+                        this.previousStepIsJustACheck = !this.currentStep.hasAction;
+                        if (this.debugMode) {
+                            if (!step.skipped && this.showPointerDuration > 0 && step.element) {
+                                // Useful in watch mode.
+                                pointer.pointTo(step.element, this);
+                                await hoot.delay(this.showPointerDuration);
+                                pointer.hide();
+                            }
+                            console.log(step.element);
+                            if (step.skipped) {
+                                console.log("This step has been skipped");
                             } else {
-                                console.log(step.describeMe);
+                                console.log("This step has run successfully");
                             }
-                            if (step.break && this.debugMode) {
-                                // eslint-disable-next-line no-debugger
-                                debugger;
-                            }
-                            // This delay is important for making the current set of tour tests pass.
-                            // IMPROVEMENT: Find a way to remove this delay.
-                            await new Promise((resolve) => requestAnimationFrame(resolve));
-                            if (this.config.stepDelay > 0) {
-                                await hoot.delay(this.config.stepDelay);
-                            }
-                        },
+                            console.groupEnd();
+                        }
+                        const result = await step.doAction();
+                        if (step.pause && this.debugMode) {
+                            await this.pause();
+                        }
+                        tourState.setCurrentIndex(step.index + 1);
+                        return result;
                     },
-                    {
-                        initialDelay: () => {
-                            return this.previousStepIsJustACheck ? 0 : null;
-                        },
-                        trigger: step.trigger ? () => step.findTrigger() : null,
-                        timeout: (step.timeout || 10000) + this.config.stepDelay,
-                        action: async () => {
-                            if (this.checkForUndeterminisms) {
-                                await step.checkForUndeterminisms();
-                            }
-                            this.previousStepIsJustACheck = !this.currentStep.hasAction;
-                            if (this.debugMode) {
-                                if (!step.skipped && this.showPointerDuration > 0 && step.element) {
-                                    // Useful in watch mode.
-                                    pointer.pointTo(step.element, this);
-                                    await hoot.delay(this.showPointerDuration);
-                                    pointer.hide();
-                                }
-                                console.log(step.element);
-                                if (step.skipped) {
-                                    console.log("This step has been skipped");
-                                } else {
-                                    console.log("This step has run successfully");
-                                }
-                                console.groupEnd();
-                            }
-                            const result = await step.doAction();
-                            if (step.pause && this.debugMode) {
-                                await this.pause();
-                            }
-                            tourState.setCurrentIndex(step.index + 1);
-                            return result;
-                        },
-                    },
-                ];
-            });
+                },
+            ]);
 
         const end = () => {
-            //Tour is finished, it's too late to console.
-            patch(console, {
-                error: () => {},
-                warn: () => {},
-            });
             delete window.hoot;
             transitionConfig.disabled = false;
             tourState.clear();
             pointer.stop();
             //No need to catch error yet.
-            window.addEventListener("error", (ev) => ev.preventDefault());
-            window.addEventListener("unhandledrejection", (ev) => ev.preventDefault());
+            window.addEventListener(
+                "error",
+                (ev) => {
+                    ev.preventDefault();
+                    ev.stopImmediatePropagation();
+                },
+                true
+            );
+            window.addEventListener(
+                "unhandledrejection",
+                (ev) => {
+                    ev.preventDefault();
+                    ev.stopImmediatePropagation();
+                },
+                true
+            );
         };
 
         this.macro = new Macro({


### PR DESCRIPTION
In [1], we commented out the tour_automatic unit test file in the
manifest to merge this PR as soon as possible. In this commit,
we uncomment this file.
The solution is to not patch browser.console because it can cause big
problems in the Hoot unit test engine.