### PR TITLE
[FIX] account: Error computing placeholder without date

### DIFF
--- a/addons/account/i18n/ar.po
+++ b/addons/account/i18n/ar.po
@@ -9,7 +9,10 @@
 # Wil Odoo, 2025
 # Beshoy Nabeih, 2025
 # Malaz Abuidris <msea@odoo.com>, 2025
+<<<<<<< HEAD
 # Mustafa J. Kadhem <safi2266@gmail.com>, 2025
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 # 
 msgid ""
 msgstr ""
@@ -17,7 +20,11 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-19 20:36+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
+<<<<<<< HEAD
 "Last-Translator: Mustafa J. Kadhem <safi2266@gmail.com>, 2025\n"
+=======
+"Last-Translator: Malaz Abuidris <msea@odoo.com>, 2025\n"
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 "Language-Team: Arabic (https://app.transifex.com/odoo/teams/41243/ar/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/account/i18n/ca.po
+++ b/addons/account/i18n/ca.po
@@ -43,7 +43,11 @@
 # EstudiTIC - estuditic.com <odoo@estuditic.com>, 2025
 # Santiago Payà <santiagopim@gmail.com>, 2025
 # Noemi Pla, 2025
+<<<<<<< HEAD
 # Josep Anton Belchi, 2025
+=======
+# Santiago Payà <santiagopim@gmail.com>, 2025
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 # 
 msgid ""
 msgstr ""
@@ -51,7 +55,11 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-19 20:36+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
+<<<<<<< HEAD
 "Last-Translator: Josep Anton Belchi, 2025\n"
+=======
+"Last-Translator: Santiago Payà <santiagopim@gmail.com>, 2025\n"
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 "Language-Team: Catalan (https://app.transifex.com/odoo/teams/41243/ca/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/account/i18n/cs.po
+++ b/addons/account/i18n/cs.po
@@ -16,7 +16,10 @@
 # Wil Odoo, 2025
 # Radim Bílý, 2025
 # Denis Gobin, 2025
+<<<<<<< HEAD
 # Vojtěch Olšan, 2025
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 # 
 msgid ""
 msgstr ""
@@ -24,7 +27,11 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-19 20:36+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
+<<<<<<< HEAD
 "Last-Translator: Vojtěch Olšan, 2025\n"
+=======
+"Last-Translator: Denis Gobin, 2025\n"
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 "Language-Team: Czech (https://app.transifex.com/odoo/teams/41243/cs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/account/i18n/hu.po
+++ b/addons/account/i18n/hu.po
@@ -18577,7 +18577,11 @@ msgstr "Nem tud regisztrálni kifizetéseket vegyes tételekhez."
 #. odoo-python
 #: code:addons/account/models/mail_message.py:0
 msgid "You cannot remove parts of the audit trail."
+<<<<<<< HEAD
 msgstr "Nem távolíthat el részeket az audit nyomvonalból."
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account
 #. odoo-python

--- a/addons/account/i18n/id.po
+++ b/addons/account/i18n/id.po
@@ -18601,7 +18601,11 @@ msgstr "Anda tidak dapat mendaftarkan pembayaran untuk entri miscellaneous."
 #. odoo-python
 #: code:addons/account/models/mail_message.py:0
 msgid "You cannot remove parts of the audit trail."
+<<<<<<< HEAD
 msgstr "Anda tidak dapat menghapus bagian dari jejak audit."
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account
 #. odoo-python

--- a/addons/account/i18n/ja.po
+++ b/addons/account/i18n/ja.po
@@ -17859,7 +17859,11 @@ msgstr "その他仕訳用に支払登録することはできません。"
 #. odoo-python
 #: code:addons/account/models/mail_message.py:0
 msgid "You cannot remove parts of the audit trail."
+<<<<<<< HEAD
 msgstr "監査証跡の一部を削除することはできません。"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account
 #. odoo-python

--- a/addons/account/i18n/pt_BR.po
+++ b/addons/account/i18n/pt_BR.po
@@ -18660,7 +18660,11 @@ msgstr "Não é possível registrar pagamentos para lançamentos diversos."
 #. odoo-python
 #: code:addons/account/models/mail_message.py:0
 msgid "You cannot remove parts of the audit trail."
+<<<<<<< HEAD
 msgstr "Não é possível remover partes da trilha de auditoria."
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account
 #. odoo-python

--- a/addons/account/i18n/zh_CN.po
+++ b/addons/account/i18n/zh_CN.po
@@ -18474,7 +18474,11 @@ msgstr "You cannot register payments for miscellaneous entries."
 #. odoo-python
 #: code:addons/account/models/mail_message.py:0
 msgid "You cannot remove parts of the audit trail."
+<<<<<<< HEAD
 msgstr "不能删除审计追踪的部分。"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account
 #. odoo-python

--- a/addons/account/i18n/zh_TW.po
+++ b/addons/account/i18n/zh_TW.po
@@ -17817,7 +17817,11 @@ msgstr "你不可為雜項記項登記付款。"
 #. odoo-python
 #: code:addons/account/models/mail_message.py:0
 msgid "You cannot remove parts of the audit trail."
+<<<<<<< HEAD
 msgstr "你不可移除審計追蹤的某些部份。"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account
 #. odoo-python

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -912,7 +912,7 @@ class AccountMove(models.Model):
     @api.depends('date', 'journal_id', 'move_type', 'name', 'posted_before', 'sequence_number', 'sequence_prefix', 'state')
     def _compute_name_placeholder(self):
         for move in self:
-            if (not move.name or move.name == '/') and not move._get_last_sequence():
+            if (not move.name or move.name == '/') and not move._get_last_sequence() and self.date:
                 sequence_format_string, sequence_format_values = move._get_next_sequence_format()
                 sequence_format_values['seq'] = sequence_format_values['seq'] + 1
                 move.name_placeholder = sequence_format_string.format(**sequence_format_values)

--- a/addons/account_peppol/i18n/de.po
+++ b/addons/account_peppol/i18n/de.po
@@ -30,19 +30,31 @@ msgstr " (Kunde nicht in Peppol)"
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Demo)"
+<<<<<<< HEAD
 msgstr " (Demo)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Test)"
+<<<<<<< HEAD
 msgstr " (Test)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (no VAT)"
+<<<<<<< HEAD
 msgstr " (keine USt-IdNr.)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
@@ -1196,8 +1208,11 @@ msgid ""
 "Your Peppol registration will be activated soon. You can already send "
 "invoices."
 msgstr ""
+<<<<<<< HEAD
 "Ihre Peppol-Registrierung wird in Kürze aktiviert. Sie können bereits "
 "Rechnungen senden."
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
@@ -1206,8 +1221,11 @@ msgid ""
 "Your company is already registered on another Access Point for receiving "
 "invoices.We will register you as a sender only."
 msgstr ""
+<<<<<<< HEAD
 "Ihr Unternehmen ist bereits bei einem anderen Zugangspunkt für den Empfang "
 "von Rechnungen registriert. Wir werden Sie nur als Absender registrieren."
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.peppol_registration_form

--- a/addons/account_peppol/i18n/es.po
+++ b/addons/account_peppol/i18n/es.po
@@ -30,19 +30,31 @@ msgstr " (el cliente no está en Peppol)"
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Demo)"
+<<<<<<< HEAD
 msgstr " (Demostración)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Test)"
