### PR TITLE
[FIX] stock: ensure company field is required for scrap orders

### DIFF
--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -77,7 +77,7 @@ class StockScrap(models.Model):
         for scrap in self:
             if scrap.picking_id:
                 scrap.location_id = scrap.picking_id.location_dest_id if scrap.picking_id.state == 'done' else scrap.picking_id.location_id
-            else:
+            elif scrap.company_id:
                 scrap.location_id = locations_per_company[scrap.company_id.id]
 
     @api.depends('company_id')
@@ -89,7 +89,8 @@ class StockScrap(models.Model):
             for company, stock_warehouse_id in groups
         }
         for scrap in self:
-            scrap.scrap_location_id = locations_per_company[scrap.company_id.id]
+            if scrap.company_id:
+                scrap.scrap_location_id = locations_per_company[scrap.company_id.id]
 
     @api.depends('move_ids', 'move_ids.move_line_ids.quantity', 'product_id')
     def _compute_scrap_qty(self):


### PR DESCRIPTION
Issue Before This Commit:
------------------------------
The 'company' field was required but not validated in relevant triggers for scrap orders. This allowed operations to proceed even when the 'company' field was unset, leading to unexpected issues and inconsistent behavior.

Steps to reproduce:
------------------------------
1. Enable multi-step routes.
2. Create a new scrap order and add a product.
3. Remove the company from the company field.

With This Commit:
------------------------------
- Added a check for 'company' in relevant triggers to ensure that operations only proceed if a company is set.
- This fix guarantees that the 'company' field is always set (required), preventing errors and maintaining consistent behavior in scrap orders.

task-4497387