### PR TITLE
[FIX] l10n_ec_sale: missing sudo on geting default EC payment methods

### DIFF
--- a/addons/l10n_ec_sale/models/sale_order.py
+++ b/addons/l10n_ec_sale/models/sale_order.py
@@ -8,7 +8,7 @@ class SaleOrder(models.Model):
         comodel_name="l10n_ec.sri.payment",
         string="Payment Method (SRI)",
         help="Ecuador: Payment Methods Defined by the SRI.",
-        default=lambda self: self.env['l10n_ec.sri.payment'].search([], limit=1),
+        default=lambda self: self.env['l10n_ec.sri.payment'].sudo().search([], limit=1),
     )
 
     def _prepare_invoice(self):


### PR DESCRIPTION
This commit fixes an AccessError on a failing test in runbot, by granting a `sudo` on the default record search for EC Payment Method field.

runbot: [102689](https://runbot.odoo.com/odoo/action-573/102689)