### PR TITLE
[FIX] website: facebook snippet visibility on mobile

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-02-06 13:31+0000\n"
-"PO-Revision-Date: 2024-12-17 14:46+0000\n"
+"PO-Revision-Date: 2025-01-23 17:12+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -7888,13 +7888,6 @@ msgstr ""
 
 #. module: website
 #. odoo-javascript
-#: code:addons/website/static/src/snippets/s_facebook_page/options.js:0
-#, python-format
-msgid "Recent Facebook Issues"
-msgstr ""
-
-#. module: website
-#. odoo-javascript
 #: code:addons/website/static/src/js/form_editor_registry.js:0
 #, python-format
 msgid "Recipient Email"
@@ -9518,15 +9511,6 @@ msgstr ""
 #: code:addons/website/static/src/components/dialog/page_properties.xml:0
 #, python-format
 msgid "This URL is contained in the “%(field)s” of the following “%(model)s”"
-msgstr ""
-
-#. module: website
-#. odoo-javascript
-#: code:addons/website/static/src/snippets/s_facebook_page/options.js:0
-#, python-format
-msgid ""
-"This block will temporarily not be shown on mobile due to recent Facebook "
-"issues."
 msgstr ""
 
 #. module: website

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2432,18 +2432,3 @@ input[value*="data-oe-translation-initial-sha"] {
 .o_dropdown_menu {
     @extend .dropdown-menu;
 }
-
-// o_facebook_page (Facebook page plugin)
-
-// Since October 2024, the Facebook mobile site (m.facebook.com) uses an
-// 'X-Frame-Options' header set to 'deny', preventing iframe embedding across
-// different domains. This header enforces a security policy restricting
-// cross-origin access to the content.
-// Meta has not provided any communication regarding this change. Until it is
-// resolved, we have no choice but to hide the iframe on mobile to prevent users
-// from seeing a "unavailable content" icon.
-@include media-breakpoint-down(md) {
-    .o_facebook_page {
-        display: none;
-    }
-}

--- a/addons/website/static/src/snippets/s_facebook_page/options.js
+++ b/addons/website/static/src/snippets/s_facebook_page/options.js
@@ -94,20 +94,6 @@ options.registry.facebookPage = options.Class.extend({
     //--------------------------------------------------------------------------
 
     /**
-     * @override
-     */
-    _renderCustomXML(uiFragment) {
-        const alertEl = document.createElement("we-alert");
-        const titleEl = document.createElement("we-title");
-        titleEl.textContent = _t("Recent Facebook Issues");
-        const descEl = document.createElement("span");
-        descEl.textContent = _t("This block will temporarily not be shown on mobile due to recent Facebook issues.");
-        alertEl.appendChild(titleEl);
-        alertEl.appendChild(descEl);
-        uiFragment.prepend(alertEl);
-        return this._super(...arguments);
-    },
-    /**
      * Sets the correct dataAttributes on the facebook iframe and refreshes it.
      *
      * @see this.selectClass for parameters


### PR DESCRIPTION
Revert changes from [commit] due to `m.facebook.com` using 'X-Frame-Options' header set to 'deny', which prevented iframe embedding across domains. META has now fixed this issue, so this PR restores the snippet's visibility on mobile devices.

[commit]: https://github.com/odoo/odoo/commit/588f910da03d6284a57c2fab8fd042ef3169666f

task-4507102