### PR TITLE
[IMP] spreadsheet_dashboard: manager can see all dashboards

### DIFF
--- a/addons/spreadsheet_dashboard/security/security.xml
+++ b/addons/spreadsheet_dashboard/security/security.xml
@@ -27,6 +27,13 @@
         <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
     </record>
 
+    <record id="spreadsheet_dashboard_rule_manager" model="ir.rule">
+        <field name="name">Spreadsheet dashboard: manager</field>
+        <field name="model_id" ref="model_spreadsheet_dashboard" />
+        <field name="groups" eval="[(4, ref('spreadsheet_dashboard.group_dashboard_manager'))]" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+    </record>
+
     <record id="spreadsheet_dashboard_share_create_uid_rule" model="ir.rule">
         <field name="name">spreadsheet.dashboard.share: create uid</field>
         <field name="model_id" ref="model_spreadsheet_dashboard_share" />


### PR DESCRIPTION
Steps to reproduce:

- Add the "Dashboard / Admin" group to Marc Demo
- Connect as Marc Demo
- Go to Dashboard configuration
- Change the group of a dashboard to "Administration / Access Rights" (or any group March Demo doesn't have)

=> Marc Demo is faced with an access error and lost the access to the Dashboard. There's no way he can get it back. Users in the other group can still see/read it, but they cannot edit it.

A user managing dashboards (with "Dashboard / Admin" group) should always see every dashboard. He was able to see it at one point anyway (to create and design it)

Note that being able to read a dashboard doesn't grant access to the underlying data/models used in the dashboard. Regular access rights apply there.

Task: 4458192

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
