### PR TITLE
[IMP] base: Highlight invalid locators in ir.ui.view form view.

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -22,6 +22,7 @@ This module provides the core of the Odoo Web Client.
         'views/speedscope_template.xml',
         'views/speedscope_config_wizard.xml',
         'views/neutralize_views.xml',
+        'views/ir_ui_view_views.xml',
         'data/ir_attachment.xml',
         'data/report_layout.xml',
     ],

--- a/addons/web/static/src/core/ir_ui_view_code_editor/code_editor.js
+++ b/addons/web/static/src/core/ir_ui_view_code_editor/code_editor.js
@@ -1,0 +1,76 @@
+/** @odoo-module **/
+import { useEffect, onMounted } from "@odoo/owl";
+import { CodeEditor } from "@web/core/code_editor/code_editor";
+import { escapeRegExp } from "@web/core/utils/strings";
+
+export class IrUiViewCodeEditor extends CodeEditor {
+    static props = {
+        ...this.props,
+        record: { type: Object },
+    };
+
+    setup() {
+        super.setup(...arguments);
+        this.markers = [];
+
+        onMounted(() => {
+            this.aceEditor.getSession().on("change", () => {
+                // Markers have fixed pixel positions, so they get wonky on change.
+                this.clearMarkers();
+            });
+        });
+
+        useEffect(
+            (arch, invalid_locators) => {
+                if (arch && invalid_locators) {
+                    this.highlightInvalidLocators(arch, invalid_locators);
+                    return () => this.clearMarkers();
+                }
+            },
+            () => [this.props.value, this.props.record?.data.invalid_locators]
+        );
+    }
+
+    async highlightInvalidLocators(arch, invalid_locators) {
+        const resModel = this.env.model?.config.resModel;
+        const resId = this.env.model?.config.resId;
+        if (resModel === "ir.ui.view" && resId) {
+            const { doc } = this.aceEditor.session;
+            for (const spec of invalid_locators) {
+                const { tag, attrib, sourceline } = spec;
+                const attribRegex = Object.entries(attrib)
+                    .map(([key, value]) => {
+                        const escapedValue = escapeRegExp(value).replace(/"/g, '("|&quot;)');
+                        return (
+                            `(?=[^>]*?\\b${escapeRegExp(key)}\\s*=\\s*` +
+                            `(?:"[^"]*${escapedValue}[^"]*"|'[^']*${escapedValue}[^']*'))`
+                        );
+                    })
+                    .join("");
+                const nodeRegex = new RegExp(`<${escapeRegExp(tag)}\\s+${attribRegex}[^>]*>`, "g");
+                for (const match of arch.matchAll(nodeRegex)) {
+                    const startIndex = match.index;
+                    const endIndex = startIndex + match[0].length;
+                    const startPos = doc.indexToPosition(startIndex);
+                    const endPos = doc.indexToPosition(endIndex);
+                    if (startPos.row + 1 === sourceline) {
+                        const range = new window.ace.Range(
+                            startPos.row,
+                            startPos.column,
+                            endPos.row,
+                            endPos.column
+                        );
+                        this.markers.push(
+                            this.aceEditor.session.addMarker(range, "invalid_locator", "text")
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    clearMarkers() {
+        this.markers.forEach((marker) => this.aceEditor.session.removeMarker(marker));
+        this.markers = [];
+    }
+}

--- a/addons/web/static/src/core/ir_ui_view_code_editor/code_editor.scss
+++ b/addons/web/static/src/core/ir_ui_view_code_editor/code_editor.scss
@@ -1,0 +1,5 @@
+.invalid_locator {
+    position: absolute;
+    background: red;
+    opacity: 0.25;
+}

--- a/addons/web/static/src/views/fields/ir_ui_view_ace/ace_field.js
+++ b/addons/web/static/src/views/fields/ir_ui_view_ace/ace_field.js
@@ -1,0 +1,17 @@
+/** @odoo-module **/
+import { registry } from "@web/core/registry";
+import { aceField, AceField } from "@web/views/fields/ace/ace_field";
+import { IrUiViewCodeEditor } from "@web/core/ir_ui_view_code_editor/code_editor";
+
+export class IrUiViewAceField extends AceField {
+    static template = "web.IrUIViewAceField";
+    static components = { IrUiViewCodeEditor };
+}
+
+export const irUiViewAceField = {
+    ...aceField,
+    component: IrUiViewAceField,
+    additionalClasses: ["o_field_ace"],
+};
+
+registry.category("fields").add("code_ir_ui_view", irUiViewAceField);

--- a/addons/web/static/src/views/fields/ir_ui_view_ace/ace_field.xml
+++ b/addons/web/static/src/views/fields/ir_ui_view_ace/ace_field.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="web.IrUIViewAceField">
+        <div class="o_field_widget oe_form_field o_ace_view_editor oe_ace_open">
+            <IrUiViewCodeEditor
+                value="state.initialValue"
+                mode="mode"
+                readonly="props.readonly"
+                record="props.record"
+                onBlur.bind="commitChanges"
+                onChange.bind="handleChange"
+                class="'ace-view-editor'"
+                theme="theme"
+                maxLines="200"
+            />
+        </div>
+    </t>
+</templates>

--- a/addons/web/static/tests/views/fields/ir_ui_view_ace_field.test.js
+++ b/addons/web/static/tests/views/fields/ir_ui_view_ace_field.test.js
@@ -1,0 +1,105 @@
+import { expect, test, describe } from "@odoo/hoot";
+
+import {
+    defineModels,
+    fields,
+    models,
+    mountView,
+    preloadBundle,
+    preventResizeObserverError,
+} from "@web/../tests/web_test_helpers";
+
+const INVALID_LOCATOR = ".invalid_locator";
+
+class IrUiView extends models.Model {
+    _name = "ir.ui.view";
+    _rec_name = "name";
+
+    name = fields.Char({ required: true });
+    arch = fields.Text({});
+    invalid_locators = fields.Json();
+
+    _records = [
+        {
+            id: 1,
+            name: "Child View",
+            arch: `
+<data>
+    <xpath expr="//field[@name='name']" position="after"/>
+    <xpath expr="//group" position="inside"/>
+    <xpath expr="//field[@name='inherit_id']" position="replace"/>
+    <xpath expr="//field[@name='non_existent_field']" position="after"/>
+    <xpath expr="//nonexistent_tag" position="inside"/>
+    <xpath expr="//field[@name='arch_invalid']" position="after"/>
+    <field name="invalid" position="replace"/>
+</data>
+            `,
+            invalid_locators: false,
+        },
+    ];
+}
+defineModels([IrUiView]);
+
+// Preload necessary bundles and prevent ResizeObserver errors
+preloadBundle("web.ace_lib");
+preventResizeObserverError();
+
+const mountChildView = async () =>
+    await mountView({
+        resModel: "ir.ui.view",
+        resId: 1,
+        type: "form",
+        arch: `
+            <form>
+                <field name="invalid_locators"/>
+                <field name="arch" widget="code_ir_ui_view" options='{"mode": "xml"}'/>
+            </form>
+        `,
+    });
+
+describe("Highlight invalid locators in inherited ir.ui.view", () => {
+    test("with no invalid locators", async () => {
+        await mountChildView();
+        expect(INVALID_LOCATOR).toHaveCount(0);
+    });
+
+    test("with invalid locators", async () => {
+        const invalid_locators = [
+            {
+                tag: "xpath",
+                attrib: {
+                    expr: "//field[@name='non_existent_field']",
+                    position: "after",
+                },
+                sourceline: 6,
+            },
+            {
+                tag: "xpath",
+                attrib: {
+                    expr: "//nonexistent_tag",
+                    position: "inside",
+                },
+                sourceline: 7,
+            },
+            {
+                tag: "xpath",
+                attrib: {
+                    expr: "//field[@name='arch_invalid']",
+                    position: "after",
+                },
+                sourceline: 8,
+            },
+            {
+                tag: "field",
+                attrib: {
+                    name: "invalid",
+                    position: "replace",
+                },
+                sourceline: 9,
+            },
+        ];
+        IrUiView._records[0].invalid_locators = invalid_locators;
+        await mountChildView();
+        expect(INVALID_LOCATOR).toHaveCount(invalid_locators.length);
+    });
+});

--- a/addons/web/views/ir_ui_view_views.xml
+++ b/addons/web/views/ir_ui_view_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_view_form_inherit_view" model="ir.ui.view">
+        <field name="name">ir.ui.view.form.inherit</field>
+        <field name="model">ir.ui.view</field>
+        <field name="inherit_id" ref="base.view_view_form"/>
+        <field name="arch" type="xml">
+        	<xpath expr="//div[hasclass('alert-info')]" position="after">
+                <div class="alert alert-danger" role="alert" invisible="not invalid_locators">
+                    Please note that your view includes invalid locators.<br/>
+                    These nodes could not be anchored to the parent view and have no effect.<br/>
+                    This issue may have arisen as a result of manual modifications or during the upgrade process.<br/>
+                    For your reference, invalid xpath nodes are highlighted in red.
+                </div>
+                <field name="invalid_locators" invisible="1"/> <!-- required for the alert -->
+            </xpath>
+            <xpath expr="//field[@name='arch_base']" position="attributes">
+                <attribute name="widget">code_ir_ui_view</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -14,6 +14,7 @@ from lxml import etree
 from lxml.etree import LxmlError
 from lxml.builder import E
 from markupsafe import Markup
+from contextlib import suppress
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import ValidationError, AccessError, UserError
@@ -26,6 +27,7 @@ from odoo.tools.misc import file_path, get_diff, ConstantMapping
 from odoo.tools.template_inheritance import apply_inheritance_specs, locate_node
 from odoo.tools.translate import xml_translate, TRANSLATED_ATTRS
 from odoo.tools.view_validation import valid_view, get_domain_value_names, get_expression_field_names, get_dict_asts
+from odoo.osv import expression
 
 _logger = logging.getLogger(__name__)
 
@@ -201,6 +203,8 @@ actual arch.
          """)
     model_id = fields.Many2one("ir.model", string="Model of the view", compute='_compute_model_id', inverse='_inverse_compute_model_id')
 
+    invalid_locators = fields.Json(compute='_compute_invalid_locators')
+
     @api.depends('arch_db', 'arch_fs', 'arch_updated')
     @api.depends_context('read_arch_from_file', 'lang', 'edit_translations', 'check_translations')
     def _compute_arch(self):
@@ -313,6 +317,49 @@ actual arch.
     def _inverse_compute_model_id(self):
         for record in self:
             record.model = record.model_id.model
+
+    @api.depends('arch', 'inherit_id')
+    def _compute_invalid_locators(self):
+        self.invalid_locators = []
+        for view in self.filtered('inherit_id'):
+            source = view.with_context(ir_ui_view_tree_cut_off_view=view)._get_combined_arch()
+            invalid_locators = []
+            specs = collections.deque([etree.fromstring(view.arch)])
+            while specs:
+                spec = specs.popleft()
+                if spec.tag == 'data':
+                    specs.extend(spec)
+                    continue
+                # Capture 'move' nodes to handles cases where move operations are nested within other xpath operations
+                # <xpath expr="parent" position="after">
+                #   <xpath expr="child" position="move"/>
+                # </xpath>
+                specs.extend(c for c in spec if c.get("position") == 'move')
+                node = None
+                with suppress(ValidationError):  # Syntax error
+                    # If locate_node returns None here:
+                    # Invalid expression: Ok Syntax, but cannot be anchored to the parent view.
+                    node = self.locate_node(source, spec)
+                if node is None:
+                    invalid_locators.append({
+                        "tag": spec.tag,
+                        "attrib": dict(spec.attrib),
+                        "sourceline": spec.sourceline
+                    })
+                else:
+                    try:
+                        # Since subsequent xpaths may be dependent on previous xpaths, we apply the spec.
+                        source = apply_inheritance_specs(source, spec)
+                    except ValueError as e:
+                        # This function is only interested in locating invalid locators.
+                        # Here, ValueError is raised for:
+                        #   Invalid mode attribute
+                        #   Invalid attributes attribute
+                        #   Invalid position
+                        #   Element <attribute> with 'add' or 'remove' cannot contain text
+                        #   Invalid separator for python expressions in attributes
+                        pass
+            view.invalid_locators = invalid_locators
 
     def _compute_xml_id(self):
         xml_ids = collections.defaultdict(list)
@@ -572,7 +619,15 @@ actual arch.
     @api.model
     def _get_inheriting_views_domain(self):
         """ Return a domain to filter the sub-views to inherit from. """
-        return [('active', '=', True)]
+        base_domain =  [('active', '=', True)]
+        tree_cut_off_view = self.env.context.get("ir_ui_view_tree_cut_off_view")
+        if not tree_cut_off_view:
+            return base_domain
+        cut_off_domain = [
+            "|", ("priority", "<", tree_cut_off_view.priority),
+            "&", ("priority", "=", tree_cut_off_view.priority), ("id", "<", tree_cut_off_view.id)
+        ]
+        return expression.AND([base_domain, cut_off_domain])
 
     @api.model
     def _get_filter_xmlid_query(self):


### PR DESCRIPTION
## Highlight invalid locators in ir.ui.view form view
![image](https://github.com/user-attachments/assets/cceea975-0f12-4640-ab40-8875103fded5)
    
This PR introduces "Highlight invalid locators" feature to the `ir.ui.view` form view's code editor. This enhancement directly addresses common upgrade challenges and boosts productivity for Upgrade Projects, Rolling Release tickets, and Odoo Partners who upgrade their clients' database.

**Why this is needed:**

Upgrading Odoo databases to newer versions often results in broken Studio customizations.  These customizations become incompatible due to various reasons.

Currently, identifying these invalid locators is a tedious and error-prone manual process. Developers must go through each line of the view's XML (`arch`) field to find which locator is invalid. This significantly slows down the upgrade process.

**Benefits:**

*   **Increased Productivity:**  Dramatically reduces the time and effort required to identify and fix invalid XPath expressions.
*   **Faster Upgrade Process:** Streamlines the upgrade workflow for Upgrade Projects, Rolling Release tickets, and post-upgrade issue resolution.
*   **Enhanced Partner Experience:** Simplifies the process of maintaining and upgrading customizations for Odoo partners.
*   **Proactive Error Detection:** Allows developers to identify and correct invalid XPaths *before* they cause problems in a live environment.

**How to Test:**

1.  **Create a Studio View:** Using the Studio app, create a new view customization (do *not* create it manually via XML).  This ensures the view is properly registered as a Studio customization.
2.  **Access the View in `ir.ui.view` form view.
3.  **Add an Invalid XPath:** Modify the view's XML (`arch` field) by adding an invalid locator.  For example:
    *   Use an XPath that references a non-existent field:  `//field[@name='nonexistent_field']`
    *   Use incorrect XPath syntax: `//form/div[invalid_syntax]`
4.  **The invalid locators are highlighted in red within the code editor.** 

**Limitation:**

As illustrated below, invalid locators cannot be highlighted if they are nested under a parent locator that is invalid.
This is because the parent node's failure prevents the system from even attempting to evaluate the child nodes' validity.

![image](https://github.com/user-attachments/assets/45f79545-5a12-42dd-abb1-7f2b177596a8)
---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr