### PR TITLE
[FIX] analytic: analytic_distribution field UI

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.scss
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.scss
@@ -1,6 +1,6 @@
 .o_field_analytic_distribution {
 
-    height: 0px;
+    height: auto;
 
     .analytic_distribution_placeholder {
         height: 1.5em;


### PR DESCRIPTION
This commit fix this UI problem:
When you are on an account_move view, create a line and input multiple analytic distributions, the line height stay fixed, and it crop the distributions, making the line unreadable.

This commit add a variable height on the analytic_distribution field.

task-4213064