### PR TITLE
[FIX] website_sale: always show delivery row in cart summary

### DIFF
--- a/addons/website_sale/static/src/js/checkout.js
+++ b/addons/website_sale/static/src/js/checkout.js
@@ -282,6 +282,11 @@ publicWidget.registry.websiteSaleCheckout = publicWidget.Widget.extend({
         const amountTotal = document.querySelectorAll(
             '#order_total .monetary_field, #amount_total_summary.monetary_field'
         );
+        // When no dm is set and a price span is hidden, hide the message and show the price span.
+        if (amountDelivery.classList.contains('d-none')) {
+            document.querySelector('#message_no_dm_set').classList.add('d-none');
+            amountDelivery.classList.remove('d-none');
+        }
         amountDelivery.innerHTML = result.amount_delivery;
         amountUntaxed.innerHTML = result.amount_untaxed;
         amountTax.innerHTML = result.amount_tax;

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2478,20 +2478,23 @@
         <div id="cart_total" t-if="website_sale_order and website_sale_order.website_order_line" t-att-class="_cart_total_classes">
             <table class="table mb-0">
                 <tr
-                    t-if="website_sale_order._has_deliverable_products() and website_sale_order.carrier_id"
+                    t-if="website_sale_order._has_deliverable_products()"
                     id="order_delivery"
                 >
-                    <td
-                        class="ps-0 pt-0 pb-2 border-0 text-muted"
-                        colspan="2"
-                        title="Delivery will be updated after choosing a new delivery method"
-                    >
+                    <td class="ps-0 pt-0 pb-2 border-0 text-muted" colspan="2">
                         Delivery
                     </td>
                     <td class="text-end pe-0 pt-0 pb-2 border-0">
                         <span
+                            id="message_no_dm_set"
+                            t-att-class="'d-none' if website_sale_order.carrier_id else ''"
+                            title="Price will be updated after choosing a delivery method"
+                        >
+                            -
+                        </span>
+                        <span
                             t-out="website_sale_order.amount_delivery"
-                            class="monetary_field"
+                            t-att-class="'monetary_field' + ('' if website_sale_order.carrier_id else ' d-none')"
                             style="white-space: nowrap;"
                             t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"
                         />


### PR DESCRIPTION
Before delivery row was not displayed when dm was not set. It was confusing to not show delivery row when a product required delivery, and it caused a traceback on the checkout page when no delivery method was preselected and a user selected one.
After this commit when delivery is not set yet, we will show explicitly that delivery is required but the price will be updated after its selection.

task-4422630
opw-4397672
