### PR TITLE
[FIX] point_of_sale, pos_restaurant: Add UUID in demo data

### DIFF
--- a/addons/point_of_sale/data/orders_demo.xml
+++ b/addons/point_of_sale/data/orders_demo.xml
@@ -23,6 +23,7 @@
             <field name="amount_paid">4.81</field>
             <field name="amount_return">0.0</field>
             <field name="pos_reference">Order 00000-001-1001</field>
+            <field name="uuid">01c17cf0-2d57-42bc-9766-08a2b128f071</field>
         </record>
 
         <record id="pos_closed_orderline_1_1_1" model="pos.order.line" forcecreate="False">
@@ -32,6 +33,7 @@
             <field name="price_unit">1.98</field>
             <field name="order_id" ref="pos_closed_order_1_1" />
             <field name="full_product_name">Wall Shelf</field>
+            <field name="uuid">5a584718-5e82-481a-b0c9-edc769c27bca</field>
         </record>
 
         <record id="pos_closed_orderline_1_1_2" model="pos.order.line" forcecreate="False">
@@ -41,12 +43,14 @@
             <field name="price_unit">2.83</field>
             <field name="order_id" ref="pos_closed_order_1_1" />
             <field name="full_product_name">Small Shelf</field>
+            <field name="uuid">0282a5b2-d233-4842-8e11-baae81a746c0</field>
         </record>
 
         <record id="pos_payment_1" model="pos.payment" forcecreate="False">
             <field name="payment_method_id" ref="point_of_sale.cash_payment_method_furniture" />
             <field name="pos_order_id" ref="pos_closed_order_1_1" />
             <field name="amount">4.81</field>
+            <field name="uuid">18a0c6bf-3679-4c17-93ba-ea3b1d5c558b</field>
         </record>
 
         <record id="pos_closed_order_1_2" model="pos.order" forcecreate="False">
@@ -59,6 +63,7 @@
             <field name="amount_paid">6.78</field>
             <field name="amount_return">0.0</field>
             <field name="pos_reference">Order 00000-001-1002</field>
+            <field name="uuid">66537f57-5df4-47d6-828d-a7679f0a6914</field>
         </record>
 
         <record id="pos_closed_orderline_1_2_1" model="pos.order.line" forcecreate="False">
@@ -68,6 +73,7 @@
             <field name="price_unit">1.98</field>
             <field name="order_id" ref="pos_closed_order_1_2" />
             <field name="full_product_name">Magnetic Board</field>
+            <field name="uuid">d30fe864-6612-4443-976b-75717e5aa896</field>
         </record>
 
         <record id="pos_closed_orderline_1_2_2" model="pos.order.line" forcecreate="False">
@@ -77,12 +83,14 @@
             <field name="price_unit">4.80</field>
             <field name="order_id" ref="pos_closed_order_1_2" />
             <field name="full_product_name">Letter Tray</field>
+            <field name="uuid">7d575349-01ec-49b2-a392-74a4b05b853b</field>
         </record>
 
         <record id="pos_payment_2" model="pos.payment" forcecreate="False">
             <field name="payment_method_id" ref="point_of_sale.cash_payment_method_furniture" />
             <field name="pos_order_id" ref="pos_closed_order_1_2" />
             <field name="amount">6.78</field>
+            <field name="uuid">5c61e4d2-c41d-4b6b-b5bd-b89edbdb0e79</field>
         </record>
 
         <function model="pos.session" name="post_closing_cash_details" eval="[[ref('pos_closed_session_1')], 2225.31]" />
@@ -113,6 +121,7 @@
             <field name="amount_paid">9.90</field>
             <field name="amount_return">0.0</field>
             <field name="pos_reference">Order 00000-002-1001</field>
+            <field name="uuid">b47a316a-e8cb-4222-960d-a0dcae3148a9</field>
         </record>
 
         <record id="pos_closed_orderline_2_1_1" model="pos.order.line" forcecreate="False">
@@ -123,6 +132,7 @@
             <field name="price_unit">4.80</field>
             <field name="order_id" ref="pos_closed_order_2_1" />
             <field name="full_product_name">Letter Tray</field>
+            <field name="uuid">9864fdf2-0f60-4fcd-a99a-9d2a96d121c5</field>
         </record>
 
         <record id="pos_closed_orderline_2_1_2" model="pos.order.line" forcecreate="False">
@@ -133,12 +143,14 @@
             <field name="price_unit">5.10</field>
             <field name="order_id" ref="pos_closed_order_2_1" />
             <field name="full_product_name">Desk Organizer</field>
