### PR TITLE
[FIX] account_check_printing: print info on checks without entry

### DIFF
--- a/addons/account_check_printing/i18n/account_check_printing.pot
+++ b/addons/account_check_printing/i18n/account_check_printing.pot
@@ -44,6 +44,12 @@ msgid "Amount in Words"
 msgstr ""
 
 #. module: account_check_printing
+#. odoo-python
+#: code:addons/account_check_printing/models/account_payment.py:0
+msgid "Bills"
+msgstr ""
+
+#. module: account_check_printing
 #: model_terms:ir.ui.view,arch_db:account_check_printing.print_pre_numbered_checks_view
 msgid "Cancel"
 msgstr ""
@@ -290,6 +296,12 @@ msgstr ""
 #: model:ir.model,name:account_check_printing.model_print_prenumbered_checks
 #: model_terms:ir.ui.view,arch_db:account_check_printing.print_pre_numbered_checks_view
 msgid "Print Pre-numbered Checks"
+msgstr ""
+
+#. module: account_check_printing
+#. odoo-python
+#: code:addons/account_check_printing/models/account_payment.py:0
+msgid "Refunds"
 msgstr ""
 
 #. module: account_check_printing

--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -248,7 +248,7 @@ class AccountPayment(models.Model):
         """
         self.ensure_one()
 
-        def prepare_vals(invoice, partials):
+        def prepare_vals(invoice, partials=None, current_amount=0):
             number = ' - '.join([invoice.name, invoice.ref] if invoice.ref else [invoice.name])
 
             if invoice.is_outbound() or invoice.move_type == 'in_receipt':
@@ -258,51 +258,65 @@ class AccountPayment(models.Model):
                 invoice_sign = -1
                 partial_field = 'credit_amount_currency'
 
-            if invoice.currency_id.is_zero(invoice.amount_residual):
+            amount_residual = invoice.amount_residual - current_amount
+            if invoice.currency_id.is_zero(amount_residual):
                 amount_residual_str = '-'
             else:
-                amount_residual_str = formatLang(self.env, invoice_sign * invoice.amount_residual, currency_obj=invoice.currency_id)
+                amount_residual_str = formatLang(self.env, invoice_sign * amount_residual, currency_obj=invoice.currency_id)
+            amount_paid = current_amount if current_amount else sum(partials.mapped(partial_field))
 
             return {
                 'due_date': format_date(self.env, invoice.invoice_date_due),
                 'number': number,
                 'amount_total': formatLang(self.env, invoice_sign * invoice.amount_total, currency_obj=invoice.currency_id),
                 'amount_residual': amount_residual_str,
-                'amount_paid': formatLang(self.env, invoice_sign * sum(partials.mapped(partial_field)), currency_obj=self.currency_id),
+                'amount_paid': formatLang(self.env, invoice_sign * amount_paid, currency_obj=self.currency_id),
                 'currency': invoice.currency_id,
             }
 
-        # Decode the reconciliation to keep only invoices.
-        term_lines = self.move_id.line_ids.filtered(lambda line: line.account_id.account_type in ('asset_receivable', 'liability_payable'))
-        invoices = (term_lines.matched_debit_ids.debit_move_id.move_id + term_lines.matched_credit_ids.credit_move_id.move_id)\
-            .filtered(lambda x: x.is_outbound() or x.move_type == 'in_receipt')
-        invoices = invoices.sorted(lambda x: x.invoice_date_due or x.date)
+        if self.move_id:
+            # Decode the reconciliation to keep only invoices.
+            term_lines = self.move_id.line_ids.filtered(lambda line: line.account_id.account_type in ('asset_receivable', 'liability_payable'))
+            invoices = (term_lines.matched_debit_ids.debit_move_id.move_id + term_lines.matched_credit_ids.credit_move_id.move_id)\
+                .filtered(lambda x: x.is_outbound(include_receipts=True))
 
-        # Group partials by invoices.
-        invoice_map = {invoice: self.env['account.partial.reconcile'] for invoice in invoices}
-        for partial in term_lines.matched_debit_ids:
-            invoice = partial.debit_move_id.move_id
-            if invoice in invoice_map:
-                invoice_map[invoice] |= partial
-        for partial in term_lines.matched_credit_ids:
-            invoice = partial.credit_move_id.move_id
-            if invoice in invoice_map:
-                invoice_map[invoice] |= partial
-
-        # Prepare stub_lines.
-        if 'out_refund' in invoices.mapped('move_type'):
-            stub_lines = [{'header': True, 'name': "Bills"}]
-            stub_lines += [prepare_vals(invoice, partials)
-                           for invoice, partials in invoice_map.items()
-                           if invoice.move_type == 'in_invoice']
-            stub_lines += [{'header': True, 'name': "Refunds"}]
-            stub_lines += [prepare_vals(invoice, partials)
-                           for invoice, partials in invoice_map.items()
-                           if invoice.move_type == 'out_refund']
+            # Group partials by invoices.
+            invoice_map = {invoice: self.env['account.partial.reconcile'] for invoice in invoices}
+            for partial in term_lines.matched_debit_ids:
+                invoice = partial.debit_move_id.move_id
+                if invoice in invoice_map:
+                    invoice_map[invoice] |= partial
+            for partial in term_lines.matched_credit_ids:
+                invoice = partial.credit_move_id.move_id
+                if invoice in invoice_map:
+                    invoice_map[invoice] |= partial
         else:
-            stub_lines = [prepare_vals(invoice, partials)
-                          for invoice, partials in invoice_map.items()
-                          if invoice.move_type in ('in_invoice', 'in_receipt')]
+            invoices = self.invoice_ids.filtered(lambda x: x.is_outbound(include_receipts=True))
+            remaining = self.amount
+
+        stub_lines = []
+        type_groups = {
+            ('in_invoice', 'in_receipt'): _("Bills"),
+            ('out_refund',): _("Refunds"),
+        }
+        invoices_grouped = invoices.grouped(lambda i: next(group for group in type_groups if i.move_type in group))
+        for type_group, invoices in invoices_grouped.items():
+            invoices = iter(invoices.sorted(lambda x: x.invoice_date_due or x.date))
+            if len(invoices_grouped) > 1:
+                stub_lines += [{'header': True, 'name': type_groups[type_group]}]
+            if self.move_id:
+                stub_lines += [
+                    prepare_vals(invoice, partials=invoice_map[invoice])
+                    for invoice in invoices
+                ]
+            else:
+                while remaining and (invoice := next(invoices, None)):
+                    current_amount = min(remaining, invoice.currency_id._convert(
+                        from_amount=invoice.amount_residual,
+                        to_currency=self.currency_id,
+                    ))
+                    stub_lines += [prepare_vals(invoice, current_amount=current_amount)]
+                    remaining -= current_amount
 
         # Crop the stub lines or split them on multiple pages
         if not self.company_id.account_check_printing_multi_stub:


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Configure a Check Layout in Accounting settings
- Go to Bank journal configuration
- Make sure that "Checks" payment mehtod doesn't have an Outstanding Payment account
- Create a bill
- Register a Check payment for the bill
- Print the check

**Issue:**
All the data about the bill are missing from the check.

**Cause:**
These data were retrieved from the journal entry linked to the check payment.
As there is no journal entry in this case, they cannot be computed.

**Solution:**
Compute these data from the amount of the check and the linked bills.

opw-4482589




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
