### PR TITLE
[IMP] hr: add Employee Type as Group By option and hidden column in list view

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -38,6 +38,7 @@
                         <filter name="group_manager" string="Manager" domain="[]" context="{'group_by': 'parent_id'}"/>
                         <filter name="group_department" string="Department" domain="[]" context="{'group_by': 'department_id'}"/>
                         <filter name="group_job" string="Job Position" domain="[]" context="{'group_by': 'job_id'}"/>
+                        <filter name="group_employee_type" string="Employee Type" domain="[]" context="{'group_by': 'employee_type'}"/>
                         <separator name="main_groupby_separator"/>
                         <filter name="group_birthday" domain="[]" context="{'group_by': 'birthday'}"/>
                         <filter name="group_start" string="Start Date" domain="[]" context="{'group_by': 'create_date'}"/>
@@ -278,6 +279,7 @@
                     <field name="name" readonly="1"/>
                     <field name="work_phone" class="o_force_ltr" readonly="1" optional="show"/>
                     <field name="work_email" optional="hide"/>
+                    <field name="employee_type" optional="hide"/>
                     <field name="activity_ids" widget="list_activity" optional="hide"/>
                     <field name="activity_user_id" optional="hide" string="Activity by" widget="many2one_avatar_user"/>
                     <field name="activity_date_deadline" widget="remaining_days" optional="hide"/>


### PR DESCRIPTION
The purpose of this change is to allow users to group employees by their 'Employee Type' and improve the visibility of employee categorization in the employee list view.

This PR includes the following changes:

- Added 'Employee Type' as a Group By option in the search view for employees.
- Added 'Employee Type' as a hidden column in the employee list view.

Task - 4504301

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:
