### PR TITLE
[IMP] pos_restaurant, point_of_sale: send dishes by course

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -38,6 +38,7 @@ export const SERIALIZABLE_MODELS = [
     "product.attribute.custom.value",
     "event.registration", // FIXME should be overrided from pos_event
     "event.registration.answer",
+    "restaurant.order.course",
 ];
 
 function processModelDefs(modelDefs) {

--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -78,6 +78,7 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
                 pos_categ_id: product.pos_categ_ids[0]?.id ?? 0,
                 pos_categ_sequence: product.pos_categ_ids[0]?.sequence ?? 0,
                 display_name: product.display_name,
+                group: receiptLineGrouper.getGroup(orderline),
             };
 
             if (quantityDiff && orderline.skip_change === skipped) {
@@ -128,6 +129,7 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
                     isCombo: lineResume["isCombo"],
                     note: lineResume["note"],
                     attribute_value_names: lineResume["attribute_value_names"],
+                    group: lineResume["group"],
                     quantity: -quantity,
                 };
                 changeAbsCount += Math.abs(quantity);
@@ -156,4 +158,10 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
         result.internal_note = order.internal_note;
     }
     return result;
+};
+
+export const receiptLineGrouper = {
+    getGroup(orderLine) {
+        // To be overridden
+    },
 };

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1194,9 +1194,7 @@ export class PosStore extends WithLazyGetterTrap {
     getPendingOrder() {
         const orderToCreate = this.models["pos.order"].filter(
             (order) =>
-                this.pendingOrder.create.has(order.id) &&
-                (order.lines.length > 0 ||
-                    order.payment_ids.some((p) => p.payment_method_id.type === "pay_later"))
+                this.pendingOrder.create.has(order.id) && this.shouldCreatePendingOrder(order)
         );
         const orderToUpdate = this.models["pos.order"].readMany(
             Array.from(this.pendingOrder.write)
@@ -1210,6 +1208,13 @@ export class PosStore extends WithLazyGetterTrap {
             orderToCreate,
             orderToUpdate,
         };
+    }
+
+    shouldCreatePendingOrder(order) {
+        return (
+            order.lines.length > 0 ||
+            order.payment_ids.some((p) => p.payment_method_id.type === "pay_later")
+        );
     }
 
     getOrderIdsToDelete() {
@@ -1677,9 +1682,10 @@ export class PosStore extends WithLazyGetterTrap {
             }
 
             if (changes.noteUpdate.length) {
+                const { noteUpdateTitle, printNoteUpdateData = true } = orderChange;
                 orderData.changes = {
-                    title: _t("NOTE UPDATE"),
-                    data: changes.noteUpdate,
+                    title: noteUpdateTitle || _t("NOTE UPDATE"),
+                    data: printNoteUpdateData ? changes.noteUpdate : [],
                 };
                 const result = await this.printOrderChanges(orderData, printer);
                 if (!result.successful) {
@@ -1708,6 +1714,18 @@ export class PosStore extends WithLazyGetterTrap {
     }
 
     async printOrderChanges(data, printer) {
+        const dataChanges = data.changes?.data;
+        if (dataChanges && dataChanges.some((c) => c.group)) {
+            const groupedData = dataChanges.reduce((acc, c) => {
+                const { name = "", index = -1 } = c.group || {};
+                if (!acc[name]) {
+                    acc[name] = { name, index, data: [] };
+                }
+                acc[name].data.push(c);
+                return acc;
+            }, {});
+            data.changes.groupedData = Object.values(groupedData).sort((a, b) => a.index - b.index);
+        }
         const receipt = renderToElement("point_of_sale.OrderChangeReceipt", {
             data: data,
         });

--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -26,21 +26,32 @@
 
             <!-- Receipt Body -->
             <div class="pos-receipt-body mb-4">
-                <div t-if="data.changes.data?.length" class="new-changes border-bottom w-100">
+                <t t-set="hasDataChanges" t-value="data.changes.data or data.changes.groupedData" />
+                <div t-if="hasDataChanges" class="new-changes border-bottom w-100">
                     <div class="pos-receipt-title text-center w-100">
                         <strong t-esc="data.changes.title" />
                     </div>
-                    <div t-foreach="data.changes.data" t-as="line" t-key="change_index">
-                        <t t-call="point_of_sale.OrderChangeReceiptLine" />
-                    </div>
+                    <t t-if="data.changes.groupedData">
+                        <div t-foreach="data.changes.groupedData" t-as="group" t-key="group_index">
+                            <div style="border-bottom: 1px dashed black;" class="mb-2 pb-1 fw-bold " t-att-class="{'mt-1': !group_first}" t-esc="group.name" />
+                            <div t-foreach="group.data" t-as="line" class="ps-2" t-key="change_index">
+                                <t t-call="point_of_sale.OrderChangeReceiptLine" />
+                            </div>
+                        </div>
+                    </t>
+                    <t t-else="">
+                        <div t-foreach="data.changes.data" t-as="line" t-key="change_index">
+                            <t t-call="point_of_sale.OrderChangeReceiptLine" />
+                        </div>
+                    </t>
                 </div>
-                <div t-if="data.internal_note and !data.changes.data" class="new-changes border-bottom w-100">
+                <div t-if="data.internal_note and !hasDataChanges" class="new-changes border-bottom w-100">
                     <div class="pos-receipt-title text-center w-100">
                         <strong>INTERNAL NOTE</strong>
                     </div>
                     <div class="text-center fs-2" t-esc="data.internal_note.split('\n').join(', ')" />
                 </div>
-                <div t-if="data.general_customer_note and !data.changes.data" class="new-changes border-bottom w-100">
+                <div t-if="data.general_customer_note and !hasDataChanges" class="new-changes border-bottom w-100">
                     <div class="pos-receipt-title text-center w-100">
                         <strong>CUSTOMER NOTE</strong>
                     </div>

--- a/addons/pos_restaurant/models/__init__.py
+++ b/addons/pos_restaurant/models/__init__.py
@@ -3,8 +3,10 @@
 
 from . import pos_config
 from . import pos_order
+from . import pos_order_line
 from . import pos_payment
 from . import pos_restaurant
 from . import pos_session
 from . import res_config_settings
 from . import pos_preset
+from . import restaurant_order_course

--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -2,12 +2,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import api, fields, models
 
-
 class PosOrder(models.Model):
     _inherit = 'pos.order'
 
     table_id = fields.Many2one('restaurant.table', string='Table', help='The table where this order was served', index='btree_not_null', readonly=True)
     customer_count = fields.Integer(string='Guests', help='The amount of customers that have been served by this order.', readonly=True)
+    course_ids = fields.One2many('restaurant.order.course', 'order_id', string="Courses")
 
     def _get_open_order(self, order):
         config_id = self.env['pos.session'].browse(order.get('session_id')).config_id
@@ -25,21 +25,35 @@ class PosOrder(models.Model):
     def sync_from_ui(self, orders):
         result = super().sync_from_ui(orders)
 
-        if self.env.context.get('table_ids'):
-            order_ids = [order['id'] for order in result['pos.order']]
-            table_orders = self.search([
-                "&",
-                ('table_id', 'in', self.env.context['table_ids']),
-                ('state', '=', 'draft'),
-                ('id', 'not in', order_ids)
-            ])
-
-            if len(table_orders) > 0:
-                config_id = table_orders[0].config_id.id
-                result['pos.order'].extend(table_orders.read(table_orders._load_pos_data_fields(config_id), load=False))
-                result['pos.payment'].extend(table_orders.payment_ids.read(table_orders.payment_ids._load_pos_data_fields(config_id), load=False))
-                result['pos.order.line'].extend(table_orders.lines.read(table_orders.lines._load_pos_data_fields(config_id), load=False))
-                result['pos.pack.operation.lot'].extend(table_orders.lines.pack_lot_ids.read(table_orders.lines.pack_lot_ids._load_pos_data_fields(config_id), load=False))
-                result["product.attribute.custom.value"].extend(table_orders.lines.custom_attribute_value_ids.read(table_orders.lines.custom_attribute_value_ids._load_pos_data_fields(config_id), load=False))
-
+        order_ids = self.browse([o['id'] for o in result["pos.order"]])
+        if order_ids:
+            config_id = order_ids.config_id.ids[0] if order_ids else False
+            result['restaurant.order.course'] = order_ids.course_ids.read(order_ids.course_ids._load_pos_data_fields(config_id)) if config_id else []
+        else:
+            result['restaurant.order.course'] = []
         return result
+
+    def _process_order(self, order, existing_order):
+        restaurant_course_lines = order.pop("restaurant_course_lines", None)
+        order_id = super()._process_order(order, existing_order)
+        self._update_course_lines(order_id, restaurant_course_lines)
+        return order_id
+
+    def _update_course_lines(self, order_id, restaurant_course_lines):
+        """
+        Assigns the `course_id` field of order lines based on the relationship defined in the `order_course_lines` dictionary.
+        This dictionary links each course UUID to its corresponding list of line UUIDs.
+        """
+        if not restaurant_course_lines:
+            return
+        courses = self.env['restaurant.order.course'].search_read([('order_id', '=', order_id)], fields=['uuid', 'id'], load=False)
+        course_id_by_uuid = {c['uuid']: c['id'] for c in courses}
+        line_uuids = set()
+        for course_line_uuids in restaurant_course_lines.values():
+            line_uuids.update(course_line_uuids)
+        line_uuids = list(line_uuids)
+        lines = self.env['pos.order.line'].search([('order_id', '=', order_id), ('uuid', 'in', line_uuids)])
+        for course_uuid, line_uuids in restaurant_course_lines.items():
+            course_id = course_id_by_uuid.get(course_uuid)
+            if course_id:
+                lines.filtered(lambda l: l.uuid in line_uuids).write({'course_id': course_id})

--- a/addons/pos_restaurant/models/pos_order_line.py
+++ b/addons/pos_restaurant/models/pos_order_line.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import api, fields, models
+
+
+class PosOrderLine(models.Model):
+    _inherit = 'pos.order.line'
+    course_id = fields.Many2one('restaurant.order.course', string="Course Ref", ondelete="set null", index='btree_not_null')
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        result = super()._load_pos_data_fields(config_id)
+        return result + ["course_id"]

--- a/addons/pos_restaurant/models/pos_session.py
+++ b/addons/pos_restaurant/models/pos_session.py
@@ -12,7 +12,7 @@ class PosSession(models.Model):
     def _load_pos_data_models(self, config_id):
         data = super()._load_pos_data_models(config_id)
         if self.config_id.module_pos_restaurant:
-            data += ['restaurant.floor', 'restaurant.table']
+            data += ['restaurant.floor', 'restaurant.table', 'restaurant.order.course']
         return data
 
     @api.model

--- a/addons/pos_restaurant/models/restaurant_order_course.py
+++ b/addons/pos_restaurant/models/restaurant_order_course.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import api, fields, models
+from uuid import uuid4
+
+
+class RestaurantOrderCourse(models.Model):
+    _name = 'restaurant.order.course'
+    _description = 'POS Restaurant Order Course'
+    _inherit = ['pos.load.mixin']
+
+    fired = fields.Boolean(string="Fired", default=False)
+    fired_date = fields.Datetime(string="Fired Date")
+    uuid = fields.Char(string='Uuid', readonly=True, default=lambda self: str(uuid4()), copy=False)
+    index = fields.Integer(string="Course index", default=0)
+    order_id = fields.Many2one('pos.order', string='Order Ref', required=True, index=True, ondelete='cascade')
+    line_ids = fields.One2many('pos.order.line', 'course_id', string="Order Lines", readonly=True)
+
+    def write(self, vals):
+        if vals.get('fired') and not self.fired_date:
+            vals['fired_date'] = fields.Datetime.now()
+        return super().write(vals)
+
+    @api.model
+    def _load_pos_data_domain(self, data):
+        return [('order_id', 'in', [order['id'] for order in data['pos.order']])]
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        return ['uuid', 'fired', 'order_id', 'line_ids', 'index']

--- a/addons/pos_restaurant/security/ir.model.access.csv
+++ b/addons/pos_restaurant/security/ir.model.access.csv
@@ -3,3 +3,4 @@ access_restaurant_floor,restaurant.floor.user,model_restaurant_floor,point_of_sa
 access_restaurant_floor_manager,restaurant.floor.manager,model_restaurant_floor,point_of_sale.group_pos_manager,1,1,1,1
 access_restaurant_table,restaurant.table.user,model_restaurant_table,point_of_sale.group_pos_user,1,0,0,0
 access_restaurant_table_manager,restaurant.table.manager,model_restaurant_table,point_of_sale.group_pos_manager,1,1,1,1
+access_restaurant_order_course,restaurant.order.course,model_restaurant_order_course,point_of_sale.group_pos_user,1,1,1,1

--- a/addons/pos_restaurant/static/src/app/components/order_course/order_course.js
+++ b/addons/pos_restaurant/static/src/app/components/order_course/order_course.js
@@ -1,0 +1,23 @@
+import { Component } from "@odoo/owl";
+
+export class OrderCourse extends Component {
+    static template = "pos_restaurant.OrderCourse";
+    static props = {
+        course: Object,
+        course_index: Number,
+        slots: { type: Object, optional: true },
+    };
+
+    get course() {
+        return this.props.course;
+    }
+
+    clickCourse(evt, course) {
+        const order = course.order_id;
+        if (course.isSelected()) {
+            order.deselectCourse();
+        } else {
+            order.selectCourse(course);
+        }
+    }
+}

--- a/addons/pos_restaurant/static/src/app/components/order_course/order_course.xml
+++ b/addons/pos_restaurant/static/src/app/components/order_course/order_course.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_restaurant.OrderCourse">
+        <div t-att-class="{'mb-1' : course.isEmpty()}">
+            <div class="order-course-name p-2 fw-bolder text-truncate"
+                 t-att-class="{
+                  'o_colorlist_item_color_10' : course.isSelected(),
+                  'bg-secondary': !course.isSelected(),
+                  'cursor-pointer': !course.fired}"
+                 t-on-click="(event) => this.clickCourse(event, course)">
+                <t t-esc="course.name"></t>
+                <i t-if="course.fired" class="ms-2 fa fa-check text-success" />
+            </div>
+            <t t-foreach="course.lines" t-as="line" t-key="line_index">
+                <t t-slot="default" line="line" />
+            </t>
+        </div>
+    </t>
+</templates>

--- a/addons/pos_restaurant/static/src/app/components/order_display/order_display.js
+++ b/addons/pos_restaurant/static/src/app/components/order_display/order_display.js
@@ -1,7 +1,7 @@
 import { patch } from "@web/core/utils/patch";
 import { _t } from "@web/core/l10n/translation";
 import { OrderDisplay } from "@point_of_sale/app/components/order_display/order_display";
-
+import { OrderCourse } from "@pos_restaurant/app/components/order_course/order_course";
 patch(OrderDisplay.prototype, {
     emptyCartText() {
         let text = super.emptyCartText(...arguments);
@@ -10,4 +10,16 @@ patch(OrderDisplay.prototype, {
         }
         return text;
     },
+
+    get displayCourses() {
+        if (
+            !this.order.config.module_pos_restaurant ||
+            this.props.mode !== "display" ||
+            this.order.finalized
+        ) {
+            return false;
+        }
+        return this.order.course_ids.length > 0;
+    },
 });
+OrderDisplay.components = { ...OrderDisplay.components, OrderCourse };

--- a/addons/pos_restaurant/static/src/app/components/order_display/order_display.xml
+++ b/addons/pos_restaurant/static/src/app/components/order_display/order_display.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_restaurant.OrderDisplay" t-inherit="point_of_sale.OrderDisplay" t-inherit-mode="extension">
+
+        <xpath expr="(//t[@t-if='lines.length'])[1]" position="attributes" >
+             <attribute name="t-if">lines.length or displayCourses</attribute>
+        </xpath>
+
+        <xpath expr="(//div[hasclass('order-container')]/t[@t-foreach='lines'])[1]" position="replace" >
+            <t t-if="displayCourses">
+                <t t-foreach="order.courses" t-as="course" t-key="course_index">
+                    <OrderCourse course="course" course_index="course_index" t-slot-scope="course_scope">
+                        <t t-if="props.slots.default" t-slot="default" line="course_scope.line"/>
+                        <Orderline t-else="" line="course_scope.line" mode="this.props.mode"/>
+                    </OrderCourse>
+                </t>
+            </t>
+            <t t-else="">$0</t>
+        </xpath>
+    </t>
+</templates>

--- a/addons/pos_restaurant/static/src/app/models/data_service_options.js
+++ b/addons/pos_restaurant/static/src/app/models/data_service_options.js
@@ -1,0 +1,18 @@
+import { DataServiceOptions } from "@point_of_sale/app/models/data_service_options";
+import { patch } from "@web/core/utils/patch";
+
+patch(DataServiceOptions.prototype, {
+    get databaseTable() {
+        return {
+            ...super.databaseTable,
+            "restaurant.order.course": {
+                key: "uuid",
+                condition: (record) =>
+                    record.order_id?.finalized && typeof record.order_id.id === "number",
+            },
+        };
+    },
+    get cascadeDeleteModels() {
+        return [...super.cascadeDeleteModels, "restaurant.order.course"];
+    },
+});

--- a/addons/pos_restaurant/static/src/app/models/pos_order.js
+++ b/addons/pos_restaurant/static/src/app/models/pos_order.js
@@ -7,6 +7,7 @@ patch(PosOrder.prototype, {
         super.setup(...arguments);
         if (this.config.module_pos_restaurant) {
             this.customer_count = this.customer_count || 1;
+            this.uiState.selected_course_uuid = undefined;
         }
     },
     getCustomerCount() {
@@ -71,5 +72,111 @@ patch(PosOrder.prototype, {
             this.floating_order_name = partner.name;
         }
         return super.setPartner(...arguments);
+    },
+    serialize(options = {}) {
+        const data = super.serialize(...arguments);
+        if (options.orm === true && this.lines.length) {
+            if (this.hasCourses()) {
+                data.restaurant_course_lines = this.getORMCourseMappings(data);
+            }
+        }
+        return data;
+    },
+    getORMCourseMappings(serializedData) {
+        // Map each course uuid to its corresponding list line uuids to ensure proper assignment of new created course
+        const updatedLineIds = (serializedData.lines || [])
+            .filter((line) => line[0] === 1)
+            .map((line) => line[1]);
+        return this.lines.reduce((mapping, line) => {
+            if (
+                line.course_id &&
+                (typeof line.id === "string" || // New line
+                    typeof line.course_id.id === "string" || // New course
+                    updatedLineIds.includes(line.id)) // Updated line
+            ) {
+                const courseUuid = line.course_id.uuid;
+                mapping[courseUuid] = mapping[courseUuid] || [];
+                mapping[courseUuid].push(line.uuid);
+            }
+            return mapping;
+        }, {});
+    },
+    cleanCourses() {
+        if (!this.hasCourses()) {
+            return;
+        }
+        let lastFiredIndex = -1;
+        const courses = this.courses;
+        for (let i = courses.length - 1; i >= 0; i--) {
+            if (courses[i].fired) {
+                lastFiredIndex = i;
+                break;
+            }
+        }
+        const originalLength = courses.length;
+        const removedCourses = [];
+        const cleanedCourses = courses
+            .filter((course, index) => {
+                const shouldKeep = index <= lastFiredIndex || !course.isEmpty();
+                if (!shouldKeep) {
+                    removedCourses.push(course);
+                }
+                return shouldKeep;
+            })
+            .map((course, newIndex) => {
+                course.index = newIndex + 1;
+                return course;
+            });
+        removedCourses.forEach((c) => {
+            c.delete();
+        });
+        if (cleanedCourses.length !== originalLength) {
+            this.course_ids = cleanedCourses;
+        }
+    },
+    get courses() {
+        return this.course_ids.sort((a, b) => a.index - b.index);
+    },
+    hasCourses() {
+        return this.course_ids.length > 0;
+    },
+    getFirstCourse() {
+        return this.courses[0];
+    },
+    getLastCourse() {
+        return this.courses.at(-1);
+    },
+    ensureCourseSelection() {
+        if (!this.hasCourses()) {
+            return;
+        }
+        // Select the first non fired course
+        const nonFiredCourse = this.courses.find((course) => !course.fired);
+        this.selectCourse(nonFiredCourse ?? this.getLastCourse());
+    },
+    deselectCourse() {
+        this.selectCourse(undefined);
+    },
+    selectCourse(course) {
+        if (course) {
+            this.uiState.selected_course_uuid = course.uuid;
+            this.deselectOrderline();
+        } else {
+            this.uiState.selected_course_uuid = undefined;
+        }
+    },
+    getSelectedCourse() {
+        if (!this.uiState.selected_course_uuid) {
+            return;
+        }
+        return this.course_ids.find((course) => course.uuid === this.uiState.selected_course_uuid);
+    },
+    getNextCourseIndex() {
+        return (
+            this.course_ids.reduce(
+                (maxIndex, course) => (course.index > maxIndex ? course.index : maxIndex),
+                0
+            ) + 1
+        );
     },
 });

--- a/addons/pos_restaurant/static/src/app/models/pos_order_line.js
+++ b/addons/pos_restaurant/static/src/app/models/pos_order_line.js
@@ -13,6 +13,10 @@ patch(PosOrderline.prototype, {
         return orderline;
     },
     toggleSkipChange() {
+        if (this.course_id) {
+            return;
+        }
+
         if (this.uiState.hasChange || this.skip_change) {
             this.setDirty();
             this.skip_change = !this.skip_change;
@@ -34,8 +38,15 @@ patch(PosOrderline.prototype, {
             }
         }
     },
+    serialize(options = {}) {
+        const data = super.serialize(...arguments);
+        if (options.orm && data.course_id) {
+            delete data.course_id;
+        }
+        return data;
+    },
     showSkipChange() {
-        return this.skip_change && !this.uiState.hideSkipChangeClass;
+        return this.skip_change && !this.uiState.hideSkipChangeClass && !this.course_id;
     },
     getDisplayClasses() {
         return {
@@ -43,5 +54,16 @@ patch(PosOrderline.prototype, {
             "has-change": this.uiState.hasChange && this.config.module_pos_restaurant,
             "skip-change": this.showSkipChange() && this.config.module_pos_restaurant,
         };
+    },
+    canBeMergedWith(orderline) {
+        if (this.course_id) {
+            if (this.course_id.uuid !== orderline.course_id?.uuid) {
+                return false;
+            }
+        } else if (orderline.course_id?.uuid) {
+            // In case of order merge
+            return false;
+        }
+        return super.canBeMergedWith(orderline);
     },
 });

--- a/addons/pos_restaurant/static/src/app/models/restaurant_order_course.js
+++ b/addons/pos_restaurant/static/src/app/models/restaurant_order_course.js
@@ -1,0 +1,44 @@
+import { registry } from "@web/core/registry";
+import { Base } from "@point_of_sale/app/models/related_models";
+import { _t } from "@web/core/l10n/translation";
+
+export class RestaurantOrderCourse extends Base {
+    static pythonModel = "restaurant.order.course";
+
+    setup(vals) {
+        super.setup(vals);
+        this.uiState = {};
+    }
+    serialize(options = {}) {
+        const data = super.serialize(...arguments);
+        if (options.orm === true) {
+            // The line_ids relationship is serialized in pos_order (restaurant_course_lines)
+            // using a course_uuid -> line_uuids mapping to prevent inserting the same new line
+            // multiple times in the data model.
+            delete data.line_ids;
+        }
+        return data;
+    }
+    get name() {
+        return _t("Course") + " " + this.index;
+    }
+    isSelected() {
+        return this.order_id.uiState.selected_course_uuid === this.uuid;
+    }
+    get lines() {
+        return this.line_ids;
+    }
+    isEmpty() {
+        return this.line_ids?.length === 0;
+    }
+    isReadyToFire() {
+        return !this.fired && !this.isEmpty();
+    }
+    isNew() {
+        return typeof this.id === "string";
+    }
+}
+
+registry
+    .category("pos_available_models")
+    .add(RestaurantOrderCourse.pythonModel, RestaurantOrderCourse);

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.js
@@ -1,6 +1,7 @@
 import { patch } from "@web/core/utils/patch";
 import { ActionpadWidget } from "@point_of_sale/app/screens/product_screen/action_pad/action_pad";
 import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_screen";
+import { _t } from "@web/core/l10n/translation";
 
 /**
  * @props partner
@@ -59,5 +60,33 @@ patch(ActionpadWidget.prototype, {
             return true;
         }
         return false;
+    },
+    get displayFireCourseBtn() {
+        const order = this.currentOrder;
+        if (order.isDirectSale || !order.hasCourses()) {
+            return false;
+        }
+        return this.getCourseToFire() != null;
+    },
+    get fireCourseBtnText() {
+        const selectedCourse = this.getCourseToFire();
+        if (selectedCourse) {
+            return _t("Fire %s", selectedCourse.name);
+        }
+        return "";
+    },
+    getCourseToFire() {
+        const course = this.currentOrder.getSelectedCourse();
+        if (course?.isReadyToFire()) {
+            return course;
+        }
+    },
+    async clickFireCourse() {
+        const course = this.getCourseToFire();
+        if (!course) {
+            return;
+        }
+        await this.pos.fireCourse(course);
+        this.pos.showDefault();
     },
 });

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_restaurant.ActionpadWidget" t-inherit="point_of_sale.ActionpadWidget" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('actionpad')]/div/button[last()]" position="before">
+            <button t-if="pos.config.module_pos_restaurant and !this.currentOrder._isRefundOrder()"
+                    class="btn btn-secondary btn-lg flex-shrink-0 border-0" t-on-click="()=>this.pos.addCourse()">
+                <span>Course</span>
+            </button>
+        </xpath>
         <xpath expr="//BackButton" position="attributes">
             <attribute name="t-if">!this.swapButton and !props.showActionButton and pos.showBackButton()</attribute>
         </xpath>
@@ -34,6 +40,13 @@
                     </div>
                 </button>
                 <button
+                    class="h-100 button btn btn-secondary btn-lg d-flex flex-row align-items-center justify-content-center w-50"
+                    t-on-click="() => this.clickFireCourse()"
+                    t-elif="this.displayFireCourseBtn"
+                >
+                    <span t-esc="this.fireCourseBtnText"></span>
+                </button>
+                <button
                     class="h-100 button btn btn-secondary btn-lg d-flex flex-row align-items-center justify-content-center"
                     t-on-click="() => this.submitOrder()"
                     t-elif="this.pos.unwatched.printers.length and this.currentOrder.uiState.lastPrint">
@@ -42,7 +55,7 @@
                 <button
                     class="h-100 button btn btn-secondary btn-lg d-flex flex-row align-items-center justify-content-center w-50"
                     t-on-click="() => this.pos.showDefault()"
-                    t-if="!this.currentOrder.isDirectSale and !this.displayCategoryCount.length and !this.currentOrder.isEmpty()"
+                    t-elif="!this.currentOrder.isDirectSale and !this.displayCategoryCount.length and !this.currentOrder.isEmpty()"
                 >
                     <span>New</span>
                 </button>

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -26,6 +26,17 @@ patch(ControlButtons.prototype, {
         this.dialog.closeAll();
         this.pos.startTransferOrder();
     },
+    showTransferCourse() {
+        const order = this.currentOrder;
+        if (!order || !order.hasCourses()) {
+            return false;
+        }
+        return order.getSelectedCourse() || order.getSelectedOrderline();
+    },
+    async clickTransferCourse() {
+        this.dialog.closeAll();
+        await this.pos.transferLinesToCourse();
+    },
 });
 patch(ControlButtons, {
     components: {

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_restaurant.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
+       <xpath
+            expr="//button[hasclass('more-btn')]"
+            position="before">
+           <button t-if="pos.config.module_pos_restaurant and !props.showRemainingButtons and !pos.getOrder()?._isRefundOrder()"
+                   t-att-class="buttonClass" t-on-click="()=>this.pos.addCourse()">
+                <span>Course</span>
+           </button>
+       </xpath>
         <xpath
             expr="//t[@t-if='props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]"
             position="before">
@@ -28,6 +36,9 @@
                 </button>
                 <button class="btn btn-secondary btn-lg py-5" t-on-click.stop="() => this.clickTransferOrder()">
                     <i class="oi oi-arrow-right me-1" />Transfer / Merge
+                </button>
+                   <button t-att-disabled="!this.showTransferCourse()" class="btn btn-secondary btn-lg py-5" t-on-click.stop="() => this.clickTransferCourse()">
+                    <i class="oi oi-arrow-down me-1" />Transfer course
                 </button>
                 <button t-if="!pos.getOrder()?.table_id" class="btn btn-secondary btn-lg py-5" t-on-click="() => this.pos.editFloatingOrderName(this.pos.getOrder())">
                     <i class="fa fa-pencil-square-o me-1" />Edit Order Name

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -36,15 +36,20 @@ patch(OrderSummary.prototype, {
                         o.finalized === false &&
                         !o.isBooked
                 ) &&
-                this.pos.getOrder().lines.length === 0
+                this.pos.getOrder().lines.length === 0 &&
+                !this.pos.getOrder().hasCourses()
             );
         }
         const currentOrder = this.pos.getOrder();
+        if (!currentOrder) {
+            return false;
+        }
         return (
             this.pos.config.module_pos_restaurant &&
             !currentOrder.finalized &&
             currentOrder.isBooked &&
-            currentOrder.lines.length === 0
+            currentOrder.lines.length === 0 &&
+            !currentOrder.hasCourses()
         );
     },
 });

--- a/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
@@ -138,8 +138,23 @@ export class SplitBillScreen extends Component {
 
         // Create lines for the new order
         const lineToDel = [];
+        const newCourses = new Map();
         for (const line of originalOrder.lines) {
             if (this.qtyTracker[line.uuid]) {
+                let newCourse;
+                if (line.course_id) {
+                    // Create courses in the new order
+                    const { course_id: oldCourse } = line;
+                    const courseIndex = oldCourse.index;
+                    newCourse = newCourses.get(courseIndex);
+                    if (!newCourse) {
+                        newCourse = this.pos.models["restaurant.order.course"].create({
+                            order_id: newOrder,
+                            index: courseIndex,
+                        });
+                        newCourses.set(courseIndex, newCourse);
+                    }
+                }
                 const data = line.serialize();
                 delete data.uuid;
                 const newLine = this.pos.models["pos.order.line"].create(
@@ -147,6 +162,7 @@ export class SplitBillScreen extends Component {
                         ...data,
                         qty: this.qtyTracker[line.uuid],
                         order_id: newOrder.id,
+                        course_id: newCourse?.id,
                     },
                     false,
                     true

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -5,6 +5,7 @@ import { _t } from "@web/core/l10n/translation";
 import { EditOrderNamePopup } from "@pos_restaurant/app/popup/edit_order_name_popup/edit_order_name_popup";
 import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
 import { NumberPopup } from "@point_of_sale/app/components/popups/number_popup/number_popup";
+import { SelectionPopup } from "@point_of_sale/app/components/popups/selection_popup/selection_popup";
 import { makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
 
 patch(PosStore.prototype, {
@@ -77,24 +78,31 @@ patch(PosStore.prototype, {
         this.addPendingOrder([currentOrder.id]);
         return true;
     },
-    async sendOrderInPreparationUpdateLastChange(o, cancelled = false) {
-        const currentPreset = o.preset_id;
+    async sendOrderInPreparationUpdateLastChange(order, cancelled = false) {
+        const currentPreset = order.preset_id;
         if (
             this.config.use_presets &&
             currentPreset?.use_guest &&
-            !o.uiState.guestSetted &&
+            !order.uiState.guestSetted &&
             !cancelled
         ) {
-            const response = await this.setCustomerCount(o);
-
+            const response = await this.setCustomerCount(order);
             if (!response) {
                 return;
             }
-
-            o.uiState.guestSetted = true;
+            order.uiState.guestSetted = true;
         }
 
-        return await super.sendOrderInPreparationUpdateLastChange(o, cancelled);
+        if (!cancelled) {
+            order.cleanCourses();
+            const firstCourse = order.getFirstCourse();
+            if (firstCourse && !firstCourse.fired) {
+                firstCourse.fired = true;
+                this.getOrder().deselectCourse();
+            }
+        }
+
+        return await super.sendOrderInPreparationUpdateLastChange(order, cancelled);
     },
     handlePreparationHistory(srcPrep, destPrep, srcLine, destLine, qty) {
         const srcKey = srcLine.preparationKey;
@@ -114,15 +122,14 @@ patch(PosStore.prototype, {
     },
     async mergeOrders(sourceOrder, destOrder) {
         let whileGuard = 0;
+        const mergedCourses = this.mergeCourses(sourceOrder, destOrder);
         while (sourceOrder.lines.length) {
             const orphanLine = sourceOrder.lines[0];
-            const destinationLine = destOrder?.lines.find((l) => l.canBeMergedWith(orphanLine));
+            const destinationLine = destOrder.lines.find((l) => l.canBeMergedWith(orphanLine));
             let uuid = "";
-
             if (destinationLine) {
                 destinationLine.merge(orphanLine);
                 uuid = destinationLine.uuid;
-
                 this.handlePreparationHistory(
                     sourceOrder.last_order_preparation_change.lines,
                     destOrder.last_order_preparation_change.lines,
@@ -136,8 +143,17 @@ patch(PosStore.prototype, {
                 delete serializedLine.uuid;
                 delete serializedLine.id;
                 const newLine = this.models["pos.order.line"].create(serializedLine, false, true);
+                newLine.course_id = orphanLine.course_id?.id;
                 uuid = newLine.uuid;
-
+                if (orphanLine.course_id && mergedCourses) {
+                    // Replace new line uuid in the merged courses
+                    const course = mergedCourses[orphanLine.course_id.uuid];
+                    if (course?.lines) {
+                        course.lines = course.lines.map((lineUuid) =>
+                            lineUuid === orphanLine.uuid ? uuid : lineUuid
+                        );
+                    }
+                }
                 this.handlePreparationHistory(
                     sourceOrder.last_order_preparation_change.lines,
                     destOrder.last_order_preparation_change.lines,
@@ -147,10 +163,12 @@ patch(PosStore.prototype, {
                 );
             }
 
-            destOrder.uiState.unmerge[uuid] = {
-                table_id: sourceOrder.table_id.id,
-                quantity: orphanLine.qty,
-            };
+            if (sourceOrder.table_id) {
+                destOrder.uiState.unmerge[uuid] = {
+                    table_id: sourceOrder.table_id.id,
+                    quantity: orphanLine.qty,
+                };
+            }
 
             orphanLine.delete();
             whileGuard++;
@@ -158,10 +176,70 @@ patch(PosStore.prototype, {
                 break;
             }
         }
+        if (mergedCourses) {
+            destOrder.uiState.unmergeCourses = {
+                ...destOrder.uiState.unmergeCourses,
+                ...mergedCourses,
+            };
+        }
+        if (destOrder.courses) {
+            // Ensure unassigned lines in destOrder are linked to the last course
+            const lastCourse = destOrder.courses?.at(-1);
+            if (lastCourse) {
+                destOrder.lines.forEach((line) => {
+                    if (!line.course_id) {
+                        line.course_id = lastCourse;
+                    }
+                });
+            }
+        }
 
         await this.deleteOrders([sourceOrder], [], true);
         await this.syncAllOrders({ orders: [destOrder] });
         return destOrder;
+    },
+    mergeCourses(sourceOrder, destOrder) {
+        if (!sourceOrder.hasCourses() && !destOrder?.hasCourses()) {
+            return;
+        }
+        const result = {}; // Contains the required info to restore merge courses in the original table
+        const courseMap = new Map();
+        sourceOrder.course_ids.forEach((course) => {
+            courseMap.set(course.index, course);
+            result[course.uuid] = {
+                table_id: sourceOrder.table_id?.id,
+                lines: course.line_ids.map((l) => l.uuid),
+                index: course.index,
+                fired: course.fired,
+                fired_date: course.fired_date,
+            };
+        });
+
+        // Add courses from the target, merging lines if course numbers match
+        destOrder.course_ids?.forEach((targetCourse) => {
+            if (courseMap.has(targetCourse.index)) {
+                // If the course already exists, merge the lines
+                const sourceCourse = courseMap.get(targetCourse.index);
+                if (sourceCourse) {
+                    const sourceCourseLines = [...sourceCourse.line_ids];
+                    sourceCourseLines.forEach((source_line) => {
+                        source_line.course_id = targetCourse;
+                        source_line.combo_line_ids?.forEach((line) => {
+                            line.course_id = targetCourse;
+                        });
+                    });
+                    result[targetCourse.uuid] = result[sourceCourse.uuid];
+                    delete result[sourceCourse.uuid];
+                }
+            }
+            courseMap.set(targetCourse.index, targetCourse);
+        });
+
+        // Ensures all courses are assigned to the target order
+        const mergedCourses = Array.from(courseMap.values()).sort((a, b) => a.index - b.index);
+        mergedCourses.forEach((course) => (course.order_id = destOrder.id));
+        destOrder.course_ids = mergedCourses;
+        return result;
     },
     async restoreOrdersToOriginalTable(order, unmergeTable) {
         if (!order?.uiState?.unmerge) {
@@ -180,28 +258,62 @@ patch(PosStore.prototype, {
             },
             []
         );
+        let beforeMergeCourseDetails;
+        if (order?.uiState?.unmergeCourses) {
+            beforeMergeCourseDetails = Object.entries(order.uiState.unmergeCourses).reduce(
+                (acc, [uuid, details]) => {
+                    if (details.table_id === unmergeTable.id) {
+                        acc.push({
+                            ...details,
+                            uuid: uuid,
+                        });
+                    }
+                    return acc;
+                },
+                []
+            );
+        }
 
         if (beforeMergeDetails.length) {
             const newOrder = this.addNewOrder({ table_id: unmergeTable });
+
+            const courseByLines = {};
+            if (beforeMergeCourseDetails?.length) {
+                // Restore courses
+                for (const courseDetails of beforeMergeCourseDetails) {
+                    const course = this.data.models["restaurant.order.course"].create({
+                        order_id: newOrder,
+                        index: courseDetails.index,
+                        fired: courseDetails.fired,
+                        fired_date: courseDetails.fired_date,
+                    });
+                    courseDetails.lines?.forEach((lineUuid) => {
+                        courseByLines[lineUuid] = course;
+                    });
+                    delete order.uiState.unmergeCourses[courseDetails.uuid];
+                }
+            }
+
             for (const detail of beforeMergeDetails) {
                 const line = order.lines.find((l) => l.uuid === detail.uuid);
                 const serializedLine = line.serialize({ orm: true });
-
                 delete serializedLine.uuid;
                 delete serializedLine.id;
-
+                const course = courseByLines[detail.uuid];
                 Object.assign(serializedLine, {
                     order_id: newOrder.id,
                     qty: detail.quantity,
                 });
 
                 const newLine = this.models["pos.order.line"].create(serializedLine, false, true);
+                if (course) {
+                    newLine.course_id = course;
+                }
                 if (parseFloat(line.qty - detail.quantity) === 0) {
                     line.delete();
                 } else {
                     line.setQuantity(line.qty - newLine.qty);
                 }
-
                 this.handlePreparationHistory(
                     order.last_order_preparation_change.lines,
                     newOrder.last_order_preparation_change.lines,
@@ -404,10 +516,31 @@ patch(PosStore.prototype, {
         return super.createOrderIfNeeded(...arguments);
     },
     async addLineToCurrentOrder(vals, opts = {}, configure = true) {
-        if (this.config.module_pos_restaurant && !this.getOrder().uiState.booked) {
-            this.getOrder().setBooked(true);
+        let currentCourse;
+        if (this.config.module_pos_restaurant) {
+            const order = this.getOrder();
+            if (!order.uiState.booked) {
+                order.setBooked(true);
+            }
+            if (order.hasCourses()) {
+                let course = order.getSelectedCourse();
+                if (!course) {
+                    course = order.getLastCourse();
+                }
+                currentCourse = course;
+                order.selectCourse(course);
+                vals = { ...vals, course_id: course };
+            }
         }
-        return super.addLineToCurrentOrder(vals, opts, configure);
+        const result = await super.addLineToCurrentOrder(vals, opts, configure);
+
+        if (currentCourse && result?.combo_line_ids) {
+            result.combo_line_ids.forEach((line) => {
+                line.course_id = currentCourse;
+            });
+        }
+
+        return result;
     },
     async getServerOrders() {
         if (this.config.module_pos_restaurant) {
@@ -546,9 +679,7 @@ patch(PosStore.prototype, {
         }
     },
     getActiveOrdersOnTable(table) {
-        return this.models["pos.order"].filter(
-            (o) => o.table_id?.id === table.id && !o.finalized && o.lines.length
-        );
+        return this.models["pos.order"].filter((o) => o.table_id?.id === table.id && !o.finalized);
     },
     tableHasOrders(table) {
         return Boolean(table.getOrder());
@@ -600,6 +731,7 @@ patch(PosStore.prototype, {
         if (!destinationTable && !destinationOrder) {
             return;
         }
+
         const sourceOrder = this.models["pos.order"].getBy("uuid", orderUuid);
 
         if (destinationTable) {
@@ -608,7 +740,7 @@ patch(PosStore.prototype, {
             }
             destinationOrder = this.getActiveOrdersOnTable(destinationTable.rootTable)[0];
         }
-        await this.mergeOrders(sourceOrder, destinationOrder);
+        await this.mergeOrders(sourceOrder, destinationOrder, destinationTable);
         if (destinationTable) {
             await this.setTable(destinationTable);
         }
@@ -657,5 +789,97 @@ patch(PosStore.prototype, {
             return;
         }
         return this.floorScrollPositions[floorId];
+    },
+    shouldCreatePendingOrder(order) {
+        return super.shouldCreatePendingOrder(order) || order.course_ids?.length > 0;
+    },
+    setOrder(order) {
+        order?.ensureCourseSelection();
+        super.setOrder(order);
+    },
+    addCourse() {
+        const order = this.getOrder();
+
+        const course = this.data.models["restaurant.order.course"].create({
+            order_id: order,
+            index: order.getNextCourseIndex(),
+        });
+        let selectedCourse = course;
+        if (order.course_ids.length === 1 && order.lines.length > 0) {
+            // Assign order lines to the first course
+            order.lines.forEach((line) => (line.course_id = course));
+            // Create a second empty course
+            selectedCourse = this.data.models["restaurant.order.course"].create({
+                order_id: order,
+                index: order.getNextCourseIndex(),
+            });
+        }
+        order.recomputeOrderData(); // To ensure that courses are stored locally
+        order.selectCourse(selectedCourse);
+        return course;
+    },
+    async fireCourse(course) {
+        const order = this.getOrder();
+        if (!order || !course || course.fired) {
+            return false;
+        }
+        course.fired = true;
+        this.addPendingOrder([order.id]);
+        order.deselectCourse();
+        await this.syncAllOrders();
+        course = this.models["restaurant.order.course"].getBy("uuid", course.uuid);
+        await this._onCourseFired(course);
+        return true;
+    },
+    async _onCourseFired(course) {
+        try {
+            const changes = {
+                new: [],
+                cancelled: [],
+                noteUpdate: course.lines.map((line) => ({ product_id: line.getProduct().id })),
+                noteUpdateTitle: _t("Course %s fired", "" + course.index),
+                printNoteUpdateData: false,
+            };
+            this.getOrder().uiState.lastPrint = changes;
+            await this.printChanges(this.getOrder(), changes, false);
+        } catch (e) {
+            console.error("Unable to print course", e);
+        }
+    },
+    async transferLinesToCourse() {
+        const order = this.getOrder();
+        if (!order) {
+            return;
+        }
+        const selectedLine = order.getSelectedOrderline();
+        const selectedCourse = order.getSelectedCourse()
+            ? order.getSelectedCourse()
+            : selectedLine.course_id;
+        const selectionList = this.getOrder().courses.map((course) => ({
+            id: course.id,
+            label: course.name,
+            isSelected: course.id === selectedCourse?.id,
+            item: course,
+        }));
+        const dialogTitle = selectedLine
+            ? _t('Transfer "%s" to:', selectedLine.getFullProductName())
+            : _t('Transfer all products of "%s" into:', selectedCourse.name);
+        const destCourse = await makeAwaitable(this.dialog, SelectionPopup, {
+            title: dialogTitle,
+            list: selectionList,
+        });
+        if (!destCourse) {
+            return;
+        }
+        if (selectedLine) {
+            selectedLine.course_id = destCourse.id;
+        } else {
+            const lines = [...selectedCourse.lines];
+            lines.forEach((line) => {
+                line.course_id = destCourse.id;
+            });
+        }
+        order.selectCourse(destCourse);
+        order.recomputeOrderData();
     },
 });

--- a/addons/pos_restaurant/static/src/app/utils/order_change.js
+++ b/addons/pos_restaurant/static/src/app/utils/order_change.js
@@ -1,0 +1,11 @@
+import { receiptLineGrouper } from "@point_of_sale/app/models/utils/order_change";
+import { patch } from "@web/core/utils/patch";
+
+patch(receiptLineGrouper, {
+    getGroup(line) {
+        if (!line.config?.module_pos_restaurant || !line.course_id) {
+            return super.getGroup(line);
+        }
+        return { index: line.course_id.index, name: line.course_id.name };
+    },
+});


### PR DESCRIPTION
This commit introduces the ability to sort order lines by course (e.g., starters, mains, desserts)  and trigger course notifications for the kitchen. The kitchen will know when to prepare each course to ensure that the client do not wait too much.

Task: 4444501
