### PR TITLE
[FIX] im_livechat: allow operators to leave ended livechat channels

### DIFF
--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -36,6 +36,13 @@ patch(Thread.prototype, {
                 }
             },
         });
+        this.livechat_active = Record.attr(undefined, {
+            onUpdate() {
+                if (!this.livechat_active) {
+                    this.markAsRead({ sync: true });
+                }
+            },
+        });
     },
     get autoOpenChatWindowOnNewMessage() {
         return this.channel_type === "livechat" || super.autoOpenChatWindowOnNewMessage;

--- a/addons/im_livechat/static/tests/channel_join_leave.test.js
+++ b/addons/im_livechat/static/tests/channel_join_leave.test.js
@@ -129,13 +129,23 @@ test("visitor leaving ends the livechat conversation", async () => {
         livechat_operator_id: serverState.partnerId,
         create_uid: serverState.publicUserId,
     });
+    pyEnv["mail.message"].create([
+        {
+            author_guest_id: guestId,
+            body: "Hello",
+            model: "discuss.channel",
+            res_id: channel_id,
+        },
+    ]);
     setupChatHub({ opened: [channel_id] });
     await start();
     await contains(".o-mail-ChatWindow");
+    await contains(".o-mail-Thread-banner");
     // simulate visitor leaving
     await withGuest(guestId, () => rpc("/im_livechat/visitor_leave_session", { channel_id }));
     await contains("span", { text: "This livechat conversation has ended" });
     await contains(".o-mail-Composer-input"); // so that can still `/lead` or last resort send message to visitor
+    await contains(".o-mail-Thread-banner", { count: 0 });
     await click("button[title*='Close Chat Window']");
     await contains(".o-mail-ChatWindow", { count: 0 });
 });

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -217,6 +217,7 @@ test("Counter should have correct value of unread threads if category is folded 
             Command.create({ guest_id: guestId }),
         ],
         channel_type: "livechat",
+        livechat_active: true,
         livechat_operator_id: serverState.partnerId,
     });
     pyEnv["mail.message"].create({


### PR DESCRIPTION
**Current behavior before PR:**

 Since [1](https://github.com/odoo/odoo/pull/192378) when an operator accessed a live chat where the visitor had left, the composer was disabled, preventing markAsRead() from executing and showing the unread message counter badge instead of the leave action.

**Desired behavior after PR is merged:**

markAsRead() is now called when the visitor leaves the livechat, ensuring the operator can leave the channel.

Task-4500402

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
