### PR TITLE
[IMP] point_of_sale: partner list infinite scroll

### DIFF
--- a/addons/point_of_sale/models/res_partner.py
+++ b/addons/point_of_sale/models/res_partner.py
@@ -16,8 +16,13 @@ class ResPartner(models.Model):
     @api.model
     def get_new_partner(self, config_id, domain, offset):
         config = self.env['pos.config'].browse(config_id)
-        limited_partner_ids = {partner[0] for partner in config.get_limited_partners_loading(offset)}
-        new_partner = self.search_read(domain + [('id', 'in', list(limited_partner_ids))], self._load_pos_data_fields(config_id), load=False)
+        if len(domain) == 0:
+            limited_partner_ids = {partner[0] for partner in config.get_limited_partners_loading(offset)}
+            domain += [('id', 'in', list(limited_partner_ids))]
+            new_partner = self.search_read(domain, self._load_pos_data_fields(config_id), load=False)
+        else:
+            # If search domain is not empty, we need to search inside all partners
+            new_partner = self.search_read(domain, self._load_pos_data_fields(config_id), offset=offset, limit=100, load=False)
         return {
             'res.partner': new_partner,
         }

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -8,6 +8,7 @@ import { Input } from "@point_of_sale/app/components/inputs/input/input";
 import { Component, useEffect, useRef, useState } from "@odoo/owl";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 import { unaccent } from "@web/core/utils/strings";
