### PR TITLE
[IMP] pos_self_order: automatically enable preset in self demo data

### DIFF
--- a/addons/pos_restaurant/__manifest__.py
+++ b/addons/pos_restaurant/__manifest__.py
@@ -25,6 +25,7 @@ This module adds several features to the Point of Sale that are specific to rest
         'views/res_config_settings_views.xml',
     ],
     'demo': [
+        'data/preset_data.xml',
         'data/demo_data.xml',
     ],
     'installable': True,

--- a/addons/pos_restaurant/data/preset_data.xml
+++ b/addons/pos_restaurant/data/preset_data.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="pos_resource_preset" model="resource.calendar">
+            <field name="name">Opening time</field>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="attendance_ids" eval="[(5, 0, 0),
+                    (0, 0, {'name': 'Tuesday Lunch', 'dayofweek': '1', 'hour_from': 12, 'hour_to': 15, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 18, 'hour_to': 22, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Wednesday Lunch', 'dayofweek': '2', 'hour_from': 12, 'hour_to': 15, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 18, 'hour_to': 22, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Thursday Lunch', 'dayofweek': '3', 'hour_from': 12, 'hour_to': 15, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Thursday Afternoon', 'dayofweek': '3', 'hour_from': 18, 'hour_to': 22, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Friday Lunch', 'dayofweek': '4', 'hour_from': 12, 'hour_to': 15, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 18, 'hour_to': 22, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Saturday Lunch', 'dayofweek': '5', 'hour_from': 12, 'hour_to': 15, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Saturday Afternoon', 'dayofweek': '5', 'hour_from': 18, 'hour_to': 22, 'day_period': 'afternoon'})
+                ]"
+            />
+        </record>
+        <record model="pos.preset" id="pos_takein_preset">
+            <field name="name">Eat In</field>
+            <field name="color">4</field>
+        </record>
+        <record model="pos.preset" id="pos_takeout_preset">
+            <field name="name">Takeout</field>
+            <field name="color">3</field>
+            <field name="identification">name</field>
+            <field name="use_timing">True</field>
+            <field name="resource_calendar_id" eval="ref('pos_resource_preset')"/>
+        </record>
+        <record model="pos.preset" id="pos_delivery_preset">
+            <field name="name">Delivery</field>
+            <field name="color">2</field>
+            <field name="identification">address</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/pos_restaurant/data/scenarios/restaurant_data.xml
+++ b/addons/pos_restaurant/data/scenarios/restaurant_data.xml
@@ -1,40 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
-        <record id="pos_resource_preset" model="resource.calendar">
-            <field name="name">Opening time</field>
-            <field name="company_id" ref="base.main_company"/>
-            <field name="attendance_ids" eval="[(5, 0, 0),
-                    (0, 0, {'name': 'Tuesday Lunch', 'dayofweek': '1', 'hour_from': 12, 'hour_to': 15, 'day_period': 'lunch'}),
-                    (0, 0, {'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 18, 'hour_to': 22, 'day_period': 'afternoon'}),
-                    (0, 0, {'name': 'Wednesday Lunch', 'dayofweek': '2', 'hour_from': 12, 'hour_to': 15, 'day_period': 'lunch'}),
-                    (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 18, 'hour_to': 22, 'day_period': 'afternoon'}),
-                    (0, 0, {'name': 'Thursday Lunch', 'dayofweek': '3', 'hour_from': 12, 'hour_to': 15, 'day_period': 'lunch'}),
-                    (0, 0, {'name': 'Thursday Afternoon', 'dayofweek': '3', 'hour_from': 18, 'hour_to': 22, 'day_period': 'afternoon'}),
-                    (0, 0, {'name': 'Friday Lunch', 'dayofweek': '4', 'hour_from': 12, 'hour_to': 15, 'day_period': 'lunch'}),
-                    (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 18, 'hour_to': 22, 'day_period': 'afternoon'}),
-                    (0, 0, {'name': 'Saturday Lunch', 'dayofweek': '5', 'hour_from': 12, 'hour_to': 15, 'day_period': 'lunch'}),
-                    (0, 0, {'name': 'Saturday Afternoon', 'dayofweek': '5', 'hour_from': 18, 'hour_to': 22, 'day_period': 'afternoon'})
-                ]"
-            />
-        </record>
-        <record model="pos.preset" id="pos_takein_preset">
-            <field name="name">Eat In</field>
-            <field name="color">4</field>
-        </record>
-        <record model="pos.preset" id="pos_takeout_preset">
-            <field name="name">Takeout</field>
-            <field name="color">3</field>
-            <field name="identification">name</field>
-            <field name="use_timing">True</field>
-            <field name="resource_calendar_id" eval="ref('pos_resource_preset')"/>
-        </record>
-        <record model="pos.preset" id="pos_delivery_preset">
-            <field name="name">Delivery</field>
-            <field name="color">2</field>
-            <field name="identification">address</field>
-        </record>
-
         <record id="base.group_user" model="res.groups">
             <field name="implied_ids" eval="[(4, ref('product.group_product_variant'))]"/>
         </record>

--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -22,6 +22,7 @@
         "views/point_of_sale_dashboard.xml",
     ],
     "demo": [
+        "data/preset_data.xml",
         "data/kiosk_demo_data.xml",
     ],
     "assets": {

--- a/addons/pos_self_order/data/preset_data.xml
+++ b/addons/pos_self_order/data/preset_data.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record model="pos.preset" id="pos_restaurant.pos_takein_preset">
+            <field name="available_in_self">True</field>
+            <field name="service_at">table</field>
+        </record>
+        <record model="pos.preset" id="pos_restaurant.pos_takeout_preset">
+            <field name="available_in_self">True</field>
+        </record>
+        <record model="pos.preset" id="pos_restaurant.pos_delivery_preset">
+            <field name="available_in_self">True</field>
+            <field name="service_at">delivery</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -377,19 +377,3 @@ class PosConfig(models.Model):
             'module_pos_restaurant': True,
             'self_ordering_mode': 'kiosk',
         })
-
-    @api.model
-    def load_onboarding_restaurant_scenario(self):
-        super().load_onboarding_restaurant_scenario()
-        preset_ids = self.get_record_by_ref([
-            'pos_restaurant.pos_takein_preset',
-            'pos_restaurant.pos_takeout_preset',
-            'pos_restaurant.pos_delivery_preset',
-        ])
-        presets = self.env['pos.preset'].browse(preset_ids)
-        stack = ['table', 'counter', 'delivery']
-        for preset in presets:
-            preset.write({
-                'available_in_self': True,
-                'service_at': stack.pop(0),
-            })


### PR DESCRIPTION
Before this commit:
===
- there was preset demo data was not enabled for self order

After this commit:
===
- updated preset demo data to default enabled in pos self order

Task: 4501570