### PR TITLE
[FIX] l10n_my_edi: partner view.

### DIFF
--- a/addons/l10n_my_edi/models/res_partner.py
+++ b/addons/l10n_my_edi/models/res_partner.py
@@ -53,7 +53,8 @@ class ResPartner(models.Model):
     @api.depends_context('company', 'l10n_my_identification_number')
     def _compute_l10n_my_edi_display_tin_warning(self):
         """ We want to display the tin warning for companies registered to use MyInvois. """
-        proxy_user = self.env.company.l10n_my_edi_proxy_user_id
+        # We need to sudo here, as all users having access to partners may not have the rights to access the proxy users.
+        proxy_user = self.env.company.sudo().l10n_my_edi_proxy_user_id
         is_edi_used = proxy_user and proxy_user.proxy_type == 'l10n_my_edi'
         for partner in self:
             # Users with no business number can't be validated using the api
@@ -69,7 +70,8 @@ class ResPartner(models.Model):
         if not self.vat or not self.l10n_my_identification_type or not self.l10n_my_identification_number:
             raise UserError(_('In order to validate the TIN, you must provide the Identification type and number.'))
 
-        proxy_user = self.env.company.l10n_my_edi_proxy_user_id
+        # Sudo to allow a user without access to the proxy user to validate the ID if needed.
+        proxy_user = self.env.company.sudo().l10n_my_edi_proxy_user_id
         if not proxy_user:
             raise UserError(_("Please register for the E-Invoicing service in the settings first."))
 


### PR DESCRIPTION
Fixes an issue on the partner view where a compute would try to read the proxy user, while not all
users who can read the partner would have read
access to the proxy user.

Also fix a similar case in the action used to validate the ID, which tries to read the proxy user.

error-105104

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
