### PR TITLE
[IMP] stock_account: Hide valuation data on lots

### DIFF
--- a/addons/stock_account/models/stock_lot.py
+++ b/addons/stock_account/models/stock_lot.py
@@ -10,6 +10,7 @@ from odoo.tools import float_compare, float_round
 class StockLot(models.Model):
     _inherit = 'stock.lot'
 
+    lot_valuated = fields.Boolean(related='product_id.lot_valuated', readonly=True, store=False)
     value_svl = fields.Float(compute='_compute_value_svl', compute_sudo=True)
     quantity_svl = fields.Float(compute='_compute_value_svl', compute_sudo=True)
     avg_cost = fields.Monetary(string="Average Cost", compute='_compute_value_svl', compute_sudo=True, currency_field='company_currency_id')

--- a/addons/stock_account/views/stock_lot_views.xml
+++ b/addons/stock_account/views/stock_lot_views.xml
@@ -19,18 +19,20 @@
         </xpath>
         <xpath expr="//group[@name='main_group']/group[2]" position="inside">
             <field name="company_currency_id" invisible="1"/>
-            <label for="total_value"/>
-            <div class="o_row">
-                <field name="total_value" widget='monetary' class="oe_inline" options="{'currency_field': 'company_currency_id'}"/>
-            </div>
-            <label for="avg_cost"/>
-            <div class="o_row">
-                <field name="avg_cost" widget='monetary' class="oe_inline" options="{'currency_field': 'company_currency_id'}"/>
-            </div>
-            <label for="standard_price"/>
-            <div class="o_row">
-                <field name="standard_price" widget='monetary' class="oe_inline" options="{'currency_field': 'company_currency_id'}"/>
-            </div>
+            <group invisible="not lot_valuated">
+                <label for="total_value"/>
+                <div class="o_row">
+                    <field name="total_value" widget='monetary' class="oe_inline" options="{'currency_field': 'company_currency_id'}"/>
+                </div>
+                <label for="avg_cost"/>
+                <div class="o_row">
+                    <field name="avg_cost" widget='monetary' class="oe_inline" options="{'currency_field': 'company_currency_id'}"/>
+                </div>
+                <label for="standard_price"/>
+                <div class="o_row">
+                    <field name="standard_price" widget='monetary' class="oe_inline" options="{'currency_field': 'company_currency_id'}"/>
+                </div>
+            </group>
             </xpath>
         </field>
         </record>


### PR DESCRIPTION
If a ProductProduct is not lot_valuated, then the StockLot avg_cost/total_value/standard_price fields are not relevant. To prevent any confusion for the user, we can hide those fields in the StockLot form view.

### Without LOT_VALUATED
![image](https://github.com/user-attachments/assets/bbc614d7-69bd-45a5-afc9-21d3c81e4336)
![image](https://github.com/user-attachments/assets/284b30be-1c02-4d40-8fac-7d67dd627a45)


### With LOT_VALUATED
![image](https://github.com/user-attachments/assets/5beeee13-1cbb-4166-a5bb-34322f95a6fd)
![image](https://github.com/user-attachments/assets/38febf6a-1f1d-4ce1-886f-84c05ab6f32f)
