### PR TITLE
[FIX] l10n_in_gstin_status: restrict GSTIN update to IN companies

### DIFF
--- a/addons/l10n_in_gstin_status/i18n/l10n_in_gstin_status.pot
+++ b/addons/l10n_in_gstin_status/i18n/l10n_in_gstin_status.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-30 11:53+0000\n"
-"PO-Revision-Date: 2024-10-30 11:53+0000\n"
+"POT-Creation-Date: 2025-01-24 08:17+0000\n"
+"PO-Revision-Date: 2025-01-24 08:17+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -147,4 +147,10 @@ msgstr ""
 #. module: l10n_in_gstin_status
 #: model_terms:ir.ui.view,arch_db:l10n_in_gstin_status.move_form_inherit_l10n_in_gst_verification
 msgid "Verify GSTIN status"
+msgstr ""
+
+#. module: l10n_in_gstin_status
+#. odoo-python
+#: code:addons/l10n_in_gstin_status/models/res_partner.py:0
+msgid "You must be logged in an Indian company to use this feature"
 msgstr ""

--- a/addons/l10n_in_gstin_status/models/res_partner.py
+++ b/addons/l10n_in_gstin_status/models/res_partner.py
@@ -34,6 +34,9 @@ class ResPartner(models.Model):
 
     def action_l10n_in_verify_gstin_status(self):
         self.ensure_one()
+        self.check_access('write')
+        if self.env.company.sudo().account_fiscal_country_id.code != 'IN':
+            raise UserError(_('You must be logged in an Indian company to use this feature'))
         if not self.vat:
             raise ValidationError(_("Please enter the GSTIN"))
         is_production = self.env.company.sudo().l10n_in_edi_production_env

--- a/addons/l10n_in_gstin_status/tests/test_check_status.py
+++ b/addons/l10n_in_gstin_status/tests/test_check_status.py
@@ -46,6 +46,7 @@ class TestGSTStatusFeature(TransactionCase):
                 "error": [{"code": "FO8000", "message": "No records found for the provided GSTIN."}],
             },
         }
+        self.env.company.account_fiscal_country_id = self.env.ref("base.in")
 
     @freeze_time('2024-05-20')
     @mute_logger('odoo.addons.l10n_in_gstin_status.models.res_partner')

--- a/addons/l10n_in_gstin_status/views/res_partner_views.xml
+++ b/addons/l10n_in_gstin_status/views/res_partner_views.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="base_vat.view_partner_base_vat_form" />
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='vies_valid']" position="after">
-                    <span invisible="country_code != 'IN' or not vat">
+                    <span invisible="country_code != 'IN' or not vat or 'IN' not in fiscal_country_codes">
                         <span invisible="not l10n_in_gstin_verified_date or not l10n_in_gstin_verified_status"
                             class="oe_inline text-success">Active</span>
                         <span invisible="not l10n_in_gstin_verified_date or l10n_in_gstin_verified_status"


### PR DESCRIPTION
This commit fixes a few issues in multi-company context:

- only show the GSTIN status/update button when user has at least one IN companies selected

- only allow the update when user's active company is an IN company (to ensure we correctly determine the EDI test/production status)

opw-4367302

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
