### PR TITLE
[FIX] product, website_sale: fall back on geoip country for pricelists

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -344,6 +344,8 @@ class Pricelist(models.Model):
             remaining_partners = self.env['res.partner'].browse(remaining_partner_ids)
             partners_by_country = remaining_partners.grouped('country_id')
             for country, partners in partners_by_country.items():
+                if not country and (country_code := self.env.context.get('country_code')):
+                    country = self.env['res.country'].search([('code', '=', country_code)], limit=1)
                 pl = Pricelist.search(pl_domain + [('country_group_ids.country_ids', '=', country.id if country else False)], limit=1)
                 pl = pl or pl_fallback
                 result.update(dict.fromkeys(partners._ids, pl))

--- a/addons/product/models/res_partner.py
+++ b/addons/product/models/res_partner.py
@@ -18,7 +18,7 @@ class ResPartner(models.Model):
         help="This pricelist will be used, instead of the default one, for sales to the current partner")
 
     @api.depends('country_id')
-    @api.depends_context('company')
+    @api.depends_context('company', 'country_code')
     def _compute_product_pricelist(self):
         res = self.env['product.pricelist']._get_partner_pricelist_multi(self._ids)
         for partner in self:

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -219,7 +219,8 @@ class Website(models.Model):
         is_user_public = self.env.user._is_public()
         if not is_user_public:
             last_order_pricelist = partner_sudo.last_website_so_id.pricelist_id
-            partner_pricelist = partner_sudo.property_product_pricelist
+            ctx = {'country_code': country_code} if country_code else {}
+            partner_pricelist = partner_sudo.with_context(**ctx).property_product_pricelist
         else:  # public user: do not compute partner pl (not used)
             last_order_pricelist = self.env['product.pricelist']
             partner_pricelist = self.env['product.pricelist']

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -562,6 +562,31 @@ class TestWebsitePriceListAvailableGeoIP(TestWebsitePriceListAvailable):
             pls = self.website.get_pricelist_available(show_visible=True)
         self.assertEqual(pls, pls_to_return + current_pl, "Only pricelists for BE, accessible en website and selectable should be returned. It should also return the applied promo pl")
 
+    def test_get_pricelist_available_geoip5(self):
+        """Remove country group from certain pricelists, and check that pricelists
+        with country group get prioritized when geoip is available."""
+        exclude = self.backend_pl + self.generic_pl_code + self.w1_pl_select + self.w1_pl_code
+        exclude.country_group_ids = False
+        self.website1_be_pl -= exclude
+
+        with patch(
+            'odoo.addons.website_sale.models.website.Website._get_geoip_country_code',
+            return_value=self.BE.code,
+        ):
+            pls = self.website.get_pricelist_available()
+
+        for pl in pls:
+            self.assertIn(
+                self.BE,
+                pl.country_group_ids.country_ids,
+                "Pricelists without country groups should get excluded",
+            )
+        self.assertEqual(
+            pls,
+            self.website1_be_pl,
+            "Only pricelists for BE and accessible on website should be returned",
+        )
+
 
 @tagged('post_install', '-at_install')
 class TestWebsitePriceListHttp(HttpCaseWithUserPortal):


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Ensure `geoip` works (or patch the `_get_geoip_country_code` method);
2. create two pricelists for the website;
3. first should be restricted to EU countries & use EUR;
4. second one shouldn't be restricted to any country & use USD;
5. log in as a Portal user without address details from a EU IP;
6. open the shop.

Issue
-----
The prices are displayed in USD.

Cause
-----
The geoip country is taken into account for public users, but not for partners. Instead it relies on the partner's country_id, which could be empty.

Solution
--------
When computing the `property_product_pricelist`, add the geoip country to the context. Use this value in the fallback for partners without specific pricelist property set, and without a `country_id`.

opw-4398543