### PR TITLE
[IMP] payment_mercado_pago: support tokenization and OAuth onboarding

### DIFF
--- a/addons/payment/data/payment_method_data.xml
+++ b/addons/payment/data/payment_method_data.xml
@@ -550,12 +550,6 @@
         <field name="support_express_checkout">False</field>
         <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
-        <field name="supported_currency_ids"
-               eval="[Command.set([
-                         ref('base.INR'),
-                         ref('base.NGN'),
-                     ])]"
-        />
     </record>
 
     <record id="payment_method_becs_direct_debit" model="payment.method">
@@ -1933,6 +1927,18 @@
                          ref('base.EUR'),
                      ])]"
         />
+    </record>
+
+    <record id="payment_method_mercado_pago_wallet" model="payment.method">
+        <field name="name">Mercado Pago Wallet</field>
+        <field name="code">mercado_pago_wallet</field>
+        <field name="sequence">1000</field>
+        <field name="active">False</field>
+        <field name="image" type="base64" file="payment/static/img/mercado_livre.png"/>
+        <field name="support_tokenization">False</field>
+        <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
+        <field name="support_refund">none</field>
     </record>
 
     <record id="payment_method_mobile_money" model="payment.method">

--- a/addons/payment/data/payment_provider_data.xml
+++ b/addons/payment/data/payment_provider_data.xml
@@ -257,9 +257,9 @@
         -->
         <field name="payment_method_ids"
                eval="[Command.set([
-                         ref('payment.payment_method_card'),
                          ref('payment.payment_method_bank_transfer'),
-                         ref('payment.payment_method_paypal'),
+                         ref('payment.payment_method_card'),
+                         ref('payment.payment_method_mercado_pago_wallet'),
                      ])]"
         />
     </record>

--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -12,6 +12,7 @@ from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.const import REPORT_REASONS_MAPPING, SENSITIVE_KEYS
 from odoo.addons.payment.logging import get_payment_logger
 
+
 # Pass the possibly empty set of sensitive keys to the logger in case a provider module extends it.
 _logger = get_payment_logger(__name__, sensitive_keys=SENSITIVE_KEYS)
 
@@ -480,6 +481,34 @@ class PaymentProvider(models.Model):
 
         :param int menu_id: The menu from which the onboarding is started, as an `ir.ui.menu` id.
         :return: The onboarding action.
