### PR TITLE
[FIX] account: Show partner limit currency

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -235,7 +235,7 @@
                                 <label for="use_partner_credit_limit"/>
                                 <div class="o_row">
                                     <field name="use_partner_credit_limit"/>
-                                    <field name="credit_limit" class="oe_inline" attrs="{'invisible': [('use_partner_credit_limit', '=', False)]}"/>
+                                    <field name="credit_limit" class="oe_inline" widget="monetary" options="{'currency_field': 'currency_id'}"  attrs="{'invisible': [('use_partner_credit_limit', '=', False)]}"/>
                                 </div>
                             </group>
                         </group>


### PR DESCRIPTION
The credit limit in the partner form view was missing a currency symbol, leading to ambiguity about whether the limit was in the customer's currency or the company's currency.

Displayed the partner limit in the company currency to avoid confusion.

task-4507336


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
