### PR TITLE
[FIX] web: handle field sorting should include id

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -158,7 +158,8 @@ export class KanbanArchParser {
         const colorField = (colorEl && colorEl.getAttribute("data-field")) || "color";
 
         if (!defaultOrder.length && handleField) {
-            defaultOrder = stringToOrderBy(handleField);
+            const handleFieldSort = `${handleField}, id`;
+            defaultOrder = stringToOrderBy(handleFieldSort);
         }
 
         return {

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -2778,6 +2778,35 @@ QUnit.module("Fields", (hooks) => {
         assert.verifySteps(["web_read"]);
     });
 
+    QUnit.test("one2many kanban order with handle widget", async (assert) => {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="p">
+                        <kanban>
+                            <field name="int_field" widget="handle"/>
+                            <templates>
+                                <t t-name="kanban-box">
+                                    <field name="foo"/>
+                                </t>
+                            </templates>
+                        </kanban>
+                    </field>
+                </form>`,
+            resId: 1,
+            mockRPC(route, args) {
+                if (args.method === "web_read") {
+                    assert.step(`web_read`);
+                    assert.strictEqual(args.kwargs.specification.p.order, "int_field ASC, id ASC");
+                }
+            },
+        });
+        assert.verifySteps(["web_read"]);
+    });
+
     QUnit.test("one2many field when using the pager", async function (assert) {
         const ids = [];
         for (let i = 0; i < 45; i++) {

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -11824,7 +11824,7 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("ungrouped kanban with handle field", async (assert) => {
-        assert.expect(3);
+        assert.expect(5);
 
         await makeView({
             type: "kanban",
@@ -11839,6 +11839,9 @@ QUnit.module("Views", (hooks) => {
                 "</div>" +
                 "</t></templates></kanban>",
             async mockRPC(route, args) {
+                if (args.method === "web_search_read") {
+                    assert.step(`web_search_read: order: ${args.kwargs.order}`);
+                }
                 if (route === "/web/dataset/resequence") {
                     assert.deepEqual(
                         args.ids,
@@ -11854,6 +11857,7 @@ QUnit.module("Views", (hooks) => {
         await dragAndDrop(".o_kanban_record", ".o_kanban_record:nth-child(4)");
 
         assert.deepEqual(getCardTexts(target), ["blip", "yop", "gnap", "blip"]);
+        assert.verifySteps(["web_search_read: order: int_field ASC, id ASC"]);
     });
 
     QUnit.test("ungrouped kanban without handle field", async (assert) => {


### PR DESCRIPTION
This commit makes the same fix as [1] but it does t for kanban views instead of list views.

We discovered in task [2] we were developing for the master branch that we needed this fix and that we wanted to fix it from 17.0

[1]: ecc0a38a1d3b04f854d761fd498b120a4dfef5ad
[2]: opw-4370092

Task: opw-4370092