### PR TITLE
[FIX] website_payment: public user tokenize donation feedback

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -135,7 +135,7 @@ class PaymentPortal(portal.CustomerPortal):
             'partner_is_different': partner_is_different,
         }
         payment_form_values = {
-            'show_tokenize_input_mapping': PaymentPortal._compute_show_tokenize_input_mapping(
+            'show_tokenize_input_mapping': self._compute_show_tokenize_input_mapping(
                 providers_sudo, **kwargs
             ),
         }

--- a/addons/website_payment/controllers/portal.py
+++ b/addons/website_payment/controllers/portal.py
@@ -132,3 +132,22 @@ class PaymentPortal(payment_portal.PaymentPortal):
         if kwargs.get('is_donation'):
             return 'website_payment.donation_pay'
         return super()._get_payment_page_template_xmlid(**kwargs)
+
+    @staticmethod
+    def _compute_show_tokenize_input_mapping(providers_sudo, **kwargs):
+        """ Override of `payment` to hide the "Save my payment details" input in the payment form
+        when its a donation and user is not logged in.
+
+        :param payment.provider providers_sudo: The providers for which to determine whether the
+                                                tokenization input should be shown or not.
+        :param dict kwargs: The optional data passed to the helper methods.
+        :return: The mapping of the computed value for each provider id.
+        :rtype: dict
+        """
+        res = super(PaymentPortal, PaymentPortal)._compute_show_tokenize_input_mapping(
+            providers_sudo, **kwargs
+        )
+        if kwargs.get('is_donation') and request.env.user._is_public():
+            for provider_sudo in providers_sudo:
+                res[provider_sudo.id] = False
+        return res

--- a/addons/website_payment/static/src/js/payment_form.js
+++ b/addons/website_payment/static/src/js/payment_form.js
@@ -101,6 +101,7 @@ PaymentForm.include({
                     _t("Payment processing failed"),
                     _t("Some information is missing to process your payment.")
                 );
+                this._enableButton();
                 return;
             }
         }


### PR DESCRIPTION
After commit ddda5d4a2623d03699d5cb6860d5c984807b6e3d public users were allowed to tokenize their payments with the exception of donation the tokenize field was forced to be False.
However Stripe threw an error when the received intent was different than the one on the frontend.

Fix:
Hide option to tokenize for unlogged in users for donations.

opw-4389881



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
