### PR TITLE
[FIX] sale_loyalty: calculate proper discount amount when tax included

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -596,9 +596,9 @@ class SaleOrder(models.Model):
 
                 reward_line_values['tax_id'] = [Command.set(mapped_taxes.ids)]
 
-            # Discount amount should not exceed the untaxed amount on the order
-            if abs(reward_line_values['price_unit']) > self.amount_untaxed:
-                reward_line_values['price_unit'] = -self.amount_untaxed
+            # Discount amount should not exceed the total amount on the order
+            if abs(reward_line_values['price_unit']) > self.amount_total:
+                reward_line_values['price_unit'] = -self.amount_total
 
             return [reward_line_values]
 


### PR DESCRIPTION
If user had set to have tax included in their price and tried to apply
 discount code only the untaxed amount could be discounted even if discount
 code was higher than untaxed amount.

opw-4486030

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
