### PR TITLE
[FIX] mrp: duplicate MO and change date

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -869,9 +869,10 @@ class MrpProduction(models.Model):
 
         date_start_map = dict()
         if 'date_start' in vals:
+            date_start = fields.Datetime.to_datetime(vals['date_start'])
             date_start_map = {
-                prod: vals['date_start'] - datetime.timedelta(days=prod.bom_id.produce_delay)
-                if prod.bom_id else vals['date_start']
+                prod: date_start - datetime.timedelta(days=prod.bom_id.produce_delay)
+                if prod.bom_id else date_start
                 for prod in self
             }
             res = True
@@ -903,7 +904,7 @@ class MrpProduction(models.Model):
                 if 'qty_producing' in vals:
                     finished_move.quantity = vals.get('qty_producing')
             if self._has_workorders() and not production.workorder_ids.operation_id and vals.get('date_start') and not vals.get('date_finished'):
-                new_date_start = fields.Datetime.to_datetime(production.date_start)
+                new_date_start = production.date_start
                 if not production.date_finished or new_date_start >= production.date_finished:
                     production.date_finished = new_date_start + datetime.timedelta(hours=1)
         return res


### PR DESCRIPTION
Steps to reproduce:
-----

- Create a MO
- Duplicate it
- Change the scheduled date
- Confirm

Issue:
---

This [changes](https://github.com/odoo/odoo/commit/7c808beaf36853b4d9171ef0981d1ec9c4b73a44), is trying to timedelta between str and datetime leading to an error.

Fix:
---
To fix this the date_start is set as a datetime and removing the conversion later in the code.

opw-4489618


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
