### PR TITLE
[FIX] stock: compute accurate consumed quantities for lots

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -377,7 +377,7 @@ class StockMove(models.Model):
                 move_lines_ids |= set(move.move_line_ids.ids)
 
             data = self.env['stock.move.line']._read_group(
-                [('id', 'in', list(move_lines_ids))],
+                ['&', ('id', 'in', list(move_lines_ids)), ('picked', '=', True)],
                 ['move_id', 'product_uom_id'], ['quantity:sum']
             )
             sum_qty = defaultdict(float)


### PR DESCRIPTION
Issue
-----
When manually changing the quantity and lot consumed through the Shop Floor, the consumed quantity is computed wrong and the user gets a "Consumption Warning".

Steps to reproduce
-----
- Install MRP
- Create a "Cons" product, tracked by lot
- Change the "Cons" on hand quantity, create lot 1 with 10 units & lot 2 with 20
- Create a "Final" product
- Create a Bill of Materials for "Final"
    - Add "Cons" as a component of the BoM
    - Add an operation to the BoM
        - Add an instruction to the operation with "Type" set to "Register Consumed Materials" & "Product To Register" set to "Cons"
- Create a Manufacturing Order for 20 of "Final" & confirm it (the "Cons" consumption should be split 10/10 between the 2 lots)
- Go to the Shop Floor
    - Register the production of the 20 units
    - Open the instruction
        - Change the consumed quantity to 20
        - Change the lot number to use the 2nd one
    - Mark as done & close the 

-> A pop-up appears because the consumed quantity is registered as 30 instead of the 20 that were actually used

Cause
-----
A stock move is automatically created with the manufacturing order for all of the required components. The problem arises when one of these components is tracked by lots. The move line for this component is created using the first available lot found. If this lot isn't sufficient, the remaining necessary quantity is taken from the next lot (through another move line). If the user manually changes the consumed quantity for a lot, it only updates the corresponding line.

When updating the line, it sets 'picked' as True so we can use this field to only use the actually registered consumed quantities for computing the total.

-----
Ticket:
opw-4357996
