### PR TITLE
[FIX] survey: disable embedded components in survey editor

### DIFF
--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -188,6 +188,7 @@
                         </page>
                         <page string="Description" name="survey_description">
                             <field name="description" widget="html"
+                                   options="{'embedded_components': false}"
                                    placeholder="e.g. Guidelines, instructions, picture, ... to help attendees answer"/>
                         </page>
                         <page string="Options" name="options" invisible="is_page">


### PR DESCRIPTION
**Problem**:
Embedded components do not render when the `html` field content is displayed outside the editor, as their mechanism relies on the editor plugin.

**Solution**:
Disable embedded components for the survey.

**Steps to Reproduce**:
1. In a survey, add a section.
2. Add a "View" button. (Debug mode ON)
3. Use the `/` command box and add the "Video link" option.
4. Save and test the survey.
5. The video does not display.

opw-4487027

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
