### PR TITLE
[Imp] html_editor: allow dynamic title on toolbar buttons

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -86,7 +86,10 @@ export class FormatPlugin extends Plugin {
             },
             {
                 id: "removeFormat",
-                title: _t("Remove Format"),
+                title: (sel, nodes) =>
+                    nodes && this.hasAnyFormat(nodes)
+                        ? _t("Remove Format")
+                        : _t("Selection has no format"),
                 icon: "fa-eraser",
                 run: this.removeFormat.bind(this),
             },

--- a/addons/html_editor/static/src/main/toolbar/toolbar.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.js
@@ -24,7 +24,7 @@ export class Toolbar extends Component {
                                         const base = {
                                             id: String,
                                             groupId: String,
-                                            title: String,
+                                            title: { type: [String, Function] },
                                             isAvailable: { type: Function, optional: true },
                                         };
                                         if (button.Component) {
@@ -56,6 +56,7 @@ export class Toolbar extends Component {
                         buttonsActiveState: Object,
                         buttonsDisabledState: Object,
                         buttonsAvailableState: Object,
+                        buttonsTitleState: Object,
                         namespace: {
                             type: String,
                             optional: true,
@@ -89,6 +90,6 @@ export class Toolbar extends Component {
 }
 
 export const toolbarButtonProps = {
-    title: String,
+    title: [String, Function],
     getSelection: Function,
 };

--- a/addons/html_editor/static/src/main/toolbar/toolbar.xml
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.xml
@@ -9,7 +9,7 @@
                             <t t-if="button.Component">
                                 <t t-component="button.Component"
                                     t-props="button.props"
-                                    title="button.title"
+                                    title="state.buttonsTitleState[button.id]"
                                     getSelection.bind="props.toolbar.getSelection"/>
                             </t>
                             <button t-else=""
@@ -19,7 +19,7 @@
                                     disabled: state.buttonsDisabledState[button.id]
                                 }"
                                 t-att-disabled="state.buttonsDisabledState[button.id]"
-                                t-att-title="button.title"
+                                t-att-title="state.buttonsTitleState[button.id]"
                                 t-att-name="button.id"
                                 t-on-click="() => this.onButtonClick(button)"
                             >

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -112,11 +112,16 @@ test("toolbar buttons react to selection change", async () => {
 
     // check that bold button is not active
     expect(".btn[name='bold']").not.toHaveClass("active");
+    // check that remove format buton isdisabled and have correct title
+    expect(".btn[name='remove_format']").toHaveAttribute("disabled");
+    expect(".btn[name='remove_format']").toHaveAttribute("title", "Selection has no format");
 
     // click on toggle bold
     await contains(".btn[name='bold']").click();
     expect(getContent(el)).toBe("<p><strong>[test]</strong> some text</p>");
     expect(".btn[name='bold']").toHaveClass("active");
+    expect(".btn[name='remove_format']").not.toHaveAttribute("disabled");
+    expect(".btn[name='remove_format']").toHaveAttribute("title", "Remove Format");
 
     // set selection where text is not bold
     setContent(el, "<p><strong>test</strong> some [text]</p>");
@@ -585,11 +590,12 @@ test("toolbar buttons should have title attribute", async () => {
 test("toolbar buttons should have title attribute with translated text", async () => {
     // Retrieve toolbar buttons descriptions in English
     const { editor, plugins } = await setupEditor("");
+    // map function to get the title string value
+    const itemTitleString = (item) =>
+        item.title instanceof Function ? item.title().toString() : item.title.toString();
+
     // item.label could be a LazyTranslatedString so we ensure it is a string with toString()
-    const titles = plugins
-        .get("toolbar")
-        .getButtons()
-        .map((item) => item.title.toString());
+    const titles = plugins.get("toolbar").getButtons().map(itemTitleString);
     editor.destroy();
 
     // Patch translations to return "Translated" for these terms
@@ -604,7 +610,7 @@ test("toolbar buttons should have title attribute with translated text", async (
         .getButtons()
         .forEach((item) => {
             // item.label could be a LazyTranslatedString so we ensure it is a string with toString()
-            expect(item.title.toString()).toBe("Translated");
+            expect(itemTitleString(item)).toBe("Translated");
         });
 
     await waitFor(".o-we-toolbar");


### PR DESCRIPTION
Change the title props of the toolbar's button to allow a dynamic content.

The props can now either be,
Static : A hard coded translated String.
Or dynamic : A getter function that return a translated String.

This function will receive some selection context to be able to change the title accordingly.

task-4463559



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
