### PR TITLE
[IMP] im_livechat: add end_session step type to chatbot

### DIFF
--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -30,6 +30,7 @@ class ChatbotScriptStep(models.Model):
         ('forward_operator', 'Forward to Operator'),
         ('free_input_single', 'Free Input'),
         ('free_input_multi', 'Free Input (Multi-Line)'),
+        ('end_session', 'End Session'),
     ], default='text', required=True)
     # answers
     answer_ids = fields.One2many(
@@ -217,6 +218,8 @@ class ChatbotScriptStep(models.Model):
             -> NOK
         """
         self.ensure_one()
+        if self.step_type == "end_session":
+            return self.env["chatbot.script.step"]
         domain = [('chatbot_script_id', '=', self.chatbot_script_id.id), ('sequence', '>', self.sequence)]
         if selected_answer_ids:
             domain = expression.AND([domain, [


### PR DESCRIPTION
Purpose of this PR:

Introduce a new 'end_session' step type to the chatbot. When the chatbot reaches this step, the live chat conversation will terminate, ensuring that any subsequent steps are not executed.

task-id:4509331

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
