### PR TITLE
[FIX] hr_timesheet: fix the validation error on create in form

### DIFF
--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -45,8 +45,7 @@
                 <field name="analytic_account_active" invisible="1"/>
                 <field name="allow_timesheets" invisible="1"/>
                 <page string="Timesheets" name="page_timesheets" id="timesheets_tab" invisible="not allow_timesheets">
-                    <field name="timesheet_ids" mode="tree,kanban"
-                          readonly="not analytic_account_active">
+                    <field name="timesheet_ids" mode="tree,kanban" readonly="1">
                         <tree string="Timesheet Activities" default_order="date" no_open="1" create="false" delete="0">
                             <field name="date"/>
                             <field name="employee_id"/>


### PR DESCRIPTION
Steps to reproduce:

- Open any editable project from portal
- Open any task
- Create a task using Form New button.
- Give the changes and save

Issue:

- A validation error

Reason:

- The timesheets ids field in project sharing view has readonly attruibute which
it shouldn't have.
- Due to this changes are fetched and context in evaluated this field
becomes writable.

Fix:

- Remove the readonly attribute as timesheet_ids is already a readonly field
in portal side.

task- 4494040