### PR TITLE
[FIX] point_of_sale: prevent showing archived products

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -253,5 +253,8 @@ export class ProductProduct extends Base {
     get productDisplayName() {
         return this.default_code ? `[${this.default_code}] ${this.name}` : this.name;
     }
+    get canBeDisplayed() {
+        return this.active && this.available_in_pos;
+    }
 }
 registry.category("pos_available_models").add(ProductProduct.pythonModel, ProductProduct);

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -364,7 +364,7 @@ export class ProductScreen extends Component {
             if (filteredList.length >= 100) {
                 break;
             }
-            if (!excludedProductIds.includes(product.id) && product.available_in_pos) {
+            if (!excludedProductIds.includes(product.id) && product.canBeDisplayed) {
                 filteredList.push(product);
             }
         }

--- a/addons/pos_event/static/src/app/models/product_product.js
+++ b/addons/pos_event/static/src/app/models/product_product.js
@@ -9,4 +9,10 @@ patch(ProductProduct.prototype, {
 
         return this.models["event.event"].get(this._event_id);
     },
+    get canBeDisplayed() {
+        if (this.event_id) {
+            return true;
+        }
+        return super.canBeDisplayed;
+    },
 });


### PR DESCRIPTION
Before this commit, when a product used in a paid order was archived, loading the paid order would cause the product to appear on the product screen.

opw-4493666

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
