### PR TITLE
[FIX] mail : Show mails from automation rules in portal view

### DIFF
--- a/addons/mail/models/ir_actions_server.py
+++ b/addons/mail/models/ir_actions_server.py
@@ -240,12 +240,14 @@ class ServerActions(models.Model):
 
         if self.mail_post_method in ('comment', 'note'):
             records = self.env[self.model_name].with_context(cleaned_ctx).browse(res_ids)
+            message_type = 'auto_comment' if self.state == 'mail_post' else 'notification'
             if self.mail_post_method == 'comment':
                 subtype_id = self.env['ir.model.data']._xmlid_to_res_id('mail.mt_comment')
             else:
                 subtype_id = self.env['ir.model.data']._xmlid_to_res_id('mail.mt_note')
             records.message_post_with_source(
                 self.template_id,
+                message_type=message_type,
                 subtype_id=subtype_id,
             )
         else:

--- a/addons/portal/models/mail_thread.py
+++ b/addons/portal/models/mail_thread.py
@@ -13,7 +13,7 @@ class MailThread(models.AbstractModel):
     _mail_post_token_field = 'access_token' # token field for external posts, to be overridden
 
     website_message_ids = fields.One2many('mail.message', 'res_id', string='Website Messages',
-        domain=lambda self: [('model', '=', self._name), ('message_type', 'in', ('comment', 'email', 'email_outgoing'))],
+        domain=lambda self: [('model', '=', self._name), ('message_type', 'in', ('comment', 'email', 'email_outgoing', 'auto_comment'))],
         auto_join=True,
         help="Website communication history")
 

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -208,7 +208,7 @@ class Task(models.Model):
     working_days_open = fields.Float(compute='_compute_elapsed', string='Working Days to Assign', store=True, group_operator="avg")
     working_days_close = fields.Float(compute='_compute_elapsed', string='Working Days to Close', store=True, group_operator="avg")
     # customer portal: include comment and (incoming/outgoing) emails in communication history
-    website_message_ids = fields.One2many(domain=lambda self: [('model', '=', self._name), ('message_type', 'in', ['email', 'comment', 'email_outgoing'])])
+    website_message_ids = fields.One2many(domain=lambda self: [('model', '=', self._name), ('message_type', 'in', ['email', 'comment', 'email_outgoing', 'auto_comment'])])
     allow_milestones = fields.Boolean(related='project_id.allow_milestones')
     milestone_id = fields.Many2one(
         'project.milestone',

--- a/addons/test_mail/tests/test_ir_actions.py
+++ b/addons/test_mail/tests/test_ir_actions.py
@@ -81,7 +81,7 @@ class TestServerActionsEmail(MailCommon, TestServerActionsBase):
                               'fields_values': {
                                 'author_id': self.env.user.partner_id,
                               },
-                              'message_type': 'notification',
+                              'message_type': 'auto_comment',
                               'subtype': 'mail.mt_comment',
                              }
             ):
@@ -98,7 +98,7 @@ class TestServerActionsEmail(MailCommon, TestServerActionsBase):
         with self.assertSinglePostNotifications(
                 [{'partner': self.test_partner, 'type': 'email', 'status': 'ready'}],
                 message_info={'content': 'Hello %s' % self.test_partner.name,
-                              'message_type': 'notification',
+                              'message_type': 'auto_comment',
                               'subtype': 'mail.mt_note',
                              }
             ):


### PR DESCRIPTION
### Steps to reproduce:
	1. Create a portal user.
	2. Create an automation rule to send an email as a message. Example: https://drive.google.com/file/d/1mIa4R7a2Z2fnkngOMD7zN2t9Z2XHhGY7/view
	3. Now, add the portal user as a follower on a task.
	4. Change the state of a task to execute an automation rule.
	5. Email will be received by a portal user but it will not be visible on the messaging history on the portal.

### Cause:
This is happening because when running an automation rule that will send an email we set the 'mail.message' state as System notification by default which leads that this mail will be sent normally to every follower of the record but will be only shown in the chat history for internal users not portal as we are just showing 'comment', 'incoming_email' and 'outgoing_email' messages.

### Fix:
Checking if the server action that is being run is sending an email we will
set the state of the 'mail.message' as 'auto_comment' -introduced in https://github.com/odoo/odoo/pull/94018/commits/d1dd307555ac78841384d1158de5a0a7787370db - and add 'auto_comment'
to the domain of the field website_message_id which is for the messages
shown to the portal user in his view

P.S. LNA confirmed that we need to show it to the portal user.

opw-4459754