### PR TITLE
[FIX] l10n_es_tbai_multi_refund: fix non-bizkaia situation

### DIFF
--- a/addons/l10n_es_edi_tbai/data/template_invoice.xml
+++ b/addons/l10n_es_edi_tbai/data/template_invoice.xml
@@ -96,7 +96,6 @@
                     </FacturaRectificativa>
                     <FacturasRectificadasSustituidas>
                         <IDFacturaRectificadaSustituida>
-                            <!-- NOTE: could support issuing a single credit note for multiple invoices (optional) -->
                             <t t-set="seq_and_num" t-value="credit_note_invoice._get_l10n_es_tbai_sequence_and_number()"/>
                             <SerieFactura t-out="seq_and_num[0]"/>
                             <NumFactura t-out="seq_and_num[1]"/>

--- a/addons/l10n_es_edi_tbai/i18n/es.po
+++ b/addons/l10n_es_edi_tbai/i18n/es.po
@@ -6,18 +6,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-09 09:10+0000\n"
-"PO-Revision-Date: 2023-08-09 09:10+0000\n"
-"Last-Translator: \n"
+"POT-Creation-Date: 2025-01-28 11:10+0000\n"
+"PO-Revision-Date: 2025-01-28 11:13+0000\n"
+"Last-Translator: Jairo Llopis <jairo@moduon.team>\n"
 "Language-Team: \n"
-"Language: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: \n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.4\n"
 
 #. module: l10n_es_edi_tbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner
+#: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner_recibidas
 msgid "1.0"
 msgstr "1.0"
 
@@ -28,6 +30,7 @@ msgstr "1.1"
 
 #. module: l10n_es_edi_tbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner
+#: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner_recibidas
 msgid "240"
 msgstr "240"
 
@@ -255,11 +258,6 @@ msgid "R5: Factura rectificativa en facturas simplificadas"
 msgstr "R5: Factura rectificativa en facturas simplificadas"
 
 #. module: l10n_es_edi_tbai
-#: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_invoice_desglose
-msgid "RL"
-msgstr "RL"
-
-#. module: l10n_es_edi_tbai
 #. odoo-python
 #: code:addons/l10n_es_edi_tbai/models/account_edi_format.py:0
 #, python-format
@@ -282,11 +280,6 @@ msgstr ""
 #, python-format
 msgid "Refund reason must be specified (TicketBAI)"
 msgstr "Se debe especificar el motivo del reembolso (TicketBai)"
-
-#. module: l10n_es_edi_tbai
-#: model:ir.model,name:l10n_es_edi_tbai.model_ir_actions_report
-msgid "Report Action"
-msgstr "Reportar acción"
 
 #. module: l10n_es_edi_tbai
 #. odoo-python
@@ -392,12 +385,19 @@ msgstr "Se requiere TicketBai"
 #. odoo-python
 #: code:addons/l10n_es_edi_tbai/models/account_edi_format.py:0
 #, python-format
+msgid "TicketBAI: Cannot post a refund without source documents"
+msgstr "TicketBAI: No se puede contabilizar un abono sin documentos de origen"
+
+#. module: l10n_es_edi_tbai
+#. odoo-python
+#: code:addons/l10n_es_edi_tbai/models/account_edi_format.py:0
+#, python-format
 msgid ""
-"TicketBAI: Cannot post a reversal move while the source document (%s) has "
-"not been posted"
+"TicketBAI: Cannot post a reversal move if its source documents (%s) have not "
+"been posted"
 msgstr ""
-"TicketBAI: No se puede contabilizar un movimiento de anulación mientras no "
-"se haya contabilizado el documento de origen (%s)"
+"TicketBAI: No se puede contabilizar un abono mientras no se hayan "
+"contabilizado sus documentos de origen (%s)"
 
 #. module: l10n_es_edi_tbai
 #. odoo-python

