### PR TITLE
[FIX] mail: fix error when sending mail notifications with no author

### DIFF
--- a/addons/mail/data/mail_templates_email_layouts.xml
+++ b/addons/mail/data/mail_templates_email_layouts.xml
@@ -11,7 +11,7 @@
 <t t-set="show_header" t-value="email_notification_force_header or (
     email_notification_allow_header and has_button_access)"/>
 <t t-set="show_footer" t-value="email_notification_force_footer or (
-    email_notification_allow_footer and show_header and author_user._is_internal())"/>
+    email_notification_allow_footer and show_header and author_user and author_user._is_internal())"/>
 <!-- HEADER -->
 <t t-call="mail.notification_preview"/>
 <div style="max-width: 900px; width: 100%;">


### PR DESCRIPTION
There are instances where an email notification may not have an associated author. In the mail notification template, we forgot to check that the author exists before calling the `_is_internal` on it. When the author is `False`, the function generating the mail crashes as the `_is_internal` function is undefined on a boolean variable.

To address this issue, we will ensure the existence of the author before invoking any methods defined in the `res.users` model. This solution prevents errors and ensures the email template functions correctly.

see: #190390

Task-4128966

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
