### PR TITLE
[FIX] uom: be able to modify the UoM on product template

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -796,6 +796,15 @@ msgid "Are you sure you want to cancel this manufacturing order?"
 msgstr ""
 
 #. module: mrp
+#. odoo-python
+#: code:addons/mrp/models/product.py:0
+msgid ""
+"As other units of measure (ex : %(problem_uom)s) than %(uom)s have already "
+"been used for this product, the change of unit of measure can not be done.If"
+" you want to change it, please archive the product and create a new one."
+msgstr ""
+
+#. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.report_mrporder
 msgid "Assembling"
 msgstr ""

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4149,9 +4149,9 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(production.workorder_ids.duration_expected, init_duration_expected + 5)
 
     def test_batch_production_01(self):
-        """ Test the wizard mrp.batch.produce without tracked components.
-        """
+        """ Test the wizard mrp.batch.produce without tracked components."""
         self.product_4.tracking = 'serial'
+        self.bom_1.product_uom_id = self.product_4.uom_id
         self.product_4.uom_id = self.uom_unit
         mo_form = Form(self.env['mrp.production'])
         mo_form.bom_id = self.bom_1
@@ -4182,6 +4182,7 @@ class TestMrpOrder(TestMrpCommon):
         self.env['stock.picking.type'].search([('code', '=', 'mrp_operation')]).use_create_components_lots = True
         self.product_1.tracking = 'serial'
         self.product_4.tracking = 'serial'
+        self.bom_1.product_uom_id = self.product_4.uom_id
         self.product_4.uom_id = self.uom_unit
 
         mo_form = Form(self.env['mrp.production'])
@@ -4223,6 +4224,7 @@ class TestMrpOrder(TestMrpCommon):
         self.product_1.tracking = 'serial'
         self.product_2.tracking = 'lot'
         self.product_4.tracking = 'serial'
+        self.bom_1.product_uom_id = self.product_4.uom_id
         self.product_4.uom_id = self.uom_unit
 
         mo_form = Form(self.env['mrp.production'])

