### PR TITLE
[FIX] html_editor: remove empty format tags

### DIFF
--- a/addons/html_editor/static/tests/format/italic.test.js
+++ b/addons/html_editor/static/tests/format/italic.test.js
@@ -2,8 +2,9 @@ import { expect, test } from "@odoo/hoot";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { getContent } from "../_helpers/selection";
 import { em, span } from "../_helpers/tags";
-import { italic, tripleClick } from "../_helpers/user_actions";
+import { italic, tripleClick, simulateArrowKeyPress } from "../_helpers/user_actions";
 import { unformat } from "../_helpers/format";
+import { tick } from "@odoo/hoot-mock";
 
 test("should make a few characters italic", async () => {
     await testEditor({
@@ -110,6 +111,18 @@ test("should not format non-editable text (italic)", async () => {
     });
 });
 
+test("should remove empty italic tag when changing selection", async () => {
+    const { editor, el } = await setupEditor("<p>ab[]cd</p>");
+
+    italic(editor);
+    await tick();
+    expect(getContent(el)).toBe(`<p>ab${em("[]\u200B", "first")}cd</p>`);
+
+    await simulateArrowKeyPress(editor, "ArrowLeft");
+    await tick(); // await selectionchange
+    expect(getContent(el)).toBe(`<p>a[]bcd</p>`);
+});
+
 test("should make a few characters italic inside table (italic)", async () => {
     await testEditor({
         contentBefore: unformat(`
@@ -131,8 +144,7 @@ test("should make a few characters italic inside table (italic)", async () => {
                         <td><p><br></p></td>
                     </tr>
                 </tbody>
-            </table>`
-        ),
+            </table>`),
         stepFunction: italic,
         contentAfterEdit: unformat(`
             <table class="table table-bordered o_table o_selected_table">
@@ -153,7 +165,6 @@ test("should make a few characters italic inside table (italic)", async () => {
                         <td><p><br></p></td>
                     </tr>
                 </tbody>
-            </table>`
-        ),
+            </table>`),
     });
 });

--- a/addons/html_editor/static/tests/format/strike_through.test.js
+++ b/addons/html_editor/static/tests/format/strike_through.test.js
@@ -1,8 +1,14 @@
 import { expect, test } from "@odoo/hoot";
+import { tick } from "@odoo/hoot-mock";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { getContent, setSelection } from "../_helpers/selection";
 import { s, span } from "../_helpers/tags";
-import { insertText, strikeThrough, tripleClick } from "../_helpers/user_actions";
+import {
+    insertText,
+    strikeThrough,
+    tripleClick,
+    simulateArrowKeyPress,
+} from "../_helpers/user_actions";
 import { unformat } from "../_helpers/format";
 
 test("should make a few characters strikeThrough", async () => {
@@ -214,8 +220,7 @@ test("should make a few characters strikeThrough inside table (strikeThrough)", 
                         <td><p><br></p></td>
                     </tr>
                 </tbody>
-            </table>`
-        ),
+            </table>`),
         stepFunction: strikeThrough,
         contentAfterEdit: unformat(`
             <table class="table table-bordered o_table o_selected_table">
@@ -236,7 +241,18 @@ test("should make a few characters strikeThrough inside table (strikeThrough)", 
                         <td><p><br></p></td>
                     </tr>
                 </tbody>
-            </table>`
-        ),
+            </table>`),
     });
+});
+
+test("should remove empty strikeThrough when changing selection", async () => {
+    const { editor, el } = await setupEditor("<p>ab[]cd</p>");
+
+    strikeThrough(editor);
+    await tick();
+    expect(getContent(el)).toBe(`<p>ab${s("[]\u200B", "first")}cd</p>`);
+
+    await simulateArrowKeyPress(editor, "ArrowLeft");
+    await tick(); // await selectionchange
+    expect(getContent(el)).toBe(`<p>a[]bcd</p>`);
 });


### PR DESCRIPTION
**Behavior before this PR:**

- Create a bold or italic tag using keyboard when selection is collapsed, leave it empty.
- Change selection using arrow key.
- Put cursor back where format tag was created.

Notice that empty element is not removed and text is formatted when writing something.

**Behavior after PR is merged:**

- This PR makes sure that empty format element gets removed when changing selection.
- Tag will not get removed if it's parent block element is empty.

task-4240818


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
