### PR TITLE
[FIX] point_of_sale: set default nb_print value for offline orders

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -24,6 +24,7 @@ export class PosOrder extends Base {
 
         // Data present in python model
         this.date_order = vals.date_order || serializeDateTime(luxon.DateTime.now());
+        this.nb_print = vals.nb_print || 0;
         this.to_invoice = vals.to_invoice || false;
         this.shipping_date = vals.shipping_date || false;
         this.state = vals.state || "draft";


### PR DESCRIPTION
Currently, an exception is generated in the log when the users create a POS order as follows:
- Install ``pos_restaurant`` module.
- Open the register for the restaurant.
- Stay connected to Wi-Fi but disconnect from the internet (Inspect > Network > Go Offline). connection (Inspect > Network > Go offline)
- Make two or more orders in offline mode and use ``Print Full Receipt``.
- Reconnect to the internet, make one order, and ``Print Full Receipt``.
- Close the register (Traceback appears in the terminal).

``error: `invalid literal for int() with base 10: 'null'``

Before commit :
---
- ``nb_print`` is initialized in Python with fields.Integer(default=0)
- When syncing data between the server and the client, nb_print is being sent as ``null`` instead of an integer.
- The Python side is trying to convert ``null`` into an integer, which causes the error. 

 After commit :
---
- Added ``this.nb_print = vals.nb_print || 0;`` in ``pos_order.js`` to ensure it initializes to 0 for offline orders, aligning with the server-side default.

sentry-6055024846

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
