### PR TITLE
[IMP] payment, sale, * : show done payment message when redirected from payment

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -417,7 +417,8 @@ class PaymentPortal(portal.CustomerPortal):
                 raise werkzeug.exceptions.NotFound()  # Don't leak information about ids.
 
             # Display the payment confirmation page to the user
-            return request.render('payment.confirm', qcontext={'tx': tx_sudo})
+            payment_success_message = kwargs.get('display_success_msg', False)
+            return request.render('payment.confirm', qcontext={'tx': tx_sudo, 'display_success_msg': payment_success_message})
         else:
             # Display the portal homepage to the user
             return request.redirect('/my/home')

--- a/addons/payment/static/src/interactions/post_processing.js
+++ b/addons/payment/static/src/interactions/post_processing.js
@@ -26,7 +26,9 @@ export class PaymentPostProcessing extends Interaction {
                 // Redirect the user to the landing route if the transaction reached a final state.
                 const { provider_code, state, landing_route } = postProcessingValues;
                 if (PaymentPostProcessing.getFinalStates(provider_code).has(state)) {
-                    window.location = landing_route;
+                    const url = new URL(landing_route, window.location.origin);
+                    url.searchParams.set('display_success_msg', 'True');
+                    window.location = url.toString();
                 } else {
                     this.poll();
                 }

--- a/addons/payment/views/portal_templates.xml
+++ b/addons/payment/views/portal_templates.xml
@@ -305,13 +305,13 @@
         </t>
         <t t-elif="tx.state == 'done'">
             <t t-set="alert_style" t-value="'success'"/>
-            <t t-if="not is_processing" t-set="status_heading">
+            <t t-if="not is_processing and display_success_msg" t-set="status_heading">
                 <p>Thank you!</p>
             </t>
             <t t-if="tx.operation == 'validation'" t-set="status_message">
                 <p>Your payment method has been saved.</p>
             </t>
-            <t t-else="" t-set="status_message" t-value="tx.provider_id.sudo().done_msg"/>
+            <t t-elif="is_processing or display_success_msg" t-set="status_message" t-value="tx.provider_id.sudo().done_msg"/>
         </t>
         <t t-elif="tx.state == 'cancel'">
             <t t-set="alert_style" t-value="'danger'"/>
@@ -354,7 +354,7 @@
                 <t t-if="tx.state_message" t-out="tx.state_message" class="mb-0"/>
             </div>
             <a t-if="is_processing"
-               t-att-href="tx.landing_route"
+               t-att-href="tx.landing_route + ('&amp;' if '?' in tx.landing_route else '?') + 'display_success_msg=True'"
                class="alert-link ms-auto text-nowrap"
             >
                 Skip <i class="oi oi-arrow-right ms-1 small"/>

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -996,6 +996,8 @@ class CustomerPortal(Controller):
             values['warning'] = kwargs['warning']
         if kwargs.get('success'):
             values['success'] = kwargs['success']
+        if kwargs.get('display_success_msg'):
+            values['display_success_msg'] = kwargs['display_success_msg']
         # Email token for posting messages in portal view with identified author
         if kwargs.get('pid'):
             values['pid'] = kwargs['pid']

--- a/addons/pos_online_payment/controllers/payment_portal.py
+++ b/addons/pos_online_payment/controllers/payment_portal.py
@@ -280,6 +280,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
             currency=tx_sudo.currency_id,
             provider_name=tx_sudo.provider_id.name,
             tx=tx_sudo, # for the payment.state_header template
+            display_success_msg=kwargs.get('display_success_msg', False),
         )
 
         if tx_sudo.state not in ('authorized', 'done'):

--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -184,7 +184,7 @@ class CustomerPortal(payment_portal.PaymentPortal):
             history_session_key = 'my_orders_history'
 
         values = self._get_page_view_values(
-            order_sudo, access_token, values, history_session_key, False)
+            order_sudo, access_token, values, history_session_key, False, **kw)
 
         return request.render('sale.sale_order_portal_template', values)
 

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from werkzeug import urls
 
 from collections import defaultdict
 from datetime import timedelta
@@ -817,6 +818,18 @@ class SaleOrder(models.Model):
                 if product_msg := line.sale_line_warn_msg:
                     warnings.add(line.product_id.display_name + ' - ' + product_msg)
             order.sale_warning_text = '\n'.join(warnings)
+
+    def _get_share_url(self, redirect=False, signup_partner=False, pid=None, share_token=True):
+        """ Override the method to add the display_success_msg parameter to the URL."""
+        res = super()._get_share_url(
+            redirect=redirect, signup_partner=signup_partner, pid=pid, share_token=share_token
+        )
+        if self._name == 'sale.order':
+            url = urls.url_parse(res)
+            url_params = url.decode_query()
+            url_params.update([('display_success_msg', True)])
+            res = url.replace(query=urls.url_encode(url_params)).to_url()
+        return res
 
     #=== CONSTRAINT METHODS ===#
 


### PR DESCRIPTION
*= portal, pos_online_payment

Before this commit,
the successful payment message showed up every time the user opened the portal
view.

After this commit, the message will only appear if the user is redirected after
making a payment or coming from a payment confirmation email.

task-4420352





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
