### PR TITLE
[FIX] mrp: inconsistency between stock.move and stock.move.line when changing byproduct's product in MO

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -369,7 +369,7 @@
                         <page string="By-Products" name="finished_products" groups="mrp.group_mrp_byproducts">
                             <field name="move_byproduct_ids" context="{'default_date': date_planned_finished, 'default_date_deadline': date_deadline, 'default_location_id': production_location_id, 'default_location_dest_id': location_dest_id, 'default_state': 'draft', 'default_production_id': id, 'default_picking_type_id': picking_type_id, 'default_company_id': company_id}" attrs="{'readonly': ['|', ('state', '=', 'cancel'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}" options="{'delete': [('state', '=', 'draft')]}">
                                 <tree default_order="is_done,sequence" decoration-muted="is_done" editable="bottom">
-                                    <field name="product_id" context="{'default_detailed_type': 'product'}" domain="[('id', '!=', parent.product_id)]" required="1"/>
+                                    <field name="product_id" context="{'default_detailed_type': 'product'}" domain="[('id', '!=', parent.product_id)]" required="1" force_save="1" attrs="{'readonly': ['|', '|', ('move_lines_count', '&gt;', 0), ('state', '=', 'cancel'), '&amp;', ('state', '!=', 'draft'), ('additional', '=', False) ]}"/>
                                     <field name="location_dest_id" string="To" readonly="1" force_save="1" groups="stock.group_stock_multi_locations"/>
                                     <field name="company_id" invisible="1"/>
                                     <field name="product_uom_category_id" invisible="1"/>


### PR DESCRIPTION
**Issue Description**
When producing a product in Odoo and changing the by-product from Product A to Product B, the stock.move record gets updated to reflect the new product (Product B), but the corresponding stock.move.line still retains the old product (Product A).

This leads to inconsistent data between stock.move and stock.move.line, which can cause inaccurate inventory reports and accounting records.

**Steps to Reproduce**
1. Create a BoM (Bill of Materials) that includes Product A as a by-product with a quantity of 1.
2. Create a Manufacturing Order (MO) from this BoM.
3. Confirm the MO and set it to In Progress.
4. In the MO interface: Change the by-product from Product A to Product B.
5. Complete the MO.


https://github.com/user-attachments/assets/811e181d-894d-4605-aeb9-027ff379d40d



**Current Behavior**
The product in the stock.move is updated to Product B. However, the product in the related stock.move.line remains as Product A.

**Expected Behavior**
The byproduct's product_id shouldn't even be editable in the first place when the MO has already been confirmed (as it is for components).
It would be worth to add the same kind of readonly condition on the byproduct side as well.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
