### PR TITLE
[IMP] base: `i18n` command to im/export files and loadlang

### DIFF
--- a/odoo/addons/base/tests/config/cli
+++ b/odoo/addons/base/tests/config/cli
@@ -54,12 +54,7 @@
 --db_app_name=myapp{pid}
 
 --load-language fr_FR
---language fr_FR
---i18n-export /tmp/translate_out.csv 
---i18n-import /tmp/translate_in.csv  
 --i18n-overwrite
---modules stock,hr,mail
-
 --no-database-list
 
 --dev xml,reload

--- a/odoo/addons/base/tests/config/non_default.conf
+++ b/odoo/addons/base/tests/config/non_default.conf
@@ -71,11 +71,7 @@ db_replica_port = 2038
 
 # i18n
 load_language = fr_FR
-language = fr_FR
-translate_out = /tmp/translate_out.csv  
-translate_in = /tmp/translate_in.csv  
-overwrite_existing_translations = True
-translate_modules = stock,hr,mail
+overwrite_existing_translations = False
 
 # security
 list_db = False

--- a/odoo/addons/base/wizard/base_export_language.py
+++ b/odoo/addons/base/wizard/base_export_language.py
@@ -42,10 +42,10 @@ class BaseLanguageExport(models.TransientModel):
         with io.BytesIO() as buf:
             if this.export_type == 'model':
                 ids = self.env[this.model_name].search(ast.literal_eval(this.domain)).ids
-                trans_export_records(lang, this.model_name, ids, buf, this.format, self._cr)
+                trans_export_records(lang, this.model_name, ids, buf, this.format, self.env)
             else:
                 mods = sorted(this.mapped('modules.name')) or ['all']
-                trans_export(lang, mods, buf, this.format, self._cr)
+                trans_export(lang, mods, buf, this.format, self.env)
             out = base64.encodebytes(buf.getvalue())
 
         filename = 'new'

