### PR TITLE
[FIX] payment_paypal: disable the payment button when not allowed to pay

### DIFF
--- a/addons/payment/static/src/js/payment_button.js
+++ b/addons/payment/static/src/js/payment_button.js
@@ -4,7 +4,7 @@ import publicWidget from '@web/legacy/js/public/public_widget';
 import { Component } from "@odoo/owl";
 
 publicWidget.registry.PaymentButton = publicWidget.Widget.extend({
-    selector: 'button[name="o_payment_submit_button"]',
+    selector: '[name="o_payment_submit_button"]',
 
     async start() {
         await this._super(...arguments);
@@ -25,7 +25,7 @@ publicWidget.registry.PaymentButton = publicWidget.Widget.extend({
      */
     _enable() {
         if (this._canSubmit()) {
-            this.paymentButton.disabled = false;
+            this._setEnabled();
         }
     },
 
@@ -45,6 +45,16 @@ publicWidget.registry.PaymentButton = publicWidget.Widget.extend({
             return true; // Ignore the check.
         }
         return document.querySelectorAll('input[name="o_payment_radio"]:checked').length === 1;
+    },
+
+    /**
+     * Enable the payment button.
+     *
+     * @private
+     * @return {void}
+     */
+    _setEnabled() {
+        this.paymentButton.disabled = false;
     },
 
     /**

--- a/addons/payment_paypal/static/src/js/payment_button.js
+++ b/addons/payment_paypal/static/src/js/payment_button.js
@@ -1,0 +1,67 @@
+/** @odoo-module **/
+
+import paymentButton from '@payment/js/payment_button';
+
+paymentButton.include({
+
+    /**
+     * Hide the disabled PayPal button and show the enabled one.
+     *
+     * @override method from @payment/js/payment_button
+     * @private
+     * @return {void}
+     */
+    _setEnabled() {
+        if (!this.paymentButton.dataset.isPaypal) {
+            this._super();
+            return;
+        }
+
+        document.getElementById('o_paypal_disabled_button').classList.add('d-none');
+        document.getElementById('o_paypal_enabled_button').classList.remove('d-none');
+    },
+
+    /**
+     * Hide the enabled PayPal button and show the disabled one.
+     *
+     * @override method from @payment/js/payment_button
+     * @private
+     * @return {void}
+     */
+    _disable() {
+        if (!this.paymentButton.dataset.isPaypal) {
+            this._super();
+            return;
+        }
+
+        document.getElementById('o_paypal_disabled_button').classList.remove('d-none');
+        document.getElementById('o_paypal_enabled_button').classList.add('d-none');
+    },
+
+    /**
+     * Disable the generic behavior that would hide the Paypal button container.
+     *
+     * @override method from @payment/js/payment_button
+     * @private
+     * @return {void}
+     */
+    _hide() {
+        if (!this.paymentButton.dataset.isPaypal) {
+            this._super();
+        }
+    },
+
+    /**
+     * Disable the generic behavior that would show the Paypal button container.
+     *
+     * @override method from @payment/js/payment_button
+     * @private
+     * @return {void}
+     */
+    _show() {
+        if (!this.paymentButton.dataset.isPaypal) {
+            this._super();
+        }
+    },
+
+});

--- a/addons/payment_paypal/views/payment_form_templates.xml
+++ b/addons/payment_paypal/views/payment_form_templates.xml
@@ -14,7 +14,12 @@
 
     <template id="payment_submit_button_inherit" inherit_id="payment.submit_button">
         <button name="o_payment_submit_button" position="before">
-            <div id="o_paypal_button" class="d-none"/>
+            <div
+                id="o_paypal_button_container" name="o_payment_submit_button" data-is-paypal="true"
+            >
+                <div id="o_paypal_enabled_button" class="d-none"/>
+                <div id="o_paypal_disabled_button"/>
+            </div>
             <div id="o_paypal_loading" class="d-flex justify-content-center d-none">
                 <div class="spinner-border"/>
             </div>

--- a/addons/website_sale/static/src/js/payment_form.js
+++ b/addons/website_sale/static/src/js/payment_form.js
@@ -9,8 +9,10 @@ PaymentForm.include({
       * @override
      */
      async start() {
-         const submitButton = document.querySelector('[name="o_payment_submit_button"]');
-         submitButton.addEventListener('click', ev => this._submitForm(ev));
+         const submitButtons = document.querySelectorAll('[name="o_payment_submit_button"]');
+         submitButtons.forEach(  // Support the additional PayPal buttons acting as submit buttons.
+             submitButton => submitButton.addEventListener('click', ev => this._submitForm(ev))
+         );
          return await this._super(...arguments);
      }
 


### PR DESCRIPTION
Prior to this commit, the PayPal SDK was used to render a single payment button that replaced the generic submit button of the payment form. This prevented disabling the button when the conditions were not met to allow the payment (e.g., the "Terms and Conditions checkbox was not ticked) as this mechanism relies on the PaymentButton public widget, which was incompatible with PayPal's custom buttons.

This commit ensures that PayPal buttons, too, are disabled when the payment is not allowed by making the PaymentButton widget attach itself to the PayPal button container, creating two PayPal buttons - one enabled and one permanently disabled - instead of one, and alternately showing them depending on whether the payment is allowed.

opw-4354267
