### PR TITLE
[FIX] hr: suppress warning on optimized domains

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -11,6 +11,7 @@ from dateutil.relativedelta import relativedelta
 from markupsafe import Markup
 
 from odoo import api, fields, models, _
+from odoo.fields import Domain
 from odoo.exceptions import ValidationError, AccessError
 from odoo.osv import expression
 from odoo.tools import convert, format_date
@@ -333,6 +334,8 @@ class HrEmployee(models.Model):
         # cache, and interpreted as an access error
         self._check_private_fields(field_names)
         self.flush_model(field_names)
+        # HACK: suppress warning if domain is optimized for another model
+        domain = list(domain) if isinstance(domain, Domain) else domain
         public = self.env['hr.employee.public'].search_fetch(domain, field_names, offset, limit, order)
         employees = self.browse(public._ids)
         employees._copy_cache_from(public, field_names)
@@ -416,6 +419,8 @@ class HrEmployee(models.Model):
         if self.browse().has_access('read'):
             return super()._search(domain, offset, limit, order)
         try:
+            # HACK: suppress warning if domain is optimized for another model
+            domain = list(domain) if isinstance(domain, Domain) else domain
             ids = self.env['hr.employee.public']._search(domain, offset, limit, order)
         except ValueError:
             raise AccessError(_('You do not have access to this document.'))


### PR DESCRIPTION
If the domain is already optimized for another model, the optimize function logs a warning.
While the domain could probably be used as is without requiring the domain to be optimized again (due to the nature of the hr.employee models), we reset the domain completely if the domain has been optimized for another model.

