### PR TITLE
[IMP] core: disable downloading during tours

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -905,6 +905,10 @@ class ChromeBrowser:
         self._websocket_send('Runtime.enable')
         self._logger.info('Chrome headless enable page notifications')
         self._websocket_send('Page.enable')
+        self._websocket_send('Page.setDownloadBehavior', params={
+            'behavior': 'deny',
+            'eventsEnabled': False,
+        })
         self._websocket_send('Emulation.setFocusEmulationEnabled', params={'enabled': True})
         emulated_device = {
             'mobile': False,


### PR DESCRIPTION
It's not *entirely* clear which and when, but some tours apparently trigger downloads, which by default will make a mess of the user's Downloads folder when running tests locally.

This has mostly been observed in 18.0 / master with Studio exports but there are a few others as well (e.g. a few reports). Either way, seems like a good idea to just configure chrome to block them.