--- a/addons/l10n_es_edi_tbai/i18n/l10n_es_edi_tbai.pot
+++ b/addons/l10n_es_edi_tbai/i18n/l10n_es_edi_tbai.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-09 09:10+0000\n"
-"PO-Revision-Date: 2023-08-09 09:10+0000\n"
+"POT-Creation-Date: 2025-01-28 11:10+0000\n"
+"PO-Revision-Date: 2025-01-28 11:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,6 +17,7 @@ msgstr ""
 
 #. module: l10n_es_edi_tbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner
+#: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner_recibidas
 msgid "1.0"
 msgstr ""
 
@@ -27,6 +28,7 @@ msgstr ""
 
 #. module: l10n_es_edi_tbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner
+#: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner_recibidas
 msgid "240"
 msgstr ""
 
@@ -246,11 +248,6 @@ msgid "R5: Factura rectificativa en facturas simplificadas"
 msgstr ""
 
 #. module: l10n_es_edi_tbai
-#: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_invoice_desglose
-msgid "RL"
-msgstr ""
-
-#. module: l10n_es_edi_tbai
 #. odoo-python
 #: code:addons/l10n_es_edi_tbai/models/account_edi_format.py:0
 #, python-format
@@ -269,11 +266,6 @@ msgstr ""
 #: code:addons/l10n_es_edi_tbai/models/account_edi_format.py:0
 #, python-format
 msgid "Refund reason must be specified (TicketBAI)"
-msgstr ""
-
-#. module: l10n_es_edi_tbai
-#: model:ir.model,name:l10n_es_edi_tbai.model_ir_actions_report
-msgid "Report Action"
 msgstr ""
 
 #. module: l10n_es_edi_tbai
@@ -378,9 +370,16 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_es_edi_tbai/models/account_edi_format.py:0
 #, python-format
+msgid "TicketBAI: Cannot post a refund without source documents"
+msgstr ""
+
+#. module: l10n_es_edi_tbai
+#. odoo-python
+#: code:addons/l10n_es_edi_tbai/models/account_edi_format.py:0
+#, python-format
 msgid ""
-"TicketBAI: Cannot post a reversal move while the source document (%s) has "
-"not been posted"
+"TicketBAI: Cannot post a reversal move if its source documents (%s) have not"
+" been posted"
 msgstr ""
 
 #. module: l10n_es_edi_tbai

--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -96,6 +96,9 @@ class AccountEdiFormat(models.Model):
 
         return errors
 
+    def _l10n_es_tbai_refunded_invoices(self, invoice):
+        return invoice.reversed_entry_id
+
     def _l10n_es_tbai_post_invoice_edi(self, invoice):
         # EXTENDS account_edi
         if self.code != 'es_tbai':
@@ -112,13 +115,20 @@ class AccountEdiFormat(models.Model):
             error_msg = ''
             if chain_head and chain_head != invoice and not chain_head._l10n_es_tbai_is_in_chain():
                 error_msg = _("TicketBAI: Cannot post invoice while chain head (%s) has not been posted", chain_head.name)
-            if (
-                invoice.move_type == 'out_refund'
-                and not invoice.reversed_entry_id or (
-                    not invoice.reversed_entry_id._l10n_es_tbai_is_in_chain()
-                    and invoice.reversed_entry_id.edi_document_ids.filtered(lambda d: d.edi_format_id.code == 'es_tbai'))  # avoid imported ones
-            ):
-                error_msg = _("TicketBAI: Cannot post a reversal move while the source document (%s) has not been posted", invoice.reversed_entry_id.name)
+            if invoice.move_type == 'out_refund':
+                refunded_invoices = self._l10n_es_tbai_refunded_invoices(invoice)
+                if not refunded_invoices:
+                    error_msg = _("TicketBAI: Cannot post a refund without source documents")
+                else:
+                    invalid_refunds = refunded_invoices.filtered(lambda inv:
+                        not inv._l10n_es_tbai_is_in_chain()
+                        and inv.edi_document_ids.filtered(lambda d: d.edi_format_id.code == 'es_tbai')  # avoid imported ones
+                    )
+                    if invalid_refunds:
+                        error_msg = _(
+                            "TicketBAI: Cannot post a reversal move if its source documents (%s) have not been posted",
+                            ', '.join(invalid_refunds.mapped('name'))
+                        )
 
             # Tax configuration check: In case of foreign customer we need the tax scope to be set
             com_partner = invoice.commercial_partner_id