+        :rtype: dict
+        """
+        return {}
+
+    def action_reset_credentials(self):
+        """Reset the credentials of the provider, disable it, and unpublish it.
+
+        Note: self.ensure_one()
+
+        :return: The result of the write operation.
+        :rtype: bool
+        """
+        self.ensure_one()
+
+        return self.write({
+            'state': 'disabled',
+            'is_published': False,
+            **self._get_reset_values(),
+        })
+
+    def _get_reset_values(self):
+        """Return the values to reset the credentials of the provider.
+
+        Providers can override this to supply their own credential fields to reset.
+
+        Note: self.ensure_one() from :meth: `action_reset_credentials`
+
+        :return: The values to reset the credentials of the provider.
         :rtype: dict
         """
         return {}

--- a/addons/payment/models/res_country.py
+++ b/addons/payment/models/res_country.py
@@ -2,17 +2,23 @@
 
 from odoo import api, fields, models
 
-import odoo.addons.payment_stripe as stripe  # prevent circular import error with payment_stripe
+# Import the payment provider modules with aliases to avoid circular import errors.
+import odoo.addons.payment_mercado_pago as mercado_pago
+import odoo.addons.payment_stripe as stripe
 
 
 class ResCountry(models.Model):
     _inherit = 'res.country'
 
-    is_stripe_supported_country = fields.Boolean(compute='_compute_is_stripe_supported_country')
+    is_mercado_pago_supported_country = fields.Boolean(compute='_compute_provider_support')
+    is_stripe_supported_country = fields.Boolean(compute='_compute_provider_support')
 
     @api.depends('code')
-    def _compute_is_stripe_supported_country(self):
+    def _compute_provider_support(self):
         for country in self:
             country.is_stripe_supported_country = stripe.const.COUNTRY_MAPPING.get(
                 country.code, country.code
             ) in stripe.const.SUPPORTED_COUNTRIES
+            country.is_mercado_pago_supported_country = (
+                country.code in mercado_pago.const.SUPPORTED_COUNTRIES
+            )

--- a/addons/payment/wizards/res_config_settings.py
+++ b/addons/payment/wizards/res_config_settings.py
@@ -14,7 +14,11 @@ class ResConfigSettings(models.TransientModel):
     )
     onboarding_payment_module = fields.Selection(
         string="Onboarding Payment Module",
-        selection=[('razorpay', "Razorpay"), ('stripe', "Stripe")],
+        selection=[
+            ('mercado_pago', "Mercado Pago"),
+            ('razorpay', "Razorpay"),
+            ('stripe', "Stripe"),
+        ],
         compute='_compute_onboarding_payment_module',
     )
 
@@ -44,6 +48,8 @@ class ResConfigSettings(models.TransientModel):
                 config.onboarding_payment_module = 'razorpay'
             elif config.company_id.country_id.is_stripe_supported_country:
                 config.onboarding_payment_module = 'stripe'
+            elif config.company_id.country_id.is_mercado_pago_supported_country:
+                config.onboarding_payment_module = 'mercado_pago'
             else:
                 config.onboarding_payment_module = None
 

--- a/addons/payment_mercado_pago/README.md
+++ b/addons/payment_mercado_pago/README.md
@@ -3,21 +3,26 @@
 ## Technical details
 
 APIs:
-- [Checkout Pro](https://www.mercadopago.com.mx/developers/en/docs/checkout-pro/landing)
-- [Checkout API](https://www.mercadopago.com.mx/developers/en/docs/checkout-api/landing)
+- [Checkout Pro](https://www.mercadopago.com.mx/developers/en/docs/checkout-pro/overview)
+- [Checkout API](https://www.mercadopago.com.mx/developers/en/docs/checkout-api/overview)
+- [Checkout Bricks](https://www.mercadopago.com.mx/developers/en/docs/checkout-bricks/overview)
 
-This module integrates Mercado Pago using a combination of "Checkout Pro" and "Checkout API". The
-generic payment with redirection flow based on form submission provided by the `payment` module is
-used to initiate the payment with the same request payload as Checkout Pro's JavaScript SDK would.
-The remaining API calls are made to the Checkout API. It was not possible to only integrate with
-Checkout Pro as it only allows redirecting customers to the payment page, nor with only the Checkout
-API only as it requires building a custom payment form to accept direct payments from the merchant's
-website.
+This module integrates Mercado Pago using a combination of "Checkout Pro", "Checkout API", and
+"Checkout Bricks" APIs.
+
+The card payment method uses the "Card Payment Brick" to enable direct payments, while other payment
+methods use the generic payment with redirection flow based on form submission provided by the
+`payment` module. Redirect payments send the same request payload as Checkout Pro's JavaScript SDK
+would. The remaining API calls are made to the Checkout API. It was not possible to only integrate
+the redirect flow with Checkout Pro as it only allows redirecting customers to the payment page, nor
+with only the Checkout API only as it requires building a custom payment form to accept direct
+payments from the merchant's website.
 
 ## Supported features
 
 - Payment with redirection flow
-- Webhook notifications
+- Tokenization
+- OAuth authentication
 
 ## Not implemented features
 
@@ -26,6 +31,9 @@ website.
 
 ## Module history
 
+- `19.0`
+  - OAuth support is added in addition to the credentials-based authentication. odoo/odoo#194998
+  - Support for tokenization is added. odoo/odoo#194998
 - `16.0`
   - The first version of the module is merged. odoo/odoo#83957
 
@@ -35,8 +43,12 @@ https://www.mercadopago.com.mx/developers/en/docs/checkout-api/additional-conten
 
 ### VISA
 
-**Card Number**: `4075595715555555`
+**Card Number**: `4075595716483764`
 
-**Expiry Date**: `11/25`
+**Expiry Date**: any future date
 
-**Security Code**: `123`
+**Security Code**: any
+
+**Card holder**: `APRO`
+
+**Email**: `test_user_[0-9]@testuser.com`

--- a/addons/payment_mercado_pago/__init__.py
+++ b/addons/payment_mercado_pago/__init__.py
@@ -3,12 +3,12 @@
 from . import controllers
 from . import models
 
-from odoo.addons.payment import setup_provider, reset_payment_provider
+import odoo.addons.payment as payment  # Prevent circular import error with payment (res.country).
 
 
 def post_init_hook(env):
-    setup_provider(env, 'mercado_pago')
+    payment.setup_provider(env, 'mercado_pago')
 
 
 def uninstall_hook(env):
-    reset_payment_provider(env, 'mercado_pago')
+    payment.reset_payment_provider(env, 'mercado_pago')

--- a/addons/payment_mercado_pago/__manifest__.py
+++ b/addons/payment_mercado_pago/__manifest__.py
@@ -9,6 +9,7 @@
     'description': " ",  # Non-empty string to avoid loading the README file.
     'depends': ['payment'],
     'data': [
+        'views/payment_form_templates.xml',
         'views/payment_mercado_pago_templates.xml',
         'views/payment_provider_views.xml',
 
@@ -16,6 +17,11 @@
     ],
     'post_init_hook': 'post_init_hook',
     'uninstall_hook': 'uninstall_hook',
+    'assets': {
+        'web.assets_frontend': [
+            'payment_mercado_pago/static/src/**/*',
+        ],
+    },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }

--- a/addons/payment_mercado_pago/const.py
+++ b/addons/payment_mercado_pago/const.py
@@ -5,33 +5,56 @@ from odoo.tools import LazyTranslate
 
 _lt = LazyTranslate(__name__)
 
+PROXY_URL = 'https://mercadopago.api.odoo.com/api/mercado_pago/1'
 
-# Currency codes of the currencies supported by Mercado Pago in ISO 4217 format.
-# See https://api.mercadopago.com/currencies. Last seen online: 2024-10-29.
-SUPPORTED_CURRENCIES = [
-    'ARS',  # Argentinian Peso
-    'BOB',  # Boliviano
-    'BRL',  # Real
-    'CLF',  # Fomento Unity
-    'CLP',  # Chilean Peso
-    'COP',  # Colombian Peso
-    'CRC',  # Colon
-    'CUC',  # Cuban Convertible Peso
-    'CUP',  # Cuban Peso
-    'DOP',  # Dominican Peso
-    'EUR',  # Euro
-    'GTQ',  # Guatemalan Quetzal
-    'HNL',  # Lempira
-    'MXN',  # Mexican Peso
-    'NIO',  # Cordoba
-    'PAB',  # Balboa
-    'PEN',  # Sol
-    'PYG',  # Guarani
-    'USD',  # US Dollars
-    'UYU',  # Uruguayan Peso
-    'VEF',  # Strong Bolivar
-    'VES',  # Sovereign Bolivar
-]
+PAYMENT_RETURN_ROUTE = '/payment/mercado_pago/return'
+OAUTH_RETURN_ROUTE = '/payment/mercado_pago/oauth/return'
+WEBHOOK_ROUTE = '/payment/mercado_pago/webhook'
+
+
+# The countries supported by Mercado Pago.
+SUPPORTED_COUNTRIES = {
+    'AR',
+    'BO',
+    'BR',
+    'CL',
+    'CO',
+    'CR',
+    'DO',
+    'EC',
+    'GT',
+    'HN',
+    'MX',
+    'NI',
+    'PA',
+    'PY',
+    'PE',
+    'SV',
+    'UY',
+    'VE',
+}
+
+# Mapping of country codes to corresponding currency codes.
+CURRENCY_MAPPING = {
+    'AR': 'ARS',  # Argentina - Argentine Peso
+    'BO': 'BOB',  # Bolivia - Boliviano
+    'BR': 'BRL',  # Brazil - Brazilian Real
+    'CL': 'CLP',  # Chile - Chilean Peso
+    'CO': 'COP',  # Colombia - Colombian Peso
+    'CR': 'CRC',  # Costa Rica - Costa Rican Colón
+    'DO': 'DOP',  # Dominican Republic - Dominican Peso
+    'EC': 'USD',  # Ecuador - United States Dollar
+    'GT': 'GTQ',  # Guatemala - Guatemalan Quetzal
+    'HN': 'HNL',  # Honduras - Honduran Lempira
+    'MX': 'MXN',  # Mexico - Mexican Peso
+    'NI': 'NIO',  # Nicaragua - Nicaraguan Córdoba
+    'PA': 'PAB',  # Panama - Panamanian Balboa (also uses USD)
+    'PY': 'PYG',  # Paraguay - Paraguayan Guaraní
+    'PE': 'PEN',  # Peru - Peruvian Sol
+    'SV': 'USD',  # El Salvador - United States Dollar
+    'UY': 'UYU',  # Uruguay - Uruguayan Peso
+    'VE': 'VES'   # Venezuela - Venezuelan Bolívar
+}
 
 # Set of currencies where Mercado Pago's minor units deviates from the ISO 4217 standard.
 # See https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xls
@@ -47,6 +70,7 @@ DEFAULT_PAYMENT_METHOD_CODES = {
     # Primary payment methods.
     'card',
     # Brand payment methods.
+    'amex',
     'visa',
     'mastercard',
     'argencard',
@@ -69,6 +93,8 @@ DEFAULT_PAYMENT_METHOD_CODES = {
 PAYMENT_METHODS_MAPPING = {
     'card': 'debit_card,credit_card,prepaid_card',
     'paypal': 'digital_wallet',
+    'mastercard': 'master',
+    'mercado_pago_wallet': 'mercado_pago',
 }
 
 # Mapping of transaction states to Mercado Pago payment statuses.

--- a/addons/payment_mercado_pago/controllers/__init__.py
+++ b/addons/payment_mercado_pago/controllers/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import main
+from . import onboarding
+from . import payment

--- a/addons/payment_mercado_pago/controllers/onboarding.py
+++ b/addons/payment_mercado_pago/controllers/onboarding.py
@@ -10,33 +10,32 @@ from odoo import _, fields
 from odoo.exceptions import ValidationError
 from odoo.http import Controller, request, route
 
+from odoo.addons.payment_mercado_pago import const
 
 _logger = logging.getLogger(__name__)
 
 
-class RazorpayController(Controller):
+class MercadoPagoOnboardingController(Controller):
 
-    OAUTH_RETURN_URL = '/payment/razorpay/oauth/return'
+    @route(const.OAUTH_RETURN_ROUTE, type='http', auth='user', methods=['GET'], website=True)
+    def mercado_pago_return_from_authorization(self, **data):
+        """Exchange the authorization code for an access token and redirect to the provider form.
 
