### PR TITLE
[IMP] account_accountant: use better management of invalid statements

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.0\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 13:22+0000\n"
 "PO-Revision-Date: 2025-02-10 13:22+0000\n"
@@ -3034,6 +3034,11 @@ msgid "Automatic Entry Default Journal"
 msgstr ""
 
 #. module: account
+#: model:account.fiscal.position,name:account.1_account_fiscal_position_avatax_us
+msgid "Automatic Tax Mapping (AvaTax)"
+msgstr ""
+
+#. module: account
 #: model:ir.model,name:account.model_sequence_mixin
 msgid "Automatic sequence"
 msgstr ""
@@ -3551,6 +3556,11 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields.selection,name:account.selection__res_partner__invoice_warn__block
 msgid "Blocking Message"
+msgstr ""
+
+#. module: account
+#: model:res.groups,name:account.group_account_user
+msgid "Bookkeeper"
 msgstr ""
 
 #. module: account
@@ -7511,6 +7521,12 @@ msgid "Has Iban Warning"
 msgstr ""
 
 #. module: account
+#: model:ir.model.fields,field_description:account.field_account_bank_statement__journal_has_invalid_statements
+#: model:ir.model.fields,field_description:account.field_account_journal__has_invalid_statements
+msgid "Has Invalid Statements"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__has_message
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__has_message
 #: model:ir.model.fields,field_description:account.field_account_journal__has_message
@@ -8294,6 +8310,11 @@ msgstr ""
 msgid ""
 "Invalid \"Zip Range\", You have to configure both \"From\" and \"To\" values"
 " for the zip range and \"To\" should be greater than \"From\"."
+msgstr ""
+
+#. module: account
+#: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
+msgid "Invalid Statement(s)"
 msgstr ""
 
 #. module: account
@@ -10945,7 +10966,6 @@ msgstr ""
 #. module: account
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
-#: model:account.account,name:account.1_account_journal_payment_credit_account_id
 msgid "Outstanding Payments"
 msgstr ""
 
@@ -10957,7 +10977,6 @@ msgstr ""
 #. module: account
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
-#: model:account.account,name:account.1_account_journal_payment_debit_account_id
 msgid "Outstanding Receipts"
 msgstr ""
 
@@ -12136,6 +12155,11 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_resequence_view
 msgid "Re-Sequence"
+msgstr ""
+
+#. module: account
+#: model:res.groups,name:account.group_account_readonly
+msgid "Read-only"
 msgstr ""
 
 #. module: account
@@ -13443,11 +13467,6 @@ msgid ""
 msgstr ""
 
 #. module: account
-#: model:res.groups,name:account.group_account_readonly
-msgid "Show Accounting Features - Readonly"
-msgstr ""
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_res_partner__show_credit_limit
 #: model:ir.model.fields,field_description:account.field_res_users__show_credit_limit
 msgid "Show Credit Limit"
@@ -13473,11 +13492,6 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model_line__show_force_tax_included
 msgid "Show Force Tax Included"
-msgstr ""
-
-#. module: account
-#: model:res.groups,name:account.group_account_user
-msgid "Show Full Accounting Features"
 msgstr ""
 
 #. module: account
@@ -16012,6 +16026,7 @@ msgid "Transaction Type Parameter"
 msgstr ""
 
 #. module: account
+#: model:ir.model.fields,field_description:account.field_account_bank_statement__line_ids_count
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
 msgid "Transactions"
 msgstr ""
@@ -16967,6 +16982,14 @@ msgid ""
 "1/ click on the top-right button 'Journal Entries' from this journal form\n"
 "2/ then filter on 'Draft' entries\n"
 "3/ select them all and post or delete them through the action menu"
+msgstr ""
+
+#. module: account
+#. odoo-python
+#: code:addons/account/models/account_bank_statement_line.py:0
+msgid ""
+"You can not delete a transaction from a valid statement.\n"
+"If you want to delete it, please remove the statement first."
 msgstr ""
 
 #. module: account

--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -76,6 +76,11 @@ class AccountBankStatement(models.Model):
         string='Statement lines',
     )
 
