### PR TITLE
[IMP] mail: insert emoji using ":"

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -413,6 +413,15 @@ export class Composer extends Component {
                         classList: "o-mail-Composer-suggestion",
                     })),
                 };
+            case "emoji":
+                return {
+                    ...props,
+                    optionTemplate: "mail.Composer.suggestionEmoji",
+                    options: suggestions.map((suggestion) => ({
+                        emoji: suggestion,
+                        label: suggestion.codepoints,
+                    })),
+                };
             default:
                 return props;
         }

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -235,4 +235,12 @@
             <t t-esc="option.label"/>
         </em>
     </t>
+    <t t-name="mail.Composer.suggestionEmoji">
+        <strong class="px-2 align-self-center flex-shrink-1 fs-3">
+            <t t-esc="option.emoji.codepoints"/>
+        </strong>
+        <em class="text-600 text-truncate align-self-center">
+            <t t-esc="option.emoji.shortcodes.join(', ')"/>
+        </em>
+    </t>
 </templates>

--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -108,10 +108,12 @@ class UseSuggestion {
 
             const findAppropriateDelimiter = () => {
                 let goodCandidate;
-                for (const [delimiter, allowedPosition] of supportedDelimiters) {
+                for (const [delimiter, allowedPosition, minCharCountAfter] of supportedDelimiters) {
                     if (
                         text.substring(candidatePosition).startsWith(delimiter) && // delimiter is used
-                        (allowedPosition === undefined || allowedPosition === candidatePosition) && // delimiter is allowed
+                        (allowedPosition === undefined || allowedPosition === candidatePosition) && // delimiter is allowed position
+                        (minCharCountAfter === undefined ||
+                            start - candidatePosition - delimiter.length + 1 > minCharCountAfter) && // delimiter is allowed (enough custom char typed after)
                         (!goodCandidate || delimiter.length > goodCandidate) // delimiter is more specific
                     ) {
                         goodCandidate = delimiter;
@@ -146,7 +148,7 @@ class UseSuggestion {
         const text = this.composer.text;
         let before = text.substring(0, this.search.position + 1);
         let after = text.substring(position, text.length);
-        if (this.search.delimiter === "::") {
+        if ([":", "::"].includes(this.search.delimiter)) {
             before = text.substring(0, this.search.position);
             after = text.substring(position, text.length);
         }

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -1097,3 +1097,30 @@ test("Tab to select of canned response suggestion works in chat window", async (
         value: "Hello! How are you? ",
     });
 });
+
+test('can quickly add emoji with ":" keyword', async () => {
+    const pyEnv = await startServer();
+    const guestId = pyEnv["mail.guest"].create({ name: "Mario" });
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "test",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ guest_id: guestId }),
+        ],
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-input");
+    await insertText(".o-mail-Composer-input", ":sweat");
+    await contains(".o-mail-Composer-suggestionList .o-open");
+    await contains(".o-mail-NavigableList-item", { text: "😅:sweat_smile:" });
+    await click(".o-mail-NavigableList-item", { text: "😅:sweat_smile:" });
+    await contains(".o-mail-Composer-input", { value: "😅 " });
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    // check at least 2 chars to trigger it, so that emoji substitution like :p are still easy to use
+    await insertText(".o-mail-Composer-input", ":sw");
+    await contains(".o-mail-Composer-suggestionList .o-open");
+    await contains(".o-mail-NavigableList-item", { text: "😅:sweat_smile:" });
+    await insertText(".o-mail-Composer-input", ":s", { replace: true });
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+});


### PR DESCRIPTION
[A previous PR](https://github.com/odoo/odoo/pull/192953) moved the canned response delimiter to "::".

This PR introduces emoji suggestions on ":".

2 extra char after `:` is necessary to trigger the suggestion, so
that this doesn't conflict with ":" when used for punctuation,
or also the few emoji substitutions like ":p".

<img width="718" alt="Screenshot 2025-01-22 at 16 21 44" src="https://github.com/user-attachments/assets/9b0646c7-bf27-4563-aee0-d0d44686074c" />
