### PR TITLE
[FIX] sale_project: fixed a test_cost_invoicing test case

### DIFF
--- a/addons/sale_project/tests/test_reinvoice.py
+++ b/addons/sale_project/tests/test_reinvoice.py
@@ -332,6 +332,9 @@ class TestReInvoice(TestSaleCommon):
         })
         prod_gap = self.company_data['product_service_order']
         project = self.env['project.project'].create({'name': 'SO Project'})
+        if not project.account_id:
+            project._create_analytic_account()
+
         self.sale_order.write({
             'project_id': project.id,
             'order_line': [Command.create({


### PR DESCRIPTION
It was failing in single module builds /locally and the reason was due to the fact that project not having a analytic account.

task-4500108
