### PR TITLE
[FIX] base: fallback first currency rate

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -285,21 +285,25 @@ class AccountTestInvoicingCommon(TransactionCase):
             'currency_subunit_label': 'Silver',
             **default_values,
         })
-        rate1 = cls.env['res.currency.rate'].create({
+        rates = cls.env['res.currency.rate'].create([{
+            'name': '1900-01-01',
+            'rate': 1,
+            'currency_id': foreign_currency.id,
+            'company_id': cls.env.company.id,
+        }, {
             'name': '2016-01-01',
             'rate': rate2016,
             'currency_id': foreign_currency.id,
             'company_id': cls.env.company.id,
-        })
-        rate2 = cls.env['res.currency.rate'].create({
+        }, {
             'name': '2017-01-01',
             'rate': rate2017,
             'currency_id': foreign_currency.id,
             'company_id': cls.env.company.id,
-        })
+        }])
         return {
             'currency': foreign_currency,
-            'rates': rate1 + rate2,
+            'rates': rates,
         }
 
     @classmethod

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4154,6 +4154,30 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         for line in move.line_ids:
             self.assertEqual(line.date, move.date)
 
+    def test_before_initial_rate(self):
+        def invoice():
+            return self.init_invoice(
+                move_type='out_invoice',
+                invoice_date='1900-01-01',
+                partner=self.partner_a,
+                amounts=[1000.0],
+                taxes=[],
+                currency=currency,
+            )
+
+        currency = self.currency_data['currency']
+        self.assertRecordValues(invoice(), [{
+            'amount_total': 1000.0,
+            'amount_total_signed': 1000.0,
+        }])
+        currency.rate_ids[-1].unlink()  # the setup creates a rate of 1 far in the past
+        self.assertRecordValues(invoice(), [{
+            'amount_total': 1000.0,
+            'amount_total_signed': 333.33,
+        }])
+
+
+
     def test_on_quick_encoding_non_accounting_lines(self):
         """ Ensure that quick encoding values are only applied to accounting lines) """
 


### PR DESCRIPTION
When creating a new database or activating a new currency, the first rate fetched will often be set only starting "today".

This can lead to issues when creating invoices in the past, especially if the conversion rate is very different from 1.

Instead of only using a fallback on 1, we also fallback on the oldest rate in the database if available.