### PR TITLE
[FIX] account: validate entire structured reference

### DIFF
--- a/addons/account/tests/test_structured_reference.py
+++ b/addons/account/tests/test_structured_reference.py
@@ -24,6 +24,8 @@ class StructuredReferenceTest(TransactionCase):
         self.assertFalse(is_valid_structured_reference_iso('18539007547034RF'))
         # Does not validate invalid checksum
         self.assertFalse(is_valid_structured_reference_iso('RF17539007547034'))
+        # Validates the entire string
+        self.assertFalse(is_valid_structured_reference_be('RF18539007547034-OTHER-RANDOM-STUFF'))
 
     def test_structured_reference_be(self):
         # Accepts references in both structured formats
@@ -38,6 +40,8 @@ class StructuredReferenceTest(TransactionCase):
         self.assertFalse(is_valid_structured_reference_be('***02/03430/57642***'))
         # Does not validate invalid checksum
         self.assertFalse(is_valid_structured_reference_be('020343057641'))
+        # Validates the entire string
+        self.assertFalse(is_valid_structured_reference_be('020343053497-OTHER-RANDOM-STUFF'))
 
     def test_structured_reference_fi(self):
         # Accepts references in structured format
@@ -53,6 +57,8 @@ class StructuredReferenceTest(TransactionCase):
         self.assertFalse(is_valid_structured_reference_fi('000000000002023000098'))
         # Does not validate invalid checksum
         self.assertFalse(is_valid_structured_reference_fi('2023000095'))
+        # Validates the entire string
+        self.assertFalse(is_valid_structured_reference_fi('2023000098-OTHER-RANDOM-STUFF'))
 
     def test_structured_reference_no_se(self):
         # Accepts references in structured format
@@ -66,3 +72,5 @@ class StructuredReferenceTest(TransactionCase):
         self.assertFalse(is_valid_structured_reference_no_se('1234/5678/97'))
         # Does not validate invalid checksum
         self.assertFalse(is_valid_structured_reference_no_se('1234567898'))
+        # Validates the entire string
+        self.assertFalse(is_valid_structured_reference_no_se('1234567897-OTHER-RANDOM-STUFF'))

--- a/addons/account/tools/structured_reference.py
+++ b/addons/account/tools/structured_reference.py
@@ -43,7 +43,7 @@ def is_valid_structured_reference_be(reference):
     :param reference: the reference to check
     """
     ref = sanitize_structured_reference(reference)
-    be_ref = re.match(r'(\d{10})(\d{2})', ref)
+    be_ref = re.fullmatch(r'(\d{10})(\d{2})', ref)
     return be_ref and int(be_ref.group(1)) % 97 == int(be_ref.group(2)) % 97
 
 def is_valid_structured_reference_fi(reference):
@@ -52,7 +52,7 @@ def is_valid_structured_reference_fi(reference):
     :param reference: the reference to check
     """
     ref = sanitize_structured_reference(reference)
-    fi_ref = re.match(r'(\d{1,19})(\d)', ref)
+    fi_ref = re.fullmatch(r'(\d{1,19})(\d)', ref)
     if not fi_ref:
         return False
     total = sum((7, 3, 1)[idx % 3] * int(val) for idx, val in enumerate(fi_ref.group(1)[::-1]))
@@ -65,5 +65,5 @@ def is_valid_structured_reference_no_se(reference):
     :param reference: the reference to check
     """
     ref = sanitize_structured_reference(reference)
-    no_se_ref = re.match(r'\d+', ref)
+    no_se_ref = re.fullmatch(r'\d+', ref)
     return no_se_ref and luhn.is_valid(ref)


### PR DESCRIPTION
In SEPA payment files, when a structured reference is used, it is put in the section `RmtInf/Strd/CdtrRefInf/Ref`. This section has a maximum length of 35 characters. Since we only use structured references that are always less that 35 characters, this should not be a problem.

However, the way we validated the structured reference was by performing a `re.match()`, which only matches from the beginning of the string. So if more characters would be after the structured reference, it would still match and it would be possible to go beyond 35 characters.

In this commit, we fix this by using a full match instead of a match from the beginning.

[opw-4357554](https://www.odoo.com/odoo/project.task/4357554)