### PR TITLE
[IMP] core, web: improve usability of hierarchy operators clientwise

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
@@ -14,7 +14,7 @@ export function getDomainDisplayedOperators(fieldDef) {
                 return ["=", "!=", "set", "not_set"];
         }
     }
-
+    const hierarchyOperators = fieldDef.allow_hierachy_operators ? ["child_of", "parent_of"] : [];
     switch (type) {
         case "boolean":
             return ["is", "is_not"];
@@ -64,6 +64,7 @@ export function getDomainDisplayedOperators(fieldDef) {
                 "!=",
                 "ilike",
                 "not ilike",
+                ...hierarchyOperators,
                 "set",
                 "not_set",
                 "starts_with",
@@ -91,8 +92,6 @@ export function getDomainDisplayedOperators(fieldDef) {
                 "not like",
                 "=like",
                 "=ilike",
-                "child_of",
-                "parent_of",
                 "in",
                 "not in",
                 "set",

--- a/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
@@ -278,21 +278,21 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
             return makeSelectEditor(options, params);
         }
         case "many2one": {
-            if (["=", "!=", "parent_of", "child_of"].includes(operator)) {
+            if (["=", "!="].includes(operator)) {
                 return {
                     component: DomainSelectorSingleAutocomplete,
-                    extractProps: ({ value, update }) => {
-                        return {
-                            resModel: getResModel(fieldDef),
-                            fieldString: fieldDef.string,
-                            update,
-                            resId: value,
-                        };
-                    },
+                    extractProps: ({ value, update }) => ({
+                        resModel: getResModel(fieldDef),
+                        fieldString: fieldDef.string,
+                        update,
+                        resId: value,
+                    }),
                     isSupported: () => true,
                     defaultValue: () => false,
                     shouldResetValue: (value) => value !== false && !isId(value),
                 };
+            } else if (["parent_of", "child_of"].includes(operator)) {
+                return makeAutoCompleteEditor(fieldDef);
             }
             break;
         }

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -2373,3 +2373,81 @@ test("many2many: domain in autocompletion", async () => {
     expect.verifySteps([`[("product_ids", "=", [41])]`]);
     expect(".dropdown-menu").toHaveCount(0);
 });
+
+test("Hierarchical operators", async () => {
+    Partner._fields.team_id = fields.Many2one({ relation: "team" });
+    onRpc("fields_get", ({ parent }) => {
+        const result = parent();
+        result.id.allow_hierachy_operators = true;
+        result.product_id.allow_hierachy_operators = true;
+        result.team_id.allow_hierachy_operators = false;
+        return result;
+    });
+    await makeDomainSelector({
+        isDebugMode: true,
+        update(domain) {
+            expect.step(domain);
+        },
+    });
+    await addNewRule();
+    expect.verifySteps(['[("id", "=", 1)]']);
+    await openModelFieldSelectorPopover();
+    await contains(
+        ".o_model_field_selector_popover .o_model_field_selector_popover_item_name:contains(Product)"
+    ).click();
+    expect.verifySteps(['[("product_id", "in", [])]']);
+    expect(getOperatorOptions()).toEqual([
+        "is in",
+        "is not in",
+        "=",
+        "!=",
+        "contains",
+        "does not contain",
+        "child of",
+        "parent of",
+        "is set",
+        "is not set",
+        "starts with",
+        "ends with",
+        "matches",
+        "matches none of",
+    ]);
+    await selectOperator("parent_of");
+    expect.verifySteps(['[("product_id", "parent_of", [])]']);
+    await editValue("x", { confirm: false });
+    await runAllTimers();
+
+    expect(".dropdown-menu").toHaveCount(1);
+    expect(queryAllTexts(".dropdown-menu li")).toEqual(["xphone", "xpad"]);
+    await contains(".dropdown-menu li").click();
+    expect.verifySteps(['[("product_id", "parent_of", [37])]']);
+    await editValue("x", { confirm: false });
+    await runAllTimers();
+
+    expect(".dropdown-menu").toHaveCount(1);
+    expect(queryAllTexts(".dropdown-menu li")).toEqual(["xpad"]);
+    await contains(".dropdown-menu li").click();
+    expect.verifySteps(['[("product_id", "parent_of", [37, 41])]']);
+    await openModelFieldSelectorPopover();
+    await contains(
+        ".o_model_field_selector_popover .o_model_field_selector_popover_item_name:contains(Team)"
+    ).click();
+    expect.verifySteps(['[("team_id", "in", [])]']);
+    expect(getOperatorOptions()).toEqual(
+        [
+            "is in",
+            "is not in",
+            "=",
+            "!=",
+            "contains",
+            "does not contain",
+            "is set",
+            "is not set",
+            "starts with",
+            "ends with",
+            "matches",
+            "matches none of",
+        ],
+        { message: "no hierarchical operator if allow_hierachy_operators is set to false" }
+    );
+});

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3111,6 +3111,11 @@ class _Relational(Field[M], typing.Generic[M]):
                 return f"({field_to_check} and {company_domain} or {no_company_domain}) + ({domain or []})"
         return domain
 
+    def _description_allow_hierachy_operators(self, env):
+        """ Return if the child_of/parent_of makes sense on this field """
+        comodel = env[self.comodel_name]
+        return comodel._parent_name in comodel._fields
+
 
 class Many2one(_Relational[M]):
     """ The value of such a field is a recordset of size 0 (no


### PR DESCRIPTION
First commit introduces the allow_hierachy_operators description on relational fields while second commit allows to use the hierarchical operators (child_of/parent_of) on these fields inside the domain selector while also allowing multiselection with these operators.

task-4492974