### PR TITLE
[IMP] spreadsheet_account: Add formula ODOO.RESIDUAL and ODOO.PARTNER.BALANCE

### DIFF
--- a/addons/spreadsheet_account/i18n/spreadsheet_account.pot
+++ b/addons/spreadsheet_account/i18n/spreadsheet_account.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.0\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-26 08:56+0000\n"
-"PO-Revision-Date: 2024-09-26 08:56+0000\n"
+"POT-Creation-Date: 2025-01-16 15:16+0000\n"
+"PO-Revision-Date: 2025-01-16 15:16+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -35,6 +35,12 @@ msgid "Account"
 msgstr ""
 
 #. module: spreadsheet_account
+#. odoo-python
+#: code:addons/spreadsheet_account/models/account.py:0
+msgid "Cell Audit"
+msgstr ""
+
+#. module: spreadsheet_account
 #: model:ir.model,name:spreadsheet_account.model_res_company
 msgid "Companies"
 msgstr ""
@@ -58,9 +64,21 @@ msgid "Get the total debit for the specified account(s) and period."
 msgstr ""
 
 #. module: spreadsheet_account
-#. odoo-python
-#: code:addons/spreadsheet_account/models/account.py:0
-msgid "Journal items for account prefix %s"
+#. odoo-javascript
+#: code:addons/spreadsheet_account/static/src/accounting_functions.js:0
+msgid "Offset applied to the years."
+msgstr ""
+
+#. module: spreadsheet_account
+#. odoo-javascript
+#: code:addons/spreadsheet_account/static/src/accounting_functions.js:0
+msgid "Return the partner balance for the specified account(s) and period"
+msgstr ""
+
+#. module: spreadsheet_account
+#. odoo-javascript
+#: code:addons/spreadsheet_account/static/src/accounting_functions.js:0
+msgid "Return the residual amount for the specified account(s) and period"
 msgstr ""
 
 #. module: spreadsheet_account
@@ -93,6 +111,12 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/spreadsheet_account/static/src/accounting_functions.js:0
 msgid "Set to TRUE to include unposted entries."
+msgstr ""
+
+#. module: spreadsheet_account
+#. odoo-javascript
+#: code:addons/spreadsheet_account/static/src/plugins/accounting_plugin.js:0
+msgid "The balance for given partners could not be computed."
 msgstr ""
 
 #. module: spreadsheet_account
@@ -136,6 +160,12 @@ msgstr ""
 #. module: spreadsheet_account
 #. odoo-javascript
 #: code:addons/spreadsheet_account/static/src/accounting_functions.js:0
+msgid "The partner ids (separated by a comma)."
+msgstr ""
+
+#. module: spreadsheet_account
+#. odoo-javascript
+#: code:addons/spreadsheet_account/static/src/accounting_functions.js:0
 msgid "The prefix of the accounts."
 msgstr ""
 
@@ -148,5 +178,13 @@ msgstr ""
 #. module: spreadsheet_account
 #. odoo-javascript
 #: code:addons/spreadsheet_account/static/src/accounting_functions.js:0
-msgid "Year offset applied to date_range."
+msgid ""
+"The prefix of the accounts. If none provided, all receivable and payable "
+"accounts will be used."
+msgstr ""
+
+#. module: spreadsheet_account
+#. odoo-javascript
+#: code:addons/spreadsheet_account/static/src/plugins/accounting_plugin.js:0
+msgid "The residual amount for given accounts could not be computed."
 msgstr ""

--- a/addons/spreadsheet_account/static/src/accounting_functions.js
+++ b/addons/spreadsheet_account/static/src/accounting_functions.js
@@ -140,19 +140,42 @@ export function parseAccountingDate(dateRange, locale) {
     }
 }
 
+const YEAR_OFFSET_ARG = arg("offset (number, default=0)", _t("Offset applied to the years."))
+const COMPANY_ARG = arg("company_id (number, optional)", _t("The company to target (Advanced)."))
+const POSTED_ARG = arg(
+    "include_unposted (boolean, default=FALSE)",
+    _t("Set to TRUE to include unposted entries.")
+)
+
 const ODOO_FIN_ARGS = () => [
     arg("account_codes (string)", _t("The prefix of the accounts.")),
     arg(
         "date_range (string, date)",
         _t(`The date range. Supported formats are "21/12/2022", "Q1/2022", "12/2022", and "2022".`)
     ),
-    arg("offset (number, default=0)", _t("Year offset applied to date_range.")),
-    arg("company_id (number, optional)", _t("The company to target (Advanced).")),
-    arg(
-        "include_unposted (boolean, default=FALSE)",
-        _t("Set to TRUE to include unposted entries.")
-    ),
+    YEAR_OFFSET_ARG,
+    COMPANY_ARG,
+    POSTED_ARG,
 ];
