### PR TITLE
[FIX] account: missing placeholder for move name

### DIFF
--- a/addons/account/static/src/components/open_move_widget/open_move_widget.xml
+++ b/addons/account/static/src/components/open_move_widget/open_move_widget.xml
@@ -2,7 +2,7 @@
 <templates>
 
     <t t-name="account.OpenMoveWidget">
-        <a href="#" t-out="props.record.data[props.name]" t-on-click.prevent.stop="(ev) => this.openMove()"/>
+        <a href="#" t-out="props.record.data[props.name] || '/'" t-on-click.prevent.stop="(ev) => this.openMove()"/>
     </t>
 
 </templates>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -474,7 +474,7 @@
                     <field name="made_sequence_gap" column_invisible="True"/>
                     <field name="invoice_date" string="Invoice Date" optional="hide" readonly="state != 'draft'"/>
                     <field name="date" readonly="state in ['cancel', 'posted']"/>
-                    <field name="name" decoration-danger="made_sequence_gap and state == 'posted'"/>
+                    <field name="name" decoration-danger="made_sequence_gap and state == 'posted'" widget="char_with_placeholder_field" placeholder="/"/>
                     <field name="partner_id" optional="show" readonly="state != 'draft'"/>
                     <field name="ref" optional="show"/>
                     <field name="journal_id"/>


### PR DESCRIPTION
The placeholder was empty in some places, leading to an annoying behavior because it isn't even possible anymore to open the related journal entry.

The fix is done directly in the widget `open_move_widget` to avoid modifying the definition of the related field and having to change it into a computed field. Also, it wouldn't make sense to store the placeholder on the journal item but not on the journal entry.
