### PR TITLE
[CLN] website_sale_collect: move dm check to the correct override

### DIFF
--- a/addons/website_sale_collect/static/src/js/checkout.js
+++ b/addons/website_sale_collect/static/src/js/checkout.js
@@ -45,11 +45,10 @@ publicWidget.registry.WebsiteSaleCheckout.include({
      *
      * @override method from `@website_sale/js/checkout`
      */
-    _canEnableMainButton() {
+    _isDeliveryMethodReady() {
         if (this.dmRadios.length === 0) {  // If there are no delivery methods.
             return this._super.apply(this, arguments);  // Skip override.
         }
-        // TODO: move logic below to `_isDeliveryMethodReady` override on master
         const checkedRadio = this.el.querySelector('input[name="o_delivery_radio"]:checked');
         const deliveryContainer = this._getDeliveryMethodContainer(checkedRadio);
         const hasWarning = (


### PR DESCRIPTION
`_isDeliveryMethodReady` is more suitable to check if in-store delivery method is correctly set.

