### PR TITLE
[FIX] l10n_in_ewaybill: LazyGettext traceback and missing response

### DIFF
--- a/addons/l10n_in_ewaybill/i18n/l10n_in_ewaybill.pot
+++ b/addons/l10n_in_ewaybill/i18n/l10n_in_ewaybill.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.1alpha1+e\n"
+"Project-Id-Version: Odoo Server saas~18.1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-24 12:06+0000\n"
-"PO-Revision-Date: 2024-10-24 12:06+0000\n"
+"POT-Creation-Date: 2025-01-22 06:18+0000\n"
+"PO-Revision-Date: 2025-01-22 06:18+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -576,6 +576,11 @@ msgid "Could not update vehicle details, pl contact helpdesk"
 msgstr ""
 
 #. module: l10n_in_ewaybill
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill.invoice_form_inherit_l10n_in_ewaybill
+msgid "Create e-Waybill"
+msgstr ""
+
+#. module: l10n_in_ewaybill
 #: model:ir.model.fields,field_description:l10n_in_ewaybill.field_l10n_in_ewaybill__create_uid
 #: model:ir.model.fields,field_description:l10n_in_ewaybill.field_l10n_in_ewaybill_cancel__create_uid
 #: model:ir.model.fields,field_description:l10n_in_ewaybill.field_l10n_in_ewaybill_type__create_uid
@@ -636,9 +641,13 @@ msgid ""
 msgstr ""
 
 #. module: l10n_in_ewaybill
+#: model:ir.model.fields,field_description:l10n_in_ewaybill.field_account_chart_template__display_name
+#: model:ir.model.fields,field_description:l10n_in_ewaybill.field_account_move__display_name
 #: model:ir.model.fields,field_description:l10n_in_ewaybill.field_l10n_in_ewaybill__display_name
 #: model:ir.model.fields,field_description:l10n_in_ewaybill.field_l10n_in_ewaybill_cancel__display_name
 #: model:ir.model.fields,field_description:l10n_in_ewaybill.field_l10n_in_ewaybill_type__display_name
+#: model:ir.model.fields,field_description:l10n_in_ewaybill.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_in_ewaybill.field_res_config_settings__display_name
 msgid "Display Name"
 msgstr ""
 
@@ -1200,9 +1209,13 @@ msgid "Has Message"
 msgstr ""
 
 #. module: l10n_in_ewaybill
+#: model:ir.model.fields,field_description:l10n_in_ewaybill.field_account_chart_template__id
+#: model:ir.model.fields,field_description:l10n_in_ewaybill.field_account_move__id
 #: model:ir.model.fields,field_description:l10n_in_ewaybill.field_l10n_in_ewaybill__id
 #: model:ir.model.fields,field_description:l10n_in_ewaybill.field_l10n_in_ewaybill_cancel__id
 #: model:ir.model.fields,field_description:l10n_in_ewaybill.field_l10n_in_ewaybill_type__id
+#: model:ir.model.fields,field_description:l10n_in_ewaybill.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_in_ewaybill.field_res_config_settings__id
 msgid "ID"
 msgstr ""
 
@@ -2203,11 +2216,6 @@ msgid "Security Token"
 msgstr ""
 
 #. module: l10n_in_ewaybill
-#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill.invoice_form_inherit_l10n_in_ewaybill
-msgid "Send E-waybill"
-msgstr ""
-
-#. module: l10n_in_ewaybill
 #. odoo-python
 #: code:addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py:0
 msgid "Set GST Treatment for in %s"
@@ -2246,11 +2254,11 @@ msgstr ""
 
 #. module: l10n_in_ewaybill
 #. odoo-python
-#: code:addons/l10n_in_ewaybill/tools/ewaybill_api.py:0
+#: code:addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py:0
 msgid ""
 "Somehow this E-waybill has been %s in the government portal before. You can "
 "verify by checking the details into the government "
-"(https://ewaybillgst.gov.in/Others/EBPrintnew.asp)"
+"(https://ewaybillgst.gov.in/Others/EBPrintnew.aspx)"
 msgstr ""
 
 #. module: l10n_in_ewaybill
@@ -3039,6 +3047,12 @@ msgstr ""
 
 #. module: l10n_in_ewaybill
 #. odoo-python
+#: code:addons/l10n_in_ewaybill/tools/ewaybill_api.py:0
+msgid "cancelled"
+msgstr ""
+
+#. module: l10n_in_ewaybill
+#. odoo-python
 #: code:addons/l10n_in_ewaybill/models/error_codes.py:0
 msgid "dispatch from gstin is mandatary "
 msgstr ""
@@ -3072,6 +3086,12 @@ msgstr ""
 #. module: l10n_in_ewaybill
 #: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill.report_ewaybill
 msgid "eway Bill No:"
+msgstr ""
+
+#. module: l10n_in_ewaybill
+#. odoo-python
+#: code:addons/l10n_in_ewaybill/tools/ewaybill_api.py:0
+msgid "generated"
 msgstr ""
 
 #. module: l10n_in_ewaybill

--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -296,6 +296,15 @@ class L10nInEwaybill(models.Model):
             'cancel_remarks': False,
         })
 
