### PR TITLE
[FIX] account_payment: display refundable amount correctly for all users

### DIFF
--- a/addons/account_payment/wizards/payment_refund_wizard.py
+++ b/addons/account_payment/wizards/payment_refund_wizard.py
@@ -58,9 +58,10 @@ class PaymentRefundWizard(models.TransientModel):
     @api.depends('transaction_id.provider_id', 'transaction_id.payment_method_id')
     def _compute_support_refund(self):
         for wizard in self:
-            p_support_refund = wizard.transaction_id.provider_id.support_refund
-            pm = wizard.transaction_id.payment_method_id
-            pm_support_refund = (pm.primary_payment_method_id or pm).support_refund
+            tx_sudo = wizard.transaction_id.sudo()  # needed for users without access to the provider
+            p_support_refund = tx_sudo.provider_id.support_refund
+            pm_sudo = tx_sudo.payment_method_id
+            pm_support_refund = (pm_sudo.primary_payment_method_id or pm_sudo).support_refund
             if not p_support_refund or not pm_support_refund:
                 wizard.support_refund = False
             elif p_support_refund == 'full_only' or pm_support_refund == 'full_only':


### PR DESCRIPTION
## Versions:
17.0+
No fix needed in 16.0 as the field was not computed and this changes with https://github.com/odoo/odoo/commit/7e012dd5441e87ce3c2688f9280381b041b00b0d

## Issue:
A payment to be refunded is displayed as already refunded in the wizard for some users.

## Steps to reproduce:
Ensure the `Demo` payment provider is enabled in `Test Mode`. Ensure you are logged in as Admin user.
- Navigate to the `Invoicing` app:
    - Create a new customer invoice and confirm it;
- Navigate to the Portal using the invoice's `Preview` button:
    - Pay the invoice with the `Demo` provider with a `Successful` Payment status;
- Come back to edit mode:
    - At the bottom of the form, click the information icon in the totalization section;
    - Click the `View` button of the popover;
    - Click the `Refund` button and remember the data;
- Copy the URL;
- Log out and log back in as Demo user;
- Paste the URL to come back to the payment:
    - Click the `Refund` button: - See the `Refunded Amount` value equal to the `Payment Amount`; - See the `Maximum Refund Allowed` value set to 0;

## Cause:
The maximal refundable amount can't be computed for users who don't have `Payment Provider` model access rights.

## Fix:
Compute the amount in `sudo` mode to bypass user's `Payment Provider` model access rights.


opw-4396372