### PR TITLE
[IMP] core: add grouping set support for pivot view

### DIFF
--- a/addons/board/static/tests/board.test.js
+++ b/addons/board/static/tests/board.test.js
@@ -608,21 +608,21 @@ describe("board_desktop", () => {
         onRpc(({ method, kwargs }) => {
             if (method === "get_property_definition") {
                 return {};
-            } else if (
-                method === "formatted_read_group" &&
-                kwargs.groupby?.includes("properties.my_char")
-            ) {
+            } else if (method === "formatted_read_grouping_sets") {
                 return [
-                    {
-                        "properties.my_char": false,
-                        __extra_domain: [["properties.my_char", "=", false]],
-                        __count: 2,
-                    },
-                    {
-                        "properties.my_char": "aaa",
-                        __extra_domain: [["properties.my_char", "=", "aaa"]],
-                        __count: 1,
-                    },
+                    [{ __count: 3, __extra_domain: [] }],
+                    [
+                        {
+                            "properties.my_char": false,
+                            __extra_domain: [["properties.my_char", "=", false]],
+                            __count: 2,
+                        },
+                        {
+                            "properties.my_char": "aaa",
+                            __extra_domain: [["properties.my_char", "=", "aaa"]],
+                            __count: 1,
+                        },
+                    ],
                 ];
             }
         });

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -829,6 +829,19 @@ class CalendarEvent(models.Model):
             domain = Domain.AND([domain, self._get_default_privacy_domain()])
         return super()._read_group(domain, groupby, aggregates, having=having, offset=offset, limit=limit, order=order)
 
+    @api.model
+    def _read_grouping_sets(self, domain, grouping_sets, aggregates=(), order=None) -> list[tuple]:
+        fnames = {
+            spec.split(':')[0] for spec in itertools.chain(
+                *grouping_sets,
+                aggregates,
+            )
+        }
+        private_fields = fnames - self._get_public_fields()
+        if not self.env.su and private_fields:
+            domain = Domain.AND([domain, self._get_default_privacy_domain()])
+        return super()._read_grouping_sets(domain, grouping_sets, aggregates, order=order)
+
     def unlink(self):
         if not self:
             return super().unlink()

--- a/addons/hr_skills/static/src/views/pivot/skills_pivot_model.js
+++ b/addons/hr_skills/static/src/views/pivot/skills_pivot_model.js
@@ -1,6 +1,5 @@
 import { PivotModel } from "@web/views/pivot/pivot_model";
 
-
 export class SkillsPivotModel extends PivotModel {
     setup() {
         super.setup(...arguments);
@@ -8,28 +7,26 @@ export class SkillsPivotModel extends PivotModel {
         this.departmentNamesById = {};
     }
 
-    async _getSubGroups(groupBy, params) {
-        if (!this.departmentsFetch){
-            const departmentNames = await this.orm.webSearchRead(
-                "hr.department",
-                [],
-                {
-                    specification: {
-                        name: {},
-                    },
-                }
-            );
+    async _getGroupsSubdivision(params, groupInfo) {
+        if (!this.departmentsFetch) {
+            const departmentNames = await this.orm.webSearchRead("hr.department", [], {
+                specification: {
+                    name: {},
+                },
+            });
             this.departmentNamesById = Object.fromEntries(
                 departmentNames.records.map(({ id, name }) => [id, name])
             );
         }
-        const data = await super._getSubGroups(...arguments);
-        if (groupBy.includes("department_id")) {
-            data.forEach((res) => {
-                res.department_id[1] = this.departmentNamesById[res.department_id[0]];
-            });
-        }
+        const multiData = await super._getGroupsSubdivision(...arguments);
 
-        return data;
+        for (const [groupBy, data] of params.groupingSets.map((g, i) => [g, multiData[i]])) {
+            if (groupBy.includes("department_id")) {
+                data.forEach((res) => {
+                    res.department_id[1] = this.departmentNamesById[res.department_id[0]];
+                });
+            }
+        }
+        return multiData;
     }
 }

--- a/addons/spreadsheet/static/src/pivot/pivot_model.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_model.js
@@ -624,17 +624,19 @@ export class OdooPivotModel extends PivotModel {
     /**
      * @override to add the order by clause to the read_group kwargs
      */
-    _getSubGroups(groupBys, params) {
+    async _getGroupsSubdivision(params, groupInfo) {
         const { columns, rows } = this.getDefinition();
+        const allGroupBys = params.groupingSets.flat();
         const order = columns
             .concat(rows)
             .filter(
-                (dimension) => dimension.order && groupBys.includes(dimension.nameWithGranularity)
+                (dimension) =>
+                    dimension.order && allGroupBys.includes(dimension.nameWithGranularity)
             )
             .map((dimension) => `${dimension.nameWithGranularity} ${dimension.order}`)
             .join(",");
         params.kwargs.order = order;
-        return super._getSubGroups(groupBys, params);
+        return super._getGroupsSubdivision(params, groupInfo);
     }
 
     /**

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -1347,18 +1347,13 @@ test("load data only once if filter is not active (without default value)", asyn
     const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method, kwargs }) {
-            if (model === "partner" && method === "formatted_read_group") {
+            if (model === "partner" && method === "formatted_read_grouping_sets") {
                 expect.step(`${model}/${method}`);
             }
         },
     });
     await waitForDataLoaded(model);
-    expect.verifySteps([
-        "partner/formatted_read_group",
-        "partner/formatted_read_group",
-        "partner/formatted_read_group",
-        "partner/formatted_read_group",
-    ]);
+    expect.verifySteps(["partner/formatted_read_grouping_sets"]);
     expect(getCellValue(model, "A1")).toBe(131);
 });
 
@@ -1396,13 +1391,13 @@ test("load data only once if filter is active (with a default value)", async fun
     const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method, kwargs }) {
-            if (model === "partner" && method === "formatted_read_group") {
+            if (model === "partner" && method === "formatted_read_grouping_sets") {
                 expect.step(`${model}/${method}`);
             }
         },
     });
     await waitForDataLoaded(model);
-    expect.verifySteps(["partner/formatted_read_group"]);
+    expect.verifySteps(["partner/formatted_read_grouping_sets"]);
     expect(getCellValue(model, "A1")).toBe("");
 });
 
@@ -1431,18 +1426,13 @@ test("don't reload data if an empty filter is added", async function () {
     const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method, kwargs }) {
-            if (model === "partner" && method === "formatted_read_group") {
+            if (model === "partner" && method === "formatted_read_grouping_sets") {
                 expect.step(`${model}/${method}`);
             }
         },
     });
     await waitForDataLoaded(model);
-    expect.verifySteps([
-        "partner/formatted_read_group",
-        "partner/formatted_read_group",
-        "partner/formatted_read_group",
-        "partner/formatted_read_group",
-    ]);
+    expect.verifySteps(["partner/formatted_read_grouping_sets"]);
     expect(getCellValue(model, "A1")).toBe(131);
     addGlobalFilter(model, {
         id: "42",
@@ -1472,7 +1462,7 @@ test("don't load data if a filter is added but the data is not needed", async fu
     const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method, kwargs }) {
-            if (model === "partner" && method === "formatted_read_group") {
+            if (model === "partner" && method === "formatted_read_grouping_sets") {
                 expect.step(`${model}/${method}`);
             }
         },
@@ -1494,7 +1484,7 @@ test("don't load data if a filter is added but the data is not needed", async fu
     expect(getCellValue(model, "A1")).toBe("Loading...");
     await animationFrame();
     expect(getCellValue(model, "A1")).toBe("");
-    expect.verifySteps(["partner/formatted_read_group"]);
+    expect.verifySteps(["partner/formatted_read_grouping_sets"]);
 });
 
 test("don't load data if a filter is activated but the data is not needed", async function () {
@@ -1522,7 +1512,7 @@ test("don't load data if a filter is activated but the data is not needed", asyn
     const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method, kwargs }) {
-            if (model === "partner" && method === "formatted_read_group") {
+            if (model === "partner" && method === "formatted_read_grouping_sets") {
                 expect.step(`${model}/${method}`);
             }
         },
@@ -1539,7 +1529,7 @@ test("don't load data if a filter is activated but the data is not needed", asyn
     expect(getCellValue(model, "A1")).toBe("Loading...");
     await animationFrame();
     expect(getCellValue(model, "A1")).toBe("");
-    expect.verifySteps(["partner/formatted_read_group"]);
+    expect.verifySteps(["partner/formatted_read_grouping_sets"]);
 });
 
 test("Default value defines value", async function () {

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -637,6 +637,107 @@ class Base(models.AbstractModel):
 
     @api.model
     @api.readonly
+    def formatted_read_grouping_sets(
+        self,
+        domain: DomainType,
+        grouping_sets: Sequence[Sequence[str]],
+        aggregates: Sequence[str] = (),
+        *,
+        having: DomainType = (),
+        order: str | None = None,
+    ):
+        """
+        A method similar to :meth:`_read_grouping_set` but with all the
+        formatting needed by the webclient.
+        It is a multi groupby version of formatted_read_group allowing to have
+        aggregates for different groupby specifications in a single SQL requests.
+
+        :param domain: :ref:`A search domain <reference/orm/domains>`.
+            Use an empty list to match all records.
+        :param grouping_sets: list of list of groupby descriptions by which the
+            records will be grouped.
+
+            A groupby description is either a field (then it will be
+            grouped by that field) or a string
+            ``'<field>:<granularity>'``.
+
+            Right now, the only supported granularities are:
+
+            * ``day``
+            * ``week``
+            * ``month``
+            * ``quarter``
+            * ``year``
+
+            and they only make sense for date/datetime fields.
+
+            Additionally integer date parts are also supported:
+
+            * ``year_number``
+            * ``quarter_number``
+            * ``month_number``
+            * ``iso_week_number``
+            * ``day_of_year``
+            * ``day_of_month``
+            * ``day_of_week``
+            * ``hour_number``
+            * ``minute_number``
+            * ``second_number``
+
+        :param aggregates: list of aggregates specification. Each
+            element is ``'<field>:<agg>'`` (aggregate field with
+            aggregation function ``agg``). The possible aggregation
+            functions are the ones provided by
+            `PostgreSQL <https://www.postgresql.org/docs/current/static/functions-aggregate.html>`_,
+            except ``count_distinct`` and ``array_agg_distinct`` with
+            the expected meaning.
+
+        :param order: optional ``order by`` specification, for
+            overriding the natural sort ordering of the groups, see
+            :meth:`~.search`.
+
+        :return: list of list of dict such as
+            ``[[{'groupy_spec': value, ...}, ...], ...]`` containing:
+
+            * the groupby values: ``{groupby[i]: <value>}``
+            * the aggregate values: ``{aggregates[i]: <value>}``
+            * ``'__extra_domain'``: list of tuples specifying the group
+              search criteria
+            * ``'__fold'``: boolean if a fold_name is set on the comodel
+              and read_group_expand is activated
+
+        :raise AccessError: if user is not allowed to access requested
+            information
+        """
+        grouping_sets = [tuple(groupby) for groupby in grouping_sets]
+        aggregates = self._web_pre_process_aggregates(aggregates)
+
+        if not order:
+            order = ', '.join(unique(spec for groupby in grouping_sets for spec in groupby))
+
+        groups_list = self._read_grouping_sets(
+            domain, grouping_sets, aggregates, order=order,
+        )
+
+        for groups_index, groupby in enumerate(grouping_sets):
+            if self._web_read_group_field_expand(groupby):
+                groups_list[groups_index] = self._web_read_group_expand(domain, groups_list[groups_index], groupby[0], aggregates, order)
+
+        for groups_index, groupby in enumerate(grouping_sets):
+            fill_temporal = self.env.context.get('fill_temporal')
+            if groupby and (fill_temporal or isinstance(fill_temporal, dict)):
+                if not isinstance(fill_temporal, dict):
+                    fill_temporal = {}
+                # This assumes that existing data is sorted by field 'groupby_name'
+                groups_list[groups_index] = self._web_read_group_fill_temporal(groups_list[groups_index], groupby, aggregates, **fill_temporal)
+
+        return [
+            self._web_read_group_format(groupby, aggregates, groups)
+            for groupby, groups in zip(grouping_sets, groups_list)
+        ]
+
+    @api.model
+    @api.readonly
     def formatted_read_group(
         self,
         domain: DomainType,

--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -199,6 +199,33 @@ export class ORM {
     /**
      * @param {string} model
      * @param {import("@web/core/domain").DomainListRepr} domain
+     * @param {string[]} fields
+     * @param {string[][]} grouping_sets
+     * @param {any} [kwargs={}]
+     * @returns {Promise<any[]>}
+     */
+    formattedReadGroupingSets(model, domain, grouping_sets, aggregates, kwargs = {}) {
+        validateArray("domain", domain);
+        validateArray("groupby", grouping_sets);
+        validatePrimitiveList("aggregates", "string", aggregates);
+        return this.call(model, "formatted_read_grouping_sets", [], {
+            domain,
+            grouping_sets,
+            aggregates,
+            ...kwargs,
+        }).then((res) => {
+            for (const groups of res) {
+                for (const group of groups) {
+                    group["__domain"] = Domain.and([domain, group["__extra_domain"]]).toList();
+                }
+            }
+            return res;
+        });
+    }
+
+    /**
+     * @param {string} model
+     * @param {import("@web/core/domain").DomainListRepr} domain
      * @param {any} [kwargs={}]
      * @returns {Promise<any[]>}
      */

--- a/addons/web/static/src/model/sample_server.js
+++ b/addons/web/static/src/model/sample_server.js
@@ -124,6 +124,8 @@ export class SampleServer {
                 return this._mockWebReadGroup(params);
             case "formatted_read_group":
                 return this._mockFormattedReadGroup(params);
+            case "formatted_read_grouping_sets":
+                return this._mockFormattedReadGroupingSets(params);
             case "read_progress_bar":
                 return this._mockReadProgressBar(params);
             case "read":
@@ -505,6 +507,23 @@ export class SampleServer {
             });
         }
         return result;
+    }
+
+    /**
+     * Mocks calls to the base method of formatted_read_grouping_sets method.
+     *
+     * @param {Object} params
+     * @param {string} params.model
+     * @param {string[][]} params.grouping_sets
+     * @param {string[]} params.aggregates
+     * @returns {Object[]} Object with keys groups and length
+     */
+    _mockFormattedReadGroupingSets(params) {
+        const res = [];
+        for (const groupBy of params.grouping_sets) {
+            res.push(this._mockFormattedReadGroup({ ...params, groupBy }));
+        }
+        return res;
     }
 
     /**

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -1997,6 +1997,45 @@ export class Model extends Array {
         return readGroupResult;
     }
 
+    formatted_read_grouping_sets(domain, grouping_sets, aggregates, having, order) {
+        const kwargs = getKwArgs(
+            arguments,
+            "domain",
+            "grouping_sets",
+            "aggregates",
+            "having",
+            "order"
+        );
+        ({ domain, grouping_sets, aggregates, having, order } = kwargs);
+        const result = [];
+        for (const groupby of grouping_sets) {
+            let current_order = order;
+            if (order) {
+                const parts = [];
+                // Remove parts of order coming from other groupby spec from grouping_sets
+                for (const order_part of order.split(",")) {
+                    const fname = order_part.split(" ", 1)[0];
+                    if (groupby.includes(fname) || aggregates.includes(fname)) {
+                        parts.push(order_part);
+                    }
+                }
+                current_order = parts.join(",");
+            }
+            result.push(
+                this.formatted_read_group(
+                    domain,
+                    groupby,
+                    aggregates,
+                    having,
+                    null,
+                    null,
+                    current_order
+                )
+            );
+        }
+        return result;
+    }
+
     /**
      * @param {[number | false, string][]} views
      * @param {{ load_filters?: boolean }} [options]

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -612,9 +612,9 @@ test('clicking on the "Total" cell with time range activated', async () => {
 });
 
 test("pivot view grouped by date field", async () => {
-    expect.assertions(2);
+    expect.assertions(1);
 
-    onRpc("formatted_read_group", ({ kwargs }) => {
+    onRpc("formatted_read_grouping_sets", ({ kwargs }) => {
         expect(kwargs.aggregates).toEqual(["foo:sum", "__count"]);
     });
 
@@ -637,7 +637,7 @@ test("without measures, pivot view uses __count by default", async () => {
     Partner._fields.foo = fields.Integer({ aggregator: null });
     expect.assertions(4);
 
-    onRpc("formatted_read_group", ({ kwargs }) => {
+    onRpc("formatted_read_grouping_sets", ({ kwargs }) => {
         expect(kwargs.aggregates).toEqual(["__count"]);
     });
 
@@ -673,7 +673,7 @@ test("pivot view grouped by many2one field", async () => {
 
 test("pivot view can be reloaded", async () => {
     let readGroupCount = 0;
-    onRpc("formatted_read_group", () => {
+    onRpc("formatted_read_grouping_sets", () => {
         readGroupCount++;
     });
     await mountView({
@@ -696,7 +696,7 @@ test("pivot view can be reloaded", async () => {
 test.tags("desktop");
 test("basic folding/unfolding", async () => {
     let rpcCount = 0;
-    onRpc("formatted_read_group", () => {
+    onRpc("formatted_read_grouping_sets", () => {
         rpcCount++;
     });
 
@@ -732,7 +732,7 @@ test("basic folding/unfolding", async () => {
 
     await contains(queryOne(".dropdown-item:eq(2)", { root: subDropdownMenu })).click();
     expect("tbody tr").toHaveCount(4);
-    expect(rpcCount).toBe(3);
+    expect(rpcCount).toBe(2);
 });
 
 test.tags("desktop");
@@ -925,9 +925,9 @@ test("pivot custom groupby: grouping on date field use default interval month", 
     expect.assertions(1);
 
     let checkReadGroup = false;
-    onRpc("formatted_read_group", ({ kwargs }) => {
+    onRpc("formatted_read_grouping_sets", ({ kwargs }) => {
         if (checkReadGroup) {
-            expect(kwargs.groupby).toEqual(["date:month"]);
+            expect(kwargs.grouping_sets[0]).toEqual(["date:month"]);
             checkReadGroup = false;
         }
     });
@@ -1076,11 +1076,11 @@ test("can toggle extra measure", async () => {
     await contains(".dropdown-item:contains(Count):eq(0").click();
     expect(".dropdown-item:contains(Count)").toHaveClass("selected");
     expect(".o_pivot_cell_value").toHaveCount(6);
-    expect(rpcCount).toBe(2);
+    expect(rpcCount).toBe(1);
     await contains(".dropdown-item:contains(Count):eq(0)").click();
     expect(".dropdown-item:contains(Count):eq(0)").not.toHaveClass("selected");
     expect(".o_pivot_cell_value").toHaveCount(3);
-    expect(rpcCount).toBe(2);
+    expect(rpcCount).toBe(1);
 });
 
 test("no content helper when no active measure", async () => {
@@ -1201,7 +1201,7 @@ test("tries to restore previous state after domain change", async () => {
     await removeFacet();
 
     expect("table").toHaveCount(1);
-    expect(rpcCount).toBe(2);
+    expect(rpcCount).toBe(1);
     expect(".o_pivot_cell_value").toHaveCount(3);
     expect(".o_pivot_measure_row:contains(Foo)").toHaveCount(1);
 });
@@ -1257,7 +1257,7 @@ test("can sort data in a column by clicking on header", async () => {
 
 test("can expand all rows", async () => {
     let nbReadGroups = 0;
-    onRpc("formatted_read_group", () => {
+    onRpc("formatted_read_grouping_sets", () => {
         nbReadGroups++;
     });
     await mountView({
@@ -1275,7 +1275,7 @@ test("can expand all rows", async () => {
 			</search>`,
     });
 
-    expect(nbReadGroups).toBe(2);
+    expect(nbReadGroups).toBe(1);
     expect(getCurrentValues()).toBe("32,12,20");
 
     // expand on date:days, product
@@ -1285,7 +1285,7 @@ test("can expand all rows", async () => {
     nbReadGroups = 0;
     await toggleMenuItem("Product");
 
-    expect(nbReadGroups).toBe(3);
+    expect(nbReadGroups).toBe(1);
     expect("tbody tr").toHaveCount(8);
 
     // collapse the first two rows
@@ -1298,13 +1298,13 @@ test("can expand all rows", async () => {
     nbReadGroups = 0;
     await contains(".o_pivot_expand_button").click();
 
-    expect(nbReadGroups).toBe(3);
+    expect(nbReadGroups).toBe(1);
     expect("tbody tr").toHaveCount(8);
 });
 
 test("expand all with a delay", async () => {
     let def;
-    onRpc("formatted_read_group", () => def);
+    onRpc("formatted_read_grouping_sets", () => def);
     await mountView({
         type: "pivot",
         resModel: "partner",
@@ -2200,7 +2200,7 @@ test("pivot still handles __count__ measure", async () => {
     // for retro-compatibility reasons, the pivot view still handles
     // '__count__' measure.
 
-    onRpc("formatted_read_group", ({ kwargs }) => {
+    onRpc("formatted_read_grouping_sets", ({ kwargs }) => {
         expect(kwargs.aggregates).toEqual(["__count"]);
     });
 
@@ -2346,7 +2346,7 @@ test("Row and column groupbys plus a domain", async () => {
 
 test("parallel data loading should discard all but the last one", async () => {
     let def;
-    onRpc("formatted_read_group", () => def);
+    onRpc("formatted_read_grouping_sets", () => def);
     await mountView({
         type: "pivot",
         resModel: "partner",
@@ -2489,7 +2489,7 @@ test("Click on the measure list but not on a menu item", async () => {
 
 test.tags("desktop");
 test("Navigation list view for a group and back with breadcrumbs", async () => {
-    expect.assertions(9);
+    expect.assertions(6);
 
     Partner._views["pivot"] = `<pivot>
 			<field name="customer" type="row"/>
@@ -2501,12 +2501,12 @@ test("Navigation list view for a group and back with breadcrumbs", async () => {
     Partner._views["form"] = `<form><field name="foo"/></form>`;
 
     let readGroupCount = 0;
-    onRpc("formatted_read_group", ({ kwargs }) => {
-        expect.step("formatted_read_group");
+    onRpc("formatted_read_grouping_sets", ({ kwargs }) => {
+        expect.step("formatted_read_grouping_sets");
         const domain = kwargs.domain;
-        if ([0, 1].indexOf(readGroupCount) !== -1) {
+        if ([0].indexOf(readGroupCount) !== -1) {
             expect(domain).toEqual([]);
-        } else if ([2, 3, 4, 5].indexOf(readGroupCount) !== -1) {
+        } else if ([1, 2].indexOf(readGroupCount) !== -1) {
             expect(domain).toEqual([["foo", "=", 12]]);
         }
         readGroupCount++;
@@ -2535,13 +2535,10 @@ test("Navigation list view for a group and back with breadcrumbs", async () => {
     await contains(".o_control_panel ol.breadcrumb li.breadcrumb-item").click();
 
     expect.verifySteps([
-        "formatted_read_group",
-        "formatted_read_group",
-        "formatted_read_group",
-        "formatted_read_group",
+        "formatted_read_grouping_sets",
+        "formatted_read_grouping_sets",
         "web_search_read",
-        "formatted_read_group",
-        "formatted_read_group",
+        "formatted_read_grouping_sets",
     ]);
 });
 
@@ -2655,26 +2652,29 @@ test("display only one dropdown menu", async () => {
 });
 
 test("Server order is kept by default", async () => {
-    let isSecondReadGroup = false;
-    onRpc("formatted_read_group", () => {
-        if (isSecondReadGroup) {
-            return [
-                {
-                    customer: [2, "Second"],
-                    "foo:sum": 18,
-                    __count: 2,
-                    __extra_domain: [["customer", "=", 2]],
-                },
-                {
-                    customer: [1, "First"],
-                    "foo:sum": 14,
-                    __count: 2,
-                    __extra_domain: [["customer", "=", 1]],
-                },
-            ];
-        }
-        isSecondReadGroup = true;
-    });
+    onRpc("formatted_read_grouping_sets", () => [
+        [
+            {
+                "foo:sum": 32,
+                __extra_domain: [],
+                __count: 4,
+            },
+        ],
+        [
+            {
+                customer: [2, "Second"],
+                "foo:sum": 18,
+                __count: 2,
+                __extra_domain: [["customer", "=", 2]],
+            },
+            {
+                customer: [1, "First"],
+                "foo:sum": 14,
+                __count: 2,
+                __extra_domain: [["customer", "=", 1]],
+            },
+        ],
+    ]);
     await mountView({
         type: "pivot",
         resModel: "partner",
@@ -2834,12 +2834,7 @@ test("pivot is reloaded when leaving and coming back", async () => {
     expect(".o_pivot_view").toHaveCount(1);
     expect(getCurrentValues()).toBe(["4", "2", "2"].join(","));
 
-    expect.verifySteps([
-        "/web/webclient/load_menus",
-        "get_views",
-        "formatted_read_group",
-        "formatted_read_group",
-    ]);
+    expect.verifySteps(["/web/webclient/load_menus", "get_views", "formatted_read_grouping_sets"]);
 
     // switch to list view
     await contains(".o_control_panel .o_switch_view.o_list").click();
@@ -2853,7 +2848,7 @@ test("pivot is reloaded when leaving and coming back", async () => {
     expect(".o_pivot_view").toHaveCount(1);
     expect(getCurrentValues()).toBe(["4", "2", "2"].join(","));
 
-    expect.verifySteps(["formatted_read_group", "formatted_read_group"]);
+    expect.verifySteps(["formatted_read_grouping_sets"]);
 });
 
 test.tags("desktop");
@@ -2943,11 +2938,11 @@ test("correctly handle concurrent reloads", async () => {
 
     let def;
     let readGroupCount = 0;
-    onRpc("formatted_read_group", () => {
+    onRpc("formatted_read_grouping_sets", () => {
         if (def) {
             readGroupCount++;
             if (readGroupCount === 2) {
-                // slow down last formatted_read_group of first reload
+                // slow down last formatted_read_grouping_sets of first reload
                 return def;
             }
         }
@@ -2988,7 +2983,7 @@ test("consecutively toggle several measures", async () => {
     Partner._fields.foo2 = fields.Integer({
         groupable: false,
     });
-    onRpc("formatted_read_group", () => def);
+    onRpc("formatted_read_grouping_sets", () => def);
     await mountView({
         type: "pivot",
         resModel: "partner",
@@ -3019,7 +3014,7 @@ test("consecutively toggle several measures", async () => {
 
 test("flip axis while loading a filter", async () => {
     let def;
-    onRpc("formatted_read_group", () => def);
+    onRpc("formatted_read_grouping_sets", () => def);
     await mountView({
         type: "pivot",
         resModel: "partner",
@@ -3056,7 +3051,7 @@ test("flip axis while loading a filter", async () => {
 
 test("sort rows while loading a filter", async () => {
     let def;
-    onRpc("formatted_read_group", () => def);
+    onRpc("formatted_read_grouping_sets", () => def);
     await mountView({
         type: "pivot",
         resModel: "partner",
@@ -3092,7 +3087,7 @@ test("sort rows while loading a filter", async () => {
 
 test("close a group while loading a filter", async () => {
     let def;
-    onRpc("formatted_read_group", () => def);
+    onRpc("formatted_read_grouping_sets", () => def);
     await mountView({
         type: "pivot",
         resModel: "partner",
@@ -3129,7 +3124,7 @@ test("close a group while loading a filter", async () => {
 
 test("add a groupby while loading a filter", async () => {
     let def;
-    onRpc("formatted_read_group", () => def);
+    onRpc("formatted_read_grouping_sets", () => def);
     await mountView({
         type: "pivot",
         resModel: "partner",
@@ -3166,7 +3161,7 @@ test("add a groupby while loading a filter", async () => {
 
 test("expand a group while loading a filter", async () => {
     let def;
-    onRpc("formatted_read_group", () => def);
+    onRpc("formatted_read_grouping_sets", () => def);
     await mountView({
         type: "pivot",
         resModel: "partner",
@@ -3207,7 +3202,7 @@ test("expand a group while loading a filter", async () => {
 
 test("concurrent reloads: add a filter, and directly toggle a measure", async () => {
     let def;
-    onRpc("formatted_read_group", () => def);
+    onRpc("formatted_read_grouping_sets", () => def);
     await mountView({
         type: "pivot",
         resModel: "partner",
@@ -3574,25 +3569,27 @@ test("group by properties in pivot view", async () => {
             expect.step("fetch_definition");
         }
     });
-    onRpc("partner", "formatted_read_group", ({ kwargs, method }) => {
-        if (kwargs.groupby?.includes("properties.my_char")) {
+    onRpc("partner", "formatted_read_grouping_sets", ({ kwargs, method }) => {
+        if (kwargs.grouping_sets[0].includes("properties.my_char")) {
             expect.step(method);
             return [
-                {
-                    "properties.my_char": false,
-                    __extra_domain: [["properties.my_char", "=", false]],
-                    __count: 2,
-                },
-                {
-                    "properties.my_char": "aaa",
-                    __extra_domain: [["properties.my_char", "=", "aaa"]],
-                    __count: 1,
-                },
-                {
-                    "properties.my_char": "bbb",
-                    __extra_domain: [["properties.my_char", "=", "bbb"]],
-                    __count: 1,
-                },
+                [
+                    {
+                        "properties.my_char": false,
+                        __extra_domain: [["properties.my_char", "=", false]],
+                        __count: 2,
+                    },
+                    {
+                        "properties.my_char": "aaa",
+                        __extra_domain: [["properties.my_char", "=", "aaa"]],
+                        __count: 1,
+                    },
+                    {
+                        "properties.my_char": "bbb",
+                        __extra_domain: [["properties.my_char", "=", "bbb"]],
+                        __count: 1,
+                    },
+                ],
             ];
         }
     });
@@ -3623,7 +3620,7 @@ test("group by properties in pivot view", async () => {
     await contains(".o_accordion_values .o_menu_item").click();
 
     await animationFrame();
-    expect.verifySteps(["formatted_read_group"]);
+    expect.verifySteps(["formatted_read_grouping_sets"]);
 
     const cells = queryAll(".o_value");
     expect(cells).toHaveLength(4);
@@ -3639,9 +3636,10 @@ test("group by properties in pivot view", async () => {
     expect(columns[2]).toHaveText("bbb");
 });
 
-test("avoid duplicates in formatted_read_group parameter 'groupby'", async () => {
-    onRpc("formatted_read_group", ({ kwargs }) => {
-        expect.step(kwargs.groupby);
+test("avoid duplicates in formatted_read_grouping_sets parameter 'groupby'", async () => {
+    onRpc("formatted_read_grouping_sets", ({ kwargs }) => {
+        expect.step(kwargs.grouping_sets[0]);
+        expect.step(kwargs.grouping_sets[1]);
     });
     await mountView({
         type: "pivot",
@@ -3717,19 +3715,27 @@ test("Close header dropdown when a simple date groupby option is selected", asyn
 
 test("missing property field definition is fetched", async function () {
     onRpc(({ method, kwargs }) => {
-        if (method === "formatted_read_group" && kwargs.groupby?.includes("properties.my_char")) {
-            expect.step(JSON.stringify(kwargs.groupby));
+        if (method === "formatted_read_grouping_sets") {
+            expect.step(JSON.stringify(kwargs.grouping_sets));
             return [
-                {
-                    "properties.my_char": false,
-                    __extra_domain: [["properties.my_char", "=", false]],
-                    __count: 2,
-                },
-                {
-                    "properties.my_char": "aaa",
-                    __extra_domain: [["properties.my_char", "=", "aaa"]],
-                    __count: 1,
-                },
+                [
+                    {
+                        __extra_domain: [],
+                        __count: 3,
+                    },
+                ],
+                [
+                    {
+                        "properties.my_char": false,
+                        __extra_domain: [["properties.my_char", "=", false]],
+                        __count: 2,
+                    },
+                    {
+                        "properties.my_char": "aaa",
+                        __extra_domain: [["properties.my_char", "=", "aaa"]],
+                        __count: 1,
+                    },
+                ],
             ];
         } else if (method === "get_property_definition") {
             return {
@@ -3756,25 +3762,33 @@ test("missing property field definition is fetched", async function () {
             },
         ],
     });
-    expect.verifySteps([`["properties.my_char"]`]);
-    expect(getCurrentValues()).toBe("4,2,1");
+    expect.verifySteps([`[[],["properties.my_char"]]`]);
+    expect(getCurrentValues()).toBe("3,2,1");
 });
 
 test("missing deleted property field definition is created", async function (assert) {
     onRpc(({ method, kwargs }) => {
-        if (method === "formatted_read_group" && kwargs.groupby?.includes("properties.my_char")) {
-            expect.step(JSON.stringify(kwargs.groupby));
+        if (method === "formatted_read_grouping_sets") {
+            expect.step(JSON.stringify(kwargs.grouping_sets));
             return [
-                {
-                    "properties.my_char": false,
-                    __extra_domain: [["properties.my_char", "=", false]],
-                    __count: 2,
-                },
-                {
-                    "properties.my_char": "aaa",
-                    __extra_domain: [["properties.my_char", "=", "aaa"]],
-                    __count: 1,
-                },
+                [
+                    {
+                        __extra_domain: [],
+                        __count: 3,
+                    },
+                ],
+                [
+                    {
+                        "properties.my_char": false,
+                        __extra_domain: [["properties.my_char", "=", false]],
+                        __count: 2,
+                    },
+                    {
+                        "properties.my_char": "aaa",
+                        __extra_domain: [["properties.my_char", "=", "aaa"]],
+                        __count: 1,
+                    },
+                ],
             ];
         } else if (method === "get_property_definition") {
             return {};
@@ -3798,8 +3812,8 @@ test("missing deleted property field definition is created", async function (ass
             },
         ],
     });
-    expect.verifySteps([`["properties.my_char"]`]);
-    expect(getCurrentValues()).toBe("4,2,1");
+    expect.verifySteps([`[[],["properties.my_char"]]`]);
+    expect(getCurrentValues()).toBe("3,2,1");
 });
 
 test("middle clicking on a cell triggers a doAction", async () => {
@@ -3894,7 +3908,7 @@ test("display the field's falsy_value_label for false group, if defined", async 
 test.tags("desktop");
 test("pivot views make their control panel available directly", async () => {
     const def = new Deferred();
-    onRpc("formatted_read_group", () => def);
+    onRpc("formatted_read_grouping_sets", () => def);
     await mountView({
         type: "pivot",
         resModel: "partner",

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -2407,8 +2407,8 @@ test("debugManager is active for views", async () => {
 
 test.tags("desktop");
 test("reload a view via the view switcher keep state", async () => {
-    onRpc("formatted_read_group", () => {
-        expect.step("formatted_read_group");
+    onRpc("formatted_read_grouping_sets", () => {
+        expect.step("formatted_read_grouping_sets");
     });
 
     await mountWithCleanup(WebClient);
@@ -2430,8 +2430,8 @@ test("reload a view via the view switcher keep state", async () => {
     await switchView("pivot");
     expect(".o_pivot_measure_row").toHaveClass("o_pivot_sort_order_asc");
     expect.verifySteps([
-        "formatted_read_group", // initial formatted_read_group
-        "formatted_read_group", // formatted_read_group at reload after switch view
+        "formatted_read_grouping_sets", // initial formatted_read_grouping_sets
+        "formatted_read_grouping_sets", // formatted_read_grouping_sets at reload after switch view
     ]);
 });
 

--- a/odoo/addons/test_read_group/models.py
+++ b/odoo/addons/test_read_group/models.py
@@ -152,7 +152,16 @@ class Test_Read_GroupTask(models.Model):
         'user_id',
         string="Collaborators",
     )
+    customer_ids = fields.Many2many(
+        'test_read_group.user',
+        'test_read_group_task_user_rel_2',
+        'task_id',
+        'user_id',
+        string="Customers",
+    )
     date = fields.Date()
+    integer = fields.Integer()
+    key = fields.Char()
 
 
 class ResPartner(models.Model):

--- a/odoo/addons/test_read_group/tests/__init__.py
+++ b/odoo/addons/test_read_group/tests/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from . import test_formatted_read_group
 from . import test_private_read_group
+from . import test_read_grouping_sets
 from . import test_read_progress_bar
 from . import test_web_fill_temporal
 from . import test_web_group_expand

--- a/odoo/addons/test_read_group/tests/test_read_grouping_sets.py
+++ b/odoo/addons/test_read_group/tests/test_read_grouping_sets.py
@@ -1,0 +1,538 @@
+from odoo import Command
+from odoo.tests import common, new_test_user
+
+
+class TestPrivateReadGroupingSets(common.TransactionCase):
+
+    def test_simple_read_grouping_sets(self):
+        Model = self.env['test_read_group.aggregate']
+        Partner = self.env['res.partner']
+        partner_1 = Partner.create({'name': 'z_one'})
+        partner_2 = Partner.create({'name': 'a_two'})
+        Model.create({'key': 1, 'partner_id': partner_1.id, 'value': 1})
+        Model.create({'key': 1, 'partner_id': partner_1.id, 'value': 2})
+        Model.create({'key': 1, 'partner_id': partner_2.id, 'value': 3})
+        Model.create({'key': 2, 'partner_id': partner_2.id, 'value': 4})
+        Model.create({'key': 2, 'partner_id': partner_2.id})
+        Model.create({'key': 2, 'value': 5})
+        Model.create({'partner_id': partner_2.id, 'value': 5})
+        Model.create({'value': 6})
+        Model.create({})
+
+        grouping_sets = [['key', 'partner_id'], ['key'], ['partner_id'], []]
+        expected_result = [
+            Model._read_group([], grouping_set, aggregates=['value:sum'])
+            for grouping_set in grouping_sets
+        ]
+
+        with self.assertQueries(["""
+            SELECT
+                GROUPING(
+                    "test_read_group_aggregate"."key",
+                    "test_read_group_aggregate"."partner_id"
+                ),
+                "test_read_group_aggregate"."key",
+                "test_read_group_aggregate"."partner_id",
+                SUM("test_read_group_aggregate"."value")
+            FROM
+                "test_read_group_aggregate"
+            GROUP BY
+                GROUPING SETS (
+                    ("test_read_group_aggregate"."key", "test_read_group_aggregate"."partner_id"),
+                    ("test_read_group_aggregate"."key"),
+                    ("test_read_group_aggregate"."partner_id"),
+                    ()
+                )
+            ORDER BY
+                "test_read_group_aggregate"."key" ASC,
+                "test_read_group_aggregate"."partner_id" ASC
+        """]):
+            self.assertEqual(
+                Model._read_grouping_sets([], grouping_sets, aggregates=['value:sum']),
+                expected_result,
+            )
+
+        grouping_sets = [['key', 'partner_id'], ['key'], ['partner_id'], []]
+        orders = ["partner_id, key", "key", 'partner_id', ""]
+        expected_result = [
+            Model._read_group([], grouping_set, aggregates=['value:sum'], order=order)
+            for grouping_set, order in zip(grouping_sets, orders)
+        ]
+
+        # Forcing order with many2one, traverse use the order of the comodel (res.partner)
+        with self.assertQueries(["""
+            SELECT
+                GROUPING(
+                    "test_read_group_aggregate"."key",
+                    "test_read_group_aggregate"."partner_id"
+                ),
+                "test_read_group_aggregate"."key",
+                "test_read_group_aggregate"."partner_id",
+                SUM("test_read_group_aggregate"."value")
+            FROM
+                "test_read_group_aggregate"
+                LEFT JOIN "res_partner" AS "test_read_group_aggregate__partner_id" ON (
+                    "test_read_group_aggregate"."partner_id" = "test_read_group_aggregate__partner_id"."id"
+                )
+            GROUP BY
+                GROUPING SETS (
+                    (
+                        "test_read_group_aggregate"."key",
+                        "test_read_group_aggregate"."partner_id",
+                        "test_read_group_aggregate__partner_id"."complete_name",
+                        "test_read_group_aggregate__partner_id"."id"
+                    ),
+                    ("test_read_group_aggregate"."key"),
+                    (
+                        "test_read_group_aggregate"."partner_id",
+                        "test_read_group_aggregate__partner_id"."complete_name",
+                        "test_read_group_aggregate__partner_id"."id"
+                    ),
+                    ()
+                )
+            ORDER BY
+                "test_read_group_aggregate__partner_id"."complete_name" ASC,
+                "test_read_group_aggregate__partner_id"."id" DESC,
+                "test_read_group_aggregate"."key" ASC
+        """]):
+            self.assertEqual(
+                Model._read_grouping_sets([], grouping_sets, aggregates=['value:sum'], order="partner_id, key"),
+                expected_result,
+            )
+
+    def test_many2many_read_grouping_sets(self):
+        User = self.env['test_read_group.user']
+        mario, luigi = User.create([{'name': 'Mario'}, {'name': 'Luigi'}])
+        tasks = self.env['test_read_group.task'].create([
+            {   # both users
+                'name': "Super Mario Bros.",
+                'user_ids': [Command.set((mario + luigi).ids)],
+                'integer': 1,
+            },
+            {   # mario only
+                'name': "Paper Mario",
+                'user_ids': [Command.set(mario.ids)],
+                'customer_ids': [Command.set(luigi.ids)],
+                'integer': 2,
+            },
+            {   # luigi only
+                'name': "Luigi's Mansion",
+                'user_ids': [Command.set(luigi.ids)],
+                'customer_ids': [Command.set(mario.ids)],
+                'integer': 3,
+            },
+            {   # no user
+                'name': 'Donkey Kong',
+                'customer_ids': [Command.set((mario + luigi).ids)],
+            },
+        ])
+
+        domain = [('id', 'in', tasks.ids)]
+        grouping_sets = [['user_ids', 'key'], ['key'], ['user_ids'], []]
+        aggregates = ['name:array_agg', '__count', 'integer:sum']
+        expected_result = [
+            tasks._read_group(domain, groupby, aggregates)
+            for groupby in grouping_sets
+        ]
+
+        with self.assertQueries([
+            """
+            SELECT
+                GROUPING("test_read_group_task__user_ids"."user_id", "test_read_group_task"."key"),
+                "test_read_group_task__user_ids"."user_id",
+                "test_read_group_task"."key",
+                ARRAY_AGG("test_read_group_task"."name" ORDER BY "test_read_group_task"."id"),
+                COUNT(*),
+                SUM("test_read_group_task"."integer")
+            FROM "test_read_group_task"
+                LEFT JOIN "test_read_group_task_user_rel" AS "test_read_group_task__user_ids" ON (
+                    "test_read_group_task"."id" = "test_read_group_task__user_ids"."task_id"
+                )
+            WHERE "test_read_group_task"."id" IN %s
+            GROUP BY GROUPING SETS (
+                ("test_read_group_task__user_ids"."user_id", "test_read_group_task"."key"),
+                ("test_read_group_task__user_ids"."user_id"))
+            ORDER BY "test_read_group_task__user_ids"."user_id" ASC,
+                "test_read_group_task"."key" ASC
+            """,
+            """
+            SELECT
+                GROUPING("test_read_group_task"."key"),
+                "test_read_group_task"."key",
+                ARRAY_AGG("test_read_group_task"."name" ORDER BY "test_read_group_task"."id"),
+                COUNT(*),
+                SUM("test_read_group_task"."integer")
+            FROM "test_read_group_task"
+            WHERE "test_read_group_task"."id" IN %s
+            GROUP BY GROUPING SETS (("test_read_group_task"."key"), ())
+            ORDER BY "test_read_group_task"."key" ASC
+            """,
+        ]):
+            self.assertEqual(
+                tasks._read_grouping_sets(domain, grouping_sets, aggregates),
+                expected_result,
+            )
+
+        complete_order = "user_ids DESC, key"
+        grouping_sets = [['user_ids', 'key'], ['key'], ['user_ids'], []]
+        orders = ["user_ids DESC, key", "key", "user_ids DESC", '']
+        aggregates = ['name:array_agg', '__count', 'integer:sum']
+        expected_result = [
+            tasks._read_group(domain, groupby, aggregates, order=order)
+            for groupby, order in zip(grouping_sets, orders)
+        ]
+
+        with self.assertQueries([
+            """
+            SELECT
+                GROUPING("test_read_group_task__user_ids"."user_id", "test_read_group_task"."key"),
+                "test_read_group_task__user_ids"."user_id",
+                "test_read_group_task"."key",
+                ARRAY_AGG("test_read_group_task"."name" ORDER BY "test_read_group_task"."id"),
+                COUNT(*),
+                SUM("test_read_group_task"."integer")
+            FROM "test_read_group_task"
+                LEFT JOIN "test_read_group_task_user_rel" AS "test_read_group_task__user_ids" ON (
+                    "test_read_group_task"."id" = "test_read_group_task__user_ids"."task_id"
+                )
+            WHERE "test_read_group_task"."id" IN %s
+            GROUP BY GROUPING SETS (
+                ("test_read_group_task__user_ids"."user_id", "test_read_group_task"."key"),
+                ("test_read_group_task__user_ids"."user_id"))
+            ORDER BY "test_read_group_task__user_ids"."user_id" DESC,
+                "test_read_group_task"."key" ASC
+            """,
+            """
+            SELECT
+                GROUPING("test_read_group_task"."key"),
+                "test_read_group_task"."key",
+                ARRAY_AGG("test_read_group_task"."name" ORDER BY "test_read_group_task"."id"),
+                COUNT(*),
+                SUM("test_read_group_task"."integer")
+            FROM "test_read_group_task"
+            WHERE "test_read_group_task"."id" IN %s
+            GROUP BY GROUPING SETS (("test_read_group_task"."key"), ())
+            ORDER BY "test_read_group_task"."key" ASC
+            """,
+        ]):
+            self.assertEqual(
+                tasks._read_grouping_sets(domain, grouping_sets, aggregates, order=complete_order),
+                expected_result,
+            )
+
+        cases = [
+            {
+                # Test 2 many2manys
+                'grouping_sets': [
+                    ['user_ids', 'customer_ids'], ['key'], ['user_ids'], ['customer_ids'], ['key', 'customer_ids'], []
+                ],
+                'aggregates': ['__count', 'integer:sum'],
+                # 1 for ('user_ids', 'customer_ids') + 1 for ('user_ids',) + 1 for ('customer_ids',) + 1 for remaining (key, [])
+                'nb_queries': 4,
+            },
+            {
+                # Test that __count doesn't make a extra query
+                'grouping_sets': [['user_ids', 'key'], ['key'], ['user_ids'], []],
+                'aggregates': ['__count'],
+                'nb_queries': 1,
+            },
+            {
+                # Test that __count as order
+                'grouping_sets': [['user_ids', 'customer_ids'], ['key'], ['user_ids'], []],
+                'read_group_orders': [
+                    "__count, user_ids, customer_ids",
+                    "__count, key",
+                    "__count, user_ids",
+                    "__count",
+                ],
+                'complete_order': "__count, user_ids, customer_ids, key",
+                'aggregates': ['__count', 'integer:min', 'integer:max', 'integer:count_distinct'],
+                'nb_queries': 1,
+            },
+            {
+                # Everything
+                'grouping_sets': [
+                    ['user_ids', 'customer_ids'],
+                    ['key'],
+                    ['integer'],
+                    [],
+                    ['customer_ids'],
+                    ['key', 'customer_ids'],
+                    ['integer', 'customer_ids'],
+                ],
+                'read_group_orders': [
+                    "__count DESC, customer_ids DESC, user_ids",
+                    "key, __count DESC",
+                    "__count DESC, integer",
+                    "__count DESC",
+                    "__count DESC, customer_ids DESC",
+                    "key, __count DESC, customer_ids DESC",
+                    "__count DESC, customer_ids DESC, integer",
+                ],
+                'complete_order': "key, __count DESC, customer_ids DESC, integer, user_ids",
+                'aggregates': ['integer:sum', '__count'],
+                # 1 for ('user_ids', 'customer_ids') + 1 for ('customer_ids',) + 1 for remainings grouping set
+                'nb_queries': 3,
+            },
+        ]
+
+        for i, case in enumerate(cases):
+            nb_queries = case['nb_queries']
+            aggregates = case['aggregates']
+            grouping_sets = case['grouping_sets']
+            read_group_orders = case.get('read_group_orders', [""] * len(grouping_sets))
+            complete_order = case.get('complete_order')
+
+            expected_result = [
+                tasks._read_group(domain, groupby, aggregates, order=order)
+                for groupby, order in zip(grouping_sets, read_group_orders)
+            ]
+            with self.subTest(f"Case {i} - {grouping_sets!r} - {aggregates!r}"), self.assertQueryCount(nb_queries):
+                result = tasks._read_grouping_sets(domain, grouping_sets, aggregates, order=complete_order)
+                self.assertEqual(result, expected_result)
+
+
+class TestFormattedReadGroupingSets(common.TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.base_user = new_test_user(cls.env, login='Base User', groups='base.group_user')
+
+    def test_simple_formatted_read_grouping_sets(self):
+        Model = self.env['test_read_group.aggregate']
+        Partner = self.env['res.partner']
+        partner_1 = Partner.create({'name': 'z_one'})
+        partner_2 = Partner.create({'name': 'a_two'})
+        Model.create({'key': 1, 'partner_id': partner_1.id, 'value': 1})
+        Model.create({'key': 1, 'partner_id': partner_1.id, 'value': 2})
+        Model.create({'key': 1, 'partner_id': partner_2.id, 'value': 3})
+        Model.create({'key': 2, 'partner_id': partner_2.id, 'value': 4})
+        Model.create({'key': 2, 'partner_id': partner_2.id})
+        Model.create({'key': 2, 'value': 5})
+        Model.create({'partner_id': partner_2.id, 'value': 5})
+        Model.create({'value': 6})
+        Model.create({})
+
+        grouping_sets = [['partner_id', 'key'], ['key'], ['partner_id'], []]
+        expected_result = [
+            Model.formatted_read_group([], grouping_set, aggregates=['value:sum'])
+            for grouping_set in grouping_sets
+        ]
+
+        with self.assertQueries(["""
+            SELECT
+                GROUPING(
+                    "test_read_group_aggregate"."partner_id",
+                    "test_read_group_aggregate"."key"
+                ),
+                "test_read_group_aggregate"."partner_id",
+                "test_read_group_aggregate"."key",
+                SUM("test_read_group_aggregate"."value")
+            FROM
+                "test_read_group_aggregate"
+                LEFT JOIN "res_partner" AS "test_read_group_aggregate__partner_id" ON (
+                    "test_read_group_aggregate"."partner_id" = "test_read_group_aggregate__partner_id"."id"
+                )
+            GROUP BY
+                GROUPING SETS (
+                    (
+                        "test_read_group_aggregate"."partner_id",
+                        "test_read_group_aggregate__partner_id"."complete_name",
+                        "test_read_group_aggregate__partner_id"."id",
+                        "test_read_group_aggregate"."key"
+                    ),
+                    ("test_read_group_aggregate"."key"),
+                    (
+                        "test_read_group_aggregate"."partner_id",
+                        "test_read_group_aggregate__partner_id"."complete_name",
+                        "test_read_group_aggregate__partner_id"."id"
+                    ),
+                    ()
+                )
+            ORDER BY
+                "test_read_group_aggregate__partner_id"."complete_name" ASC,
+                "test_read_group_aggregate__partner_id"."id" DESC,
+                "test_read_group_aggregate"."key" ASC
+        """]):
+            self.assertEqual(
+                Model.formatted_read_grouping_sets([], grouping_sets, aggregates=['value:sum']),
+                expected_result,
+            )
+
+    def test_many2many_formatted_read_grouping_sets(self):
+        User = self.env['test_read_group.user']
+        mario, luigi = User.create([{'name': 'Mario'}, {'name': 'Luigi'}])
+        tasks = self.env['test_read_group.task'].create([
+            {   # both users
+                'name': "Super Mario Bros.",
+                'user_ids': [Command.set((mario + luigi).ids)],
+                'integer': 1,
+            },
+            {   # mario only
+                'name': "Paper Mario",
+                'user_ids': [Command.set(mario.ids)],
+                'customer_ids': [Command.set(luigi.ids)],
+                'integer': 2,
+            },
+            {   # luigi only
+                'name': "Luigi's Mansion",
+                'user_ids': [Command.set(luigi.ids)],
+                'customer_ids': [Command.set(mario.ids)],
+                'integer': 3,
+            },
+            {   # no user
+                'name': 'Donkey Kong',
+                'customer_ids': [Command.set((mario + luigi).ids)],
+            },
+        ])
+
+        domain = [('id', 'in', tasks.ids)]
+        grouping_sets = [['user_ids', 'key'], ['key'], ['user_ids'], []]
+        aggregates = ['name:array_agg', '__count', 'integer:sum']
+        expected_result = [
+            tasks.formatted_read_group(domain, groupby, aggregates)
+            for groupby in grouping_sets
+        ]
+
+        self.assertEqual(
+            tasks.formatted_read_grouping_sets(domain, grouping_sets, aggregates),
+            expected_result,
+        )
+
+        complete_order = "user_ids DESC, key"
+        grouping_sets = [['user_ids', 'key'], ['key'], ['user_ids'], []]
+        orders = ["user_ids DESC, key", "key", "user_ids DESC", '']
+        aggregates = ['name:array_agg', '__count', 'integer:sum']
+        expected_result = [
+            tasks.formatted_read_group(domain, groupby, aggregates, order=order)
+            for groupby, order in zip(grouping_sets, orders)
+        ]
+
+        self.assertEqual(
+            tasks.formatted_read_grouping_sets(domain, grouping_sets, aggregates, order=complete_order),
+            expected_result,
+        )
+
+        cases = [
+            {
+                # Test 2 many2manys
+                'grouping_sets': [
+                    ['user_ids', 'customer_ids'], ['key'], ['user_ids'], ['customer_ids'], ['key', 'customer_ids'], []
+                ],
+                'aggregates': ['__count', 'integer:sum'],
+                # 1 for ('user_ids', 'customer_ids') + 1 for ('user_ids',) + 1 for ('customer_ids',) + 1 for remaining (key, [])
+                'nb_queries': 4,
+            },
+            {
+                # Test that __count doesn't make a extra query
+                'grouping_sets': [['user_ids', 'key'], ['key'], ['user_ids'], []],
+                'aggregates': ['__count'],
+                'nb_queries': 1,
+            },
+            {
+                # Test that __count as order
+                'grouping_sets': [['user_ids', 'customer_ids'], ['key'], ['user_ids'], []],
+                'read_group_orders': [
+                    "__count, user_ids, customer_ids",
+                    "__count, key",
+                    "__count, user_ids",
+                    "__count",
+                ],
+                'complete_order': "__count, user_ids, customer_ids, key",
+                'aggregates': ['__count', 'integer:min', 'integer:max', 'integer:count_distinct'],
+                'nb_queries': 1,
+            },
+            {
+                # Everything
+                'grouping_sets': [
+                    ['user_ids', 'customer_ids'],
+                    ['key'],
+                    ['integer'],
+                    [],
+                    ['customer_ids'],
+                    ['key', 'customer_ids'],
+                    ['integer', 'customer_ids'],
+                ],
+                'read_group_orders': [
+                    "__count DESC, customer_ids DESC, user_ids",
+                    "key, __count DESC",
+                    "__count DESC, integer",
+                    "__count DESC",
+                    "__count DESC, customer_ids DESC",
+                    "key, __count DESC, customer_ids DESC",
+                    "__count DESC, customer_ids DESC, integer",
+                ],
+                'complete_order': "key, __count DESC, customer_ids DESC, integer, user_ids",
+                'aggregates': ['integer:sum', '__count'],
+                # 1 for ('user_ids', 'customer_ids') + 1 for ('customer_ids',) + 1 for remainings grouping set
+                'nb_queries': 3,
+            },
+        ]
+
+        for i, case in enumerate(cases):
+            nb_queries = case['nb_queries']
+            aggregates = case['aggregates']
+            grouping_sets = case['grouping_sets']
+            read_group_orders = case.get('read_group_orders', [""] * len(grouping_sets))
+            complete_order = case.get('complete_order')
+
+            expected_result = [
+                tasks.formatted_read_group(domain, groupby, aggregates, order=order)
+                for groupby, order in zip(grouping_sets, read_group_orders)
+            ]
+            with self.subTest(f"Case {i} - {grouping_sets!r} - {aggregates!r}"), self.assertQueryCount(nb_queries):
+                result = tasks.formatted_read_grouping_sets(domain, grouping_sets, aggregates, order=complete_order)
+                self.assertEqual(result, expected_result)
+
+    def test_related(self):
+        RelatedBar = self.env['test_read_group.related_bar']
+        RelatedFoo = self.env['test_read_group.related_foo']
+        RelatedBase = self.env['test_read_group.related_base']
+
+        bars = RelatedBar.create(
+            [
+                {'name': 'bar_a'},
+                {'name': False},
+            ],
+        )
+
+        foos = RelatedFoo.create(
+            [
+                {'name': 'foo_a_bar_a', 'bar_id': bars[0].id},
+                {'name': 'foo_b_bar_false', 'bar_id': bars[1].id},
+                {'name': False, 'bar_id': bars[0].id},
+                {'name': False},
+            ],
+        )
+
+        RelatedBase.create(
+            [
+                {'name': 'base_foo_a_1', 'foo_id': foos[0].id},
+                {'name': 'base_foo_a_2', 'foo_id': foos[0].id},
+                {'name': 'base_foo_b_bar_false', 'foo_id': foos[1].id},
+                {'name': 'base_false_foo_bar_a', 'foo_id': foos[2].id},
+                {'name': 'base_false_foo', 'foo_id': foos[3].id},
+            ],
+        )
+
+        # env.su => false
+        RelatedBase = RelatedBase.with_user(self.base_user)
+
+        grouping_sets = [
+            ['foo_id_name_sudo', 'foo_id_bar_id_name', 'name'],
+            ['foo_id_name_sudo', 'foo_id_bar_id_name'],
+            ['name'],
+            [],
+        ]
+        self.assertEqual(
+            RelatedBase.formatted_read_grouping_sets([], grouping_sets, ['__count', 'name:array_agg']),
+            [
+                RelatedBase.formatted_read_group([], groupby, ['__count', 'name:array_agg'])
+                for groupby in grouping_sets
+            ],
+        )
+
+        # Cannot groupby on foo_names_sudo because it traverse One2many
+        with self.assertRaises(ValueError):
+            RelatedBar.formatted_read_grouping_sets([], [['foo_names_sudo']], ['__count'])

--- a/odoo/addons/test_read_group/tests/test_web_fill_temporal.py
+++ b/odoo/addons/test_read_group/tests/test_web_fill_temporal.py
@@ -60,6 +60,16 @@ class TestFillTemporal(common.TransactionCase):
 
         self.assertEqual(groups, expected)
 
+        Model = self.Model.with_context(fill_temporal=True)
+        # Same result for formatted_grouping_sets
+        self.assertEqual(
+            Model.formatted_read_grouping_sets([], [['date:month'], []], ['__count', 'value:sum']),
+            [
+                Model.formatted_read_group([], ['date:month'], ['__count', 'value:sum']),
+                Model.formatted_read_group([], [], ['__count', 'value:sum']),
+            ],
+        )
+
     def test_date_range_with_context_timezone(self):
         """Test if date are date_trunced correctly by pgres.
 

--- a/odoo/addons/test_read_group/tests/test_web_group_expand.py
+++ b/odoo/addons/test_read_group/tests/test_web_group_expand.py
@@ -437,6 +437,15 @@ class TestGroupExpand(common.TransactionCase):
                 ],
             )
 
+        # Same result for formatted_grouping_sets
+        self.assertEqual(
+            Line.formatted_read_grouping_sets([], [["order_expand_id"], []], ["value:sum"]),
+            [
+                Line.formatted_read_group([], ["order_expand_id"], ["value:sum"]),
+                Line.formatted_read_group([], [], ["value:sum"]),
+            ],
+        )
+
         # Modify the data so that each record has the same order,
         # and test that the _compute_display_name is called once with the correct recordset.
         all_lines.order_expand_id = order_1.id

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1589,6 +1589,243 @@ class BaseModel(metaclass=MetaModel):
         return defaults
 
     @api.model
+    def _read_grouping_sets(
+        self,
+        domain: DomainType,
+        grouping_sets: Sequence[Sequence[str]],
+        aggregates: Sequence[str] = (),
+        order: str | None = None,
+    ) -> list[list[tuple]]:
+        """ Performs multiple aggregations with different groupings in a single query if possible.
+
+        This method uses SQL `GROUPING SETS` as a more advanced and efficient
+        alternative to calling :meth:`~._read_group` multiple times with different
+        `groupby` parameters. It allows you to get different levels of aggregated
+        data in one database round-trip.
+        Note that for many2many multiple SQL might be needed because of the deduplicated rows.
+
+        :param domain: :ref:`A search domain <reference/orm/domains>` to filter records before grouping
+        :param grouping_sets: A list of `groupby` specifications. Each inner list
+                              is a set of fields to group by and is equivalent to the
+                              `groupby` parameter of the :meth:`~._read_group` method.
+                              For example: `[['partner_id'], ['partner_id', 'state']]`.
+        :param aggregates: list of aggregates specification.
+                Each element is `'field:agg'` (aggregate field with aggregation function `'agg'`).
+                The possible aggregation functions are the ones provided by
+                `PostgreSQL <https://www.postgresql.org/docs/current/static/functions-aggregate.html>`_,
+                `'count_distinct'` with the expected meaning and `'recordset'` to act like `'array_agg'`
+                converted into a recordset.
+        :param order: optional ``order by`` specification, for
+                overriding the natural sort ordering of the groups,
+                see also :meth:`~.search`.
+        :return: A list of lists of tuples. The outer list's structure mirrors the
+                 input `grouping_sets`. Each inner list contains the results for one
+                 grouping specification. Each tuple within an inner list contains the
+                 values for the grouped fields, followed by the aggregate values,
+                 in the order they were specified.
+
+                 For example, given:
+                 - `grouping_sets=[['foo'], ['foo', 'bar']]`
+                 - `aggregates=['baz:sum']`
+
+                 The returned structure would be:
+                  ::
+
+                    [
+                        # Results for ['foo']
+                        [(foo1_val, baz_sum_1), (foo2_val, baz_sum_2), ...],
+                        # Results for ['foo', 'bar']
+                        [(foo1_val, bar1_val, baz_sum_3), (foo2_val, bar2_val, baz_sum_4), ...],
+                    ]
+
+        :raise AccessError: if user is not allowed to access requested information
+        """
+        if not grouping_sets:
+            raise ValueError("The 'grouping_sets' parameter cannot be empty.")
+
+        query = self._search(domain)
+        result = [[] for __ in grouping_sets]
+        if query.is_empty():
+            return result
+
+        # grouping_sets: [(a, b), (a), ()]
+        # all_groupby_specs: (a, b)
+        all_groupby_specs = tuple(unique(spec for groupby in grouping_sets for spec in groupby))
+
+        # --- Many2many Special Handling ---
+        many2many_groupby_specs = []
+        if len(grouping_sets) > 1:  # many2many logic only applies if we have multiple groupings
+            for spec in all_groupby_specs:
+                fname, property_name, __ = parse_read_group_spec(spec)
+                field = self._fields[fname]
+                if field.type == 'many2many':
+                    many2many_groupby_specs.append(spec)
+                elif field.type == 'properties':
+                    definition = self.get_property_definition(f"{fname}.{property_name}")
+                    property_type = definition.get('type')
+                    if property_type in ('tags', 'many2many'):
+                        many2many_groupby_specs.append(spec)
+
+        if (
+            many2many_groupby_specs and
+            # If aggregates are sensitive to row duplication (like sum, avg), we must isolate M2M groupings.
+            any(
+                not aggregate.endswith(
+                    (':max', ':min', ':bool_and', ':bool_or', ':array_agg_distinct', ':recordset', ':count_distinct'),
+                )
+                for aggregate in aggregates if aggregate != '__count'
+            )
+        ):
+            # The following logic is a recursive decomposition strategy. It's complex
+            # but necessary to prevent M2M joins from corrupting aggregates in other grouping sets.
+            # We find all combinations of M2M fields and create a sub-call for grouping sets
+            # that share that exact combination of M2M fields.
+
+            # ['A', 'B', 'C'] => [('A', 'B', 'C'), ('A', 'B'), ('A', 'C'), ('B', 'C'), ('A',), ('B',), ('C',), ()]
+            m2m_combinaisons = (
+                groupby for i in range(len(many2many_groupby_specs), -1, -1)
+                for groupby in itertools.combinations(many2many_groupby_specs, i)
+            )
+
+            grouping_sets_to_process = dict(enumerate(grouping_sets))
+            batched_calls = []  # [([groupby, ...], [index_result, ...])]
+
+            for m2m_comb in m2m_combinaisons:
+                if not grouping_sets_to_process:
+                    break
+                sub_grouping_sets = []
+                sub_result_indexes = []
+                for i, groupby in list(grouping_sets_to_process.items()):
+                    if all(m2m in groupby for m2m in m2m_comb):
+                        sub_grouping_sets.append(groupby)
+                        sub_result_indexes.append(i)
+                        grouping_sets_to_process.pop(i)
+
+                if sub_grouping_sets:
+                    batched_calls.append((sub_result_indexes, sub_grouping_sets))
+
+            assert not grouping_sets_to_process
+            # If the problem was decomposed, make recursive calls and assemble results.
+            if len(batched_calls) > 1:
+                for indexes, sub_grouping_sets in batched_calls:
+
+                    sub_order_parts = []
+                    all_sub_groupby = {spec for groupby in sub_grouping_sets for spec in groupby}
+                    for order_part in (order or '').split(','):
+                        order_part = order_part.strip()
+                        if not any(
+                            order_part.startswith(spec)
+                            for spec in all_groupby_specs if spec not in all_sub_groupby
+                        ):
+                            sub_order_parts.append(order_part)
+
+                    sub_results = self._read_grouping_sets(
+                        domain, sub_grouping_sets, aggregates=aggregates, order=",".join(sub_order_parts),
+                    )
+                    for index, subresult in zip(indexes, sub_results):
+                        result[index] = subresult
+                return result
+
+        elif many2many_groupby_specs and '__count' in aggregates:
+            # Efficiently handle '__count' with M2M fields by using a distinct count on 'id'
+            # without making another _read_grouping_sets (this is the very common case).
+            aggregates = tuple(
+                aggregate if aggregate != '__count' else 'id:count_distinct'
+                for aggregate in aggregates
+            )
+            if order:
+                order = order.replace('__count', 'id:count_distinct')
+
+        # --- SQL Query Construction ---
+        groupby_terms: dict[str, SQL] = {
+            spec: self._read_group_groupby(spec, query) for spec in all_groupby_specs
+        }
+        aggregates_terms: list[SQL] = [
+            self._read_group_select(spec, query) for spec in aggregates
+        ]
+        if groupby_terms:
+            # grouping_select_sql: GROUPING(a, b)
+            grouping_select_sql = SQL("GROUPING(%s)", SQL(", ").join(groupby_terms.values()))
+        else:
+            # GROUPING() is invalid SQL, so we use the 0 as literal
+            grouping_select_sql = SQL("0")
+
+        select_args = [grouping_select_sql, *groupby_terms.values(), *aggregates_terms]
+
+        # _read_group_orderby may change groupby_terms then it is necessary to be call before
+        query.order = self._read_group_orderby(order, groupby_terms, query)
+        # GROUPING SET ((a, b), (a), ())
+        grouping_sets_sql = [
+            SQL("(%s)", SQL(", ").join(groupby_terms[groupby_spec] for groupby_spec in grouping_set))
+            for grouping_set in grouping_sets
+        ]
+        query.groupby = SQL("GROUPING SETS (%s)", SQL(", ").join(grouping_sets_sql))
+
+        # This handles the case where `order` adds columns that must also be in `GROUP BY`.
+        # Rebuild the grouping sets to include these extra terms.
+
+        # row_values: [(GROUPING(...), a1, b1, aggregates...), (GROUPING(...), a2, b2, aggregates...), ...]
+        row_values = self.env.execute_query(query.select(*select_args))
+
+        if not row_values:  # shortcut
+            return result
+
+        # --- Result Post-Processing ---
+        # This is the core of the result dispatching logic. It uses the integer
+        # returned by GROUPING() as a key to map each result row to the correct
+        # grouping set defined by the user.
+        aggregates_indexes = tuple(range(len(all_groupby_specs), len(all_groupby_specs) + len(aggregates)))
+
+        # Map each possible GROUPING() bitmask to its corresponding result list and value extractor.
+        # {GROUPING(...): (append_method, extractor_method)}
+        mask_grouping_mapping = {}
+        for result_index, groupby_specs in enumerate(grouping_sets):
+            # PostgreSQL Doc: https://www.postgresql.org/docs/17/functions-aggregate.html#Grouping-Operations
+            # GROUPING ( group_by_expression(s) ) => integer
+            # Returns a bit mask indicating which GROUP BY expressions are not included in the
+            # current grouping set. Bits are assigned with the rightmost argument corresponding to
+            # the least-significant bit; each bit is 0 if the corresponding expression is included
+            # in the grouping criteria of the grouping set generating the current result row, and 1
+            # if it is not included.
+
+            # for GROUPING SET ((a, b), (a), ())
+            # GROUPING(a, b): a and b included = 0, a included = 1, b included = 2, none included = 3
+            groupby_mask = sum(
+                1 << i for i, groupby_spec in enumerate(reversed(all_groupby_specs))
+                if groupby_spec not in groupby_specs  # 0 if included and 1 if not
+            )
+            assert groupby_mask not in mask_grouping_mapping, f"_read_grouping_sets doesn't manage duplicate groupby specs: {grouping_sets!r}"
+
+            mask_grouping_mapping[groupby_mask] = (
+                result[result_index].append,
+                itemgetter_tuple(list(itertools.chain(
+                    (all_groupby_specs.index(groupby_spec) for groupby_spec in groupby_specs),
+                    aggregates_indexes,
+                ))),
+            )
+
+        aggregates_start_index = len(all_groupby_specs) + 1
+        # Transpose rows to columns for efficient, column-wise post-processing.
+        columns = list(zip(*row_values))
+        # The first column is the grouping mask
+        dispatch_info = map(mask_grouping_mapping.__getitem__, columns[0])
+        # Post-process values column by column
+        columns = [
+            *map(self._read_group_postprocess_groupby, all_groupby_specs, columns[1:aggregates_start_index]),
+            *map(self._read_group_postprocess_aggregate, aggregates, columns[aggregates_start_index:]),
+        ]
+
+        # result: [
+        #   [(a1, b1, <aggregates>), (a2, b2, <aggregates>), ...],
+        #   [(a1, <aggregates>), (a2, <aggregates>), ...],
+        #   [(<aggregates>)],
+        # ]
+        for (append_method, extractor), *row in zip(dispatch_info, *columns, strict=True):
+            append_method(extractor(row))
+
+        return result
+
+    @api.model
     def _read_group(
         self,
         domain: DomainType,
@@ -1649,19 +1886,18 @@ class BaseModel(metaclass=MetaModel):
             spec: self._read_group_groupby(spec, query)
             for spec in groupby
         }
-        if groupby_terms:
-            query.groupby = SQL(", ").join(groupby_terms.values())
-            query.having = self._read_group_having(list(having), query)
-            # _read_group_orderby may possibly extend query.groupby for orderby
-            query.order = self._read_group_orderby(order, groupby_terms, query)
-
-        select_terms: list[SQL] = [
+        aggregates_terms: list[SQL] = [
             self._read_group_select(spec, query)
             for spec in aggregates
         ]
+        select_args = [*[groupby_terms[spec] for spec in groupby], *aggregates_terms]
+        if groupby_terms:
+            query.order = self._read_group_orderby(order, groupby_terms, query)
+            query.groupby = SQL(", ").join(groupby_terms.values())
+            query.having = self._read_group_having(list(having), query)
 
         # row_values: [(a1, b1, c1), (a2, b2, c2), ...]
-        row_values = self.env.execute_query(query.select(*[groupby_terms[spec] for spec in groupby], *select_terms))
+        row_values = self.env.execute_query(query.select(*select_args))
 
         if not row_values:
             return row_values
@@ -1832,6 +2068,8 @@ class BaseModel(metaclass=MetaModel):
         """ Return (<SQL expression>, <SQL expression>)
         corresponding to the given order and groupby terms.
 
+        Note: this method may change groupby_terms
+
         :param order: the order specification
         :param groupby_terms: the group by terms mapping ({spec: sql_expression})
         :param query: The query we are building
@@ -1874,6 +2112,10 @@ class BaseModel(metaclass=MetaModel):
             ):
                 if sql_order := self._order_to_sql(f'{term} {direction} {nulls}', query):
                     orderby_terms.append(sql_order)
+                    if query._order_groupby:
+                        groupby_terms[term] = SQL(", ").join([groupby_terms[term], *query._order_groupby])
+                        query._order_groupby.clear()
+
             elif granularity == 'day_of_week':
                 """
                 Day offset relative to the first day of week in the user lang
@@ -5003,8 +5245,7 @@ class BaseModel(metaclass=MetaModel):
                 sql_field = self._field_to_sql(alias, field_name, query)
 
             if coorder == 'id':
-                if query.groupby:
-                    query.groupby = SQL('%s, %s', query.groupby, sql_field)
+                query._order_groupby.append(sql_field)
                 return SQL("%s %s %s", sql_field, direction, nulls)
 
             # instead of ordering by the field's raw value, use the comodel's
@@ -5033,8 +5274,8 @@ class BaseModel(metaclass=MetaModel):
         sql_field = self._field_to_sql(alias, field_name, query)
         if field.type == 'boolean':
             sql_field = SQL("COALESCE(%s, FALSE)", sql_field)
-        if query.groupby:
-            query.groupby = SQL('%s, %s', query.groupby, sql_field)
+
+        query._order_groupby.append(sql_field)
 
         return SQL("%s %s %s", sql_field, direction, nulls)
 

--- a/odoo/tools/query.py
+++ b/odoo/tools/query.py
@@ -69,6 +69,7 @@ class Query:
 
         # groupby, having, order, limit, offset
         self.groupby: SQL | None = None
+        self._order_groupby: list[SQL] = []
         self.having: SQL | None = None
         self._order: SQL | None = None
         self.limit: int | None = None


### PR DESCRIPTION
Currently, opening a pivot view triggers multiple `formatted_read_group` requests. The number of these requests (X) depends on the number of expanded field columns and rows (X = (number of row fields + 1) * (number of column fields + 1)). For example, a Commission pivot view grouped by `plan_id` and `user_id` for rows, and `payment_date` for columns, would result in 6 `formatted_read_group` calls ((2 + 1) * (1 + 1)). 

These individual `formatted_read_group` requests are often slow and frequently lead to sequential scans on the target table/view. Since all these requests share the same arguments (except for the `groupby` parameter) and do not use `limit` or `offset`, they are ideal candidates for PostgreSQL's `GROUPING SETS` feature. This allows combining all these requests into a single query with comparable performance to a single previous `formatted_read_group` call. 

This commit introduces `_read_grouping_sets` and its web-client version, `formatted_read_grouping_sets`, and integrates it into the pivot model. This significantly reduces the number of heavy RPC calls to the server, making all pivot views (including those used in dashboards with spreadsheets) faster in term of user time and greatly reduces the
worker time taken for pivots/dashboards views.

### Performance

###### Local: In Sales > Reporting > Commission:

Test on my compute with sale_commission, purchase, mrp modules + populate subcommand and in multi workers=6

**Before - 6 RPC:**
User Time: 6.051 +- 0.033 sec
Worker time: 22.230 -+ 0.276 sec

**After - 1 RPC:**
User Time = Worker time: 1.988 +- 0.016 sec

###### Next: In Sales > Reporting > Commission:
Test on real data on our database:

**Before - 6 RPC:** 
User Time: 25.84 sec
Worker time: 79.78 sec

**After - 1 RPC:**
User Time = Worker time: 13.80 sec

###### Next: Dashboard > CRM - Leads:

**Before - 28 RPC:** 
User Time: -+ 40 sec
Worker time: 241.4 sec

**After - 14 RPC:**
User Time: -+ 25 sec
Worker time: 146.82 sec

https://github.com/odoo/enterprise/pull/89396

Special thanks to @Polymorphe57 for the idea long time ago.
