### PR TITLE
[IMP] mrp : revamp workorder state

### DIFF
--- a/addons/mrp/static/src/components/mo_overview_line/mo_overview_colors.js
+++ b/addons/mrp/static/src/components/mo_overview_line/mo_overview_colors.js
@@ -25,12 +25,11 @@ const PICKING_DECORATORS = {
 };
 
 const OPERATION_DECORATORS = {
-    pending: "info",
-    waiting: "info",
-    ready: "info",
-    progress: "warning",
+    blocked: "warning",
+    ready: "muted",
+    progress: "info",
     done: "success",
-    cancel: "secondary",
+    cancel: "danger",
 };
 
 const PRODUCT_DECORATORS = {

--- a/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.js
+++ b/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.js
@@ -118,7 +118,7 @@ export class MoOverviewLine extends Component {
                 search_default_ready: true,
                 search_default_waiting: true,
                 search_default_progress: true,
-                search_default_pending: true,
+                search_default_blocked: true,
                 search_default_name: this.data.name,
                 search_default_production_id: this.data.production_id,
             },

--- a/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.scss
+++ b/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.scss
@@ -1,3 +1,8 @@
 .o_mrp_overview_badge {
     font-size: $badge-font-size * 1.1;
 }
+
+.o_mrp_overview_badge.text-bg-muted {
+    @include o-print-color(map-get($o-grays, 300), background-color, bg-opacity);
+    @include o-print-color(color-contrast(map-get($o-grays, 300)), color, text-opacity);
+}

--- a/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.js
+++ b/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.js
@@ -1,15 +1,10 @@
 import { Component, useState } from "@odoo/owl";
-import { downloadReport } from "@web/webclient/actions/reports/utils";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { registry } from "@web/core/registry";
-import { rpc } from "@web/core/network/rpc";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
-import { _t } from "@web/core/l10n/translation";
-import { user } from "@web/core/user";
 import { useService } from "@web/core/utils/hooks";
 
-const workcenterStatusBlocked = "blocked";
 
 export class MOListViewDropdown extends Component {
     static template = "mrp.MOViewListDropdown";
@@ -26,8 +21,11 @@ export class MOListViewDropdown extends Component {
             state: this.props.record.data.state,
         });
         this.colorIcons = {
-            "done": "o_status_success",
-            [workcenterStatusBlocked]: "o_status_danger",
+            "blocked": "bg-warning",
+            "ready": "bg-muted",
+            "progress": "bg-info",
+            "cancel": "bg-danger",
+            "done": "bg-success",
         };
     }
 
@@ -37,58 +35,35 @@ export class MOListViewDropdown extends Component {
     }
 
     get statusColor() {
-        const state = this.isBlocked ? workcenterStatusBlocked : this.workorderState.state;
+        const state = this.workorderState.state;
         return this.colorIcons[state] || "";
     }
 
