### PR TITLE
[FIX] website: fix unable to enter edit mode on old browsers

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -126,8 +126,8 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
         // TODO remove in master and adapt XML.
         const contentAdditionEl = $html.find("#so_content_addition")[0];
         if (contentAdditionEl) {
-            // Allows dropping "inner blocks" next to an image link.
-            contentAdditionEl.dataset.dropNear += ", .row > div:not(.o_grid_item_image) > a:has(img)";
+            // Necessary to be able to drop "inner blocks" next to an image link.
+            contentAdditionEl.dataset.dropNear += ", .row > div:not(.o_grid_item_image) > a";
         }
     },
     /**


### PR DESCRIPTION
Since commit [1], we added a selector using the ":has" pseudo-class in the template that defines where "inner content" blocks can be dropped. It is no longer possible to enter edit mode (a traceback occurs) starting from Odoo version 18.0 and in browsers older than Chrome 112 or Firefox 121.

This bug happens because the same selector, used by jQuery, combines both the ":has" pseudo-class and the ":is" pseudo-class (this ":is" pseudo-class was introduced into the same selector by commit [2] starting from Odoo version 18.0). This is not compatible with the older browsers mentioned above.

The bug only appears in version 18. However, we already fixed this in 16.0 in case potential customizations had added the ":is" pseudo-class to the same selector.

[1]: https://github.com/odoo/odoo/commit/65a85009800dfa45526ebdc41d3a0a808b2e9f6d
[2]: https://github.com/odoo/odoo/commit/e0fc83760f991fa2fea39763bb2709d9e0182316

opw-4494945