### PR TITLE
[FIX] l10n_my_edi: XML format and test mode

### DIFF
--- a/addons/l10n_my_edi/data/my_ubl_templates.xml
+++ b/addons/l10n_my_edi/data/my_ubl_templates.xml
@@ -13,7 +13,7 @@
                 </cac:AdditionalDocumentReference>
             </t>
         </xpath>
-        <xpath expr="//*[local-name()='Delivery']" position="after">
+        <xpath expr="//*[local-name()='TaxTotal']" position="before">
             <!-- When applicable, the tax exchange rate MUST be provided. -->
             <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
                xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">

--- a/addons/l10n_my_edi/models/account_edi_proxy_user.py
+++ b/addons/l10n_my_edi/models/account_edi_proxy_user.py
@@ -31,7 +31,7 @@ class AccountEdiProxyClientUser(models.Model):
         urls['l10n_my_edi'] = {
             'demo': False,
             'prod': 'https://l10n-my-edi.api.odoo.com',
-            'test': self.env['ir.config_parameter'].get_param('l10n_my_edi_test_server_url', 'https://l10n-my-edi.test.odoo.com'),
+            'test': self.env['ir.config_parameter'].sudo().get_param('l10n_my_edi_test_server_url', 'https://l10n-my-edi.test.odoo.com'),
         }
         return urls
 


### PR DESCRIPTION
Fixes an issue with the xml file where the tax
exchange rate node would be added before the
payment terms node if both features are used,
which render the xml wrong.

Also add a sudo when getting the system param
for the test url; as this shouldn't block a non
administrator user from testing the feature.

opw-4425472
opw-4505562

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
