### PR TITLE
[FIX] point_of_sale: add additional field in product loader

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -2066,7 +2066,7 @@ class PosSession(models.Model):
                 'fields': [
                     'display_name', 'lst_price', 'standard_price', 'categ_id', 'pos_categ_ids', 'taxes_id', 'barcode',
                     'default_code', 'to_weight', 'uom_id', 'description_sale', 'description', 'product_tmpl_id', 'tracking',
-                    'write_date', 'available_in_pos', 'attribute_line_ids', 'active', 'image_128', 'combo_ids', 'product_tag_ids',
+                    'write_date', 'available_in_pos', 'attribute_line_ids', 'active', 'image_128', 'combo_ids', 'product_tag_ids', 'name',
                 ],
                 'order': 'sequence,default_code,name',
             },


### PR DESCRIPTION
Issue -->

Using the 'product.product.name' field in loyalty.reward.discount_product_domain that is not added via the `_loader_params_product_product` loader causes an error in the matchCondition function
https://github.com/odoo/odoo/blob/9b0f528aa02743372934df8e64d1cc0ad74903b6/addons/web/static/src/core/domain.js#L331 where variable fieldValue is undefined if the field is not available.

Solution -->

Adding the `name` field search parameters in the `_loader_params_product_product` similar to https://github.com/odoo/odoo/pull/186804

opw-4410460

