### PR TITLE
[FIX] account, *: wrap quantity uom in reports

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -133,8 +133,8 @@
                                             <td name="account_invoice_line_name">
                                                 <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">Bacon Burger</span>
                                             </td>
-                                            <td name="td_quantity" class="text-end text-nowrap">
-                                                <span t-field="line.quantity">3.00</span>
+                                            <td name="td_quantity" class="o_td_quantity text-end">
+                                                <span t-field="line.quantity" class="text-nowrap">3.00</span>
                                                 <span t-field="line.product_uom_id"  groups="uom.group_uom">units</span>
                                             </td>
                                             <td name="td_price_unit" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">

--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -276,8 +276,8 @@
                                     <td class="text-end">
                                         <span class="text-nowrap" t-field="line.price_unit"/>
                                     </td>
-                                    <td class="text-end">
-                                        <span t-field="line.quantity"/>
+                                    <td class="o_td_quantity text-end">
+                                        <span t-field="line.quantity" class="text-nowrap"/>
                                         <span t-field="line.product_uom_id" groups="uom.group_uom"/>
                                     </td>
                                     <td name="account_invoice_line_name">

--- a/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
+++ b/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
@@ -119,8 +119,8 @@
                                     <td>
                                         <span t-field="move.product_id"/>
                                     </td>
-                                    <td>
-                                        <span t-field="move.quantity"/>
+                                    <td class="o_td_quantity">
+                                        <span t-field="move.quantity" class="text-nowrap"/>
                                         <span t-field="move.product_uom" groups="uom.group_uom"/>
                                     </td>
                                     <td t-if="display_discount">

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -106,8 +106,8 @@
                         >
                             <t t-if="not line.display_type and line.product_type != 'combo'">
                                 <td name="td_name"><span t-field="line.name">Bacon Burger</span></td>
-                                <td name="td_quantity" t-attf-class="text-end {{ 'text-nowrap' if (not line.product_packaging_id or len(line.product_packaging_id.name) &lt; 10) else '' }}">
-                                    <span t-field="line.product_uom_qty">3</span>
+                                <td name="td_quantity" class="o_td_quantity text-end">
+                                    <span t-field="line.product_uom_qty" class="text-nowrap">3</span>
                                     <span t-field="line.product_uom">units</span>
                                     <span t-if="line.product_packaging_id">
                                         (<span t-field="line.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="line.product_packaging_id"/>)

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -75,15 +75,15 @@
                                         <span t-field="move.description_picking">Description on transfer</span>
                                     </p>
                                 </td>
-                                <td class="text-end">
-                                    <span t-field="move.product_uom_qty">3.00</span>
+                                <td class="o_td_quantity text-end">
+                                    <span t-field="move.product_uom_qty" class="text-nowrap">3.00</span>
                                     <span t-field="move.product_uom" groups="uom.group_uom">units</span>
                                     <span t-if="move.product_packaging_id">
                                         (<span t-field="move.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="move.product_packaging_id"/>)
                                     </span>
                                 </td>
-                                <td class="text-end">
-                                    <span t-field="move.quantity">3.00</span>
+                                <td class="o_td_quantity text-end">
+                                    <span t-field="move.quantity" class="text-nowrap">3.00</span>
                                     <span t-field="move.product_uom" groups="uom.group_uom">units</span>
                                     <span t-if="move.product_packaging_id">
                                         (<span t-field="move.product_packaging_quantity" t-options='{"widget": "integer"}'/> <span t-field="move.product_packaging_id"/>)

--- a/addons/stock/report/report_stockinventory.xml
+++ b/addons/stock/report/report_stockinventory.xml
@@ -35,12 +35,12 @@
                                         <td><span t-field="line.product_id">Laptop</span></td>
                                         <td groups="stock.group_production_lot"><span t-field="line.lot_id"/></td>
                                         <td groups="stock.group_tracking_lot"><span t-field="line.package_id"/></td>
-                                        <td class="text-end"><span t-field="line.available_quantity">2</span> <span t-field="line.product_uom_id" groups="uom.group_uom">Units</span></td>
-                                        <td class="text-end"><span t-field="line.quantity">5</span> <span t-field="line.product_uom_id" groups="uom.group_uom">Units</span></td>
-                                        <td class="text-end">
+                                        <td class="o_td_quantity text-end"><span t-field="line.available_quantity" class="text-nowrap">2</span> <span t-field="line.product_uom_id" groups="uom.group_uom">Units</span></td>
+                                        <td class="o_td_quantity text-end"><span t-field="line.quantity" class="text-nowrap">5</span> <span t-field="line.product_uom_id" groups="uom.group_uom">Units</span></td>
+                                        <td class="o_td_quantity text-end">
                                             <!-- If 0, then leave blank so users have space to write a number -->
                                             <t t-if="line.inventory_quantity == 0"><span></span></t>
-                                            <t t-else=""><span t-field="line.inventory_quantity">7</span></t>
+                                            <t t-else=""><span t-field="line.inventory_quantity" class="text-nowrap">7</span></t>
                                             <span t-field="line.product_uom_id" groups="uom.group_uom">Units</span>
                                         </td>
                                     </tr>

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -118,8 +118,8 @@
                                             <span t-field="ml.product_id.display_name">Customizable Desk</span><br/>
                                             <span t-if="ml.product_id.description_picking" t-field="ml.product_id.description_picking"></span>
                                         </td>
-                                        <td class="text-end">
-                                            <span t-field="ml.quantity">3.00</span>
+                                        <td class="o_td_quantity text-end">
+                                            <span t-field="ml.quantity" class="text-nowrap">3.00</span>
                                             <span t-field="ml.product_uom_id" groups="uom.group_uom">units</span>
                                             <span t-if="ml.move_id.product_packaging_id">
                                                 <span t-if="o.state != 'done'">

--- a/addons/web/static/src/webclient/actions/reports/report.scss
+++ b/addons/web/static/src/webclient/actions/reports/report.scss
@@ -159,6 +159,12 @@ span[itemprop="streetAddress"] {
     white-space: normal;
 }
 
+// Force a max width on quantity column to handle long UoM
+.o_td_quantity {
+    min-width: 7rem;
+    max-width: 9rem;
+}
+
 // Override html_editor display styles as it uses 'calc' which doesn't work with wkhtmltopdf
 .display-1-fs {
     font-size: 6rem;


### PR DESCRIPTION
*: l10n_gcc_invoice,l10n_it_stock_ddt,sale,stock,web

[1]: https://github.com/odoo/odoo/commit/344bdb1ed4cecdaef007200c011f87e58e36c87d
Issue: [Commit](https://github.com/odoo/odoo/commit/344bdb1ed4cecdaef007200c011f87e58e36c87d) introduced a `text-nowrap` on the quantity column, this unnecessarily crops the other columns if we use a long UoM.

This commit adds a max-width to the UoM column and applies the text-nowrap to the quantity only, letting the long UoM wrap if too long.

task-4478718




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
