### PR TITLE
[FIX] account_edi_ubl_cii: Make Peppol Adress always visible

### DIFF
--- a/addons/account_edi_ubl_cii/views/res_partner_views.xml
+++ b/addons/account_edi_ubl_cii/views/res_partner_views.xml
@@ -5,8 +5,8 @@
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@id='invoice_send_settings']" position="inside">
-                <label for="peppol_eas" string="Peppol Address" invisible="not is_peppol_edi_format"/>
-                <div id="peppol_address" invisible="not is_peppol_edi_format" class="row">
+                <label for="peppol_eas" string="Peppol Address"/>
+                <div id="peppol_address" class="row">
                     <field name="peppol_eas" placeholder="EAS" style="width:50%;"/>
                     <field name="peppol_endpoint" placeholder="Endpoint" style="width:50%;"/>
                 </div>


### PR DESCRIPTION
OIOUBL (which is not a Peppol format) uses the fields from peppol. 
So it should be visible to be edited too.

Even more, we will make it always visible, as the Peppol may be proposed more, 
and so, the fields should be more easily modifiable.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
