### PR TITLE
[FIX] website_sale: allow browser history navigation on product pages

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -183,9 +183,13 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, cartHandlerM
         const inputs = document.querySelectorAll(
             'input.js_variant_change:checked, select.js_variant_change option:checked'
         );
+        if (!inputs.length) {
+            return;
+        }
         let attributeIds = [];
         inputs.forEach((element) => attributeIds.push(element.dataset.attributeValueId));
-        window.location.hash = 'attribute_values=' + attributeIds.join(',');
+        // Avoid adding new entries in session history by replacing the current one
+        history.replaceState(null, '', '#attribute_values=' + attributeIds.join(','));
     },
     /**
      * Set the checked values active.


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Go eCommerce products page;
2. click on a product;
3. use browser's "Go back" button to go back.

Issue
-----
There's no going back.

Cause
-----
PR https://github.com/odoo/odoo/pull/157412 modified the `_setUrlHash` method used to manage product attributes. One of the changes it made is modified the current URL using `window.location.hash` instead of `window.location.replace`.

While both methods can make identical changes to the URL, a key side-effect of `Location:replace()` is that the URL being replaced won't get saved in the session's `History`[^1].

As this method is called the moment the page loads, modifying the URL via `location.hash` will store the initial product page URL without attribute hashes in the session history. Then when trying to navigate back, the method will be called again immediately to apply attribute hashes, again modifying the session history, making it virtually impossible to leave the page without clicking a new URL.

Solution
--------
Use `history.replaceState`[^2] to update the current state, and not create any new entries.

Also re-introduce early return when there are no product attributes to avoid polluting URLs, originally added in https://github.com/odoo/odoo/pull/159474 but removed via https://github.com/odoo/odoo/pull/157412.

opw-4416701

[^1]: https://developer.mozilla.org/en-US/docs/Web/API/Location/replace
[^2]: https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState