### PR TITLE
[REF] web_tour: macro.js

### DIFF
--- a/addons/test_website/static/tests/tours/systray.js
+++ b/addons/test_website/static/tests/tours/systray.js
@@ -201,4 +201,7 @@ register("test_systray_not_reditor_not_tester", () => [
     ...cannotAddNewContent(),
     ...canViewInBackEnd(),
     ...cannotEdit(),
+    {
+        trigger: ":iframe main:contains(test model)",
+    },
 ]);

--- a/addons/web/static/src/core/macro.js
+++ b/addons/web/static/src/core/macro.js
@@ -1,12 +1,10 @@
-import { browser } from "@web/core/browser/browser";
 import { isVisible } from "@web/core/utils/ui";
-import { delay, Mutex } from "@web/core/utils/concurrency";
+import { delay } from "@web/core/utils/concurrency";
 import { validate } from "@odoo/owl";
 
 const macroSchema = {
     name: { type: String, optional: true },
     checkDelay: { type: Number, optional: true }, //Delay before checking if element is in DOM.
-    stepDelay: { type: Number, optional: true }, //Wait this delay between steps
     timeout: { type: Number, optional: true },
     steps: {
         type: Array,
@@ -16,11 +14,8 @@ const macroSchema = {
                 action: { type: [Function, String], optional: true },
                 timeout: { type: Number, optional: true },
                 trigger: { type: [Function, String], optional: true },
-                value: { type: [String, Number], optional: true },
             },
-            validate: (step) => {
-                return step.action || step.trigger;
-            },
+            validate: (step) => step.action || step.trigger,
         },
     },
     onComplete: { type: Function, optional: true },
@@ -28,12 +23,23 @@ const macroSchema = {
     onError: { type: Function, optional: true },
 };
 
-const mutex = new Mutex();
-
 class MacroError extends Error {
     constructor(type, message, options) {
         super(message, options);
         this.type = type;
+    }
+}
+
+async function performAction(trigger, action) {
+    if (!action) {
+        return;
+    }
+    try {
+        return await action(trigger);
+    } catch (error) {
+        throw new MacroError("Action", `ERROR during perform action:\n${error.message}`, {
+            cause: error,
+        });
     }
 }
 
@@ -56,10 +62,50 @@ export async function waitForStable(target = document, timeout = 1000 / 16) {
     });
 }
 
