### PR TITLE
[FIX] html_editor: wrong cursor direction on paragraph break

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -340,6 +340,10 @@ export class FontPlugin extends Plugin {
                 closestBlockNode.remove();
             }
             const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            const dir = closestBlockNode.getAttribute("dir") || closestPre.getAttribute("dir");
+            if (dir) {
+                baseContainer.setAttribute("dir", dir);
+            }
             closestPre.after(baseContainer);
             fillEmpty(baseContainer);
             this.dependencies.selection.setCursorStart(baseContainer);
@@ -377,6 +381,10 @@ export class FontPlugin extends Plugin {
                 closestBlockNode.remove();
             }
             const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            const dir = closestBlockNode.getAttribute("dir") || closestQuote.getAttribute("dir");
+            if (dir) {
+                baseContainer.setAttribute("dir", dir);
+            }
             closestQuote.after(baseContainer);
             fillEmpty(baseContainer);
             this.dependencies.selection.setCursorStart(baseContainer);
@@ -405,6 +413,10 @@ export class FontPlugin extends Plugin {
                 !descendants(newElement).some(isVisibleTextNode)
             ) {
                 const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                const dir = newElement.getAttribute("dir");
+                if (dir) {
+                    baseContainer.setAttribute("dir", dir);
+                }
                 newElement.replaceWith(baseContainer);
                 baseContainer.replaceChildren(this.document.createElement("br"));
                 this.dependencies.selection.setCursorStart(baseContainer);

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -179,6 +179,20 @@ describe("Selection collapsed", () => {
                 contentAfter: "<pre><p>abc</p><p>def</p></pre><p>[]<br></p>",
             });
         });
+        test("should insert a new paragraph after a pre tag with rtl direction", async () => {
+            await testEditor({
+                contentBefore: `<pre dir="rtl">ab[]</pre>`,
+                stepFunction: splitBlock,
+                contentAfter: `<pre dir="rtl">ab</pre><p dir="rtl">[]<br></p>`,
+            });
+        });
+        test("should insert a new paragraph after a pre tag with rtl direction (2)", async () => {
+            await testEditor({
+                contentBefore: `<pre><p dir="rtl">abc</p><p dir="rtl">[]<br></p></pre>`,
+                stepFunction: splitBlock,
+                contentAfter: `<pre><p dir="rtl">abc</p></pre><p dir="rtl">[]<br></p>`,
+            });
+        });
     });
 
     describe("Blockquote", () => {
@@ -215,6 +229,20 @@ describe("Selection collapsed", () => {
                 contentBefore: "<blockquote><p>abc</p><p>def</p><p>[]<br></p></blockquote>",
                 stepFunction: splitBlock,
                 contentAfter: "<blockquote><p>abc</p><p>def</p></blockquote><p>[]<br></p>",
+            });
+        });
+        test("should insert a new paragraph after a blockquote tag with rtl direction", async () => {
+            await testEditor({
+                contentBefore: `<blockquote dir="rtl">ab[]</blockquote>`,
+                stepFunction: splitBlock,
+                contentAfter: `<blockquote dir="rtl">ab</blockquote><p dir="rtl">[]<br></p>`,
+            });
+        });
+        test("should insert a new paragraph after a blockquote tag with rtl direction (2)", async () => {
+            await testEditor({
+                contentBefore: `<blockquote><p dir="rtl">abc</p><p dir="rtl">[]<br></p></blockquote>`,
+                stepFunction: splitBlock,
+                contentAfter: `<blockquote><p dir="rtl">abc</p></blockquote><p dir="rtl">[]<br></p>`,
             });
         });
     });
@@ -557,6 +585,13 @@ describe("Selection collapsed", () => {
                 contentBefore: `<h1 style="color: red">ab[]</h1>`,
                 stepFunction: splitBlock,
                 contentAfter: `<h1 style="color: red">ab</h1><p>[]<br></p>`,
+            });
+        });
+        test("should insert a new paragraph after a heading tag with rtl direction", async () => {
+            await testEditor({
+                contentBefore: `<h1 dir="rtl">ab[]</h1>`,
+                stepFunction: splitBlock,
+                contentAfter: `<h1 dir="rtl">ab</h1><p dir="rtl">[]<br></p>`,
             });
         });
     });


### PR DESCRIPTION
**Current behavior before PR:**

When there is a `heading`, `pre` or `blockquote` tag in `rtl` direction, pressing enter at the end of element creates a new `p` tag in `ltr` direction rather than `rtl`.

**Desired behavior after PR:**

Now, pressing enter at the end of `heading`, `pre` or `blockquote` tag in `rtl` direction creates a new empty paragraph tag with `rtl` direction.

task-4484619



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
