### PR TITLE
[FIX] pos_restaurant: cancel last order cause traceback

### DIFF
--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -469,6 +469,10 @@ patch(PosStore.prototype, {
     },
     getPotentialFreeProductRewards() {
         const order = this.getOrder();
+        const result = [];
+        if (!order) {
+            return result;
+        }
         const allCouponPrograms = Object.values(order.uiState.couponPointChanges)
             .map((pe) => ({
                 program_id: pe.program_id,
@@ -480,7 +484,6 @@ patch(PosStore.prototype, {
                     coupon_id: coupon.id,
                 }))
             );
-        const result = [];
         for (const couponProgram of allCouponPrograms) {
             const program = this.models["loyalty.program"].get(couponProgram.program_id);
             if (

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -41,6 +41,7 @@ patch(OrderSummary.prototype, {
         }
         const currentOrder = this.pos.getOrder();
         return (
+            currentOrder &&
             this.pos.config.module_pos_restaurant &&
             !currentOrder.finalized &&
             currentOrder.isBooked &&


### PR DESCRIPTION
We check that currentOrder exist before accessing its attribute inside the function `showUnbookButton`. This was causing a traceback when canceling the last order in restaurant. After this fix, deleting the last order redirect correctly to the floorplan.

Steps to reproduce :
- Open "Restaurant"
- Go to "Orders"
- Delete all orders
- For the last one (Direct sale), there is no "Delete" button in the ticket screen if the order is empty, so open it and then delete it with the action button "Cancel order"

task-id: 4507062

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
