### PR TITLE
[FIX] pos_self_order: fix wrong data in test

### DIFF
--- a/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
@@ -14,7 +14,7 @@ registry.category("web_tour.tours").add("self_order_preset_eat_in_tour", {
         Utils.clickBtn("Order"),
         CartPage.checkProduct("Coca-Cola", "2.53", "1"),
         Utils.clickBtn("Pay"),
-        ...CartPage.selectTable("103"),
+        ...CartPage.selectTable("1"),
         Utils.clickBtn("Ok"),
     ],
 });


### PR DESCRIPTION
Before the test `test_preset_eat_in_tour` was using the table 103 which is created in demo data. This table is not created in the test data so the test was failing when trying with no demo.

Now the test use the table 1 which is created in the test data.

Runbot error: 112371
