### PR TITLE
[FIX] account: add is_invoice_report to account.report_invoice

### DIFF
--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -542,7 +542,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
             'extra_edis': False,
             'extra_edi_checkboxes': False,
             'pdf_report_id': wizard._get_default_pdf_report_id(invoice).id,
-            'display_pdf_report_id': False,
+            'display_pdf_report_id': True,
             'mail_template_id': wizard._get_default_mail_template_id(invoice).id,
             'mail_lang': 'en_US',
             'mail_partner_ids': wizard.move_id.partner_id.ids,

--- a/addons/account/views/account_report.xml
+++ b/addons/account/views/account_report.xml
@@ -34,6 +34,7 @@
             <field name="report_type">qweb-pdf</field>
             <field name="report_name">account.report_invoice</field>
             <field name="report_file">account.report_invoice</field>
+            <field name="is_invoice_report">True</field>
             <field name="print_report_name">(object._get_report_base_filename())</field>
             <field name="attachment"/>
             <field name="binding_model_id" ref="model_account_move"/>


### PR DESCRIPTION
### Steps to reproduce:
- Install "l10n_ch" and switch to a Swiss company
- Create a new invoice with a Swiss customer
- Confirm
- In the actions, select "PDF without payments"
- The generated PDF has a blank page at the end

### Cause:
The report "account.report_invoice" does not have a field `is_invoice_report` set to `True`. When generating an invoice with Swiss localization. It reads the field `is_invoice_report` to add or not the QR code.

The bug appears after this [commit](https://github.com/odoo/odoo/commit/bb60952c944db27d71d7fe32ead2dff05c3fe922#diff-b6e108b605fbefba066e3b20f8e030ea78881bbed816f8ac5cb38e745c542739R50) which modified the `_is_invoice_report` method to use the field, but only added the field in "account_invoices". 

### Solution:
Set the field to True for the report.

opw-4467250