+<<<<<<< HEAD
 msgstr " (Prueba)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (no VAT)"
+<<<<<<< HEAD
 msgstr " (sin IVA)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
@@ -1190,7 +1202,11 @@ msgstr "Su ID de PEPPOL"
 msgid ""
 "Your Peppol registration will be activated soon. You can already send "
 "invoices."
+<<<<<<< HEAD
 msgstr "Su registro Peppol se activará pronto. Ya puede enviar facturas."
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
@@ -1199,8 +1215,11 @@ msgid ""
 "Your company is already registered on another Access Point for receiving "
 "invoices.We will register you as a sender only."
 msgstr ""
+<<<<<<< HEAD
 "Su compañía ya está registrada en otro punto de acceso para recibir "
 "facturas. Le registraremos solo como remitente."
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.peppol_registration_form

--- a/addons/account_peppol/i18n/es_419.po
+++ b/addons/account_peppol/i18n/es_419.po
@@ -3,6 +3,10 @@
 # 	* account_peppol
 # 
 # Translators:
+<<<<<<< HEAD
+=======
+# Patricia Gutiérrez Capetillo <pagc@odoo.com>, 2025
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 # Wil Odoo, 2025
 # Fernanda Alvarez, 2025
 # Patricia Gutiérrez Capetillo <pagc@odoo.com>, 2025
@@ -31,19 +35,31 @@ msgstr " (el cliente no está en Peppol)"
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Demo)"
+<<<<<<< HEAD
 msgstr " (Demo)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Test)"
+<<<<<<< HEAD
 msgstr "(Prueba)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (no VAT)"
+<<<<<<< HEAD
 msgstr "(Sin IVA)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
@@ -1186,7 +1202,11 @@ msgstr "Su ID de Peppol"
 msgid ""
 "Your Peppol registration will be activated soon. You can already send "
 "invoices."
+<<<<<<< HEAD
 msgstr "Su registro Peppol se activará pronto. Ya puede enviar facturas."
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
@@ -1195,8 +1215,11 @@ msgid ""
 "Your company is already registered on another Access Point for receiving "
 "invoices.We will register you as a sender only."
 msgstr ""
+<<<<<<< HEAD
 "Su empresa ya está registrada en otro punto de acceso para recibir facturas."
 " Le registraremos solo como un emisor."
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.peppol_registration_form

--- a/addons/account_peppol/i18n/fr.po
+++ b/addons/account_peppol/i18n/fr.po
@@ -30,19 +30,31 @@ msgstr " (Client non inscrit sur Peppol)"
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Demo)"
+<<<<<<< HEAD
 msgstr " (Démo)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Test)"
+<<<<<<< HEAD
 msgstr " (Test)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (no VAT)"
+<<<<<<< HEAD
 msgstr " (hors TVA)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
@@ -1192,8 +1204,11 @@ msgid ""
 "Your Peppol registration will be activated soon. You can already send "
 "invoices."
 msgstr ""
+<<<<<<< HEAD
 "Votre inscription Peppol sera bientôt activée. Vous pouvez déjà commencer à "
 "envoyer des factures."
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
@@ -1202,9 +1217,12 @@ msgid ""
 "Your company is already registered on another Access Point for receiving "
 "invoices.We will register you as a sender only."
 msgstr ""
+<<<<<<< HEAD
 "Votre entreprise est déjà enregistrée sur un autre point d'accès pour "
 "recevoir des factures. Vous serez enregistré en tant qu'expéditeur "
 "uniquement."
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.peppol_registration_form

--- a/addons/account_peppol/i18n/it.po
+++ b/addons/account_peppol/i18n/it.po
@@ -30,19 +30,31 @@ msgstr "(Il cliente non è su Peppol)"
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Demo)"
+<<<<<<< HEAD
 msgstr " (Demo)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Test)"
+<<<<<<< HEAD
 msgstr " (Test)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (no VAT)"
+<<<<<<< HEAD
 msgstr " (no IVA)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
@@ -1181,8 +1193,11 @@ msgid ""
 "Your Peppol registration will be activated soon. You can already send "
 "invoices."
 msgstr ""
+<<<<<<< HEAD
 "La tua registrazione Peppol verrà attivata a breve. Puoi già inviare "
 "fatture."
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
@@ -1191,8 +1206,11 @@ msgid ""
 "Your company is already registered on another Access Point for receiving "
 "invoices.We will register you as a sender only."
 msgstr ""
+<<<<<<< HEAD
 "L'azienda è già registrata su un altro Access Point per ricevere fatture. Ti"
 " registreremo solo come mittente."
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.peppol_registration_form

--- a/addons/account_peppol/i18n/ja.po
+++ b/addons/account_peppol/i18n/ja.po
@@ -30,19 +30,31 @@ msgstr "(Peppol未対応の顧客)"
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Demo)"
+<<<<<<< HEAD
 msgstr " (デモ)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Test)"
+<<<<<<< HEAD
 msgstr " (テスト)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (no VAT)"
+<<<<<<< HEAD
 msgstr " (VATなし)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
@@ -1140,7 +1152,11 @@ msgstr "Peppol ID"
 msgid ""
 "Your Peppol registration will be activated soon. You can already send "
 "invoices."
+<<<<<<< HEAD
 msgstr "Peppolの登録はまもなく有効化されます。すでに顧客請求書を送付することができます。"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
@@ -1148,7 +1164,11 @@ msgstr "Peppolの登録はまもなく有効化されます。すでに顧客請
 msgid ""
 "Your company is already registered on another Access Point for receiving "
 "invoices.We will register you as a sender only."
+<<<<<<< HEAD
 msgstr "貴社はすでに、顧客請求書を受け取るための別のアクセスポイントに登録されています。貴社を送信者のみとして登録します。"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.peppol_registration_form

--- a/addons/account_peppol/i18n/ko.po
+++ b/addons/account_peppol/i18n/ko.po
@@ -31,19 +31,31 @@ msgstr "(고객이 Peppol에 가입되어 있지 않음)"
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Demo)"
+<<<<<<< HEAD
 msgstr " (데모)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Test)"
+<<<<<<< HEAD
 msgstr " (테스트)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (no VAT)"
+<<<<<<< HEAD
 msgstr "(부가세 미포함)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python

--- a/addons/account_peppol/i18n/nl.po
+++ b/addons/account_peppol/i18n/nl.po
@@ -31,19 +31,31 @@ msgstr " (Klant niet op Peppol)"
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Demo)"
+<<<<<<< HEAD
 msgstr " (Demo)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Test)"
+<<<<<<< HEAD
 msgstr " (Test)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (no VAT)"
+<<<<<<< HEAD
 msgstr " (geen btw)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
@@ -1184,6 +1196,7 @@ msgstr "Je Peppol ID"
 msgid ""
 "Your Peppol registration will be activated soon. You can already send "
 "invoices."
+<<<<<<< HEAD
 msgstr ""
 "Je Peppol registratie wordt binnenkort geactiveerd. Je kunt nu al facturen "
 "versturen."
@@ -1197,6 +1210,17 @@ msgid ""
 msgstr ""
 "Je bedrijf is al geregistreerd op een ander Access Point voor het ontvangen "
 "van facturen. We registreren je alleen als verzender."
