### PR TITLE
[FIX] account: partner autocomplete

### DIFF
--- a/addons/account/views/res_company_views.xml
+++ b/addons/account/views/res_company_views.xml
@@ -52,6 +52,7 @@
                     </div>
                     <group>
                         <group>
+                            <field name="partner_gid" invisible="1"/>
                             <field name="vat"/>
                             <label for="street" string="Address"/>
                             <div class="o_address_format">


### PR DESCRIPTION
`partner_gid` was missing from `res_company_form_view_onboarding` view which was creating a bug when applying the partner autocomplete.

opw-4489441

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
