### PR TITLE
[FIX] loyalty: fix expiration date condition

### DIFF
--- a/addons/loyalty/models/loyalty_card.py
+++ b/addons/loyalty/models/loyalty_card.py
@@ -57,7 +57,7 @@ class LoyaltyCard(models.Model):
     @api.onchange('expiration_date')
     def _restrict_expiration_on_loyalty(self):
         for card in self:
-            if card.program_type == 'loyalty':
+            if card.program_type == 'loyalty' and card.expiration_date:
                 raise ValidationError(_("Expiration date cannot be set on a loyalty card."))
 
     def _format_points(self, points):

--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -74,7 +74,7 @@ class PosOrder(models.Model):
             'partner_id': p.get('partner_id', False),
             'code': p.get('barcode') or self.env['loyalty.card']._generate_code(),
             'points': 0,
-            'expiration_date': p.get('date_to'),
+            'expiration_date': p.get('date_to', False),
             'source_pos_order_id': self.id,
         } for p in coupons_to_create.values()]
 

--- a/addons/pos_loyalty/static/src/js/PaymentScreen.js
+++ b/addons/pos_loyalty/static/src/js/PaymentScreen.js
@@ -87,7 +87,9 @@ export const PosLoyaltyPaymentScreen = (PaymentScreen) =>
                 if (program.is_nominative && partner) {
                     agg[pe.coupon_id].partner_id = partner.id;
                 }
-                agg[pe.coupon_id].date_to = program.date_to;
+                if (program.program_type != 'loyalty') {
+                    agg[pe.coupon_id].date_to = program.date_to;
+                }
                 return agg;
             }, {});
             for (const line of rewardLines) {
@@ -96,9 +98,11 @@ export const PosLoyaltyPaymentScreen = (PaymentScreen) =>
                     couponData[line.coupon_id] = {
                         points: 0,
                         program_id: reward.program_id.id,
-                        date_to: reward.program_id.date_to,
                         coupon_id: line.coupon_id,
                         barcode: false,
+                    }
+                    if (reward.program_type != 'loyalty') {
+                        couponData[line.coupon_id].date_to = reward.program_id.date_to;
                     }
                 }
                 if (!couponData[line.coupon_id].line_codes) {


### PR DESCRIPTION
Steps:
- Install sale app.
- Enable Loyalty settings.
- Try to create a card on a loyalty.

Issue:
- Giving validation error.

Casue:
- In [PR] forgot to check expiration_date set or not before raise an error.

Fix:
- Added condition to check if expiration_date set or not on card before raising an error.

[PR]: https://github.com/odoo/odoo/pull/171453

opw-4492179
opw-4490587
opw-4504188
opw-4495530