+=======
+msgstr ""
+
+#. module: account_peppol
+#. odoo-python
+#: code:addons/account_peppol/wizard/peppol_registration.py:0
+msgid ""
+"Your company is already registered on another Access Point for receiving "
+"invoices.We will register you as a sender only."
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.peppol_registration_form

--- a/addons/account_peppol/i18n/pt_BR.po
+++ b/addons/account_peppol/i18n/pt_BR.po
@@ -30,19 +30,31 @@ msgstr " (Customer not on Peppol)"
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Demo)"
+<<<<<<< HEAD
 msgstr " (Demo)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Test)"
+<<<<<<< HEAD
 msgstr " (Teste)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (no VAT)"
+<<<<<<< HEAD
 msgstr " (sem VAT)"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: account_peppol
 #. odoo-python
@@ -1184,6 +1196,17 @@ msgstr "Seu ID Peppol"
 msgid ""
 "Your Peppol registration will be activated soon. You can already send "
 "invoices."
+<<<<<<< HEAD
+=======
+msgstr ""
+
+#. module: account_peppol
+#. odoo-python
+#: code:addons/account_peppol/wizard/peppol_registration.py:0
+msgid ""
+"Your company is already registered on another Access Point for receiving "
+"invoices.We will register you as a sender only."
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 msgstr ""
 "Seu registro na Peppol será ativado em breve. Você já pode enviar faturas."
 

--- a/addons/calendar/i18n/ca.po
+++ b/addons/calendar/i18n/ca.po
@@ -29,6 +29,7 @@
 # marcescu, 2024
 # Santiago Payà <santiagopim@gmail.com>, 2025
 # Noemi Pla, 2025
+# Santiago Payà <santiagopim@gmail.com>, 2025
 # 
 msgid ""
 msgstr ""
@@ -36,7 +37,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-12-16 13:39+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
-"Last-Translator: Noemi Pla, 2025\n"
+"Last-Translator: Santiago Payà <santiagopim@gmail.com>, 2025\n"
 "Language-Team: Catalan (https://app.transifex.com/odoo/teams/41243/ca/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/event/i18n/cs.po
+++ b/addons/event/i18n/cs.po
@@ -6,7 +6,10 @@
 # Tiffany Chang, 2024
 # Wil Odoo, 2025
 # Marta Wacławek, 2025
+<<<<<<< HEAD
 # Denis Gobin, 2025
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 # 
 msgid ""
 msgstr ""
@@ -14,7 +17,11 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-01-27 13:03+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
+<<<<<<< HEAD
 "Last-Translator: Denis Gobin, 2025\n"
+=======
+"Last-Translator: Marta Wacławek, 2025\n"
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 "Language-Team: Czech (https://app.transifex.com/odoo/teams/41243/cs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/hr_holidays/i18n/ar.po
+++ b/addons/hr_holidays/i18n/ar.po
@@ -1677,6 +1677,12 @@ msgid "Employee accrue"
 msgstr "تراكم الموظف "
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "الموظف (الموظفين) "
@@ -3592,6 +3598,13 @@ msgid ""
 msgstr ""
 "تتم تعبئة هذه المنطقة تلقائياً بواسطة المستخدم الذي يقوم بتصديق المخصصات مع "
 "المستوى الثاني (إذا كانت الإجازة تحتاج إلى تصديق ثاني) "
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr ""
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/az.po
+++ b/addons/hr_holidays/i18n/az.po
@@ -1634,6 +1634,12 @@ msgid "Employee accrue"
 msgstr ""
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "İşçi (lər)"
@@ -3499,6 +3505,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/bg.po
+++ b/addons/hr_holidays/i18n/bg.po
@@ -1645,6 +1645,12 @@ msgid "Employee accrue"
 msgstr ""
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Служител(и)"
@@ -3487,6 +3493,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/ca.po
+++ b/addons/hr_holidays/i18n/ca.po
@@ -1672,6 +1672,12 @@ msgid "Employee accrue"
 msgstr ""
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Empleat(s)"
@@ -3559,6 +3565,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/cs.po
+++ b/addons/hr_holidays/i18n/cs.po
@@ -1658,6 +1658,12 @@ msgid "Employee accrue"
 msgstr ""
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Zaměstnanci"
@@ -3539,6 +3545,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/da.po
+++ b/addons/hr_holidays/i18n/da.po
@@ -1654,6 +1654,12 @@ msgid "Employee accrue"
 msgstr ""
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Medarbejder(e)"
@@ -3531,6 +3537,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/de.po
+++ b/addons/hr_holidays/i18n/de.po
@@ -1696,6 +1696,12 @@ msgid "Employee accrue"
 msgstr "Rückstellung des Mitarbeiters"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr "Foto des Mitarbeiters"
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Mitarbeiter"
@@ -3652,6 +3658,13 @@ msgstr ""
 "Dieser Bereich wird automatisch vom Benutzer ausgefüllt, der den "
 "Urlaubsanspruch mit der zweiten Ebene validiert (wenn die Abwesenheitsart "
 "eine zweite Validierung erfordert)."
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr "Dieses Unternehmen hat keine Mitarbeiter."
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/el.po
+++ b/addons/hr_holidays/i18n/el.po
@@ -1640,6 +1640,12 @@ msgid "Employee accrue"
 msgstr ""
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Υπάλληλος/οι"
@@ -3480,6 +3486,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/es.po
+++ b/addons/hr_holidays/i18n/es.po
@@ -1688,6 +1688,12 @@ msgid "Employee accrue"
 msgstr "Acumulación del empleado"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr "Foto del empleado"
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Empleado(s)"
@@ -3632,6 +3638,13 @@ msgid ""
 msgstr ""
 "Este área se rellena automáticamente con el usuario que valida la asignación"
 " en segundo nivel (si el tipo de ausencia necesita una segunda validación)"
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr "Esta compañía no cuenta con empleados."
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/es_419.po
+++ b/addons/hr_holidays/i18n/es_419.po
@@ -1692,6 +1692,12 @@ msgid "Employee accrue"
 msgstr "Acumulación del empleado"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr "Imagen del empleado"
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Empleado(s)"
@@ -3643,6 +3649,13 @@ msgstr ""
 "Esta área se completa automáticamente con el usuario que valida la "
 "asignación con segundo nivel (si el tipo de tiempo personal necesita una "
 "segunda validación)"
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr "Esta empresa no tiene empleados."
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/et.po
+++ b/addons/hr_holidays/i18n/et.po
@@ -1687,6 +1687,12 @@ msgid "Employee accrue"
 msgstr "Töötajale koguneb"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Töötaja(d)"
@@ -3565,6 +3571,13 @@ msgstr "Selle välja täidab automaatselt kasutaja, kes jaotuse kinnitab"
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/fa.po
+++ b/addons/hr_holidays/i18n/fa.po
@@ -1676,6 +1676,12 @@ msgid "Employee accrue"
 msgstr "کارمند بدست می‌آورد"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "کارمند(ها)"
@@ -3575,6 +3581,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/fi.po
+++ b/addons/hr_holidays/i18n/fi.po
@@ -1720,6 +1720,12 @@ msgid "Employee accrue"
 msgstr "Työntekijän kertymä"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Työntekijä(t)"
