### PR TITLE
[FIX] contacts,*: improve contact computed fields

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -404,7 +404,7 @@ class ResPartner(models.Model):
         all_partner_ids = []
         for partner in self.filtered('id'):
             # price_total is in the company currency
-            all_partners_and_children[partner] = self.with_context(active_test=False).search([('id', 'child_of', partner.id)]).ids
+            all_partners_and_children[partner] = set(self.with_context(active_test=False).search([('id', 'child_of', partner.id)]).ids)
             all_partner_ids += all_partners_and_children[partner]
 
         domain = [
@@ -549,9 +549,8 @@ class ResPartner(models.Model):
             partner.bank_account_count = mapped_data.get(partner.id, 0)
 
     def _compute_supplier_invoice_count(self):
-        # retrieve all children partners and prefetch 'parent_id' on them
+        # retrieve all children partners
         all_partners = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
-        all_partners.read(['parent_id'])
 
         supplier_invoice_groups = self.env['account.move']._read_group(
             domain=[('partner_id', 'in', all_partners.ids),

--- a/addons/purchase/models/res_partner.py
+++ b/addons/purchase/models/res_partner.py
@@ -10,9 +10,8 @@ class res_partner(models.Model):
     _inherit = 'res.partner'
 
     def _compute_purchase_order_count(self):
-        # retrieve all children partners and prefetch 'parent_id' on them
+        # retrieve all children partners
         all_partners = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
-        all_partners.read(['parent_id'])
 
         purchase_order_groups = self.env['purchase.order']._read_group(
             domain=[('partner_id', 'in', all_partners.ids)],

--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -18,9 +18,8 @@ class ResPartner(models.Model):
         return []
 
     def _compute_sale_order_count(self):
-        # retrieve all children partners and prefetch 'parent_id' on them
+        # retrieve all children partners
         all_partners = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
-        all_partners.read(['parent_id'])
 
         sale_order_groups = self.env['sale.order']._read_group(
             domain=expression.AND([self._get_sale_order_domain_count(), [('partner_id', 'in', all_partners.ids)]]),


### PR DESCRIPTION
**Problem**:

The following res_partner computed fields are taking a lot of time to compute for contacts with 500K+ children (+2 minutes)
Fields:
    * total_invoiced
    * meeting_count
    * purchase_order_count
    * sale_order_count
    * supplier_invoice_count

The issue in four of thies five fields is comming from read method.
Prefetching using read was a necessary step before updating orm, as mentioned in the task related to the PR it was added in.
task link: https://www.odoo.com/odoo/all-tasks/1919933

**Solution**:
    * Avoid read method in computation of the fields.
    * Speedup sum generator expression of total_invoiced computation by replacing list with set.

**Benchmark**
| # of children | Before | After |
|--------|--------|--------|
| 8500 | 3s | 2.5s |
| 54000 | 30s | 15s |
| 580000 | 3.20m | 34s |

opw-4421866