### PR TITLE
[FIX] stock: unarchive parent location on location toggle active

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -224,6 +224,12 @@ class Location(models.Model):
                     super(Location, children_location - self).with_context(do_not_check_quant=True).write({
                         'active': values['active'],
                     })
+                # If a location is unarchived, unarchive all its parent path
+                if values['active']:
+                    parent_locations = self.env['stock.location'].browse({ int(id) for loc in self for id in loc.parent_path.strip('/').split('/') })
+                    super(Location, parent_locations - self).with_context(do_not_check_quant=True).write({
+                        'active': True,
+                    })
 
         res = super(Location, self).write(values)
         self.invalidate_model(['warehouse_id'])


### PR DESCRIPTION
### Issue:

While archiving a parent location automatically archive all its children locations, unarchiving a children location do not currently unarchive its parent locations. This leads to unexpected error when the parent is used as a default value for instance in picking edition from the barcode app.

### Steps to reproduce:
- In the settings enable Warehouse > Storage Locations
- Inventory > Configuration > Warehouse Management > Locations
- Create new Location whose parent location is "WH/Stock/Shelf 1"
- Archive "WH/Stock/Shelf 1"
> This should automatically archive your new location
- Unarchive your child location
- Go to the barcode app
- Scan your child location
- Scan any product
####  > UncaughtPromiseError location with id=`id of parent` not found.

### Cause of the issue:

The archived location is used a default location dest when new barcode line is created:
https://github.com/odoo/enterprise/blob/0f543460039dc06ee66ccad0b075a89086afbd31/stock_barcode/static/src/models/barcode_picking_model.js#L889-L894 https://github.com/odoo/enterprise/blob/0f543460039dc06ee66ccad0b075a89086afbd31/stock_barcode/static/src/models/barcode_picking_model.js#L844-L846
However, since the location is archived it is nowhere to be found in the cache and an error is raised.

### Fix:

Even though we already have a mechanism that archives all children locations when one archives the parent location, we should also implement the complementary mechanism of unarchiving the parent locations when a child location is unarchived to avoid any setup inconsistency.

opw-4464704 and opw-4423110
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
