### PR TITLE
[FIX] website: translation regex match any character of the content

### DIFF
--- a/addons/website/static/src/components/translator/translator.js
+++ b/addons/website/static/src/components/translator/translator.js
@@ -161,7 +161,7 @@ export class WebsiteTranslator extends WebsiteEditorComponent {
         const self = this;
         var attrs = ['placeholder', 'title', 'alt', 'value'];
         const $editable = this.getEditableArea();
-        const translationRegex = /<span [^>]*data-oe-translation-initial-sha="([^"]+)"[^>]*>(.*)<\/span>/;
+        const translationRegex = /<span [^>]*data-oe-translation-initial-sha="([^"]+)"[^>]*>([\s\S]*?)<\/span>/;
         let $edited = $();
         attrs.forEach((attr) => {
             const attrEdit = $editable.filter('[' + attr + '*="data-oe-translation-initial-sha="]').filter(':empty, input, select, textarea, img');


### PR DESCRIPTION
Steps to reproduce:
(This are for this specific case)

1. Get website_appointment_sale and a 2nd language for our website.
2. Make sure that for the appointment we select Allow Guests.
3. Now, we go to the website and go to the appointment, until we reach the "Add more details about you" page.
4. Here is when we have to try to modify the translation with editor.

Issue: 
We're receiving an error as
"Cannot read properties of null (reading '2')" which arises from the `trans` not being appropiate due to the translation regex, which will cause the match to be null when calling it on this "defective" `trans`.

Solution: 
The current solution will make the regex to better match anything in the translation, by modifying `(.*)` to ([\s\S]*?) we make sure that we're matching any character, including new lines.

opw-4442038
