### PR TITLE
[FIX] sale: product desctiption readonly

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -544,7 +544,7 @@
                                     widget="sol_product_many2one"/>
                                 <field name="product_template_id"
                                     string="Product"
-                                    readonly="not product_updatable"
+                                    readonly="id and not product_updatable"
                                     required="not display_type and not is_downpayment"
                                     context="{
                                         'partner_id': parent.partner_id,


### PR DESCRIPTION
Steps:
- Install sale_project
- Create a service type product
- Create a SO and confirm it
- In the confirmed order add a SOL with the new product

Issue:
- cannot edit the description of the new SOL

Cause:
- readonly for the SOL is set based on product_updatable and product_updatable is set false when product type service even for new order line

Fix
- Updated the readonly condition to account for new lines

opw - 4473488

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
