### PR TITLE
[FIX] website: clean keywords in SEO dialog

### DIFF
--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { escapeRegExp } from "@web/core/utils/strings";
 import { useService, useAutofocus } from '@web/core/utils/hooks';
 import { MediaDialog } from '@web_editor/components/media_dialog/media_dialog';
 import { WebsiteDialog } from './dialog';
@@ -147,13 +148,19 @@ class Keyword extends Component {
                 lang: this.props.language,
                 keywords: this.props.keyword,
             });
-            const regex = new RegExp(WORD_SEPARATORS_REGEX + this.props.keyword + WORD_SEPARATORS_REGEX, 'gi');
+            const regex = new RegExp(
+                WORD_SEPARATORS_REGEX + escapeRegExp(this.props.keyword) + WORD_SEPARATORS_REGEX,
+                "gi"
+            );
             this.state.suggestions = [...new Set(JSON.parse(suggestions).map(word => word.replace(regex, '').trim()))];
         });
     }
 
     isKeywordIn(string) {
-        return new RegExp(WORD_SEPARATORS_REGEX + this.props.keyword + WORD_SEPARATORS_REGEX, 'gi').test(string);
+        return new RegExp(
+            WORD_SEPARATORS_REGEX + escapeRegExp(this.props.keyword) + WORD_SEPARATORS_REGEX,
+            "gi"
+        ).test(string);
     }
 
     getHeaders(tag) {
@@ -228,7 +235,7 @@ class MetaKeywords extends Component {
     }
 
     addKeyword(keyword) {
-        keyword = keyword.trim();
+        keyword = keyword.replaceAll(/,\s*/gi, " ").trim();
         if (keyword && !this.isFull && !this.seoContext.keywords.includes(keyword)) {
             this.seoContext.keywords.push(keyword);
             this.state.keyword = '';


### PR DESCRIPTION
Steps to reproduce:

- Edit a page
- open "Optimize SEO" dialog
- Add a tag with a parenthesis. eg. "Webinar Tools (OBS, YouTube)"
- Save
- Reload the page
- Reopen the "Optimize SEO" dialog
- ... crash

Since [1], the application crashes because keywords are dynamically used in a regular expression, and special characters (e.g., parentheses) are not properly escaped.

We address the keywords issues by escaping control characters before using them in the regular expression to prevent crashes.

[1]: https://github.com/odoo/odoo/commit/ac55f2bb113ecf7c774fe6e96d28e716184a97d1#diff-b51336c1ad97255bfb3646f013327eca1904ca194078f4ce671e517096233c58

task-4420262
