### PR TITLE
[FIX] website_sale: add disclaimer for combo product VAT included

### DIFF
--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -2034,6 +2034,13 @@ msgid "Fill in your address"
 msgstr ""
 
 #. module: website_sale
+#. odoo-python
+#: code:addons/website_sale/models/product_template.py:0
+msgid ""
+"Final price may vary based on selection. Tax will be calculated at checkout."
+msgstr ""
+
+#. module: website_sale
 #: model:ir.model.fields,field_description:website_sale.field_website__fiscal_position_id
 msgid "Fiscal Position"
 msgstr ""

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.osv import expression
 from odoo.tools import float_is_zero, is_html_empty
 from odoo.tools.translate import html_translate
@@ -438,6 +438,18 @@ class ProductTemplate(models.Model):
             combination_info['product_tracking_info'] = self._get_google_analytics_data(
                 product,
                 combination_info,
+            )
+
+        if (
+            product_or_template.type == 'combo'
+            and website.show_line_subtotals_tax_selection == 'tax_included'
+            and not all(
+                tax.price_include
+                for tax in product_or_template.combo_ids.combo_items_ids.product_id.taxes_id
+            )
+        ):
+            combination_info['tax_disclaimer'] = _(
+                "Final price may vary based on selection. Tax will be calculated at checkout."
             )
 
         return combination_info

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1725,6 +1725,9 @@
                     </bdi>
                 </del>
             </h3>
+            <small t-if="combination_info.get('tax_disclaimer')" class="text-muted">
+                <t t-out="combination_info['tax_disclaimer']"/>
+            </small>
         </div>
         <div id="product_unavailable" t-attf-class="{{'d-flex' if combination_info['prevent_zero_price_sale'] else 'd-none'}}">
             <h3 class="fst-italic" t-field="website.prevent_zero_price_sale_text"/>


### PR DESCRIPTION
**Issue:**

When the website is configured to display prices VAT included, combo products incorrectly show their prices VAT excluded.

**Steps to Reproduce:**

 - in website setting check tax included of `Display Product Prices`
 - Sales > Products > Products
 - Create a new product of type "Combo" and set a price
 - click on go to  website

The price displayed on the website is VAT excluded, even though VAT inclusion is configured.

To address this issue, a disclaimer has been added to inform users that while taxes are not displayed for combo products, they will be properly calculated during checkout.

opw-4454112
