### PR TITLE
[FIX] mail: livechat from visitor stays open in mobile [18.0]

### DIFF
--- a/addons/im_livechat/static/tests/embed/chat_window.test.js
+++ b/addons/im_livechat/static/tests/embed/chat_window.test.js
@@ -7,7 +7,12 @@ import {
 import { describe, test } from "@odoo/hoot";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 import { getOrigin } from "@web/core/utils/urls";
-import { mountWithCleanup, patchWithCleanup, serverState } from "@web/../tests/web_test_helpers";
+import {
+    Command,
+    mountWithCleanup,
+    patchWithCleanup,
+    serverState,
+} from "@web/../tests/web_test_helpers";
 import {
     assertSteps,
     click,
@@ -15,11 +20,14 @@ import {
     inputFiles,
     insertText,
     onRpcBefore,
+    patchUiSize,
+    SIZES,
     start,
     startServer,
     step,
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
+import { expirableStorage } from "@im_livechat/embed/common/expirable_storage";
 
 describe.current.tags("desktop");
 defineLivechatModels();
@@ -113,4 +121,36 @@ test("avatar url contains access token for non-internal users", async () => {
             guest.id
         }/avatar_128?access_token=${guest.id}&unique=${deserializeDateTime(guest.write_date).ts}"]`
     );
+});
+
+test("livechat is shown as bubble on page reload", async () => {
+    const pyEnv = await startServer();
+    const livechatChannelId = await loadDefaultEmbedConfig();
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ guest_id: guestId, fold_state: "open" }),
+        ],
+        channel_type: "livechat",
+        livechat_active: true,
+        livechat_channel_id: livechatChannelId,
+        livechat_operator_id: serverState.partnerId,
+    });
+    expirableStorage.setItem(
+        "im_livechat.saved_state",
+        JSON.stringify({
+            store: { "discuss.channel": [{ id: channelId }] },
+            persisted: true,
+            livechatUserId: serverState.publicUserId,
+        })
+    );
+
+    pyEnv["res.partner"].write(serverState.partnerId, { user_livechat_username: "MitchellOp" });
+    patchUiSize({ size: SIZES.SM });
+    await start({
+        authenticateAs: { ...pyEnv["mail.guest"].read(guestId)[0], _name: "mail.guest" },
+    });
+    await click(".o-mail-ChatBubble");
+    await contains(".o-mail-ChatWindow-header", { text: "MitchellOp" });
 });

--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -8,6 +8,7 @@ import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { ChatBubble } from "./chat_bubble";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 export class ChatHub extends Component {
     static components = { ChatBubble, ChatWindow, Dropdown };
@@ -48,6 +49,10 @@ export class ChatHub extends Component {
         });
     }
 
+    get isMobileOS() {
+        return isMobileOS();
+    }
+
     onResize() {
         this.chatHub.onRecompute();
     }