+async function waitForTrigger(trigger) {
+    if (!trigger) {
+        return;
+    }
+    try {
+        await delay(50);
+        return await waitUntil(() => {
+            if (typeof trigger === "function") {
+                return trigger();
+            } else if (typeof trigger === "string") {
+                const triggerEl = document.querySelector(trigger);
+                return isVisible(triggerEl) && triggerEl;
+            }
+        });
+    } catch (error) {
+        throw new MacroError("Trigger", `ERROR during find trigger:\n${error.message}`, {
+            cause: error,
+        });
+    }
+}
+
+async function waitUntil(predicate) {
+    const result = predicate();
+    if (result) {
+        return Promise.resolve(result);
+    }
+    let handle;
+    return new Promise((resolve) => {
+        const runCheck = () => {
+            const result = predicate();
+            if (result) {
+                resolve(result);
+            }
+            handle = requestAnimationFrame(runCheck);
+        };
+        handle = requestAnimationFrame(runCheck);
+    }).finally(() => {
+        cancelAnimationFrame(handle);
+    });
+}
+
 export class Macro {
     currentIndex = 0;
     isComplete = false;
-    calledBack = false;
     constructor(descr) {
         try {
             validate(descr, macroSchema);
@@ -69,197 +115,64 @@ export class Macro {
             );
         }
         Object.assign(this, descr);
-        this.name = this.name || "anonymous";
         this.onComplete = this.onComplete || (() => {});
         this.onStep = this.onStep || (() => {});
         this.onError =
             this.onError ||
-            ((e) => {
-                console.error(e);
+            ((error, step, index) => {
+                console.error(error.message, step, index);
             });
-        this.stepElFound = new Array(this.steps.length).fill(false);
-        this.stepHasStarted = new Array(this.steps.length).fill(false);
-        this.observer = new MacroMutationObserver(() => this.debounceAdvance("mutation"));
     }
 
-    async start(target = document) {
-        this.observer.observe(target);
-        this.debounceAdvance("next");
-    }
-
-    getDebounceDelay() {
-        let delay = Math.max(this.checkDelay ?? 750, 50);
-        // Called only once per step.
-        if (!this.stepHasStarted[this.currentIndex]) {
-            delay = this.currentIndex === 0 ? 0 : 50;
-            this.stepHasStarted[this.currentIndex] = true;
-        }
-        return delay;
+    async start() {
+        await this.advance();
     }
 
     async advance() {
-        if (this.isComplete) {
-            return;
-        }
-        if (this.currentStep.trigger) {
-            this.setTimer();
-        }
-        let proceedToAction = true;
-        if (this.currentStep.trigger) {
-            proceedToAction = this.findTrigger();
-        }
-        if (proceedToAction) {
-            this.onStep(this.currentElement, this.currentStep, this.currentIndex);
-            this.clearTimer();
-            const actionResult = await this.stepAction(this.currentElement);
-            if (!actionResult) {
-                // If falsy action result, it means the action worked properly.
-                // So we can proceed to the next step.
-                this.currentIndex++;
-                if (this.currentIndex >= this.steps.length) {
-                    this.stop();
-                }
-                this.debounceAdvance("next");
-            }
-        }
-    }
-
-    /**
-     * Find the trigger and assess whether it can continue on performing the actions.
-     * @returns {boolean}
-     */
-    findTrigger() {
-        const { trigger } = this.currentStep;
-        if (this.isComplete) {
-            return;
-        }
-        try {
-            if (typeof trigger === "function") {
-                this.currentElement = trigger();
-            } else if (typeof trigger === "string") {
-                const triggerEl = document.querySelector(trigger);
-                this.currentElement = isVisible(triggerEl) && triggerEl;
-            } else {
-                throw new Error(`Trigger can only be string or function.`);
-            }
-        } catch (error) {
-            this.stop(
-                new MacroError("Trigger", `ERROR during find trigger:\n${error.message}`, {
-                    cause: error,
-                })
-            );
-        }
-        return !!this.currentElement;
-    }
-
-    /**
-     * Must not return anything for macro to continue.
-     */
-    async stepAction(element) {
-        const { action } = this.currentStep;
-        if (this.isComplete || !action) {
-            return;
-        }
-        try {
-            return await action(element);
-        } catch (error) {
-            this.stop(
-                new MacroError("Action", `ERROR during perform action:\n${error.message}`, {
-                    cause: error,
-                })
-            );
-        }
-    }
-
-    get currentStep() {
-        return this.steps[this.currentIndex];
-    }
-
-    get currentElement() {
-        return this.stepElFound[this.currentIndex];
-    }
-
-    set currentElement(value) {
-        this.stepElFound[this.currentIndex] = value;
-    }
-
-    /**
-     * Timer for findTrigger only (not for doing action)
-     */
-    setTimer() {
-        this.clearTimer();
-        const timeout = this.currentStep.timeout || this.timeout;
-        if (timeout > 0) {
-            this.timer = browser.setTimeout(() => {
-                this.stop(
-                    new MacroError(
-                        "Timeout",
-                        `TIMEOUT step failed to complete within ${timeout} ms.`
-                    )
-                );
-            }, timeout);
-        }
-    }
-
-    clearTimer() {
-        this.resetDebounce();
-        if (this.timer) {
-            browser.clearTimeout(this.timer);
-        }
-    }
-
-    resetDebounce() {
-        if (this.debouncedAdvance) {
-            browser.clearTimeout(this.debouncedAdvance);
-        }
-    }
-
-    /**
-     * @param {"next"|"mutation"} from
-     */
-    async debounceAdvance(from) {
-        this.resetDebounce();
-        // Make sure to take the only possible path.
-        // A step always starts with "next".
-        // A step can only be continued with "mutation".
-        // We abort when the macro is finished or if a mutex occurs afterwards.
-        if (
-            this.isComplete ||
-            (from === "next" && this.stepHasStarted[this.currentIndex]) ||
-            (from === "mutation" && !this.stepHasStarted[this.currentIndex]) ||
-            (from === "mutation" && this.currentElement)
-        ) {
-            return;
-        }
-        // When browser refresh just after the last step.
-        if (!this.currentStep && this.currentIndex === 0) {
-            await delay(300);
+        if (this.isComplete || this.currentIndex >= this.steps.length) {
             this.stop();
-        } else if (from === "next" && !this.currentStep.trigger) {
-            this.advance();
-        } else {
-            this.debouncedAdvance = browser.setTimeout(
-                () => mutex.exec(() => this.advance()),
-                this.getDebounceDelay()
-            );
+            return;
         }
+        try {
+            const currentStep = this.steps[this.currentIndex];
+            const executeStep = async () => {
+                const trigger = await waitForTrigger(currentStep.trigger);
+                await this.onStep(currentStep, trigger, this.currentIndex);
+                return await performAction(trigger, currentStep.action);
+            };
+            const launchTimer = async () => {
+                const timeout_delay = currentStep.timeout || this.timeout || 10000;
+                await delay(timeout_delay);
+                throw new MacroError(
+                    "Timeout",
+                    `TIMEOUT step failed to complete within ${timeout_delay} ms.`
+                );
+            };
+            // If falsy action result, it means the action worked properly.
+            // So we can proceed to the next step.
+            const actionResult = await Promise.race([executeStep(), launchTimer()]);
+            if (actionResult) {
+                this.stop();
+                return;
+            }
+        } catch (error) {
+            this.stop(error);
+            return;
+        }
+        this.currentIndex++;
+        await this.advance();
     }
 
     stop(error) {
-        this.clearTimer();
-        this.isComplete = true;
-        this.observer.disconnect();
-        if (!this.calledBack) {
-            this.calledBack = true;
-            if (error) {
-                this.onError(error, this.currentStep, this.currentIndex);
-            } else if (this.currentIndex === this.steps.length) {
-                mutex.getUnlockedDef().then(() => {
-                    this.onComplete();
-                });
-            }
+        if (this.isComplete) {
+            return;
         }
-        return;
+        this.isComplete = true;
+        if (error) {
+            this.onError(error, this.steps[this.currentIndex], this.currentIndex);
+        } else if (this.currentIndex === this.steps.length) {
+            this.onComplete();
+        }
     }
 }
 

--- a/addons/web_tour/static/src/tour_service/tour_helpers.js
+++ b/addons/web_tour/static/src/tour_service/tour_helpers.js
@@ -114,7 +114,7 @@ export class TourHelpers {
         await dragEffectDelay();
         const target = await hoot.waitFor(selector, {
             visible: true,
-            timeout: 500,
+            timeout: 1000,
         });
         await moveTo(target, options);
         await dragEffectDelay();

--- a/addons/website/static/tests/tours/client_action_redirect.js
+++ b/addons/website/static/tests/tours/client_action_redirect.js
@@ -1,5 +1,6 @@
 /** @odoo-module */
 
+import { delay } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 const testUrl = '/test_client_action_redirect';
@@ -7,7 +8,10 @@ const testUrl = '/test_client_action_redirect';
 const goToFrontendSteps = [{
     content: "Go to the frontend",
     trigger: 'body',
-    run: `goToUrl ${testUrl}`,
+    async run() {
+        await delay(2000);
+        window.location.assign(testUrl);
+    }
 }, {
     content: "Check we are in the frontend",
     trigger: 'body:not(:has(.o_website_preview)) #test_contact_FE',
@@ -15,7 +19,10 @@ const goToFrontendSteps = [{
 const goToBackendSteps = [{
     content: "Go to the backend",
     trigger: 'body',
-    run: `goToUrl /@${testUrl}`,
+    async run() {
+        await delay(2000);
+        window.location.assign(`/@${testUrl}`);
+    }
 }, {
     content: "Check we are in the backend",
     trigger: ".o_website_preview[data-view-xmlid='website.test_client_action_redirect'] :iframe",

--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -109,10 +109,6 @@ for (let snippet of snippetsNames) {
                 content: `Hide the ${snippet.name} popup`,
                 trigger: `:iframe [data-snippet='${snippet.name}'] .s_popup_close`,
                 run: "click",
-            },
-            {
-                content: `Make sure ${snippet.name} is hidden`,
-                trigger: ":iframe body:not(.modal-open)",
             }
         );
     } else if (isDropInOnlySnippet) {


### PR DESCRIPTION
In this commit, we're refactoring macro.js by completely changing
its operation.
To detect triggers in the DOM, we no longer rely on DOM mutations, but
instead check for each frame to see if the trigger is in the DOM.
Once the trigger is found, we perform the action and move on to the
next step.
This significantly simplifies understanding of how macro.js works,
tours, and, more importantly, the bugs that can occur in tours.
This also avoids many indeterministic errors that could occur in the
tours due to the completely arbitrary "checkDelay" parameter (the time
period after which there are no more mutations before the element is
checked to see if it is in the DOM).
This checkDelay parameter is therefore no longer used.
It will be completely removed from the codebase in a future PR.