+            <field name="uuid">7a93836a-d4a9-44a8-8575-5abccbff65ac</field>
         </record>
 
         <record id="pos_payment_3" model="pos.payment" forcecreate="False">
             <field name="payment_method_id" ref="point_of_sale.cash_payment_method_furniture" />
             <field name="pos_order_id" ref="pos_closed_order_2_1" />
             <field name="amount">9.90</field>
+            <field name="uuid">4700fd64-b393-4559-89a3-7d5c9c8405f0</field>
         </record>
 
         <record id="pos_closed_order_2_2" model="pos.order" forcecreate="False">
@@ -151,6 +163,7 @@
             <field name="amount_paid">8.36</field>
             <field name="amount_return">0.0</field>
             <field name="pos_reference">Order 00000-002-1002</field>
+            <field name="uuid">a553a976-4b80-431d-b0df-52c327815755</field>
         </record>
 
         <record id="pos_closed_orderline_2_2_1" model="pos.order.line" forcecreate="False">
@@ -161,6 +174,7 @@
             <field name="price_unit">1.98</field>
             <field name="order_id" ref="pos_closed_order_2_2" />
             <field name="full_product_name">Magnetic Board</field>
+            <field name="uuid">599af560-44b3-4d81-8545-d6a6c7f7f2f8</field>
         </record>
 
         <record id="pos_closed_orderline_2_2_2" model="pos.order.line" forcecreate="False">
@@ -172,12 +186,14 @@
             <field name="price_unit">3.19</field>
             <field name="order_id" ref="pos_closed_order_2_2" />
             <field name="full_product_name">Monitor Stand</field>
+            <field name="uuid">49c2abb3-a509-4a89-9f1d-6f3ca98a43f8</field>
         </record>
 
         <record id="pos_payment_4" model="pos.payment" forcecreate="False">
             <field name="payment_method_id" ref="point_of_sale.cash_payment_method_furniture" />
             <field name="pos_order_id" ref="pos_closed_order_2_2" />
             <field name="amount">8.36</field>
+            <field name="uuid">91f7f3f8-8a7f-401a-b182-dde06f977e22</field>
         </record>
 
         <function model="pos.session" name="post_closing_cash_details"

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from markupsafe import Markup
 from itertools import groupby
 from collections import defaultdict
-from uuid import uuid4
 from random import randrange
 from pprint import pformat
 
@@ -312,7 +311,7 @@ class PosOrder(models.Model):
     has_refundable_lines = fields.Boolean('Has Refundable Lines', compute='_compute_has_refundable_lines')
     ticket_code = fields.Char(help='5 digits alphanumeric code to be used by portal user to request an invoice')
     tracking_number = fields.Char(string="Order Number", compute='_compute_tracking_number', search='_search_tracking_number')
-    uuid = fields.Char(string='Uuid', readonly=True, default=lambda self: str(uuid4()), copy=False)
+    uuid = fields.Char(string='Uuid', readonly=True, copy=False)
     email = fields.Char(string='Email', compute="_compute_contact_details", readonly=False, store=True)
     mobile = fields.Char(string='Mobile', compute="_compute_contact_details", readonly=False, store=True)
     is_edited = fields.Boolean(string='Edited', compute='_compute_is_edited')
@@ -1307,7 +1306,7 @@ class PosOrderLine(models.Model):
     refund_orderline_ids = fields.One2many('pos.order.line', 'refunded_orderline_id', 'Refund Order Lines', help='Orderlines in this field are the lines that refunded this orderline.')
     refunded_orderline_id = fields.Many2one('pos.order.line', 'Refunded Order Line', help='If this orderline is a refund, then the refunded orderline is specified in this field.')
     refunded_qty = fields.Float('Refunded Quantity', compute='_compute_refund_qty', help='Number of items refunded in this orderline.')
-    uuid = fields.Char(string='Uuid', readonly=True, default=lambda self: str(uuid4()), copy=False)
+    uuid = fields.Char(string='Uuid', readonly=True, copy=False)
     note = fields.Char('Product Note')
 
     combo_parent_id = fields.Many2one('pos.order.line', string='Combo Parent') # FIXME rename to parent_line_id

--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -1,7 +1,6 @@
 from odoo import api, fields, models, _
 from odoo.tools import formatLang, float_is_zero
 from odoo.exceptions import ValidationError
-from uuid import uuid4
 
 
 class PosPayment(models.Model):
@@ -41,7 +40,7 @@ class PosPayment(models.Model):
     ticket = fields.Char(string='Payment Receipt Info')
     is_change = fields.Boolean(string='Is this payment change?', default=False)
     account_move_id = fields.Many2one('account.move', index='btree_not_null')
