### PR TITLE
[FIX] point_of_sale: correctly print attribute name of cancelled orde…

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -303,15 +303,13 @@ export class PosOrder extends Base {
                         line.getQuantity();
                 } else {
                     this.last_order_preparation_change.lines[line.preparationKey] = {
-                        attribute_value_ids: line.attribute_value_ids.map((a) => ({
-                            ...a.serialize({ orm: true }),
-                            name: a.name,
-                        })),
+                        attribute_value_names: line.attribute_value_ids.map((a) => a.name),
                         uuid: line.uuid,
                         isCombo: line.combo_item_id?.id,
                         product_id: line.getProduct().id,
                         name: line.getFullProductName(),
                         basic_name: line.getProduct().name,
+                        display_name: line.getProduct().display_name,
                         note: line.getNote(),
                         quantity: line.getQuantity(),
                     };

--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -72,7 +72,7 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
                 basic_name: orderline.product_id.name,
                 isCombo: orderline.combo_item_id?.id,
                 product_id: product.id,
-                attribute_value_ids: orderline.attribute_value_ids.map((a) => a.name),
+                attribute_value_names: orderline.attribute_value_ids.map((a) => a.name),
                 quantity: quantityDiff,
                 note: note,
                 pos_categ_id: product.pos_categ_ids[0]?.id ?? 0,
@@ -124,9 +124,10 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
                     product_id: lineResume["product_id"],
                     name: lineResume["name"],
                     basic_name: lineResume["basic_name"],
+                    display_name: lineResume["display_name"],
                     isCombo: lineResume["isCombo"],
                     note: lineResume["note"],
-                    attribute_value_ids: lineResume["attribute_value_ids"],
+                    attribute_value_names: lineResume["attribute_value_names"],
                     quantity: -quantity,
                 };
                 changeAbsCount += Math.abs(quantity);

--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -55,8 +55,8 @@
             <div class="d-flex medium">
                 <span class="me-3" t-esc="line.quantity"/> <span class="product-name" t-esc="line.display_name"/>
             </div>
-            <div t-if="line.attribute_value_ids?.length" class="mx-5 fs-2">
-                <t t-foreach="line.attribute_value_ids" t-as="name" t-key="name_index">
+            <div t-if="line.attribute_value_names?.length" class="mx-5 fs-2">
+                <t t-foreach="line.attribute_value_names" t-as="name" t-key="name_index">
                     <p class="p-0 m-0">
                         - <t t-esc="name" /><br/>
                     </p>


### PR DESCRIPTION
Before this commit, the name of a canceled order line attribute was incorrectly printed as [object Object] on the preparation printer ticket.

This commit fixes the issue by ensuring the correct attribute name is printed.

Steps to reproduce:
- Configure a preparation printer for the restaurant
- Order a product that has attribute.
- Cancel this order 
- The preparation printer incorrectly prints “- [object Object]

Task-4500890

