### PR TITLE
[FIX] web_editor: change inline editor root to block on save

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4652,6 +4652,16 @@ export class OdooEditor extends EventTarget {
         for (const el of element.querySelectorAll('*[class=""]')) {
             el.removeAttribute('class');
         }
+
+        // Fix t-field inline nodes to use div as root instead.
+        for (const el of element.querySelectorAll('b[data-oe-field][data-oe-type="html"]')) {
+            const blockEl = this.document.createElement('div');
+            for (const attr of el.attributes) {
+                blockEl.setAttribute(attr.name, attr.value);
+            }
+            blockEl.replaceChildren(...el.childNodes);
+            el.replaceWith(blockEl);
+        }
     }
     /**
      * Handle the hint preview for the Powerbox.


### PR DESCRIPTION
**Problem**:
When we have `<b t-field="html">`, it is rendered in the DOM as
`<b data-oe-attr="..."><p>content</p></b>`. When this is converted to a string
and parsed in the backend, the `html.fromstring` method removes the `p` from
the `b` because `b` is an inline element and cannot contain block elements.
This results in:
`<b data-oe-attr="..."></b><p>content</p>`.

Since this structure has two root elements, the parser wraps them in a block
element (`div`), generating:
`<div><b data-oe-attr="..."></b><p>content</p></div>`.

This causes a traceback when trying to access `data-oe` attributes, as they
are expected to be in the root element.

**Solution**:
Convert any `b` elements used as HTML fields to `div` elements before saving.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