-    @route(OAUTH_RETURN_URL, type='http', auth='user', methods=['GET'], website=True)
-    def razorpay_return_from_authorization(self, **data):
-        """ Exchange the authorization code for an access token and redirect to the provider form.
-
-        :param dict data: The authorization code received from Razorpay, in addition to the provided
-                          provider id and CSRF token that were sent back by the proxy.
+        :param dict data: The authorization code received from Mercado Pago, in addition to the
+                          provided provider id and CSRF token that were sent back by the proxy.
         :raise Forbidden: If the received CSRF token cannot be verified.
-        :raise ValidationError: If the provider id does not match any Razorpay provider.
+        :raise ValidationError: If the provider id does not match any Mercado Pago provider.
         :return: Redirect to the payment provider form.
         """
         _logger.info("Returning from authorization with data:\n%s", pprint.pformat(data))
 
-        # Retrieve the Razorpay data and Odoo metadata from the redirect data.
+        # Retrieve the Mercado Pago data and Odoo metadata from the redirect data.
         provider_id = int(data['provider_id'])
         authorization_code = data.get('authorization_code')
-        csrf_token = data['csrf_token']
+        csrf_token = data.get('csrf_token')  # Could be missing if authorization was cancelled.
         provider_sudo = request.env['payment.provider'].sudo().browse(provider_id).exists()
-        if not provider_sudo or provider_sudo.code != 'razorpay':
-            raise ValidationError(_("Could not find Razorpay provider with id %s", provider_sudo))
+        if not provider_sudo or provider_sudo.code != 'mercado_pago':
+            raise ValidationError(_("Could not find Mercado Pago provider %s", provider_sudo))
 
         # Verify the CSRF token.
         if not request.validate_csrf(csrf_token):
@@ -55,31 +54,30 @@ class RazorpayController(Controller):
         )
         try:
             response_content = provider_sudo._send_api_request(
-                'POST', '/get_access_token', json=proxy_payload, is_proxy_request=True
+                'POST', '/get_access_token', json=proxy_payload, is_proxy_request=True,
             )
         except ValidationError as e:
             return request.render(
-                'payment_razorpay.authorization_error',
-                qcontext={'error_message': str(e), 'provider_url': redirect_url},
+                'payment_mercado_pago.authorization_error',
+                {'error_message': str(e), 'provider_url': redirect_url},
             )
-        expires_in = fields.Datetime.now() + timedelta(seconds=int(response_content['expires_in']))
+        # Backdate the access token expiry to refresh it before it expires, since the refresh token
+        # would become unusable at that time (according to Mercado Pago's dev team).
+        expires_in = (
+            fields.Datetime.now()
+            + timedelta(seconds=int(response_content['expires_in']))
+            - timedelta(days=31)
+        )
         provider_sudo.write({
-            # Reset the classical API key fields.
-            'razorpay_key_id': None,
-            'razorpay_key_secret': None,
-            'razorpay_webhook_secret': None,
             # Save the OAuth credentials.
-            'razorpay_account_id': response_content['razorpay_account_id'],
-            'razorpay_public_token': response_content['public_token'],
-            'razorpay_refresh_token': response_content['refresh_token'],
-            'razorpay_access_token': response_content['access_token'],
-            'razorpay_access_token_expiry': expires_in,
+            'mercado_pago_access_token': response_content['access_token'],
+            'mercado_pago_refresh_token': response_content['refresh_token'],
+            'mercado_pago_access_token_expiry': expires_in,
+            'mercado_pago_public_key': response_content['public_key'],
             # Enable the provider.
             'state': 'enabled',
             'is_published': True,
+            'allow_tokenization': True,
         })
