### PR TITLE
[FIX] web_editor: add small font sizes to the font size dropdown

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -856,6 +856,11 @@ export class OdooEditor extends EventTarget {
         let previousItem = null;
         let previousValue = -1;
         const style = this.document.defaultView.getComputedStyle(this.document.body);
+        const smallFontSizeVariables = [
+            "small-twelve-font-size",
+            "small-ten-font-size",
+            "small-eight-font-size",
+        ];
         for (const itemEl of fontSizeDropdownEl.querySelectorAll("[data-dynamic-value]")) {
             const variableName = itemEl.dataset.dynamicValue;
             const strValue = this.options.getCSSVariableValue(variableName, style);
@@ -872,6 +877,13 @@ export class OdooEditor extends EventTarget {
             }
             previousItem = itemEl;
             previousValue = pxValue;
+
+            if (
+                this.options.showResponsiveFontSizesBadges &&
+                smallFontSizeVariables.includes(variableName)
+            ) {
+                itemEl.classList.add("d-none");
+            }
         }
 
         for (const badgeEl of fontSizeDropdownEl.querySelectorAll(".o_we_font_size_badge")) {

--- a/addons/web_editor/static/src/scss/bootstrap_overridden.scss
+++ b/addons/web_editor/static/src/scss/bootstrap_overridden.scss
@@ -94,3 +94,6 @@ $small-font-size: if(
     ($o-small-font-size / $font-size-base) * 1em,
     null
 ) !default;
+$small-twelve-font-size: ($o-small-twelve-font-size / 1rem) * 1em !default;
+$small-ten-font-size: ($o-small-ten-font-size / 1rem) * 1em !default;
+$small-eight-font-size: ($o-small-eight-font-size / 1rem) * 1em !default;

--- a/addons/web_editor/static/src/scss/secondary_variables.scss
+++ b/addons/web_editor/static/src/scss/secondary_variables.scss
@@ -146,3 +146,6 @@ $o-we-auto-contrast-exclusions: () !default;
 //------------------------------------------------------------------------------
 
 $o-small-font-size: 0.875rem !default;
+$o-small-twelve-font-size: 0.75rem !default;
+$o-small-ten-font-size: 0.625rem !default;
+$o-small-eight-font-size: 0.5rem !default;

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -91,6 +91,9 @@
     @include print-variable('h6-font-size', $h6-font-size);
     @include print-variable('font-size-base', $font-size-base);
     @include print-variable('small-font-size', $small-font-size);
+    @include print-variable('small-twelve-font-size', $small-twelve-font-size);
+    @include print-variable('small-ten-font-size', $small-ten-font-size);
+    @include print-variable('small-eight-font-size', $small-eight-font-size);
     @include print-variable('lead-font-size', $lead-font-size);
 }
 
@@ -302,6 +305,15 @@ img.ms-auto, img.mx-auto {
 // consistent with the other classes which act that way (as display-x).
 .o_small-fs {
     @include font-size($small-font-size);
+}
+.o_small_twelve-fs {
+    @include font-size($o-small-twelve-font-size);
+}
+.o_small_ten-fs {
+    @include font-size($o-small-ten-font-size);
+}
+.o_small_eight-fs {
+    @include font-size($o-small-eight-font-size);
 }
 
 div.media_iframe_video {

--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -113,6 +113,9 @@
                         <li><a class="dropdown-item d-flex justify-content-between align-items-center" data-dynamic-value="h6-font-size" data-apply-class="h6-fs" href="#">? <span class="d-none o_we_font_size_badge badge rounded-pill text-bg-dark ms-4">Heading 6</span></a></li>
                         <li><a class="dropdown-item d-flex justify-content-between align-items-center" data-dynamic-value="font-size-base" data-apply-class="base-fs" href="#">? <span class="d-none o_we_font_size_badge badge rounded-pill text-bg-dark ms-4">Normal</span></a></li>
                         <li><a class="dropdown-item d-flex justify-content-between align-items-center" data-dynamic-value="small-font-size" data-apply-class="o_small-fs" href="#">? <span class="d-none o_we_font_size_badge badge rounded-pill text-bg-dark ms-4">Small</span></a></li>
+                        <li><a class="dropdown-item d-flex justify-content-between align-items-center" data-dynamic-value="small-twelve-font-size" data-apply-class="o_small_twelve-fs" href="#"> </a></li>
+                        <li><a class="dropdown-item d-flex justify-content-between align-items-center" data-dynamic-value="small-ten-font-size" data-apply-class="o_small_ten-fs" href="#"> </a></li>
+                        <li><a class="dropdown-item d-flex justify-content-between align-items-center" data-dynamic-value="small-eight-font-size" data-apply-class="o_small_eight-fs" href="#"> </a></li>
                     </ul>
                 </div>
             </t>


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- Small font sizes ("8", "10", "12") were unavailable in the font size dropdown. These options were only required in the backend and not where custom input for font sizes is provided.

### Desired behavior after PR is merged:

- The font size options "8", "10", and "12" are now included in the dropdown. The `d-none` class is conditionally applied to these options based on the value of `showResponsiveFontSizesBadges`.

task-3829323