--- a/addons/mrp/tests/test_smp.py
+++ b/addons/mrp/tests/test_smp.py
@@ -294,6 +294,7 @@ class TestMrpSerialMassProduce(TestMrpCommon):
         - Create a MO with 12 final products to produce.
         - update the component quantity to 100
         """
+        self.bom_1.product_uom_id = self.bom_1.product_id.uom_id
         self.bom_1.product_id.uom_id = self.ref('uom.product_uom_unit')
         self.bom_1.product_id.tracking = 'serial'
         self.bom_1.product_qty = 1

--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -32,6 +32,7 @@ class TestMrpAccount(TestMrpCommon):
             'time_stop': 5,
             'time_efficiency': 85,
         })
+        cls.bom_1.product_uom_id = cls.uom_dozen
         cls.product_4.uom_id = cls.uom_unit
         cls.planning_bom = cls.env['mrp.bom'].create({
             'product_id': cls.product_4.id,

--- a/addons/purchase/i18n/purchase.pot
+++ b/addons/purchase/i18n/purchase.pot
@@ -666,6 +666,15 @@ msgid "Are you sure you want to cancel the selected RFQs/Orders?"
 msgstr ""
 
 #. module: purchase
+#. odoo-python
+#: code:addons/purchase/models/product.py:0
+msgid ""
+"As other units of measure (ex : %(problem_uom)s) than %(uom)s have already "
+"been used for this product, the change of unit of measure can not be done.If"
+" you want to change it, please archive the product and create a new one."
+msgstr ""
+
+#. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_order__message_attachment_count
 msgid "Attachment Count"
 msgstr ""

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -313,7 +313,7 @@ class PurchaseOrderLine(models.Model):
     @api.depends('product_qty', 'product_uom_id', 'company_id', 'order_id.partner_id')
     def _compute_price_unit_and_date_planned_and_name(self):
         for line in self:
-            if not line.product_id or line.invoice_lines or not line.company_id:
+            if not line.product_id or line.invoice_lines or not line.company_id or self.env.context.get('skip_uom_conversion'):
                 continue
             params = line._get_select_sellers_params()
             seller = line.product_id._select_seller(

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -101,11 +101,6 @@ class PurchaseOrderLine(models.Model):
         lines = self.filtered(lambda l: l.order_id.state == 'purchase'
                                         and not l.display_type)
 
-        if 'product_uom_id' in values and values['product_uom_id'] != self.product_id.uom_id.id:
-            self.move_ids.filtered(
-                lambda m: m.state not in ['cancel', 'done']
-            ).product_uom = values['product_uom_id']
-
         previous_product_uom_qty = {line.id: line.product_uom_qty for line in lines}
         previous_product_qty = {line.id: line.product_qty for line in lines}
         result = super(PurchaseOrderLine, self).write(values)

--- a/addons/repair/i18n/repair.pot
+++ b/addons/repair/i18n/repair.pot
@@ -224,6 +224,15 @@ msgid "Any Part is late"
 msgstr ""
 
 #. module: repair
+#. odoo-python
+#: code:addons/repair/models/product.py:0
+msgid ""
+"As other units of measure (ex : %(problem_uom)s) than %(uom)s have already "
+"been used for this product, the change of unit of measure can not be done.If"
+" you want to change it, please archive the product and create a new one."
+msgstr ""
+
+#. module: repair
 #: model:ir.model.fields,field_description:repair.field_repair_order__message_attachment_count
 msgid "Attachment Count"
 msgstr ""

--- a/addons/repair/models/product.py
+++ b/addons/repair/models/product.py
@@ -36,6 +36,20 @@ class ProductProduct(models.Model):
         ])
         return super()._count_returned_sn_products_domain(sn_lot, or_domains)
 
+    def _update_uom(self, to_uom_id):
+        for uom, product, repairs in self.env['repair.order']._read_group(
+            [('product_id', 'in', self.ids)],
+            ['product_uom', 'product_id'],
+            ['id:recordset'],
+        ):
+            if uom != product.product_tmpl_id.uom_id:
+                raise UserError(_(
+                'As other units of measure (ex : %(problem_uom)s) '
+                'than %(uom)s have already been used for this product, the change of unit of measure can not be done.'
+                'If you want to change it, please archive the product and create a new one.',
+                problem_uom=uom.display_name, uom=product.product_tmpl_id.uom_id.display_name))
+            repairs.product_uom = to_uom_id
+        return super()._update_uom(to_uom_id)
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"

--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -1011,6 +1011,15 @@ msgid ""
 msgstr ""
 
 #. module: sale
+#. odoo-python
+#: code:addons/sale/models/product_product.py:0
+msgid ""
+"As other units of measure (ex : %(problem_uom)s) than %(uom)s have already "
+"been used for this product, the change of unit of measure can not be done.If"
+" you want to change it, please archive the product and create a new one."
+msgstr ""
+
+#. module: sale
 #: model:ir.model.fields.selection,name:sale.selection__product_template__expense_policy__cost
 msgid "At cost"
 msgstr ""

--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -1210,6 +1210,15 @@ msgid "Are you sure you want to cancel this transfer?"
 msgstr ""
 
 #. module: stock
+#. odoo-python
+#: code:addons/stock/models/product.py:0
+msgid ""
+"As other units of measure (ex : %(problem_uom)s) than %(uom)s have already "
+"been used for this product, the change of unit of measure can not be done.If"
+" you want to change it, please archive the product and create a new one."
+msgstr ""
+
+#. module: stock
 #: model:ir.model.fields.selection,name:stock.selection__stock_picking__move_type__direct
 #: model:ir.model.fields.selection,name:stock.selection__stock_picking_type__move_type__direct
 msgid "As soon as possible"

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -12,6 +12,7 @@ from odoo.osv import expression
 from odoo.tools import float_is_zero, check_barcode_encoding
 from odoo.tools.float_utils import float_round
 from odoo.tools.mail import html2plaintext, is_html_empty
+from odoo.tools.misc import groupby
 
 OPERATORS = {
     '<': py_operator.lt,
@@ -658,6 +659,32 @@ class ProductProduct(models.Model):
         or_domains = expression.OR(or_domains)
         return expression.AND([base_domain, or_domains])
 
+    def _update_uom(self, to_uom_id):
+        for uom, product, moves in self.env['stock.move']._read_group(
+            [('product_id', 'in', self.ids)],
+            ['product_uom', 'product_id'],
+            ['id:recordset'],
+        ):
+            if uom != product.product_tmpl_id.uom_id:
+                raise UserError(_('As other units of measure (ex : %(problem_uom)s) '
+                'than %(uom)s have already been used for this product, the change of unit of measure can not be done.'
+                'If you want to change it, please archive the product and create a new one.',
+                problem_uom=uom.name, uom=product.product_tmpl_id.uom_id.name))
+            moves.product_uom = to_uom_id
+
+        for uom, product, move_lines in self.env['stock.move.line']._read_group(
+            [('product_id', 'in', self.ids)],
+            ['product_uom_id', 'product_id'],
+            ['id:recordset'],
+        ):
+            if uom != product.product_tmpl_id.uom_id:
+                raise UserError(_('As other units of measure (ex : %(problem_uom)s) '
+                'than %(uom)s have already been used for this product, the change of unit of measure can not be done.'
+                'If you want to change it, please archive the product and create a new one.',
+                problem_uom=uom.name, uom=product.product_tmpl_id.uom_id.name))
+            move_lines.product_uom_id = to_uom_id
+        return super()._update_uom(to_uom_id)
+
     def filter_has_routes(self):
         """ Return products with route_ids
             or whose categ_id has total_route_ids.
