### PR TITLE
[FIX] sale_loyalty: traceback when coupon applied on so

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -581,7 +581,7 @@ class SaleOrder(models.Model):
                 # Check for any order line where its taxes exactly match reward_taxes
                 matching_lines = [
                     line for line in self.order_line
-                    if not line.is_delivery and set(line.tax_id) == set(mapped_taxes)
+                    if not line._is_delivery() and set(line.tax_id) == set(mapped_taxes)
                 ]
 
                 if not matching_lines:


### PR DESCRIPTION
Steps to reproduce:
- Create SO and add a product.
- Apply  discount coupon to SO.

Issue:
- Traceback occurs when the delivery module is not installed.

Cause:
- The line.is_delivery attribute is not accessible when the delivery module is not installed, leading to an error.

Fix:
- Use the line._is_delivery() method to correctly check for delivery lines.

opw-4509360

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
