### PR TITLE
[FIX] mail, im_livechat: prevent renaming livechat channels

### DIFF
--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -63,4 +63,8 @@ patch(Thread.prototype, {
         }
         return super.leaveNotificationMessage;
     },
+
+    get canBeRenamed() {
+        return super.canBeRenamed && this.channel_type != "livechat";
+    },
 });

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -26,11 +26,7 @@ threadActionsRegistry
     })
     .add("rename-thread", {
         condition(component) {
-            return (
-                component.thread &&
-                component.props.chatWindow?.isOpen &&
-                (component.thread.is_editable || component.thread.channel_type === "chat")
-            );
+            return component.thread?.canBeRenamed && component.props.chatWindow?.isOpen;
         },
         icon: "fa fa-fw fa-pencil",
         name: _t("Rename Thread"),

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -414,6 +414,10 @@ export class Thread extends Record {
         return {};
     }
 
+    get canBeRenamed() {
+        return this.is_editable || this.channel_type === "chat";
+    }
+
     executeCommand(command, body = "") {
         return this.store.env.services.orm.call(
             "discuss.channel",

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -30,7 +30,7 @@
                         </div>
                         <AutoresizeInput
                             className="'o-mail-Discuss-threadName fw-bolder flex-shrink-1 text-dark py-0'"
-                            enabled="thread.is_editable or thread.channel_type === 'chat'"
+                            enabled="thread.canBeRenamed"
                             onValidate.bind="renameThread"
                             value="thread.displayName"
                         />
@@ -39,7 +39,7 @@
                             <t t-set="autogrowDescriptionPlaceholder">Add a description</t>
                             <AutoresizeInput
                                 className="'o-mail-Discuss-threadDescription flex-shrink-1 text-muted small pt-1'"
-                                enabled="thread.is_editable"
+                                enabled="thread.canBeRenamed"
                                 onValidate.bind="updateThreadDescription"
                                 placeholder="thread.is_editable ? autogrowDescriptionPlaceholder : ''"
                                 value="thread.description or ''"


### PR DESCRIPTION
Before this commit it was possible to rename livechat channels in the front-end interface even though it would not be allowed server-side.
This commit removes the action button to rename a livechat channel and disables the AutoresizeInput of the thread name.
