### PR TITLE
[FIX] pos_sale: update quotation delivered qty

### DIFF
--- a/addons/pos_sale/models/stock_picking.py
+++ b/addons/pos_sale/models/stock_picking.py
@@ -16,4 +16,4 @@ class StockPicking(models.Model):
                 continue
             lines_to_unreserve |= line
         lines_to_unreserve.sale_order_line_id.move_ids.filtered(lambda ml: ml.state not in ['cancel', 'done'])._do_unreserve()
-        return super()._create_move_from_pos_order_lines(lines.filtered(lambda l: not l.sale_order_line_id or l.sale_order_line_id.has_valued_move_ids()))
+        return super()._create_move_from_pos_order_lines(lines.filtered(lambda l: not l.sale_order_line_id or (l.sale_order_line_id.has_valued_move_ids() or not l.sale_order_line_id.move_ids)))

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -381,3 +381,16 @@ registry.category("web_tour.tours").add("PoSDownPaymentFixedTax", {
             }),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PoSSettleQuotation", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            PosSale.settleNthOrder(1),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+        ].flat(),
+});

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1079,3 +1079,22 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSDownPaymentFixedTax', login="accountman")
+
+    def test_settle_quotation_delivered_qty(self):
+        """ Test if a quotation (unconfirmed sale order) is settled in the PoS, the delivered quantity is updated correctly """
+
+        product1 = self.env['product.product'].create({
+            'name': 'product1',
+            'available_in_pos': True,
+            'is_storable': True,
+            'lst_price': 10,
+            'taxes_id': [odoo.Command.clear()],
+        })
+        partner_1 = self.env['res.partner'].create({'name': 'Test Partner 1'})
+        order = self.env['sale.order'].create({
+            'partner_id': partner_1.id,
+            'order_line': [odoo.Command.create({'product_id': product1.id})],
+        })
+        self.main_pos_config.open_ui()
+        self.start_pos_tour('PoSSettleQuotation', login="accountman")
+        self.assertEqual(order.order_line.qty_delivered, 1)


### PR DESCRIPTION
When settling a quotation (unconfirmed sale order) from the POS, the
delivered quantity was not updated in the quotation.

Steps to reproduce:
-------------------
* Make a sale order but don't confirm it
* Go to the POS and settle the quotation
> Observation: The delivered quantity is not updated in the quotation

Why the fix:
------------
If the quotation was not confirmed no move lines were created, so the
`has_valued_moves` was False and no move lines were created for the PoS
order. And because the pos order has no move lines the quotation was not
updated with the delivered quantity.

opw-4479862