### PR TITLE
[FIX] l10n_in_hr_holidays: fix sandwich leave option visibility.

### DIFF
--- a/addons/l10n_in_hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/l10n_in_hr_holidays/views/hr_leave_type_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="hr_holidays.edit_holiday_status_form"/>
         <field name="arch" type="xml">
             <field name="show_on_dashboard" position="after">
-                <field name="l10n_in_is_sandwich_leave" string="Sandwich Leaves" invisible="country_code != 'IN'" />
+                <field name="l10n_in_is_sandwich_leave" string="Sandwich Leaves" invisible="country_code and country_code != 'IN'"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Steps to Reproduce:
- Install the `l10n_in_hr_holidays` module.
- Ensure there is only one company, and its country is set to India.
- Sandwich leave feature is not available for common time-off types like Paid, Sick, etc.

Cause:
- Time off types for common categories (e.g., Paid, Sick) have `company_id` and `country_id` set to False.
- In a single-company setup, users cannot change the country in these time-off types due to the lack of multi-company access.

Fix:
- Adjusted the visibility condition for the sandwich leave feature. If the `country_id` for the time-off type is False or India then the sandwich leave feature will now be available.

task-4430006