+    line_ids_count = fields.Integer(
+        string="Transactions",
+        compute="_compute_line_ids_count"
+    )
+
     # A statement assumed to be complete when the sum of encoded lines is equal to the difference between start and
     # end balances.
     is_complete = fields.Boolean(
@@ -91,6 +96,10 @@ class AccountBankStatement(models.Model):
     is_valid = fields.Boolean(
         compute='_compute_is_valid',
         search='_search_is_valid',
+    )
+
+    journal_has_invalid_statements = fields.Boolean(
+        related='journal_id.has_invalid_statements'
     )
 
     problem_description = fields.Text(
@@ -118,6 +127,11 @@ class AccountBankStatement(models.Model):
     # -------------------------------------------------------------------------
     # COMPUTE METHODS
     # -------------------------------------------------------------------------
+
+    @api.depends('line_ids')
+    def _compute_line_ids_count(self):
+        for stmt in self:
+            stmt.line_ids_count = len(stmt.line_ids)
 
     @api.depends('create_date')
     def _compute_name(self):

--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -76,11 +76,6 @@ class AccountBankStatement(models.Model):
         string='Statement lines',
     )
 
-    line_ids_count = fields.Integer(
-        string="Transactions",
-        compute="_compute_line_ids_count"
-    )
-
     # A statement assumed to be complete when the sum of encoded lines is equal to the difference between start and
     # end balances.
     is_complete = fields.Boolean(
@@ -127,11 +122,6 @@ class AccountBankStatement(models.Model):
     # -------------------------------------------------------------------------
     # COMPUTE METHODS
     # -------------------------------------------------------------------------
-
-    @api.depends('line_ids')
-    def _compute_line_ids_count(self):
-        for stmt in self:
-            stmt.line_ids_count = len(stmt.line_ids)
 
     @api.depends('create_date')
     def _compute_name(self):

--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -443,6 +443,7 @@ class AccountBankStatementLine(models.Model):
 
     def unlink(self):
         # OVERRIDE to unlink the inherited account.move (move_id field) as well.
+        self._check_allow_unlink()
         tracked_lines = self.filtered(lambda stl: stl.company_id.check_account_audit_trail)
         tracked_lines.move_id.button_cancel()
         moves_to_delete = (self - tracked_lines).move_id
@@ -488,6 +489,12 @@ class AccountBankStatementLine(models.Model):
     # -------------------------------------------------------------------------
     # HELPERS
     # -------------------------------------------------------------------------
+
+    def _check_allow_unlink(self):
+        valid_statements = self.statement_id.filtered(lambda stmt: stmt.is_valid and stmt.is_complete)
+        if valid_statements:
+            raise UserError(_("You can not delete a transaction from a valid statement.\n"
+                              "If you want to delete it, please remove the statement first."))
 
     def _find_or_create_bank_account(self):
         self.ensure_one()

--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -443,7 +443,6 @@ class AccountBankStatementLine(models.Model):
 
     def unlink(self):
         # OVERRIDE to unlink the inherited account.move (move_id field) as well.
-        self._check_allow_unlink()
         tracked_lines = self.filtered(lambda stl: stl.company_id.check_account_audit_trail)
         tracked_lines.move_id.button_cancel()
         moves_to_delete = (self - tracked_lines).move_id
@@ -490,9 +489,9 @@ class AccountBankStatementLine(models.Model):
     # HELPERS
     # -------------------------------------------------------------------------
 
+    @api.ondelete(at_uninstall=False)
     def _check_allow_unlink(self):
-        valid_statements = self.statement_id.filtered(lambda stmt: stmt.is_valid and stmt.is_complete)
-        if valid_statements:
+        if self.statement_id.filtered(lambda stmt: stmt.is_valid and stmt.is_complete):
             raise UserError(_("You can not delete a transaction from a valid statement.\n"
                               "If you want to delete it, please remove the statement first."))
 

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -230,10 +230,14 @@ class AccountJournal(models.Model):
     ]
 
     def _compute_has_invalid_statements(self):
-        invalid_statements_domain = [('journal_id', 'in', self.ids), '|', ('is_valid', '=', False), ('is_complete', '=', False)]
-        journals_with_invalid_statements = self.env['account.bank.statement'].search(invalid_statements_domain).mapped('journal_id')
-        (self - journals_with_invalid_statements).has_invalid_statements = False
+        journals_with_invalid_statements = self.env['account.bank.statement'].search([
+            ('journal_id', 'in', self.ids), 
+            '|',
+            ('is_valid', '=', False),
+            ('is_complete', '=', False),
+        ]).journal_id
         journals_with_invalid_statements.has_invalid_statements = True
+        (self - journals_with_invalid_statements).has_invalid_statements = False
 
     def _compute_display_alias_fields(self):
         self.display_alias_fields = self.env['mail.alias.domain'].search_count([], limit=1)

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -286,7 +286,7 @@
                             </div>
                             <t t-call="JournalChecks"/>
                             <t t-if="dashboard.has_invalid_statements">
-                                <div class="row" name="invalid_statements">
+                                <div class="row">
                                     <a type="object"
                                         name="open_invalid_statements_action"
                                         title="Invalid Statement(s)"

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -252,7 +252,7 @@
                                     <span dir="ltr"><t t-out="dashboard.account_balance"/></span>
                                 </div>
                             </div>
-                            <t t-if="dashboard.has_at_least_one_statement and dashboard.account_balance != dashboard.last_balance">
+                            <t t-if="dashboard.has_at_least_one_statement and dashboard.account_balance != dashboard.last_balance and dashboard.last_statement_visible">
                                 <div class="row" name="latest_statement">
                                     <div class="col overflow-hidden text-start">
                                         <span title="Latest Statement">Last Statement</span>
@@ -285,6 +285,16 @@
                                 </div>
                             </div>
                             <t t-call="JournalChecks"/>
+                            <t t-if="dashboard.has_invalid_statements">
+                                <div class="row" name="invalid_statements">
+                                    <a type="object"
+                                        name="open_invalid_statements_action"
+                                        title="Invalid Statement(s)"
+                                        class="text-danger">
+                                        Invalid Statement(s)
+                                    </a>
+                                </div>
+                            </t>
                         </div>
                     </t>
                     <t t-name="JournalBodySalePurchase" id="account.JournalBodySalePurchase">


### PR DESCRIPTION
This commit brings more clarity on invalid statements. The reflected
changes are :
- Hiding Last Statement if its date is <= Lock Date
- "Invalid Statement(s)" alert on the journal dashboard
- Red balance amount and warning in the BankRecW when it contains
invalid statements (clicking on the warning applies the filter)
- Possibility to choose a statement when creating a transaction
- Invalid statement warning in the statement creation form
- Displays all warnings in the statement form view
- When a file generate a statement, it is kept in its attachments
- Prevent deletion of transactions if they belong to a valid statement
- Empty statement are not taken into account for the dashboard
Last Statement and the BankRecW balance

task-4413473