### PR TITLE
[IMP] google_recaptcha: hide reCAPTCHA toggle once enabled

### DIFF
--- a/addons/google_recaptcha/__manifest__.py
+++ b/addons/google_recaptcha/__manifest__.py
@@ -25,6 +25,7 @@
             # of here and/or adding it in the "website.assets_wysiwyg" bundle,
             # which is lazy loaded.
             'google_recaptcha/static/src/xml/recaptcha.xml',
+            'google_recaptcha/static/src/scss/recaptcha_backend.scss',
         ],
     },
     'license': 'LGPL-3',

--- a/addons/google_recaptcha/static/src/scss/recaptcha_backend.scss
+++ b/addons/google_recaptcha/static/src/scss/recaptcha_backend.scss
@@ -1,0 +1,13 @@
+// TODO adapt in master: Allow disabling reCAPTCHA without uninstalling the
+// modules, instead of hiding the toggle.
+.o_settings_container {
+    .o_setting_box {
+        [name="module_google_recaptcha"] {
+            pointer-events: none;
+            display: none;
+        }
+        label[for="module_google_recaptcha"] {
+            pointer-events: none;
+        }
+    }
+}


### PR DESCRIPTION
The reCAPTCHA feature is currently controlled by the "Module
Installation" setting: `module_google_recaptcha`, which, due to
dependencies, caused the removal of many other modules when disabled.

The goal of this commit is to simply hide this option in stable to
prevent this misleading behaviour.

A user can still disable the reCAPTCHA checks by removing API keys
(Which was already mentioned on the setting block)

The feature behaviour will be updated in master to allow disabling
reCAPTCHA without uninstalling the modules.

task-3380702