### PR TITLE
[FW][FIX] base: Unallowed to fetch files from addon

### DIFF
--- a/odoo/addons/base/models/ir_asset.py
+++ b/odoo/addons/base/models/ir_asset.py
@@ -343,7 +343,6 @@ class IrAsset(models.Model):
         if addon_manifest:
             if addon not in installed:
                 # Assert that the path is in the installed addons
-                # raise Exception(f"Unallowed to fetch files from addon {addon} for file {path_def}")
                 _logger.warning(f"Unallowed to fetch files from addon {addon} for file {path_def}")
                 pass
             addons_path = addon_manifest['addons_path']

--- a/odoo/addons/base/models/ir_asset.py
+++ b/odoo/addons/base/models/ir_asset.py
@@ -343,7 +343,9 @@ class IrAsset(models.Model):
         if addon_manifest:
             if addon not in installed:
                 # Assert that the path is in the installed addons
-                raise Exception(f"Unallowed to fetch files from addon {addon} for file {path_def}")
+                # raise Exception(f"Unallowed to fetch files from addon {addon} for file {path_def}")
+                _logger.warning(f"Unallowed to fetch files from addon {addon} for file {path_def}")
+                pass
             addons_path = addon_manifest['addons_path']
             full_path = os.path.normpath(os.sep.join([addons_path, *path_parts]))
             # forbid escape from the current addon


### PR DESCRIPTION
Steps to reproduce:
1. Import a module from the Odoo UI.
2. The imported zip file contains static files defined as follows:
   'assets': {
       'web.assets_backend': [
           'mob_sii_chile/static/src/backend/core/mob/mob_service.js',
       ],
   }
3. Upon importing the module, the instance encounters an Internal Server Error due to the following exception being raised:
   raise Exception(f"Unallowed to fetch files from addon {addon} for file {path_def}")

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
