### PR TITLE
[FIX] account: address product price rounding discrepancy in tax computation

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -626,7 +626,6 @@ class AccountTax(models.Model):
                     else:
                         # tax.amount_type == other (python)
                         tax_amount = tax._compute_amount(base, sign * price_unit, quantity, product, partner, fixed_multiplicator)
-                        tax_amount = float_round(tax_amount, precision_rounding=prec)
                         incl_tax_amounts['fixed_amount'] += tax_amount
                         # Avoid unecessary re-computation
                         cached_tax_amounts[i] = tax_amount
@@ -686,8 +685,7 @@ class AccountTax(models.Model):
                     tax_base_amount, sign * price_unit, quantity, product, partner, fixed_multiplicator)
 
             # Round the tax_amount multiplied by the computed repartition lines factor.
-            tax_amount = float_round(tax_amount, precision_rounding=prec)
-            factorized_tax_amount = float_round(tax_amount * sum_repartition_factor, precision_rounding=prec)
+            factorized_tax_amount = tax_amount * sum_repartition_factor
 
             if price_include and total_included_checkpoints.get(i) is None:
                 cumulated_tax_included_amount += factorized_tax_amount
@@ -770,7 +768,7 @@ class AccountTax(models.Model):
             'base_tags': base_rep_lines.tag_ids.ids + product_tag_ids,
             'taxes': taxes_vals,
             'total_excluded': sign * total_excluded,
-            'total_included': sign * currency.round(total_included),
+            'total_included': sign * total_included,
             'total_void': sign * total_void,
         }
 


### PR DESCRIPTION
The customer reported a rounding discrepancy in product price calculations. For instance, a product priced at 12,632.0160 with a 25% tax should result in a total of 15,790.02, but in Odoo versions 16 and 17, it incorrectly displays 15,790.03.

This issue occurs because tax calculations in versions 16 and 17 round intermediate tax amounts during computation. This behavior leads to slight inaccuracies in the final total.

In version 18, the tax computation has been updated to avoid rounding during intermediate steps, aligning with the product owner’s decision to calculate taxes without intermediate rounding. This ensures that the total amount reflects the exact tax computation.

This commit removes the rounding during intermediate steps in tax computation to align with the behavior introduced in version 18. It specifically addresses the rounding discrepancy issue without refactoring the entire tax computation logic, as that was already done in version 18.

opw-4471913

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