@@ -3646,6 +3652,13 @@ msgid ""
 msgstr ""
 "Tämän alueen täyttää automaattisesti käyttäjä, joka vahvistaa varauksen "
 "toisella tasolla (jos vapaa-aikatyyppi tarvitsee toisen vahvistuksen)"
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr ""
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/fr.po
+++ b/addons/hr_holidays/i18n/fr.po
@@ -1689,6 +1689,12 @@ msgid "Employee accrue"
 msgstr "Cumul de l'employé"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr "Image de l'employé"
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Employé(s)"
@@ -3637,6 +3643,13 @@ msgstr ""
 "Cet espace est rempli automatiquement par l'utilisateur qui valide "
 "l'allocation au deuxième niveau (si le type de congé demande une deuxième "
 "validation)"
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr "Cette entreprise n'a pas d'employés."
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/he.po
+++ b/addons/hr_holidays/i18n/he.po
@@ -1649,6 +1649,12 @@ msgid "Employee accrue"
 msgstr ""
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "עובדים"
@@ -3489,6 +3495,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/hi.po
+++ b/addons/hr_holidays/i18n/hi.po
@@ -1623,6 +1623,12 @@ msgid "Employee accrue"
 msgstr ""
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "कर्मचारी"
@@ -3455,6 +3461,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/hr.po
+++ b/addons/hr_holidays/i18n/hr.po
@@ -1657,6 +1657,12 @@ msgid "Employee accrue"
 msgstr "Obračun djelatnika"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Djelatnik (ci)"
@@ -3545,6 +3551,13 @@ msgid ""
 msgstr ""
 "Ovo područje je automatski popunjeno od strane korisnika koji radi drugo "
 "odobravanje (ako tip odsustva tražu dvostruku ovjeru)"
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr ""
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/hu.po
+++ b/addons/hr_holidays/i18n/hu.po
@@ -1633,6 +1633,12 @@ msgid "Employee accrue"
 msgstr ""
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Munkavállaló"
@@ -3485,6 +3491,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/id.po
+++ b/addons/hr_holidays/i18n/id.po
@@ -1680,6 +1680,12 @@ msgid "Employee accrue"
 msgstr "Employee accrue"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Karyawan"
@@ -3607,6 +3613,13 @@ msgid ""
 msgstr ""
 "Area ini secara otomatis diisi oleh user yang memvalidasi alokasi dengan "
 "level kedua (Bila tipe cuti membutuhkan validasi kedua)"
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr ""
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/it.po
+++ b/addons/hr_holidays/i18n/it.po
@@ -1691,6 +1691,12 @@ msgid "Employee accrue"
 msgstr "Maturazione dipendente"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr "Foto dipendente"
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Dipendente/i"
@@ -3633,6 +3639,13 @@ msgid ""
 msgstr ""
 "Sezione compilata automaticamente dall'utente che valida l'assegnazione con "
 "secondo livello (se per la tipologia è necessaria una seconda convalida)"
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr "L'azienda non ha nessun dipendente."
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/ja.po
+++ b/addons/hr_holidays/i18n/ja.po
@@ -1651,6 +1651,12 @@ msgid "Employee accrue"
 msgstr "従業員の累積"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "従業員"
@@ -3513,6 +3519,13 @@ msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
 msgstr "このエリアは、2次レベルで休暇割当を検証するユーザによって自動的に入力されます(休暇タイプが2次承認を必要とする場合)。"
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr ""
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/ko.po
+++ b/addons/hr_holidays/i18n/ko.po
@@ -6,6 +6,7 @@
 # JH CHOI <hwangtog@gmail.com>, 2024
 # Wil Odoo, 2024
 # Daye Jeong, 2025
+# Sarah Park, 2025
 # 
 msgid ""
 msgstr ""
@@ -13,7 +14,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-12-16 13:39+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
-"Last-Translator: Daye Jeong, 2025\n"
+"Last-Translator: Sarah Park, 2025\n"
 "Language-Team: Korean (https://app.transifex.com/odoo/teams/41243/ko/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1651,6 +1652,12 @@ msgstr "직원 태그"
 #: model_terms:ir.ui.view,arch_db:hr_holidays.hr_accrual_level_view_form
 msgid "Employee accrue"
 msgstr "직원 누계"
+
+#. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr "직원 이미지"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
@@ -3524,6 +3531,13 @@ msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
 msgstr "이 영역은 2단계 휴가 승인을 하는 사용자에 의해 자동적으로 채워집니다.(휴가 유형이 2단계 승인인 경우)"
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr "이 회사에는 직원이 없습니다."
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/ku.po
+++ b/addons/hr_holidays/i18n/ku.po
@@ -1619,6 +1619,12 @@ msgid "Employee accrue"
 msgstr ""
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr ""
@@ -3451,6 +3457,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/lv.po
+++ b/addons/hr_holidays/i18n/lv.po
@@ -1641,6 +1641,12 @@ msgid "Employee accrue"
 msgstr ""
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Darbinieks(-i)"
@@ -3484,6 +3490,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/mn.po
+++ b/addons/hr_holidays/i18n/mn.po
@@ -1658,6 +1658,12 @@ msgid "Employee accrue"
 msgstr ""
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Ажилтан"
@@ -3537,6 +3543,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/nb.po
+++ b/addons/hr_holidays/i18n/nb.po
@@ -1671,6 +1671,12 @@ msgid "Employee accrue"
 msgstr "Ansatt periodisering"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Ansatt(e)"
@@ -3567,6 +3573,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/nl.po
+++ b/addons/hr_holidays/i18n/nl.po
@@ -1687,6 +1687,12 @@ msgid "Employee accrue"
 msgstr "Opbouw werknemer"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr "Afbeelding van de werknemer"
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Werknemer(s)"
@@ -3632,6 +3638,13 @@ msgstr ""
 "Deze velden worden automatisch ingevuld door de gebruiker die de toewijzing "
 "goedkeurt op het tweede niveau (indien het type verlof een tweede "
 "goedkeuring vereist)."
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr "Dit bedrijf heeft geen werknemers."
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/pl.po
+++ b/addons/hr_holidays/i18n/pl.po
@@ -1666,6 +1666,12 @@ msgid "Employee accrue"
 msgstr "Naliczenie pracownika"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Pracowników"
@@ -3580,6 +3586,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/pt.po
+++ b/addons/hr_holidays/i18n/pt.po
@@ -1630,6 +1630,12 @@ msgid "Employee accrue"
 msgstr ""
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Funcionário(s)"
@@ -3472,6 +3478,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/pt_BR.po
+++ b/addons/hr_holidays/i18n/pt_BR.po
@@ -1683,6 +1683,12 @@ msgid "Employee accrue"
 msgstr "Acúmulo do funcionário"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Funcionário(s)"
@@ -3619,6 +3625,13 @@ msgid ""
 msgstr ""
 "Essa área é preenchida automaticamente pelo usuário que valida a alocação de"
 " segundo nível (se o tipo de folga precisar de uma segunda validação)."
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr ""
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/ro.po
+++ b/addons/hr_holidays/i18n/ro.po
@@ -1681,6 +1681,12 @@ msgid "Employee accrue"
 msgstr "Angajați acumulați"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Salariat(i)"
@@ -3596,6 +3602,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/ru.po
+++ b/addons/hr_holidays/i18n/ru.po
@@ -1670,6 +1670,12 @@ msgid "Employee accrue"
 msgstr "Начисление сотрудникам"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Сотрудник(и)"
