### PR TITLE
[FIX] spreadsheet: drop sorting if field is not a measure

### DIFF
--- a/addons/spreadsheet/static/src/o_spreadsheet/migration.js
+++ b/addons/spreadsheet/static/src/o_spreadsheet/migration.js
@@ -3,7 +3,7 @@ import { OdooCorePlugin } from "@spreadsheet/plugins";
 const { tokenize, parse, convertAstNodes, astToFormula } = spreadsheet;
 const { corePluginRegistry, migrationStepRegistry } = spreadsheet.registries;
 
-export const ODOO_VERSION = 13;
+export const ODOO_VERSION = 14;
 
 const MAP_V1 = {
     PIVOT: "ODOO.PIVOT",
@@ -34,6 +34,25 @@ migrationStepRegistry.add("odoo_migration_sorted_column", {
         const version = data.odooVersion || 0;
         if (version < 13) {
             data = migrate12to13(data);
+        }
+        return data;
+    },
+});
+
+migrationStepRegistry.add("odoo_missing_sorted_column", {
+    versionFrom: "25.1",
+    migrate(data) {
+        if (!data.pivots) {
+            return data;
+        }
+        for (const pivot of Object.values(data.pivots)) {
+            if (!pivot.sortedColumn) {
+                continue;
+            }
+            const measureIds = pivot.measures.map((measure) => measure.id);
+            if (!measureIds.includes(pivot.sortedColumn.measure)) {
+                delete pivot.sortedColumn;
+            }
         }
         return data;
     },

--- a/addons/spreadsheet/static/tests/migrations/migrations.test.js
+++ b/addons/spreadsheet/static/tests/migrations/migrations.test.js
@@ -513,27 +513,72 @@ test("Pivot sorted columns are migrated (12 to 13)", () => {
         pivots: {
             1: {
                 name: "test",
-                sortedColumn: { groupId: [[], []], measure: "testMeasure", order: "desc" },
+                sortedColumn: { groupId: [[], []], measure: "testMeasure:sum", order: "desc" },
                 columns: [],
                 rows: [],
-                measures: [],
+                measures: [{ id: "testMeasure:sum", fieldName: "testMeasure", aggregator: "sum" }],
             },
             2: {
                 name: "test2",
-                sortedColumn: { groupId: [[], [1]], measure: "testMeasure", order: "desc" },
+                sortedColumn: { groupId: [[], [1]], measure: "testMeasure:sum", order: "desc" },
                 columns: [{ fieldName: "product_id" }],
                 rows: [],
-                measures: [],
+                measures: [{ id: "testMeasure:sum", fieldName: "testMeasure", aggregator: "sum" }],
             },
         },
     };
     const migratedData = load(data);
     expect(migratedData.pivots["1"].sortedColumn).toEqual({
         domain: [],
-        measure: "testMeasure",
+        measure: "testMeasure:sum",
         order: "desc",
     });
     expect(migratedData.pivots["2"].sortedColumn).toBe(undefined);
+});
+
+test("drop sorted column if not part of measures", async () => {
+    const data = {
+        version: 23,
+        pivots: {
+            1: {
+                type: "ODOO",
+                columns: [],
+                domain: [],
+                measures: [{ id: "probability:sum", fieldName: "probability", aggregator: "sum" }],
+                model: "partner",
+                rows: [{ fieldName: "bar" }],
+                sortedColumn: {
+                    measure: "foo",
+                    order: "asc",
+                    groupId: [[], [1]],
+                },
+                name: "A pivot",
+                context: {},
+                fieldMatching: {},
+                formulaId: "1",
+            },
+            2: {
+                type: "ODOO",
+                columns: [],
+                domain: [],
+                measures: [{ id: "probability:sum", fieldName: "probability", aggregator: "sum" }],
+                model: "partner",
+                rows: [{ fieldName: "bar" }],
+                sortedColumn: {
+                    measure: "probability:sum",
+                    order: "asc",
+                    groupId: [[], [1]],
+                },
+                name: "A pivot",
+                context: {},
+                fieldMatching: {},
+                formulaId: "2",
+            },
+        },
+    };
+    const migratedData = load(data);
+    expect(migratedData.pivots["1"].sortedColumn).toBe(undefined);
+    expect(migratedData.pivots["2"].sortedColumn).toBe(data.pivots["2"].sortedColumn); // unchanged
 });
 
 test("Odoo version is exported", () => {


### PR DESCRIPTION
Master companion for a fix in 18.0

Steps: Go to a pivot view with:

- either a predefined sort on the action/filter.
- sort by a measure then uncheck the measure.

We can't keep the sorting because the sorting is done client-side. If the field is not part of the measures, we don't have the data to sort...

In 18.0, the sorted column is ignored. Here in master, we drop it from the core definition

Task: 4467262


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
