### PR TITLE
[IMP] auth_ldap: Add function to test LDAP connection in LDAP Server configuration model

### DIFF
--- a/addons/auth_ldap/__manifest__.py
+++ b/addons/auth_ldap/__manifest__.py
@@ -11,7 +11,7 @@
         'views/res_config_settings_views.xml',
     ],
     'external_dependencies': {
-        'python': ['ldap'],
+        'python': ['python-ldap'],
     },
     'license': 'LGPL-3',
 }

--- a/addons/auth_ldap/views/ldap_installer_views.xml
+++ b/addons/auth_ldap/views/ldap_installer_views.xml
@@ -7,28 +7,33 @@
             <field name="model">res.company.ldap</field>
             <field name="arch" type="xml">
                 <form string="LDAP Configuration">
-                    <group>
-                        <field name="company"/>
-                        <newline/>
-                        <group string="Server Information">
-                              <field name="ldap_server"/>
-                              <field name="ldap_server_port"/>
-                              <field name="ldap_tls"/>
+                    <header>
+                        <button name="test_ldap_connection" type="object" string="Test Connection" icon="fa-television" class="btn-primary"/>
+                    </header>
+                    <sheet>
+                        <group>
+                            <field name="company"/>
+                            <newline/>
+                            <group string="Server Information">
+                                <field name="ldap_server"/>
+                                <field name="ldap_server_port"/>
+                                <field name="ldap_tls"/>
+                            </group>
+                            <group string="Login Information">
+                                <field name="ldap_binddn"/>
+                                <field name="ldap_password" password="True"/>
+                            </group>
+                            <group string="Process Parameter">
+                                <field name="ldap_base"/>
+                                <field name="ldap_filter"/>
+                                <field name="sequence"/>
+                            </group>
+                            <group string="User Information">
+                                <field name="create_user"/>
+                                <field name="user"/>
+                            </group>
                         </group>
-                        <group string="Login Information">
-                              <field name="ldap_binddn"/>
-                              <field name="ldap_password" password="True"/>
-                        </group>
-                        <group string="Process Parameter">
-                             <field name="ldap_base"/>
-                             <field name="ldap_filter"/>
-                             <field name="sequence"/>
-                        </group>
-                        <group string="User Information">
-                             <field name="create_user"/>
-                             <field name="user"/>
-                        </group>
-                    </group>
+                    </sheet>
                 </form>
             </field>
         </record>

--- a/doc/cla/individual/fasilwdr.md
+++ b/doc/cla/individual/fasilwdr.md
@@ -1,0 +1,11 @@
+India, 2025-01-23
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Fasil Muhammed fasilwdr@hotmail.com https://github.com/fasilwdr


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Currently, administrators do not have a straightforward way to test LDAP server configurations within Odoo. This can lead to difficulties in diagnosing connection issues or invalid credentials, resulting in a time-consuming setup process.

Current behavior before PR:
- No built-in function to test LDAP server connectivity and authentication in the LDAP server configuration model.
- Administrators have to rely on external tools or guesswork to verify their LDAP configurations.

Desired behavior after PR is merged:
- A new function test_ldap_connection is added to the res.company.ldap model.
- Administrators can easily test LDAP server connectivity and authentication directly from the Odoo interface.
- The function provides clear and informative notifications about the success or failure of the connection test, including specific error messages for common issues like invalid credentials or server down.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
