### PR TITLE
[FIX] account: check country_id before loading chart

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -482,6 +482,11 @@ class AccountChartTemplate(models.Model):
         if not company:
             if request and hasattr(request, 'allowed_company_ids'):
                 company = self.env['res.company'].browse(request.allowed_company_ids[0])
+            elif self.country_id:
+                company = self.env.company
+                company_countries = company.country_id + company.account_fiscal_country_id
+                if company_countries and self.country_id not in company_countries:
+                    return
             else:
                 company = self.env.company
         # If we don't have any chart of account on this company, install this chart of account


### PR DESCRIPTION
When installing a l10n module the data often include a `try_loading` for the chart template. The chart should not be applied to the current env.company if the country id does not match the template.

When the CI installs modules via commandline with demo, the env company does not match the l10n most of the times, yet the chart is being applied to it.
This leads to incorrect data and some tests failing, like applying edi format validations on unrelated companies. We previously had patches in tests to disable some edi validations but the root cause is a wrong fiscal country id on the env company.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
