### PR TITLE
[IMP] orm: keep indexes without comments

### DIFF
--- a/odoo/addons/base/tests/test_sql.py
+++ b/odoo/addons/base/tests/test_sql.py
@@ -198,8 +198,9 @@ class TestSqlTools(TransactionCase):
         sql.add_index(self.env.cr, 'res_bank_test_name', 'res_bank', definition, unique=False)
 
         # check the definition
-        db_definition = sql.index_definition(self.env.cr, 'res_bank_test_name')
+        db_definition, db_comment = sql.index_definition(self.env.cr, 'res_bank_test_name')
         self.assertIn(definition, db_definition)
+        self.assertIs(db_comment, None)
 
     def test_add_index_escape(self):
         definition = "(id) WHERE name ~ '%'"
@@ -207,5 +208,6 @@ class TestSqlTools(TransactionCase):
         sql.add_index(self.env.cr, 'res_bank_test_percent_escape', 'res_bank', definition, unique=False, comment=comment)
 
         # ensure the definitions match (definition is the comment if it is set)
-        db_definition = sql.index_definition(self.env.cr, 'res_bank_test_percent_escape')
-        self.assertEqual(db_definition, comment)
+        db_definition, db_comment = sql.index_definition(self.env.cr, 'res_bank_test_percent_escape')
+        self.assertIn('WHERE', db_definition)  # the definition is rewritten by postgres
+        self.assertEqual(db_comment, comment)

--- a/odoo/orm/table_objects.py
+++ b/odoo/orm/table_objects.py
@@ -145,11 +145,13 @@ class Index(TableObject):
         cr = model.env.cr
         conname = self.full_name(model)
         definition = self.definition
-        current_definition = sql.index_definition(cr, conname)
-        if current_definition == definition:
+        db_definition, db_comment = sql.index_definition(cr, conname)
+        if db_comment == definition or (not db_comment and db_definition):
+            # keep when the definition matches the comment in the database
+            # or if we have an index without a comment (this is used by support to tweak indexes)
             return
 
-        if current_definition:
+        if db_definition:
             # constraint exists but its definition may have changed
             sql.drop_index(cr, conname, model._table)
 

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -546,13 +546,13 @@ def check_index_exist(cr, indexname):
 def index_definition(cr, indexname):
     """ Read the index definition from the database """
     cr.execute(SQL("""
-        SELECT COALESCE(d.description, idx.indexdef) AS def
+        SELECT idx.indexdef, d.description
         FROM pg_class c
         JOIN pg_indexes idx ON c.relname = idx.indexname
         LEFT JOIN pg_description d ON c.oid = d.objoid
         WHERE c.relname = %s AND c.relkind = 'i'
     """, indexname))
-    return cr.fetchone()[0] if cr.rowcount else None
+    return cr.fetchone() if cr.rowcount else (None, None)
 
 
 def create_index(


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When upgrading, the team would like to keep existing modified indexes. Therefore, we will not re-create indexes that already exist and have no comments. We create the index only when the comment does not match or when the index does not exist.

Current behavior before PR:
If there is no comment, drop and re-create the index during the upgrade.

Desired behavior after PR is merged:
Keep the indexes during the upgrade.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
