### PR TITLE
[16.0][FIX] web: Use absoulteURL for "ir.actions.act_url"

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -825,7 +825,9 @@ function makeActionManager(env) {
      */
     function _executeActURLAction(action, options) {
         let url = action.url;
-        if (url && !(url.startsWith("http") || url.startsWith("/"))) {
+        let isAbsoluteUrl = action.isAbsoluteUrl ? action.isAbsoluteUrl : false;
+
+        if(url && (!(isAbsoluteUrl)) && !(url.startsWith("http") || url.startsWith("/"))){
             url = "/" + url;
         }
         if (action.target === "self") {

--- a/doc/cla/individual/anusriNPS.md
+++ b/doc/cla/individual/anusriNPS.md
@@ -1,0 +1,11 @@
+
+
+Italy, 2023-01-23
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Veerappan Prakasam Anusri  aprakhasam@nps100.com https://github.com/anusriNPS


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
    Able to use absolute URLs while trying to open an external url using "ir.actions.act_url"

Current behavior before PR:
    Whenever an external URL is provided as part of "url" key in "ir.actions.act_url", actionService changes URL to relative URL. Absolute URL cannot be used to open an external URL

Desired behavior after PR is merged:
    Absolute Url can also be used for opening an external URL by passing "isAbsoluteUrl" key set as "True".



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