+import { debounce } from "@web/core/utils/timing";
 
 export class PartnerList extends Component {
     static components = { PartnerLine, Dialog, Input };
@@ -27,16 +28,17 @@ export class PartnerList extends Component {
         this.notification = useService("notification");
         this.dialog = useService("dialog");
         this.list = useRef("partner-list");
-
         this.state = useState({
-            initialPartners: new Set(this.pos.models["res.partner"].getAll()),
-            loadedPartners: new Set(),
+            initialPartners: this.pos.models["res.partner"].getAll(),
+            loadedPartners: [],
             query: "",
             loading: false,
         });
+        this.loadedPartnerIds = new Set(this.state.initialPartners.map((p) => p.id));
         useHotkey("enter", () => this.onEnter(), {
             bypassEditableProtection: true,
         });
+        this.onScroll = debounce(this.onScroll.bind(this), 200);
 
         useEffect(
             () => {
@@ -57,10 +59,14 @@ export class PartnerList extends Component {
         return this.pos.screenState.partnerList;
     }
     onScroll(ev) {
+        if (this.state.loading || !this.list || !this.list.el) {
+            return;
+        }
         const height = this.list.el.offsetHeight;
-        const bottomScrollPosition = Math.ceil(this.list.el.scrollTop + height);
+        const scrollTop = this.list.el.scrollTop;
+        const scrollHeight = this.list.el.scrollHeight;
 
-        if (this.list.el.scrollHeight === bottomScrollPosition) {
+        if (scrollTop + height >= scrollHeight * 0.8) {
             this.getNewPartners();
         }
     }
@@ -104,8 +110,7 @@ export class PartnerList extends Component {
         this.props.resolve({ confirmed: true, payload: this.state.selectedPartner });
         this.pos.closeTempScreen();
     }
-    getPartners(partnersSet) {
-        const partners = Array.from(partnersSet);
+    getPartners(partners) {
         const searchWord = unaccent((this.state.query || "").trim(), false);
         const exactMatches = partners.filter((partner) => partner.exactMatch(searchWord));
 
@@ -141,7 +146,9 @@ export class PartnerList extends Component {
     async getNewPartners() {
         let domain = [];
         const offset = this.globalState.offsetBySearch[this.state.query] || 0;
-
+        if (offset > this.loadedPartnerIds.size) {
+            return [];
+        }
         if (this.state.query) {
             const search_fields = [
                 "name",
@@ -164,6 +171,7 @@ export class PartnerList extends Component {
 
         try {
             this.state.loading = true;
+
             const result = await this.pos.data.callRelated("res.partner", "get_new_partner", [
                 this.pos.config.id,
                 domain,
@@ -172,15 +180,19 @@ export class PartnerList extends Component {
 
             this.globalState.offsetBySearch[this.state.query] =
                 offset + (result["res.partner"].length || 100);
-            this.state.loadedPartners = new Set([
-                ...this.state.loadedPartners,
-                ...result["res.partner"],
-            ]);
 
-            return result;
+            for (const partner of result["res.partner"]) {
+                if (!this.loadedPartnerIds.has(partner.id)) {
+                    this.loadedPartnerIds.add(partner.id);
+                    this.state.loadedPartners.push(partner);
+                }
+            }
+
+            return result["res.partner"];
         } catch {
-            this.state.loading = false;
             return [];
+        } finally {
+            this.state.loading = false;
         }
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
@@ -19,40 +19,42 @@
                     autofocus="true"
                     debounceMillis="100" />
             </t>
-            <div class="fixed-head h-100 pt-0" t-ref="partner-list">
-                <t t-set="initialPartners" t-value="getPartners(this.state.initialPartners)"/>
-                <t t-set="loadedPartners" t-value="getPartners(this.state.loadedPartners)"/>
-                <t t-set="nbrPartners" t-value="initialPartners.length + loadedPartners.length"/>
-                <table class="table table-hover">
-                    <tbody class="overflow-scroll h-100" t-att-class="{'d-none': !nbrPartners}">
-                        <t t-foreach="initialPartners" t-as="partner" t-key="partner.id">
-                            <PartnerLine
-                                close="props.close"
-                                partner="partner"
-                                isSelected="props.partner?.id === partner.id"
-                                isBalanceDisplayed="isBalanceDisplayed"
-                                onClickEdit.bind="(p) => this.editPartner(p)"
-                                onClickUnselect.bind="() => this.clickPartner()"
-                                onClickOrders.bind="(p) => this.goToOrders(p)"
-                                onClickPartner.bind="clickPartner"/>
-                        </t>
-                        <t t-foreach="loadedPartners" t-as="partner" t-key="partner.id">
-                            <PartnerLine
-                                close="props.close"
-                                partner="partner"
-                                isSelected="props.partner?.id === partner.id"
-                                isBalanceDisplayed="isBalanceDisplayed"
-                                onClickEdit.bind="(p) => this.editPartner(p)"
-                                onClickUnselect.bind="() => this.clickPartner()"
-                                onClickOrders.bind="(p) => this.goToOrders(p)"
-                                onClickPartner.bind="clickPartner"/>
-                        </t>
-                    </tbody>
-                </table>
-                <div class="text-center" t-if="!nbrPartners">
-                    <div class="text-muted mt-5">
-                        <i class="fa fa-users fa-3x"></i>
-                        <p class="mt-3">No customers found, press enter to load more.</p>
+            <div class="fixed-head h-100 pt-0 overflow-hidden">
+                <div class="overflow-y-auto overflow-x-hidden h-100" t-ref="partner-list">
+                    <t t-set="initialPartners" t-value="getPartners(this.state.initialPartners)"/>
+                    <t t-set="loadedPartners" t-value="getPartners(this.state.loadedPartners)"/>
+                    <t t-set="nbrPartners" t-value="initialPartners.length + loadedPartners.length"/>
+                    <table class="table table-hover">
+                        <tbody class="h-100" t-att-class="{'d-none': !nbrPartners}">
+                            <t t-foreach="initialPartners" t-as="partner" t-key="partner.id">
+                                <PartnerLine
+                                    close="props.close"
+                                    partner="partner"
+                                    isSelected="props.partner?.id === partner.id"
+                                    isBalanceDisplayed="isBalanceDisplayed"
+                                    onClickEdit.bind="(p) => this.editPartner(p)"
+                                    onClickUnselect.bind="() => this.clickPartner()"
+                                    onClickOrders.bind="(p) => this.goToOrders(p)"
+                                    onClickPartner.bind="clickPartner"/>
+                            </t>
+                            <t t-foreach="loadedPartners" t-as="partner" t-key="partner.id">
+                                <PartnerLine
+                                    close="props.close"
+                                    partner="partner"
+                                    isSelected="props.partner?.id === partner.id"
+                                    isBalanceDisplayed="isBalanceDisplayed"
+                                    onClickEdit.bind="(p) => this.editPartner(p)"
+                                    onClickUnselect.bind="() => this.clickPartner()"
+                                    onClickOrders.bind="(p) => this.goToOrders(p)"
+                                    onClickPartner.bind="clickPartner"/>
+                            </t>
+                        </tbody>
+                    </table>
+                    <div class="text-center" t-if="!nbrPartners">
+                        <div class="text-muted mt-5">
+                            <i class="fa fa-users fa-3x"></i>
+                            <p class="mt-3">No customers found, press enter to load more.</p>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Fix multiple issues with partner list :
- The list was not updated when scrolling down
- When searching customers, the partner list could contains duplicate (because before this commit a `Set` structure was used to store objects. This wasn't working as expecting because in JS a Set use references of objects to compare them (now we use a set to store unique IDs).
- Traceback occured when following these steps :
   - Open "Customer" popup
   - Type "ss"
   - Press "enter" => Traceback

Here is how it works now:
- When reaching 80% (scroll) of the partner list, we fetch 100 more partners and add them to the list
- When typing in search bar: search inside the fetched partner list
- Press enter in search bar: fetch new customer matching the search from database

task-id: 4489331

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