+
+const ODOO_RESIDUAL_ARGS = () => [
+    arg(
+        "account_codes (string, optional)",
+        _t("The prefix of the accounts. If none provided, all receivable and payable accounts will be used.")
+    ),
+    arg(
+        "date_range (string, date, optional)",
+        _t(`The date range. Supported formats are "21/12/2022", "Q1/2022", "12/2022", and "2022".`)
+    ),
+    YEAR_OFFSET_ARG,
+    COMPANY_ARG,
+    POSTED_ARG,
+];
+
+const ODOO_PARTNER_BALANCE_ARGS = () => {
+    const partner_arg = arg("partner_ids (string)", _t("The partner ids (separated by a comma)."));
+    return [partner_arg, ...ODOO_RESIDUAL_ARGS()];
+}
 
 functionRegistry.add("ODOO.CREDIT", {
     description: _t("Get the total credit for the specified account(s) and period."),
@@ -335,3 +358,82 @@ functionRegistry.add("ODOO.ACCOUNT.GROUP", {
         return accountTypes.join(",");
     },
 });
+
+functionRegistry.add("ODOO.RESIDUAL", {
+    description: _t("Return the residual amount for the specified account(s) and period"),
+    args: ODOO_RESIDUAL_ARGS(),
+    category: "Odoo",
+    returns: ["NUMBER"],
+    compute: function (
+        accountCodes,
+        dateRange,
+        offset = { value: 0 },
+        companyId = { value: null },
+        includeUnposted = { value: false }
+    ) {
+        const _accountCodes = toString(accountCodes)
+            .split(",")
+            .map((code) => code.trim())
+            .sort();
+        const _offset = toNumber(offset, this.locale);
+        if ( !dateRange?.value ) {
+            dateRange = { value: new Date().getFullYear() }
+        }
+        const _dateRange = parseAccountingDate(dateRange, this.locale);
+        const _companyId = toNumber(companyId, this.locale);
+        const _includeUnposted = toBoolean(includeUnposted);
+        return {
+            value: this.getters.getAccountResidual(
+                _accountCodes,
+                _dateRange,
+                _offset,
+                _companyId,
+                _includeUnposted
+            ),
+            format: this.getters.getCompanyCurrencyFormat(_companyId) || "#,##0.00",
+        };
+    },
+})
+
+functionRegistry.add("ODOO.PARTNER.BALANCE", {
+    description: _t("Return the partner balance for the specified account(s) and period"),
+    args: ODOO_PARTNER_BALANCE_ARGS(),
+    category: "Odoo",
+    returns: ["NUMBER"],
+    compute: function (
+        partnerIds,
+        accountCodes,
+        dateRange,
+        offset = { value: 0 },
+        companyId = { value: null },
+        includeUnposted = { value: false }
+    ) {
+        const _partnerIds = toString(partnerIds)
+            .split(",")
+            .map((partnerId) => toNumber(partnerId, this.locale))
+            .sort();
+        const _accountCodes = toString(accountCodes)
+            .split(",")
+            .map((code) => code.trim())
+            .sort();
+        const _offset = toNumber(offset, this.locale);
+
+        if ( !dateRange?.value ) {
+            dateRange = { value: new Date().getFullYear() }
+        }
+        const _dateRange = parseAccountingDate(dateRange, this.locale);
+        const _companyId = toNumber(companyId, this.locale);
+        const _includeUnposted = toBoolean(includeUnposted);
+        return {
+            value: this.getters.getAccountPartnerData(
+                _accountCodes,
+                _dateRange,
+                _offset,
+                _companyId,
+                _includeUnposted,
+                _partnerIds
+            ),
+            format: this.getters.getCompanyCurrencyFormat(_companyId) || "#,##0.00",
+        };
+    },
+})

--- a/addons/spreadsheet_account/static/src/index.js
+++ b/addons/spreadsheet_account/static/src/index.js
@@ -20,13 +20,31 @@ cellMenuRegistry.add("move_lines_see_records", {
         const position = env.model.getters.getActivePosition();
         const sheetId = position.sheetId;
         const cell = env.model.getters.getCell(position);
-        const { args } = getFirstAccountFunction(cell.compiledFormula.tokens);
-        let [codes, date_range, offset, companyId, includeUnposted] = args
-            .map(astToFormula)
-            .map((arg) => env.model.getters.evaluateFormulaResult(sheetId, arg));
-        codes = toString(codes?.value).split(",");
+        const func = getFirstAccountFunction(cell.compiledFormula.tokens);
+        let codes, partner_ids = "";
+        let date_range, offset, companyId, includeUnposted = false;
+        const parsed_args = func.args.map(astToFormula).map(
+            (arg) => env.model.getters.evaluateFormulaResult(sheetId, arg)
+        );
+        if ( func.functionName === "ODOO.PARTNER.BALANCE" ) {
+            [partner_ids, codes, date_range, offset, companyId, includeUnposted] = parsed_args;
+        } else {
+            [codes, date_range, offset, companyId, includeUnposted] = parsed_args;
+        }
+        if ( codes?.value && !isEvaluationError(codes.value) ) {
+            codes = toString(codes?.value).split(",").map((code) => code.trim());
+        } else {
+            codes = [];
+        }
         const locale = env.model.getters.getLocale();
-        const dateRange = parseAccountingDate(date_range, locale);
+        let dateRange;
+        if ( date_range?.value && !isEvaluationError(date_range.value) ) {
+            dateRange = parseAccountingDate(date_range, locale);
+        } else {
+            if ( ["ODOO.PARTNER.BALANCE", "ODOO.RESIDUAL"].includes(func.functionName) ) {
+                dateRange = parseAccountingDate({ value: new Date().getFullYear() }, locale);
+            }
+        }
         offset = parseInt(offset?.value) || 0;
         dateRange.year += offset || 0;
         companyId = parseInt(companyId?.value) || null;
@@ -35,11 +53,18 @@ cellMenuRegistry.add("move_lines_see_records", {
         } catch {
             includeUnposted = false;
         }
+        const partnerIds = toString(partner_ids).split(",").map((code) => code.trim());
 
+        let param;
+        if ( func.functionName === "ODOO.PARTNER.BALANCE" ) {
+            param = [camelToSnakeObject({ dateRange, companyId, codes, includeUnposted, partnerIds })]
+        } else {
+            param = [camelToSnakeObject({ dateRange, companyId, codes, includeUnposted })]
+        }
         const action = await env.services.orm.call(
             "account.account",
             "spreadsheet_move_line_action",
-            [camelToSnakeObject({ dateRange, companyId, codes, includeUnposted })]
+            param
         );
         await env.services.action.doAction(action);
     },

--- a/addons/spreadsheet_account/static/src/plugins/accounting_plugin.js
+++ b/addons/spreadsheet_account/static/src/plugins/accounting_plugin.js
@@ -18,6 +18,8 @@ export class AccountingPlugin extends OdooUIPlugin {
         "getAccountGroupCodes",
         "getFiscalStartDate",
         "getFiscalEndDate",
+        "getAccountResidual",
+        "getAccountPartnerData",
     ]);
     constructor(config) {
         super(config);
@@ -136,5 +138,67 @@ export class AccountingPlugin extends OdooUIPlugin {
             throw new EvaluationError(_t("The company fiscal year could not be found."));
         }
         return result;
+    }
+
+    /**
+     * Gets the residual amount for given account code prefixes over a given period
+     * @param {string[]} codes prefixes of the accounts codes
+     * @param {DateRange} dateRange start date of the period to look
+     * @param {number} offset year offset of the period to search
+     * @param {number} companyId specific company to target
+     * @param {boolean} includeUnposted whether or not select unposted entries
+     * @returns {number | undefined}
+     */
+    getAccountResidual(codes, dateRange, offset, companyId, includeUnposted) {
+        dateRange = deepCopy(dateRange);
+        dateRange.year += offset;
+        // Excel dates start at 1899-12-30, we should not support date ranges
+        // that do not cover dates prior to it.
+        // Unfortunately, this check needs to be done right before the server
+        // call as a date to low (year <= 1) can raise an error server side.
+        if (dateRange.year < 1900) {
+            throw new EvaluationError(_t("%s is not a valid year.", dateRange.year));
+        }
+        const result = this.serverData.batch.get(
+            "account.account",
+            "spreadsheet_fetch_residual_amount",
+            camelToSnakeObject({ codes, dateRange, companyId, includeUnposted })
+        );
+        if (result === false) {
+            throw new EvaluationError(_t("The residual amount for given accounts could not be computed."));
+        }
+        return result.amount_residual;
+    }
+
+    /**
+     * Fetch the account information for a given account code and partner
+     * @private
+     * @param {string[]} codes prefix of the accounts' codes
+     * @param {DateRange} dateRange start date of the period to look
+     * @param {number} offset year offset of the period to look
+     * @param {number | null} companyId specific companyId to target
+     * @param {boolean} includeUnposted wether or not select unposted entries
+     * @param {number[]} partnerIds ids of the partners
+     * @returns {number | undefined}
+     */
+    getAccountPartnerData(codes, dateRange, offset, companyId, includeUnposted, partnerIds) {
+        dateRange = deepCopy(dateRange);
+        dateRange.year += offset;
+        // Excel dates start at 1899-12-30, we should not support date ranges
+        // that do not cover dates prior to it.
+        // Unfortunately, this check needs to be done right before the server
+        // call as a date to low (year <= 1) can raise an error server side.
+        if (dateRange.year < 1900) {
+            throw new EvaluationError(_t("%s is not a valid year.", dateRange.year));
+        }
+        const result = this.serverData.batch.get(
+            "account.account",
+            "spreadsheet_fetch_partner_balance",
+            camelToSnakeObject({ dateRange, codes, companyId, includeUnposted, partnerIds })
+        );
+        if (result === false) {
+            throw new EvaluationError(_t("The balance for given partners could not be computed."));
+        }
+        return result.balance;
     }
 }

--- a/addons/spreadsheet_account/static/src/utils.js
+++ b/addons/spreadsheet_account/static/src/utils.js
@@ -15,7 +15,7 @@ const { getFunctionsFromTokens } = helpers;
  * @returns {number}
  */
 export function getNumberOfAccountFormulas(tokens) {
-    return getFunctionsFromTokens(tokens, ["ODOO.BALANCE", "ODOO.CREDIT", "ODOO.DEBIT"]).length;
+    return getFunctionsFromTokens(tokens, ["ODOO.BALANCE", "ODOO.CREDIT", "ODOO.DEBIT", "ODOO.RESIDUAL", "ODOO.PARTNER.BALANCE"]).length;
 }
 
 /**
@@ -25,5 +25,5 @@ export function getNumberOfAccountFormulas(tokens) {
  * @returns {OdooFunctionDescription | undefined}
  */
 export function getFirstAccountFunction(tokens) {
-    return getFunctionsFromTokens(tokens, ["ODOO.BALANCE", "ODOO.CREDIT", "ODOO.DEBIT"])[0];
+    return getFunctionsFromTokens(tokens, ["ODOO.BALANCE", "ODOO.CREDIT", "ODOO.DEBIT", "ODOO.RESIDUAL", "ODOO.PARTNER.BALANCE"])[0];
 }

--- a/addons/spreadsheet_account/static/tests/model/partner_balance.test.js
+++ b/addons/spreadsheet_account/static/tests/model/partner_balance.test.js
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { setCellContent } from "@spreadsheet/../tests/helpers/commands";
+import { getCellValue, getEvaluatedCell } from "@spreadsheet/../tests/helpers/getters";
+import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
+import {
+    defineSpreadsheetAccountModels,
+} from "@spreadsheet_account/../tests/accounting_test_data";
+import { waitForDataLoaded } from "@spreadsheet/helpers/model";
+
+describe.current.tags("headless");
+defineSpreadsheetAccountModels();
+
+test("Basic evaluation", async () => {
+    const model = await createModelWithDataSource({
+        mockRPC: async function (route, args) {
+            if (args.method === "spreadsheet_fetch_partner_balance") {
+                expect.step("spreadsheet_fetch_partner_balance");
+                expect(args.args[0]).toEqual([
+                    {
+                        partner_ids: [
+                            14, 16
+                        ],
+                        codes: [
+                            "112",
+                        ],
+                        date_range: {
+                            range_type: "year",
+                            year: 2023,
+                        },
+                        company_id: 0,
+                        include_unposted: false,
+                    },
+                ]);
+                return [{ balance: 26 }];
+            }
+        },
+    });
+    setCellContent(model, "A1", `=ODOO.PARTNER.BALANCE("14, 16", "112", 2023)`);
+    await waitForDataLoaded(model);
+    expect.verifySteps(["spreadsheet_fetch_partner_balance"]);
+    expect(getCellValue(model, "A1")).toBe(26);
+});
+
+test("with wrong date format", async () => {
+    const model = await createModelWithDataSource();
+    setCellContent(model, "A1", `=ODOO.PARTNER.BALANCE("14, 16", "112", "This is not a valid date")`);
+    await waitForDataLoaded(model);
+    expect(getEvaluatedCell(model, "A1").message).toBe(
+        "'This is not a valid date' is not a valid period. Supported formats are \"21/12/2022\", \"Q1/2022\", \"12/2022\", and \"2022\"."
+    );
+});
+
+test("with no date", async () => {
+    const model = await createModelWithDataSource({
+        mockRPC: async function (route, args) {
+            if (args.method === "spreadsheet_fetch_partner_balance") {
+                expect.step("spreadsheet_fetch_partner_balance");
+                expect(args.args[0]).toEqual([
+                    {
+                        partner_ids: [
+                            14, 16
+                        ],
+                        codes: [
+                            "112",
+                        ],
+                        date_range: {
+                            range_type: "year",
+                            year: new Date().getFullYear(),
+                        },
+                        company_id: 0,
+                        include_unposted: false,
+                    },
+                ]);
+                return [{ balance: 26 }];
+            }
+        },
+    });
+    setCellContent(model, "A1", `=ODOO.PARTNER.BALANCE("14, 16", "112")`);
+    await waitForDataLoaded(model);
+    expect.verifySteps(["spreadsheet_fetch_partner_balance"]);
+    expect(getCellValue(model, "A1")).toBe(26);
+});

--- a/addons/spreadsheet_account/static/tests/model/residual_amount.test.js
+++ b/addons/spreadsheet_account/static/tests/model/residual_amount.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { setCellContent } from "@spreadsheet/../tests/helpers/commands";
+import { getCellValue, getEvaluatedCell } from "@spreadsheet/../tests/helpers/getters";
+import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
+import {
+    defineSpreadsheetAccountModels,
+} from "@spreadsheet_account/../tests/accounting_test_data";
+import { waitForDataLoaded } from "@spreadsheet/helpers/model";
+
+describe.current.tags("headless");
+defineSpreadsheetAccountModels();
+
+test("Basic evaluation", async () => {
+    const model = await createModelWithDataSource({
+        mockRPC: async function (route, args) {
+            if (args.method === "spreadsheet_fetch_residual_amount") {
+                expect.step("spreadsheet_fetch_residual_amount");
+                expect(args.args[0]).toEqual([
+                    {
+                        codes: [
+                            "112",
+                        ],
+                        date_range: {
+                            range_type: "year",
+                            year: 2023,
+                        },
+                        company_id: 0,
+                        include_unposted: false,
+                    },
+                ]);
+                return [{ amount_residual: 111.11 }];
+            }
+        },
+    });
+    setCellContent(model, "A1", `=ODOO.RESIDUAL("112", 2023)`);
+    await waitForDataLoaded(model);
+    expect.verifySteps(["spreadsheet_fetch_residual_amount"]);
+    expect(getCellValue(model, "A1")).toBe(111.11);
+});
+
+test("with wrong date format", async () => {
+    const model = await createModelWithDataSource();
+    setCellContent(model, "A1", `=ODOO.RESIDUAL("112", "This is not a valid date")`);
+    await waitForDataLoaded(model);
+    expect(getEvaluatedCell(model, "A1").message).toBe(
+        "'This is not a valid date' is not a valid period. Supported formats are \"21/12/2022\", \"Q1/2022\", \"12/2022\", and \"2022\"."
+    );
+});
+
+test("with no date", async () => {
+    const model = await createModelWithDataSource({
+        mockRPC: async function (route, args) {
+            if (args.method === "spreadsheet_fetch_residual_amount") {
+                expect.step("spreadsheet_fetch_residual_amount");
+                expect(args.args[0]).toEqual([
+                    {
+                        codes: [
+                            "112",
+                        ],
+                        date_range: {
+                            range_type: "year",
+                            year: new Date().getFullYear(),
+                        },
+                        company_id: 0,
+                        include_unposted: false,
+                    },
+                ]);
+                return [{ amount_residual: 111.11 }];
+            }
+        },
+    });
+    setCellContent(model, "A1", `=ODOO.RESIDUAL("112")`);
+    await waitForDataLoaded(model);
+    expect.verifySteps(["spreadsheet_fetch_residual_amount"]);
+    expect(getCellValue(model, "A1")).toBe(111.11);
+});

--- a/addons/spreadsheet_account/tests/__init__.py
+++ b/addons/spreadsheet_account/tests/__init__.py
@@ -4,3 +4,5 @@
 from . import test_account_group
 from . import test_debit_credit
 from . import test_company_fiscal_year
+from . import test_residual_amount
+from . import test_partner_balance

--- a/addons/spreadsheet_account/tests/test_debit_credit.py
+++ b/addons/spreadsheet_account/tests/test_debit_credit.py
@@ -986,7 +986,7 @@ class SpreadsheetAccountingFunctionsTest(AccountTestInvoicingCommon):
                     ("company_id", "=", self.account_revenue_c1.company_ids.id),
                     ("move_id.state", "!=", "cancel"),
                 ],