-        try:
-            provider_sudo.action_razorpay_create_webhook()
-        except ValidationError as error:
-            _logger.warning(error)
+
         return request.redirect(redirect_url)

--- a/addons/payment_mercado_pago/data/payment_provider_data.xml
+++ b/addons/payment_mercado_pago/data/payment_provider_data.xml
@@ -4,6 +4,7 @@
     <record id="payment.payment_provider_mercado_pago" model="payment.provider">
         <field name="code">mercado_pago</field>
         <field name="redirect_form_view_id" ref="redirect_form"/>
+        <field name="inline_form_view_id" ref="inline_form"/>
     </record>
 
 </odoo>

--- a/addons/payment_mercado_pago/models/__init__.py
+++ b/addons/payment_mercado_pago/models/__init__.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import payment_provider
+from . import payment_token
 from . import payment_transaction

--- a/addons/payment_mercado_pago/models/payment_provider.py
+++ b/addons/payment_mercado_pago/models/payment_provider.py
@@ -1,8 +1,17 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
-from odoo.tools import urls
+import json
+from datetime import timedelta
+from urllib.parse import urlencode
 
+from odoo import _, api, fields, models
+from odoo.exceptions import RedirectWarning, ValidationError
+from odoo.fields import Command
+from odoo.http import request
+from odoo.tools.urls import urljoin
+
+from odoo.addons.payment import utils as payment_utils
+from odoo.addons.payment.const import REPORT_REASONS_MAPPING
 from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_mercado_pago import const
 
@@ -16,22 +25,77 @@ class PaymentProvider(models.Model):
     code = fields.Selection(
         selection_add=[('mercado_pago', "Mercado Pago")], ondelete={'mercado_pago': 'set default'}
     )