@@ -3589,6 +3595,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/sk.po
+++ b/addons/hr_holidays/i18n/sk.po
@@ -1639,6 +1639,12 @@ msgid "Employee accrue"
 msgstr ""
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Zamestnanci"
@@ -3501,6 +3507,13 @@ msgstr "Túto oblasť automaticky vyplní používateľ, ktorý overuje pridelen
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/sv.po
+++ b/addons/hr_holidays/i18n/sv.po
@@ -1700,6 +1700,12 @@ msgid "Employee accrue"
 msgstr "Upplupen personal"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Anställd(a)"
@@ -3626,6 +3632,13 @@ msgid ""
 msgstr ""
 "Detta område fylls automatiskt i av den användare som validerar "
 "tilldelningen med andra nivån (om ledig tidstyp kräver andra validering)"
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr ""
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/th.po
+++ b/addons/hr_holidays/i18n/th.po
@@ -1674,6 +1674,12 @@ msgid "Employee accrue"
 msgstr "วันลาคงค้างของพนักงาน"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "พนักงาน"
@@ -3581,6 +3587,13 @@ msgid ""
 msgstr ""
 "พื้นที่นี้จะถูกกรอกโดยอัตโนมัติโดยผู้ใช้ที่ตรวจสอบการจัดสรรด้วยระดับที่สอง "
 "(หากประเภทเวลาการลาจำเป็นต้องมีการตรวจสอบครั้งที่สอง)"
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr ""
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/tr.po
+++ b/addons/hr_holidays/i18n/tr.po
@@ -1664,6 +1664,12 @@ msgid "Employee accrue"
 msgstr ""
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Personel(ler)"
@@ -3538,6 +3544,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/uk.po
+++ b/addons/hr_holidays/i18n/uk.po
@@ -1668,6 +1668,12 @@ msgid "Employee accrue"
 msgstr "Нарахування співробітника"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Співробітник(и)"
@@ -3577,6 +3583,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/i18n/vi.po
+++ b/addons/hr_holidays/i18n/vi.po
@@ -1679,6 +1679,12 @@ msgid "Employee accrue"
 msgstr "Nhân viên tích lũy"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "Nhân viên"
@@ -3602,6 +3608,13 @@ msgid ""
 msgstr ""
 "Phần này được điền tự động bởi người dùng xác thực phân bổ ở cấp độ thứ hai "
 "(Nếu loại ngày nghỉ cần xác thực lần hai)"
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr ""
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/zh_CN.po
+++ b/addons/hr_holidays/i18n/zh_CN.po
@@ -1649,6 +1649,12 @@ msgid "Employee accrue"
 msgstr "员工累计"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "员工"
@@ -3516,6 +3522,13 @@ msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
 msgstr "该区域由用户自动填写，并通过第二级验证分配（如果休假类型需要第二级验证）。"
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr ""
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/hr_holidays/i18n/zh_TW.po
+++ b/addons/hr_holidays/i18n/zh_TW.po
@@ -1649,6 +1649,12 @@ msgid "Employee accrue"
 msgstr "員工累計"
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr "員工"
@@ -3516,6 +3522,13 @@ msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
 msgstr "此區域由第二級驗證分配的使用者自動填入（如果休假類型需要第二級驗證）"
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
+msgstr ""
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_level__accrual_validity_type

--- a/addons/mail_group/i18n/cs.po
+++ b/addons/mail_group/i18n/cs.po
@@ -5,7 +5,10 @@
 # Translators:
 # Wil Odoo, 2024
 # Marta Wacławek, 2025
+<<<<<<< HEAD
 # Chris Podivinsky, 2025
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 # 
 msgid ""
 msgstr ""
@@ -13,7 +16,11 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-12-16 13:40+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
+<<<<<<< HEAD
 "Last-Translator: Chris Podivinsky, 2025\n"
+=======
+"Last-Translator: Marta Wacławek, 2025\n"
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 "Language-Team: Czech (https://app.transifex.com/odoo/teams/41243/cs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/mass_mailing/i18n/cs.po
+++ b/addons/mass_mailing/i18n/cs.po
@@ -6,7 +6,10 @@
 # Wil Odoo, 2024
 # Aleš Fiala <f.ales1@seznam.cz>, 2024
 # Marta Wacławek, 2025
+<<<<<<< HEAD
 # Vojtěch Olšan, 2025
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 # 
 msgid ""
 msgstr ""
@@ -14,7 +17,11 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 13:22+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
+<<<<<<< HEAD
 "Last-Translator: Vojtěch Olšan, 2025\n"
+=======
+"Last-Translator: Marta Wacławek, 2025\n"
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 "Language-Team: Czech (https://app.transifex.com/odoo/teams/41243/cs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/mrp/i18n/cs.po
+++ b/addons/mrp/i18n/cs.po
@@ -6,7 +6,10 @@
 # Wil Odoo, 2024
 # Aleš Fiala <f.ales1@seznam.cz>, 2025
 # Denis Gobin, 2025
+<<<<<<< HEAD
 # Vojtěch Olšan, 2025
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 # 
 msgid ""
 msgstr ""
@@ -14,7 +17,11 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 13:22+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
+<<<<<<< HEAD
 "Last-Translator: Vojtěch Olšan, 2025\n"
+=======
+"Last-Translator: Denis Gobin, 2025\n"
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 "Language-Team: Czech (https://app.transifex.com/odoo/teams/41243/cs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/portal/i18n/ru.po
+++ b/addons/portal/i18n/ru.po
@@ -3,7 +3,11 @@
 # 	* portal
 # 
 # Translators:
+<<<<<<< HEAD
 # Wil Odoo, 2024
+=======
+# Wil Odoo, 2025
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 # Ilya Rozhkov, 2025
 # 
 msgid ""
@@ -1179,7 +1183,11 @@ msgstr "Ключ нельзя будет восстановить позже, и
 #. odoo-javascript
 #: code:addons/portal/static/src/xml/portal_security.xml:0
 msgid "The key will be deleted once this period has elapsed."
+<<<<<<< HEAD
 msgstr "Ключ будет удален после истечения этого срока."
+=======
+msgstr "Ключ будет удален после истечения этого периода."
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: portal
 #. odoo-python

--- a/addons/product/i18n/de.po
+++ b/addons/product/i18n/de.po
@@ -3443,7 +3443,11 @@ msgid ""
 msgstr ""
 "Der Mindestpreis unter den Produkten in dieser Kombi. Dieser Wert wird "
 "verwendet, um den Preis dieser Kombi im Verhältnis zu den anderen Kombis in "
+<<<<<<< HEAD
 "einem Kombi-Produkt zu berechnen. Diese Heuristik stellt sicher, dass der "
+=======
+"einem Kombiprodukt zu berechnen. Diese Heuristik stellt sicher, dass der "
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 "Preis für jedes Produkt, das der Benutzer in einer Kombi auswählt, immer "
 "gleich bleibt."
 

--- a/addons/sale/i18n/ca.po
+++ b/addons/sale/i18n/ca.po
@@ -32,7 +32,12 @@
 # Santiago Payà <santiagopim@gmail.com>, 2025
 # EstudiTIC - estuditic.com <odoo@estuditic.com>, 2025
 # Noemi Pla, 2025
+<<<<<<< HEAD
 # Josep Anton Belchi, 2025
+=======
+# Santiago Payà <santiagopim@gmail.com>, 2025
+# EstudiTIC - estuditic.com <odoo@estuditic.com>, 2025
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 # 
 msgid ""
 msgstr ""
