### PR TITLE
[FIX] core: flush as public user when there is no default_env

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -360,8 +360,6 @@ class IrHttp(models.AbstractModel):
             return parent
 
         # minimal setup to serve frontend pages
-        if not request.uid:
-            cls._auth_method_public()
         cls._frontend_pre_dispatch()
         cls._handle_debug()
 

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -246,6 +246,7 @@ class IrHttp(models.AbstractModel):
     @classmethod
     def _auth_method_none(cls):
         request.env = api.Environment(request.env.cr, None, request.env.context)
+        request.env.transaction.default_env = request.env
 
     @classmethod
     def _auth_method_public(cls):

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1944,6 +1944,7 @@ class Request:
         provided a response, a generic 404 - Not Found page is returned.
         """
         self.params = self.get_http_params()
+        self.registry['ir.http']._auth_method_public()
         response = self.registry['ir.http']._serve_fallback()
         if response:
             self.registry['ir.http']._post_dispatch(response)

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -521,6 +521,12 @@ class Transaction:
         """ Flush pending computations and updates in the transaction. """
         if self.default_env is not None:
             self.default_env.flush_all()
+        else:
+            for env in self.envs:
+                _logger.warning("Missing default_env, flushing as public user")
+                public_user = env.ref('base.public_user')
+                Environment(env.cr, public_user.id, {}).flush_all()
+                break
 
     def clear(self):
         """ Clear the caches and pending computations and updates in the transactions. """

--- a/odoo/service/common.py
+++ b/odoo/service/common.py
@@ -25,6 +25,7 @@ def exp_authenticate(db, login, password, user_agent_env):
         user_agent_env = {}
     with Registry(db).cursor() as cr:
         env = odoo.api.Environment(cr, None, {})
+        env.transaction.default_env = env  # force default_env
         try:
             credential = {'login': login, 'password': password, 'type': 'password'}
             return env['res.users'].authenticate(credential, {**user_agent_env, 'interactive': False})['uid']


### PR DESCRIPTION
When using livechat, there may be no default environment because during the whole transaction, no environment with a real user was created. In such a case, we should fallback to the public user.

task-4452913


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
