### PR TITLE
[FIX] account: fix autopost of bills

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -956,7 +956,7 @@ class AccountJournal(models.Model):
                 'move_type': move_type,
             })
 
-            invoice._extend_with_attachments(attachment, new=True)
+            invoice.with_context(skip_is_manually_modified=True)._extend_with_attachments(attachment, new=True)
 
             all_invoices |= invoice
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4137,6 +4137,7 @@ class AccountMove(models.Model):
                 continue
 
             decoder = (current_invoice or current_invoice.new(self.default_get(['move_type', 'journal_id'])))._get_edi_decoder(file_data, new=new)
+            current_invoice.flush_recordset()
             if decoder or file_data['type'] in ('pdf', 'binary'):
                 try:
                     with self.env.cr.savepoint():


### PR DESCRIPTION
In b1046c8156ee3d3699d5b229720134cc3b2532d4, we introduced a new feature to allow autoposting of bills. When a user does not modify the imported bill for 3 consecutive times, we ask the user if he wants to activate the feature.

To detect whether the user has modified the imported bill or not, we use a new field `is_manually_modified` which is always set to `True` when the bill is edited except for automatic flows (OCR, CRON, email).

test_autopost_bills will fail when the l10n_eg_edi_eta module is installed. This is due to fact that calling import_facturx will end up calling _extend_with_attachments, which in turn changes the value of l10n_eg_eta_json_doc_id.raw which triggers the computes that depend on it. This is why we add the context key before calling _extend_with_attachments. Moreover, in the same function, a savepoint is created, triggering a flush that triggers the recomputes. A savepoint is created without the context, therefore we flush right before we create the savepoint.

runbot-110629
