### PR TITLE
[FIX] html_editor: ZWS before banner

### DIFF
--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -101,11 +101,12 @@ export class BannerPlugin extends Plugin {
         ).childNodes[0];
         this.dependencies.dom.insert(bannerElement);
         // If the first child of editable is contenteditable false element
-        // a chromium bug prevents selecting the container. Prepend a
-        // zero-width space so it's no longer the first child.
+        // a chromium bug prevents selecting the container.
+        // Add a paragraph above it so it's no longer the first child.
         if (this.editable.firstChild === bannerElement) {
-            const zws = document.createTextNode("\u200B");
-            bannerElement.before(zws);
+            const p = this.document.createElement("p");
+            p.append(this.document.createElement("br"));
+            bannerElement.before(p);
         }
         const baseContainerName = this.dependencies.baseContainer.getDefaultNodeName();
         this.dependencies.selection.setCursorStart(

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -114,27 +114,64 @@ test("remove all content should preserves the first paragraph tag inside the ban
     );
 });
 
+test("Inserting a banner at the top of the editable also inserts a paragraph above it", async () => {
+    const { el, editor } = await setupEditor("<p>[]</p>");
+    await insertText(editor, "/bannerinfo");
+    await press("enter");
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<p><br></p>
+            <div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
+                <div class="w-100 px-3 o_editable" contenteditable="true">
+                    <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
+                </div>
+            </div>
+            <p><br></p>`
+        )
+    );
+});
+
 test("Everything gets selected with ctrl+a, including a contenteditable=false as first element", async () => {
+    const { el } = await setupEditor(
+        `<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
+                <div class="w-100 px-3" contenteditable="true">
+                    <p><br></p>
+                </div>
+            </div><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
+    );
+    await press(["ctrl", "a"]);
+    await animationFrame();
+    expect(getContent(el)).toBe(
+        `[<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
+                <div class="w-100 px-3" contenteditable="true">
+                    <p><br></p>
+                </div>
+            </div><p placeholder='Type "/" for commands' class="o-we-hint"><br></p>]`
+    );
+});
+
+test("Everything gets selected with ctrl+a, including a banner", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
     await insertText(editor, "/bannerinfo");
     await press("enter");
     // Move the selection outside of the banner
-    setSelection({ anchorNode: el.querySelectorAll("p")[1], anchorOffset: 0 });
+    setSelection({ anchorNode: el.querySelectorAll("p")[2], anchorOffset: 0 });
     await insertText(editor, "Test1");
     await manuallyDispatchProgrammaticEvent(editor.editable, "beforeinput", {
         inputType: "insertParagraph",
     });
     await insertText(editor, "Test2");
     await press(["ctrl", "a"]);
-    expect(unformat(getContent(el))).toBe(
-        unformat(
-            `[\u200b<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                    <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                    <div class="w-100 px-3 o_editable" contenteditable="true">
-                        <p><br></p>
-                    </div>
-                </div><p>Test1</p><p>Test2<br></p>]`
-        ),
+    expect(getContent(el)).toBe(
+        `[<p><br></p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
+                <div class="w-100 px-3 o_editable" contenteditable="true">
+                    <p><br></p>
+                </div>
+            </div><p>Test1</p><p>Test2<br></p>]`,
         { message: "should select everything" }
     );
 


### PR DESCRIPTION
Before this commit and since [1], when inserting a banner at the top of the editable, a zero-width space (ZWS) was inserted before the banner to circuvent a Chromium bug that prevents fully selecting the banner with the mouse [2].

This led to the undesirable behavior of having a text node (with a ZWS) as the first child of the editable, creating a line above the banner and allowing for text insertion at the editable's root.

This commit replaces the ZWS insertion with an empty paragraph, which can be later be moved around by the user.

[1]: https://github.com/odoo/odoo/commit/a0fcba694a8a23a947ba28d188d6806272627447
[2]: https://issues.chromium.org/issues/40822311

task-4512959
