### PR TITLE
[FIX] event_sale: failed payment on soldout events

### DIFF
--- a/addons/event_sale/__manifest__.py
+++ b/addons/event_sale/__manifest__.py
@@ -24,6 +24,7 @@ this event.
         'views/event_registration_views.xml',
         'views/event_views.xml',
         'views/sale_order_views.xml',
+        'views/templates.xml',
         'data/event_sale_data.xml',
         'data/mail_templates.xml',
         'report/event_event_templates.xml',

--- a/addons/event_sale/views/templates.xml
+++ b/addons/event_sale/views/templates.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="sale_order_portal_template" inherit_id="sale.sale_order_portal_template" name="Event sale order portal">
+        <xpath expr="//div[@t-if='sale_order.is_expired']" position="before">
+            <div t-if="sale_order.has_soldout_event" class="alert alert-warning alert-dismissible d-print-none" role="alert">
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="close"></button>
+                <strong>The event is sold out!</strong> <a role="button" href="#discussion"><i class="fa fa-comment"/> Contact us for more information.</a>
+            </div>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
versions 16, 17, 18 and master. Indeed from v17, the attendees are registered by default with no need of flag.

When there's a quotation for events registrations and the seats are limited, if the customer pays the quoutation the payment will fail when the quoutation gets confirmed.

With this change we prevent the customer from paying that event that is soldout.

Steps to reproduce:

- Limit the seats for a given event.
- Set autoconfirmation on
- Create a quotation for a ticket in that event.
- Use the customer preview link to go to the portal view.
- Pay the quotation (i.e. with demo payment method)
- The confirmation crashes as there aren't seats available.

This is an issue as well as the payment is already fulfilled at bank level, but as the system crashes the callback isn't confirmed at Odoo.

cc @Tecnativa @pedrobaeza TT54556



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
