### PR TITLE
Master lazy config res

### DIFF
--- a/addons/hr_attendance/models/__init__.py
+++ b/addons/hr_attendance/models/__init__.py
@@ -6,5 +6,6 @@ from . import hr_attendance_overtime
 from . import hr_employee_base
 from . import hr_employee
 from . import hr_employee_public
+from . import ir_http
 from . import res_company
 from . import res_users

--- a/addons/hr_attendance/models/ir_http.py
+++ b/addons/hr_attendance/models/ir_http.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.hr_attendance.controllers.main import HrAttendance
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    def lazy_session_info(self):
+        res = super().lazy_session_info()
+        if self.env.user and self.env.user.employee_id:
+            employee = self.env.user.employee_id
+            res['attendance_user_data'] = HrAttendance._get_user_attendance_data(employee)
+        return res

--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
@@ -1,4 +1,4 @@
-import { Component, useState } from "@odoo/owl";
+import { Component, onWillStart, useState } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
@@ -16,6 +16,7 @@ export class ActivityMenu extends Component {
 
     setup() {
         this.ui = useService("ui");
+        this.lazySession = useService("lazy_session");
         this.employee = false;
         this.state = useState({
             checkedIn: false,
@@ -23,14 +24,23 @@ export class ActivityMenu extends Component {
         });
         this.date_formatter = registry.category("formatters").get("float_time")
         this.dropdown = useDropdownState();
-        // load data but do not wait for it to render to prevent from delaying
-        // the whole webclient
-        this.searchReadEmployee();
+        onWillStart(()=> {
+            // access lazy session but do no wait for it, to prevent from delaying the whole webclient
+            this.lazySession.getValue("attendance_user_data", (employee) => {
+                if (employee) {
+                    this.employee = employee;
+                    this._searchReadEmployeeFill();
+                }
+            });
+        });
     }
 
     async searchReadEmployee(){
-        const result = await rpc("/hr_attendance/attendance_user_data");
-        this.employee = result;
+        this.employee = await rpc("/hr_attendance/attendance_user_data");
+        this._searchReadEmployeeFill();
+    }
+
+    _searchReadEmployeeFill() {
         if (this.employee.id) {
             this.hoursToday = this.date_formatter(
                 this.employee.hours_today

--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
@@ -65,23 +65,23 @@ export class ActivityMenu extends Component {
         if (!isIosApp()) { // iOS app lacks permissions to call `getCurrentPosition`
             navigator.geolocation.getCurrentPosition(
                 async ({coords: {latitude, longitude}}) => {
-                    await rpc("/hr_attendance/systray_check_in_out", {
+                    this.employee = await rpc("/hr_attendance/systray_check_in_out", {
                         latitude,
                         longitude
                     })
-                    await this.searchReadEmployee()
+                    this._searchReadEmployeeFill();
                 },
                 async err => {
-                    await rpc("/hr_attendance/systray_check_in_out")
-                    await this.searchReadEmployee()
+                    this.employee = await rpc("/hr_attendance/systray_check_in_out")
+                    this._searchReadEmployeeFill();
                 },
                 {
                     enableHighAccuracy: true,
                 }
             )
         } else {
-            await rpc("/hr_attendance/systray_check_in_out")
-            await this.searchReadEmployee()
+            this.employee = await rpc("/hr_attendance/systray_check_in_out")
+            this._searchReadEmployeeFill();
         }
     }
 }

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -72,6 +72,9 @@ class IrHttp(models.AbstractModel):
             'session_info': self.session_info(),
         }
 
+    def lazy_session_info(self):
+        return {}
+
     def session_info(self):
         user = self.env.user
         session_uid = request.session.uid

--- a/addons/web/static/src/core/session_service.js
+++ b/addons/web/static/src/core/session_service.js
@@ -1,0 +1,26 @@
+import { registry } from "@web/core/registry";
+import { deepCopy } from "@web/core/utils/objects";
+
+export const lazySession = {
+    dependencies: ["orm"],
+    start(env, { orm }) {
+        let resolveWebClientReady;
+        let lazyConfigPromise;
+        const fetchServerData = async () => {
+            await webClientReadyPromise;
+            return orm.call("ir.http", "lazy_session_info", [[]]);
+        };
+        const webClientReadyPromise = new Promise((r) => (resolveWebClientReady = r));
+        env.bus.addEventListener("WEB_CLIENT_READY", resolveWebClientReady);
+        return {
+            getValue(key, callback) {
+                if (!lazyConfigPromise) {
+                    lazyConfigPromise = fetchServerData();
+                }
+                lazyConfigPromise.then((config) => callback(deepCopy(config)[key]));
+            },
+        };
+    },
+};
+
+registry.category("services").add("lazy_session", lazySession);

--- a/addons/web/static/tests/core/session_service.test.js
+++ b/addons/web/static/tests/core/session_service.test.js
@@ -1,0 +1,176 @@
+import { Component, onMounted, onWillStart, xml } from "@odoo/owl";
+import { expect, test } from "@odoo/hoot";
+import { animationFrame } from "@odoo/hoot-mock";
+import {
+    getService,
+    mountWithCleanup,
+    onRpc,
+    patchWithCleanup,
+} from "@web/../tests/web_test_helpers";
+
+import { registry } from "@web/core/registry";
+import { WebClient } from "@web/webclient/webclient";
+import { useService } from "@web/core/utils/hooks";
+
+test("Only call once session info data when services calls lazy session", async () => {
+    patchWithCleanup(WebClient.prototype, {
+        setup() {
+            super.setup();
+            onMounted(() => expect.step("web_client_mounted"));
+        },
+    });
+    onRpc("lazy_session_info", () => {
+        expect.step("load_session_info");
+        return { a: "a", b: "b" };
+    });
+
+    const serviceRegistry = registry.category("services");
+    serviceRegistry.add("fake_a", {
+        dependencies: ["lazy_session"],
+        start(env, { lazy_session }) {
+            expect.step("service_a_before");
+            lazy_session.getValue("a", (value) => {
+                expect(value).toBe("a");
+                expect.step("session_a_after_lazy");
+            });
+            expect.step("service_a_after");
+        },
+    });
+    serviceRegistry.add("fake_b", {
+        dependencies: ["lazy_session"],
+        start(env, { lazy_session }) {
+            expect.step("service_b_before");
+            lazy_session.getValue("b", (value) => {
+                expect(value).toBe("b");
+                expect.step("session_b_after_lazy");
+            });
+            expect.step("service_b_after");
+        },
+    });
+
+    await mountWithCleanup(WebClient);
+    await animationFrame();
+    expect.verifySteps([
+        "service_a_before",
+        "service_a_after",
+        "service_b_before",
+        "service_b_after",
+        "web_client_mounted",
+        "load_session_info", // <= only do it once after webclient is mounted
+        "session_a_after_lazy",
+        "session_b_after_lazy",
+    ]);
+});
+
+test("Only call once lazy session info data on action", async () => {
+    patchWithCleanup(WebClient.prototype, {
+        setup() {
+            super.setup();
+            onMounted(() => expect.step("web_client_mounted"));
+        },
+    });
+    onRpc("lazy_session_info", () => {
+        expect.step("load_session_info");
+        return { a: "a" };
+    });
+    const actionRegistry = registry.category("actions");
+    class TestClientAction extends Component {
+        static template = xml`<div/>`;
+        static props = ["*"];
+        setup() {
+            expect.step("myaction_before");
+            this.lazySession = useService("lazy_session");
+            onWillStart(() => {
+                expect.step("myaction_on_will_start");
+                this.lazySession.getValue("a", (value) => {
+                    expect(value).toEqual("a");
+                    expect.step("myaction_on_will_start_after");
+                });
+            });
+        }
+    }
+    actionRegistry.add("__test__client__action__", TestClientAction);
+
+    await mountWithCleanup(WebClient);
+    await animationFrame();
+    await getService("action").doAction({
+        tag: "__test__client__action__",
+        type: "ir.actions.client",
+    });
+    await animationFrame();
+    await getService("action").doAction({
+        tag: "__test__client__action__",
+        type: "ir.actions.client",
+    });
+    await animationFrame();
+    expect.verifySteps([
+        "web_client_mounted",
+        "myaction_before",
+        "myaction_on_will_start",
+        "load_session_info", // <= only do it once after webclient is mounted
+        "myaction_on_will_start_after",
+        "myaction_before",
+        "myaction_on_will_start",
+        "myaction_on_will_start_after",
+    ]);
+});
+
+test("Call lazy session info after webclient init with action and service", async () => {
+    patchWithCleanup(WebClient.prototype, {
+        setup() {
+            super.setup();
+            onMounted(() => expect.step("web_client_mounted"));
+        },
+    });
+    onRpc("lazy_session_info", () => {
+        expect.step("load_session_info");
+        return { a: "a", b: "b" };
+    });
+    const serviceRegistry = registry.category("services");
+    serviceRegistry.add("fake_a", {
+        dependencies: ["lazy_session"],
+        start(env, { lazy_session }) {
+            expect.step("service_before");
+            lazy_session.getValue("a", (value) => {
+                expect(value).toBe("a");
+                expect.step("session_after_lazy");
+            });
+            expect.step("service_after");
+        },
+    });
+    const actionRegistry = registry.category("actions");
+    class TestClientAction extends Component {
+        static template = xml`<div/>`;
+        static props = ["*"];
+        setup() {
+            expect.step("myaction_before");
+            this.lazySession = useService("lazy_session");
+            onWillStart(() => {
+                expect.step("myaction_on_will_start");
+                this.lazySession.getValue("b", (value) => {
+                    expect(value).toEqual("b");
+                    expect.step("myaction_on_will_start_after");
+                });
+            });
+        }
+    }
+    actionRegistry.add("__test__client__action__", TestClientAction);
+
+    await mountWithCleanup(WebClient);
+    await animationFrame();
+    await getService("action").doAction({
+        tag: "__test__client__action__",
+        type: "ir.actions.client",
+    });
+    await animationFrame();
+    expect.verifySteps([
+        "service_before",
+        "service_after",
+        "web_client_mounted",
+        "load_session_info", // <= only do it once after webclient is mounted
+        "session_after_lazy",
+        "myaction_before",
+        "myaction_on_will_start",
+        "myaction_on_will_start_after",
+    ]);
+});


### PR DESCRIPTION
This PR introduces a new mechanism that allows pieces of code to fetch data at webclient startup, in a single rpc.
There introduced python method `lazy_session_info` is called when the webclient is mounted. It returns an object. That method can be overridden to add keys inside that object, and the values can then be accessed in the webclient, by the pieces of code needed it. It works similarly to `session_info`, which is computed when rendering the page, and whose values are directly inserted in the page.

This PR uses that new mechanism to remove an rpc done in hr_attendance at webclient startup.

task-4341388
