### PR TITLE
[IMP] website_sale: Only get draft sale orders

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -340,6 +340,10 @@ class Website(models.Model):
         ):
             sale_order_sudo = None
 
+        # Also ignore the cart if it is not in draft state.
+        if sale_order_sudo and sale_order_sudo.state != 'draft':
+            sale_order_sudo = None
+
         if not (sale_order_sudo or force_create):
             # Do not create a SO record unless needed
             if request.session.get('sale_order_id'):


### PR DESCRIPTION
We shouldn't use other sale orders, as the system might apply changes to `done` sale.orders

Description of the issue/feature this PR addresses: If we change the state of a website order and the user accesses again, it might apply modifications. This can happen with the customer.

Current behavior before PR: 

[Grabación de pantalla desde 24-01-25 12:09:07.webm](https://github.com/user-attachments/assets/63627b1d-8b3f-4b0c-8301-69606e994e3d)

Desired behavior after PR is merged:

The sale order is not modified




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