--- a/odoo/cli/i18n.py
+++ b/odoo/cli/i18n.py
@@ -1,0 +1,238 @@
+import argparse
+import logging
+import sys
+import textwrap
+from pathlib import Path
+
+from odoo import SUPERUSER_ID
+from odoo.api import Environment
+from odoo.cli.command import Command
+from odoo.modules import get_module_path
+from odoo.modules.registry import Registry
+from odoo.tools import OrderedSet, config
+from odoo.tools.translate import TranslationImporter, load_language, trans_export
+
+_logger = logging.getLogger(__name__)
+
+EXPORT_EXTENSIONS = ['.po', '.pot', '.tgz', '.csv']
+IMPORT_EXTENSIONS = ['.po', '.csv']
+
+
+class SubcommandHelpFormatter(argparse.RawTextHelpFormatter):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, max_help_position=80)
+
+
+class I18n(Command):
+    """ Import, export, setup languages and internationalization files """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        subparsers = self.parser.add_subparsers(
+            dest='subcommand', required=True,
+            help='Subcommands help')
+
+        self.import_parser = subparsers.add_parser(
+            'import',
+            help="Import i18n files",
+            description="Imports provided translation files",
+            formatter_class=SubcommandHelpFormatter,
+        )
+        self.export_parser = subparsers.add_parser(
+            'export',
+            help="Export i18n files",
+            description="Exports language files into the i18n folder of each module",
+            formatter_class=SubcommandHelpFormatter,
+        )
+        self.loadlang_parser = subparsers.add_parser(
+            'loadlang',
+            help="Load languages",
+            description="Loads languages",
+            formatter_class=SubcommandHelpFormatter,
+        )
+
+        for parser in (self.import_parser, self.export_parser, self.loadlang_parser):
+            parser.add_argument(
+                '-c', '--config', dest='config',
+                help="use a specific configuration file")
+            parser.add_argument(
+                '-d', '--database', dest='db_name', default=None,
+                help="database name, connection details will be taken from the config file")
+            parser.epilog = textwrap.dedent("""\
+                Language codes must follow the XPG (POSIX) locale format.
+                see: https://www.gnu.org/software/libc/manual/html_node/Locale-Names.html
+
+                To list available codes, you can search them querying the database:
+                    $ psql -d <dbname> -c "SELECT iso_code FROM res_lang ORDER BY iso_code"
+
+                Examples:
+                    odoo-bin i18n loadlang -l en         # English (U.S.)
+                    odoo-bin i18n loadlang -l es es_AR   # Spanish (Spain, Argentina)
+                    odoo-bin i18n loadlang -l sr@latin   # Serbian (Latin)
+            """)
+
+        self.import_parser.add_argument(
+            'files', nargs='+', metavar='FILE', type=Path,
+            help=f"files to be imported. Allowed extensions: {', '.join(IMPORT_EXTENSIONS)}\n")
+        self.import_parser.add_argument(
+            '-w', '--overwrite', action='store_true',
+            help="overwrite existing terms")
+        self.import_parser.add_argument(
+            '-l', '--language', dest='language', metavar='LANG', required=True,
+            help="language code")
+
+        self.export_parser.add_argument(
+            '-l', '--languages', dest='languages', nargs='+', default=['pot'], metavar='LANG',
+            help="list of language codes, 'pot' for template (default)")
+        self.export_parser.add_argument(
+            'modules', nargs='+', metavar='MODULE',
+            help="modules to be exported")
+        self.export_parser.add_argument(
+            '-o', '--output', metavar="FILE", dest='output',
+            help=(
+                "output only one file with translations from all provided modules\n"
+                f"allowed extensions: {', '.join(EXPORT_EXTENSIONS)},"
+                " '-' writes a '.po' file to stdout\n"
+                "only one language is allowed when this option is active"
+            ),
+        )
+
+        self.loadlang_parser.add_argument(
+            '-l', '--languages', dest='languages', nargs='+', metavar='LANG',
+            help="List of language codes to install")
+
+    def run(self, cmdargs):
+        parsed_args = self.parser.parse_args(args=cmdargs)
+
+        config_args = []
+        if parsed_args.config:
+            config_args += ['-c', parsed_args.config]
+        if parsed_args.db_name:
+            config_args += ['-d', parsed_args.db_name]
+
+        config.parse_config(config_args, setup_logging=True)
+
+        db_names = config['db_name']
+        if not db_names or len(db_names) > 1:
+            self.parser.error("Please provide a single database in the config file")
+        parsed_args.db_name = db_names[0]
+
+        match parsed_args.subcommand:
+            case 'import':
+                self._import(parsed_args)
+            case 'export':
+                self._export(parsed_args)
+            case 'loadlang':
+                self._loadlang(parsed_args)
+
+    def _get_languages(self, env, language_codes, active_test=True):
+        # We want to log invalid parameters
+        Lang = env['res.lang'].with_context(active_test=False)
+        languages = Lang.search([('iso_code', 'in', language_codes)])
+        if not_found_language_codes := set(language_codes) - set(languages.mapped("iso_code")):
+            _logger.warning("Ignoring not found languages: %s", ', '.join(not_found_language_codes))
+        if active_test:
+            if not_installed_languages := languages.filtered(lambda x: not x.active):
+                languages -= not_installed_languages
+                iso_code_str = ", ".join(not_installed_languages.mapped("iso_code"))
+                _logger.warning("Ignoring not installed languages: %s", iso_code_str)
+        return languages
+
+    def _import(self, parsed_args):
+        paths = OrderedSet(parsed_args.files)
+        if invalid_paths := [path for path in paths if (
+            not path.exists()
+            or path.suffix not in IMPORT_EXTENSIONS
+        )]:
+            _logger.warning("Ignoring invalid paths: %s",
+                ', '.join(str(path) for path in invalid_paths))
+            paths -= set(invalid_paths)
+        if not paths:
+            self.import_parser.error("No valid path was provided")
+
+        with Registry(parsed_args.db_name).cursor() as cr:
+            env = Environment(cr, SUPERUSER_ID, {})
+            translation_importer = TranslationImporter(cr)
+            language = self._get_languages(env, [parsed_args.language])
+            if not language:
+                self.import_parser.error("No valid language has been provided")
+            for path in paths:
+                with path.open("rb") as infile:
+                    translation_importer.load(infile, path.suffix.removeprefix('.'), language.code)
+            translation_importer.save(overwrite=parsed_args.overwrite)
+
+    def _export(self, parsed_args):
+        export_pot = 'pot' in parsed_args.languages
+
+        if parsed_args.output:
+            if len(parsed_args.languages) != 1:
+                self.export_parser.error(
+                    "When --output is specified, one single --language must be supplied")
+            if parsed_args.output != '-':
+                parsed_args.output = Path(parsed_args.output)
+                if parsed_args.output.suffix not in EXPORT_EXTENSIONS:
+                    self.export_parser.error(
+                        f"Extensions allowed for --output are {', '.join(EXPORT_EXTENSIONS)}")
+                if export_pot and parsed_args.output.suffix == '.csv':
+                    self.export_parser.error(
+                        "Cannot export template in .csv format, please specify a language.")
+
+        if export_pot:
+            parsed_args.languages.remove('pot')
+
+        with Registry(parsed_args.db_name).cursor(readonly=True) as cr:
+            env = Environment(cr, SUPERUSER_ID, {})
+
+            # We want to log invalid parameters
+            modules = env['ir.module.module'].search_fetch(
+                [('name', 'in', parsed_args.modules)], ['name', 'state'])
+            if not_found_module_names := set(parsed_args.modules) - set(modules.mapped("name")):
+                _logger.warning("Ignoring not found modules: %s",
+                    ", ".join(not_found_module_names))
+            if not_installed_modules := modules.filtered(lambda x: x.state != 'installed'):
+                _logger.warning("Ignoring not installed modules: %s",
+                    ", ".join(not_installed_modules.mapped("name")))
+                modules -= not_installed_modules
+            if len(modules) < 1:
+                self.export_parser.error("No valid module has been provided")
+            module_names = modules.mapped("name")
+
+            languages = self._get_languages(env, parsed_args.languages)
+            languages_count = len(languages) + export_pot
+            if languages_count == 0:
+                self.export_parser.error("No valid language has been provided")
+
+            if parsed_args.output:
+                self._export_file(env, module_names, languages.code, parsed_args.output)
+            else:
+                # Po(t) files in the modules' i18n folders
+                for module_name in module_names:
+                    i18n_path = Path(get_module_path(module_name), 'i18n')
+                    if export_pot:
+                        path = i18n_path / f'{module_name}.pot'
+                        self._export_file(env, [module_name], None, path)
+                    for language in languages:
+                        path = i18n_path / f'{language.iso_code}.po'
+                        self._export_file(env, [module_name], language.code, path)
+
+    def _export_file(self, env, module_names, lang_code, path):
+        source = module_names[0] if len(module_names) == 1 else 'modules'
+        destination = 'stdout' if path == '-' else path
+        _logger.info("Exporting %s (%s) to %s", source, lang_code or 'pot', destination)
+
+        if destination == 'stdout':
+            trans_export(lang_code, module_names, sys.stdout.buffer, 'po', env)
+            return
+
+        path.parent.mkdir(exist_ok=True)
+        export_format = path.suffix.removeprefix('.')
+        if export_format == 'pot':
+            export_format = 'po'
+        with path.open('wb') as outfile:
+            trans_export(lang_code, module_names, outfile, export_format, env)
+
+    def _loadlang(self, parsed_args):
+        with Registry(parsed_args.db_name).cursor() as cr:
+            env = Environment(cr, SUPERUSER_ID, {})
+            for language in self._get_languages(env, parsed_args.languages, active_test=False):
+                load_language(env.cr, language.code)

