### PR TITLE
[17.0][FIX] mail: Render message actions correctly with callComponent

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -155,8 +155,11 @@
                 <t t-set-slot="default">
                     <t t-foreach="messageActions.actions.slice(quickActionCount)" t-as="action" t-key="action.id">
                         <DropdownItem class="'px-2 d-flex align-items-center rounded-0'" title="action.title" onSelected="action.onClick">
-                            <i class="fa fa-lg fa-fw pe-2" t-att-class="action.icon"/>
-                            <t t-esc="action.title"/>
+                            <t t-if="action.callComponent" t-component="action.callComponent" t-props="action.props"/>
+                            <t t-else="">
+                                <i class="fa fa-lg fa-fw pe-2" t-att-class="action.icon"/>
+                                <t t-esc="action.title"/>
+                            </t>
                         </DropdownItem>
                     </t>
                 </t>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When a custom module (e.g., [OCA/social#1536](https://github.com/OCA/social/pull/1536)) adds a new message action using `callComponent`, it is not invoked in certain scenarios.

**Current behavior before PR:**

Odoo only invokes `callComponent` for `quick actions` (2 or 3 actions). For remaining actions rendered as `DropdownItem`, the `callComponent` is not invoked.

**Desired behavior after PR is merged:**

This commit ensures consistent rendering behavior, invoking the `callComponent` for all actions, whether quick actions or dropdown items.

Complementary to: https://github.com/odoo/odoo/pull/131426


@phenix-factory @alexkuhn coud you please review this?

CC @pedrobaeza @chienandalu 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
