### PR TITLE
[FIX] l10n_es: missing country_id in tax group

### DIFF
--- a/addons/l10n_es/data/account_tax_group_data.xml
+++ b/addons/l10n_es/data/account_tax_group_data.xml
@@ -23,6 +23,7 @@
         </record>
         <record id="tax_group_recargo_1" model="account.tax.group">
             <field name="name">Recargo de Equivalencia 1%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_retenciones_0" model="account.tax.group">
             <field name="name">Retenciones 0%</field>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Not sure if the `country_id` was removed by error in https://github.com/odoo/odoo/pull/166499. Could someone check?




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr