### PR TITLE
[IMP] stock: move the "Return All" button in the return wizard

### DIFF
--- a/addons/stock/wizard/stock_picking_return_views.xml
+++ b/addons/stock/wizard/stock_picking_return_views.xml
@@ -25,8 +25,8 @@
                 </field>
                 <footer>
                     <button name="action_create_returns" string="Return" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button name="action_create_returns_all" string="Return All" type="object" class="btn-primary"/>
                     <button name="action_create_exchanges" string="Return for Exchange" type="object" class="btn-primary"/>
+                    <button name="action_create_returns_all" string="Return All" type="object" class="btn-primary"/>
                     <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
                 </footer>
             </form>


### PR DESCRIPTION
We move the "Return All" button of the return wizard as the penultimate button since it is a bit Awkward to see it between "Return" and "Return for Exchange".