@@ -40,7 +45,11 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-19 20:37+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
+<<<<<<< HEAD
 "Last-Translator: Josep Anton Belchi, 2025\n"
+=======
+"Last-Translator: EstudiTIC - estuditic.com <odoo@estuditic.com>, 2025\n"
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 "Language-Team: Catalan (https://app.transifex.com/odoo/teams/41243/ca/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/sale/i18n/de.po
+++ b/addons/sale/i18n/de.po
@@ -5157,7 +5157,11 @@ msgid ""
 "choices."
 msgstr ""
 "Die Anzahl der ausgewählten Kombi-Artikel muss mit der Anzahl der "
+<<<<<<< HEAD
 "verfügbaren Kombi-Möglichkeiten übereinstimmen."
+=======
+"verfügbaren Kombimöglichkeiten übereinstimmen."
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template

--- a/addons/sale/i18n/fa.po
+++ b/addons/sale/i18n/fa.po
@@ -4872,7 +4872,11 @@ msgstr "کشور مالیاتی"
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 msgid "Tax Excl."
+<<<<<<< HEAD
 msgstr "بدون مالیات"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.report_saleorder_document
@@ -4882,7 +4886,11 @@ msgstr "شناسه مالیاتی"
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 msgid "Tax Incl."
+<<<<<<< HEAD
 msgstr "مشمول مالیات"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_tree

--- a/addons/sale/i18n/fr.po
+++ b/addons/sale/i18n/fr.po
@@ -7,6 +7,7 @@
 # Cécile Collart <cco@odoo.com>, 2024
 # Wil Odoo, 2025
 # Manon Rondou, 2025
+# Wil Odoo, 2025
 # 
 msgid ""
 msgstr ""
@@ -14,7 +15,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-19 20:37+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
-"Last-Translator: Manon Rondou, 2025\n"
+"Last-Translator: Wil Odoo, 2025\n"
 "Language-Team: French (https://app.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/sale/i18n/ko.po
+++ b/addons/sale/i18n/ko.po
@@ -6,6 +6,7 @@
 # Daye Jeong, 2025
 # Wil Odoo, 2025
 # Sarah Park, 2025
+# Wil Odoo, 2025
 # 
 msgid ""
 msgstr ""
@@ -13,7 +14,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-19 20:37+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
-"Last-Translator: Sarah Park, 2025\n"
+"Last-Translator: Wil Odoo, 2025\n"
 "Language-Team: Korean (https://app.transifex.com/odoo/teams/41243/ko/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/sale/i18n/pt_BR.po
+++ b/addons/sale/i18n/pt_BR.po
@@ -6,6 +6,7 @@
 # a75f12d3d37ea5bf159c4b3e85eb30e7_0fa6927, 2024
 # Wil Odoo, 2025
 # Maitê Dietze, 2025
+# Wil Odoo, 2025
 # 
 msgid ""
 msgstr ""
@@ -13,7 +14,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-19 20:37+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
-"Last-Translator: Maitê Dietze, 2025\n"
+"Last-Translator: Wil Odoo, 2025\n"
 "Language-Team: Portuguese (Brazil) (https://app.transifex.com/odoo/teams/41243/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/sale/i18n/zh_TW.po
+++ b/addons/sale/i18n/zh_TW.po
@@ -3,8 +3,8 @@
 # 	* sale
 # 
 # Translators:
-# Wil Odoo, 2025
 # Tony Ng, 2025
+# Wil Odoo, 2025
 # 
 msgid ""
 msgstr ""
@@ -12,7 +12,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-19 20:37+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
-"Last-Translator: Tony Ng, 2025\n"
+"Last-Translator: Wil Odoo, 2025\n"
 "Language-Team: Chinese (Taiwan) (https://app.transifex.com/odoo/teams/41243/zh_TW/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/snailmail/i18n/cs.po
+++ b/addons/snailmail/i18n/cs.po
@@ -5,7 +5,10 @@
 # Translators:
 # Wil Odoo, 2024
 # Marta Wacławek, 2025
+<<<<<<< HEAD
 # Vojtěch Olšan, 2025
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 # 
 msgid ""
 msgstr ""
@@ -13,7 +16,11 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-09-26 08:56+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
+<<<<<<< HEAD
 "Last-Translator: Vojtěch Olšan, 2025\n"
+=======
+"Last-Translator: Marta Wacławek, 2025\n"
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 "Language-Team: Czech (https://app.transifex.com/odoo/teams/41243/cs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/stock/i18n/ca.po
+++ b/addons/stock/i18n/ca.po
@@ -34,7 +34,10 @@
 # Jonatan Gk, 2025
 # Noemi Pla, 2025
 # Santiago Payà <santiagopim@gmail.com>, 2025
+<<<<<<< HEAD
 # Josep Anton Belchi, 2025
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 # 
 msgid ""
 msgstr ""
@@ -42,7 +45,11 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-19 20:36+0000\n"
 "PO-Revision-Date: 2024-09-25 09:42+0000\n"
+<<<<<<< HEAD
 "Last-Translator: Josep Anton Belchi, 2025\n"
+=======
+"Last-Translator: Santiago Payà <santiagopim@gmail.com>, 2025\n"
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 "Language-Team: Catalan (https://app.transifex.com/odoo/teams/41243/ca/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/stock/i18n/el.po
+++ b/addons/stock/i18n/el.po
@@ -18,7 +18,10 @@
 # Larissa Manderfeld, 2025
 # Charalampos Loukas, 2025
 # Agapi Psyllou, 2025
+<<<<<<< HEAD
 # Anastasia Mimou, 2025
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 # 
 msgid ""
 msgstr ""
@@ -26,7 +29,11 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-19 20:36+0000\n"
 "PO-Revision-Date: 2024-09-25 09:42+0000\n"
+<<<<<<< HEAD
 "Last-Translator: Anastasia Mimou, 2025\n"
+=======
+"Last-Translator: Agapi Psyllou, 2025\n"
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 "Language-Team: Greek (https://app.transifex.com/odoo/teams/41243/el/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/stock_landed_costs/i18n/cs.po
+++ b/addons/stock_landed_costs/i18n/cs.po
@@ -5,7 +5,10 @@
 # Translators:
 # Wil Odoo, 2024
 # Denis Gobin, 2025
+<<<<<<< HEAD
 # Vojtěch Olšan, 2025
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 # 
 msgid ""
 msgstr ""
@@ -13,7 +16,11 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-09-25 08:39+0000\n"
 "PO-Revision-Date: 2024-09-25 09:42+0000\n"
+<<<<<<< HEAD
 "Last-Translator: Vojtěch Olšan, 2025\n"
+=======
+"Last-Translator: Denis Gobin, 2025\n"
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 "Language-Team: Czech (https://app.transifex.com/odoo/teams/41243/cs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/web/i18n/el.po
+++ b/addons/web/i18n/el.po
@@ -18,8 +18,8 @@
 # Leonidas Chiotis, 2025
 # Larissa Manderfeld, 2025
 # Maria Chalepiadou, 2025
-# Agapi Psyllou, 2025
 # Anastasia Mimou, 2025
+# Agapi Psyllou, 2025
 # 
 msgid ""
 msgstr ""
@@ -27,7 +27,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 13:24+0000\n"
 "PO-Revision-Date: 2024-09-25 09:42+0000\n"