+    @api.model
+    def _get_default_help_message(self, status):
+        return self.env._(
+            "Somehow this E-waybill has been %s in the government portal before. "
+            "You can verify by checking the details into the government "
+            "(https://ewaybillgst.gov.in/Others/EBPrintnew.aspx)",
+            status
+        )
+
     def _check_configuration(self):
         error_message = []
         methods_to_check = [

--- a/addons/l10n_in_ewaybill/tools/ewaybill_api.py
+++ b/addons/l10n_in_ewaybill/tools/ewaybill_api.py
@@ -10,7 +10,6 @@ from odoo import fields
 from odoo.exceptions import AccessError
 from odoo.addons.l10n_in_ewaybill.models.error_codes import ERROR_CODES
 from odoo.tools import _, LazyTranslate
-_lt = LazyTranslate(__name__)
 
 
 _logger = logging.getLogger(__name__)
@@ -47,12 +46,6 @@ class EWayBillError(Exception):
 
 
 class EWayBillApi:
-
-    DEFAULT_HELP_MESSAGE = _lt(
-        "Somehow this E-waybill has been %s in the government portal before. "
-        "You can verify by checking the details into the government "
-        "(https://ewaybillgst.gov.in/Others/EBPrintnew.aspx)"
-    )
 
     def __init__(self, company):
         company.ensure_one()
@@ -150,7 +143,9 @@ class EWayBillApi:
                 # this happens when timeout from the Government portal but IRN is generated
                 e.error_json['odoo_warning'].append({
                     'message': Markup("%s<br/>%s:<br/>%s") % (
-                        self.DEFAULT_HELP_MESSAGE % 'cancelled',
+                        self.env['l10n.in.ewaybill']._get_default_help_message(
+                            self.env._('cancelled')
+                        ),
                         _("Error"),
                         e.get_all_error_message()
                     ),
@@ -185,7 +180,9 @@ class EWayBillApi:
         # Add warning that ewaybill was already generated
         response.update({
             'odoo_warning': [{
-                'message': self.DEFAULT_HELP_MESSAGE % 'generated',
+                'message': self.env['l10n.in.ewaybill']._get_default_help_message(
+                    self.env._('generated')
+                ),
                 'message_post': True
             }]
         })

--- a/addons/l10n_in_ewaybill_irn/i18n/l10n_in_ewaybill_irn.pot
+++ b/addons/l10n_in_ewaybill_irn/i18n/l10n_in_ewaybill_irn.pot
@@ -4,16 +4,26 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.1alpha1+e\n"
+"Project-Id-Version: Odoo Server saas~18.1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-24 12:07+0000\n"
-"PO-Revision-Date: 2024-10-24 12:07+0000\n"
+"POT-Creation-Date: 2025-01-22 06:20+0000\n"
+"PO-Revision-Date: 2025-01-22 06:20+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: l10n_in_ewaybill_irn
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_irn.field_l10n_in_ewaybill__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_in_ewaybill_irn
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_irn.field_l10n_in_ewaybill__id
+msgid "ID"
+msgstr ""
 
 #. module: l10n_in_ewaybill_irn
 #: model:ir.model.fields,field_description:l10n_in_ewaybill_irn.field_l10n_in_ewaybill__is_process_through_irn
@@ -31,6 +41,12 @@ msgstr ""
 #. module: l10n_in_ewaybill_irn
 #: model:ir.model,name:l10n_in_ewaybill_irn.model_l10n_in_ewaybill
 msgid "e-Waybill"
+msgstr ""
+
+#. module: l10n_in_ewaybill_irn
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py:0
+msgid "generated"
 msgstr ""
 
 #. module: l10n_in_ewaybill_irn

--- a/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py
@@ -122,10 +122,10 @@ class L10nInEwaybill(models.Model):
             if '4002' in error_codes or '4026' in error_codes:
                 # Get E-waybill by details in case of IRN is already generated
                 # this happens when timeout from the Government portal but E-waybill is generated
-                self._ewaybill_get_by_irn(json_payload.get("Irn"))
+                response = self._ewaybill_get_by_irn(json_payload.get("Irn"))
                 response.update({
                     'odoo_warning': [{
-                        'message': EWayBillApi.DEFAULT_HELP_MESSAGE % 'generated',
+                        'message': self._get_default_help_message(self.env._('generated')),
                         'message_post': True
                     }]
                 })


### PR DESCRIPTION
on generating ewaybill through irn following traceback is produced
```py
Traceback (most recent call last):
  File "/home/odoo/src/odoo/saas-18.1/odoo/http.py", line 1997, in _transactioning
    return service_model.retrying(func, env=self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/saas-18.1/odoo/service/model.py", line 137, in retrying
    result = func()
             ^^^^^^
  File "/home/odoo/src/odoo/saas-18.1/odoo/http.py", line 1964, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/saas-18.1/odoo/http.py", line 2214, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/saas-18.1/odoo/addons/base/models/ir_http.py", line 334, in _dispatch
    result = endpoint(**request.params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/saas-18.1/odoo/http.py", line 733, in route_wrapper
    result = endpoint(self, *args, **params_ok)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/saas-18.1/addons/web/controllers/dataset.py", line 36, in call_button
    action = call_kw(request.env[model], method, args, kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/saas-18.1/odoo/service/model.py", line 62, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/saas-18.1/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py", line 49, in action_generate_ewaybill
    ewaybill._generate_ewaybill_by_irn()
  File "/home/odoo/src/odoo/saas-18.1/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py", line 56, in _generate_ewaybill_by_irn
    response = self._ewaybill_generate_by_irn(self._ewaybill_generate_irn_json())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/saas-18.1/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py", line 128, in _ewaybill_generate_by_irn
    'message': EWayBillApi.DEFAULT_HELP_MESSAGE % 'generated',
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
TypeError: unsupported operand type(s) for %: 'LazyGettext' and 'str'
```
In this commit, we fix the above traceback and also fixes a line where the response was not overriden on the next request



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