-    uuid = fields.Char(string='Uuid', readonly=True, default=lambda self: str(uuid4()), copy=False)
+    uuid = fields.Char(string='Uuid', readonly=True, copy=False)
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/pos_restaurant/data/restaurant_session_floor.xml
+++ b/addons/pos_restaurant/data/restaurant_session_floor.xml
@@ -512,6 +512,7 @@
             <field name="partner_id" ref="customer_1" />
             <field name="table_id" ref="table_01" />
             <field name="customer_count">8</field>
+            <field name="uuid">b3abf526-e575-4c29-a1b7-0264e21c6dda</field>
         </record>
 
         <record id="pos_orderline_2" model="pos.order.line" forcecreate="False">
@@ -523,6 +524,7 @@
             <field name="qty">2</field>
             <field name="order_id" ref="pos_open_order_2" />
             <field name="full_product_name">Coca-Cola</field>
+            <field name="uuid">42ca3fb9-dc7a-4b4b-bb42-9027f07569e6</field>
         </record>
 
         <record id="pos_orderline_3" model="pos.order.line" forcecreate="False">
@@ -534,6 +536,7 @@
             <field name="qty">2</field>
             <field name="order_id" ref="pos_open_order_2" />
             <field name="full_product_name">Salmon and Avocado</field>
+            <field name="uuid">e5b8c7fc-d279-4285-a5c3-5e289043d9d8</field>
         </record>
 
         <record id="pos_open_order_3" model="pos.order" forcecreate="False">
@@ -549,6 +552,7 @@
             <field name="partner_id" ref="customer_1" />
             <field name="table_id" ref="table_02" />
             <field name="customer_count">3</field>
+            <field name="uuid">b3abf526-e575-4c29-a1b7-0264e21c6ddb</field>
         </record>
 
         <record id="pos_orderline_4" model="pos.order.line" forcecreate="False">
@@ -560,6 +564,7 @@
             <field name="qty">1</field>
             <field name="order_id" ref="pos_open_order_3" />
             <field name="full_product_name">Lunch Temaki mix 3pc</field>
+            <field name="uuid">42ca3fb9-dc7a-4b4b-bb42-9027f07569e7</field>
         </record>
 
         <record id="pos_orderline_5" model="pos.order.line" forcecreate="False">
@@ -571,6 +576,7 @@
             <field name="qty">2</field>
             <field name="order_id" ref="pos_open_order_3" />
             <field name="full_product_name">Mozzarella Sandwich</field>
+            <field name="uuid">e5b8c7fc-d279-4285-a5c3-5e289043d9d9</field>
         </record>
 
         <record id="pos_open_order_4" model="pos.order" forcecreate="False">
@@ -586,6 +592,7 @@
             <field name="partner_id" ref="customer_1" />
             <field name="table_id" ref="table_04" />
             <field name="customer_count">5</field>
+            <field name="uuid">b3abf526-e575-4c29-a1b7-0264e21c6ddc</field>
         </record>
 
         <record id="pos_orderline_6" model="pos.order.line" forcecreate="False">
@@ -597,6 +604,7 @@
             <field name="qty">1</field>
             <field name="order_id" ref="pos_open_order_4" />
             <field name="full_product_name">Chicken Curry Sandwich</field>
+            <field name="uuid">42ca3fb9-dc7a-4b4b-bb42-9027f07569e8</field>
         </record>
 
         <record id="pos_orderline_7" model="pos.order.line" forcecreate="False">
@@ -608,6 +616,7 @@
             <field name="qty">1</field>
             <field name="order_id" ref="pos_open_order_4" />
             <field name="full_product_name">Bacon Burger</field>
+            <field name="uuid">e5b8c7fc-d279-4285-a5c3-5e289043d9da</field>
         </record>
 
         <record id="pos_open_order_5" model="pos.order" forcecreate="False">
@@ -623,6 +632,7 @@
             <field name="partner_id" ref="customer_1" />
             <field name="table_id" ref="table_06" />
             <field name="customer_count">1</field>
+            <field name="uuid">b3abf526-e575-4c29-a1b7-0264e21c6ddd</field>
         </record>
 
         <record id="pos_orderline_8" model="pos.order.line" forcecreate="False">
@@ -634,6 +644,7 @@
             <field name="qty">1</field>
             <field name="order_id" ref="pos_open_order_5" />
             <field name="full_product_name">Pizza 4 Formaggi</field>
+            <field name="uuid">42ca3fb9-dc7a-4b4b-bb42-9027f07569e9</field>
         </record>
 
         <function model="pos.session" name="_set_last_order_preparation_change"


### PR DESCRIPTION
Before this commit, demo data had no uuid, which is necessary for the rontend to function properly.

A fix had been merged by adding a default value to the uuid field, but this did not work.

The frontend is responsible for creating UUIDs, so we added the uuid to the demo data.


