### PR TITLE
[FIX] l10n_ar_withholding: prevent error when clicking on create payment button

### DIFF
--- a/addons/l10n_ar_withholding/wizards/l10n_ar_payment_register_withholding.py
+++ b/addons/l10n_ar_withholding/wizards/l10n_ar_payment_register_withholding.py
@@ -35,6 +35,8 @@ class l10nArPaymentRegisterWithholding(models.TransientModel):
             partner=False,
             is_refund=False,
         )
+        if not taxes_res['taxes']:
+            return 0.0, None, None
         tax_amount = taxes_res['taxes'][0]['amount']
         tax_account_id = taxes_res['taxes'][0]['account_id']
         tax_repartition_line_id = taxes_res['taxes'][0]['tax_repartition_line_id']


### PR DESCRIPTION
When working with the `(AR) Monotributista` company and handling taxes, an error may occur during the payment registration process for confirmed invoices.

Steps to produce:
- Install the `l10n_ar_withholding` module.
- Switch to `(AR) Monotributista` company.
- Navigate to Invoicing > Configuration > Accounting > Taxes
- Create a new tax TEST > set `Tax Type = 'None'`, `Argentinean Withholding type = 'Customer'` and `Tax Computation = 'Group of Taxes​'`
- Create and confirm an invoice.
- Click on the `Register Payment` button, select tax TEST in the `tax` field, and fill in the `number` field.
- Click on `Create Payment` button.
- Observed the error.

error: `IndexError: list index out of range`

Currently, an error occurs when attempting to access the first element of `taxes_res['taxes']` without verifying if the list is empty. This happens in cases where `taxes_res['taxes']` contains no elements - [1].

This commit resolves the issue by adding a check to ensure the list is not empty before accessing its elements. If the list is empty, appropriate values are passed for further processing to avoid errors.

[1] - https://github.com/odoo/odoo/blob/d0677fc342e92cc64a9d83106b6f84810dc1569e/addons/l10n_ar_withholding/wizards/l10n_ar_payment_register_withholding.py#L38

Sentry-6220922322

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
