### PR TITLE
[FIX] pos_{sale,repair}: update quotation delivered qty

### DIFF
--- a/addons/pos_repair/__init__.py
+++ b/addons/pos_repair/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import models

--- a/addons/pos_repair/__manifest__.py
+++ b/addons/pos_repair/__manifest__.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "POS - Repair",
+    'category': "Technical",
+    'summary': 'Link module between Point of Sale and Repair',
+    'depends': ['point_of_sale', 'repair'],
+    'installable': True,
+    'auto_install': True,
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'pos_repair/static/src/**/*',
+        ],
+          'web.assets_tests': [
+            'pos_repair/static/tests/tours/**/*',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/addons/pos_repair/models/__init__.py
+++ b/addons/pos_repair/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import sale_order_line
+from . import stock_picking

--- a/addons/pos_repair/models/sale_order_line.py
+++ b/addons/pos_repair/models/sale_order_line.py
@@ -1,0 +1,20 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models, fields
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    is_repair_line = fields.Boolean("Is linked to repair", compute='_compute_is_repair_line')
+
+    @api.depends('move_ids.repair_id')
+    def _compute_is_repair_line(self):
+        for so_line in self:
+            so_line.is_repair_line = bool(so_line.move_ids.sudo().filtered(lambda m: m.repair_id))
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        result = super()._load_pos_data_fields(config_id)
+        result += ['is_repair_line']
+        return result

--- a/addons/pos_repair/models/stock_picking.py
+++ b/addons/pos_repair/models/stock_picking.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    def _create_move_from_pos_order_lines(self, lines):
+        return super()._create_move_from_pos_order_lines(lines.filtered(lambda line: not line.sale_order_line_id or not line.sale_order_line_id.is_repair_line))

--- a/addons/pos_repair/static/src/overrides/models/pos_order_line.js
+++ b/addons/pos_repair/static/src/overrides/models/pos_order_line.js
@@ -1,0 +1,13 @@
+import { PosOrderline } from "@point_of_sale/app/models/pos_order_line";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosOrderline.prototype, {
+    //@override
+    setQuantityFromSOL(saleOrderLine) {
+        if (saleOrderLine.is_repair_line) {
+            this.setQuantity(saleOrderLine.product_uom_qty);
+        } else {
+            super.setQuantityFromSOL(...arguments);
+        }
+    },
+});

--- a/addons/pos_repair/static/tests/tours/pos_repair_tour.js
+++ b/addons/pos_repair/static/tests/tours/pos_repair_tour.js
@@ -1,0 +1,15 @@
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import * as PosSale from "@pos_sale/../tests/tours/utils/pos_sale_utils";
+import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("PosRepairSettleOrder", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            PosSale.settleNthOrder(1),
+            ProductScreen.selectedOrderlineHas("Test Product", 1),
+        ].flat(),
+});

--- a/addons/pos_repair/tests/__init__.py
+++ b/addons/pos_repair/tests/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import test_frontend

--- a/addons/pos_repair/tests/test_frontend.py
+++ b/addons/pos_repair/tests/test_frontend.py
@@ -1,0 +1,36 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests import tagged
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+
+
+@tagged('post_install', '-at_install')
+class TestUi(TestPointOfSaleHttpCommon):
+
+    def test_pos_repair(self):
+        self.product_1 = self.env['product.product'].create({
+            'name': 'Test product 1'
+        })
+        self.stock_warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        self.repair1 = self.env['repair.order'].create({
+            'product_id': self.product_1.id,
+            'product_uom': self.env.ref('uom.product_uom_unit').id,
+            'picking_type_id': self.stock_warehouse.repair_type_id.id,
+            'move_ids': [
+                (0, 0, {
+                    'product_id': self.product_1.id,
+                    'product_uom_qty': 1.0,
+                    'state': 'draft',
+                    'repair_line_type': 'add',
+                    'company_id': self.env.company.id,
+                })
+            ],
+            'partner_id': self.env['res.partner'].create({'name': 'Partner 1'}).id
+        })
+        self.repair1._action_repair_confirm()
+        self.repair1.action_repair_start()
+        self.repair1.action_repair_end()
+        self.repair1.action_create_sale_order()
+        self.assertEqual(len(self.product_1.stock_move_ids.ids), 2, "There should be 2 stock moves for the product created by the repair order")
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosRepairSettleOrder', login="pos_user")
+        self.assertEqual(len(self.product_1.stock_move_ids.ids), 2, "Paying for the order in PoS should not create new stock moves")

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -162,8 +162,3 @@ class SaleOrderLine(models.Model):
                     downpayment_sol.name = _("%(line_description)s (Cancelled)", line_description=downpayment_sol.name)
             else:
                 super()._compute_name()
