### PR TITLE
[IMP] pos_hr: make edit payment button invisible on receipt print

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -20,7 +20,6 @@ export class ReceiptScreen extends Component {
         this.renderer = useService("renderer");
         this.notification = useService("notification");
         this.dialog = useService("dialog");
-        this.currentOrder = this.pos.get_order();
         const partner = this.currentOrder.get_partner();
         this.state = useState({
             email: partner?.email || "",
@@ -48,6 +47,9 @@ export class ReceiptScreen extends Component {
             destination: this.state.email,
             name: "Email",
         });
+    }
+    get currentOrder() {
+        return this.pos.get_order();
     }
     get orderAmountPlusTip() {
         const order = this.currentOrder;

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
@@ -12,7 +12,7 @@
                                 <span class="fs-3 fw-bolder">Payment Successful</span>
                                 <div class="fs-4 fw-bold d-flex justify-content-center align-items-center gap-2">
                                     <span t-esc="orderAmountPlusTip" />
-                                    <span t-if="this.currentOrder.nb_print === 0" class="edit-order-payment badge bg-success text-white rounded cursor-pointer pt-1" t-on-click="() => this.pos.orderDetails(this.pos.get_order())">Edit payment</span>
+                                    <span t-if="this.currentOrder.nb_print === 0" class="edit-order-payment badge bg-success text-white rounded cursor-pointer pt-1" t-on-click="() => this.pos.orderDetails(this.currentOrder)">Edit Payment</span>
                                 </div>
                             </div>
                             <hr />

--- a/addons/pos_hr/static/src/overrides/screens/receipt_screen/receipt_screen.xml
+++ b/addons/pos_hr/static/src/overrides/screens/receipt_screen/receipt_screen.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="ReceiptScreen" t-inherit="point_of_sale.ReceiptScreen" t-inherit-mode="extension">
         <xpath expr="//span[hasclass('edit-order-payment')]" position="attributes">
-            <attribute name="t-if">!this.pos.config.module_pos_hr || this.pos.employeeIsAdmin</attribute>
+            <attribute name="t-if">(!this.pos.config.module_pos_hr || this.pos.employeeIsAdmin) and this.currentOrder.nb_print === 0</attribute>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
Before this commit:
===============
- The 'Edit Payment' button appears even after printing the receipt. (only when pos_hr installed)

After this commit:
===============
- The 'Edit Payment' button will disappear after printing the receipt.

task-4507326


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
