### PR TITLE
[FIX] sale_loyalty: update coupon partner after login

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -864,6 +864,9 @@ class SaleOrder(models.Model):
         )
         point_ids_per_program = defaultdict(lambda: self.env['sale.order.coupon.points'])
         for pe in self.coupon_point_ids:
+            # Update coupons that were created for Public User
+            if pe.coupon_id.partner_id.is_public and not self.partner_id.is_public:
+                pe.coupon_id.partner_id = self.partner_id
             # Remove any point entry for a coupon that does not belong to the customer
             if pe.coupon_id.partner_id and pe.coupon_id.partner_id != self.partner_id:
                 pe.points = 0
@@ -905,10 +908,12 @@ class SaleOrder(models.Model):
                     pe.points = points
                 if len(program_point_entries) < len(all_point_changes):
                     new_coupon_points = all_point_changes[len(program_point_entries):]
+                    # next_order_coupons should be linked to the order's partner
+                    partner_id = program.program_type == 'next_order_coupons' and self.partner_id.id
                     # NOTE: Maybe we could batch the creation of coupons across multiple programs but this really only applies to gift cards
                     new_coupons = self.env['loyalty.card'].with_context(loyalty_no_mail=True, tracking_disable=True).create([{
                         'program_id': program.id,
-                        'partner_id': False,
+                        'partner_id': partner_id,
                         'points': 0,
                         'order_id': self.id,
                     } for _ in new_coupon_points])


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Create a `next_order_coupons` loyalty program;
2. go to eCommerce as Public User;
3. add products to cart so that the program gets applied;
4. on checkout, log in as Portal User during delivery step;
5. finalize payment.

Issue
-----
Two coupons were created: one for Public User with 0 points, one with no partner and 1 point.

There should only be one coupon, and it should be linked to the logged in user.

Cause
-----
PR https://github.com/odoo/odoo/pull/163545 changed `next_order_coupons` programs to set a partner when created. Issue is when they get created as Public user, the next call to `_update_programs_and_rewards` when logged in will remove the point entries for that coupon, as it's linked to partner that doesn't match the sale order's: https://github.com/odoo/odoo/blob/278ce01fe1882ea424032dcf97c4d345816be96e/addons/sale_loyalty/models/sale_order.py#L867-L870

Solution
--------
Before checking whether to unlink the point entries, update the coupon's `partner_id` if it was created for Public User and the sale order itself is no longer linked to Public User.

Also when generating new coupons in `_update_programs_and_rewards`, link `next_order_coupons` to the customer to make it behave identical to coupons created via `__try_apply_program` (relevant when changing the SO customer from a one specific partner to another specific partner).

opw-4397753