### PR TITLE
[FIX] point_of_sale: fix order quantity rounding

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/contextual_utils_service.js
+++ b/addons/point_of_sale/static/src/app/utils/contextual_utils_service.js
@@ -32,8 +32,11 @@ export const contextualUtilsService = {
             floatRegex = new RegExp(`^-?(?:\\d+)?(?:${escapedDecimalPoint}\\d*)?$`);
         }
 
-        const formatProductQty = (qty) => {
-            return formatFloat(qty, { digits: [true, productUoMDecimals] });
+        const formatProductQty = (qty, trailingZeros = true) => {
+            return formatFloat(qty, {
+                digits: [true, productUoMDecimals],
+                trailingZeros: trailingZeros,
+            });
         };
 
         const formatStrCurrency = (valueStr, hasSymbol = true) => {

--- a/addons/pos_restaurant/static/src/app/floor_screen/table.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/table.xml
@@ -12,7 +12,7 @@
                     class="badge d-flex align-items-center justify-content-center position-absolute rounded-pill" 
                     t-attf-class="{{ orderCount === 0 or pos.isEditMode ? 'd-none' : ''}}"
                     t-att-style="badgeStyle"
-                    t-esc="orderCount"/>
+                    t-esc="this.env.utils.formatProductQty(orderCount, false)"/>
             </div>
             <span class="table-seats position-absolute bottom-0 start-50 translate-middle-x mb-1 px-2 py-1 rounded text-bg-dark bg-opacity-25 fs-4">
                 <div class="cover" t-att-style="`width: ${Math.ceil(fill * 100)}%`" />

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.xml
@@ -18,7 +18,7 @@
                 <div t-if="displayCategoryCount.length" class="break-line fw-normal fs-6 w-100  border-top mt-1 pt-1">
                     <t t-foreach="displayCategoryCount" t-as="categoryCountLine"  t-key="categoryCountLine_index">
                         <div class="d-flex justify-content-start g-0 my-1 w-100">
-                            <label class="rounded px-2 py-0 me-1" style="background-color:rgba(0, 0, 0, 0.3);"><t t-esc="categoryCountLine.count"/></label>
+                            <label class="rounded px-2 py-0 me-1" style="background-color:rgba(0, 0, 0, 0.3);"><t t-esc="this.env.utils.formatProductQty(categoryCountLine.count, false)"/></label>
                             <label class="text-truncate ps-0" ><t t-esc="categoryCountLine.name"/></label>
                         </div>
                     </t>


### PR DESCRIPTION
Fixed inconsistent rounding of quantities displayed on the order button and table diff counters in the floor plan.

**Steps to reproduce the issue:**
1. Add an orderline by clicking on a product.
2. Set the quantity to "2".
3. Click "Order".
4. Click "." and then "2" to adjust the quantity.
5. We can observe really long quantity (not rounded like `0.20000000000000018` instead of `0.2`)

**Changes:**
- Added `roundQuantity` utility to ensure consistent rounding to 2 decimals.
- Applied `roundQuantity` to table diff counters (on floorplan) and order category counters (on the order button inside ProductScreen) .

task-id: 4488523

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
