### PR TITLE
[IMP] mail: indicated thread on message

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -114,6 +114,15 @@
                                     imagesHeight="message.attachment_ids.length === 1 ? 300 : 75"
                                     messageSearch="props.messageSearch"/>
                                 <LinkPreviewList t-if="message.link_preview_ids.length > 0 and store.hasLinkPreviewFeature and !message.linkPreviewSquash" linkPreviews="message.link_preview_ids" deletable="props.message.editable"/>
+                                <div class="position-relative mb-2" t-if="props.message.linkedSubChannel and props.message.linkedSubChannel != props.thread" >
+                                    <svg class="position-absolute" xmlns="http://www.w3.org/2000/svg" width="10" height="20" viewBox="0 0 10 20">
+                                        <line x1="0" y1="3" x2="0" y2="100%" stroke="currentColor" stroke-width="3"/>
+                                        <line x1="0" y1="100%" x2="100%" y2="100%" stroke="currentColor" stroke-width="3"/>
+                                    </svg>
+                                    <div t-on-click="openSubChannel" class="cursor-pointer ms-4 mt-2 p-2 bg-200 rounded-2">
+                                        <t t-call="mail.MessageSubChannel"/>
+                                    </div>
+                                </div>
                             </div>
                             <t t-if="!message.is_note and !message.isPending and (!message.hasTextContent or env.inChatWindow)" t-call="mail.Message.actions"/>
                         </div>
@@ -225,6 +234,29 @@
 
 <t t-name="mail.Message.mentionedChannelIcon">
     <i t-att-class="icon"/>
+</t>
+
+<t t-name="mail.MessageSubChannel">
+    <t t-set="subChannelLastMessage" t-value="props.message.linkedSubChannel.oldestPersistentMessage"/>
+    <div>
+        <strong><t t-esc="props.message.linkedSubChannel.name"/></strong> - <t t-out="props.message.linkedSubChannel.message_counter"/> messages <span class="smaller"> <i class="fa fa-chevron-right"/></span>
+    </div>
+    <div t-if="subChannelLastMessage" class="overflow-hidden text-truncate" style="max-width: 700px">
+        <img class="o-mail-MessageInReply-avatar me-2 rounded o_object_fit_cover" t-att-src="subChannelLastMessage.author?.avatarUrl" t-att-title="subChannelLastMessage.author?.name ?? subChannelLastMessage.email_from" alt="Avatar"/>
+        <span>
+            <t t-out="subChannelLastMessage.author?.name"/>
+        </span>:
+        <span class="ms-1" >
+            <t t-if="!props.message.parentMessage.isBodyEmpty">
+                <t t-out="subChannelLastMessage.inlineBody"/>
+                <em t-if="subChannelLastMessage.edited" class="smaller fw-bold text-500"> (edited)</em>
+            </t>
+            <t t-elif="subChannelLastMessage.attachment_ids.length > 0">
+                <span class="me-2 fst-italic">Click to see the attachments</span>
+                <i class="fa fa-image"/>
+            </t>
+        </span>
+    </div>
 </t>
 
 </templates>

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -174,7 +174,11 @@ export class Thread extends Record {
      *
      * Content should be fetched and inserted in a controlled way.
      */
-    messages = Record.many("mail.message");
+    messages = Record.many("mail.message", {
+        onUpdate() {
+            this.oldestPersistentMessage = this.messages.find((msg) => Number.isInteger(msg.id));
+        },
+    });
     /** @type {string} */
     modelName;
     /** @type {string} */
@@ -362,11 +366,8 @@ export class Thread extends Record {
             return this.newestPersistentAllMessages[0];
         },
     });
-
-    get oldestPersistentMessage() {
-        return this.messages.find((msg) => Number.isInteger(msg.id));
-    }
-
+    oldestPersistentMessage = Record.one("mail.message");
+    message_counter = 0;
     onPinStateUpdated() {}
 
     get invitationLink() {

--- a/addons/mail/static/src/discuss/core/common/message_patch.js
+++ b/addons/mail/static/src/discuss/core/common/message_patch.js
@@ -10,5 +10,8 @@ const messagePatch = {
     get showSeenIndicator() {
         return this.props.message.isSelfAuthored && this.props.thread?.hasSeenFeature;
     },
+    openSubChannel() {
+        this.props.message.linkedSubChannel.open();
+    },
 };
 patch(Message.prototype, messagePatch);

--- a/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
@@ -199,3 +199,23 @@ test("sub thread is available for channel and group, not for chat", async () => 
     await click(".o-mail-DiscussSidebarChannel", { text: "Demo" });
     await contains("button[title='Threads']", { count: 0 });
 });
+
+test("Show thread below message.", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "General",
+    });
+    const messageId = pyEnv["mail.message"].create({
+        model: "discuss.channel",
+        res_id: channelId,
+        body: "test",
+    });
+    pyEnv["discuss.channel"].create({
+        name: "ThreadOne",
+        parent_channel_id: channelId,
+        from_message_id: messageId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message-content div strong", { text: "ThreadOne" });
+});


### PR DESCRIPTION
Before this PR, messages with threads where not properly displayed in the message
list, only a notification was created.
This PR introduces a card for the subthread below the message.

task-