### PR TITLE
[FIX] web: remove useless test steps

### DIFF
--- a/addons/web/static/tests/core/model_selector.test.js
+++ b/addons/web/static/tests/core/model_selector.test.js
@@ -164,12 +164,6 @@ test("model_selector: click on start typing", async () => {
     await contains("li.o-autocomplete--dropdown-item:eq(8)").click();
     expect(".o-autocomplete--input").toHaveValue("");
     expect(".o-autocomplete.dropdown ul").toHaveCount(0);
-
-    //label must be empty
-    expect(".o_global_filter_label").toHaveCount(0);
-
-    //Default value and matching fields should not be available
-    expect(".o_side_panel_section").toHaveCount(0);
 });
 
 test("model_selector: with an initial value", async () => {


### PR DESCRIPTION
Commit https://github.com/odoo/odoo/commit/98218629f88b619ca9c8013ecbffaa221d82531c introduced a test with two non-related steps (these steps were certainly copy-pasted from another test, in spreadsheet).
This commit removes these steps.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
