### PR TITLE
[FIX] account: draft badge in blue

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -541,6 +541,7 @@
                     <field name="status_in_payment"
                            string="Status"
                            widget="badge"
+                           decoration-info="state == 'draft'"
                            decoration-danger="payment_state == 'not_paid' and invoice_date_due &lt; context_today().strftime('%Y-%m-%d')"
                            decoration-warning="payment_state in ('partial', 'in_payment')"
                            decoration-success="payment_state in ('paid', 'reversed')"


### PR DESCRIPTION
In the account move view, since this commit:
https://github.com/odoo/odoo/commit/9b47dd1158b2819c74431f30ff137cbb13ce0d4f We made a new column that is status_in_payment but with that we removed the decoration for draft moves

task-4497735




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
