### PR TITLE
[FIX] point_of_sale: `console.error` unknown issue in `printHtml`

### DIFF
--- a/addons/point_of_sale/static/src/app/printer/pos_printer_service.js
+++ b/addons/point_of_sale/static/src/app/printer/pos_printer_service.js
@@ -44,9 +44,12 @@ export class PosPrinterService extends PrinterService {
         }
     }
     async printHtmlAlternative(error, ...args) {
+        if (error.body === undefined) {
+            console.error("An unknown error occured in printHtml:", error);
+        }
         const { confirmed } = await this.popup.add(ConfirmPopup, {
             title: error.title || _t("Printing error"),
-            body: error.body + _t("Do you want to print using the web printer? "),
+            body: (error.body ?? "") + _t("Do you want to print using the web printer? "),
         });
         if (!confirmed) {
             return false;


### PR DESCRIPTION
__Current behavior before commit:__
If an unexpected error that has no body is thrown inside `printHtml`, the popup shows "undefinedDo you want to print using the web printer?" and nothing is written in the console, making it impossible to troubleshoot.

__Description of the fix:__
Don't print "undefined" in the popup if the error has no body but write the error in the console.

opw-4322339
