### PR TITLE
[FIX] pos_self_order: merge orders from same table

### DIFF
--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -57,7 +57,9 @@ class PosOrder(models.Model):
         if not self.env.context.get('from_self'):
             return open_order
         elif open_order:
-            del order['table_id']
+            # If we found an open order they should be merged
+            order['id'] = open_order.id
+            return open_order
         return self.env['pos.order'].search([('uuid', '=', order.get('uuid'))], limit=1)
 
     def _process_saved_order(self, draft):


### PR DESCRIPTION
When 2 orders are made from the same QR Code representing the same table all the orders would not be merged on the table

Steps to reproduce:
-------------------
* Setup QR + Ordering and serving at Table in PoS settings
* Open one table QR Code in 2 different devices/browsers
* Make an order in each device
> Observation: Only one will appear on the table

Why the fix:
------------
Based on the behavior in 17.4 we should merge the orders from the same table. To do this when we find an open order for the table we change the id of the new order to the one of the existing order so that those 2 orders are merged.

opw-4482805