### PR TITLE
[FIX] web_hierarchy: fix the view icon rendering

### DIFF
--- a/addons/web_hierarchy/models/ir_ui_view.py
+++ b/addons/web_hierarchy/models/ir_ui_view.py
@@ -54,4 +54,4 @@ class View(models.Model):
             self._raise_view_error(msg, node)
 
     def _get_view_info(self):
-        return {'hierarchy': {'icon': 'fa fa-share-alt o_hierarchy_icon'}} | super()._get_view_info()
+        return {'hierarchy': {'icon': 'fa fa-share-alt fa-rotate-90'}} | super()._get_view_info()

--- a/addons/web_hierarchy/static/src/hierarchy_arch_parser.js
+++ b/addons/web_hierarchy/static/src/hierarchy_arch_parser.js
@@ -12,7 +12,7 @@ export class HierarchyArchParser {
             activeActions: getActiveActions(xmlDoc),
             defaultOrder: stringToOrderBy(xmlDoc.getAttribute("default_order") || null),
             draggable: false,
-            icon: "fa-share-alt o_hierarchy_icon",
+            icon: "fa-share-alt fa-rotate-90 align-text-top",
             parentFieldName: "parent_id",
             fieldNodes: {},
             templateDocs: {},

--- a/addons/web_hierarchy/static/src/hierarchy_card.scss
+++ b/addons/web_hierarchy/static/src/hierarchy_card.scss
@@ -73,9 +73,5 @@
 
     .o_hierarchy_node_button {
         grid-template-columns: 50px 1fr 50px;
-
-        .o_hierarchy_icon {
-            vertical-align: text-top;
-        }
     }
 }

--- a/addons/web_hierarchy/static/src/hierarchy_view.scss
+++ b/addons/web_hierarchy/static/src/hierarchy_view.scss
@@ -1,3 +1,0 @@
-.o_hierarchy_icon { // hierarchy icon
-    rotate: 90deg;
-}

--- a/addons/web_hierarchy/static/tests/hierarchy_view.test.js
+++ b/addons/web_hierarchy/static/tests/hierarchy_view.test.js
@@ -110,7 +110,7 @@ test("load hierarchy view", async () => {
     expect(".o_hierarchy_node_button.btn-primary").toHaveCount(1);
     expect(".o_hierarchy_node_button.btn-primary.d-grid").toHaveCount(1);
     expect(".o_hierarchy_node_button.btn-primary.rounded-0").toHaveCount(1);
-    expect(".o_hierarchy_node_button.btn-primary .o_hierarchy_icon").toHaveCount(1);
+    expect(".o_hierarchy_node_button.btn-primary .fa-rotate-90.align-text-top").toHaveCount(1);
     expect(".o_hierarchy_node_button.btn-primary").toHaveText("Unfold\n1");
 
     expect(".o_hierarchy_row:eq(0) .o_hierarchy_node").toHaveCount(1);
@@ -1127,7 +1127,7 @@ test("check default icon is correctly used inside button to display child nodes"
         "Unfold\n1"
     );
     expect(
-        ".o_hierarchy_node button[name=hierarchy_search_subsidiaries] i.fa-share-alt.o_hierarchy_icon"
+        ".o_hierarchy_node button[name=hierarchy_search_subsidiaries] i.fa-share-alt.fa-rotate-90.align-text-top"
     ).toHaveCount(1, {
         message:
             "The default icon of the hierarchy view should be displayed inside the button to unfold the node.",


### PR DESCRIPTION
This PR aims to fix an issue about the icon related to the hierarchy view not being rotated anymore.

| 18.0 and above | This PR |
|--------|--------|
| <img width="529" alt="image" src="https://github.com/user-attachments/assets/11289aa4-948d-4725-b8d5-e91bf5d601fc" /> | <img width="531" alt="image" src="https://github.com/user-attachments/assets/bc74ef4e-6e74-47d1-ac06-6bde1d6ed933" /> | 

To render the icon of the hierarchy view, we use a little trick by rotating the `fa-share-alt` icon so that it looks like a tree diagram one.

Unfortunately, this does not work anymore in `18.0` and above. It seems the CSS won't be loaded until you entered the module, which leads to the icon being rendered to `fa-share-alt` by default and then rotated correctly once you click on it.

To fix this issue, we actually make use of available utility classes `fa-rotate-90`to handle the icon rotation and `align-text-top` to handle the vertical alignment when the icon is rendered within a node.

task-4501317


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
