### PR TITLE
[PERF] pos_self_order: prevent loading product images in load

### DIFF
--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -71,6 +71,8 @@ class ProductProduct(models.Model):
             order='sequence,default_code,name',
             load=False
         )
+        for product in products:
+            product['image_128'] = bool(product['image_128'])
 
         data['pos.config']['data'][0]['_product_default_values'] = \
             self.env['account.tax']._eval_taxes_computation_prepare_product_default_values(product_fields)


### PR DESCRIPTION
Before this commit, product images were unnecessarily loaded along with the POS data. This was redundant since the images are loaded separately. Additionally, loading the images caused excessive memory usage, leading to memory errors in certain scenarios.

opw-4494712

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