-"Last-Translator: Anastasia Mimou, 2025\n"
+"Last-Translator: Agapi Psyllou, 2025\n"
 "Language-Team: Greek (https://app.transifex.com/odoo/teams/41243/el/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/website_blog/i18n/nl.po
+++ b/addons/website_blog/i18n/nl.po
@@ -4,8 +4,8 @@
 # 
 # Translators:
 # Wil Odoo, 2024
-# Manon Rondou, 2025
 # Erwin van der Ploeg <erwin@odooexperts.nl>, 2025
+# Manon Rondou, 2025
 # 
 msgid ""
 msgstr ""
@@ -13,7 +13,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-09-26 08:56+0000\n"
 "PO-Revision-Date: 2024-09-25 09:42+0000\n"
-"Last-Translator: Erwin van der Ploeg <erwin@odooexperts.nl>, 2025\n"
+"Last-Translator: Manon Rondou, 2025\n"
 "Language-Team: Dutch (https://app.transifex.com/odoo/teams/41243/nl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/addons/website_sale/i18n/es.po
+++ b/addons/website_sale/i18n/es.po
@@ -594,8 +594,11 @@ msgstr "<u>Términos y condiciones</u>"
 #: code:addons/website_sale/controllers/combo_configurator.py:0
 msgid "A combo product can't be empty. Please select at least one option."
 msgstr ""
+<<<<<<< HEAD
 "Un producto de combinación no puede estar vacío. Seleccione al menos una "
 "opción."
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale
 #: model:ir.model.fields,help:website_sale.field_delivery_carrier__website_description

--- a/addons/website_sale/i18n/es_419.po
+++ b/addons/website_sale/i18n/es_419.po
@@ -593,7 +593,10 @@ msgstr "<u>Términos y condiciones</u>"
 #: code:addons/website_sale/controllers/combo_configurator.py:0
 msgid "A combo product can't be empty. Please select at least one option."
 msgstr ""
+<<<<<<< HEAD
 "Un combo de producto no puede estar vacío. Seleccione al menos una opción."
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale
 #: model:ir.model.fields,help:website_sale.field_delivery_carrier__website_description

--- a/addons/website_sale/i18n/fa.po
+++ b/addons/website_sale/i18n/fa.po
@@ -529,7 +529,10 @@ msgstr "شرایط و ضوابط"
 #: code:addons/website_sale/controllers/combo_configurator.py:0
 msgid "A combo product can't be empty. Please select at least one option."
 msgstr ""
+<<<<<<< HEAD
 "یک محصول ترکیبی نمی تواند خالی باشد. لطفا حداقل یک گزینه را انتخاب کنید."
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale
 #: model:ir.model.fields,help:website_sale.field_delivery_carrier__website_description

--- a/addons/website_sale/i18n/fr.po
+++ b/addons/website_sale/i18n/fr.po
@@ -595,8 +595,11 @@ msgstr "<u>Conditions générales</u>"
 #: code:addons/website_sale/controllers/combo_configurator.py:0
 msgid "A combo product can't be empty. Please select at least one option."
 msgstr ""
+<<<<<<< HEAD
 "Un produit combo ne peut pas être vide. Veuillez sélectionner au moins une "
 "option."
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale
 #: model:ir.model.fields,help:website_sale.field_delivery_carrier__website_description

--- a/addons/website_sale/i18n/it.po
+++ b/addons/website_sale/i18n/it.po
@@ -590,7 +590,11 @@ msgstr "<u>Termini e condizioni</u>"
 #. odoo-python
 #: code:addons/website_sale/controllers/combo_configurator.py:0
 msgid "A combo product can't be empty. Please select at least one option."
+<<<<<<< HEAD
 msgstr "Un prodotto combo non può essere vuoto. Scegli almeno un'opzione."
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale
 #: model:ir.model.fields,help:website_sale.field_delivery_carrier__website_description

--- a/addons/website_sale/i18n/ja.po
+++ b/addons/website_sale/i18n/ja.po
@@ -584,7 +584,11 @@ msgstr "<u>利用規約</u>"
 #. odoo-python
 #: code:addons/website_sale/controllers/combo_configurator.py:0
 msgid "A combo product can't be empty. Please select at least one option."
+<<<<<<< HEAD
 msgstr "コンボプロダクトは空にすることはできません。 少なくとも1つのオプションを選択して下さい。"
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale
 #: model:ir.model.fields,help:website_sale.field_delivery_carrier__website_description

--- a/addons/website_sale/i18n/nl.po
+++ b/addons/website_sale/i18n/nl.po
@@ -592,7 +592,11 @@ msgstr "<u>Algemene voorwaarden</u>"
 #. odoo-python
 #: code:addons/website_sale/controllers/combo_configurator.py:0
 msgid "A combo product can't be empty. Please select at least one option."
+<<<<<<< HEAD
 msgstr "Een comboproduct kan niet leeg zijn. Selecteer ten minste één optie."
+=======
+msgstr ""
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale
 #: model:ir.model.fields,help:website_sale.field_delivery_carrier__website_description

--- a/addons/website_sale/i18n/pt_BR.po
+++ b/addons/website_sale/i18n/pt_BR.po
@@ -591,7 +591,10 @@ msgstr "<u>Termos e Condições</u>"
 #: code:addons/website_sale/controllers/combo_configurator.py:0
 msgid "A combo product can't be empty. Please select at least one option."
 msgstr ""
+<<<<<<< HEAD
 "Um produto de combo não pode estar vazio. Selecione pelo menos uma opção."
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale
 #: model:ir.model.fields,help:website_sale.field_delivery_carrier__website_description

--- a/addons/website_sale_stock_wishlist/i18n/es.po
+++ b/addons/website_sale_stock_wishlist/i18n/es.po
@@ -57,8 +57,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Añadir</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_stock_wishlist
 #. odoo-javascript

--- a/addons/website_sale_stock_wishlist/i18n/es_419.po
+++ b/addons/website_sale_stock_wishlist/i18n/es_419.po
@@ -57,8 +57,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Agregar</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_stock_wishlist
 #. odoo-javascript

--- a/addons/website_sale_stock_wishlist/i18n/fr.po
+++ b/addons/website_sale_stock_wishlist/i18n/fr.po
@@ -57,8 +57,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Ajouter</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_stock_wishlist
 #. odoo-javascript

--- a/addons/website_sale_stock_wishlist/i18n/id.po
+++ b/addons/website_sale_stock_wishlist/i18n/id.po
@@ -57,8 +57,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Tambah</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_stock_wishlist
 #. odoo-javascript

--- a/addons/website_sale_stock_wishlist/i18n/it.po
+++ b/addons/website_sale_stock_wishlist/i18n/it.po
@@ -57,8 +57,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Aggiungi</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_stock_wishlist
 #. odoo-javascript

--- a/addons/website_sale_stock_wishlist/i18n/ja.po
+++ b/addons/website_sale_stock_wishlist/i18n/ja.po
@@ -57,8 +57,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">追加</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_stock_wishlist
 #. odoo-javascript

--- a/addons/website_sale_stock_wishlist/i18n/ko.po
+++ b/addons/website_sale_stock_wishlist/i18n/ko.po
@@ -57,8 +57,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">추가</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_stock_wishlist
 #. odoo-javascript

