### PR TITLE
[FIX] l10n_in_ewaybill_irn: prevent error when generating E-Way bill

### DIFF
--- a/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py
@@ -125,7 +125,7 @@ class L10nInEwaybill(models.Model):
                 self._ewaybill_get_by_irn(json_payload.get("Irn"))
                 response.update({
                     'odoo_warning': [{
-                        'message': EWayBillApi.DEFAULT_HELP_MESSAGE % 'generated',
+                        'message': str(EWayBillApi.DEFAULT_HELP_MESSAGE) % 'generated',
                         'message_post': True
                     }]
                 })


### PR DESCRIPTION
Currently, an error occurs when attempting to access `EWayBillApi.DEFAULT_HELP_MESSAGE` - [1]. This happens because `LazyGettext` objects do not support direct string formatting operations.

`TypeError: unsupported operand type(s) for %: 'LazyGettext' and 'str'.`

[1] - https://github.com/odoo/odoo/blob/3b5ab38e473ca0f59b2c157bf0231a0b24163d16/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py#L128

The issue is resolved by converting the result of
`EWayBillApi.DEFAULT_HELP_MESSAGE` to a string using `str()`.

sentry-6234363097

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
