### PR TITLE
[FIX] point_of_sale: cancel order sends empty ticket to the kitchen

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -338,6 +338,7 @@ export class PosOrder extends Base {
                         product_id: line.get_product().id,
                         name: line.get_full_product_name(),
                         basic_name: line.get_product().name,
+                        display_name: line.get_product().name,
                         note: line.getNote(),
                         quantity: line.get_quantity(),
                     };

--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -123,6 +123,7 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
                     product_id: lineResume["product_id"],
                     name: lineResume["name"],
                     basic_name: lineResume["basic_name"],
+                    display_name: lineResume["display_name"],
                     isCombo: lineResume["isCombo"],
                     note: lineResume["note"],
                     attribute_value_ids: lineResume["attribute_value_ids"],


### PR DESCRIPTION
steps to reproduce:
===
- open POS 
- make an order 
- click on order
- open this order 
- delete order lines 
- click on order (negatives qty) 

Issue:
===
- insufficient data to display in receipt

fixed:
===
- configured data required to print

task: 4507218
