### PR TITLE
[FIX] web: respect X2many field context when order is present

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -135,7 +135,9 @@ class Base(models.AbstractModel):
                 co_records = self[field_name]
 
                 if 'order' in field_spec and field_spec['order']:
-                    co_records = co_records.search([('id', 'in', co_records.ids)], order=field_spec['order'])
+                    co_records = co_records.with_context(active_test=False).search(
+                        [('id', 'in', co_records.ids)], order=field_spec['order'],
+                    ).with_context(co_records.env.context)  # Reapply previous context
                     order_key = {
                         co_record.id: index
                         for index, co_record in enumerate(co_records)

--- a/odoo/addons/test_new_api/models/test_unity_read.py
+++ b/odoo/addons/test_new_api/models/test_unity_read.py
@@ -25,7 +25,7 @@ class Lesson(models.Model):
 
     name = fields.Char('Name')
     course_id = fields.Many2one('test_new_api.course')
-    attendee_ids = fields.Many2many('test_new_api.person', 'lesson_ids')
+    attendee_ids = fields.Many2many('test_new_api.person', 'lesson_ids', context={'active_test': False})
     teacher_id = fields.Many2one('test_new_api.person')
     date = fields.Date()
 
@@ -47,6 +47,7 @@ class Person(models.Model):
     name = fields.Char('Name')
     lesson_ids = fields.Many2many('test_new_api.lesson', 'course_id')
     employer_id = fields.Many2one('test_new_api.employer')
+    active = fields.Boolean(default=True)
 
     def _compute_display_name(self):
         """
@@ -64,6 +65,7 @@ class Employer(models.Model):
 
     name = fields.Char('Name')
     employee_ids = fields.One2many('test_new_api.person', 'employer_id')
+    all_employee_ids = fields.One2many('test_new_api.person', 'employer_id', context={'active_test': False})
 
 
 class PersonAccount(models.Model):


### PR DESCRIPTION
Issue:
If we have a X2many that allows to have inactive records (with `context={'active_test': False}` on the field definition) and we specify a specific order for this X2many in this view, web_read won't respect the context of the field and will filter out inactive records.

This is because to apply a specific order in the web_read, we use search(), which will filter out inactive records from the `corecords` recordset.

Fix:
We fix this by forcing active_test=False before calling search and reapplying the previous context immediately after.

Closes #194311