### PR TITLE
[FIX] mail: missing message formatting when creating a subchannel

### DIFF
--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -59,7 +59,7 @@ const threadPatch = {
             }
             const data = await rpc("/discuss/channel/info", { channel_id: this.id });
             if (data) {
-                this.store.insert(data);
+                this.store.insert(data, { html: true });
             } else {
                 this.delete();
             }


### PR DESCRIPTION
Before this commit, when a user accesses a sub-thread of channel made from a message for the 1st time, the format of the message body shows html as textcontent rather as inner html.

Steps to reproduce:
- Post a message as user A
- Create a thread from this message as user B
- User A accesses this sub-thread and posts a new message
-> User A sees 1st message with bad formatting

This happens because on sub-thread join, the data of sub-thread info are fetched, and since the sub-thread is created from a message, the channel info data also contains the message data. This data was inserted without `html: true`, leading to message body being inserted in a non-trusted way in JS models, causing this formatting issue.

This commit fixes the issue by flagging the insert with `html: true`, as this is from trusted origin and content is trusted, so the message body is inserted to be used properly in message component. Note that this behaviour applies to html fields, which message body is. The insert `html: true` is assessed for data on all targeted html fields.

task-4506489