--- a/odoo/cli/scaffold.py
+++ b/odoo/cli/scaffold.py
@@ -78,7 +78,7 @@ def directory(p, create=False):
     if create and not os.path.exists(expanded):
         os.makedirs(expanded)
     if not os.path.isdir(expanded):
-        die("%s is not a directory" % p)
+        sys.exit("%s is not a directory" % p)
     return expanded
 
 env = jinja2.Environment()
@@ -96,7 +96,7 @@ class template(object):
         self.path = identifier
         if os.path.isdir(self.path):
             return
-        die("{} is not a valid module template".format(identifier))
+        sys.exit(f"{identifier} is not a valid module template")
 
     def __str__(self):
         return self.id
@@ -136,10 +136,6 @@ class template(object):
                        .stream(params or {})\
                        .dump(f, encoding='utf-8')
                     f.write(b'\n')
-
-def die(message, code=1):
-    print(message, file=sys.stderr)
-    sys.exit(code)
 
 def warn(message):
     # ASK: shall we use logger ?

--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -92,45 +92,6 @@ def setup_pid_file():
             fd.write(str(pid))
         atexit.register(rm_pid_file, pid)
 
-def export_translation():
-    from odoo.modules.registry import Registry  # noqa: PLC0415
-    from odoo.tools.translate import trans_export  # noqa: PLC0415
-    dbnames = config['db_name']
-    if len(dbnames) > 1:
-        sys.exit("-d/--database/db_name has multiple database, please provide a single one")
-    if config["language"]:
-        msg = "language %s" % (config["language"],)
-    else:
-        msg = "new language"
-    _logger.info('writing translation file for %s to %s', msg,
-        config["translate_out"])
-
-    fileformat = os.path.splitext(config["translate_out"])[-1][1:].lower()
-    # .pot is the same fileformat as .po
-    if fileformat == "pot":
-        fileformat = "po"
-
-    with open(config["translate_out"], "wb") as buf:
-        registry = Registry.new(dbnames[0])
-        with registry.cursor() as cr:
-            trans_export(config["language"],
-                config["translate_modules"] or ["all"], buf, fileformat, cr)
-
-    _logger.info('translation file written successfully')
-
-def import_translation():
-    from odoo.modules.registry import Registry  # noqa: PLC0415
-    from odoo.tools.translate import TranslationImporter  # noqa: PLC0415
-    overwrite = config["overwrite_existing_translations"]
-    dbnames = config['db_name']
-    if len(dbnames) > 1:
-        sys.exit("-d/--database/db_name has multiple database, please provide a single one")
-    registry = Registry.new(dbnames[0])
-    with registry.cursor() as cr:
-        translation_importer = TranslationImporter(cr)
-        translation_importer.load_file(config["translate_in"], config["language"])
-        translation_importer.save(overwrite=overwrite)
-
 
 def main(args):
     check_root_user()
