### PR TITLE
[IMP] maintenance: use `date_dl` existing variable instead of computing it twice

### DIFF
--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -393,7 +393,7 @@ class MaintenanceRequest(models.Model):
                 note = request._get_activity_note()
                 request.activity_schedule(
                     'maintenance.mail_act_maintenance_request',
-                    fields.Datetime.from_string(request.schedule_date).date(),
+                    date_dl,
                     note=note, user_id=request.user_id.id or request.owner_user_id.id or self.env.uid)
 
     def _add_followers(self):

--- a/doc/cla/individual/benoitanastay.md
+++ b/doc/cla/individual/benoitanastay.md
@@ -1,0 +1,11 @@
+France, 24th January 2025
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Benoit Anastay benoit@anastay.dev https://github.com/BenoitAnastay


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In the bellow bloc code `fields.Datetime.from_string(request.schedule_date).date()` is computed twice, but was saved into a variable just above. 

```py
            date_dl = fields.Datetime.from_string(request.schedule_date).date()
            updated = request.activity_reschedule(
                ['maintenance.mail_act_maintenance_request'],
                date_deadline=date_dl,
                new_user_id=request.user_id.id or request.owner_user_id.id or self.env.uid)
            if not updated:
                note = request._get_activity_note()
                request.activity_schedule(
                    'maintenance.mail_act_maintenance_request',
                    fields.Datetime.from_string(request.schedule_date).date(),
                    note=note, user_id=request.user_id.id or request.owner_user_id.id or self.env.uid)
```
Current behavior before PR:
The variable is computed twice
Desired behavior after PR is merged:
Using the cached variable instead



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
