### PR TITLE
[IMP] hr_holidays: improve report by type graph views

### DIFF
--- a/addons/hr_holidays/report/hr_leave_reports.xml
+++ b/addons/hr_holidays/report/hr_leave_reports.xml
@@ -38,8 +38,8 @@
         <field name="arch" type="xml">
             <list create="0" edit="0" delete="0" action="action_open_record" type="object">
                 <field name="employee_id"/>
-                <field name="number_of_days" string="Number of Days" sum="Remaining Days"/>
-                <field name="number_of_hours" string="Number of Hours" sum="Remaining Hours"/>
+                <field name="number_of_days" string="Number of Days" sum="Remaining Days" width="110px"/>
+                <field name="number_of_hours" string="Number of Hours" sum="Remaining Hours" width="120px"/>
                 <field name="leave_type"/>
                 <field name="date_from"/>
                 <field name="date_to"/>

--- a/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_controller.xml
+++ b/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_controller.xml
@@ -2,6 +2,9 @@
 <templates xml:space="preserve">
 
     <t t-name="hr_holidays.HrHolidaysGraphView.Buttons" t-inherit="web.GraphView.Buttons">
+        <!--Remove the line and pie chart views-->
+        <xpath expr="//button[@data-mode='line']" position="replace"/>
+        <xpath expr="//button[@data-mode='pie']" position="replace"/>
         <!--The bar chart will always be stacked. So the stack button is of no use-->
         <xpath expr="//div[hasclass('btn-group')][3]" position="replace"/>
     </t>

--- a/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_renderer.js
+++ b/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_renderer.js
@@ -2,8 +2,12 @@
 
 import { _t } from "@web/core/l10n/translation";
 
+import { cookie } from "@web/core/browser/cookie";
+import { getColor } from "@web/core/colors/colors";
 import { GraphRenderer } from "@web/views/graph/graph_renderer";
 import { groupBy } from "@web/core/utils/arrays";
+
+const colorScheme = cookie.get("color_scheme");
 
 
 export class HrHolidaysGraphRenderer extends GraphRenderer {
@@ -43,18 +47,19 @@ export class HrHolidaysGraphRenderer extends GraphRenderer {
             .map(labelPart => labelPart === this.model.allocation_label || labelPart === this.model.timeoff_label ? this.balance_label : labelPart)
             .join(this.delimiter)
         );
-        const balanceDatasets = Object.entries(datasetsByLabel).map(([label, datasets]) =>
-            this._initializeBalanceDatasetFrom(datasets, label)
+        this.datasets_offset = data.datasets.length;
+        this.datasets_length = this.datasets_offset + Object.keys(datasetsByLabel).length;
+        const balanceDatasets = Object.entries(datasetsByLabel).map(([label, datasets], index) =>
+            this._initializeBalanceDatasetFrom(datasets, label, index)
         );
         return balanceDatasets;
     }
 
-    _initializeBalanceDatasetFrom(datasets, label){
+    _initializeBalanceDatasetFrom(datasets, label, index){
         let dataset = datasets[0];
-        let backgroundColor = datasets.filter(dataset => dataset.stack === this.model.allocation_label)[0]?.backgroundColor;
-        if (!backgroundColor){
-            backgroundColor = dataset.backgroundColor;
-        }
+
+        const dataset_index = this.datasets_offset + index;
+        const backgroundColor = getColor(dataset_index, colorScheme, this.datasets_length);
 
         let balanceDataset = {
             'trueLabels': dataset.trueLabels,

--- a/addons/hr_holidays/static/tests/tours/time_off_graph_view_tour.js
+++ b/addons/hr_holidays/static/tests/tours/time_off_graph_view_tour.js
@@ -24,16 +24,6 @@ registry.category("web_tour.tours").add("time_off_graph_view_tour", {
             content: "Open bar chart view",
             trigger: "button[data-mode='bar']",
             run: "click",
-        },
-        {
-            content: "Open line chart view",
-            trigger: "button[data-mode='line']",
-            run: "click",
-        },
-        {
-            content: "Open pie chart view",
-            trigger: "button[data-mode='pie']",
-            run: "click",
         }
     ]
 });


### PR DESCRIPTION
- Removed the line and pie graph views of the time off report by type report as they do not convey useful information
- Fix the bar chart colors. Before this commit, the 'balance' bar was the same color as the 'allocation' bar which could be confusing. After this commit, each bar has a different color.
- Before this PR, the two columns indicating the number of days and hours were by default truncated, which was causing confusion as only "Number of" was shown. This is fixed by this PR which expand the column name by default.

task-4488987
