### PR TITLE
[FIX] mail: msg post in group chat with mention shows blue bubble

### DIFF
--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -97,8 +97,7 @@ class ResPartner(models.Model):
             ]
         )
         store = Store(members, fields={"channel": [], "persona": []})
-        for p in partners:
-            store.add(p,{
-                "groups_id": [("ADD", next((group.id for group in p.user_ids.groups_id if group.id == channel.group_public_id.id), None))]
-            })
+        if channel.group_public_id:
+            for p in partners:
+                store.add(p, {"groups_id": [("ADD", (channel.group_public_id & p.user_ids.groups_id).ids)]})
         return store.get_result()

--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -192,11 +192,12 @@ class UseSuggestion {
                 abortSignal: this.abortController.signal,
             });
         } catch (e) {
+            this.lastFetchedSearch = null;
             if (e instanceof ConnectionAbortedError) {
                 resetFetchingState = false;
                 return;
             }
-            this.lastFetchedSearch = null;
+            throw e;
         } finally {
             if (resetFetchingState) {
                 this.state.isFetching = false;


### PR DESCRIPTION
Before this commit, when posting a message with a `@` mention in group chat, the message had blue bubble instead of green bubble. This color means that the message is not recognized as a self message.

Steps to reproduce:
- make group chat
- post a message with `@` mention
=> the message bubble is blue rather than green

This problem is a consequence of https://github.com/odoo/odoo/pull/176758 In this PR, when mentioning from any channel, the `groups_id` of partners from mention suggestions could be returned. If the users are in the group of group_public of channel, this means these partners could be invited in the channel. This is useful to make them elligible for `@` mention even when they are not member. This partial knowledge of the group id of partner is provided to client code so that the suggestions are shown too, since the list results in the JS modeling.

This PR however introduced a silent crash in JS code from this LOC: https://github.com/odoo/odoo/pull/176758/files#diff-515b5eba2d7fbff9826774f16c701063cfd9c95967287eaec36b16db66ef8c48R102

The server data may send `[ADD, null]` for partner `groups_id`, which is the case in group chat. The internal code of JS models does not expect this kind of command data: it crashes because `ADD` command assumes the other part is genuine data or record(s). However `null` means nothingness, so internally the `target` is missing thus it leads to a crash in the internal code of JS models.

Why is the crash not bubbled then? Well, this is silently ignored in business code by the fetch mention function, in `fetchSuggestions`.

The silent crash is suspicious, but not necessarily the primary cause of the problem... No no no. Internal code of JS models has made a bigger sin: the silent crash aborts the pending update cycle, thus not flushing it. This is a huge problem, because the implementation of update cycle is made in a way that its integrity depends on no crash during the update cycle. That's because the synchronous processing of update cycle defines layers of update cycle with a
global counter that is incremented and decremented. The 1st update cycle layer manages the flush, while the other layers do the operations without flush.

If there's a crash during the update cycle, the update cycle is aborted but its counter is preserved. Let's say the counter is 4: that means the update queues are never flushed, because the only way to change this value is through `MAKE_UPDATE`, and this function only preserves its value or temporarily increases it.

So what's the deal with the green bubble being blue? Well, there's a computed field `isSelfAuthored` that was never computed because of the silent crash. Thus it had the default value `false` rather than `true` for self messages.

While the symptoms show blue bubble instead of green bubble, which feels cute but not a big deal... This was actually a side-effect of a much much bigger issue that compromises the overall modeling of JS. Yes, that's like having an eye tickling, thinking that we're just tired but it's actually a symptom of final stage cancer.

Do not worry though: this commit doesn't cure cancer, but it fixes this problem as follow: `fetchSuggestions` in business code should not silently catch non-abort errors, and bubble it.