### PR TITLE
[FIX] account: add credit in compute available payment methods

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -325,12 +325,12 @@ class AccountJournal(models.Model):
         method_information_mapping = results['method_information_mapping']
         providers_per_code = results['providers_per_code']
 
-        journal_bank_cash = self.filtered(lambda j: j.type in ('bank', 'cash'))
-        journal_other = self - journal_bank_cash
+        journal_bank_cash_credit = self.filtered(lambda j: j.type in ('bank', 'cash','credit'))
+        journal_other = self - journal_bank_cash_credit
         journal_other.available_payment_method_ids = False
 
-        # Compute the candidates for each bank/cash journal.
-        for journal in journal_bank_cash:
+        # Compute the candidates for each bank/cash/credit journal.
+        for journal in journal_bank_cash_credit:
             commands = [Command.clear()]
             company = journal.company_id
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR addresses an issue where, in the credit card journal configuration form (for either Incoming Payments or Outgoing Payments), users are unable to add a new payment method.

Steps to reproduce the error:
1. Open the credit card journal configuration form.
2. In either Incoming Payments or Outgoing Payments, delete the default manual payment method.
3. Attempt to add either the deleted payment method or a new one.

Video: https://drive.google.com/file/d/1CnghnPyfn90xIv5TZiU8PVyMatX7rGt3/view

Current behavior before PR:
The list view of Incoming/Outgoing payments displays a 'no record' label, and users are unable to add either the deleted payment method or a new one.

Desired behavior after PR is merged:
The credit card journal configuration should display all available payment methods, similar to how the bank journal behaves, allowing users to add new payment methods.

I've created a related ticket here: https://www.odoo.com/es_ES/my/tasks/4501396

Thanks in advance! :) 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
