### PR TITLE
[FIX] web: Many2OneAvatarField canOpen option

### DIFF
--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
@@ -7,7 +7,7 @@
                 <span t-if="props.value === false and !props.readonly" class="o_m2o_avatar_empty"></span>
                 <img t-if="props.value !== false" t-attf-src="/web/image/{{relation}}/{{props.value[0]}}/avatar_128" />
             </span>
-            <Many2OneField t-props="props" canOpen="!props.readonly"/>
+            <Many2OneField t-props="props" canOpen="!props.readonly and props.canOpen"/>
         </div>
     </t>
 


### PR DESCRIPTION
The goal of this commit is to be able to use the option _no_open_ when displaying fields with the _many2one_avatar_user_ widget in a form view.

Prior to this commit, the _no_open_ option was ineffective for fields using the _many2one_avatar_user_ widget in form views if the field was not set as _readonly_. This was because the _no_open_ option was overridden, and the expression `!props.readonly` was always used, regardless of the specified value for _no_open_. As a result, the field's behavior could not be customized to prevent opening.

After this commit, the _no_open_ option is fully supported in this scenario. If the field is _readonly_, the `canOpen` expression will always evaluate to _False_, maintaining the expected behavior. For fields that are not _readonly_, you can now explicitly use the _no_open_ option to control whether the field can be opened

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
