### PR TITLE
[FIX] account: ignore canceled statement lines in statement assignment

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -295,15 +295,17 @@ class AccountBankStatement(models.Model):
             lines = self.env['account.bank.statement.line'].browse(active_ids).sorted()
             if len(lines.journal_id) > 1:
                 raise UserError(_("A statement should only contain lines from the same journal."))
-            # Check that the selected lines are contiguous
+            # Check that the selected lines are contiguous (there might be canceled lines between the indexes and these should be ignored from the check)
             indexes = lines.mapped('internal_index')
-            count_lines_between = self.env['account.bank.statement.line'].search_count([
+            lines_between = self.env['account.bank.statement.line'].search([
                 ('internal_index', '>=', min(indexes)),
                 ('internal_index', '<=', max(indexes)),
                 ('journal_id', '=', lines.journal_id.id),
             ])
-            if len(lines) != count_lines_between:
+            canceled_lines = lines_between.filtered(lambda l: l.state == 'cancel')
+            if len(lines) != len(lines_between - canceled_lines):
                 raise UserError(_("Unable to create a statement due to missing transactions. You may want to reorder the transactions before proceeding."))
+            lines |= canceled_lines
 
         if lines:
             defaults['line_ids'] = [Command.set(lines.ids)]

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -1401,6 +1401,20 @@ class TestAccountBankStatementLine(AccountTestInvoicingCommon):
             'is_complete': True,
         }])
 
+        # create the third statement using multi edit with canceled line in between
+        lines[2].move_id.button_cancel()
+        context = {
+            'active_ids': [lines[1].id, lines[3].id],
+            'st_line_id': lines[3].id,
+        }
+        st3 = self.env['account.bank.statement'].with_context(context).create({'name': 'Statement 3'})
+        self.assertRecordValues(st3, [{
+            'balance_start': 10.0,
+            'balance_end_real': 55.0,
+            'is_valid': True,
+            'is_complete': True,
+        }])
+
     def test_statement_attachments(self):
         ''' Ensure that attachments are properly linked to bank statements '''
 


### PR DESCRIPTION
Before this commit:
Steps
1) Create 3 statement lines in bank journal
2) Cancel the journal entry of the middle one
3) Try to add the first and third lines to a statement

=> It shows an `Invalid Operation: Unable to create a statement due to missing transactions. You may want to reorder the transactions before proceeding` This happens because the lines are considered non-contiguous due to the canceled middle line.

After this commit:
This operation can be performed as the missing line is canceled, and it shouldn’t be counted for the contiguity check. Also, it should be considered in the statement assignment, similar to how the statement button works in the widget/kanban view.

Recording of reproducing the issue: 
https://drive.google.com/file/d/1I5xwNie1HL9ifuK0z21a6yWDdqI_xbTU/view?usp=sharing 

Discussion with OLMA: https://discord.com/channels/678381219515465750/1099994955830796348/1330856829638545429

opw-4385040