### PR TITLE
[FIX] l10n_latam_check: existing third party check outgoing payment method.

### DIFF
--- a/addons/l10n_latam_check/models/account_payment_method.py
+++ b/addons/l10n_latam_check/models/account_payment_method.py
@@ -9,6 +9,7 @@ class AccountPaymentMethod(models.Model):
         res = super()._get_payment_method_information()
         res['new_third_party_checks'] = {'mode': 'multi', 'type': ('cash',)}
         res['in_third_party_checks'] = {'mode': 'multi', 'type': ('cash',)}
+        res['out_third_party_checks'] = {'mode': 'multi', 'type': ('cash',)}
         res['return_third_party_checks'] = {'mode': 'multi', 'type': ('bank',)}
         res['own_checks'] = {'mode': 'multi', 'type': ('bank',)}
         return res


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**: 
1) It is necessay not to set "Existing Third Party Checks" outgoing payment method in all argentinean cash journals. It is only needed to be set on "Third Party Checks" and "Rejected Third Party Checks" Argentinean journals that are created when the module is installed or a new argentinean company is created. 
2) Also when a user mistakenly remove the 'Existing Third Party Checks' payment method from the 'Third Party Checks' journal then is not able to add it back. This bug was introduced on this commit https://github.com/odoo/odoo/pull/188451/commits/0618fff9f9bb4716d22dc2ce8950cada824b90f4.

**Current behavior before PR**:
1) "Existing Third Party Checks" outgoing payment method is set in all argentinean cash journals.
2) When a user mistakenly remove the 'Existing Third Party Checks' payment method from the 'Third Party Checks' journal then is not able to add it back.

**Desired behavior after PR is merged**:
1) "Existing Third Party Checks" outgoing payment method is set only in "Third Party Checks" and "Rejected Third Party Checks" argentinean journals.
2) When a user mistakenly remove the 'Existing Third Party Checks' payment method from the 'Third Party Checks' journal then is able to add it back.

_Ticket Adhoc side_: 83443
_Task Latam side_: 1309



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