-
-    def pos_has_valued_move_ids(self):
-        return {
-            "has_valued_move_ids": bool(self.has_valued_move_ids())
-        }

--- a/addons/pos_sale/models/stock_picking.py
+++ b/addons/pos_sale/models/stock_picking.py
@@ -16,4 +16,4 @@ class StockPicking(models.Model):
                 continue
             lines_to_unreserve |= line
         lines_to_unreserve.sale_order_line_id.move_ids.filtered(lambda ml: ml.state not in ['cancel', 'done'])._do_unreserve()
-        return super()._create_move_from_pos_order_lines(lines.filtered(lambda l: not l.sale_order_line_id or l.sale_order_line_id.has_valued_move_ids()))
+        return super()._create_move_from_pos_order_lines(lines)

--- a/addons/pos_sale/static/src/app/models/pos_order_line.js
+++ b/addons/pos_sale/static/src/app/models/pos_order_line.js
@@ -44,9 +44,7 @@ patch(PosOrderline.prototype, {
      * @param {'sale.order.line'} saleOrderLine
      */
     async setQuantityFromSOL(saleOrderLine) {
-        if (!saleOrderLine.has_valued_move_ids && !saleOrderLine.is_downpayment) {
-            this.setQuantity(saleOrderLine.product_uom_qty);
-        } else if (
+        if (
             this.product_id.type === "service" &&
             !["sent", "draft"].includes(this.sale_order_origin_id.state)
         ) {

--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -133,10 +133,6 @@ patch(PosStore.prototype, {
                     });
                 }
             }
-            const response = await this.data.call("sale.order.line", "pos_has_valued_move_ids", [
-                line.id,
-            ]);
-            line.has_valued_move_ids = response.has_valued_move_ids;
             newLine.setQuantityFromSOL(line);
             newLine.setUnitPrice(line.price_unit);
             newLine.setDiscount(line.discount);

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -326,16 +326,6 @@ registry.category("web_tour.tours").add("PosSettleOrder4", {
         ].flat(),
 });
 
-registry.category("web_tour.tours").add("PosRepairSettleOrder", {
-    steps: () =>
-        [
-            Chrome.startPoS(),
-            Dialog.confirm("Open Register"),
-            PosSale.settleNthOrder(1),
-            ProductScreen.selectedOrderlineHas("Test Product", 1),
-        ].flat(),
-});
-
 registry.category("web_tour.tours").add("PosSettleOrderShipLater", {
     steps: () =>
         [
@@ -419,5 +409,18 @@ registry.category("web_tour.tours").add("PoSDownPaymentFixedTax", {
                 quantity: "1.0",
                 price: "22.00",
             }),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PoSSettleQuotation", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            PosSale.settleNthOrder(1),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
         ].flat(),
 });


### PR DESCRIPTION
When settling a quotation (unconfirmed sale order) from the POS, the
delivered quantity was not updated in the quotation.

Steps to reproduce:
-------------------
* Make a sale order but don't confirm it
* Go to the POS and settle the quotation
> Observation: The delivered quantity is not updated in the quotation

Why the fix:
------------
We move all the logic related to the repair module in a dedicated
pos_repair module. This way, we can keep the pos_sale module clean.

opw-4479862