### PR TITLE
[FIX] sale: allow editing delivered quantity on combo item SOLs

### DIFF
--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
@@ -70,7 +70,8 @@ export class SaleOrderLineListRenderer extends ProductLabelSectionAndNoteListRen
 
     isCellReadonly(column, record) {
         return super.isCellReadonly(column, record) || (
-            this.isComboItem(record) && column.name !== this.titleField && column.name !== 'tax_id'
+            this.isComboItem(record)
+                && ![this.titleField, 'tax_id', 'qty_delivered'].includes(column.name)
         );
     }
 


### PR DESCRIPTION
Previously, only the description and taxes could be edited on combo item SOLs. However, the delivered quantity should also be editable.

opw-4454205