### PR TITLE
[FIX] web_editor: check range count when positioning toolbar

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3149,6 +3149,9 @@ export class OdooEditor extends EventTarget {
         this.toolbar.classList.toggle('d-none', false);
         this.toolbar.style.maxWidth = window.innerWidth - OFFSET * 2 + 'px';
         const sel = this.document.getSelection();
+        if (!sel.rangeCount) {
+            return;
+        }
         const range = sel.getRangeAt(0);
         const isSelForward =
             sel.anchorNode === range.startContainer && sel.anchorOffset === range.startOffset;


### PR DESCRIPTION
**Problem**:
In rare edge cases, the selection can have no ranges, causing a crash when attempting to `getRangeAt(0)`.

**Solution**:
Ensure there are ranges in the selection before accessing them.

**Steps to Reproduce**:
1. Split the window, with Odoo on one side and any other application on the other.
2. Navigate to a sales order in Odoo.
3. From the sales order, navigate to the partner.
4. Maximize the window.
5. Return to the sales order.
6. Split the window again.
7. Scroll down.

opw-4279813

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
