### PR TITLE
[FIX] base_vat: add a method to validate Moroccan VAT numbers

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -57,6 +57,7 @@ _ref_vat = {
     'lt': 'LT123456715',
     'lu': 'LU12345613',
     'lv': 'LV41234567891',
+    'ma': '12345678',
     'mc': 'FR53000004605',
     'mt': 'MT12345634',
     'mx': _('MXGODE561231GR8 or GODE561231GR8'),
@@ -788,6 +789,9 @@ class ResPartner(models.Model):
     def check_vat_il(self, vat):
         check_func = stdnum.util.get_cc_module('il', 'idnr').is_valid
         return check_func(vat)
+
+    def check_vat_ma(self, vat):
+        return vat.isdigit() and len(vat) == 8
 
     def format_vat_sm(self, vat):
         stdnum_vat_format = stdnum.util.get_cc_module('sm', 'vat').compact


### PR DESCRIPTION
### Steps to reproduce:
- Create a new Contact
- Set the country to Morocco
- Add "52258521" as a VAT number
- Try to validate -> Error

### Cause:
Only occurs after saas-17.4 because it is related to the library `stdnum`. The version of this library change when the Python version is >3.11.  As the SaaS version use Python3.12 since saas-17.4 and Python3.10 before, the bug only appears in saas-17.4, but this change targets 17.0 because 17.0 supports Python > 3.10.

The cause of the bug is the new version of the library which implements a verification method that corresponds to Moroccan ICE numbers and not VAT numbers.

### Solution:
Create the method to check the Moroccan VAT numbers. The format is just a number with 8 digits.

opw-4447478