### PR TITLE
[FIX] point_of_sale: fix crash with problematic chars in htmlToCanvas

### DIFF
--- a/addons/point_of_sale/static/src/app/printer/render_service.js
+++ b/addons/point_of_sale/static/src/app/printer/render_service.js
@@ -90,6 +90,16 @@ const applyWhenMounted = async ({ el, container, callback }) => {
     return res;
 };
 
+const sanitizeNodeText = (element) => {
+    if (element.nodeType === Node.TEXT_NODE) {
+        element.textContent = element.textContent.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, "");
+        return;
+    }
+    for (let child of element.childNodes) {
+        sanitizeNodeText(child);
+    }
+}
+
 /**
  * This function assumes that the `renderer` service is available.
  */
@@ -99,6 +109,7 @@ export const htmlToCanvas = async (el, options) => {
     {
         $('.pos-receipt-print').css({ 'padding': '15px', 'padding-bottom': '30px'})
     }
+    sanitizeNodeText(el);
     return await applyWhenMounted({
         el,
         container: document.querySelector(".render-container"),

--- a/addons/point_of_sale/static/tests/unit/render_service_tests.js
+++ b/addons/point_of_sale/static/tests/unit/render_service_tests.js
@@ -1,0 +1,30 @@
+/** @odoo-module */
+
+import { getFixture } from "@web/../tests/helpers/utils";
+import { htmlToCanvas } from "@point_of_sale/app/printer/render_service";
+
+QUnit.module("RenderService", () => {
+    QUnit.test("htmlToCanvas", async function (assert) {
+        assert.expect(1);
+
+        const target = getFixture();
+        const node = document.createElement("div");
+        node.classList.add("render-container");
+        target.appendChild(node);
+        
+        const asciiChars = Array.from({length: 256}, (_, i) => String.fromCharCode(i)).join('');
+        node.textContent = asciiChars;
+
+        let canvas = null;
+        try {
+            canvas = await htmlToCanvas(node, { addClass: "pos-receipt-print" });
+        } catch (error) {
+            // htmlToCanvas create an <img> by setting a svg to its src attribute
+            // if this fails, an Event of type "error" is thrown
+            if (error.constructor.name !== "Event") {
+                throw error;
+            }
+        }
+        assert.notStrictEqual(canvas, null, `htmlToCanvas should work with all ascii characters`);
+    });
+});


### PR DESCRIPTION
__Current behavior before commit:__
Sometimes when a Worldline terminal makes a payment with Edenred or Sodexo, it creates a ticket with special ascii characters like `0x0E` that are not supposed to be printed. Some of those characters make the [`createImage`][1] method throw an error with the `onerror` Event.

__Description of the fix:__
Added the `sanitizeNodeText` function to remove all problematic ascii characters that should not be printed anyway.
Added a test to make sure `htmlToCanvas` can handle all ascii characters without crashing.

opw-4322339

[1]:https://github.com/odoo/odoo/blob/a98e802976f6798f3aea07231a366fbcd8002ce2/addons/point_of_sale/static/src/app/utils/html-to-image.js#L217