### PR TITLE
[FIX] mail: prevent traceback error when deleting quotation attachment

### DIFF
--- a/addons/mail/static/src/core/web/mail_composer_attachment_list.js
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_list.js
@@ -20,7 +20,9 @@ export class MailComposerAttachmentList extends Many2ManyBinaryField {
     async onFileRemove(fileId) {
         super.onFileRemove(fileId);
         const attachment = this.mailStore.Attachment.get(fileId);
-        await this.attachmentUploadService.unlink(attachment);
+        if (attachment) {
+            await this.attachmentUploadService.unlink(attachment);
+        }
     }
 }
 

--- a/addons/sale/static/tests/tours/mail_attachment_removal_test_tour.js
+++ b/addons/sale/static/tests/tours/mail_attachment_removal_test_tour.js
@@ -1,0 +1,32 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("mail_attachment_removal_tour", {
+    steps: () => [
+
+    {
+        content: "click on send by email",
+        trigger: ".o_statusbar_buttons > button[name='action_quotation_send']",
+        run: "click"
+    },
+    {
+        content: "save a new layout",
+        trigger: ".o_technical_modal button[name='document_layout_save']",
+        run: "click"
+    },
+    {
+        content: "delete attachment",
+        trigger: ".o_field_widget[name='attachment_ids'] li > button .fa-times",
+        run: "click"
+    },
+    {
+        content: "send the email",
+        trigger: ".o_mail_send",
+        run: "click"
+    },
+    {
+        content: "confirm quotation",
+        trigger: ".o_menu_brand",
+        run: "click"
+    }
+]
+})


### PR DESCRIPTION
**Issue**:
A traceback error is raised when deleting the quotation attachment before sending it via email.

**Steps to reproduce:**
	- go to Sales.
	- open a quotation.
	- click "Send by Email."
	- delete the attachment.

A traceback error occurs.

opw-4486182