-    get isBlocked() {
-        return this.props.record.data.working_state == workcenterStatusBlocked;
-    }
-
-    get blockTitle(){
-        if (this.isBlocked) {
-            return _t("Unblock");
+    async setState(state) {
+        let selectedWorkorders = this.props.record.model.root.selection;
+        if (!selectedWorkorders || selectedWorkorders.length == 0) {
+            selectedWorkorders = [this.props.record];
         }
-        return _t("Block");
-    }
-
-    async toggleBlock() {
-        if (this.isBlocked) {
-            await this.callOrm("button_unblock");
-            return;
+        let ids = selectedWorkorders.filter((wo) => !([state, 'done'].includes(wo.data.state) || wo.data.production_state == 'done')).map((wo) => wo.resId)  
+        if (ids && ids.length > 0) {
+            await this.callOrm("set_state", [state], ids);
         }
-        const options = {
-            additionalContext: { default_workcenter_id: this.props.record.data.workcenter_id[0] },
-            onClose: async () => {
-                await this.reload();
-            },
-        };
-        this.action.doAction("mrp.act_mrp_block_workcenter_wo", options);
     }
 
-    async markAsDone() {
-        await this.callOrm("action_mark_as_done");
-    }
 
-    async printWO() {
-        await downloadReport(
-            rpc,
-            {
-                ...{ report_name: "mrp.report_mrp_workorder", report_type: "qweb-pdf" },
-                context: { active_ids: [this.props.record.resId] },
-            },
-            "pdf",
-            user.context
-        );
-    }
-
-    async callOrm(functionName){
-        let ids = this.props.record.model.root.selection?.map((element) => element.evalContext.id);
+    async callOrm(functionName, args, ids = undefined) {
+        if (!ids){
+            ids = this.props.record.model.root.selection?.map((element) => element.evalContext.id);
+        }
         // if no records selected, take the current clicked one
         if (!ids || ids.length == 0) {
             ids = [this.props.record.resId];
         }
-        await this.orm.call("mrp.workorder", functionName, [ids]);
+        if (args !== undefined) {
+            await this.orm.call("mrp.workorder", functionName, [ids, ...args]);
+        } else {
+            await this.orm.call("mrp.workorder", functionName, [ids]);
+        }
         await this.reload();
     }
 }

--- a/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.scss
+++ b/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.scss
@@ -6,12 +6,6 @@
         width: 16px;
         height: 16px;
     }
-    .o_status_success {
-        background-color: $o-success;
-    }
-    .o_status_danger {
-        background-color: $o-danger;
-    }
 }
 
 td.o_data_cell:has(> div.o_widget_mo_view_list_dropdown) {

--- a/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.xml
+++ b/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mrp.MOViewListDropdown" style="btn">
+    <t t-name="mrp.MOViewListDropdown" style="btn" t-if="this.props.record.data.state !== 'done' and !['draft', 'done', 'cancel'].includes(this.props.record.data.production_state)">
         <Dropdown>
-            <button t-attf-class="btn btn-link d-flex p-0 {{!this.props.record.resId ? 'invisible': ''}}">
+            <button t-attf-class="btn btn-link d-flex p-0 pb-1 {{!this.props.record.resId ? 'invisible': ''}}">
                 <div class="d-flex align-items-center">
                     <span t-attf-class="o_status {{statusColor}}"/>
                 </div>
@@ -11,22 +11,33 @@
             <t t-set-slot="content">
                 <DropdownItem
                     class="`d-flex align-items-center`"
-                    onSelected="() => this.markAsDone()">
+                    onSelected="() => this.setState('blocked')">
+                        <span t-attf-class="fa fa-lg fa-exclamation-circle text-warning me-2"/>
+                        <span>Blocked</span>
+                </DropdownItem>
+                <DropdownItem
+                    class="`d-flex align-items-center`"
+                    onSelected="() => this.setState('ready')">
+                        <span t-attf-class="fa fa-lg fa-circle text-muted me-2"/>
+                        <span>To Do</span>
+                </DropdownItem>
+                <DropdownItem
+                    class="`d-flex align-items-center`"
+                    onSelected="() => this.setState('progress')">
+                        <span t-attf-class="fa fa-lg fa-play-circle text-info me-2"/>
+                        <span>In Progress</span>
+                </DropdownItem>
+                <DropdownItem
+                    class="`d-flex align-items-center`"
+                    onSelected="() => this.setState('cancel')">
+                        <span t-attf-class="fa fa-lg fa-times-circle text-danger me-2"/>
+                        <span>Cancelled</span>
+                </DropdownItem>
+                <DropdownItem
+                    class="`d-flex align-items-center`"
+                    onSelected="() => this.setState('done')">
                         <span t-attf-class="fa fa-lg fa-check-circle text-success me-2"/>
                         <span>Done</span>
-                </DropdownItem>
-                <DropdownItem
-                    class="`d-flex align-items-center`"
-                    onSelected="() => this.toggleBlock()">
-                        <span t-attf-class="fa fa-lg fa-times-circle text-danger me-2"/>
-                        <span t-esc="this.blockTitle"></span>
-                </DropdownItem>
-                <div role="separator" class="dropdown-divider"/>
-                <DropdownItem
-                    class="`d-flex align-items-center`"
-                    onSelected="() => this.printWO()">
-                        <span t-attf-class="fa fa-print me-2"/>
-                        <span>Print Work Order</span>
                 </DropdownItem>
             </t>
         </Dropdown>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -474,8 +474,9 @@
                         </page>
                         <page string="Work Orders" name="operations" groups="mrp.group_mrp_routings">
                             <field name="workorder_ids"
-                                readonly="state == 'cancel' or (state == 'done' and is_locked)"
-                                context="{'list_view_ref': 'mrp.mrp_production_workorder_tree_editable_view_mo_form', 'default_product_uom_id': product_uom_id, 'from_manufacturing_order': True}"/>
+                                context="{'list_view_ref': 'mrp.mrp_production_workorder_tree_editable_view_mo_form', 'from_manufacturing_order': True}"
+                                options="{'create': [('id', '!=', False), ('state', '!=', 'done')]}"
+                                />
                         </page>
                         <page string="By-Products" name="finished_products" groups="mrp.group_mrp_byproducts">
                             <field name="move_byproduct_ids"

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -117,8 +117,7 @@
             <field name="domain">[]</field>
             <field name="context">{'search_default_workcenter': 1,
                                    'search_default_ready': True,
-                                   'search_default_waiting': True,
-                                   'search_default_pending': True,
+                                   'search_default_blocked': True,
                                    'search_default_progress': True,}</field>
             <field name="view_mode">graph,pivot,list,form</field>
             <field name="search_view_id" ref="view_mrp_production_work_order_search"/>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -9,9 +9,8 @@
                 <field name="workcenter_id"/>
                 <field name="product_id"/>
                 <field name="finished_lot_id"/>
-                <filter string="Ready" name="ready" domain="[('state','=','ready')]"/>
-                <filter string="Waiting" name="waiting" domain="[('state','=','waiting')]"/>
-                <filter string="Pending" name="pending" domain="[('state','=','pending')]"/>
+                <filter string="To Do" name="ready" domain="[('state','=','ready')]"/>
+                <filter string="Blocked" name="blocked" domain="[('state','=','blocked')]"/>
                 <filter string="In Progress" name="progress" domain="[('state','=','progress')]"/>
                 <filter string="Done" name="done" domain="[('state','=', 'done')]"/>
                 <filter string="Late" name="late" domain="[('date_start','&lt;=',time.strftime('%Y-%m-%d'))]"/>
@@ -61,7 +60,7 @@
         <field name="model">mrp.workorder</field>
         <field name="priority" eval="100"/>
         <field name="arch" type="xml">
-            <list editable="bottom" multi_edit="1">
+            <list>
                 <field name="consumption" column_invisible="True"/>
                 <field name="company_id" column_invisible="True"/>
                 <field name="is_produced" column_invisible="True"/>
@@ -76,9 +75,8 @@
                 <field name="name" string="Operation" readonly="state in ['cancel', 'done']"/>
                 <field name="workcenter_id" readonly="state in ['cancel', 'done', 'progress']"/>
                 <field name="product_id" optional="show"/>
-                <field name="qty_remaining" optional="show" string="Quantity Remaining"/>
-                <field name="qty_produced" optional="hide" string="Quantity Produced" readonly="state in ['done', 'cancel'] or not production_availability"/>
-                <field name="qty_ready" optional="hide"/>
+                <field name="qty_remaining" optional="show" string="Quantity"/>
+                <field name="qty_ready" optional="hide" groups="base.group_no_one"/>
                 <field name="finished_lot_id" optional="hide" string="Lot/Serial"/>
                 <field name="date_start" optional="hide" readonly="state in ['progress', 'done', 'cancel']"/>
                 <field name="date_finished" optional="hide" readonly="state in ['progress', 'done', 'cancel']"/>
@@ -86,9 +84,6 @@
                 <field name="duration" widget="mrp_timer"
                   invisible="production_state == 'draft'"
                   readonly="is_user_working" sum="real duration"/>
-                <field name="state" widget="badge" decoration-warning="state == 'progress'" decoration-success="state == 'done'" decoration-danger="state == 'cancel'" decoration-info="state not in ('progress', 'done', 'cancel')"
-                  column_invisible="parent and parent.state == 'draft'"
-                  invisible="production_state == 'draft'"/>
                 <button name="button_start" type="object" title="Start" class="btn-success px-2"
                   invisible="production_state in ('draft', 'done', 'cancel') or working_state == 'blocked' or state in ('done', 'cancel') or is_user_working" icon="fa-play"/>
                 <button name="button_pending" type="object" title="Pause" class="btn-warning px-2" icon="fa-pause"
@@ -96,8 +91,9 @@
                 <button name="button_finish" type="object" title="Done" class="btn-success px-2" icon="fa-check"
                   invisible="production_state in ('draft', 'done', 'cancel') or working_state == 'blocked' or not is_user_working"/>
                 <widget name="mo_view_list_dropdown"/>
-                <field name="show_json_popover" column_invisible="True"/>
-                <field name="json_popover" widget="mrp_workorder_popover" string=" " invisible="not show_json_popover"  width="30px"/>
+                <field name="state" widget="badge" decoration-info="state == 'progress'" decoration-success="state == 'done'" decoration-danger="state == 'cancel'" decoration-warning="state == 'blocked'" decoration-muted="state == 'ready'"
+                  column_invisible="parent and parent.state == 'draft'"
+                  invisible="production_state == 'draft'"/>
             </list>
         </field>
     </record>
@@ -113,9 +109,6 @@
             </xpath>
             <xpath expr="//list/field[@name='qty_ready']" position="attributes">
                 <attribute name="column_invisible">parent.state == 'done'</attribute>
-            </xpath>
-            <xpath expr="//field[@name='show_json_popover']" position='before'>
-                <button name="action_open_wizard" type="object" icon="fa-external-link" class="oe_edit_only" title="Open Work Order" context="{'default_workcenter_id': workcenter_id}"/>
             </xpath>
             <xpath expr="//field[@name='name']" position='before'>
                 <field name="sequence" widget="handle" column_invisible="parent.state != 'draft'"/>
@@ -153,8 +146,10 @@
             <field name="is_user_working" invisible="1"/>
             <field name="working_state" invisible="1"/>
             <field name="production_state" invisible="1"/>
+            <field name="operation_id" invisible="1"/>
+            <field name="sequence" invisible="1"/>
             <header>
-                <field name="state" widget="statusbar" statusbar_visible="pending,waiting,ready,progress,done"/>
+                <field name="state" widget="statusbar" statusbar_visible="blocked,ready,progress,done"/>
             </header>
             <sheet>
                 <div class="oe_button_box" name="button_box">
@@ -171,12 +166,13 @@
                 <field name="finished_lot_id" invisible="1"/>
                 <group>
                     <group>
-                        <field name="name" readonly="1"/>
+                        <field name="name" readonly="state in ['cancel', 'done']" force_save="1"/>
                         <field name="workcenter_id" readonly="state in ['cancel', 'done', 'progress']"/>
                     </group>
                     <group>
                         <field name="product_id" readonly="1"/>
-                        <field name="qty_remaining" string="Quantity" readonly="1"/>
+                        <field name="qty_remaining" string="Quantity" readonly="1" invisible="state == 'done'"/>
+                        <field name="qty_produced" string="Produced Quantity" groups="base.group_no_one" readonly="state == 'done'"/>
                         <field name="finished_lot_id" readonly="1"/>
                     </group>
                 </group>
@@ -198,7 +194,7 @@
                         </div>
                     </group>
                     <group>
-                        <field name="production_id"/>
+                        <field name="production_id" force_save="1"/>
                     </group>
                 </group>
                 <notebook>
@@ -233,7 +229,7 @@
                         <div>
                             <label for="duration" class="pe-2"/>
                             <field name="duration" widget="float_time" readonly="1"/>
-                            <span>&amp;nbsp;(minutes)</span>
+                            <span>&#160;(minutes)</span>
                         </div>
                 </page>
                 <page string="Components" name="components">
@@ -257,8 +253,8 @@
                 </page>
                 <field name="allow_workorder_dependencies" invisible="1"/>
                 <page string="Blocked By" name="dependencies" invisible="not allow_workorder_dependencies">
-                    <field name="blocked_by_workorder_ids" nolabel="1">
-                        <list editable="bottom">
+                    <field name="blocked_by_workorder_ids" nolabel="1" readonly="1">
+                        <list>
                             <field name="company_id" column_invisible="True"/>
                             <field name="name" string="Operation" readonly="state in ['cancel', 'done']"/>
                             <field name="company_id" optional="hide" groups="base.group_multi_company"/>
@@ -291,11 +287,10 @@
                 <field name="product_id"/>
                 <field name="finished_lot_id"/>
                 <filter string="In Progress" name="progress" domain="[('state', '=', 'progress')]"/>
-                <filter string="Ready" name="ready" domain="[('state', '=', 'ready')]"/>
-                <filter string="Waiting" name="waiting" domain="[('state', '=', 'waiting')]"/>
-                <filter string="Pending" name="pending" domain="[('state', '=', 'pending'), ('production_state', '!=', 'draft')]"/>
-                <filter string="Draft" name="draft" domain="[('state', '=', 'pending'), ('production_state', '=', 'draft')]"/>
+                <filter string="To Do" name="ready" domain="[('state', '=', 'ready')]"/>
+                <filter string="Blocked" name="blocked" domain="[('state', '=', 'blocked')]"/>
                 <filter string="Finished" name="finish" domain="[('state', '=', 'done')]"/>
+                <filter string="Cancelled" name="cancel" domain="[('state', '=', 'cancel')]"/>
                 <separator/>
                 <filter string="Late" name="late" domain="['&amp;', ('date_start', '&lt;', datetime.datetime.now()), ('state', '=', 'ready')]"
                     help="Production started late"/>
@@ -371,7 +366,7 @@
                                 <field t-if="!record.date_start.raw_value" name="production_date"/>
                             </div>
                             <div class="h2 ms-2">
-                                <span t-attf-class="badge #{['progress'].indexOf(record.state.raw_value) > -1 ? 'text-bg-warning' : ['ready', 'waiting', 'pending'].indexOf(record.state.raw_value) > -1 ? 'text-bg-primary' : ['done'].indexOf(record.state.raw_value) > -1 ? 'text-bg-success' : 'text-bg-danger'}">
+                                <span t-attf-class="badge #{['progress'].indexOf(record.state.raw_value) > -1 ? 'text-bg-warning' : ['ready', 'blocked'].indexOf(record.state.raw_value) > -1 ? 'text-bg-primary' : ['done'].indexOf(record.state.raw_value) > -1 ? 'text-bg-success' : 'text-bg-danger'}">
                                     <field name="state"/>
                                 </span>
                             </div>
@@ -399,7 +394,7 @@
         <field name="path">workcenter-planning</field>
         <field name="view_mode">list,form,calendar,pivot,graph</field>
         <field name="search_view_id" ref="view_mrp_production_workorder_form_view_filter"/>
-        <field name="context">{'search_default_work_center': True, 'search_default_ready': True, 'search_default_waiting': True, 'search_default_progress': True, 'search_default_pending': True}</field>
+        <field name="context">{'search_default_work_center': True, 'search_default_ready': True, 'search_default_blocked': True, 'search_default_progress': True}</field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
             No work orders to do!
@@ -417,7 +412,7 @@
         <field name="domain">[('production_state','not in',('done','cancel'))]</field>
         <field name="view_mode">list,form,calendar,pivot,graph</field>
         <field name="search_view_id" ref="view_mrp_production_workorder_form_view_filter"/>
-        <field name="context">{'search_default_production': True, 'search_default_ready': True, 'search_default_waiting': True, 'search_default_progress': True, 'search_default_pending': True}</field>
+        <field name="context">{'search_default_production': True, 'search_default_ready': True, 'search_default_blocked': True, 'search_default_progress': True}</field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
             No work orders to do!
@@ -443,7 +438,7 @@
         <field name="view_mode">list,kanban,form,calendar,pivot,graph</field>
         <field name="view_id" ref="mrp.mrp_production_workorder_tree_view"/>
         <field name="search_view_id" ref="view_mrp_production_workorder_form_view_filter"/>
-        <field name="context">{'search_default_ready': True, 'search_default_progress': True, 'search_default_pending': True, 'search_default_waiting': True}</field>
+        <field name="context">{'search_default_ready': True, 'search_default_progress': True, 'search_default_blocked': True}</field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
             No work orders to do!

--- a/addons/project_mrp_account/tests/test_analytic_account.py
+++ b/addons/project_mrp_account/tests/test_analytic_account.py
@@ -146,27 +146,23 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         self.assertEqual(len(mo.workorder_ids.wc_analytic_account_line_ids), 0)
 
         # change duration to 60
-        mo_form = Form(mo)
-        with mo_form.workorder_ids.edit(0) as line_edit:
-            line_edit.duration = 60.0
-        mo_form.save()
+        mo.workorder_ids[0].duration = 60.0
         self.assertEqual(mo.workorder_ids.mo_analytic_account_line_ids.amount, -10.0)
         self.assertEqual(mo.workorder_ids.mo_analytic_account_line_ids[self.analytic_plan._column_name()], self.analytic_account)
         self.assertEqual(mo.workorder_ids.wc_analytic_account_line_ids.amount, -10.0)
         self.assertEqual(mo.workorder_ids.wc_analytic_account_line_ids[analytic_plan._column_name()], wc_analytic_account)
 
         # change duration to 120
-        with mo_form.workorder_ids.edit(0) as line_edit:
-            line_edit.duration = 120.0
-        mo_form.save()
+        mo.workorder_ids[0].duration = 120.0
         self.assertEqual(mo.workorder_ids.mo_analytic_account_line_ids.amount, -20.0)
         self.assertEqual(mo.workorder_ids.mo_analytic_account_line_ids[self.analytic_plan._column_name()], self.analytic_account)
         self.assertEqual(mo.workorder_ids.wc_analytic_account_line_ids.amount, -20.0)
         self.assertEqual(mo.workorder_ids.wc_analytic_account_line_ids[analytic_plan._column_name()], wc_analytic_account)
 
         # mark as done
-        mo_form.qty_producing = 10.0
-        mo_form.save()
+
+        mo.qty_producing = 10.0
+        mo.set_qty_producing()
         mo.button_mark_done()
         self.assertEqual(mo.state, 'done')
         self.assertEqual(mo.workorder_ids.mo_analytic_account_line_ids.amount, -20.0)
@@ -193,10 +189,7 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         self.assertEqual(len(mo.workorder_ids.mo_analytic_account_line_ids), 0)
 
         # Change duration to 60
-        mo_form = Form(mo)
-        with mo_form.workorder_ids.edit(0) as line_edit:
-            line_edit.duration = 60.0
-        mo_form.save()
+        mo.workorder_ids[0].duration = 60.0
         self.assertEqual(mo.workorder_ids.mo_analytic_account_line_ids[self.analytic_plan._column_name()], self.analytic_account)
 
         # Mark as done


### PR DESCRIPTION
- Allow manual editing of work order states to provide greater flexibility.
- Simplify work order status computation, reducing rigid state dependencies.
- Minimize state recalculations, ensuring a more straightforward and maintainable codebase.
- Address pain points where state transitions were irreversible and difficult to modify.
- Facilitate easier application of future changes and enhancements.

Task: [4289826](https://www.odoo.com/odoo/966/tasks/4289826)
EE: odoo/enterprise#77691
UPG: odoo/upgrade#7405