### PR TITLE
[FIX] point_of_sale, pos_restaurant, pos_event: sync with write date

### DIFF
--- a/addons/point_of_sale/static/src/app/debug/debug_widget.xml
+++ b/addons/point_of_sale/static/src/app/debug/debug_widget.xml
@@ -37,6 +37,11 @@
                     <div class="debug-orders">
                         <h5 class="category">Orders</h5>
                         <ul class="mb-3">
+                            <li class="button btn btn-link" t-on-click="() => this.toggleRandomLine()">
+                                <t t-if="state.createRandomLineToggle">Stop</t>
+                                <t t-else="">Start</t>
+                                <span> random lines</span>
+                            </li>
                             <li class="button btn btn-link" t-on-click="() => this.deleteOrders({ paid: true })">
                                 Delete Paid Orders
                             </li>

--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -24,7 +24,7 @@ function mapObj(obj, fn) {
 const RELATION_TYPES = new Set(["many2many", "many2one", "one2many"]);
 const X2MANY_TYPES = new Set(["many2many", "one2many"]);
 const AVAILABLE_EVENT = ["create", "update", "delete"];
-const SERIALIZABLE_MODELS = [
+export const SERIALIZABLE_MODELS = [
     "pos.order",
     "pos.order.line",
     "pos.payment",

--- a/addons/point_of_sale/static/tests/unit/utils.js
+++ b/addons/point_of_sale/static/tests/unit/utils.js
@@ -25,6 +25,15 @@ registry.category("mock_server").add("pos.session/load_data", async function (ro
 
 registry
     .category("mock_server")
+    .add("pos.config/get_pos_config_orders", async function (route, { args }) {
+        return {
+            data: {},
+            deleted_orders: [],
+        };
+    });
+
+registry
+    .category("mock_server")
     .add("pos.session/get_pos_ui_product_product_by_params", async function (route, { args }) {
         return this.mockSearchRead("product.product", args[1], {});
     });

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -261,7 +261,7 @@ class TestFrontend(TestFrontendCommon):
         self.assertTrue(order2.is_tipped and order2.tip_amount == 1.00)
         self.assertTrue(order3.is_tipped and order3.tip_amount == 1.50)
         self.assertTrue(order4.is_tipped and order4.tip_amount == 1.00)
-        self.assertTrue(order5.is_tipped and order5.tip_amount == 0.00)
+        self.assertTrue(order5.tip_amount == 0.00)
 
         self.assertEqual(order4.customer_count, 2)
 


### PR DESCRIPTION
Prior to this change, some customers had problems with the synchronization of certain orders. Sometimes, some of them were not synchronized correctly.

This was due to the fact that we were sending ids to be retrieved by other devices each time we synchronized them.

Now, every time a synchronization request is received, we send all local orders write_date to the server for updates.

