### PR TITLE
[FIX] mail: update systray counter on discard of native notification

### DIFF
--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -93,10 +93,7 @@ patch(MessagingMenu.prototype, {
             displayName: _t("Turn on notifications"),
             iconSrc: this.store.odoobot.avatarUrl,
             partner: this.store.odoobot,
-            isShown:
-                this.store.discuss.activeTab === "main" &&
-                this.shouldAskPushPermission &&
-                !this.store.isNotificationPermissionDismissed,
+            isShown: this.store.discuss.activeTab === "main" && this.shouldAskPushPermission,
         };
     },
     get tabs() {
@@ -180,7 +177,10 @@ patch(MessagingMenu.prototype, {
         return this.store.discuss.activeTab !== "channel" && !this.state.adding;
     },
     get shouldAskPushPermission() {
-        return this.notification.permission === "prompt";
+        return (
+            this.notification.permission === "prompt" &&
+            !this.store.isNotificationPermissionDismissed
+        );
     },
     getFailureNotificationName(failure) {
         if (failure.type === "email") {

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -101,13 +101,13 @@ test("rendering with chat push notification default permissions", async () => {
 test("can quickly dismiss 'Turn on notification' suggestion", async () => {
     patchBrowserNotification("default");
     await start();
-    await contains(".o-mail-MessagingMenu-counter");
     await contains(".o-mail-MessagingMenu-counter", { text: "1" });
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem");
     await contains(".o-mail-NotificationItem", { text: "Turn on notifications" });
     await click(".o-mail-NotificationItem:contains(Turn on notifications) [title='Dismiss']");
     await contains(".o-mail-NotificationItem", { text: "Turn on notifications", count: 0 });
+    await contains(".o-mail-MessagingMenu-counter", { count: 0 });
 });
 
 test("rendering with chat push notification permissions denied", async () => {


### PR DESCRIPTION
**Current behavior before PR:**

Since [1](https://github.com/odoo/odoo/pull/192336) when a user discarded the `Turn on notifications` option from the 
messaging menu,  the systray notification counter was not updated. 
This issue occurred due to an incorrectly written condition.

**Desired behavior after PR is merged:**

The issue is resolved, and the systray notification counter is correctly 
updated when the user discards the native notification prompt.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
