### PR TITLE
[FIX] hr_holidays: restore cancelled in domain

### DIFF
--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -39,7 +39,7 @@ class CalendarLeaves(models.Model):
                     ('date_to', '>', date['date_from']),
                     ('date_from', '<', date['date_to'])]
             ])
-        return expression.AND([domain, [('state', '!=', 'refuse')]])
+        return expression.AND([domain, [('state', 'not in', ['refuse', 'cancel'])]])
 
     def _get_time_domain_dict(self):
         return [{


### PR DESCRIPTION
In https://github.com/odoo/odoo/pull/127877, the active field was removed and replaced with state: cancel. This domain was modified but removed the check for the cancelled state.

opw-4420347