### PR TITLE
[FIX] point_of_sale: fix closing session popup

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -244,7 +244,7 @@ export class PosStore extends Reactive {
     }
 
     async closingSessionNotification(data) {
-        if (data.login_number === this.session.login_number) {
+        if (data.login_number == this.session.login_number) {
             return;
         }
 
@@ -287,7 +287,7 @@ export class PosStore extends Reactive {
             console.info("Session Ids", odoo.pos_session_id, data.session_id);
         }
 
-        if (data.login_number === odoo.login_number || data.session_id !== odoo.pos_session_id) {
+        if (data.login_number == odoo.login_number || data.session_id !== odoo.pos_session_id) {
             return;
         }
 


### PR DESCRIPTION
- The `login_number` can be a string so we need to use "==" to avoid unexpected behaviour.
- This fix an issue where each time you close a PoS session a popup appears with the message "The session is being closed by another user. The page will be reloaded". This was caused by the comparison of a string and an integer.

task-id: 4485659

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
