### PR TITLE
[IMP] crm: add link to Ringover in settings

### DIFF
--- a/addons/crm/views/res_config_settings_views.xml
+++ b/addons/crm/views/res_config_settings_views.xml
@@ -25,6 +25,12 @@
                         <setting help="Assign salespersons into multiple Sales Teams.">
                             <field name="is_membership_multi"/>
                         </setting>
+                        <setting string="Ringover VOIP Phone" id="ringover-voip" help="Make and receive calls from Odoo with Ringover's dialer. Track calls, SMS messages, and get AI-powered transcripts of your conversations.">
+                            <a class="oe_link fw-bold" href="https://chromewebstore.google.com/detail/ringover-voip-phone-for-o/bdeapcnahigpibeoehandgaiijljkdnl" target="_blank">
+                                <i class="oi oi-arrow-right"/>
+                                Install Extension
+                            </a>
+                        </setting>
                     </block>
                     <block>
                         <field name="predictive_lead_scoring_fields_str" invisible="1"/>


### PR DESCRIPTION
We now partner with Ringover to provide VOIP capabilities using a browser extension for integration.

We add a link to that extension in the "integrations".

This is done in CRM because this is the most relevant app for VOIP usage.

task-4488082
