### PR TITLE
[FIX] sale: prevent error when clicking on Sales Orders in kanban view

### DIFF
--- a/addons/sale/views/res_partner_views.xml
+++ b/addons/sale/views/res_partner_views.xml
@@ -27,9 +27,9 @@
                 <a t-if="record.sale_order_count?.value"
                     class="btn btn-sm btn-link smaller"
                     groups="sales_team.group_sale_salesman"
-                    name="action_view_sale_order"
+                    name="sale.act_res_partner_2_sale_order"
                     role="button"
-                    type="object">
+                    type="action">
                     <i class="fa fa-usd me-1" role="img" aria-label="Sale orders" title="Sales orders"/>
                     <field name="sale_order_count"/>
                 </a>


### PR DESCRIPTION
When a user clicks on the view Sales Orders button in Kanban view of customers,
a traceback will appear.

Steps to reproduce the error:
- Go to Sales > Orders > Customers >
- In kanban view, Click on ``Sales Orders ($ button)``

Traceback:
```
AttributeError:
The method 'action_view_sale_order' does not exist on the model 'res.partner'
```

``action_view_sale_order`` is removed in this commit: 81c9fc1fb5b67781ff22062d4cc776f90bbfbb0e but it is still used here, https://github.com/odoo/odoo/blob/4c0487008aac63937e10883a62dfdf15abca3c42/addons/sale/views/res_partner_views.xml#L30

sentry-6232318595

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
