### PR TITLE
[IMP] mail: avoid using store.insert result (and fix lazy session)

### DIFF
--- a/addons/hr_attendance/models/ir_http.py
+++ b/addons/hr_attendance/models/ir_http.py
@@ -7,8 +7,8 @@ from odoo import models
 class IrHttp(models.AbstractModel):
     _inherit = 'ir.http'
 
-    def lazy_session_info(self):
-        res = super().lazy_session_info()
+    def lazy_session_info(self, **kwargs):
+        res = super().lazy_session_info(**kwargs)
         if self.env.user and self.env.user.employee_id:
             employee = self.env.user.employee_id
             res['attendance_user_data'] = HrAttendance._get_user_attendance_data(employee)

--- a/addons/im_livechat/static/tests/embed/autopopup.test.js
+++ b/addons/im_livechat/static/tests/embed/autopopup.test.js
@@ -39,8 +39,8 @@ test("rule received in init", async () => {
         action: "auto_popup",
     });
     patchWithCleanup(mailDataHelpers, {
-        async _process_request_for_all(store) {
-            await super._process_request_for_all(...arguments);
+        _process_request_for_all(store) {
+            super._process_request_for_all(...arguments);
             store.add(pyEnv["im_livechat.channel.rule"].browse(autopopupRuleId), {
                 action: "auto_popup",
                 auto_popup_timer: 0,

--- a/addons/im_livechat/static/tests/embed/livechat_button.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_button.test.js
@@ -54,8 +54,8 @@ test("livechat not available", async () => {
     await startServer();
     await loadDefaultEmbedConfig();
     patchWithCleanup(mailDataHelpers, {
-        async _process_request_for_all(store) {
-            await super._process_request_for_all(...arguments);
+        _process_request_for_all(store) {
+            super._process_request_for_all(...arguments);
             store.add({ livechat_available: false });
         },
     });
@@ -71,8 +71,8 @@ test("clicking on notification opens the chat", async () => {
         action: "display_button_and_text",
     });
     patchWithCleanup(mailDataHelpers, {
-        async _process_request_for_all(store) {
-            await super._process_request_for_all(...arguments);
+        _process_request_for_all(store) {
+            super._process_request_for_all(...arguments);
             store.add(pyEnv["im_livechat.channel.rule"].browse(btnAndTextRuleId), {
                 action: "display_button_and_text",
             });

--- a/addons/im_livechat/static/tests/messaging_service_patch.test.js
+++ b/addons/im_livechat/static/tests/messaging_service_patch.test.js
@@ -1,14 +1,13 @@
-import { contains, start, startServer } from "@mail/../tests/mail_test_helpers";
+import {
+    contains,
+    listenStoreFetch,
+    start,
+    startServer,
+    waitStoreFetch,
+} from "@mail/../tests/mail_test_helpers";
 import { withGuest } from "@mail/../tests/mock_server/mail_mock_server";
 import { describe, test } from "@odoo/hoot";
-import {
-    asyncStep,
-    Command,
-    onRpc,
-    patchWithCleanup,
-    serverState,
-    waitForSteps,
-} from "@web/../tests/web_test_helpers";
+import { Command, patchWithCleanup, serverState } from "@web/../tests/web_test_helpers";
 
 import { rpc } from "@web/core/network/rpc";
 import { defineLivechatModels } from "./livechat_test_helpers";
@@ -40,11 +39,9 @@ test("push notifications are Odoo toaster on Android", async () => {
             Command.create({ guest_id: guestId }),
         ],
     });
-    onRpc("/web/dataset/call_kw/ir.http/lazy_session_info", () => {
-        asyncStep("lazy_session_info");
-    });
+    listenStoreFetch("init_messaging");
     await start();
-    await waitForSteps([`lazy_session_info`]);
+    await waitStoreFetch("init_messaging");
     // send after init_messaging because bus subscription is done after init_messaging
     await withGuest(guestId, () =>
         rpc("/mail/message/post", {

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -50,27 +50,24 @@ class DiscussChannelWebclientController(WebclientController):
                 OrderedSet(int(cid) for cid in params) - OrderedSet(channels.ids)
             ):
                 store.delete(not_found_channels)
+        if name == "/discuss/get_or_create_chat":
+            channel = request.env["discuss.channel"]._get_or_create_chat(
+                params["partners_to"], params.get("pin", True)
+            )
+            store.add(channel).resolve_data_request(channel=Store.One(channel, []))
+        if name == "/discuss/create_channel":
+            channel = request.env["discuss.channel"]._create_channel(params["name"], params["group_id"])
+            store.add(channel).resolve_data_request(channel=Store.One(channel, []))
+        if name == "/discuss/create_group":
+            channel = request.env["discuss.channel"]._create_group(
+                params["partners_to"],
+                params.get("default_display_mode", False),
+                params.get("name", ""),
+            )
+            store.add(channel).resolve_data_request(channel=Store.One(channel, []))
 
 
 class ChannelController(http.Controller):
-    @http.route("/discuss/channel/get_or_create_chat", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
-    def discuss_get_or_create_chat(self, partners_to, pin=True):
-        channel = request.env["discuss.channel"]._get_or_create_chat(partners_to, pin)
-        return {"channel_id": channel.id, "data": Store(channel).get_result()}
-
-    @http.route("/discuss/channel/create_channel", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
-    def discuss_create_channel(self, name, group_id):
-        channel = request.env["discuss.channel"]._create_channel(name, group_id)
-        return Store(channel).get_result()
-
-    @http.route("/discuss/channel/create_group", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
-    def discuss_create_group(self, partners_to, default_display_mode=False, name=''):
-        channel = request.env["discuss.channel"]._create_group(partners_to, default_display_mode, name)
-        return Store(channel).get_result()
-
     @http.route("/discuss/channel/members", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
     @add_guest_to_context
     def discuss_channel_members(self, channel_id, known_member_ids):

--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -36,12 +36,18 @@ class WebclientController(http.Controller):
     @classmethod
     def _process_request_loop(self, store: Store, fetch_params):
         for fetch_param in fetch_params:
-            name, params = (fetch_param, None) if isinstance(fetch_param, str) else fetch_param
+            name, params, data_id = (
+                (fetch_param, None, None)
+                if isinstance(fetch_param, str)
+                else (fetch_param + [None, None])[:3]
+            )
+            store.data_id = data_id
             self._process_request_for_all(store, name, params)
             if not request.env.user._is_public():
                 self._process_request_for_logged_in_user(store, name, params)
             if request.env.user._is_internal():
                 self._process_request_for_internal_user(store, name, params)
+        store.data_id = None
 
     @classmethod
     def _process_request_for_all(self, store: Store, name, params):

--- a/addons/mail/static/src/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/core/common/@types/models.d.ts
@@ -6,6 +6,7 @@ declare module "models" {
     import { ChatWindow as ChatWindowClass } from "@mail/core/common/chat_window_model";
     import { Composer as ComposerClass } from "@mail/core/common/composer_model";
     import { Country as CountryClass } from "@mail/core/common/country_model";
+    import { DataResponse as DataResponseClass } from "@mail/core/common/data_request_model";
     import { Failure as FailureClass } from "@mail/core/common/failure_model";
     import { Follower as FollowerClass } from "@mail/core/common/follower_model";
     import { LinkPreview as LinkPreviewClass } from "@mail/core/common/link_preview_model";
@@ -27,6 +28,7 @@ declare module "models" {
     export interface ChatWindow extends ChatWindowClass {}
     export interface Composer extends ComposerClass {}
     export interface Country extends CountryClass {}
+    export interface DataResponse extends DataResponseClass {}
     export interface Failure extends FailureClass {}
     export interface Follower extends FollowerClass {}
     export interface LinkPreview extends LinkPreviewClass {}
@@ -45,6 +47,7 @@ declare module "models" {
         ChatHub: StaticMailRecord<ChatHub, typeof ChatHubClass>;
         ChatWindow: StaticMailRecord<ChatWindow, typeof ChatWindowClass>;
         Composer: StaticMailRecord<Composer, typeof ComposerClass>;
+        DataResponse: StaticMailRecord<DataResponse, typeof DataResponseClass>;
         Failure: StaticMailRecord<Failure, typeof FailureClass>;
         "ir.attachment": StaticMailRecord<Attachment, typeof AttachmentClass>;
         "mail.activity": StaticMailRecord<Activity, typeof ActivityClass>;
@@ -68,6 +71,7 @@ declare module "models" {
         ChatHub: ChatHub;
         ChatWindow: ChatWindow;
         Composer: Composer;
+        DataResponse: DataResponse;
         Failure: Failure;
         "ir.attachment": Attachment;
         "mail.activity": Activity;

--- a/addons/mail/static/src/core/common/data_response_model.js
+++ b/addons/mail/static/src/core/common/data_response_model.js
@@ -1,0 +1,65 @@
+import { Record } from "@mail/core/common/record";
+
+import { Deferred } from "@web/core/utils/concurrency";
+
+/**
+ * This class represents a specific and unique request coming from the client to the server, and it
+ * also holds the corresponding response coming from the server.
+ * It is useful when batching requests together to determine which data to return for a specific
+ * request. It basically does the un-batching by referencing the given id. The rest of the data
+ * being grouped together in the store, flattened and with no duplicate records/fields, no matter
+ * how many requests are returning the same data.
+ * Instances of the class are created by the fetch method on each call, and they are deleted once
+ * they are resolved with their data. This class should not be used directly under typical use.
+ */
+export class DataResponse extends Record {
+    static id = "id";
+    static _lastId = 0;
+
+    static createRequest() {
+        return this.insert({ id: ++this._lastId });
+    }
+
+    /** @type {number} */
+    id;
+    /**
+     * When set to true, this data request is resolved as soon as its RPC returns, even if there was
+     * no actual data for this request inside it. This is useful for fetch request that only fills
+     * the store but does not need to wait any particular value.
+     */
+    _autoResolve = false;
+    /**
+     * Promise that is resolved with the data when the data request is complete.
+     */
+    _resultDef = new Deferred();
+    /**
+     * When set to true, resolves this data request with the current values of the fields as data,
+     * and then deletes the data request.
+     *
+     * @type {boolean}
+     */
+    _resolve = Record.attr(undefined, {
+        /** @this {import("models").DataResponse} */
+        onUpdate() {
+            if (this._resolve) {
+                this._resultDef.resolve({ ...this });
+                this.delete();
+            }
+        },
+    });
+    /*
+     * Fields are contextual to each data request. They are generically added here to benefit from
+     * fields behavior as well as auto-complete, but their meaning depends on each data request.
+     * Existing fields defined here should be used in new data requests if they fit the purpose, and
+     * other fields can be added if necessary.
+     */
+    attachments = Record.many("ir.attachment");
+    channel = Record.one("Thread");
+    channels = Record.many("Thread");
+    /** @type {number} */
+    count;
+    message = Record.one("mail.message");
+    partners = Record.many("Persona");
+}
+
+DataResponse.register();

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
@@ -3,7 +3,6 @@ import { cleanTerm } from "@mail/utils/common/format";
 import { Component, useState } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
-import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import { ImStatus } from "@mail/core/common/im_status";
 import { useService } from "@web/core/utils/hooks";
@@ -112,14 +111,17 @@ commandSetupRegistry.add("@", {
     placeholder: _t("Search a conversation"),
 });
 
+/**
+ * @param {string} name
+ * @param {import("models").Store} store
+ */
 async function makeNewChannel(name, store) {
-    const data = await rpc("/discuss/channel/create_channel", {
-        name: name,
-        group_id: store.internalUserGroupId,
-    });
-    const { Thread } = store.insert(data);
-    const [channel] = Thread;
-    channel.open({ focus: true, bypassCompact: true });
+    const { channel } = await store.fetchStoreData(
+        "/discuss/create_channel",
+        { name, group_id: store.internalUserGroupId },
+        { readonly: false, requestData: true }
+    );
+    await channel.open({ focus: true, bypassCompact: true });
 }
 
 export class DiscussCommandPalette {

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -7,7 +7,7 @@ import {
     inputFiles,
     insertText,
     isInViewportOf,
-    onRpcBefore,
+    listenStoreFetch,
     openDiscuss,
     openFormView,
     openListView,
@@ -18,18 +18,17 @@ import {
     start,
     startServer,
     triggerHotkey,
+    waitStoreFetch,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
 import { mockDate, tick } from "@odoo/hoot-mock";
 import { EventBus } from "@odoo/owl";
 import {
-    asyncStep,
     Command,
     getService,
     patchWithCleanup,
     preloadBundle,
     serverState,
-    waitForSteps,
     withUser,
 } from "@web/../tests/web_test_helpers";
 import { browser } from "@web/core/browser/browser";
@@ -554,11 +553,9 @@ test("chat window should open when receiving a new DM", async () => {
         ],
         channel_type: "chat",
     });
-    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", async () => {
-        asyncStep("init_messaging");
-    });
+    listenStoreFetch("init_messaging");
     await start();
-    await waitForSteps(["init_messaging"]);
+    await waitStoreFetch("init_messaging");
     await contains(".o-mail-ChatHub");
     withUser(userId, () =>
         rpc("/mail/message/post", {

--- a/addons/mail/static/tests/core/common/store_service.test.js
+++ b/addons/mail/static/tests/core/common/store_service.test.js
@@ -73,12 +73,9 @@ test("store.insert different PY model having same JS model", async () => {
         ],
     };
 
-    const { Thread: threads } = store.insert(data);
-    expect(threads).toHaveLength(3);
-    const general = store.Thread.get({ id: 1, model: "discuss.channel" });
-    const sales = store.Thread.get({ id: 2, model: "discuss.channel" });
-    const rd = store.Thread.get({ id: 3, model: "discuss.channel" });
-    expect(general.in(threads)).toBe(true);
-    expect(sales.in(threads)).toBe(true);
-    expect(rd.in(threads)).toBe(true);
+    store.insert(data);
+    expect(store.Thread.records).toHaveLength(6); // 3 mailboxes + 3 channels
+    expect(Boolean(store.Thread.get({ id: 1, model: "discuss.channel" }))).toBe(true);
+    expect(Boolean(store.Thread.get({ id: 2, model: "discuss.channel" }))).toBe(true);
+    expect(Boolean(store.Thread.get({ id: 3, model: "discuss.channel" }))).toBe(true);
 });

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -2,14 +2,15 @@ import {
     click,
     contains,
     defineMailModels,
+    listenStoreFetch,
     mockGetMedia,
-    onRpcBefore,
     openDiscuss,
     patchUiSize,
     SIZES,
     start,
     startServer,
     triggerEvents,
+    waitStoreFetch,
 } from "@mail/../tests/mail_test_helpers";
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 import {
@@ -165,9 +166,6 @@ test("should display invitations", async () => {
         channel_member_id: memberId,
         channel_id: channelId,
     });
-    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", () => {
-        asyncStep(`init_messaging`);
-    });
     mockService("mail.sound_effects", {
         play(name) {
             asyncStep(`play - ${name}`);
@@ -176,8 +174,9 @@ test("should display invitations", async () => {
             asyncStep(`stop - ${name}`);
         },
     });
+    listenStoreFetch("init_messaging");
     await start();
-    await waitForSteps([`init_messaging`]);
+    await waitStoreFetch("init_messaging");
     const [partner] = pyEnv["res.partner"].read(serverState.partnerId);
     // send after init_messaging because bus subscription is done after init_messaging
     pyEnv["bus.bus"]._sendone(

--- a/addons/mail/static/tests/messaging/messaging.test.js
+++ b/addons/mail/static/tests/messaging/messaging.test.js
@@ -2,20 +2,15 @@ import {
     contains,
     defineMailModels,
     insertText,
-    onRpcBefore,
+    listenStoreFetch,
     openDiscuss,
     openFormView,
     start,
     startServer,
+    waitStoreFetch,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
-import {
-    asyncStep,
-    Command,
-    serverState,
-    waitForSteps,
-    withUser,
-} from "@web/../tests/web_test_helpers";
+import { Command, serverState, withUser } from "@web/../tests/web_test_helpers";
 import { press } from "@odoo/hoot-dom";
 
 import { rpc } from "@web/core/network/rpc";
@@ -34,11 +29,9 @@ test("Receiving a new message out of discuss app should open a chat bubble", asy
         ],
         channel_type: "chat",
     });
-    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", (args) => {
-        asyncStep("init_messaging");
-    });
+    listenStoreFetch("init_messaging");
     await start();
-    await waitForSteps(["init_messaging"]);
+    await waitStoreFetch("init_messaging");
     // send after init_messaging because bus subscription is done after init_messaging
     // simulate receving new message
     withUser(userId, () =>
@@ -62,11 +55,9 @@ test("Receiving a new message in discuss app should open a chat bubble after lea
         ],
         channel_type: "chat",
     });
-    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", (args) => {
-        asyncStep("init_messaging");
-    });
+    listenStoreFetch("init_messaging");
     await start();
-    await waitForSteps(["init_messaging"]);
+    await waitStoreFetch("init_messaging");
     // send after init_messaging because bus subscription is done after init_messaging
     await openDiscuss();
     // simulate receiving new message

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -226,7 +226,7 @@ export class DiscussChannel extends models.ServerModel {
         );
         const [partner] = ResPartner.read(this.env.user.partner_id);
         this._broadcast([id], [partner]);
-        return new mailDataHelpers.Store(DiscussChannel.browse(id)).get_result();
+        return DiscussChannel.browse(id);
     }
 
     /** @param {number[]} ids */
@@ -367,7 +367,7 @@ export class DiscussChannel extends models.ServerModel {
             [id],
             partners.map(({ id }) => id)
         );
-        return DiscussChannel.browse(id)[0];
+        return DiscussChannel.browse(id);
     }
 
     /** @param {number[]} ids */
@@ -571,7 +571,7 @@ export class DiscussChannel extends models.ServerModel {
             [id],
             partners.map((partner) => partner.id)
         );
-        return new mailDataHelpers.Store(DiscussChannel.browse(id)).get_result();
+        return DiscussChannel.browse(id);
     }
 
     _create_sub_channel(ids, from_message_id, name) {

--- a/addons/mail/static/tests/widgets/activity_widget.test.js
+++ b/addons/mail/static/tests/widgets/activity_widget.test.js
@@ -2,9 +2,12 @@ import {
     click,
     contains,
     defineMailModels,
+    listenStoreFetch,
     openListView,
     start,
     startServer,
+    userContext,
+    waitStoreFetch,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
 import { Deferred, tick } from "@odoo/hoot-dom";
@@ -16,19 +19,12 @@ import {
     waitForSteps,
 } from "@web/../tests/web_test_helpers";
 import { serializeDate } from "@web/core/l10n/dates";
-import { user } from "@web/core/user";
 
 defineMailModels();
 describe.current.tags("desktop");
 
 test("list activity widget with no activity", async () => {
-    const mailDataDoneDef = new Deferred();
-    onRpc("/web/dataset/call_kw/ir.http/lazy_session_info", () => {
-        asyncStep("lazy_session_info");
-        mailDataDoneDef.resolve();
-    });
     onRpc("res.users", "web_search_read", async (params) => {
-        await mailDataDoneDef; // Ensure order of steps.
         expect(params.kwargs).toEqual({
             specification: {
                 activity_ids: { fields: {} },
@@ -42,23 +38,19 @@ test("list activity widget with no activity", async () => {
             offset: 0,
             order: "",
             limit: 80,
-            context: {
-                lang: "en",
-                tz: "taht",
-                uid: serverState.userId,
-                bin_size: true,
-                allowed_company_ids: user.allowedCompanies.map((c) => c.id),
-            },
+            context: { ...userContext(), bin_size: true },
             count_limit: 10001,
             domain: [],
         });
         asyncStep("web_search_read");
     });
+    listenStoreFetch("init_messaging");
     await start();
+    await waitStoreFetch("init_messaging");
     await openListView("res.users", {
         arch: `<list><field name="activity_ids" widget="list_activity"/></list>`,
     });
-    await waitForSteps(["lazy_session_info", "web_search_read"]);
+    await waitForSteps(["web_search_read"]);
     await contains(".o-mail-ActivityButton i.text-muted");
     await contains(".o-mail-ListActivity-summary", { text: "" });
 });

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -81,6 +81,7 @@ class Store:
 
     def __init__(self, records=None, fields=None, extra_fields=None, as_thread=False, **kwargs):
         self.data = {}
+        self.data_id = None
         if records:
             self.add(records, fields, extra_fields, as_thread=as_thread, **kwargs)
 
@@ -197,6 +198,15 @@ class Store:
             else:
                 res[model_name] = [dict(sorted(record.items())) for record in records.values()]
         return res
+
+    def resolve_data_request(self, **values):
+        """Add values to the store for the current data request.
+
+        Use case: resolve a specific data request from a client."""
+        if not self.data_id:
+            return self
+        self.add_model_values("DataResponse", {"id": self.data_id, "_resolve": True, **values})
+        return self
 
     def _add_values(self, values, model_name, index=None):
         """Adds values to the store for a given model name and index."""

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -72,7 +72,7 @@ class IrHttp(models.AbstractModel):
             'session_info': self.session_info(),
         }
 
-    def lazy_session_info(self):
+    def lazy_session_info(self, **kwargs):
         return {}
 
     def session_info(self):

--- a/addons/web/static/src/webclient/session_service.js
+++ b/addons/web/static/src/webclient/session_service.js
@@ -6,19 +6,20 @@ export const lazySession = {
     start(env, { orm }) {
         let resolveWebClientReady;
         let lazyConfigPromise;
-        const fetchServerData = async () => {
+        const fetchServerData = async (params) => {
             await webClientReadyPromise;
-            return orm.call("ir.http", "lazy_session_info", [[]]);
+            return orm.call("ir.http", "lazy_session_info", [[]], params);
         };
         const webClientReadyPromise = new Promise((r) => (resolveWebClientReady = r));
         env.bus.addEventListener("WEB_CLIENT_READY", resolveWebClientReady);
         return {
-            getValue(key, callback) {
+            getValue(key, callback, params) {
                 if (!lazyConfigPromise) {
-                    lazyConfigPromise = fetchServerData();
+                    lazyConfigPromise = fetchServerData(params);
                 }
                 lazyConfigPromise.then((config) => callback(deepCopy(config)[key]));
             },
+            rpcDone: () => !!lazyConfigPromise,
         };
     },
 };


### PR DESCRIPTION
Using store insert result is unreliable because it might contain more data than expected. Expected data should be explicitly returned rather than guessed. Several times in the past hard to track bugs were related to this issue.

For exemple, when adding a "main" channel to store, it might add its parent channel or its sub-channels at the same time, leading to several channels being returned. When knowing the "main" channel is important, guessing which of the 3 returned channels is the correct one can lead to issues if other unexpected channels are present or if the order changed (depending on how the guess was made).

A new JS model is created for this purpose, holding request specific data. On top of fixing the potential bugs, this allows multiple requests to be batched, returning a unified store data, while each request keeps its respective data available.

Only the channel create routes have been converted in this commit to avoid lenghtly diff and conflicts. Other routes will be improved as follow up.

The opportunity is taken to fix and improve the lazy sessio info.
- First of all, it directly imported the controller, which means overrides were not taken into account (discuss in particular).
- Second it only took into account init messaging but didn't group other possible requests.
- Third it returned init messaging data even when it was not necessary.

task-4676536

https://github.com/odoo/enterprise/pull/77434

Everything now supported in the same request, even with chat hub (otherwise doing a separate call for channel) and when opening the discuss app (otherwise doing a separate call for channels_as_member).

![image](https://github.com/user-attachments/assets/ab642e9a-2b3c-4362-800d-0b7e6b675f3d)

messages route to be done in a follow up PR.