--- a/addons/website_sale_stock_wishlist/i18n/nl.po
+++ b/addons/website_sale_stock_wishlist/i18n/nl.po
@@ -57,8 +57,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Toevoegen</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_stock_wishlist
 #. odoo-javascript

--- a/addons/website_sale_stock_wishlist/i18n/pt_BR.po
+++ b/addons/website_sale_stock_wishlist/i18n/pt_BR.po
@@ -57,8 +57,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Add</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_stock_wishlist
 #. odoo-javascript

--- a/addons/website_sale_stock_wishlist/i18n/zh_CN.po
+++ b/addons/website_sale_stock_wishlist/i18n/zh_CN.po
@@ -5,7 +5,10 @@
 # Translators:
 # Wil Odoo, 2024
 # 何彬 <vnsoft.he@gmail.com>, 2024
+<<<<<<< HEAD
 # Chloe Wang, 2025
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 # 
 msgid ""
 msgstr ""
@@ -13,7 +16,11 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-10-26 21:56+0000\n"
 "PO-Revision-Date: 2024-09-25 09:42+0000\n"
+<<<<<<< HEAD
 "Last-Translator: Chloe Wang, 2025\n"
+=======
+"Last-Translator: 何彬 <vnsoft.he@gmail.com>, 2024\n"
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 "Language-Team: Chinese (China) (https://app.transifex.com/odoo/teams/41243/zh_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,8 +65,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">添加</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_stock_wishlist
 #. odoo-javascript

--- a/addons/website_sale_stock_wishlist/i18n/zh_TW.po
+++ b/addons/website_sale_stock_wishlist/i18n/zh_TW.po
@@ -57,8 +57,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                <span class=\"d-none d-md-inline\">加入</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_stock_wishlist
 #. odoo-javascript

--- a/addons/website_sale_wishlist/i18n/es.po
+++ b/addons/website_sale_wishlist/i18n/es.po
@@ -49,8 +49,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Añadir</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_wishlist
 #: model_terms:ir.ui.view,arch_db:website_sale_wishlist.add_to_wishlist

--- a/addons/website_sale_wishlist/i18n/es_419.po
+++ b/addons/website_sale_wishlist/i18n/es_419.po
@@ -50,8 +50,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Agregar</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_wishlist
 #: model_terms:ir.ui.view,arch_db:website_sale_wishlist.add_to_wishlist

--- a/addons/website_sale_wishlist/i18n/fa.po
+++ b/addons/website_sale_wishlist/i18n/fa.po
@@ -50,8 +50,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">افزودن</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_wishlist
 #: model_terms:ir.ui.view,arch_db:website_sale_wishlist.add_to_wishlist

--- a/addons/website_sale_wishlist/i18n/fr.po
+++ b/addons/website_sale_wishlist/i18n/fr.po
@@ -49,8 +49,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Ajouter</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_wishlist
 #: model_terms:ir.ui.view,arch_db:website_sale_wishlist.add_to_wishlist

--- a/addons/website_sale_wishlist/i18n/id.po
+++ b/addons/website_sale_wishlist/i18n/id.po
@@ -49,8 +49,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Tambah</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_wishlist
 #: model_terms:ir.ui.view,arch_db:website_sale_wishlist.add_to_wishlist

--- a/addons/website_sale_wishlist/i18n/it.po
+++ b/addons/website_sale_wishlist/i18n/it.po
@@ -49,8 +49,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Aggiungi</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_wishlist
 #: model_terms:ir.ui.view,arch_db:website_sale_wishlist.add_to_wishlist

--- a/addons/website_sale_wishlist/i18n/ja.po
+++ b/addons/website_sale_wishlist/i18n/ja.po
@@ -49,8 +49,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">追加</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_wishlist
 #: model_terms:ir.ui.view,arch_db:website_sale_wishlist.add_to_wishlist

--- a/addons/website_sale_wishlist/i18n/ko.po
+++ b/addons/website_sale_wishlist/i18n/ko.po
@@ -50,8 +50,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">추가</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_wishlist
 #: model_terms:ir.ui.view,arch_db:website_sale_wishlist.add_to_wishlist

--- a/addons/website_sale_wishlist/i18n/nl.po
+++ b/addons/website_sale_wishlist/i18n/nl.po
@@ -50,8 +50,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Toevoegen</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_wishlist
 #: model_terms:ir.ui.view,arch_db:website_sale_wishlist.add_to_wishlist

--- a/addons/website_sale_wishlist/i18n/pt_BR.po
+++ b/addons/website_sale_wishlist/i18n/pt_BR.po
@@ -49,8 +49,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Add</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_wishlist
 #: model_terms:ir.ui.view,arch_db:website_sale_wishlist.add_to_wishlist

--- a/addons/website_sale_wishlist/i18n/zh_CN.po
+++ b/addons/website_sale_wishlist/i18n/zh_CN.po
@@ -50,8 +50,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">添加</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_wishlist
 #: model_terms:ir.ui.view,arch_db:website_sale_wishlist.add_to_wishlist

--- a/addons/website_sale_wishlist/i18n/zh_TW.po
+++ b/addons/website_sale_wishlist/i18n/zh_TW.po
@@ -49,8 +49,11 @@ msgid ""
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
+<<<<<<< HEAD
 "<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
 "                                                <span class=\"d-none d-md-inline\">加入</span>"
+=======
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 
 #. module: website_sale_wishlist
 #: model_terms:ir.ui.view,arch_db:website_sale_wishlist.add_to_wishlist

--- a/addons/website_slides/i18n/nl.po
+++ b/addons/website_slides/i18n/nl.po
@@ -3,9 +3,15 @@
 # 	* website_slides
 # 
 # Translators:
+<<<<<<< HEAD
 # Wil Odoo, 2025
 # Manon Rondou, 2025
 # Erwin van der Ploeg <erwin@odooexperts.nl>, 2025
+=======
+# Erwin van der Ploeg <erwin@odooexperts.nl>, 2025
+# Wil Odoo, 2025
+# Manon Rondou, 2025
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 # 
 msgid ""
 msgstr ""
@@ -13,7 +19,11 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-19 20:36+0000\n"
 "PO-Revision-Date: 2024-09-25 09:42+0000\n"
+<<<<<<< HEAD
 "Last-Translator: Erwin van der Ploeg <erwin@odooexperts.nl>, 2025\n"
+=======
+"Last-Translator: Manon Rondou, 2025\n"
+>>>>>>> 316094dbb972 ([I18N] *: fetch 18.0 translations)
 "Language-Team: Dutch (https://app.transifex.com/odoo/teams/41243/nl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/odoo/addons/base/i18n/ru.po
+++ b/odoo/addons/base/i18n/ru.po
@@ -46445,7 +46445,7 @@ msgstr "внешний ID"
 #. odoo-python
 #: code:addons/base/models/ir_fields.py:0
 msgid "false"
-msgstr "ложь"
+msgstr "false"
 
 #. module: base
 #: model:ir.model.fields.selection,name:base.selection__ir_model_fields__ttype__float


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When creating a new journal entry, clearing the date field causes an error because the system tries to compute the placeholder name field using the date, which is missing.

Current behavior before PR:
An error is raised when the date field is cleared while creating a journal entry, as the computation of the name field relies on the date field being present.

Desired behavior after PR is merged:
The system will check if the date field is present before computing the name field. If the date field is missing, a default value will be used, or a clear validation error will be displayed to the user.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
