### PR TITLE
[FIX] spreadsheet_account: 'See Records' icon in context menu

### DIFF
--- a/addons/spreadsheet_account/static/src/index.js
+++ b/addons/spreadsheet_account/static/src/index.js
@@ -55,4 +55,5 @@ cellMenuRegistry.add("move_lines_see_records", {
             getNumberOfAccountFormulas(cell.compiledFormula.tokens) === 1
         );
     },
+    icon: "o-spreadsheet-Icon.SEE_RECORDS",
 });


### PR DESCRIPTION
# Description

The 'See Records' icon was missing when attempting to open `AccountMoveLines` records from the context menu in the spreadsheet.

Task: 0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
