### PR TITLE
[FIX] im_livechat: pass avatar token to cors route

### DIFF
--- a/addons/im_livechat/controllers/cors/binary.py
+++ b/addons/im_livechat/controllers/cors/binary.py
@@ -34,9 +34,13 @@ class LivechatBinaryController(BinaryController):
 
     @route(["/im_livechat/cors/web/image"], type='http', auth="public", cors="*")
     # pylint: disable=redefined-builtin,invalid-name
-    def livechat_content_image(self, model, id, field, unique=False, guest_token=None):
+    def livechat_content_image(
+        self, model, id, field, unique=False, guest_token=None, access_token=None
+    ):
         if guest_token:
             force_guest_env(guest_token)
         else:
             downgrade_to_public_user()
-        return self.content_image(model=model, id=id, field=field, unique=unique)
+        return self.content_image(
+            model=model, id=id, field=field, unique=unique, access_token=access_token
+        )

--- a/addons/im_livechat/static/src/embed/cors/persona_model_patch.js
+++ b/addons/im_livechat/static/src/embed/cors/persona_model_patch.js
@@ -13,6 +13,9 @@ patch(Persona.prototype, {
                 unique: this.write_date,
             }
         );
+        if (!this.store.self.isInternalUser) {
+            params.access_token = this.avatar_128_access_token;
+        }
         if (this.type === "partner") {
             return url("/im_livechat/cors/web/image", {
                 field: "avatar_128",


### PR DESCRIPTION
Follow up of https://github.com/odoo/odoo/pull/187799

The livechat override needs to be adapted as well to provide the token.

- Login with Mitchell Admin to a database with im_livechat installed
- Open support page as guest
- The operator picture is missing

opw-4489740