### PR TITLE
[FIX] point_of_sale: handle offline POS traceback

### DIFF
--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -59,8 +59,6 @@ class PosPayment(models.Model):
         for payment in self:
             if payment.pos_order_id.state in ['invoiced', 'done']:
                 raise ValidationError(_('You cannot edit a payment for a posted order.'))
-            elif payment.pos_order_id.nb_print > 0:
-                raise ValidationError(_('You cannot edit a payment for a printed order.'))
 
     @api.constrains('payment_method_id')
     def _check_payment_method_id(self):


### PR DESCRIPTION
Steps to Reproduce:
===================
- Open a POS session and go offline.
- Create orders and print receipts at the receipt screen.
- Restore the internet connection and bring the POS online.
- A traceback occurs during synchronization.

Before this commit:
=====================
A traceback occurred when making a POS order, printing a receipt in offline
mode, and later going online.
The issue arose because the nb_print field was updated via a backend write call
to restrict payment method edits. However, during offline mode, the order_id
was a string, causing the traceback.

After this commit:
===================
- The backend write call for nb_print is bypassed in offline mode. Instead, the
 `nb_print` count is updated on the frontend. When the order syncs after going
  online, the increased `nb_print` value prevents payment method edits as
  expected.
- Removed the nb_print validation constrains from payment lines. Validation is
  already handled in the write method of pos.order. This change avoids
  validation errors when syncing orders from offline to online, where
  nb_print = 1 and payment lines exist. The write method ensures proper handling
  during order creation.
- A `Connection Lost` error message is displayed when attempting to send
  orders to the kitchen while in offline mode.

Task-4504625