### PR TITLE
[FIX] mail: ensure selection updates correctly after mention insertion

### DIFF
--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/mention_plugin.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/mention_plugin.js
@@ -20,6 +20,7 @@ export class MentionPlugin extends Plugin {
     }
 
     onSelect(ev, option) {
+        this.dependencies.selection.focusEditable();
         const mentionBlock = renderToElement("mail.Wysiwyg.mentionLink", {
             option,
             href: url(
@@ -47,7 +48,6 @@ export class MentionPlugin extends Plugin {
                     type: ev.data === "@" ? "partner" : "channel",
                     close: () => {
                         this.mentionList.close();
-                        this.dependencies.selection.focusEditable();
                     },
                 },
             });


### PR DESCRIPTION
**Problem**:
When typing `@` in a non-collapsed selection (`a[b]`) and selecting an item from the mention list, the selection state becomes stale. This happens because `handleObserverRecords` calls `updateHints`, which relies on `getSelectionData`. However, `this.activeSelection` retains the outdated selection due to conditions like `documentSelectionIsInEditable` and `!this.activeSelection.anchorNode.isConnected` being `false`.

As a result, `this.activeSelection` reflects `a[b]` while the DOM selection has already updated to `a[]`, leading to invalid offsets.

**Solution**:
Call `this.dependencies.selection.focusEditable();` during `onSelect` to ensure the selection is updated to reflect the editor state rather than the mention state.

**Steps to Reproduce**:
1. Open the chatter.
2. Add some text.
3. Select a portion of the text.
4. Type `@`.
5. Select an item (person) from the mention list.
6. Observe a traceback error.

opw-4498165

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
