### PR TITLE
[FIX] account: auto save partner

### DIFF
--- a/addons/account/static/src/components/many2many_tags_banks/many2many_tags_banks.js
+++ b/addons/account/static/src/components/many2many_tags_banks/many2many_tags_banks.js
@@ -16,6 +16,13 @@ export class FieldMany2ManyTagsBanks extends Many2ManyTagsFieldColorEditable {
         TagsList: FieldMany2ManyTagsBanksTagsList,
     };
 
+    setup() {
+        super.setup();
+        // Needed when you create a partner (from a move for example), we want the partner to be saved to be able
+        // to have it as account holder
+        this.props.record.model.root.save();
+    }
+
     getTagProps(record) {
         return {
             ...super.getTagProps(record),


### PR DESCRIPTION
In this pr https://github.com/odoo/odoo/commit/0b8bd891fad1c84607fe147a32d705917341fed7 we improved the partner form but by doing that we removed the use of the auto_save_partner widget which was wrong since we need it in the following case:
- Create an invoice
- Create and edit a new partner
- Trying to add a bank account
- The account holder was empty since the partner was not saved

task-4507042




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