-    mercado_pago_access_token = fields.Char(
-        string="Mercado Pago Access Token",
+    mercado_pago_account_country_id = fields.Many2one(
+        string="Mercado Pago Account Country",
+        help="The country of the Mercado Pago account. The currency will be updated to match the"
+             " country of the Mercado Pago account.",
+        comodel_name='res.country',
+        inverse='_inverse_mercado_pago_account_country_id',
+        domain=[('code', 'in', list(const.SUPPORTED_COUNTRIES))],
         required_if_provider='mercado_pago',
-        groups='base.group_system',
+    )
+
+    # OAuth fields
+    mercado_pago_access_token = fields.Char(
+        string="Mercado Pago Access Token", groups='base.group_system'
+    )
+    mercado_pago_access_token_expiry = fields.Datetime(
+        string="Mercado Pago Access Token Expiry", groups='base.group_system'
+    )
+    mercado_pago_refresh_token = fields.Char(
+        string="Mercado Pago Refresh Token", groups='base.group_system'
+    )
+    mercado_pago_public_key = fields.Char(
+        string="Mercado Pago Public Key", groups='base.group_system'
     )
 
     # === COMPUTE METHODS === #
 
-    def _get_supported_currencies(self):
-        """ Override of `payment` to return the supported currencies. """
-        supported_currencies = super()._get_supported_currencies()
-        if self.code == 'mercado_pago':
-            supported_currencies = supported_currencies.filtered(
-                lambda c: c.name in const.SUPPORTED_CURRENCIES
-            )
-        return supported_currencies
+    def _compute_feature_support_fields(self):
+        """Override of `payment` to enable additional features."""
+        super()._compute_feature_support_fields()
+        self.filtered(lambda p: p.code == 'mercado_pago').update({
+            'support_tokenization': True,
+        })
+
+    def _inverse_mercado_pago_account_country_id(self):
+        for provider in self.filtered(
+            lambda p: p.code == 'mercado_pago' and p.mercado_pago_account_country_id
+        ):
+            currency_code = const.CURRENCY_MAPPING.get(self.mercado_pago_account_country_id.code)
+            currency = self.env['res.currency'].with_context(
+                active_test=False,
+            ).search([('name', '=', currency_code)], limit=1)
+            provider.available_currency_ids = [Command.set(currency.ids)]
+
+    # === CONSTRAINT METHODS === #
+
+    @api.constrains('state', 'mercado_pago_access_token')
+    def _check_mercado_pago_credentials_are_set_before_enabling(self):
+        """Check that the Mercado Pago credentials are valid when the provider is enabled.
+
+        :raise ValidationError: If the Mercado Pago credentials are not set.
+        """
+        for provider in self.filtered(lambda p: p.code == 'mercado_pago' and p.state != 'disabled'):
+            if not provider.mercado_pago_access_token:
+                raise ValidationError(_(
+                    "Mercado Pago credentials are missing. Click the \"Connect\" button to set up"
+                    " your account."
+                ))
+
+    @api.constrains('allow_tokenization', 'mercado_pago_public_key')
+    def _check_mercado_pago_credentials_are_set_before_allowing_tokenization(self):
+        """Check that the OAuth credentials are valid when the tokenization is enabled.
+
+        :raise ValidationError: If the Mercado Pago credentials are not valid.
+        """
+        if any(
+            p.code == 'mercado_pago'
+            and p.allow_tokenization
+            and not p.mercado_pago_public_key
+            for p in self
+        ):
+            raise ValidationError(_("Connect your account before enabling tokenization."))
 
     # === CRUD METHODS === #
 
@@ -42,22 +106,193 @@ class PaymentProvider(models.Model):
             return super()._get_default_payment_method_codes()
         return const.DEFAULT_PAYMENT_METHOD_CODES
 
+    # === ACTIONS METHODS === #
+
+    def action_start_onboarding(self, menu_id=None):
+        """Override of `payment` to redirect to the Mercado Pago OAuth URL.
+
+        Note: `self.ensure_one()`
+
+        :param int menu_id: The menu from which the onboarding is started, as an `ir.ui.menu` id.
+        :return: An URL action to redirect to the Mercado Pago OAuth URL.
+        :rtype: dict
+        :raise RedirectWarning: If the company's currency is not supported.
+        """
+        self.ensure_one()
+
+        if self.code != 'mercado_pago':
+            return super().action_start_onboarding(menu_id=menu_id)
+
+        if self.company_id.country_id.code not in const.SUPPORTED_COUNTRIES:
+            raise RedirectWarning(
+                _(
+                    "Mercado Pago is not available in your country; please use another payment"
+                    " provider."
+                ),
+                self.env.ref('payment.action_payment_provider').id,
+                _("Other Payment Providers"),
+            )
+
+        if not self.mercado_pago_account_country_id:
+            raise ValidationError(_("Set the account country before connecting the account."))
+
+        # Encode the return URL parameters here rather than passing them in the 'state' parameter
+        # from IAP, because Mercado Pago doesn't JSON dumps in that parameter.
+        return_url_params = {
+            'provider_id': self.id,
+            'csrf_token': request.csrf_token(),
+        }
+        return_url = urljoin(self.get_base_url(), const.OAUTH_RETURN_ROUTE)
+        proxy_url_params = {
+            'return_url': f'{return_url}?{urlencode(return_url_params)}',
+        }
+        proxy_url = self._build_request_url('/authorize', is_proxy_request=True)
+        return {
+            'type': 'ir.actions.act_url',
+            'url': f'{proxy_url}?{urlencode(proxy_url_params)}',
+            'target': 'self',
+        }
+
+    def _get_reset_values(self):
+        """Override of `payment` to supply the provider-specific credential values to reset."""
+        if self.code != 'mercado_pago':
+            return super()._get_reset_values()
+
+        return {
+            'mercado_pago_access_token': None,
+            'mercado_pago_access_token_expiry': None,
+            'mercado_pago_public_key': None,
+            'mercado_pago_refresh_token': None,
+            'allow_tokenization': False,  # The account must be connected to allow tokenization.
+        }
+
+    # === BUSINESS METHODS === #
+
+    @api.model
+    def _get_compatible_providers(self, *args, is_validation=False, report=None, **kwargs):
+        """ Override of `payment` to filter out Mercado Pago providers for validation operations.
+        """
+        providers = super()._get_compatible_providers(
+            *args, is_validation=is_validation, report=report, **kwargs
+        )
+
+        if is_validation:
+            unfiltered_providers = providers
+            providers = providers.filtered(lambda p: p.code != 'mercado_pago')
+            payment_utils.add_to_report(
+                report,
+                unfiltered_providers - providers,
+                available=False,
+                reason=REPORT_REASONS_MAPPING['validation_not_supported'],
+            )
+
+        return providers
+
+    def _mercado_pago_get_inline_form_values(self, partner_id):
+        """Return a serialized JSON of the values required to render the inline form.
+
+        Note: `self.ensure_one()`
+
+        :param int partner_id: The partner of the transaction, as a `res.partner` id.
+        :return: The JSON serial of the inline form values.
+        :rtype: str
+        """
+        self.ensure_one()
+
+        partner = self.env['res.partner'].browse(partner_id).exists()
+        inline_form_values = {
+            'email': partner.email,
+            'public_key': self.mercado_pago_public_key,
+        }
+        return json.dumps(inline_form_values)
+
     # === REQUEST HELPERS === #
 
-    def _build_request_url(self, endpoint, **kwargs):
+    def _build_request_url(self, endpoint, *, is_proxy_request=False, **kwargs):
         """Override of `payment` to build the request URL."""
         if self.code != 'mercado_pago':
-            return super()._build_request_url(endpoint, **kwargs)
-        return urls.urljoin('https://api.mercadopago.com', endpoint)
+            return super()._build_request_url(endpoint, is_proxy_request=is_proxy_request, **kwargs)
 
-    def _build_request_headers(self, *args, **kwargs):
+        if is_proxy_request:
+            return urljoin(f'{const.PROXY_URL}/1', endpoint)
+
+        return urljoin('https://api.mercadopago.com', endpoint)
+
+    def _build_request_headers(
+        self,
+        method,
+        *args,
+        idempotency_key=None,
+        is_proxy_request=False,
+        is_refresh_token_request=False,
+        **kwargs,
+    ):
         """Override of `payment` to build the request headers."""
         if self.code != 'mercado_pago':
-            return super()._build_request_headers(*args, **kwargs)
-        return {
-            'Authorization': f'Bearer {self.mercado_pago_access_token}',
+            return super()._build_request_headers(
+                method,
+                *args,
+                idempotency_key=idempotency_key,
+                is_proxy_request=is_proxy_request,
+                **kwargs,
+            )
+
+        headers = {
             'X-Platform-Id': 'dev_cdf1cfac242111ef9fdebe8d845d0987',
         }
+        if method == 'POST' and idempotency_key:
+            headers['X-Idempotency-Key'] = idempotency_key
+        if not is_proxy_request and not is_refresh_token_request:
+            access_token = self._mercado_pago_fetch_access_token()
+            headers['Authorization'] = f'Bearer {access_token}'
+        return headers
+
+    def _mercado_pago_fetch_access_token(self):
+        """Generate a new access token if it's expired, otherwise return the existing access token.
+
+        Note: `self.ensure_one()`
+
+        :return: A valid access token.
+        :rtype: str
+        :raise ValidationError: If the access token can not be fetched.
+        """
+        self.ensure_one()
+
+        if (
+            self.mercado_pago_access_token
+            and fields.Datetime.now() <= self.mercado_pago_access_token_expiry
+        ):
+            return self.mercado_pago_access_token
+        else:
+            proxy_payload = self._prepare_json_rpc_payload(
+                {'refresh_token': self.mercado_pago_refresh_token}
+            )
+            response_content = self._send_api_request(
+                'POST',
+                '/refresh_access_token',
+                json=proxy_payload,
+                is_proxy_request=True,
+                is_refresh_token_request=True,
+            )
+            expires_in = (
+                fields.Datetime.now()
+                + timedelta(seconds=int(response_content['expires_in']))
+                - timedelta(days=31)
+            )
+            self.write({
+                'mercado_pago_access_token': response_content['access_token'],
+                'mercado_pago_access_token_expiry': expires_in,
+                'mercado_pago_refresh_token': response_content['refresh_token'],
+            })
+            return self.mercado_pago_access_token
+
+    def _parse_response_content(self, response, *, is_proxy_request=False, **kwargs):
+        """Override of `payment` to parse the response content."""
+        if self.code != 'mercado_pago' or not is_proxy_request:
+            return super()._parse_response_content(
+                response, is_proxy_request=is_proxy_request, **kwargs
+            )
+        return self._parse_proxy_response(response)
 
     def _parse_response_error(self, response):
         """Override of `payment` to parse the error message."""

--- a/addons/payment_mercado_pago/models/payment_token.py
+++ b/addons/payment_mercado_pago/models/payment_token.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class PaymentToken(models.Model):
+    _inherit = 'payment.token'
+
+    # Mercado Pago's id of the customer at the time the token was created."
+    mercado_pago_customer_id = fields.Char(readonly=True)

--- a/addons/payment_mercado_pago/static/src/js/payment_form.js
+++ b/addons/payment_mercado_pago/static/src/js/payment_form.js
@@ -1,0 +1,162 @@
+/* global MercadoPago */
+
+import { _t } from '@web/core/l10n/translation';
+import { loadJS } from '@web/core/assets';
+import { rpc, RPCError } from '@web/core/network/rpc';
+
+import paymentForm from '@payment/js/payment_form';
+
+paymentForm.include({
+
+    mercadoPagoBricksBuilder: undefined,
+    lastMercadoPagoPMId: undefined,  // The last instantiated payment method ID.
+    lastMercadoPagoBrick: undefined,  // The brick of the last instantiated payment method.
+
+    // === DOM MANIPULATION === //
+
+    /**
+     * Prepare the inline form of Mercado Pago for direct payment.
+     *
+     * @override method from payment.payment_form
+     * @private
+     * @param {number} providerId - The id of the selected payment option's provider.
+     * @param {string} providerCode - The code of the selected payment option's provider.
+     * @param {number} paymentOptionId - The id of the selected payment option
+     * @param {string} paymentMethodCode - The code of the selected payment method, if any.
+     * @param {string} flow - The online payment flow of the selected payment option
+     * @return {void}
+     */
+    async _prepareInlineForm(providerId, providerCode, paymentOptionId, paymentMethodCode, flow) {
+        if (providerCode !== 'mercado_pago' || paymentMethodCode !== 'card') {
+            this._super(...arguments);
+            return;
+        }
+
+        // Check if instantiation of the component is needed.
+        if (flow === 'token') {
+            return; // No component for tokens.
+        } else if (paymentOptionId === this.lastMercadoPagoPMId) {
+            this._setPaymentFlow('direct'); // Overwrite the flow even if no re-instantiation.
+            return; // Don't re-instantiate if already done for this payment method.
+        }
+
+        // Extract and deserialize the inline form values.
+        const radio = document.querySelector('input[name="o_payment_radio"]:checked');
+        const inlineFormValues = JSON.parse(radio.dataset['mercadoPagoInlineFormValues']);
+
+        // Process card payments with the redirect flow if the account is not onboarded with OAuth.
+        const publicKey = inlineFormValues['public_key'];
+        if (!publicKey) { // The account was not onboarded with OAuth and can't support direct flow.
+            return; // Keep the flow to redirect.
+        }
+
+        // Overwrite the flow of the selected payment method.
+        this._setPaymentFlow('direct');
+
+        // Create the bricksBuilder object if not already done for another payment method.
+        if (!this.mercadoPagoBricksBuilder) {
+            await loadJS('https://sdk.mercadopago.com/js/v2');
+            const mercadoPago = new MercadoPago(publicKey, { locale: 'en-US' });
+            this.mercadoPagoBricksBuilder = mercadoPago.bricks();
+        }
+
+        // Unmount the previous brick, if any, as only one brick can be mounted at a time.
+        this.lastMercadoPagoBrick?.unmount();
+
+        // Instantiate and mount the card brick.
+        const settings = {
+            initialization: {
+                amount: this.paymentContext['amount'],
+                payer: {
+                    email: inlineFormValues['email'],
+                },
+            },
+            customization: {
+                visual: {
+                    hideFormTitle: true,
+                    hidePaymentButton: true,
+                },
+                paymentMethods: {
+                    maxInstallments: 12,
+                },
+            },
+            callbacks: { // Callbacks are required even if empty.
+                onReady: () => {},
+                onError: () => {},
+            },
+        };
+        this.lastMercadoPagoBrick = await this.mercadoPagoBricksBuilder.create(
+            'cardPayment',
+            `o_mercado_pago_brick_container_${providerId}_${paymentOptionId}`,
+            settings,
+        );
+        this.lastMercadoPagoPMId = paymentOptionId;
+    },
+
+        /**
+         * Validate the form inputs before initiating the payment flow.
+         *
+         * @override method from @payment/js/payment_form
+         * @private
+         * @param {string} providerCode - The code of the selected payment option's provider.
+         * @param {number} paymentOptionId - The id of the selected payment option.
+         * @param {string} paymentMethodCode - The code of the selected payment method, if any.
+         * @param {string} flow - The payment flow of the selected payment option.
+         * @return {void}
+         */
+    async _initiatePaymentFlow(providerCode, paymentOptionId, paymentMethodCode, flow) {
+        if (providerCode !== 'mercado_pago' || flow !== 'direct') {
+            // Tokens and redirect payment methods are handled by the generic flow.
+            await this._super(...arguments);
+            return;
+        }
+
+        // Trigger form validation.
+        const _super = this._super.bind(this);
+        this.mercadoPagoFormData = await this.lastMercadoPagoBrick.getFormData();
+        if (!this.mercadoPagoFormData){
+            this._displayErrorDialog(_t("Incorrect payment details"));
+            this._enableButton();  // The submit button is disabled at this point, enable it.
+            return;
+        }
+        return await _super(...arguments);
+    },
+
+    /**
+     * Process Mercado Pago's implementation of the direct payment flow.
+     *
+     * @override method from payment.payment_form
+     * @private
+     * @param {string} providerCode - The code of the selected payment option's provider.
+     * @param {number} paymentOptionId - The id of the selected payment option.
+     * @param {string} paymentMethodCode - The code of the selected payment method, if any.
+     * @param {object} processingValues - The processing values of the transaction.
+     * @return {void}
+     */
+    async _processDirectFlow(providerCode, paymentOptionId, paymentMethodCode, processingValues) {
+        if (providerCode !== 'mercado_pago') {
+            this._super(...arguments);
+            return;
+        }
+
+        try {
+            await rpc('/payment/mercado_pago/payments', {
+                'reference': processingValues.reference,
+                'transaction_amount': processingValues.amount,
+                'token': this.mercadoPagoFormData.token,
+                'installments': this.mercadoPagoFormData.installments,
+                'payment_method_brand': this.mercadoPagoFormData.payment_method_id,
+                'issuer_id': this.mercadoPagoFormData.issuer_id,
+            });
+            window.location = '/payment/status';
+        } catch(error) {
+            if (error instanceof RPCError) {
+                this._displayErrorDialog(_t("Payment processing failed"), error.data.message);
+                this._enableButton();
+            } else {
+                return Promise.reject(error);
+            }
+        }
+    },
+
+});

--- a/addons/payment_mercado_pago/tests/common.py
+++ b/addons/payment_mercado_pago/tests/common.py
@@ -12,6 +12,7 @@ class MercadoPagoCommon(PaymentCommon):
         super().setUpClass()
 
         cls.provider = cls._prepare_provider('mercado_pago', update_values={
+            'mercado_pago_account_country_id': cls.env.ref('base.mx').id,
             'mercado_pago_access_token': 'TEST-4850554046279901-TEST-TEST',
         })
         cls.payment_id = '123456'

--- a/addons/payment_mercado_pago/tests/test_payment_provider.py
+++ b/addons/payment_mercado_pago/tests/test_payment_provider.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 
 from odoo.addons.payment_mercado_pago.tests.common import MercadoPagoCommon
@@ -7,6 +8,19 @@ from odoo.addons.payment_mercado_pago.tests.common import MercadoPagoCommon
 
 @tagged('post_install', '-at_install')
 class TestPaymentProvider(MercadoPagoCommon):
+
+    def test_allow_enabling_if_credentials_are_set(self):
+        """ Test that enabling a Mercado Pago provider with credentials succeeds. """
+        self._assert_does_not_raise(ValidationError, self.provider.write({'state': 'enabled'}))
+
+    def test_prevent_enabling_if_credentials_are_not_set(self):
+        """ Test that enabling a Mercado Pago provider without credentials raises a ValidationError.
+        """
+        # Reset the state and credentials together to avoid triggering the constraint outside of the
+        # 'assertRaises'.
+        self.provider.action_reset_credentials()
+        with self.assertRaises(ValidationError):
+            self.provider.state = 'enabled'
 
     def test_incompatible_with_unsupported_currencies(self):
         """ Test that Mercado Pago providers are filtered out from compatible providers when the

--- a/addons/payment_mercado_pago/tests/test_payment_transaction.py
+++ b/addons/payment_mercado_pago/tests/test_payment_transaction.py
@@ -22,25 +22,25 @@ class TestPaymentTransaction(MercadoPagoCommon, PaymentHttpCommon):
         webhook_url = self._build_url('/payment/mercado_pago/webhook')
         sanitized_reference = url_quote(tx.reference)
         self.assertDictEqual(request_payload, {
+            'external_reference': tx.reference,
+            'notification_url': f'{webhook_url}/{sanitized_reference}',
             'auto_return': 'all',
             'back_urls': {
                 'failure': return_url,
                 'pending': return_url,
                 'success': return_url,
             },
-            'external_reference': tx.reference,
             'items': [{
                 'currency_id': tx.currency_id.name,
                 'quantity': 1,
                 'title': tx.reference,
                 'unit_price': tx.amount,
             }],
-            'notification_url': f'{webhook_url}/{sanitized_reference}',
             'payer': {
-                'address': {'street_name': tx.partner_address, 'zip_code': tx.partner_zip},
-                'email': tx.partner_email,
                 'name': tx.partner_name,
+                'email': tx.partner_email,
                 'phone': {'number': tx.partner_phone},
+                'address': {'street_name': tx.partner_address, 'zip_code': tx.partner_zip},
             },
         })
 

--- a/addons/payment_mercado_pago/tests/test_processing_flows.py
+++ b/addons/payment_mercado_pago/tests/test_processing_flows.py
@@ -6,7 +6,7 @@ from odoo.tests import tagged
 from odoo.tools import mute_logger
 
 from odoo.addons.payment.tests.http_common import PaymentHttpCommon
-from odoo.addons.payment_mercado_pago.controllers.main import MercadoPagoController
+from odoo.addons.payment_mercado_pago import const
 from odoo.addons.payment_mercado_pago.tests.common import MercadoPagoCommon
 
 
@@ -18,7 +18,7 @@ class TestProcessingFlows(MercadoPagoCommon, PaymentHttpCommon):
         """ Test that receiving a redirect notification triggers the processing of the notification
         data. """
         self._create_transaction(flow='redirect')
-        url = self._build_url(MercadoPagoController._return_url)
+        url = self._build_url(const.PAYMENT_RETURN_ROUTE)
         with patch(
             'odoo.addons.payment.models.payment_provider.PaymentProvider._send_api_request',
             return_value=self.verification_data,
@@ -33,7 +33,7 @@ class TestProcessingFlows(MercadoPagoCommon, PaymentHttpCommon):
         """ Test that receiving a valid webhook notification triggers the processing of the
         payment data. """
         tx = self._create_transaction(flow='redirect')
-        url = self._build_url(f'{MercadoPagoController._webhook_url}/{tx.reference}')
+        url = self._build_url(f'{const.WEBHOOK_ROUTE}/{tx.reference}')
         with patch(
             'odoo.addons.payment.models.payment_provider.PaymentProvider._send_api_request',
             return_value=self.verification_data,

--- a/addons/payment_mercado_pago/views/payment_form_templates.xml
+++ b/addons/payment_mercado_pago/views/payment_form_templates.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="payment_mercado_pago.method_form" inherit_id="payment.method_form">
+        <xpath expr="//input[@name='o_payment_radio']" position="attributes">
+            <attribute name="t-att-data-mercado-pago-inline-form-values">
+                provider_sudo._mercado_pago_get_inline_form_values(partner_id)
+            </attribute>
+        </xpath>
+    </template>
+
+</odoo>

--- a/addons/payment_mercado_pago/views/payment_mercado_pago_templates.xml
+++ b/addons/payment_mercado_pago/views/payment_mercado_pago_templates.xml
@@ -11,4 +11,28 @@
         </form>
     </template>
 
+    <template id="inline_form">
+        <div t-attf-id="o_mercado_pago_brick_container_{{provider_sudo.id}}_{{pm_sudo.id}}"/>
+    </template>
+
+    <!-- Variables description:
+        - 'error_message' - The reason of the error.
+        - 'provider_url' - The URL to the Mercado Pago provider.
+    -->
+    <template id="authorization_error">
+        <t t-call="portal.frontend_layout">
+            <div class="wrap">
+                <div class="container">
+                    <h1>An error occurred</h1>
+                    <p>An error occurred while linking your Mercado Pago account with Odoo.</p>
+                    <p><t t-out="error_message"/></p>
+                    <a t-att-href="provider_url" class="btn btn-primary mt-2">
+                        Back to the Mercado Pago provider
+                    </a>
+                </div>
+            </div>
+        </t>
+    </template>
+
+
 </odoo>

--- a/addons/payment_mercado_pago/views/payment_provider_views.xml
+++ b/addons/payment_mercado_pago/views/payment_provider_views.xml
@@ -8,11 +8,55 @@
         <field name="arch" type="xml">
             <group name="provider_credentials" position="inside">
                 <group invisible="code != 'mercado_pago'">
-                    <field name="mercado_pago_access_token"
-                           string="Access Token"
-                           required="code == 'mercado_pago' and state != 'disabled'"
-                           password="True"/>
+                    <field
+                        string="Account Country"
+                        name="mercado_pago_account_country_id"
+                        required="code == 'mercado_pago' and state != 'disabled'"
+                        readonly="mercado_pago_access_token"
+                        options="{'no_create': True}"
+                    />
+                    <label
+                        for="mercado_pago_access_token" invisible="not mercado_pago_access_token"
+                    />
+                    <div class="o_row" invisible="not mercado_pago_access_token">
+                        <field
+                            string="Access Token"
+                            name="mercado_pago_access_token"
+                            readonly="True"
+                            password="True"
+                        />
+                        <button
+                            string="Disconnect Your Mercado Pago Account"
+                            type="object"
+                            name="action_reset_credentials"
+                            confirm="Are you sure you want to disconnect?"
+                            class="btn-secondary ms-2"
+                        />
+                    </div>
                 </group>
+            </group>
+            <group name="provider_credentials" position="after">
+                <div
+                    invisible="code != 'mercado_pago' or (mercado_pago_access_token and mercado_pago_public_key)"
+                >
+                    <div
+                        class="alert alert-warning mt-2"
+                        role="alert"
+                        invisible="not mercado_pago_access_token and not mercado_pago_public_key"
+                    >
+                        You must renew your connection to Mercado Pago in order to enable the new
+                        Card payment method experience, which allows saving payment details for
+                        recurring payments.
+                    </div>
+                    <button
+                        string="Connect"
+                        type="object"
+                        name="action_start_onboarding"
+                        class="btn-primary"
+                        invisible="mercado_pago_access_token and not mercado_pago_public_key"
+                        colspan="2"
+                    />
+                </div>
             </group>
         </field>
     </record>

--- a/addons/payment_razorpay/README.md
+++ b/addons/payment_razorpay/README.md
@@ -8,9 +8,10 @@ version `1`
 ## Supported features
 
 - Direct payment flow
-- Webhook notifications
+- Tokenization
 - Full manual capture
 - Partial refunds
+- OAuth authentication
 
 ## Not implemented features
 
@@ -21,6 +22,7 @@ version `1`
 - `17.0`
   - The previous Hosted Checkout API that allowed for redirect payments is replaced by the Recurring
     Payments API that supports direct payments and tokenization. odoo/odoo#143525
+  - OAuth support is added in addition to the credentials-based authentication. odoo/odoo#158578
 - `16.0`
   - The first version of the module is merged. odoo/odoo#92848
 

--- a/addons/payment_razorpay/models/payment_provider.py
+++ b/addons/payment_razorpay/models/payment_provider.py
@@ -76,7 +76,7 @@ class PaymentProvider(models.Model):
                 if not provider.razorpay_key_id or not provider.razorpay_key_secret:
                     raise ValidationError(_(
                         "Razorpay credentials are missing. Click the \"Connect\" button to set up"
-                        " your account"
+                        " your account."
                     ))
 
     # === CRUD METHODS === #
@@ -127,24 +127,18 @@ class PaymentProvider(models.Model):
             'target': 'self',
         }
 
-    def action_razorpay_reset_oauth_account(self):
-        """ Reset the Razorpay OAuth account.
+    def _get_reset_values(self):
+        """Override of `payment` to supply the provider-specific credential values to reset."""
+        if self.code != 'razorpay':
+            return super()._get_reset_values()
 
-        Note: self.ensure_one()
-
-        :return: None
-        """
-        self.ensure_one()
-
-        return self.write({
+        return {
             'razorpay_account_id': None,
             'razorpay_public_token': None,
             'razorpay_refresh_token': None,
             'razorpay_access_token': None,
             'razorpay_access_token_expiry': None,
-            'state': 'disabled',
-            'is_published': False,
-        })
+        }
 
     def action_razorpay_create_webhook(self):
         """ Create a webhook and display a toast notification.

--- a/addons/payment_razorpay/views/payment_provider_views.xml
+++ b/addons/payment_razorpay/views/payment_provider_views.xml
@@ -23,7 +23,7 @@
                         <button
                             string="Reset Your Razorpay Account"
                             type="object"
-                            name="action_razorpay_reset_oauth_account"
+                            name="action_reset_credentials"
                             class="btn-secondary ms-2"
                             confirm="Are you sure you want to disconnect?"
                             invisible="not razorpay_account_id"


### PR DESCRIPTION
Add an integration with Mercado Pago's Checkout Bricks API for card payments. They will now follow a direct flow with the added possibility to tokenize the card for further usage.

The user onboarding must be done through OAuth in order to enable
tokenization.

task-3992303