### PR TITLE
[IMP] sale,website_sale: combo improvements

### DIFF
--- a/addons/sale/controllers/combo_configurator.py
+++ b/addons/sale/controllers/combo_configurator.py
@@ -146,6 +146,7 @@ class SaleComboConfiguratorController(Controller):
         return {
             'id': combo_item.id,
             'extra_price': combo_item.extra_price,
+            'is_preselected': is_preselected,
             'is_selected': bool(selected_combo_item) or is_preselected,
             'is_configurable': is_configurable,
             'product': {
@@ -153,6 +154,7 @@ class SaleComboConfiguratorController(Controller):
                 'product_tmpl_id': combo_item.product_id.product_tmpl_id.id,
                 'display_name': combo_item.product_id.display_name,
                 'ptals': self._get_ptals_data(combo_item.product_id, selected_combo_item),
+                'description': combo_item.product_id.description_sale,
                 **request.env['product.template']._get_additional_configurator_data(
                     combo_item.product_id, date, currency, pricelist, **kwargs
                 ),

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1654,4 +1654,7 @@ class SaleOrderLine(models.Model):
         """ A combo product line always has a zero price (by design). The actual price of the combo
         product can be computed by summing the prices of its combo items (i.e. its linked lines).
         """
-        return self.linked_line_ids if self.product_type == 'combo' else self
+        if self.product_type == 'combo':
+            # Only consider combo item lines (not optional product lines)
+            return self.linked_line_ids.filtered('combo_item_id')
+        return self

--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
@@ -54,6 +54,9 @@ export class ComboConfiguratorDialog extends Component {
         this._initSelectedComboItems();
         this.getPriceUrl = '/sale/combo_configurator/get_price';
         useSubEnv({ currency: { id: this.props.currency_id } });
+
+        this.unconfigurableCombos = this.props.combos.filter(combo => !combo.isConfigurable);
+        this.configurableCombos = this.props.combos.filter(combo => combo.isConfigurable);
     }
 
     /**

--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
@@ -5,10 +5,48 @@
             title="props.display_name"
             contentClass="'sale-combo-configurator-dialog'"
         >
-            <div t-foreach="props.combos" t-as="combo" t-key="combo.id">
+            <div t-if="unconfigurableCombos.length" class="mb-4">
+                <span class="d-inline-block mb-3 h4">
+                    Included
+                </span>
+                <div class="container">
+                    <div
+                        t-foreach="unconfigurableCombos"
+                        t-as="combo"
+                        t-key="combo.id"
+                        class="row mb-3"
+                    >
+                        <t t-set="product" t-value="combo.combo_items[0].product"/>
+                        <div class="col-2 p-0">
+                            <img
+                                t-attf-src="/web/image/product.product/{{product.id}}/image_256"
+                                alt="Product Image"
+                                role="img"
+                                class="img-thumbnail rounded"
+                            />
+                        </div>
+                        <div
+                            name="preselected_product_name"
+                            class="col d-flex justify-content-center text-break flex-column"
+                        >
+                            <span
+                                name="preselected_product_title"
+                                t-out="product.display_name"
+                                class="h5"
+                            />
+                            <div
+                                t-if="product.description"
+                                t-out="product.description"
+                                class="text-muted small text-truncate"
+                            />
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div t-foreach="configurableCombos" t-as="combo" t-key="combo.id">
                 <span
                     name="sale_combo_configurator_title"
-                    class="d-inline-block mt-4 mb-3 h4"
+                    t-attf-class="d-inline-block mb-3 h4 {{combo_index !== 0? 'mt-4' : ''}}"
                     t-out="combo.name"
                 />
                 <div class="combo-item-grid d-flex d-md-grid gap-4 pb-2 pb-md-0 overflow-x-auto">
@@ -18,6 +56,7 @@
                             extraPrice="comboItem.extra_price"
                             onClick="() => this.selectComboItem(combo.id, comboItem)"
                             isSelected="state.selectedComboItems.get(combo.id)?.id === comboItem.id"
+                            isConfigurable="comboItem.is_configurable"
                         />
                     </t>
                 </div>

--- a/addons/sale/static/src/js/models/product_combo.js
+++ b/addons/sale/static/src/js/models/product_combo.js
@@ -20,4 +20,22 @@ export class ProductCombo {
     get selectedComboItem() {
         return this.combo_items.find(item => item.is_selected);
     }
+
+    /**
+    * Return the preselected combo item, if any.
+    *
+    * @return {ProductComboItem|undefined} The preselected combo items, if any.
+    */
+    get preselectedComboItem() {
+        return this.combo_items.find(item => item.is_preselected);
+    }
+
+    /**
+     * Check whether this combo is configurable.
+     *
+     * @return {Boolean} Whether this combo is configurable.
+     */
+    get isConfigurable() {
+        return !this.combo_items.some(item => item.is_preselected);
+    }
 }

--- a/addons/sale/static/src/js/models/product_combo_item.js
+++ b/addons/sale/static/src/js/models/product_combo_item.js
@@ -4,13 +4,15 @@ export class ProductComboItem {
     /**
      * @param {number} id
      * @param {number} extra_price
+     * @param {boolean} is_preselected
      * @param {boolean} is_selected
      * @param {boolean} is_configurable
      * @param {ProductProduct|object} product
      */
-    constructor({id, extra_price, is_selected, is_configurable, product}) {
+    constructor({id, extra_price, is_preselected, is_selected, is_configurable, product}) {
         this.id = id;
         this.extra_price = extra_price;
+        this.is_preselected = is_preselected;
         this.is_selected = is_selected;
         this.is_configurable = is_configurable;
         this.product = new ProductProduct(product);

--- a/addons/sale/static/src/js/models/product_product.js
+++ b/addons/sale/static/src/js/models/product_product.js
@@ -14,13 +14,15 @@ export class ProductProduct {
      * @param {string} display_name
      * @param {ProductTemplateAttributeLine[]|object[]} ptals
      * @param {string} image_src
+     * @param {string} description
      */
-    setup({id, product_tmpl_id, display_name, ptals, image_src}) {
+    setup({id, product_tmpl_id, display_name, ptals, image_src, description}) {
         this.id = id;
         this.product_tmpl_id = product_tmpl_id;
         this.display_name = display_name;
         this.ptals = ptals.map(ptal => new ProductTemplateAttributeLine(ptal));
         this.image_src = image_src;
+        this.description = description;
     }
 
     /**

--- a/addons/sale/static/src/js/product/product.js
+++ b/addons/sale/static/src/js/product/product.js
@@ -28,6 +28,14 @@ export class Product extends Component {
         parent_exclusions: Object,
         parent_product_tmpl_id: { type: Number, optional: true },
         price_info: { type: String, optional: true },
+        selectedComboItems: {
+            type: Array,
+            element: Object,
+            shape: {
+                name: String,
+            },
+            optional: true,
+        },
     };
 
     //--------------------------------------------------------------------------

--- a/addons/sale/static/src/js/product/product.xml
+++ b/addons/sale/static/src/js/product/product.xml
@@ -16,6 +16,14 @@
                     t-out="this.props.description_sale"
                     class="text-muted small text-truncate"
                 />
+                <div t-if="this.props.selectedComboItems" class="text-muted small">
+                    <div
+                        t-foreach="this.props.selectedComboItems"
+                        t-as="comboItem"
+                        t-key="comboItem_index"
+                        t-out="comboItem.name"
+                    />
+                </div>
             </div>
             <t t-foreach="this.props.attribute_lines" t-as="ptal" t-key="ptal.id">
                 <PTAL
@@ -40,11 +48,18 @@
             <td
                 class="o_sale_product_configurator_qty py-3 px-0 text-end text-md-center d-block d-md-table-cell"
             >
-                <QuantityButtons
-                    t-if="env.showQuantity"
-                    quantity="this.props.quantity"
-                    setQuantity="quantity => this.env.setQuantity(this.props.product_tmpl_id, quantity)"
-                    isMinusButtonDisabled="this.props.quantity === 1 &amp;&amp; isMainProduct"
+                <t t-set="isComboProduct" t-value="isMainProduct &amp;&amp; this.props.selectedComboItems.length"/>
+                <t t-if="env.showQuantity &amp;&amp; !isComboProduct">
+                    <QuantityButtons
+                        quantity="this.props.quantity"
+                        setQuantity="quantity => this.env.setQuantity(this.props.product_tmpl_id, quantity)"
+                        isMinusButtonDisabled="this.props.quantity === 1 &amp;&amp; isMainProduct"
+                    />
+                </t>
+                <span
+                    t-elif="env.showQuantity &amp;&amp; isComboProduct"
+                    t-out="this.props.quantity"
+                    class="h5"
                 />
                 <a
                     class="d-block mt-2 text-end"

--- a/addons/sale/static/src/js/product_card/product_card.js
+++ b/addons/sale/static/src/js/product_card/product_card.js
@@ -10,6 +10,7 @@ export class ProductCard extends Component {
         extraPrice: { type: Number, optional: true },
         onClick: Function,
         isSelected: { type: Boolean, optional: true },
+        isConfigurable: { type: Boolean, optional: true }
     };
 
     /**

--- a/addons/sale/static/src/js/product_card/product_card.xml
+++ b/addons/sale/static/src/js/product_card/product_card.xml
@@ -16,13 +16,18 @@
             </div>
             <div class="card-body">
                 <div class="card-title" t-out="props.product.display_name"/>
-                <div class="card-subtitle text-muted">
-                    <div
-                        t-foreach="props.product.ptals.filter(shouldShowPtal)"
-                        t-as="ptal"
-                        t-key="ptal.id"
-                        t-out="ptal.ptalDisplayName"
-                    />
+                <t t-set="ptalsToShow" t-value="props.product.ptals.filter(shouldShowPtal)"/>
+                <div class="card-subtitle">
+                    <t t-if="ptalsToShow.length">
+                        <div
+                            t-foreach="ptalsToShow"
+                            t-as="ptal"
+                            t-key="ptal.id"
+                            t-out="ptal.ptalDisplayName"
+                            class="text-muted"
+                        />
+                    </t>
+                    <a t-elif="props.isConfigurable" href="#">Configure</a>
                 </div>
                 <BadgeExtraPrice
                     t-if="props.extraPrice"

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -23,6 +23,14 @@ export class ProductConfiguratorDialog extends Component {
         companyId: { type: Number, optional: true },
         pricelistId: { type: Number, optional: true },
         currencyId: { type: Number, optional: true },
+        selectedComboItems: {
+            type: Array,
+            element: Object,
+            shape: {
+                name: String,
+            },
+            optional: true,
+        },
         soDate: String,
         edit: { type: Boolean, optional: true },
         options: {
@@ -80,6 +88,13 @@ export class ProductConfiguratorDialog extends Component {
                 optional_products,
                 currency_id,
             } = await this._loadData(this.props.edit);
+
+            // If the product configurator is opened after the combo configurator (which happens if
+            // a combo product has optional products), `_loadData` will return a single product
+            // (i.e. the combo product), which should be linked to the previously selected combo
+            // items.
+            products[0].selectedComboItems = this.props.selectedComboItems || [];
+
             this.state.products = products;
             this.state.optionalProducts = optional_products;
             for (const customPtav of this.props.customPtavs) {

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
@@ -45,17 +45,15 @@ export class SaleOrderLineListRenderer extends ProductLabelSectionAndNoteListRen
      * Combo logic
      */
 
-    /**
-     * Whether the provided record is a section, a note, or a combo.
-     *
-     * This method's name isn't ideal since it doesn't mention combos, but we'd have to override a
-     * few other methods to fix this, and the added complexity isn't worth it.
-     *
-     * @param record The record to check
-     * @return {Boolean} Whether the record is a section, a note, or a combo.
-     */
-    isSectionOrNote(record=null) {
-        return super.isSectionOrNote(record) || this.isCombo(record);
+    getCellClass(column, record) {
+        const classNames = super.getCellClass(column, record);
+        if (
+            this.isCombo(record)
+            && ![this.titleField, 'product_uom_qty', 'discount'].includes(column.name)
+        ) {
+            return `${classNames} opacity-0 pe-none`;
+        }
+        return classNames;
     }
 
     getRowClass(record) {

--- a/addons/sale/static/src/js/tours/combo_configurator_tour_utils.js
+++ b/addons/sale/static/src/js/tours/combo_configurator_tour_utils.js
@@ -55,6 +55,19 @@ function assertSelectedComboItemCount(count) {
     };
 }
 
+function assertPreselectedComboItemCount(count) {
+    return {
+        content: `Assert that there are ${count} preselected combo items`,
+        trigger: '.sale-combo-configurator-dialog',
+        run() {
+            const selector = '.sale-combo-configurator-dialog div[name="preselected_product_name"]';
+            if (queryAll(selector).length !== count) {
+                console.error(`Assertion failed`);
+            }
+        },
+    };
+}
+
 function selectComboItem(comboItemName) {
     return {
         content: `Select combo item ${comboItemName}`,
@@ -67,6 +80,13 @@ function assertComboItemSelected(comboItemName) {
     return {
         content: `Assert that combo item ${comboItemName} is selected`,
         trigger: comboItemSelector(comboItemName, ['selected']),
+    };
+}
+
+function assertComboItemPreselected(comboItemName) {
+    return {
+        content: `Assert that combo item ${comboItemName} is preselected`,
+        trigger: `[name="preselected_product_name"]:contains(${comboItemName})`,
     };
 }
 
@@ -174,8 +194,10 @@ export default {
     assertComboCount,
     assertComboItemCount,
     assertSelectedComboItemCount,
+    assertPreselectedComboItemCount,
     selectComboItem,
     assertComboItemSelected,
+    assertComboItemPreselected,
     increaseQuantity,
     decreaseQuantity,
     setQuantity,

--- a/addons/sale/static/tests/tours/sale_combo_configurator.js
+++ b/addons/sale/static/tests/tours/sale_combo_configurator.js
@@ -105,3 +105,32 @@ registry
             ...stepUtils.saveForm(),
         ],
     });
+
+    registry
+    .category('web_tour.tours')
+    .add('sale_combo_configurator_with_optional_products', {
+        url: '/odoo',
+        steps: () => [
+            ...stepUtils.goToAppSteps('sale.sale_menu_root', "Open the sales app"),
+            ...tourUtils.createNewSalesOrder(),
+            ...tourUtils.selectCustomer("Test Partner"),
+            ...tourUtils.addProduct("Combo product"),
+            comboConfiguratorTourUtils.selectComboItem("Product B2"),
+            ...comboConfiguratorTourUtils.saveConfigurator(),
+            productConfiguratorTourUtils.addOptionalProduct("Optional product"),
+            {
+                content: "verify that we cannot reduce main product quantity",
+                trigger: ':not(button[name="sale_quantity_button_minus"])',
+            },
+            {
+                content: "verify that we cannot increase main product quantity",
+                trigger: ':not(button[name="sale_quantity_button_plus"])',
+            },
+            ...productConfiguratorTourUtils.saveConfigurator(),
+            tourUtils.checkSOLDescriptionContains("Combo product"),
+            tourUtils.checkSOLDescriptionContains("Product B2"),
+            tourUtils.checkSOLDescriptionContains("Optional product"),
+            // Don't end the tour with a form in edition mode.
+            ...stepUtils.saveForm(),
+        ],
+    });

--- a/addons/sale/static/tests/tours/sale_combo_configurator_preselect_single_unconfigurable_items.js
+++ b/addons/sale/static/tests/tours/sale_combo_configurator_preselect_single_unconfigurable_items.js
@@ -14,9 +14,9 @@ registry
             ...tourUtils.selectCustomer("Test Partner"),
             ...tourUtils.addProduct("Combo product"),
             // Assert that only single unconfigurable items are preselected.
-            comboConfiguratorTourUtils.assertSelectedComboItemCount(2),
-            comboConfiguratorTourUtils.assertComboItemSelected("Product A"),
-            comboConfiguratorTourUtils.assertComboItemSelected("Product C"),
+            comboConfiguratorTourUtils.assertPreselectedComboItemCount(2),
+            comboConfiguratorTourUtils.assertComboItemPreselected("Product A"),
+            comboConfiguratorTourUtils.assertComboItemPreselected("Product C"),
             comboConfiguratorTourUtils.assertConfirmButtonDisabled(),
             // Configure the remaining combos.
             comboConfiguratorTourUtils.selectComboItem("Product B"),

--- a/addons/sale_product_matrix/static/src/js/sale_product_field.js
+++ b/addons/sale_product_matrix/static/src/js/sale_product_field.js
@@ -12,11 +12,11 @@ patch(SaleOrderLineProductField.prototype, {
         return this.matrixConfigurator.open(this.props.record, edit);
     },
 
-    async _openProductConfigurator(edit=false) {
+    async _openProductConfigurator(edit=false, selectedComboItems=[]) {
         if (edit && this.props.record.data.product_add_mode == 'matrix') {
             this._openGridConfigurator(true);
         } else {
-            return super._openProductConfigurator(edit);
+            return super._openProductConfigurator(...arguments);
         }
     },
 });

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -545,6 +545,10 @@ class SaleOrder(models.Model):
         if not product:
             raise UserError(_("The given combination does not exist therefore it cannot be added to cart."))
 
+        if linked_line_id and linked_line_id not in self.order_line.ids:
+            # Make sure the provided parent line belongs to the current order.
+            raise UserError(_("Invalid request parameters."))
+
         values = {
             'product_id': product.id,
             'product_uom_qty': quantity,

--- a/addons/website_sale/static/src/js/cart_service.js
+++ b/addons/website_sale/static/src/js/cart_service.js
@@ -144,20 +144,20 @@ export class CartService {
                     ...rest
                 }
             );
-            const selectedComboItems = combos
+            const preselectedComboItems = combos
                  .map(combo => new ProductCombo(combo))
-                 .map(combo => combo.selectedComboItem)
+                 .map(combo => combo.preselectedComboItem)
                  .filter(Boolean);
-            // If the combo product is already fully configured (i.e. a combo item has been selected
-            // for each combo choice), then it can be added to the cart without opening the combo
-            // configurator.
-            if (selectedComboItems.length === combos.length) {
+            // If the combo product is already fully configured (i.e. a combo item has been
+            // preselected for each combo choice), then it can be added to the cart without
+            // opening the combo configurator.
+            if (preselectedComboItems.length === combos.length) {
                 return this._makeRequest({
                     productTemplateId: productTemplateId,
                     productId: productId,
                     quantity: remainingData.quantity,
                     uomId: uomId,
-                    linked_products: selectedComboItems.map(
+                    linked_products: preselectedComboItems.map(
                         (comboItem) => this._serializeComboItem(
                             comboItem, productTemplateId, remainingData.quantity
                         )
@@ -332,6 +332,7 @@ export class CartService {
                 soDate: serializeDateTime(DateTime.now()),
                 edit: false,
                 isFrontend: true,
+                selectedComboItems: [],  // optional products for combo aren't supported on ecommerce for now.
                 options,
                 ...additionalData,
                 save: async (mainProduct, optionalProducts, options) => {

--- a/addons/website_sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
+++ b/addons/website_sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
@@ -4,6 +4,9 @@
         <span name="sale_combo_configurator_title" position="attributes">
             <attribute name="class" remove="h4" add="h5" separator=" "/>
         </span>
+        <span name="preselected_product_title" position="attributes">
+            <attribute name="class" remove="h5" add="h6" separator=" "/>
+        </span>
         <span name="sale_combo_configurator_total" position="attributes">
             <attribute name="class" remove="h4" add="h5" separator=" "/>
         </span>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2785,7 +2785,7 @@
                                 <t t-call="website_sale.cart_line_description_following_lines"/>
                                 <ul t-if="is_combo" class="list-group">
                                     <t
-                                        t-foreach="line.linked_line_ids"
+                                        t-foreach="line.linked_line_ids.filtered('combo_item_id')"
                                         t-as="combo_item_line"
                                     >
                                         <t t-call="website_sale.cart_combo_item_line"/>

--- a/addons/website_sale_stock/tests/test_website_sale_stock_sale_order_line.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_sale_order_line.py
@@ -41,11 +41,13 @@ class TestWebsiteSaleStockSaleOrderLine(HttpCase, WebsiteSaleStockCommon):
                 'product_id': product_a.id,
                 'product_uom_qty': 3,
                 'linked_line_id': combo_product_line.id,
+                'combo_item_id': combo_a.combo_item_ids[0].id,
             }, {
                 'order_id': self.cart.id,
                 'product_id': product_b.id,
                 'product_uom_qty': 3,
                 'linked_line_id': combo_product_line.id,
+                'combo_item_id': combo_b.combo_item_ids[0].id,
             },
         ])
 


### PR DESCRIPTION
prior to this commit :
- Optional products did not work with combos
- the header line for combo did not show discount/quantity
- in sale back-end single choice combo required user to select the choice

post this commit :
- the combo header line in sale is no longer a section
- single choice options will be pre-selected in the combo dialog
- added the feature of optional products for combos

task-4314424

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