@@ -70,7 +75,7 @@ export class ChatHub extends Component {
     }
 
     get isShown() {
-        return !this.ui.isSmall;
+        return true;
     }
 
     expand() {

--- a/addons/mail/static/src/core/common/chat_hub.scss
+++ b/addons/mail/static/src/core/common/chat_hub.scss
@@ -12,7 +12,7 @@
 }
 
 .o-mail-ChatHub-bubbleBtn {
-    padding: 0;
+    padding: 0 !important;
     border: none !important;
     border-radius: 50%;
     box-shadow: $box-shadow-sm;

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -8,14 +8,14 @@
                 <ChatWindow chatWindow="cw" right="env.embedLivechat ? chatHub.WINDOW_GAP : (chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (chatHub.opened.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2))"/>
             </t>
         </t>
-        <div t-if="isShown" class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto', 'o-liftUp': busMonitoring.hasConnectionIssues }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
+        <div class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto', 'o-liftUp': busMonitoring.hasConnectionIssues }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
             <div class="d-flex flex-column align-content-start justify-content-end align-items-center gap-1">
                 <t t-if="store.chatHub.compact">
                     <t t-call="mail.ChatHub.compactButton"/>
                 </t>
                 <t t-else="">
                     <Dropdown t-if="(chatHub.opened.length + chatHub.folded.length) gt 0" state="options" position="'top-end'" menuClass="'d-flex flex-column bg-100 shadow-sm m-0 p-0 mb-1 border-secondary'">
-                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-100 mt-1" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !options.isOpen, 'text-500': bubblesHover.isHover and !options.isOpen, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"/>
+                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-100 mt-1" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !options.isOpen, 'text-500': bubblesHover.isHover and !options.isOpen and !isMobileOS, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"/>
                         <t t-set-slot="content">
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.compact = true"><i class="fa fa-fw fa-eye-slash"></i>Hide all conversations</button>
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close"></i>Close all conversations</button>

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -149,7 +149,7 @@ export class ChatWindow extends Component {
 
     toggleFold() {
         const chatWindow = toRaw(this.props.chatWindow);
-        if (this.ui.isSmall || this.state.actionsMenuOpened) {
+        if (this.state.actionsMenuOpened) {
             return;
         }
         chatWindow.fold();

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -10,9 +10,10 @@ threadActionsRegistry
     .add("fold-chat-window", {
         condition(component) {
             return (
-                !component.ui.isSmall &&
                 component.props.chatWindow &&
-                component.props.chatWindow.thread
+                component.props.chatWindow.thread &&
+                (component.env.services["im_livechat.livechat"] ||
+                    !component.env.services.ui.isSmall)
             );
         },
         icon: "fa fa-fw fa-minus",
@@ -107,6 +108,9 @@ function transformAction(component, id, action) {
         },
         /** Condition to display this action. */
         get condition() {
+            if (action.condition === undefined) {
+                return true;
+            }
             return action.condition(component);
         },
         /** Condition to disable the button of this action (but still display it). */

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -44,15 +44,20 @@ export class Thread extends Record {
     static new() {
         const thread = super.new(...arguments);
         Record.onChange(thread, ["state"], () => {
+            if (
+                thread.state === "folded" ||
+                (thread.state === "open" &&
+                    this.store.env.services.ui.isSmall &&
+                    this.store.env.services["im_livechat.livechat"])
+            ) {
+                const cw = this.store.ChatWindow?.insert({ thread });
+                thread.store.chatHub.folded.delete(cw);
+                thread.store.chatHub.folded.unshift(cw);
+            }
             if (thread.state === "open" && !this.store.env.services.ui.isSmall) {
                 const cw = this.store.ChatWindow?.insert({ thread });
                 thread.store.chatHub.opened.delete(cw);
                 thread.store.chatHub.opened.unshift(cw);
-            }
-            if (thread.state === "folded") {
-                const cw = this.store.ChatWindow?.insert({ thread });
-                thread.store.chatHub.folded.delete(cw);
-                thread.store.chatHub.folded.unshift(cw);
             }
         });
         return thread;


### PR DESCRIPTION
Before this commit, when using livechat by visitor in mobile, any page reload would remove access to the livechat.

Steps to reproduce:
- access to website with livechat installed on mobile
- click on livechat button (bubble icon in bottom right)
- send a message
- reload the page

=> the livechat is not open, not even as a chat bubble.

This prevents visitor from access the livechat again, except if user finds a workaround to open the same page in non-mobile mode (e.g. landscape mode or disabling high-dpi).

This happens because livechat relies on discuss chat hub, and there's some code to prevent server-side synchronisation of chat windows and bubbles in mobile. As a reminder, conversation in mobile are shown as fullscreen chat windows.
This code was preventing the opening of chat window on livechat for visitor, leading to prevention of continuing to live chat on the device.

This commit fixes by adding fold action to chat windows in mobile specifically for livechat visitors, thus allowing to have chat bubbles in mobile. This fixes allow to show chat windows as bubbles to livechat visitors, which is the primary fix of these changes.

Due to chat windows being server-synced, we made sure to not sync chat windows in the backend. To do so, we rely on presence of livechat service to determine when the chat bubble feature should work in mobile.

opw-4423556
opw-4488830