### PR TITLE
[IMP] web: x2m field kanban: replace `Add` button with a Kanban card

### DIFF
--- a/addons/crm/static/tests/tours/create_crm_team_tour.js
+++ b/addons/crm/static/tests/tours/create_crm_team_tour.js
@@ -18,7 +18,7 @@ registry.category("web_tour.tours").add('create_crm_team_tour', {
     trigger: 'input[id="name_0"]',
     run: "edit My CRM Team",
 }, {
-    trigger: 'button.o-kanban-button-new',
+    trigger: '.btn.o-kanban-button-new',
     run: "click",
 }, {
     trigger: 'div.modal-dialog tr:contains("Test Salesman") input.form-check-input',

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -168,9 +168,11 @@
                         <field name="level_ids" mode="kanban" nolabel="1"
                             class="o_hr_holidays_plan_level_container"
                             widget="accrual_levels_one2many"
-                            add-label="New Milestone"
                             >
                             <kanban default_order="sequence">
+                                <control>
+                                    <create class="o-kanban-button-new" string="New Milestone"/>
+                                </control>
                                 <field name="sequence"/>
                                 <field name="action_with_unused_accruals"/>
                                 <field name="accrual_validity_count"/>

--- a/addons/sales_team/static/tests/crm_team_form.test.js
+++ b/addons/sales_team/static/tests/crm_team_form.test.js
@@ -66,8 +66,8 @@ test("crm team form activate multi-team option via alert", async () => {
     });
 
     // Members list should have Maria which is already in Team2 => Alert should be shown
-    await expect(".o_field_widget[name='member_ids'] .o_kanban_record:visible").toHaveCount(1);
-    await expect(".o_field_widget[name='member_ids'] .o_kanban_record:visible").toHaveText("Maria");
+    await expect(".o_field_widget[name='member_ids'] .o_kanban_record:visible:not(.o-kanban-button-new)").toHaveCount(1);
+    await expect(".o_field_widget[name='member_ids'] .o_kanban_record:visible:not(.o-kanban-button-new)").toHaveText("Maria");
     await contains(".alert:visible", { count: 1 });
 
     // Clicking on the button should update the multi-team option and remove the alert

--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -53,15 +53,7 @@ export class X2ManyField extends Component {
 
         const { activeActions, controls } = this.archInfo;
         if (this.props.viewMode === "kanban") {
-            this.controls = controls.length
-                ? controls
-                : [
-                      {
-                          type: "create",
-                          string: this.props.addLabel || _t("Add"),
-                          class: "o-kanban-button-new",
-                      },
-                  ];
+            this.controls = controls || [];
         }
         const subViewActiveActions = activeActions;
         this.activeActions = useActiveActions({
@@ -136,8 +128,11 @@ export class X2ManyField extends Component {
     }
 
     get displayControlPanelButtons() {
+        return this.props.viewMode === "kanban" && this.canCreate && this.controls.length > 0;
+    }
+
+    get canCreate() {
         return (
-            this.props.viewMode === "kanban" &&
             ("link" in this.activeActions ? this.activeActions.link : this.activeActions.create) &&
             !this.props.readonly
         );
@@ -206,6 +201,10 @@ export class X2ManyField extends Component {
                 }
                 return this.list.delete(record);
             };
+            if (this.canCreate && this.controls.length === 0) {
+                props.addLabel = this.props.addLabel || _t("Add %s", this.field.string);
+                props.onAdd = this.onAdd.bind(this);
+            }
             return props;
         }
 

--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -70,6 +70,7 @@ export class KanbanArchParser {
                             context: childNode.getAttribute("context"),
                             string: childNode.getAttribute("string"),
                             invisible: childNode.getAttribute("invisible"),
+                            class: childNode.getAttribute("class"),
                         });
                     } else if (childNode.tagName === "delete") {
                         controls.push({

--- a/addons/web/static/src/views/kanban/kanban_record.scss
+++ b/addons/web/static/src/views/kanban/kanban_record.scss
@@ -118,4 +118,14 @@
             content: "";
         }
     }
+
+    &.o-kanban-button-new {
+        border-radius: 0;
+        text-align: center;
+        justify-content: center;
+
+        &:focus-within, &:hover {
+            background-color: $gray-100;
+        }
+    }
 }

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -57,6 +57,8 @@ export class KanbanRenderer extends Component {
         "canQuickCreate?",
         "quickCreateState?",
         "progressBarState?",
+        "addLabel?",
+        "onAdd?",
     ];
 
     static defaultProps = {

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -110,6 +110,9 @@
                 </t>
             </t>
             <t t-else="">
+                <div t-if="props.addLabel" class="o_kanban_record o-kanban-button-new btn btn-link py-4" accesskey="c" t-on-click.stop.prevent="() => props.onAdd()">
+                    <t t-out="props.addLabel" />
+                </div>
                 <!-- kanban ghost cards are used to properly space last elements. -->
                 <div t-foreach="[,,,,,,]" t-as="i" t-key="i_index" class="o_kanban_record o_kanban_ghost flex-grow-1 flex-md-shrink-1 flex-shrink-0 my-0" />
             </t>

--- a/addons/web/static/tests/views/fields/image_field.test.js
+++ b/addons/web/static/tests/views/fields/image_field.test.js
@@ -558,10 +558,10 @@ test("ImageField in subviews is loaded correctly", async () => {
     });
 
     expect(`img[data-src="data:image/png;base64,${MY_IMAGE}"]`).toHaveCount(1);
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(1);
 
     // Actual flow: click on an element of the m2m to get its form view
-    await click(".o_kanban_record:not(.o_kanban_ghost)");
+    await click(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)");
     await animationFrame();
     expect(".modal").toHaveCount(1, { message: "The modal should have opened" });
 

--- a/addons/web/static/tests/views/fields/image_url_field.test.js
+++ b/addons/web/static/tests/views/fields/image_url_field.test.js
@@ -98,12 +98,12 @@ test("ImageUrlField in subviews are loaded correctly", async () => {
     expect(`img[data-src="${FR_FLAG_URL}"]`).toHaveCount(1, {
         message: "The view's image is in the DOM",
     });
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1, {
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(1, {
         message: "There should be one record in the many2many",
     });
 
     // Actual flow: click on an element of the m2m to get its form view
-    await click(".o_kanban_record:not(.o_kanban_ghost)");
+    await click(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)");
     await animationFrame();
     expect(".modal").toHaveCount(1, { message: "The modal should have opened" });
     expect(`img[data-src="${EN_FLAG_URL}"]`).toHaveCount(1, {

--- a/addons/web/static/tests/views/fields/many2many_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_field.test.js
@@ -8,7 +8,6 @@ import {
     clickKanbanRecord,
     clickModalButton,
     clickSave,
-    clickViewButton,
     contains,
     defineModels,
     fieldInput,
@@ -264,10 +263,10 @@ test("many2many kanban: edition", async () => {
             </form>`,
     });
 
-    expect(`.o_kanban_record:visible`).toHaveCount(2);
+    expect(`.o_kanban_record:visible:not(.o-kanban-button-new)`).toHaveCount(2);
     expect(`.o_kanban_record:first`).toHaveText("gold");
     expect(`.o_kanban_renderer .delete_icon`).toBeVisible();
-    expect(`.o_field_many2many .o-kanban-button-new:visible`).toHaveText("Add");
+    expect(`.o_field_many2many .o-kanban-button-new:visible`).toHaveText("Add pokemon");
 
     // edit existing subrecord
 
@@ -281,17 +280,17 @@ test("many2many kanban: edition", async () => {
 
     // add subrecords
     // -> single select
-    await clickViewButton({ text: "Add" });
+    await contains(".o_view_controller .btn:contains(Add pokemon)").click();
 
     expect(".modal .o_list_view tbody .o_list_record_selector").toHaveCount(3);
 
     await contains(".modal .o_list_view tbody tr:contains(red) .o_data_cell").click();
 
-    expect(".o_kanban_record:visible").toHaveCount(3);
+    expect(".o_kanban_record:visible:not(.o-kanban-button-new)").toHaveCount(3);
     expect(".o_kanban_record:contains(red)").toBeVisible();
 
     // -> multiple select
-    await clickViewButton({ text: "Add" });
+    await contains(".o_view_controller .btn:contains(Add pokemon)").click();
     expect(".modal .o_select_button").not.toBeEnabled();
     await animationFrame();
 
@@ -301,10 +300,10 @@ test("many2many kanban: edition", async () => {
     await clickModalButton({ text: "Select" });
 
     expect(".modal .o_list_view").toHaveCount(0);
-    expect(".o_kanban_record:visible").toHaveCount(5);
+    expect(".o_kanban_record:visible:not(.o-kanban-button-new)").toHaveCount(5);
 
     // -> created record
-    await clickViewButton({ text: "Add" });
+    await contains(".o_view_controller .btn:contains(Add pokemon)").click();
     await clickModalButton({ text: "New" });
 
     expect(".modal .o_form_view .o_form_editable").toBeVisible();
@@ -312,7 +311,7 @@ test("many2many kanban: edition", async () => {
     await fieldInput("name").edit("A new type");
     await clickModalButton({ text: "Save & Close" });
 
-    expect(".o_kanban_record:visible").toHaveCount(6);
+    expect(".o_kanban_record:visible:not(.o-kanban-button-new)").toHaveCount(6);
     expect(".o_kanban_record:contains(A new type)").toBeVisible();
 
     // delete subrecords
@@ -322,12 +321,12 @@ test("many2many kanban: edition", async () => {
     await clickModalButton({ text: "Remove" });
 
     expect(".modal").toHaveCount(0);
-    expect(".o_kanban_record:visible").toHaveCount(5);
+    expect(".o_kanban_record:visible:not(.o-kanban-button-new)").toHaveCount(5);
     expect(".o_kanban_record:contains(silver)").toHaveCount(0);
 
     await clickKanbanRecord({ text: "blue", target: ".delete_icon" });
 
-    expect(".o_kanban_record:visible").toHaveCount(4);
+    expect(".o_kanban_record:visible:not(.o-kanban-button-new)").toHaveCount(4);
     expect(".o_kanban_record:contains(blue)").toHaveCount(0);
 
     // save the record
@@ -1466,20 +1465,20 @@ test("onchange with 40+ commands for a many2many", async () => {
 
     await contains(".o_field_widget[name=foo] input").edit("trigger onchange");
     expect.verifySteps(["onchange"]);
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(40);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(40);
     await contains(".o_field_widget[name=timmy] .o_pager_next:eq(0)").click();
     expect.verifySteps([]);
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(5);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(5);
 
     await clickSave();
 
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(40);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(40);
 
     await contains(".o_field_widget[name=timmy] .o_pager_next:eq(0)").click();
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(5);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(5);
 
     await contains(".o_field_widget[name=timmy] .o_pager_next:eq(0)").click();
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(40);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(40);
 
     expect.verifySteps(["web_save", "web_read"]);
 });

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -2395,30 +2395,30 @@ test("one2many field when using the pager", async () => {
     });
 
     expect.verifySteps(["unity read 1"]);
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(40);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(40);
 
     // move to record 2, which has 3 related records (and shouldn't contain the
     // related records of record 1 anymore)
     await contains(".o_form_view .o_control_panel .o_pager_next").click();
     expect.verifySteps(["unity read 2"]);
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(3);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(3);
 
     // move back to record 1, which should contain again its first 40 related
     // records
     await contains(".o_form_view .o_control_panel .o_pager_previous").click();
     expect.verifySteps(["unity read 1"]);
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(40);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(40);
 
     // move to the second page of the o2m: 1 RPC should have been done to fetch
     // the 2 subrecords of page 2, and those records should now be displayed
     await contains(".o_x2m_control_panel .o_pager_next").click();
     expect.verifySteps(["unity read 50,51"]);
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(2);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(2);
 
     // move to record 2 again and check that everything is correctly updated
     await contains(".o_form_view .o_control_panel .o_pager_next").click();
     expect.verifySteps(["unity read 2"]);
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(3);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(3);
 
     // move back to record 1 and move to page 2 again: all data should have
     // been correctly reloaded
@@ -2426,7 +2426,7 @@ test("one2many field when using the pager", async () => {
     expect.verifySteps(["unity read 1"]);
     await contains(".o_x2m_control_panel .o_pager_next").click();
     expect.verifySteps(["unity read 50,51"]);
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(2);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(2);
 });
 
 test("edition of one2many field with pager", async () => {
@@ -2493,7 +2493,7 @@ test("edition of one2many field with pager", async () => {
         resId: 1,
     });
 
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(40);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(40);
 
     // add a record on page one
     checkRead = true;
@@ -2504,16 +2504,20 @@ test("edition of one2many field with pager", async () => {
 
     // checks
     expect(readIDs).toBe(undefined, { message: "should not have read any record" });
-    expect(".o_kanban_record:not(.o_kanban_ghost):contains('new record')").toHaveCount(0);
+    expect(
+        ".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new):contains('new record')"
+    ).toHaveCount(0);
 
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(40);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(40);
 
     // save
     await clickSave();
 
     // delete a record on page one
     checkRead = true;
-    expect(".o_kanban_record:not(.o_kanban_ghost):eq(0)").toHaveText("relational record 10");
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new):eq(0)").toHaveText(
+        "relational record 10"
+    );
 
     await contains(".delete_icon").click(); // should remove record!!!
 
@@ -2521,7 +2525,7 @@ test("edition of one2many field with pager", async () => {
     expect(readIDs).toEqual([50], {
         message: "should have read a record (to display 40 records on page 1)",
     });
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(40);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(40);
     // save
     await clickSave();
 
@@ -2532,9 +2536,12 @@ test("edition of one2many field with pager", async () => {
     await contains(".o-kanban-button-new").click();
     await contains(".modal input").edit("new record page 1");
     await contains(".modal .modal-footer .btn-primary").click();
-    expect(".o_kanban_record:not(.o_kanban_ghost):eq(0)").toHaveText("relational record 11", {
-        message: "first record should be the one with id 11 (next checks rely on that)",
-    });
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new):eq(0)").toHaveText(
+        "relational record 11",
+        {
+            message: "first record should be the one with id 11 (next checks rely on that)",
+        }
+    );
 
     await contains(".delete_icon").click(); // should remove record!!!
     expect(readIDs).toEqual([51], {
@@ -2543,9 +2550,12 @@ test("edition of one2many field with pager", async () => {
     // add and delete a record in page 2
     await contains(".o_x2m_control_panel .o_pager_next").click();
 
-    expect(".o_kanban_record:not(.o_kanban_ghost):eq(0)").toHaveText("relational record 52", {
-        message: "first record should be the one with id 52 (next checks rely on that)",
-    });
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new):eq(0)").toHaveText(
+        "relational record 52",
+        {
+            message: "first record should be the one with id 52 (next checks rely on that)",
+        }
+    );
 
     checkRead = true;
     readIDs = undefined;
@@ -2557,9 +2567,13 @@ test("edition of one2many field with pager", async () => {
 
     expect(readIDs).toBe(undefined, { message: "should not have read any record" });
     // checks
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(5);
-    expect(".o_kanban_record:not(.o_kanban_ghost):contains('new record page 1')").toHaveCount(1);
-    expect(".o_kanban_record:not(.o_kanban_ghost):contains('new record page 2')").toHaveCount(1);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(5);
+    expect(
+        ".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new):contains('new record page 1')"
+    ).toHaveCount(1);
+    expect(
+        ".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new):contains('new record page 2')"
+    ).toHaveCount(1);
     // save
     await clickSave();
 
@@ -3471,13 +3485,15 @@ test("one2many kanban: edition", async () => {
         resId: 1,
     });
 
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(1);
     expect(".o_kanban_record span:eq(0)").toHaveText("second record");
     expect(".o_kanban_record span:eq(1)").toHaveText("Red");
     expect(".delete_icon").toHaveCount(1);
     expect(".o_field_one2many .o-kanban-button-new").toHaveCount(1);
-    expect(".o_field_one2many .o-kanban-button-new").toHaveClass("btn-secondary");
-    expect(".o_field_one2many .o-kanban-button-new").toHaveText("Add");
+    expect(".o_field_one2many .o-kanban-button-new").toHaveClass(
+        "o_kanban_record o-kanban-button-new btn btn-link py-4"
+    );
+    expect(".o_field_one2many .o-kanban-button-new").toHaveText("Add one2many field");
 
     // edit existing subrecord
     await contains(".o_kanban_record:eq(0)").click();
@@ -3490,7 +3506,7 @@ test("one2many kanban: edition", async () => {
     await contains(".o-kanban-button-new:eq(0)").click();
     await contains(".modal .o_form_view .o_field_widget:eq(0) input").edit("new subrecord 1");
     await contains(".modal .modal-footer .btn-primary:eq(0)").click();
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(2);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(2);
     expect(".o_kanban_record:eq(1) span:eq(0)").toHaveText("new subrecord 1", {
         message: 'value of newly created subrecord should be "new subrecord 1"',
     });
@@ -3500,17 +3516,17 @@ test("one2many kanban: edition", async () => {
     await contains(".modal .modal-footer .btn-primary:eq(1)").click();
     await contains(".modal .o_form_view .o_field_widget:eq(0) input").edit("new subrecord 3");
     await contains(".modal .modal-footer .btn-primary:eq(0)").click();
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(4);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(4);
 
     // delete subrecords
     await contains(".o_kanban_record:eq(0)").click();
     expect(".modal .modal-footer .o_btn_remove").toHaveCount(1);
     await contains(".modal .modal-footer .o_btn_remove:eq(0)").click();
     expect(".o_modal").toHaveCount(0, { message: "modal should have been closed" });
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(3);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(3);
     await contains(".o_kanban_renderer .delete_icon:first():eq(0)").click();
     await contains(".o_kanban_renderer .delete_icon:first():eq(0)").click();
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(1);
     expect(".o_kanban_record span:first").toHaveText("new subrecord 3", {
         message: 'the remaining subrecord should be "new subrecord 3"',
     });
@@ -6527,10 +6543,9 @@ test("one2many field with virtual ids", async () => {
     expect(".o_field_widget .o_kanban_renderer").toHaveCount(1, {
         message: "should have one inner kanban view for the one2many field",
     });
-    expect(".o_field_widget .o_kanban_renderer .o_kanban_record:not(.o_kanban_ghost)").toHaveCount(
-        0,
-        { message: "should not have kanban records yet" }
-    );
+    expect(
+        ".o_field_widget .o_kanban_renderer .o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)"
+    ).toHaveCount(0, { message: "should not have kanban records yet" });
 
     // create a new kanban record
     await contains(".o_field_widget .o-kanban-button-new").click();
@@ -6544,15 +6559,14 @@ test("one2many field with virtual ids", async () => {
     expect(".o_field_widget .o_kanban_renderer").toHaveCount(1, {
         message: "should have one inner kanban view for the one2many field",
     });
-    expect(".o_field_widget .o_kanban_renderer .o_kanban_record:not(.o_kanban_ghost)").toHaveCount(
-        1,
-        { message: "should now have one kanban record" }
-    );
     expect(
-        ".o_field_widget .o_kanban_renderer .o_kanban_record:not(.o_kanban_ghost) .o_test_id"
+        ".o_field_widget .o_kanban_renderer .o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)"
+    ).toHaveCount(1, { message: "should now have one kanban record" });
+    expect(
+        ".o_field_widget .o_kanban_renderer .o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new) .o_test_id"
     ).toHaveText("", { message: "should not have a value for the id field" });
     expect(
-        ".o_field_widget .o_kanban_renderer .o_kanban_record:not(.o_kanban_ghost) .o_test_foo"
+        ".o_field_widget .o_kanban_renderer .o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new) .o_test_foo"
     ).toHaveText("My little Foo Value", { message: "should have a value for the foo field" });
 
     // save the view to force a create of the new record in the one2many
@@ -6560,15 +6574,14 @@ test("one2many field with virtual ids", async () => {
     expect(".o_field_widget .o_kanban_renderer").toHaveCount(1, {
         message: "should have one inner kanban view for the one2many field",
     });
-    expect(".o_field_widget .o_kanban_renderer .o_kanban_record:not(.o_kanban_ghost)").toHaveCount(
-        1,
-        { message: "should now have one kanban record" }
-    );
     expect(
-        ".o_field_widget .o_kanban_renderer .o_kanban_record:not(.o_kanban_ghost) .o_test_id"
+        ".o_field_widget .o_kanban_renderer .o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)"
+    ).toHaveCount(1, { message: "should now have one kanban record" });
+    expect(
+        ".o_field_widget .o_kanban_renderer .o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new) .o_test_id"
     ).toHaveText("5", { message: "should now have a value for the id field" });
     expect(
-        ".o_field_widget .o_kanban_renderer .o_kanban_record:not(.o_kanban_ghost) .o_test_foo"
+        ".o_field_widget .o_kanban_renderer .o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new) .o_test_foo"
     ).toHaveText("My little Foo Value", { message: "should still have a value for the foo field" });
 });
 
@@ -6617,7 +6630,8 @@ test("one2many field with virtual ids with kanban button", async () => {
 
     // 1. Define all css selector
     const oKanbanView = ".o_field_widget .o_kanban_renderer";
-    const oKanbanRecordActive = oKanbanView + " .o_kanban_record:not(.o_kanban_ghost)";
+    const oKanbanRecordActive =
+        oKanbanView + " .o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)";
     const oAllKanbanButton = oKanbanRecordActive + " button";
     const btn1 = oKanbanRecordActive + ":eq(0) button";
     const btn2 = oKanbanRecordActive + ":eq(1) button";
@@ -9815,7 +9829,7 @@ test("field context is correctly passed to x2m subviews", async () => {
         resId: 1,
     });
 
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(1);
     expect(".o_kanban_record span:contains('blip')").toHaveCount(1);
 });
 
@@ -9850,18 +9864,22 @@ test("one2many kanban with widget handle", async () => {
         resId: 1,
     });
 
-    expect(queryAllTexts(".o_kanban_record:not(.o_kanban_ghost)")).toEqual(["yop", "blip", "kawa"]);
+    expect(
+        queryAllTexts(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)")
+    ).toEqual(["yop", "blip", "kawa"]);
 
     // // should not work (form in mode "readonly")
     // await contains(".o_kanban_record:eq(0)").dragAndDrop(".o_kanban_record:eq(2)");
     // expect(
-    //     queryAllTexts(".o_kanban_record:not(.o_kanban_ghost)")).toEqual(
+    //     queryAllTexts(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)")).toEqual(
     //     ["yop", "blip", "kawa"]
     // );
 
     await contains(".o_kanban_record:eq(0)").dragAndDrop(".o_kanban_record:eq(2)");
 
-    expect(queryAllTexts(".o_kanban_record:not(.o_kanban_ghost)")).toEqual(["blip", "kawa", "yop"]);
+    expect(
+        queryAllTexts(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)")
+    ).toEqual(["blip", "kawa", "yop"]);
 
     await clickSave();
 });
@@ -11717,17 +11735,17 @@ test("one2many can delete a new record", async () => {
             </form>`,
         resId: 1,
     });
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(0);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(0);
 
     await contains(".o-kanban-button-new").click();
     await contains(".modal .o_form_button_save").click();
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(1);
 
-    await contains(".o_kanban_record:not(.o_kanban_ghost)").click();
+    await contains(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").click();
     expect(".modal .o_btn_remove").toHaveCount(1);
 
     await contains(".modal .o_btn_remove").click();
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(0);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(0);
 
     await clickSave();
     expect.verifySteps([]);
@@ -12174,16 +12192,18 @@ test("kanban one2many in opened view form", async () => {
         resId: 1,
     });
     await contains(".o_data_row td[name=name]").click();
-    expect(".modal .o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
+    expect(".modal .o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(1);
     expect(".modal .o_field_x2many_kanban").toHaveClass("o-custom-class");
 
-    await contains(".modal .o_kanban_record:not(.o_kanban_ghost)").click();
-    expect(".modal .o_kanban_record:not(.o_kanban_ghost)").toBeFocused();
+    await contains(
+        ".modal .o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)"
+    ).click();
+    expect(".modal .o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toBeFocused();
 
     await press("ArrowUp");
     await animationFrame();
 
-    expect(".modal .o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
+    expect(".modal .o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(1);
 });
 
 test("kanban one2many in opened view form (with _view_ref)", async () => {
@@ -12216,16 +12236,18 @@ test("kanban one2many in opened view form (with _view_ref)", async () => {
         resId: 1,
     });
     await contains(".o_data_row td[name=name]").click();
-    expect(".modal .o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
+    expect(".modal .o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(1);
     expect(".modal .o_field_x2many_kanban").toHaveClass("o-custom-class");
 
-    await contains(".modal .o_kanban_record:not(.o_kanban_ghost)").click();
-    expect(".modal .o_kanban_record:not(.o_kanban_ghost)").toBeFocused();
+    await contains(
+        ".modal .o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)"
+    ).click();
+    expect(".modal .o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toBeFocused();
 
     await press("ArrowUp");
     await animationFrame();
 
-    expect(".modal .o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
+    expect(".modal .o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(1);
 });
 
 test("kanban one2many (with widget) in opened view form", async () => {
@@ -12251,7 +12273,7 @@ test("kanban one2many (with widget) in opened view form", async () => {
         resId: 1,
     });
 
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(1);
     expect(".o_kanban_record:eq(0)").toHaveText("first record");
 
     await contains(".o_kanban_record").click();
@@ -13057,7 +13079,7 @@ test("x2many kanban with float field in form (non inline) but not in kanban", as
     });
 
     expect(".o_field_widget[name=turtles]").toHaveCount(1);
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(2);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(2);
 
     // open the first record
     await contains(".o_kanban_record").click();
@@ -13075,7 +13097,7 @@ test("x2many kanban with float field in form (non inline) but not in kanban", as
     // toggle bar again to make the x2many visible and force kanban cards to re-render
     await contains(".o_field_widget[name=bar] input").click();
     expect(".o_field_widget[name=turtles]").toHaveCount(1);
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(2);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(2);
 });
 
 test("onchange on x2many returning an update command with only readonly fields", async () => {
@@ -13251,4 +13273,51 @@ test("expand record in dialog", async () => {
     expect(".o_dialog .modal-header .o_expand_button").toHaveCount(1);
     await contains(".o_dialog .modal-header .o_expand_button").click();
     expect.verifySteps([[4, "turtle", "ir.actions.act_window", [[false, "form"]]]]);
+});
+
+test("one2many kanban: add button kanban's card only with no control", async () => {
+    Partner._fields.control = fields.One2many({
+        string: "one2many field",
+        relation: "partner",
+        relation_field: "trululu",
+    });
+    Partner._records[0].p = [4];
+    Partner._records[0].control = [4];
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="p">
+                    <kanban>
+                        <templates>
+                            <t t-name="card">
+                                <field name="name"/>
+                            </t>
+                        </templates>
+                    </kanban>
+                </field>
+                <field name="control">
+                    <kanban>
+                        <control>
+                            <create string="Add Custom" class="myCustomClass" />
+                        </control>
+                        <templates>
+                            <t t-name="card">
+                                <field name="name"/>
+                            </t>
+                        </templates>
+                    </kanban>
+                </field>
+            </form>`,
+        resId: 1,
+    });
+
+    expect("[name='p'] .o_x2m_control_panel .o-kanban-button-new").toHaveCount(0);
+    expect("[name='p'] .o_kanban_renderer .o-kanban-button-new").toHaveCount(1);
+
+    expect("[name='control'] .o_x2m_control_panel .o-kanban-button-new").toHaveCount(0);
+    expect("[name='control'] .o_kanban_renderer .o-kanban-button-new").toHaveCount(0);
+    expect("[name='control'] .myCustomClass").toHaveText("Add Custom");
 });

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -13201,7 +13201,7 @@ test("kanbans with basic and custom compiler, same arch", async () => {
     expect(".o_form_view .o_field_widget[name=one2many]").toHaveCount(1);
 
     // x2many kanban, basic renderer
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(1);
     expect(".my_kanban_compiler").toHaveCount(0);
 });
 


### PR DESCRIPTION
This commit, aims change the look of the `Add` button. From now, it's a kanban card at the end of the Kanban. The label is "Add" followed by the model name of the field.

The `Add` card appears only when the field match these condition:
* not readonly
* the kanban has the attribute "create=true" (default value)
* the kanban has the attribute "link=true" (default value)
* the kanban has no "control"

task-4361655


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
