### PR TITLE
[I18N] point_of_sale: make receipt header fully translated

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -77,6 +77,13 @@ msgid "%(pos_name)s (not used)"
 msgstr ""
 
 #. module: point_of_sale
+#. odoo-javascript
+#: code:addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js:0
+#, python-format
+msgid "%(vatLabel)s: %(vatId)s"
+msgstr ""
+
+#. module: point_of_sale
 #. odoo-python
 #: code:addons/point_of_sale/models/pos_session.py:0
 #, python-format
@@ -6804,6 +6811,13 @@ msgstr ""
 #: code:addons/point_of_sale/static/src/app/screens/partner_list/partner_editor/partner_editor.xml:0
 #, python-format
 msgid "Tax ID"
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-javascript
+#: code:addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js:0
+#, python-format
+msgid "Tax ID: %(vatId)s"
 msgstr ""
 
 #. module: point_of_sale

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { _t } from "@web/core/l10n/translation";
 import { Component } from "@odoo/owl";
 
 export class ReceiptHeader extends Component {
@@ -15,4 +16,14 @@ export class ReceiptHeader extends Component {
             },
         },
     };
+
+    get vatText() {
+        if (this.props.data.company.country?.vat_label) {
+            return _t("%(vatLabel)s: %(vatId)s", {
+                vatLabel: this.props.data.company.country.vat_label,
+                vatId: this.props.data.company.vat,
+            });
+        }
+        return _t("Tax ID: %(vatId)s", { vatId: this.props.data.company.vat });
+    }
 }

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -11,7 +11,7 @@
                 <div>Tel:<t t-esc="props.data.company.phone" /></div>
             </t>
             <t t-if="props.data.company.vat">
-                <div><t t-esc="props.data.company.country?.vat_label || 'Tax ID'"/>: <t t-esc="props.data.company.vat" /></div>
+                <div t-esc="vatText"/>
             </t>
             <div t-if="props.data.company.email" t-esc="props.data.company.email" />
             <div t-if="props.data.company.website" t-esc="props.data.company.website" />


### PR DESCRIPTION
Because 'Tax ID' was within the `t-esc` the term was never translated. This goes against some country's compliance requirements for receipts, so we make it translatable now.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