--- a/addons/l10n_es_edi_tbai_multi_refund/data/template_LROE_bizkaia.xml
+++ b/addons/l10n_es_edi_tbai_multi_refund/data/template_LROE_bizkaia.xml
@@ -2,12 +2,23 @@
 <data>
     <template id="template_LROE_240_inner_recibidas" inherit_id="l10n_es_edi_tbai.template_LROE_240_inner_recibidas">
         <xpath expr="//FacturasRectificadasSustituidas" position="attributes">
-            <attribute name="t-if" value="credit_note_invoices"/>
+            <attribute name="t-if">credit_note_invoices</attribute>
         </xpath>
 
         <xpath expr="//IDFacturaRectificadaSustituida" position="attributes">
-            <attribute name="t-foreach" value="credit_note_invoices"/>
-            <attribute name="t-as" value="credit_note_invoice"/>
+            <attribute name="t-foreach">credit_note_invoices</attribute>
+            <attribute name="t-as">credit_note_invoice</attribute>
+        </xpath>
+    </template>
+
+    <template id="template_invoice_factura" inherit_id="l10n_es_edi_tbai.template_invoice_factura">
+        <xpath expr="//FacturasRectificadasSustituidas" position="attributes">
+            <attribute name="t-if">credit_note_invoices</attribute>
+        </xpath>
+
+        <xpath expr="//IDFacturaRectificadaSustituida" position="attributes">
+            <attribute name="t-foreach">credit_note_invoices</attribute>
+            <attribute name="t-as">credit_note_invoice</attribute>
         </xpath>
     </template>
 </data>

--- a/addons/l10n_es_edi_tbai_multi_refund/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai_multi_refund/models/account_edi_format.py
@@ -4,8 +4,18 @@ from odoo import models
 class AccountEdiFormat(models.Model):
     _inherit = 'account.edi.format'
 
+    def _l10n_es_tbai_refunded_invoices(self, invoice):
+        return super()._l10n_es_tbai_refunded_invoices(invoice) | invoice.l10n_es_tbai_reversed_ids
+
     def _l10n_es_tbai_get_in_invoice_values_batuz(self, invoice):
         values = super()._l10n_es_tbai_get_in_invoice_values_batuz(invoice)
+        credit_notes = values.pop('credit_note_invoice', self.env['account.move']) | invoice.l10n_es_tbai_reversed_ids
+        if credit_notes:
+            values['credit_note_invoices'] = credit_notes
+        return values
+
+    def _l10n_es_tbai_get_invoice_values(self, invoice, cancel):
+        values = super()._l10n_es_tbai_get_invoice_values(invoice, cancel)
         credit_notes = values.pop('credit_note_invoice', self.env['account.move']) | invoice.l10n_es_tbai_reversed_ids
         if credit_notes:
             values['credit_note_invoices'] = credit_notes


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

Applies https://github.com/odoo/odoo/pull/194130 for all TicketBAI invoices, and not only for those for Bizkaia.


Current behavior before PR:
When invoice is not for Bizkaia, it fails to render the XML.

<details>

