### PR TITLE
[FIX] hr: fix singleton record error

### DIFF
--- a/addons/hr/wizard/mail_activity_schedule.py
+++ b/addons/hr/wizard/mail_activity_schedule.py
@@ -18,7 +18,7 @@ class MailActivitySchedule(models.TransientModel):
             if not scheduler.department_id:
                 final_domain = expression.AND([base_domain, [('department_id', '=', False)]])
             else:
-                final_domain = expression.AND([base_domain, ['|', ('department_id', '=', False), ('department_id', '=', self.department_id.id)]])
+                final_domain = expression.AND([base_domain, ['|', ('department_id', '=', False), ('department_id', '=', scheduler.department_id.id)]])
             scheduler.plan_available_ids = self.env['mail.activity.plan'].search(final_domain)
         super(MailActivitySchedule, self - todo)._compute_plan_available_ids()
 


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
- Similar error: https://github.com/odoo/odoo/pull/194338
- In `_compute_plan_available_ids()` with `self` there can be multiple records but still use `self.department_id` in `for scheduler in todo`.

### Current behavior before PR:
- The error ValueError: Expected singleton: mail.activity.schedule(1, 2) occurred

Desired behavior after PR is merged:
- The problem has been fixed.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
