### PR TITLE
[IMP] pos_{, razorpay}: allow refund for multiple paymentlines

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -6352,6 +6352,12 @@ msgstr ""
 
 #. module: point_of_sale
 #. odoo-javascript
+#: code:addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml:0
+msgid "Refund in process"
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-javascript
 #: code:addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml:0
 msgid "Refunded"
 msgstr ""

--- a/addons/point_of_sale/static/src/app/models/pos_payment.js
+++ b/addons/point_of_sale/static/src/app/models/pos_payment.js
@@ -79,9 +79,11 @@ export class PosPayment extends Base {
         return isPaymentSuccessful;
     }
 
-    updateRefundPaymentLine(refundedPaymentLine) {
-        this.transaction_id = refundedPaymentLine.transaction_id;
-    }
+    /**
+     * @param {object} - refundedPaymentLine
+     * Override in dependent modules to update the refund payment line with the refunded payment line
+     */
+    updateRefundPaymentLine(refundedPaymentLine) {}
 }
 
 registry.category("pos_available_models").add(PosPayment.pythonModel, PosPayment);

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
@@ -54,7 +54,12 @@
                                 </t>
                                 <t t-elif="line.payment_status == 'waitingCard'">
                                     <div class="electronic_status">
-                                        Waiting for card
+                                        <t t-if="this.props.isRefundOrder">
+                                            Refund in process
+                                        </t>
+                                        <t t-else="">
+                                            Waiting for card
+                                        </t>
                                     </div>
                                     <div t-if="!this.props.isRefundOrder" class="button send_payment_cancel" title="Cancel Payment Request" t-on-click="() => this.props.sendPaymentCancel(line)">
                                         Cancel

--- a/addons/pos_razorpay/i18n/pos_razorpay.pot
+++ b/addons/pos_razorpay/i18n/pos_razorpay.pot
@@ -17,6 +17,14 @@ msgstr ""
 
 #. module: pos_razorpay
 #. odoo-javascript
+#: code:addons/pos_razorpay/static/src/app/utls/payment/payment_razorpay.js:0
+msgid ""
+"A partial refund is not allowed because the transaction has not yet been "
+"settled."
+msgstr ""
+
+#. module: pos_razorpay
+#. odoo-javascript
 #: code:addons/pos_razorpay/static/src/app/screens/payment_screen/payment_screen.js:0
 msgid ""
 "Adding a new Razorpay payment line is not allowed under the current "
@@ -31,12 +39,6 @@ msgstr ""
 #. module: pos_razorpay
 #: model:ir.model.fields.selection,name:pos_razorpay.selection__pos_payment_method__razorpay_allowed_payment_modes__bharatqr
 msgid "BHARATQR"
-msgstr ""
-
-#. module: pos_razorpay
-#. odoo-javascript
-#: code:addons/pos_razorpay/static/src/app/utls/payment/payment_razorpay.js:0
-msgid "Cancel"
 msgstr ""
 
 #. module: pos_razorpay
@@ -191,6 +193,22 @@ msgid "Reference number mismatched"
 msgstr ""
 
 #. module: pos_razorpay
+#. odoo-javascript
+#: code:addons/pos_razorpay/static/src/app/utls/payment/payment_razorpay.js:0
+msgid ""
+"Related transaction has already been Refunded. Please try using another "
+"payment method."
+msgstr ""
+
+#. module: pos_razorpay
+#. odoo-javascript
+#: code:addons/pos_razorpay/static/src/app/utls/payment/payment_razorpay.js:0
+msgid ""
+"Related transaction has already been voided. Please try using another "
+"payment method."
+msgstr ""
+
+#. module: pos_razorpay
 #: model:ir.model.fields,help:pos_razorpay.field_pos_payment__razorpay_p2p_request_id
 msgid "Required to fetch payment status during the refund order process"
 msgstr ""
@@ -236,24 +254,4 @@ msgstr ""
 msgid ""
 "Username(Device Login) \n"
 " ex: 1234500121"
-msgstr ""
-
-#. module: pos_razorpay
-#. odoo-javascript
-#: code:addons/pos_razorpay/static/src/app/utls/payment/payment_razorpay.js:0
-msgid "Void Payment Confirmation"
-msgstr ""
-
-#. module: pos_razorpay
-#. odoo-javascript
-#: code:addons/pos_razorpay/static/src/app/utls/payment/payment_razorpay.js:0
-msgid "Void Transaction"
-msgstr ""
-
-#. module: pos_razorpay
-#. odoo-javascript
-#: code:addons/pos_razorpay/static/src/app/utls/payment/payment_razorpay.js:0
-msgid ""
-"Your transaction isn't settled yet, and the refund is less than the amount paid.\n"
-"The full amount will be cancelled, do you want to proceed?"
 msgstr ""

--- a/addons/pos_razorpay/models/pos_payment_method.py
+++ b/addons/pos_razorpay/models/pos_payment_method.py
@@ -92,6 +92,11 @@ class PosPaymentMethod(models.Model):
                     'p2pRequestId': response.get('p2pRequestId'),
                     'settlementStatus': response.get('settlementStatus'),
                 }