@@ -151,14 +112,6 @@ def main(args):
                          "skipping auto-creation: %s", db_name, err)
         except db.DatabaseExists:
             pass
-
-    if config["translate_out"]:
-        export_translation()
-        sys.exit(0)
-
-    if config["translate_in"]:
-        import_translation()
-        sys.exit(0)
 
     stop = config["stop_after_init"]
 

--- a/odoo/cli/start.py
+++ b/odoo/cli/start.py
@@ -57,7 +57,7 @@ class Start(Command):
         except DatabaseExists as e:
             pass
         except Exception as e:
-            die("Could not create database `%s`. (%s)" % (args.db_name, e))
+            sys.exit("Could not create database `%s`. (%s)" % (args.db_name, e))
 
         if '--db-filter' not in cmdargs:
             cmdargs.append('--db-filter=^%s$' % args.db_name)
@@ -70,7 +70,3 @@ class Start(Command):
                    if not to_remove(i, cmdargs)]
 
         main(cmdargs)
-
-def die(message, code=1):
-    print(message, file=sys.stderr)
-    sys.exit(code)

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -370,7 +370,7 @@ def load_modules(
             if not update_module:
                 _logger.error("Database %s not initialized, you can force it with `-i base`", cr.dbname)
                 return
-            _logger.info("init db")
+            _logger.info("Initializing database %s", cr.dbname)
             modules_db.initialize(cr)
 
         if 'base' in upgrade_modules:

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -386,16 +386,8 @@ class configmanager:
             )
         group.add_option('--load-language', dest="load_language", file_exportable=False,
                          help="specifies the languages for the translations you want to be loaded")
-        group.add_option('-l', "--language", dest="language", file_exportable=False,
-                         help="specify the language of the translation file. Use it with --i18n-export or --i18n-import")
-        group.add_option("--i18n-export", dest="translate_out", type='path', my_default='', file_exportable=False,
-                         help="export all sentences to be translated to a CSV file, a PO file or a TGZ archive and exit")
-        group.add_option("--i18n-import", dest="translate_in", type='path', my_default='', file_exportable=False,
-                         help="import a CSV or a PO file with translations and exit. The '-l' option is required.")
-        group.add_option("--i18n-overwrite", dest="overwrite_existing_translations", action="store_true", my_default=False, file_exportable=False, file_loadable=False,
-                         help="overwrites existing translation terms on updating a module or importing a CSV or a PO file.")
-        group.add_option("--modules", dest="translate_modules", type='comma', metavar="MODULE,...", my_default=['all'], file_loadable=False,
-                         help="specify modules to export. Use in combination with --i18n-export")
+        group.add_option("--i18n-overwrite", dest="overwrite_existing_translations", action="store_true", my_default=False, file_exportable=False,
+                         help="overwrites existing translation terms on updating a module.")
         parser.add_option_group(group)
 
         # Security Group
