### PR TITLE
[FIX] account: improve help attribute on credit limit

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -12149,6 +12149,12 @@ msgid "Set a price"
 msgstr ""
 
 #. module: account
+#: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
+#: model:ir.model.fields,help:account.field_res_partner__use_partner_credit_limit
+msgid "Set a value greater than 0.0 to activate a credit limit check"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,help:account.field_account_account_tag__active
 msgid "Set active to false to hide the Account Tag without removing it."
 msgstr ""

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -478,7 +478,8 @@ class ResPartner(models.Model):
         company_dependent=True, copy=False, readonly=False)
     use_partner_credit_limit = fields.Boolean(
         string='Partner Limit', groups='account.group_account_invoice,account.group_account_readonly',
-        compute='_compute_use_partner_credit_limit', inverse='_inverse_use_partner_credit_limit')
+        compute='_compute_use_partner_credit_limit', inverse='_inverse_use_partner_credit_limit',
+        help='Set a value greater than 0.0 to activate a credit limit check')
     show_credit_limit = fields.Boolean(
         default=lambda self: self.env.company.account_use_credit_limit,
         compute='_compute_show_credit_limit', groups='account.group_account_invoice,account.group_account_readonly')

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -359,6 +359,7 @@
                                     <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." role="img"/>
                                     <div class="text-muted">
                                         Trigger alerts when creating Invoices and Sales Orders for Partners with a Total Receivable amount exceeding a limit.
+                                        <br/><small>Set a value greater than 0.0 to activate a credit limit check</small>
                                     </div>
                                     <div class="content-group mt-2" attrs="{'invisible': [('account_use_credit_limit', '=', False)]}">
                                         <div class="row">


### PR DESCRIPTION
Having a credit limit set to 0 means 'no limit', user
has to set it to 0.01 to have a minimum limit.
This can be confusing for the user, so add a little
help message to the fields in both partner and settings views.

A better solution should be to use the `ResPartner.use_partner_credit_limit`
field to be able to set 0$ limit to specifics partner, but this can't
be done in stable (computed, non stored field).

opw-4479163