+            elif payment_status in ['VOIDED', 'AUTHORIZED_REFUNDED'] and payment_messageCode == 'P2P_DEVICE_TXN_DONE':
+                return {
+                    'status': payment_status,
+                    'settlementStatus': response.get('settlementStatus'),
+                }
             elif payment_status == 'FAILED' or payment_messageCode == 'P2P_DEVICE_CANCELED':
                 return {'error': str(response.get('message', _('Razorpay POS transaction failed'))),
                         'payment_messageCode': payment_messageCode}

--- a/addons/pos_razorpay/static/src/app/services/pos_store.js
+++ b/addons/pos_razorpay/static/src/app/services/pos_store.js
@@ -5,14 +5,11 @@ patch(PosStore.prototype, {
     async pay() {
         const currentOrder = this.getOrder();
         const refundedOrder = currentOrder?.lines[0]?.refunded_orderline_id?.order_id;
-        const razorpayPaymentlines = refundedOrder?.payment_ids.filter(
-            (pi) => pi.payment_method_id.use_payment_terminal === "razorpay"
-        );
-        const reazorpayPaymentMethod = currentOrder.config_id.payment_method_ids.find(
+        const razorpayPaymentMethod = currentOrder.config_id.payment_method_ids.find(
             (pm) => pm.use_payment_terminal === "razorpay"
         );
         await super.pay();
-        if (reazorpayPaymentMethod && refundedOrder && razorpayPaymentlines?.length === 1) {
+        if (razorpayPaymentMethod && refundedOrder) {
             const paymentIds = refundedOrder.payment_ids || [];
             // Add all the available payment lines in the refunded order if the current order amount is the same as the refunded order
             if (Math.abs(currentOrder.getTotalDue()) === refundedOrder.amount_total) {
@@ -25,25 +22,29 @@ patch(PosStore.prototype, {
                 });
             } else {
                 // Add available payment lines of refunded order based on conditions.
-                const getTotalDue = currentOrder.getTotalDue();
-                if (getTotalDue < 0 && Math.abs(getTotalDue) > razorpayPaymentlines[0].amount) {
-                    const paymentLine = currentOrder.addPaymentline(
-                        razorpayPaymentlines[0].payment_method_id
-                    );
-                    paymentLine.setAmount(-razorpayPaymentlines[0].amount);
-                    paymentLine.updateRefundPaymentLine(razorpayPaymentlines[0]);
-                }
+                // Settle current order terminal based payment lines with refunded order terminal based payment lines
+                const razorpayPaymentlines = paymentIds.filter(
+                    (pi) => pi.payment_method_id.use_payment_terminal === "razorpay"
+                );
+                razorpayPaymentlines.forEach((pi) => {
+                    const currentDue = currentOrder.getDue();
+                    if (currentDue < 0) {
+                        const paymentLine = currentOrder.addPaymentline(pi.payment_method_id);
+                        paymentLine.setAmount(-Math.min(Math.abs(currentDue), pi.amount));
+                        paymentLine.updateRefundPaymentLine(pi);
+                    }
+                });
                 if (currentOrder.getDue() < 0) {
                     paymentIds.forEach((pi) => {
-                        const current_due = currentOrder.getDue();
+                        const currentDue = currentOrder.getDue();
                         if (
-                            current_due < 0 &&
+                            currentDue < 0 &&
                             pi.payment_method_id &&
-                            !pi.payment_method_id.use_payment_terminal
+                            pi.payment_method_id.use_payment_terminal !== "razorpay"
                         ) {
                             currentOrder
                                 .addPaymentline(pi.payment_method_id)
-                                .setAmount(current_due);
+                                .setAmount(-Math.min(Math.abs(currentDue), pi.amount));
                         }
                     });
                 }

--- a/addons/pos_razorpay/static/src/overrides/models/pos_payment.js
+++ b/addons/pos_razorpay/static/src/overrides/models/pos_payment.js
@@ -2,9 +2,20 @@ import { PosPayment } from "@point_of_sale/app/models/pos_payment";
 import { patch } from "@web/core/utils/patch";
 
 patch(PosPayment.prototype, {
-    //@override
+    /**
+     * override
+     */
+    setup(vals) {
+        super.setup(vals);
+        this.uiState = {
+            ...this.uiState,
+            transaction_id: null,
+            razorpay_p2p_request_id: null,
+        };
+    },
     updateRefundPaymentLine(refundedPaymentLine) {
         super.updateRefundPaymentLine(refundedPaymentLine);
-        this.razorpay_p2p_request_id = refundedPaymentLine?.razorpay_p2p_request_id;
+        this.uiState.transaction_id = refundedPaymentLine?.transaction_id;
+        this.uiState.razorpay_p2p_request_id = refundedPaymentLine?.razorpay_p2p_request_id;
     },
 });


### PR DESCRIPTION
Before this commit:
==========
- We are not allowing multiple payment lines to be refunded or partial refunds.
- We were showing `Waiting for card` for the terminal payment's refund process as payment status.

After this commit:
==========
- Refunds for multiple payment lines and partial refunds will be allowed.
- We will show `Refund in process` for the terminal payment's refund process as payment status.


task-4512844