### PR TITLE
[FIX] web: fix extractProps not executing in list widget

### DIFF
--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -138,6 +138,7 @@ export class ListArchParser {
                     // can decode it later...
                     node: encodeObjectForTemplate({ attrs: widgetInfo.attrs }).slice(1, -1),
                     className: node.getAttribute("class") || "",
+                    widgetInfo,
                 };
                 columns.push({
                     ...widgetInfo,

--- a/doc/cla/individual/tanzv.md
+++ b/doc/cla/individual/tanzv.md
@@ -1,4 +1,4 @@
-China, 2015-01-25
+India, 2020-08-21
 
 I hereby agree to the terms of the Odoo Individual Contributor License
 Agreement v1.0.
@@ -8,4 +8,4 @@ declaration.
 
 Signed,
 
-Andrey Troitskiy troizky@mail.ru https://github.com/troizky
+Sudhir Arya zkind@foxmail.com https://github.com/tanzv


### PR DESCRIPTION
Before this fix, the list widget's extractProps function was never called due to an incorrect method reference in the web module. This caused issues when rendering dynamic props or customizing the list view behavior.

After the fix:
- The extractProps function is properly invoked.
- The list widget can now retrieve props values as expected.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
