### PR TITLE
[FIX] product: search on attribute

### DIFF
--- a/addons/product/views/product_attribute_views.xml
+++ b/addons/product/views/product_attribute_views.xml
@@ -185,6 +185,7 @@
         <field name="arch" type="xml">
             <search>
                 <filter string="Inactive" name="inactive" domain="[('active', '=', False)]"/>
+                <field name="name"/>
             </search>
         </field>
     </record>


### PR DESCRIPTION
Steps to reproduce:
---

- Go to purchase -> config -> Products -> Attributes
- Search

Issue:
---

There was no search attribute for the autocompletion.The changes in
comportment is due to the changes in https://github.com/odoo/odoo/commit/72c5ed9f18bc9e2b1dde7029742d9feb34a4c52f .

Fix:
---

Added the name field to the search view.

opw-4434672

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