-                "name": "Journal items for account prefix sp1234566",
+                "name": "Cell Audit",
             },
         )
 
@@ -1002,6 +1002,10 @@ class SpreadsheetAccountingFunctionsTest(AccountTestInvoicingCommon):
                 "include_unposted": True,
             }
         )
+        company = self.company_data['company']
+        payable_receivable_accounts = self.env['account.account'].with_company(company).search([
+            ('account_type', 'in', ['liability_payable', 'asset_receivable'])
+        ])
         self.assertEqual(
             action,
             {
@@ -1010,7 +1014,23 @@ class SpreadsheetAccountingFunctionsTest(AccountTestInvoicingCommon):
                 "view_mode": "list",
                 "views": [[False, "list"]],
                 "target": "current",
-                "domain": [(0, "=", 1)],
-                "name": "Journal items for account prefix ",
+                "domain": [
+                    "&",
+                    "&",
+                    "&",
+                    ("account_id", "in", payable_receivable_accounts.ids),
+                    "|",
+                    "&",
+                    ("account_id.include_initial_balance", "=", True),
+                    ("date", "<=", date(2022, 12, 31)),
+                    "&",
+                    "&",
+                    ("account_id.include_initial_balance", "=", False),
+                    ("date", ">=", date(2022, 1, 1)),
+                    ("date", "<=", date(2022, 12, 31)),
+                    ("company_id", "=", company.id),
+                    ("move_id.state", "!=", "cancel")
+                ],
+                "name": "Cell Audit",
             },
         )

