### PR TITLE
[FIX] iot_box_image: restore image auto version

### DIFF
--- a/addons/iot_box_image/build_image.sh
+++ b/addons/iot_box_image/build_image.sh
@@ -28,8 +28,7 @@ __base="$(basename ${__file} .sh)"
 MOUNT_POINT="${__dir}/root_mount"
 OVERWRITE_FILES_BEFORE_INIT_DIR="${__dir}/overwrite_before_init"
 OVERWRITE_FILES_AFTER_INIT_DIR="${__dir}/overwrite_after_init"
-VERSION=17.0
-VERSION_IOTBOX=24.10
+VERSION_IOTBOX="$(date '+%y.%m')"
 
 if [[ "${1:-}" == "-c" || "${1:-}" == "--cleanup" ]]; then
     echo "Cleaning up..."


### PR DESCRIPTION
The forwardport PR #194085 accidentally removed the automatic IoT Box versionning added in the PR #193505.

This PR restores it as it was in #193505.
