### PR TITLE
[FIX] payment_xendit: fix rounding for PHP

### DIFF
--- a/addons/payment_xendit/const.py
+++ b/addons/payment_xendit/const.py
@@ -10,6 +10,7 @@ SUPPORTED_CURRENCIES = [
 # https://docs.xendit.co/payment-link/payment-channels
 CURRENCY_DECIMALS = {
     'IDR': 0,
+    'PHP': 0,
 }
 
 # The codes of the payment methods to activate when Xendit is activated.


### PR DESCRIPTION
Steps to reproduce:
1) Configure Xendit provider
2) Try paying in PHP currency
3) Observe: 'Amount must be integer' error

Xendit does not allow decimal places for PHP.

opw-4415419
