### PR TITLE
[IMP] res_partner: improve contact computed fields

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -404,7 +404,7 @@ class ResPartner(models.Model):
         all_partner_ids = []
         for partner in self.filtered('id'):
             # price_total is in the company currency
-            all_partners_and_children[partner] = self.with_context(active_test=False).search([('id', 'child_of', partner.id)]).ids
+            all_partners_and_children[partner] = set(self.with_context(active_test=False).search([('id', 'child_of', partner.id)]).ids)
             all_partner_ids += all_partners_and_children[partner]
 
         domain = [

--- a/addons/purchase/models/res_partner.py
+++ b/addons/purchase/models/res_partner.py
@@ -12,7 +12,6 @@ class res_partner(models.Model):
     def _compute_purchase_order_count(self):
         # retrieve all children partners and prefetch 'parent_id' on them
         all_partners = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
-        all_partners.read(['parent_id'])
 
         purchase_order_groups = self.env['purchase.order']._read_group(
             domain=[('partner_id', 'in', all_partners.ids)],
@@ -31,7 +30,6 @@ class res_partner(models.Model):
     def _compute_supplier_invoice_count(self):
         # retrieve all children partners and prefetch 'parent_id' on them
         all_partners = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
-        all_partners.read(['parent_id'])
 
         supplier_invoice_groups = self.env['account.move']._read_group(
             domain=[('partner_id', 'in', all_partners.ids),

--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -20,8 +20,7 @@ class ResPartner(models.Model):
     def _compute_sale_order_count(self):
         # retrieve all children partners and prefetch 'parent_id' on them
         all_partners = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
-        all_partners.read(['parent_id'])
-
+        
         sale_order_groups = self.env['sale.order']._read_group(
             domain=expression.AND([self._get_sale_order_domain_count(), [('partner_id', 'in', all_partners.ids)]]),
             fields=['partner_id'], groupby=['partner_id']


### PR DESCRIPTION
**Problem**:

The following res_partner computed fields are taking a lot of time to compute for contacts with 500K+ children (+2 minutes) 
Fields:
    * total_invoiced
    * meeting_count
    * purchase_order_count
    * sale_order_count
    * supplier_invoice_count

**Solution**:
    * Avoid read method in computation of the fields (for the meeting_cound, it could only be avoided in the form view).
    * Speedup sum generator expression of total_invoiced computaion by replacing list with set.

opw-4421866
