### PR TITLE
[FIX] hr_attendance : fix attendance creation

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -92,7 +92,13 @@ class HrAttendance(models.Model):
 
     @api.depends('worked_hours')
     def _compute_overtime_hours(self):
-        day_starts = {att: self._get_day_start_and_day(att.employee_id, att.check_in) for att in self}
+        day_starts = {
+            att: self._get_day_start_and_day(att.employee_id, att.check_in)
+            for att in self
+            if att.employee_id
+        }
+        if not day_starts:
+            return
         date_min, date_max = min(date for dummy, date in day_starts.values()), max(date for dummy, date in day_starts.values())
         datetime_min, datetime_max = min(time for time, dummy in day_starts.values()), max(time for time, dummy in day_starts.values())
 


### PR DESCRIPTION
STEPS TO REPRODUCE:

1- Check if marc demo doesn't have administrator right but has manager attendance right 2- Log in as Marc demo
3- Go on attendance application
4- Click on "new"
You will have a traceback

REASON:
For this type of users the default employee_id is not set; so the extra hours computation failed.

task-4512288



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