@@ -640,14 +632,8 @@ class configmanager:
         if self.options['syslog'] and self.options['logfile']:
             self.parser.error("the syslog and logfile options are exclusive")
 
-        if self.options['translate_in'] and (not self.options['language'] or not self.options['db_name']):
-            self.parser.error("the i18n-import option cannot be used without the language (-l) and the database (-d) options")
-
-        if self.options['overwrite_existing_translations'] and not (self.options['translate_in'] or self['update']):
-            self.parser.error("the i18n-overwrite option cannot be used without the i18n-import option or without the update option")
-
-        if self.options['translate_out'] and (not self.options['db_name']):
-            self.parser.error("the i18n-export option cannot be used without the database (-d) option")
+        if self.options['overwrite_existing_translations'] and not self['update']:
+            self.parser.error("the i18n-overwrite option cannot be used without the update option")
 
         if len(self['db_name']) > 1 and (self['init'] or self['update']):
             self.parser.error("Cannot use -i/--init or -u/--update with multiple databases in the -d/--database/db_name")
@@ -670,7 +656,6 @@ class configmanager:
 
         self._runtime_options['init'] = dict.fromkeys(self['init'], True) or {}
         self._runtime_options['update'] = {'base': True} if 'all' in self['update'] else dict.fromkeys(self['update'], True)
-        self._runtime_options['translate_modules'] = sorted(self['translate_modules'])
 
         # TODO saas-22.1: remove support for the empty db_replica_host
         if self['db_replica_host'] == '':


### PR DESCRIPTION
- New i18n command to deal with import/export of translation files with Odoo and loading of `res.lang`uages.
- I18n flags are now given to the command line, and they have been removed from the `server` command.
  Removed: `language`, `translate_out`, `translate_in`, `translate_modules`
  Kept: `overwrite_existing_translations` (used when you install modules) and `load_language` (useful when you create a database)
- Translation import/export functions are removed from the `server` command.
- The export only writes translation files if there actually are terms to put inside.
- The log entry upon database initialization now shows the name of the db.
- Removed the `die()` function in favour of standard `sys.exit()`

Click here:
<details>
  <summary>./odoo-bin i18n --help</summary>

```
usage: odoo-bin [--addons-path=PATH,...] i18n [-h] {export,import,loadlang} ...

Import, export, setup languages and internationalization files

positional arguments:
  {export,import,loadlang}
                        Subcommands help
    export              Export i18n files
    import              Import i18n files
    loadlang            Install languages

options:
  -h, --help            show this help message and exit
```

</details>

<details>
  <summary>./odoo-bin i18n export --help</summary>

```
usage: odoo-bin [--addons-path=PATH,...] i18n export [-h] [--config CONFIG] --stdout [--format {po,tgz,csv}] [--lang [LANG,... ...]] [MODULE,... ...]

Export i18n files

positional arguments:
  MODULE,...            Comma-separated list of modules to be exported

options:
  -h, --help            show this help message and exit
  -c CONFIG             Use a specific configuration file
  --stdout              Use standard output
  --format {po,tgz,csv}, -f {po,tgz,csv}
                        Export format, default 'po'
  --lang [LANG,... ...], -l [LANG,... ...]
                        List of language ISO codes to be exported, default 'pot' for template
```

</details>

<details>
  <summary>./odoo-bin i18n import --help</summary>

```
usage: odoo-bin [--addons-path=PATH,...] i18n import [-h] [--config CONFIG] [--only-new] [--format {po,tgz,csv}] [--lang LANG] [files ...]

Import i18n files

positional arguments:
  files                 Files to import

options:
  -h, --help            show this help message and exit
  -c CONFIG             Use a specific configuration file
  --only-new, -n        Overwrite
  --format {po,tgz,csv}, -f {po,tgz,csv}
                        Export format, default 'po'
  --lang LANG, -l LANG  Language ISO codes to be imported
```

</details>

<details>
  <summary>./odoo-bin i18n loadlang --help</summary>

```
usage: odoo-bin [--addons-path=PATH,...] i18n loadlang [-h] [--config CONFIG] --languages [LANGUAGES ...]

Install languages

options:
  -h, --help            show this help message and exit
  -c CONFIG             Use a specific configuration file
  --languages [LANGUAGES ...]
                        List of ISO codes to be installed.
```

</details>