@@ -668,6 +695,15 @@ class ProductProduct(models.Model):
         # retrive products with categ_ids having routes
         products_with_routes += self.search([('id', 'in', (self - products_with_routes).ids), ('categ_id.total_route_ids', '!=', False)])
         return products_with_routes
+
+    def _trigger_uom_warning(self):
+        res = super()._trigger_uom_warning()
+        if res:
+            return res
+        moves = self.env['stock.move'].sudo().search_count(
+            [('product_id', 'in', self.ids)], limit=1
+        )
+        return bool(moves)
 
 
 class ProductTemplate(models.Model):
@@ -886,23 +922,6 @@ class ProductTemplate(models.Model):
                 )
             }
         return res
-
-    @api.onchange('uom_id')
-    def _onchange_uom_id(self):
-        moves = self.env['stock.move'].sudo().search_count(
-            [('product_id', 'in', self.with_context(active_test=False).product_variant_ids.ids)], limit=1
-        )
-        if moves:
-            return {
-                'warning': {
-                    'title': _('Warning!'),
-                    'message': _(
-                        'This product has been used in at least one inventory movement. '
-                        'It is not advised to change the Unit of Measure since it can lead to inconsistencies. '
-                        'The existing moves will not be recalculated with the new unit of measure.'
-                    )
-                }
-            }
 
     def write(self, vals):
         if 'company_id' in vals and vals['company_id']:

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -675,7 +675,7 @@ Please change the quantity done or the rounding precision in your settings.""",
         if 'quantity' in vals:
             if any(move.state == 'cancel' for move in self):
                 raise UserError(_('You cannot change a cancelled stock move, create a new line instead.'))
-        if 'product_uom' in vals and any(move.state == 'done' for move in self):
+        if 'product_uom' in vals and any(move.state == 'done' for move in self) and not self.env.context.get('skip_uom_conversion'):
             raise UserError(_('You cannot change the UoM for a stock move that has been set to \'Done\'.'))
         if 'product_uom_qty' in vals:
             for move in self.filtered(lambda m: m.state not in ('done', 'draft') and m.picking_id):

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -433,6 +433,8 @@ class StockMoveLine(models.Model):
             vals.update(self._copy_quant_info(vals))
         updates = {}
         for key, model in triggers:
+            if self.env.context.get('skip_uom_conversion'):
+                continue
             if key in vals:
                 updates[key] = vals[key] if isinstance(vals[key], models.BaseModel) else self.env[model].browse(vals[key])
 


### PR DESCRIPTION
The constraint to change the main UoM of a product has been removed.
Globally on advanced case, it will result in a data corruption.

There is two different use case when modifying the UoM of product.
First, the user wants to manage the product flow to handle a different packaging
by default (e.g. unit to pack of 6). In this case, the previous
documents (SO/PO/...) can be trust and we need to update the current inventory
in consequence (30 units -> 5 pack of 6).
Second, he made a mistake or install the UoM setting and wants to update
the everything at once. In this case we set the new UoM everywhere and
we don't do any re-computation.

Both flows are valid use cases but we choose to handle the second for a
better on boarding of new users.

In order to do it, we check if all the documents are in the base UoM and
if it's possible to modify them everywhere without any computation. If
not, we block as before. If yes, we update all the stored many2one for
UoM accordingly.
