### PR TITLE
[FIX] mail: mark as read depends on inbox counter

### DIFF
--- a/addons/mail/static/src/core/web/thread_actions.js
+++ b/addons/mail/static/src/core/web/thread_actions.js
@@ -10,7 +10,7 @@ threadActionsRegistry
             return component.thread?.id === "inbox";
         },
         disabledCondition(component) {
-            return component.thread.isEmpty;
+            return component.thread.isEmpty && !component.store.inbox.counter;
         },
         open(component) {
             component.orm.silent.call("mail.message", "mark_all_as_read");


### PR DESCRIPTION
Before this commit, when got a needaction_message from records that you don't have access to, you will see the counter of the inbox but you cannot mark it as read.

The reason was that the mark as read action was based on the isEmpty of the thread but if you don't have access to the record, the message will not be fetched and the computation was not correct.

The fix is to depend on the inbox counter so that the behavior of the red dot is consistent with the mark as read action.

![5666720560](https://github.com/user-attachments/assets/ec800614-448e-4608-84d2-5add1599c1d2)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
