### PR TITLE
[IMP] account_peppol: speedup peppol registration flow

### DIFF
--- a/addons/account_peppol/data/cron.xml
+++ b/addons/account_peppol/data/cron.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="ir_cron_peppol_get_new_documents" model="ir.cron">
         <field name="name">PEPPOL: retrieve new documents</field>
-        <field name="interval_number">12</field>
+        <field name="interval_number">4</field>
         <field name="interval_type">hours</field>
         <field name="model_id" ref="model_account_edi_proxy_client_user"/>
         <field name="code">model._cron_peppol_get_new_documents()</field>
@@ -11,8 +11,8 @@
 
     <record id="ir_cron_peppol_get_message_status" model="ir.cron">
         <field name="name">PEPPOL: update message status</field>
-        <field name="interval_number">12</field>
-        <field name="interval_type">hours</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
         <field name="model_id" ref="model_account_edi_proxy_client_user"/>
         <field name="code">model._cron_peppol_get_message_status()</field>
         <field name="state">code</field>
@@ -20,8 +20,8 @@
 
     <record id="ir_cron_peppol_get_participant_status" model="ir.cron">
         <field name="name">PEPPOL: update participant status</field>
-        <field name="interval_number">6</field>
-        <field name="interval_type">hours</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">weeks</field>
         <field name="model_id" ref="model_account_edi_proxy_client_user"/>
         <field name="code">model._cron_peppol_get_participant_status()</field>
         <field name="state">code</field>

--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
+from datetime import timedelta
 
 from odoo import _, api, fields, models, modules, tools
 from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
@@ -104,8 +105,12 @@ class AccountEdiProxyClientUser(models.Model):
         edi_users._peppol_get_message_status()
 
     def _cron_peppol_get_participant_status(self):
-        edi_users = self.search([('company_id.account_peppol_proxy_state', 'in', ['in_verification', 'sender', 'smp_registration'])])
+        edi_users = self.search([('proxy_type', '=', 'peppol')])
         edi_users._peppol_get_participant_status()
+
+        # throughout the registration process, we need to check the status more frequently
+        if self.search_count([('company_id.account_peppol_proxy_state', '=', 'smp_registration')], limit=1):
+            self.env.ref('account_peppol.ir_cron_peppol_get_participant_status')._trigger(at=fields.Datetime.now() + timedelta(hours=1))
 
     # -------------------------------------------------------------------------
     # BUSINESS ACTIONS
@@ -306,6 +311,7 @@ class AccountEdiProxyClientUser(models.Model):
         self.company_id.account_peppol_proxy_state = 'sender'
 
     def _peppol_register_receiver(self):
+        # remove in master
         self.ensure_one()
         params = {
             'company_details': self._get_company_details(),
@@ -341,6 +347,8 @@ class AccountEdiProxyClientUser(models.Model):
         # but we need the field for future in case the user decided to migrate away from Odoo
         company.account_peppol_migration_key = False
         company.account_peppol_proxy_state = 'smp_registration'
+
+        self.env.ref('account_peppol.ir_cron_peppol_get_participant_status')._trigger(at=fields.Datetime.now() + timedelta(hours=1))
 
     def _peppol_deregister_participant(self):
         self.ensure_one()

--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -1,6 +1,7 @@
 from base64 import b64encode
+from datetime import timedelta
 
-from odoo import models, _
+from odoo import fields, models, _
 from odoo.addons.account.models.company import PEPPOL_LIST
 from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
 
@@ -199,6 +200,7 @@ class AccountMoveSend(models.AbstractModel):
                     invoices |= invoice
                 log_message = _('The document has been sent to the Peppol Access Point for processing')
                 invoices._message_log_batch(bodies={invoice.id: log_message for invoice in invoices})
+                self.env.ref('account_peppol.ir_cron_peppol_get_message_status')._trigger(at=fields.Datetime.now() + timedelta(minutes=5))
 
         if self._can_commit():
             self._cr.commit()


### PR DESCRIPTION
Currently, registering as a receiver on Peppol via Odoo has a poor user experience due to the long delays in activation. The activation process requires a DNS lookup, which is performed on the IAP side every 6 hours. Additionally, the client db queries IAP for the user state every 6 hours before enabling the receipt of invoices, resulting in a typical delay of over 8 hours—often spanning more than a full workday.

This commit, together with https://github.com/odoo/iap-apps/pull/989 tries speed things up by
- fetching the activation status 1h after registration from IAP (client-db side)
- fetching sent invoice status 5 minutes after having sent the invoice

This is also a replacement for webhooks for on-prem users who won't be able to use webhooks from this PR: https://github.com/odoo/iap-apps/pull/1008


task-4395265