```
2025-01-20 11:41:09,902 28 ERROR odoo odoo.http: Exception during request handling.                                       
Traceback (most recent call last):                                                                                        
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 997, in get                                                          
    cache_value = field_cache[record._ids[0]]                                                                             
KeyError: 55111                                                                                                           
                                                                                                                          
During handling of the above exception, another exception occurred:                                                       
                                                                                                                          
Traceback (most recent call last):                                                                                        
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1161, in __get__                                                  
    value = env.cache.get(record, self)                                                                                   
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 1004, in get                                                         
    raise CacheMiss(record, field)                                                                                        
odoo.exceptions.CacheMiss: 'account.edi.document(55111,).edi_content'                                                     
                                                                                                                          
During handling of the above exception, another exception occurred:                                                       
                                                                                                                          
Traceback (most recent call last):                                                                                        
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5201, in ensure_one
    _id, = self._ids
ValueError: not enough values to unpack (expected 1, got 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<3645>", line 580, in template_3645
  File "<3645>", line 175, in template_3645_content
  File "/opt/odoo/auto/addons/l10n_es_edi_tbai/models/account_move.py", line 130, in _get_l10n_es_tbai_sequence_and_number
    self.ensure_one()
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5204, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: account.move()

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 2066, in __call__
    response = request._serve_db()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1653, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1681, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1795, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/auto/addons/website/models/ir_http.py", line 237, in _dispatch                                                
    response = super()._dispatch(endpoint)                                                                                      
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 154, in _dispatch                                   
    result = endpoint(**request.params)                                                                                         
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 734, in route_wrapper                                                     
    result = endpoint(self, *args, **params_ok)                                                                                 
  File "/opt/odoo/auto/addons/web/controllers/binary.py", line 75, in content_common                                            
    stream = request.env['ir.binary']._get_stream_from(record, field, filename, filename_field, mimetype)                       
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_binary.py", line 126, in _get_stream_from                          
    stream = self._record_to_stream(record, field_name)                                                                         
  File "/opt/odoo/auto/addons/website/models/ir_binary.py", line 41, in _record_to_stream                                       
    return super()._record_to_stream(record, field_name)                                                                        
  File "/opt/odoo/auto/addons/documents/models/ir_binary.py", line 13, in _record_to_stream                                     
    return super()._record_to_stream(record, field_name)                                                                        
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_binary.py", line 87, in _record_to_stream                          
    return Stream.from_binary_field(record, field_name)                                                                         
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 523, in from_binary_field                                                 
    data_b64 = record[field_name]                                                                                               
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5975, in __getitem__
    return self._fields[key].__get__(self, self.env.registry[self._name])
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1210, in __get__
    self.compute_value(recs)                                                                                                    
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 2360, in compute_value
    super().compute_value(records)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1392, in compute_value
    records._compute_field_value(self)             
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4259, in _compute_field_value                                     
    fields.determine(field.compute, self)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 98, in determine   
    return needle(*args)                             
  File "/opt/odoo/auto/addons/account_edi/models/account_edi_document.py", line 63, in _compute_edi_content
    res = base64.b64encode(move_applicability['edi_content'](move))
  File "/opt/odoo/auto/addons/l10n_es_edi_tbai/models/account_edi_format.py", line 251, in _l10n_es_tbai_get_invoice_content_edi
    xml_tree = self._get_l10n_es_tbai_invoice_xml(invoice, cancel)[invoice]['xml_file']
  File "/opt/odoo/auto/addons/l10n_es_edi_tbai/models/account_edi_format.py", line 275, in _get_l10n_es_tbai_invoice_xml
    xml_str = self.env['ir.qweb']._render(template_name, values)       
  File "/opt/odoo/custom/src/odoo/odoo/tools/profiler.py", line 294, in _tracked_method_render
    return method_render(self, template, values, **options)                                                                     
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_qweb.py", line 588, in _render
    result = ''.join(rendering)                                                                                                 
  File "<3641>", line 35, in template_3641
  File "<3641>", line 24, in template_3641_content                                                                              
  File "<3643>", line 287, in template_3643                                                                                     
  File "<3643>", line 85, in template_3643_content                                                                              
  File "<3645>", line 586, in template_3645                                                                                     
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
ValueError: Expected singleton: account.move()       
Template: l10n_es_edi_tbai.template_invoice_factura                                                                             
Path: /t/CabeceraFactura/t[3]/FacturasRectificadasSustituidas/IDFacturaRectificadaSustituida/SerieFactura
Node: <SerieFactura t-out="seq_and_num[0]"/>                                                                                                                                
2025-01-20 11:41:09,903 28 INFO odoo werkzeug: 89.7.25.15 - - [20/Jan/2025 11:41:09] "GET /web/content/account.edi.document/55111/edi_content HTTP/1.1" 500 - 49 0.083 0.049
```

</details>

Desired behavior after PR is merged:
All invoices for TicketBAI work the same.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@RicGR98 @moduon MT-4966 @gelojr