### PR TITLE
[FIX] im_livechat: prevent opening ended chat on Tab key press

### DIFF
--- a/addons/im_livechat/static/src/core/web/store_service_patch.js
+++ b/addons/im_livechat/static/src/core/web/store_service_patch.js
@@ -24,7 +24,10 @@ const storePatch = {
         const [oldestUnreadThread] = this.discuss.livechats
             .filter((thread) => thread.isUnread)
             .sort(
-                (t1, t2) => compareDatetime(t1.lastInterestDt, t2.lastInterestDt) || t1.id - t2.id
+                (t1, t2) =>
+                    t2.livechat_active - t1.livechat_active ||
+                    compareDatetime(t1.lastInterestDt, t2.lastInterestDt) ||
+                    t1.id - t2.id
             );
         if (!oldestUnreadThread) {
             return false;


### PR DESCRIPTION
**Current behavior before PR:**

When a user had an open live chat window and pressed the Tab
key, it resulted in an ended chat window being opened.

**Desired behavior after PR is merged:**

This fix ensures that pressing the Tab key will open active live chats
first, then the ended chats. It also keeps the focus on the chat window
if the live chat has ended.

Task-4507082

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
