### PR TITLE
[FIX] packaging: ensure that requirements are not overwritten

### DIFF
--- a/setup/package.py
+++ b/setup/package.py
@@ -430,7 +430,7 @@ class DockerIot(DockerWine):
         self.nt_service_name = "odoo-iot"
 
     def build_image(self):
-        shutil.copy(os.path.join(self.args.build_dir, 'odoo/addons/iot_box_image/configuration/requirements.txt'), self.docker_dir)
+        shutil.copy(os.path.join(self.args.build_dir, 'odoo/addons/iot_box_image/configuration/requirements.txt'), self.docker_dir / 'requirements-iot.txt')
         self.tag = f'{self.tag}-iot'
         super().build_image()
 


### PR DESCRIPTION
When building the Docker image for iot box, the iot requirements are copied to the docker build directory. Unfortunately, the regular Odoo requirements are also copied at the same place with the same name and thus overwrite the iot requirements.

With this commit, we ensure that the names are different.