### PR TITLE
[FIX] hr_holidays: improve test stability

### DIFF
--- a/addons/hr_holidays/tests/test_holidays_calendar.py
+++ b/addons/hr_holidays/tests/test_holidays_calendar.py
@@ -3,6 +3,8 @@
 
 from datetime import date, timedelta
 
+from odoo.osv import expression
+
 from odoo.addons.base.tests.common import HttpCase
 from odoo.tests.common import tagged
 from odoo.tests.common import users
@@ -52,35 +54,37 @@ class TestHolidaysCalendar(HttpCase, TestHrHolidaysCommon):
         holiday_status_sick = self.env.ref('hr_holidays.holiday_status_sl')
         holiday_status_3_days = self.env.ref('hr_holidays.holiday_status_cl')
 
-        self.env['hr.leave'].create({
+        this_monday = date.today() - timedelta(days=date.today().weekday())
+        next_monday = this_monday + timedelta(weeks=1)
+        leaves = self.env['hr.leave'].create([{
             'name': '3 days Off',
             'employee_id': david.id,
             'holiday_status_id': holiday_status_3_days.id,
-            'request_date_from': date.today(),
-            'request_date_to': date.today() + timedelta(days=2),
-        })
-        self.env['hr.leave'].create({
+            'request_date_from': this_monday,
+            'request_date_to': this_monday + timedelta(days=2),
+        }, {
             'name': 'Sick Ronnie',
             'employee_id': david.id,
             'holiday_status_id': holiday_status_sick.id,
-            'request_date_from': date.today() + timedelta(days=3),
-            'request_date_to': date.today() + timedelta(days=5),
-        })
+            'request_date_from': next_monday,
+            'request_date_to': next_monday + timedelta(days=4),
+        }])
 
         search_cases = [
-            ('3 days', [True, True, True]),
-            ('Sick', [False, True, True]),
-            ('David', [True, True, True]),
+            ('3 days', [leaves[0], leaves[0], leaves[0]]),
+            ('Sick', [leaves.browse(), leaves[1], leaves[1]]),
+            ('David', [leaves, leaves, leaves]),
         ]
         users = [self.user_employee, self.user_hrmanager, self.user_hruser]
 
         for term, expected_results in search_cases:
             for user, expected in zip(users, expected_results):
-                records = self.env['hr.leave.report.calendar'].search(
-                    self.env['hr.leave.report.calendar'].with_user(user)._search_name('ilike', term)
-                )
+                records = self.env['hr.leave.report.calendar'].search(expression.AND([
+                    [('leave_id', 'in', leaves.ids)],
+                    self.env['hr.leave.report.calendar'].with_user(user)._search_name('ilike', term),
+                ]))
                 self.assertEqual(
-                    bool(records), 
+                    records.leave_id, 
                     expected, 
-                    f"Failed for term '{term}' with user {user.login}. Expected {expected}, got {bool(records)}."
+                    f"Failed for term '{term}' with user {user.login}. Expected {expected}, got {records}."
                 )


### PR DESCRIPTION
The test suffered from multiple problems:
 - Duration of leaves could sometimes be less or more depending on the day of the week (weekend don't count in duration)
 - Demo data could make the test pass while the leaves created during the test were not actually found Here we improved the date mechanism as well as forcing the domain to only search within our own leaves as well as comparing that those leaves are the one with fetched.

