### PR TITLE
[IMP] mail, im_livechat: remove channel leave toaster

### DIFF
--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -22,7 +22,9 @@ class DiscussChannelMember(models.Model):
         sessions_to_be_unpinned = members.filtered(lambda m: m.message_unread_counter == 0)
         sessions_to_be_unpinned.write({'unpin_dt': fields.Datetime.now()})
         for member in sessions_to_be_unpinned:
-            member._bus_send("discuss.channel/unpin", {"id": member.channel_id.id})
+            member._bus_send_store(
+                member.channel_id, {"close_chat_window": True, "is_pinned": False}
+            )
 
     def _to_store_defaults(self):
         # sudo: discuss.channel - reading livechat channel to check whether current member is a bot is allowed

--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -65,11 +65,4 @@ patch(Thread.prototype, {
             ? _t("This livechat conversation has ended")
             : null;
     },
-
-    get leaveNotificationMessage() {
-        if (this.channel_type === "livechat") {
-            return _t("You ended the conversation with %(name)s.", { name: this.displayName });
-        }
-        return super.leaveNotificationMessage;
-    },
 });

--- a/addons/im_livechat/static/tests/channel_join_leave.test.js
+++ b/addons/im_livechat/static/tests/channel_join_leave.test.js
@@ -103,7 +103,6 @@ test("from chat window", async () => {
     await click("button[title*='Close Chat Window']");
     await click("button:contains('Yes, leave conversation')");
     await contains(".o-mail-ChatWindow", { count: 0 });
-    await contains(".o_notification:contains(You ended the conversation with Visitor)");
 });
 
 test("visitor leaving ends the livechat conversation", async () => {

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -395,10 +395,11 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                         "payload": {"data": left_message_data, "id": discuss_channel.id},
                     },
                     {
-                        "type": "discuss.channel/leave",
+                        "type": "mail.record/insert",
                         "payload": {
                             "discuss.channel": [
                                 {
+                                    "close_chat_window": True,
                                     "id": discuss_channel.id,
                                     "isLocallyPinned": False,
                                     "is_pinned": False,

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -72,7 +72,9 @@ class DiscussChannelMember(models.Model):
         members = self.env["discuss.channel.member"].search(domain)
         members.unpin_dt = fields.Datetime.now()
         for member in members:
-            member._bus_send("discuss.channel/unpin", {"id": member.channel_id.id})
+            member._bus_send_store(
+                member.channel_id, {"close_chat_window": True, "is_pinned": False}
+            )
 
     @api.constrains('partner_id')
     def _contrains_no_public_member(self):

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -74,6 +74,15 @@ export class Thread extends Record {
     get canUnpin() {
         return this.channel_type === "chat" && this.importantCounter === 0;
     }
+    close_chat_window = Record.attr(undefined, {
+        /** @this {import("models").Thread} */
+        onUpdate() {
+            if (this.close_chat_window) {
+                this.closeChatWindow();
+                this.close_chat_window = undefined;
+            }
+        },
+    });
     composer = Record.one("Composer", {
         compute: () => ({}),
         inverse: "thread",

--- a/addons/mail/static/src/discuss/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/common/@types/models.d.ts
@@ -58,7 +58,6 @@ declare module "models" {
         showUnreadBanner(): boolean,
         typingMembers: ChannelMember[],
         readonly hasMemberList: boolean,
-        readonly notifyOnleave: boolean,
         readonly unknownMembersCount: number,
         private _computeOfflineMembers(): ChannelMember[],
     }

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -26,14 +26,6 @@ export class DiscussCoreCommon {
                 }),
             { once: true }
         );
-        this.busService.subscribe("discuss.channel/leave", (payload) => {
-            const { Thread } = this.store.insert(payload);
-            const [thread] = Thread;
-            if (thread.notifyOnLeave) {
-                this.notificationService.add(thread.leaveNotificationMessage, { type: "info" });
-            }
-            thread.closeChatWindow();
-        });
         this.busService.subscribe("discuss.channel/delete", (payload, metadata) => {
             const thread = this.store.Thread.insert({
                 id: payload.id,
@@ -60,13 +52,6 @@ export class DiscussCoreCommon {
             );
             message.thread.messages.push(message);
             message.thread.transientMessages.push(message);
-        });
-        this.busService.subscribe("discuss.channel/unpin", (payload) => {
-            const thread = this.store.Thread.get({ model: "discuss.channel", id: payload.id });
-            if (thread) {
-                thread.is_pinned = false;
-                thread.closeChatWindow();
-            }
         });
         this.busService.subscribe("discuss.channel.member/fetched", (payload) => {
             const { channel_id, id, last_message_id, partner_id } = payload;

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -2,7 +2,6 @@ import { Record } from "@mail/core/common/record";
 import { Thread } from "@mail/core/common/thread_model";
 import { compareDatetime, nearestGreaterThanOrEqual } from "@mail/utils/common/misc";
 
-import { _t } from "@web/core/l10n/translation";
 import { formatList } from "@web/core/l10n/utils";
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
@@ -317,14 +316,6 @@ const threadPatch = {
         return this.isChatChannel
             ? this.selfMember?.message_unread_counter ?? 0
             : super.needactionCounter;
-    },
-    get notifyOnLeave() {
-        // Skip notification if display name is unknown (might depend on
-        // knowledge of members for groups).
-        return Boolean(this.displayName);
-    },
-    get leaveNotificationMessage() {
-        return _t("You left %(channel)s.", { channel: this.displayName });
     },
     /** @override */
     onNewSelfMessage(message) {

--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -109,9 +109,6 @@ const threadPatch = {
     get isEmpty() {
         return !this.from_message_id && super.isEmpty;
     },
-    get notifyOnLeave() {
-        return super.notifyOnLeave && !this.parent_channel_id;
-    },
     /**
      * @param {Object} [param0={}]
      * @param {import("models").Message} [param0.initialMessage]

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -482,7 +482,6 @@ test("leave command on channel", async () => {
     triggerHotkey("Enter");
     await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "general" });
     await contains(".o-mail-Discuss-threadName", { value: "Inbox" });
-    await contains(".o_notification", { text: "You left general." });
 });
 
 test("Can handle leave notification from unknown member", async () => {

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -293,8 +293,7 @@ test("sidebar: unpin chat from bus", async () => {
     await contains(".o-mail-Discuss-threadName", { value: "Demo" });
     // Simulate receiving a unpin chat notification
     // (e.g. from user interaction from another device or browser tab)
-    const [partner] = pyEnv["res.partner"].read(serverState.partnerId);
-    pyEnv["bus.bus"]._sendone(partner, "discuss.channel/unpin", { id: channelId });
+    pyEnv["discuss.channel"].channel_pin([channelId], false);
     await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "Demo" });
     await contains(".o-mail-Discuss-threadName", { count: 0, value: "Demo" });
 });


### PR DESCRIPTION
This notification has little value as the channel is visually removed.

The opportunity is taken to clean the handlers to be simple store data.

Discussed as part of task-4488437

https://github.com/odoo/enterprise/pull/77760