### PR TITLE
[IMP] web, website: minimize address bar on scroll in iOS

### DIFF
--- a/addons/web/static/src/legacy/scss/base_frontend.scss
+++ b/addons/web/static/src/legacy/scss/base_frontend.scss
@@ -1,8 +1,14 @@
 // Frontend general
-html, body, #wrapwrap {
+html, body {
     width: 100%;
     height: 100%;
 }
+
+#wrapwrap:not(.o_safari_browser) {
+    width: 100%;
+    height: 100%;
+}
+
 #wrapwrap {
     // The z-index is useful to prevent that children with a negative z-index
     // go behind the wrapwrap (we create a new stacking context).
@@ -10,6 +16,10 @@ html, body, #wrapwrap {
     position: relative;
     display: flex;
     flex-flow: column nowrap;
+    &:has(.o_safari_browser) {
+        min-height: 100%;
+        width: 100%;
+    }
 
     > * {
         flex: 0 0 auto;
@@ -27,10 +37,10 @@ html, body, #wrapwrap {
 //       prevent browser to print more than what is above the fold. This block
 //       is moving the scroll to the body when printing the page.
 @media screen {
-    html, body {
+    html:not(:has(.o_safari_browser)), body:not(:has(.o_safari_browser)) {
         overflow: hidden;
     }
-    #wrapwrap {
+    #wrapwrap:not(:has(.o_safari_browser))  {
         // ... we delegate the scroll to that top element instead of the window/body
         // This is at least needed for the edit mode to not have a double scrollbar
         // due to the right editor panel (and since we want to minimize the style

--- a/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
@@ -20,7 +20,7 @@ const checkScrollbar = function (hasScrollbar) {
         run: function () {
             const wrapwrapEl = this.$anchor[0].querySelector("#wrapwrap");
             const wrapwrapStyle = window.getComputedStyle(wrapwrapEl);
-            if (!hasScrollbar && (wrapwrapStyle.overflow !== "hidden" || parseFloat(wrapwrapStyle.paddingRight) < 1)) {
+            if (!hasScrollbar && (wrapwrapStyle.overflow !== "hidden" && parseFloat(wrapwrapStyle.paddingRight) < 1)) {
                 console.error("error The #wrapwrap vertical scrollbar should be hidden");
             } else if (hasScrollbar && (wrapwrapStyle.overflow === "hidden" || parseFloat(wrapwrapStyle.paddingRight) > 0)) {
                 console.error("error The #wrapwrap vertical scrollbar should be displayed");


### PR DESCRIPTION
On iOS, the address bar doesn't minimize when scrolling, which reduces the usable screen space and impacts user experience. This commit addresses the issue by adjusting the CSS to ensure the address bar minimizes when the user begins to scroll.

Changes:
- Removed `#wrapwrap` from the `html, body` selector to allow proper scrolling behavior.
- Added `width` and `height` properties to `html, body`.
- Added `width` and `min-height` properties to `#wrapwrap` when it has the class `o_safari_browser`.
- Applied conditional styles to `html` and `body` to hide overflow when `#wrapwrap` does not have the class `o_safari_browser`.
- Ensured `#wrapwrap` has `overflow: auto` when it does not have the class `o_safari_browser`.
- Updated the test case condition to verify the overflow property as well

This change enhances the content visibility and reduces distractions for users on iOS devices.

task-4177998