### PR TITLE
[FIX] point_of_sale: synchronisation latence with connected printers

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1464,29 +1464,29 @@ export class PosStore extends Reactive {
     // Now the printer should work in PoS without restaurant
     async sendOrderInPreparation(order, cancelled = false) {
         if (this.printers_category_ids_set.size) {
-            try {
-                const changes = changesToOrder(
-                    order,
-                    false,
-                    this.orderPreparationCategories,
-                    cancelled
-                );
-                if (changes.cancelled.length > 0 || changes.new.length > 0) {
-                    const isPrintSuccessful = await order.printChanges(
+            const changes = changesToOrder(
+                order,
+                false,
+                this.orderPreparationCategories,
+                cancelled
+            );
+            if (changes.cancelled.length > 0 || changes.new.length > 0) {
+                order
+                    .printChanges(
                         false,
                         this.orderPreparationCategories,
                         cancelled,
                         this.unwatched.printers
-                    );
-                    if (!isPrintSuccessful) {
-                        this.dialog.add(AlertDialog, {
-                            title: _t("Printing failed"),
-                            body: _t("Failed in printing the changes in the order"),
-                        });
-                    }
-                }
-            } catch (e) {
-                console.info("Failed in printing the changes in the order", e);
+                    )
+                    .then((result) => {
+                        if (!result) {
+                            this.dialog.add(AlertDialog, {
+                                title: _t("Printing failed"),
+                                body: _t("Failed in printing the changes in the order"),
+                            });
+                        }
+                    })
+                    .catch((e) => console.info("Failed in printing the changes in the order", e));
             }
         }
     }


### PR DESCRIPTION
Previously, when some printers were connected to the PoS, the synchronisation of the order was slow because we were waiting for the response of each printer.

Now we don't wait for the response of the printer, we just send the order to the printer and we continue the process.
