### PR TITLE
[FIX] point_of_sale: missing related fields after synchronization

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -541,6 +541,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
         const fields = getFields(model);
         Object.assign(baseData[model][record.id], vals);
 
+        record._raw = vals;
         for (const name in vals) {
             if (!(name in fields) && name !== "id") {
                 continue;
@@ -615,8 +616,6 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
                     } else if (models[field.relation] && typeof vals[name] === "object") {
                         const newRecord = create(comodelName, vals[name]);
                         connect(field, record, newRecord);
-                    } else {
-                        record[name] = vals[name];
                     }
                 } else if (record[name]) {
                     const linkedRec = record[name];
@@ -884,7 +883,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
         const ignoreConnection = {};
 
         for (const model in rawData) {
-            ignoreConnection[model] = [];
+            ignoreConnection[model] = new Set();
             const modelKey = keyByModel[model] || "id";
 
             if (!oldStates[model]) {
@@ -946,7 +945,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
 
                     oldRecord.update(record, { silent: true });
                     oldRecord.setup(record);
-                    ignoreConnection[model].push(record.id);
+                    ignoreConnection[model].add(record.id);
                     results[model].push(oldRecord);
                     continue;
                 }
@@ -977,10 +976,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
             const fields = getFields(model);
 
             for (const rawRec of rawRecords) {
-                if (ignoreConnection[model].includes(rawRec.id)) {
-                    continue;
-                }
-
+                const ignore = ignoreConnection[model];
                 const recorded = records[model][rawRec.id];
 
                 // Check if there are any missing fields for this record
@@ -994,6 +990,10 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
                 }
 
                 for (const name in fields) {
+                    if ((ignore.has(rawRec.id) && recorded[name]) || !rawRec[name]) {
+                        continue;
+                    }
+
                     const field = fields[name];
                     alreadyLinkedSet.add(field);
 

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -279,9 +279,9 @@ export class PaymentScreen extends Component {
 
             // 2. Invoice.
             if (this.shouldDownloadInvoice() && this.currentOrder.is_to_invoice()) {
-                if (this.currentOrder.account_move) {
+                if (this.currentOrder.account_move || this.currentOrder.raw.account_move) {
                     await this.report.doAction("account.account_invoices", [
-                        this.currentOrder.account_move,
+                        this.currentOrder.account_move || this.currentOrder.raw.account_move,
                     ]);
                 } else {
                     throw {


### PR DESCRIPTION
When we sync PoS models after write to a record we don't want to
overwrite local connections.
However this means we don't create new connections when we receive
related record data from the backend, possibly breaking flows relying on
the related record, like the following:

User in Chile needs to print on the POS receipt the SII Fiscal barcode
This is currently not being printed and this makes the ticket not a validal
legal invoice or electronic ticket.

Step to reproduce:
- With a Chilean company setup
- Open POS session
- Make an order to customer "Consumidor Final Anónimo"
- Pay and check generated receipt

Issue: On the receipt no barcode is shown, a broken image placeholder
can be observed.
This occurs because the related record (account_move) is not loaded
