### PR TITLE
[IMP] project_sale: improve project creation on the fly from SO

### DIFF
--- a/addons/sale_project/views/sale_order_views.xml
+++ b/addons/sale_project/views/sale_order_views.xml
@@ -30,7 +30,8 @@
                 </button>
             </xpath>
             <field name="journal_id" position="before">
-                <field name="project_id" groups="project.group_project_user" context="{'default_allow_billable': True}"/>
+                <field name="project_id" groups="project.group_project_user"
+                    context="{'default_allow_billable': True, 'default_partner_id': partner_id, 'order_id': id, 'order_state' : state}"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION

In this commit, we made the following improvements:
- set the default sale customer as the project customer.
- if the sale order is confirmed:
  - set the default sale order in the project.
  - set the default lowest serviceable sale order line in the project.

task-4461649



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
