### PR TITLE
[FIX] account: prevent overriding of journal_id on save

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -118,7 +118,7 @@ class AccountPayment(models.Model):
         string="Customer/Vendor",
         store=True, readonly=False, ondelete='restrict',
         compute='_compute_partner_id',
-        inverse='_inverse_partner_id',
+        precompute=True,
         domain="['|', ('parent_id','=', False), ('is_company','=', True)]",
         tracking=True,
         check_company=True)
@@ -379,10 +379,21 @@ class AccountPayment(models.Model):
                     )
                 )
 
-    @api.depends('company_id')
+    @api.depends('company_id', 'partner_id')
     def _compute_journal_id(self):
         for payment in self:
-            company = self.company_id or self.env.company
+            # default customer payment method logic
+            partner = payment.partner_id
+            payment_type = payment.payment_type if payment.payment_type in ('inbound', 'outbound') else None
+            if partner or payment_type:
+                field_name = f'property_{payment_type}_payment_method_line_id'
+                default_payment_method_line = payment.partner_id.with_company(payment.company_id)[field_name]
+                journal = default_payment_method_line.journal_id
+                if journal:
+                    payment.journal_id = journal
+                    continue
+
+            company = payment.company_id or self.env.company
             payment.journal_id = self.env['account.journal'].search([
                 *self.env['account.journal']._check_company_domain(company),
                 ('type', 'in', ['bank', 'cash', 'credit']),
@@ -799,24 +810,10 @@ class AccountPayment(models.Model):
     # ONCHANGE METHODS
     # -------------------------------------------------------------------------
 
-    @api.onchange('partner_id')
     def _inverse_partner_id(self):
-        """
-            The goal of this inverse is that when changing the partner, the payment method line is recomputed, and it can
-            happen that the journal that was set doesn't have that particular payment method line, so we have to change
-            the journal otherwise the user will have an UserError.
-        """
-        for payment in self:
-            partner = payment.partner_id
-            payment_type = payment.payment_type if payment.payment_type in ('inbound', 'outbound') else None
-            if not partner or not payment_type:
-                continue
+        # todo: remove in master
+        pass
 
-            field_name = f'property_{payment_type}_payment_method_line_id'
-            default_payment_method_line = payment.partner_id.with_company(payment.company_id)[field_name]
-            journal = default_payment_method_line.journal_id
-            if journal:
-                payment.journal_id = journal
 
     # -------------------------------------------------------------------------
     # CONSTRAINT METHODS

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -718,3 +718,19 @@ class TestAccountPayment(AccountTestInvoicingCommon):
 
         self.assertEqual(payment.move_id.name, 'PBNK1/2025/00002')
         self.assertEqual(payment.name, 'PBNK1/2025/00002')
+
+    def test_vendor_payment_save_user_selected_journal_id(self):
+        journal_bank = self.env['account.journal'].search([('name', '=', 'Bank')])
+        journal_cash = self.env['account.journal'].search([('name', '=', 'Cash')])
+
+        self.partner.property_outbound_payment_method_line_id = journal_cash.outbound_payment_method_line_ids
+        payment = self.env['account.payment'].create({
+            'payment_type': 'outbound',
+            'partner_id': self.partner.id,
+            'journal_id': journal_cash.id,
+        })
+        self.assertEqual(payment.journal_id, journal_cash)
+        payment.journal_id = journal_bank
+
+        self.assertEqual(payment.payment_method_line_id.journal_id, payment.journal_id)
+        self.assertEqual(payment.journal_id, journal_bank)


### PR DESCRIPTION
Steps to Reproduce:

- Assign a partner a default payment method (e.g., Cash).

- In the vendor payment, select that partner and then change the journal to another payment method (e.g., Bank). Then save.

The Issue:

After saving, the journal field chosen by the user is overridden by the partner's default payment method.

Cause:

In `account_payment`, the method `_inverse_partner_id` controls the logic to display the default payment method (`journal_id`) for a partner. It also had `@api.onchange('partner_id')` to adjust the `journal_id` in case the user changes the partner ID in the view. However, the inverse method is triggered on a save because `partner_id` is in `vals_list` of `write`, which sets the default `journal_id` instead of the user input.

Solution:

The behavior of the inverse method can be handled instead by the compute of `journal_id` if it depends on `partner_id`.

opw-4478282




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
