### PR TITLE
[FIX] web: Add preventDefault for Chrome 132 compatibility

### DIFF
--- a/addons/web/static/src/core/errors/error_service.js
+++ b/addons/web/static/src/core/errors/error_service.js
@@ -93,6 +93,7 @@ export const errorService = {
                 "ResizeObserver loop limit exceeded",
             ];
             if (!(error instanceof Error) && errorsToIgnore.includes(message)) {
+                ev.preventDefault();
                 return;
             }
             const isRedactedError = !filename && !lineno && !colno;


### PR DESCRIPTION
In error_service, event.preventDefault() is required to prevent uncaught error message due to latest Chrome version (132) compatibility.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
