### PR TITLE
[FIX] pos_self_order_stripe: fix Stripe payments

### DIFF
--- a/addons/pos_self_order_stripe/controllers/orders.py
+++ b/addons/pos_self_order_stripe/controllers/orders.py
@@ -44,15 +44,15 @@ class PosSelfOrderControllerStripe(PosSelfOrderController):
             order.action_pos_order_paid()
 
             if order.config_id.self_ordering_mode == 'kiosk':
-                request.env['bus.bus']._sendone(f'pos_config-{order.config_id.access_token}', 'PAYMENT_STATUS', {
+                order.config_id._notify('PAYMENT_STATUS', {
                     'payment_result': 'Success',
                     'data': {
                         'pos.order': order.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-                        'pos.order.line': order.lines.read(order._load_pos_self_data_fields(order.config_id.id), load=False)
+                        'pos.order.line': order.lines.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
                     }
                 })
         else:
-            request.env['bus.bus']._sendone(f'pos_config-{order.config_id.access_token}', 'PAYMENT_STATUS', {
+            order.config_id._notify('PAYMENT_STATUS', {
                 'payment_result': 'fail',
                 'data': {
                     'pos.order': order.read(order._load_pos_self_data_fields(order.config_id.id), load=False),

--- a/addons/pos_self_order_stripe/static/src/app/self_order_service.js
+++ b/addons/pos_self_order_stripe/static/src/app/self_order_service.js
@@ -16,7 +16,7 @@ patch(SelfOrder.prototype, {
                 this.env,
                 stripePaymentMethod,
                 this.access_token,
-                this.pos_config_id,
+                this.config,
                 this.handleStripeError.bind(this),
                 this.handleReaderConnection.bind(this)
             );

--- a/addons/pos_self_order_stripe/static/src/app/stripe.js
+++ b/addons/pos_self_order_stripe/static/src/app/stripe.js
@@ -13,7 +13,7 @@ export class Stripe {
         env,
         stripePaymentMethod,
         access_token,
-        pos_config_id,
+        pos_config,
         errorCallback,
         handleReaderConnection
     ) {
@@ -21,7 +21,7 @@ export class Stripe {
         this.terminal = null;
         this.access_token = access_token;
         this.stripePaymentMethod = stripePaymentMethod;
-        this.pos_config_id = pos_config_id;
+        this.pos_config = pos_config;
         this.errorCallback = errorCallback;
         this.handleReaderConnection = handleReaderConnection;
 
@@ -46,13 +46,13 @@ export class Stripe {
 
     async startPayment(order) {
         try {
-            const result = await rpc(`/kiosk/payment/${this.pos_config_id}/kiosk`, {
-                order: order,
+            const result = await rpc(`/kiosk/payment/${this.pos_config.id}/kiosk`, {
+                order: order.serialize({ orm: true }),
                 access_token: this.access_token,
                 payment_method_id: this.stripePaymentMethod.id,
             });
             const paymentStatus = result.payment_status;
-            const savedOrder = result.order;
+            const savedOrder = result.order[0];
             await this.connectReader();
             const clientSecret = paymentStatus.client_secret;
             const paymentMethod = await this.collectPaymentMethod(clientSecret);


### PR DESCRIPTION
Currently in v18 Stripe payments are broken and don't work anymore. This PR adjusts the code so that Stripe works again in self order mode. It fixes the error "An error has occured" seen when sending a payment to a Stripe terminal + it also fixes the response sent to PoS to confirm Stripe payments.

opw-4283413
opw-4358017