--- a/addons/spreadsheet_account/tests/test_partner_balance.py
+++ b/addons/spreadsheet_account/tests/test_partner_balance.py
@@ -1,0 +1,226 @@
+from odoo import Command
+from odoo.tests import tagged
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('post_install', '-at_install')
+class SpreadsheetAccountingFunctionsTest(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.move_22 = cls.env['account.move'].create(
+            {
+                'company_id': cls.company_data['company'].id,
+                'move_type': 'entry',
+                'date': '2022-02-02',
+                'partner_id': cls.partner_a.id,
+                'line_ids': [
+                    Command.create(
+                        {
+                            'name': "line_debit_22",
+                            'account_id': cls.company_data['default_account_receivable'].id,
+                            'debit': 1500,
+                            'company_id': cls.company_data['company'].id,
+                        },
+                    ),
+                    Command.create(
+                        {
+                            'name': "line_credit_22",
+                            'account_id': cls.company_data['default_account_revenue'].id,
+                            'credit': 1500,
+                            'company_id': cls.company_data['company'].id,
+                        },
+                    ),
+                ],
+            }
+        )
+        cls.move_23 = cls.env['account.move'].create(
+            {
+                'company_id': cls.company_data['company'].id,
+                'move_type': 'entry',
+                'date': '2023-02-02',
+                'partner_id': cls.partner_a.id,
+                'line_ids': [
+                    Command.create(
+                        {
+                            'name': "line_debit_23",
+                            'account_id': cls.company_data['default_account_expense'].id,
+                            'debit': 2500,
+                            'company_id': cls.company_data['company'].id,
+                        },
+                    ),
+                    Command.create(
+                        {
+                            'name': "line_credit_23",
+                            'account_id': cls.company_data['default_account_payable'].id,
+                            'credit': 2500,
+                            'company_id': cls.company_data['company'].id,
+                        },
+                    ),
+                ],
+            }
+        )
+        cls.move_23_partner_b = cls.move_23.copy({'partner_id': cls.partner_b.id})
+
+    def test_partner_balance_empty_params(self):
+        self.assertEqual(self.env['account.account'].spreadsheet_fetch_partner_balance([]), [])
+
+    def test_partner_balance_no_account_codes(self):
+        ''' Tests that when no account codes are provided, we are returned the residual
+            amount for the receivable and payable accounts.
+        '''
+        (self.move_22 + self.move_23).action_post()
+        partner_balance = self.env['account.account'].spreadsheet_fetch_partner_balance([
+            {
+                'partner_ids': [self.move_23.partner_id.id],
+                'date_range': {
+                    'range_type': 'year',
+                    'year': 2023,
+                },
+                'codes': [],
+                'company_id': None,
+                'include_unposted': False,
+            },
+            {
+                'partner_ids': [self.move_23.partner_id.id],
+                'date_range': {
+                    'range_type': 'year',
+                    'year': 2023,
+                },
+                'codes': [self.company_data['default_account_receivable'].code],
+                'company_id': None,
+                'include_unposted': False,
+            }
+        ])
+        self.assertEqual(partner_balance, [{'balance': 1500 - 2500}, {'balance': 1500}])
+
+    def test_partner_balance_yearly(self):
+        ''' Test that only moves in the given year are returned when performing a yearly filtering. '''
+        partner_balance = self.env['account.account'].spreadsheet_fetch_partner_balance([
+            {
+                'partner_ids': [self.move_23.partner_id.id],
+                'date_range': {
+                    'range_type': 'year',
+                    'year': 2022,
+                },
+                'codes': [],
+                'company_id': None,
+                'include_unposted': True,
+            }
+        ])
+        self.assertEqual(partner_balance, [{'balance': 1500}])
+
+    def test_partner_balance_quarterly(self):
+        ''' Test that only moves in the given quarter are returned when performing a quarterly filtering. '''
+        partner_balance = self.env['account.account'].spreadsheet_fetch_partner_balance([
+            {
+                'partner_ids': [self.move_23.partner_id.id],
+                'date_range': {
+                    'range_type': 'quarter',
+                    'year': 2022,
+                    'quarter': 4,
+                },
+                'codes': [],
+                'company_id': None,
+                'include_unposted': True,
+            },
+            {
+                'partner_ids': [self.move_23.partner_id.id],
+                'date_range': {
+                    'range_type': 'quarter',
+                    'year': 2023,
+                    'quarter': 1,
+                },
+                'codes': [],
+                'company_id': None,
+                'include_unposted': True,
+            }
+        ])
+        self.assertEqual(partner_balance, [{'balance': 1500}, {'balance': 1500 - 2500}])
+
+    def test_partner_balance_daily(self):
+        ''' Test that only moves in the given day are returned when performing a daily filtering. '''
+        partner_balance = self.env['account.account'].spreadsheet_fetch_partner_balance([
+            {
+                'partner_ids': [self.move_23.partner_id.id],
+                'date_range': {
+                    'range_type': 'day',
+                    'year': 2022,
+                    'month': 2,
+                    'day': 1,
+                },
+                'codes': [],
+                'company_id': None,
+                'include_unposted': True,
+            },
+            {
+                'partner_ids': [self.move_23.partner_id.id],
+                'date_range': {
+                    'range_type': 'day',
+                    'year': 2022,
+                    'month': 2,
+                    'day': 2,
+                },
+                'codes': [],
+                'company_id': None,
+                'include_unposted': True,
+            }
+        ])
+        self.assertEqual(partner_balance, [{'balance': 0.0}, {'balance': 1500}])
+
+    def test_partner_balance_posted_filter(self):
+        partner_balance = self.env['account.account'].spreadsheet_fetch_partner_balance([
+            {
+                'partner_ids': [self.move_23.partner_id.id],
+                'date_range': {
+                    'range_type': 'year',
+                    'year': 2023,
+                },
+                'codes': [],
+                'company_id': None,
+                'include_unposted': False,
+            }
+        ])
+        self.assertEqual(partner_balance, [{'balance': 0.0}])
+
+        self.move_23.action_post()
+
+        partner_balance = self.env['account.account'].spreadsheet_fetch_partner_balance([
+            {
+                'partner_ids': [self.move_23.partner_id.id],
+                'date_range': {
+                    'range_type': 'year',
+                    'year': 2023,
+                },
+                'codes': [],
+                'company_id': None,
+                'include_unposted': False,
+            }
+        ])
+        self.assertNotEqual(partner_balance, [{'balance': 2500}])
+
+    def test_partner_filter(self):
+        partner_balance = self.env['account.account'].spreadsheet_fetch_partner_balance([
+            {
+                'partner_ids': [self.move_23.partner_id.id],
+                'date_range': {
+                    'range_type': 'year',
+                    'year': 2023,
+                },
+                'codes': [],
+                'company_id': None,
+                'include_unposted': True,
+            },
+            {
+                'partner_ids': [self.move_23_partner_b.partner_id.id],
+                'date_range': {
+                    'range_type': 'year',
+                    'year': 2023,
+                },
+                'codes': [],
+                'company_id': None,
+                'include_unposted': True,
+            },
+        ])
+        self.assertNotEqual(partner_balance, [{'balance': 1500 + 2500}, {'balance': 2500}])

--- a/addons/spreadsheet_account/tests/test_residual_amount.py
+++ b/addons/spreadsheet_account/tests/test_residual_amount.py
@@ -1,0 +1,194 @@
+from odoo import Command
+from odoo.tests import tagged
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('post_install', '-at_install')
+class SpreadsheetAccountingFunctionsTest(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.move_22 = cls.env['account.move'].create(
+            {
+                'company_id': cls.company_data['company'].id,
+                'move_type': 'entry',
+                'date': '2022-02-02',
+                'line_ids': [
+                    Command.create(
+                        {
+                            'name': "line_debit_22",
+                            'account_id': cls.company_data['default_account_receivable'].id,
+                            'debit': 1500,
+                            'company_id': cls.company_data['company'].id,
+                        },
+                    ),
+                    Command.create(
+                        {
+                            'name': "line_credit_22",
+                            'account_id': cls.company_data['default_account_revenue'].id,
+                            'credit': 1500,
+                            'company_id': cls.company_data['company'].id,
+                        },
+                    ),
+                ],
+            }
+        )
+        cls.move_23 = cls.env['account.move'].create(
+            {
+                'company_id': cls.company_data['company'].id,
+                'move_type': 'entry',
+                'date': '2023-02-02',
+                'line_ids': [
+                    Command.create(
+                        {
+                            'name': "line_debit_23",
+                            'account_id': cls.company_data['default_account_expense'].id,
+                            'debit': 2500,
+                            'company_id': cls.company_data['company'].id,
+                        },
+                    ),
+                    Command.create(
+                        {
+                            'name': "line_credit_23",
+                            'account_id': cls.company_data['default_account_payable'].id,
+                            'credit': 2500,
+                            'company_id': cls.company_data['company'].id,
+                        },
+                    ),
+                ],
+            }
+        )
+
+        cls.payment_move_22 = cls.env['account.payment'].create({
+            'amount': 150.0,
+            'payment_type': 'inbound',
+            'partner_type': 'customer',
+            'partner_id': cls.partner_a.id,
+            'date': '2022-02-10',
+        })
+
+        cls.payment_move_23 = cls.env['account.payment'].create({
+            'amount': 250.0,
+            'payment_type': 'outbound',
+            'partner_type': 'customer',
+            'partner_id': cls.partner_a.id,
+            'date': '2023-02-10',
+        })
+
+        # Post the move and payment and reconcile them
+        (cls.move_22 + cls.move_23).action_post()
+        (cls.payment_move_22 + cls.payment_move_23).action_post()
+        (cls.move_22 + cls.payment_move_22.move_id).line_ids\
+            .filtered(lambda line: line.account_type == 'asset_receivable')\
+            .reconcile()
+        (cls.move_23 + cls.payment_move_23.move_id).line_ids\
+            .filtered(lambda line: line.account_type == 'asset_receivable')\
+            .reconcile()
+
+    def test_residual_empty_params(self):
+        self.assertEqual(self.env['account.account'].spreadsheet_fetch_residual_amount([]), [])
+
+    def test_residual_no_account_codes(self):
+        ''' Tests that when no account codes are provided, we are returned the residual
+            amount for the receivable and payable accounts.
+        '''
+        residual_amount = self.env['account.account'].spreadsheet_fetch_residual_amount([
+            {
+                'date_range': {
+                    'range_type': 'year',
+                    'year': 2023,
+                },
+                'codes': [],
+                'company_id': None,
+                'include_unposted': False,
+            },
+            {
+                'date_range': {
+                    'range_type': 'year',
+                    'year': 2023,
+                },
+                'codes': [self.company_data['default_account_receivable'].code],
+                'company_id': None,
+                'include_unposted': False,
+            }
+        ])
+        self.assertEqual(residual_amount, [
+            {'amount_residual': 1500 - 2500 + 250 - 150},
+            {'amount_residual': 1500 + 250 - 150}
+        ])
+
+    def test_residual_yearly(self):
+        ''' Test that only moves in the given year are returned when performing a yearly filtering. '''
+        residual_amount = self.env['account.account'].spreadsheet_fetch_residual_amount([
+            {
+                'date_range': {
+                    'range_type': 'year',
+                    'year': 2022,
+                },
+                'codes': [],
+                'company_id': None,
+                'include_unposted': True,
+            }
+        ])
+        self.assertEqual(residual_amount, [{'amount_residual': 1500 - 150}])
+
+    def test_residual_quarterly(self):
+        ''' Test that only moves in the given quarter are returned when performing a quarterly filtering. '''
+        residual_amount = self.env['account.account'].spreadsheet_fetch_residual_amount([
+            {
+                'date_range': {
+                    'range_type': 'quarter',
+                    'year': 2022,
+                    'quarter': 4,
+                },
+                'codes': [],
+                'company_id': None,
+                'include_unposted': False,
+            },
+            {
+                'date_range': {
+                    'range_type': 'quarter',
+                    'year': 2023,
+                    'quarter': 1,
+                },
+                'codes': [],
+                'company_id': None,
+                'include_unposted': False,
+            }
+        ])
+        self.assertEqual(residual_amount, [
+            {'amount_residual': 1500 - 150},
+            {'amount_residual': 1500 - 2500 - 150 + 250},
+        ])
+
+    def test_residual_daily(self):
+        ''' Test that only moves in the given day are returned when performing a daily filtering. '''
+        residual_amount = self.env['account.account'].spreadsheet_fetch_residual_amount([
+            {
+                'date_range': {
+                    'range_type': 'day',
+                    'year': 2022,
+                    'month': 2,
+                    'day': 1,
+                },
+                'codes': [],
+                'company_id': None,
+                'include_unposted': False,
+            },
+            {
+                'date_range': {
+                    'range_type': 'day',
+                    'year': 2022,
+                    'month': 2,
+                    'day': 2,
+                },
+                'codes': [],
+                'company_id': None,
+                'include_unposted': False,
+            }
+        ])
+        self.assertEqual(residual_amount, [
+            {'amount_residual': 0.0},
+            {'amount_residual': 1500 - 150},
+        ])


### PR DESCRIPTION
Problem
---------
There is currently no formula to get the residual amount of accounts nor to get the balance of a partner in a given period of time in spreadsheets.

Objective
---------
Add the formula ODOO.RESIDUAL and ODOO.PARTNER.BALANCE that do just that

ODOO.RESIDUAL should take the following parameters:
- account_codes (mandatory)(can be more than one separate by ,): could be optional, in that case it could set the domain to all receivables/payables accounts
- due_date_range or expected_date (optional): date range referred to due dates (not AML date)
- offset (optional): adding the possibility of the offset to be not only “Year” but also, a specific date or other periods like Month, Quarter.
- company_id (optional)
- include_unposted (optional) (default: false)

ODOO.PARTNER.BALANCE should take the following paramters:
- partner_ids (mandatory) (can be more than one separate by ,)
- accound_codes (optional) (the prefix of the account(s))
- date_range (optional) (21/12/2022,Q1 2022, 12/2022, 2022)
- offset (optional) (default: 0)
- company_id (optional)
- include_unposted (optional) (default: false)

Solution
---------
1. Define the spreadsheet function with the correct parameters in `accounting_function.js`
2. Hook it to the data source so that it can perform server calls
3. Craft that server python function to returns the list a residual amounts for the given list of parameters.
4. Adds some tests.

Task-3679808

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
