### PR TITLE
[IMP] web_editor: add opacity to checked checklist items

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -164,6 +164,7 @@ ul.o_checklist {
         }
         &.o_checked {
             text-decoration: line-through;
+            opacity: 0.5;
             &::before {
                 content: "✓";
                 display: flex;

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -168,6 +168,7 @@ ul.o_checklist {
             &::before {
                 content: "✓";
                 display: flex;
+                font-size: $o-checklist-before-size;
                 align-items: center;
                 justify-content: center;
                 padding-left: 1px #{"/*rtl:ignore*/"};


### PR DESCRIPTION
**Current behavior before PR:**

- Checked checklist items were marked only with a strikethrough to differentiate them from unchecked items.
- When a font size was applied to the entire checklist, the size of the checked icon would also be affected by
  the font size of the checklist.

**Desired behavior after PR is merged:**

- In addition to the strikethrough, opacity is now applied to checked checklist items for better visual differentiation.
- The checked icon size remains consistent and is no longer affected by the font size of the checklist.

task:4477250
