### PR TITLE
[FIX] hr_holidays: fix accrual allocations with multiple levels

### DIFF
--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -310,3 +310,11 @@ class AccrualPlanLevel(models.Model):
                 return last_call + relativedelta(years=-1, month=month, day=self.yearly_day)
         else:
             return False
+
+    def _get_level_transition_date(self, allocation_start):
+        if self.start_type == 'day':
+            return allocation_start + relativedelta(days=self.start_count)
+        if self.start_type == 'month':
+            return allocation_start + relativedelta(months=self.start_count)
+        if self.start_type == 'year':
+            return allocation_start + relativedelta(years=self.start_count)

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -537,7 +537,8 @@ class HolidaysAllocation(models.Model):
             # once, preventing double allocation.
             if allocation.accrual_plan_id.accrued_gain_time == 'start':
                 # check that we are at the start of a period, not on a carry-over or level transition date
-                current_level = current_level or allocation.accrual_plan_id.level_ids[0]
+                level_start = {level._get_level_transition_date(allocation.date_from): level for level in allocation.accrual_plan_id.level_ids}
+                current_level = level_start.get(allocation.lastcall) or current_level or allocation.accrual_plan_id.level_ids[0]
                 period_start = current_level._get_previous_date(allocation.lastcall)
                 if current_level.cap_accrued_time:
                     current_level_maximum_leave = current_level.maximum_leave if current_level.added_value_type == "day" else current_level.maximum_leave / (allocation.employee_id.sudo().resource_id.calendar_id.hours_per_day or HOURS_PER_DAY)

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -2348,3 +2348,76 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             future_date = datetime.date.today() + relativedelta(days=1)
             allocation._process_accrual_plans(date_to=future_date)
+
+    def test_accrual_progressive_per_year(self):
+        accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+            'name': '1 day 1st year, 5 days 2nd year, 20 days 3rd year, 100 days 4th year (granted at start of year)',
+            'transition_mode': 'immediately',
+            'carryover_date': 'year_start',
+            'accrued_gain_time': 'start',
+            'level_ids':
+                [(0, 0, {
+                    'added_value': 1,
+                    'added_value_type': 'day',
+                    'frequency': 'yearly',
+                    'cap_accrued_time': False,
+                    'start_count': 0,
+                    'start_type': 'day',
+                    'action_with_unused_accruals': 'all',
+                }), (0, 0, {
+                    'added_value': 5,
+                    'added_value_type': 'day',
+                    'frequency': 'yearly',
+                    'cap_accrued_time': False,
+                    'start_count': 1,
+                    'start_type': 'year',
+                    'action_with_unused_accruals': 'all',
+                }), (0, 0, {
+                    'added_value': 20,
+                    'added_value_type': 'day',
+                    'frequency': 'yearly',
+                    'cap_accrued_time': False,
+                    'start_count': 2,
+                    'start_type': 'year',
+                    'action_with_unused_accruals': 'all',
+                }), (0, 0, {
+                    'added_value': 100,
+                    'added_value_type': 'day',
+                    'frequency': 'yearly',
+                    'cap_accrued_time': False,
+                    'start_count': 3,
+                    'start_type': 'year',
+                    'action_with_unused_accruals': 'all',
+                })],
+        })
+
+        with freeze_time('2024-09-02'):
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
+                'name': 'Accrual allocation',
+                'holiday_status_id': self.leave_type.id,
+                'allocation_type': 'accrual',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'date_from': '2024-01-01',
+                'number_of_days': 1,
+            })
+
+            allocation.action_validate()
+            allocation._update_accrual()
+            self.assertEqual(allocation.number_of_days, 1, 'For 2024, 1 day should have been granted immediately')
+
+        with freeze_time("2025-01-01"):
+            allocation._update_accrual()
+            self.assertEqual(allocation.number_of_days, 6, '1 day from 2025 + 5 days for 2025')
+
+        with freeze_time("2026-01-01"):
+            allocation._update_accrual()
+            self.assertEqual(allocation.number_of_days, 26, '1 day from 2025 + 5 days for 2025 + 20 days for 2026')
+
+        with freeze_time("2027-01-01"):
+            allocation._update_accrual()
+            self.assertAlmostEqual(allocation.number_of_days, 126, 1, '1 day from 2025 + 5 days for 2025 + 20 days for 2026 + 100 days for 2027')
+
+        with freeze_time("2028-01-01"):
+            allocation._update_accrual()
+            self.assertAlmostEqual(allocation.number_of_days, 226, 1, 'Same as previous year + 100 days for 2028 (no specific level for this year, use last one)')


### PR DESCRIPTION
The accrual plan is not working for the last level, it seems like the last level computation is always using the previous level instead. If those levels have a different number of days granted, this will be wrong. Else, if they grant the same amount of days, the error won't be noticed.

Steps to reproduce:
- Create an accrual plan with:
  - Accrued Gain Time -> At the start of the accrual period
  - Carry-Over Time -> At the start of the year
- Add 4 rules to the plan:
  - For all: don't set a cap, set carry-over to all, set the frequency to yearly
  - For the first, grant 1 day immediately (milestone reached 0 days after allocation start
  - For the second, grant 5 days after 1 year
  - Third, 20 days after 2 years
  - Fourth, 100 days after 3 years
- Go to Management > Allocations, and create a new allocation for someone, like Mitchell Admin, with:
  - Time off Type set to "Parental Leaves" (so you should not have any by default for testing)
  - Allocation type set to "Accrual"
  - Select the accrual plan we just created
  - Set start date at the first of january for the current year
- This should grant you immediately your first Parental Leave
- Go to the dashboard and see the 1 parental leave
- Change the date to see how many Parental Leaves you will have at other dates (years). It will always be wrong, see explanation below.

If you set 1 year after (eg 2025-01-01), you will have 2 Parental leaves instead of 6 because it does 1 + 1 instead of 1 + 5. If you set 2 year after (eg 2026-01-01), you will have 11 leaves instead of 26, because it does 1 + 5 + 5 instead of 1 + 5 + 20 For year 3, you will have 46 instead of 126, because it does 1 + 5 + 20 + 20 instead of 1 + 5 + 20 + 100.

Notice the last added number, it will also be a duplicate of the one before because it considered the wrong accrual level for the last level.

Commit [1] in Odoo 18 did fix it, on top of other bugs. This commit is thus part of a cherry-pick, on top of which a test is added to cover this specific flow.
Also, note that [1] was actually itself a forward port with different code than its version in Odoo 17.0, see [2]. That commit fixed other issues but not this one.

[1]: https://github.com/odoo/odoo/commit/1897ff0d224416fc2df19b8f9783a94709704457
[2]: https://github.com/odoo/odoo/commit/8b339fdde161e81e1a00cecd3b1fd280de51fd08


Opw https://www.odoo.com/odoo/all-tasks/4350161