### PR TITLE
[FIX] pos_self_order: issues in mobile-menu product image, cart & description

### DIFF
--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -81,6 +81,11 @@ class ProductTemplate(models.Model):
                     product._send_availability_status()
         return res
 
+    def _can_return_content(self, field_name=None, access_token=None):
+        if self.sudo().self_order_available and field_name == "image_512":
+            return True
+        return super()._can_return_content(field_name, access_token)
+
 
 class ProductProduct(models.Model):
     _inherit = "product.product"
@@ -114,6 +119,6 @@ class ProductProduct(models.Model):
                 })
 
     def _can_return_content(self, field_name=None, access_token=None):
-        if self.self_order_available and field_name in ["image_128", "image_512"]:
+        if self.sudo().self_order_available and field_name == "image_512":
             return True
         return super()._can_return_content(field_name, access_token)

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.js
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.js
@@ -103,15 +103,7 @@ export class ProductCard extends Component {
             this.flyToCart();
             this.scaleUpPrice();
 
-            const isProductInCart = this.selfOrder.currentOrder.lines.find(
-                (line) => line.product_id === product.id
-            );
-
-            if (isProductInCart) {
-                isProductInCart.qty += qty;
-            } else {
-                this.selfOrder.addToCart(product, 1);
-            }
+            this.selfOrder.addToCart(product, qty);
         }
     }
 
@@ -122,12 +114,5 @@ export class ProductCard extends Component {
                 this.selectProduct(qty);
             },
         });
-    }
-
-    get isHtmlEmpty() {
-        const div = Object.assign(document.createElement("div"), {
-            innerHTML: this.props.productTemplate.public_description,
-        });
-        return div.innerText.trim() === "";
     }
 }

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
@@ -6,7 +6,7 @@
             t-att-title="props.productTemplate.name"
             t-on-click="() => this.selectProduct()"
             t-ref="selfProductCard">
-            <div t-if="!this.isHtmlEmpty" class="product-information-tag" t-on-click.prevent.stop="showProductInfo">
+            <div t-if="props.productTemplate.public_description" class="product-information-tag" t-on-click.prevent.stop="showProductInfo">
                 <i class="product-information-tag-logo fa fa-info fs-4" role="img" aria-label="Product Information" title="Product Information" />
             </div>
             <div

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -473,7 +473,7 @@ export class SelfOrder extends Reactive {
     }
 
     markupDescriptions() {
-        for (const product of this.models["product.product"].getAll()) {
+        for (const product of this.models["product.template"].getAll()) {
             product.public_description = product.public_description
                 ? markup(product.public_description)
                 : "";


### PR DESCRIPTION
Steps to Reproduce:
===
- Open the restaurant's mobile menu in a browser where you are not logged in.
- Interact with the product info (`i` button) and cart features.

Issues:
===
1. Product images were not displayed correctly, showing a default image instead.
2. Clicking the info (`i`) button displayed "false" or unformatted description if the product had no public description.
3. Adding more than one quantity of a product through the info popup only added a single item to the cart.

Fixed:
===
1. Resolved the image issue by ensuring images are accessible even when not logged in.
2. Corrected the display of public descriptions to show properly formatted text, else blank.
3. Fixed the cart issue to allow adding multiple quantities of a product correctly.

Task: 4463971
