### PR TITLE
[IMP] pos_viva_wallet: add refund support

### DIFF
--- a/addons/pos_viva_wallet/models/__init__.py
+++ b/addons/pos_viva_wallet/models/__init__.py
@@ -1,4 +1,5 @@
 # coding: utf-8
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import pos_payment
 from . import pos_payment_method

--- a/addons/pos_viva_wallet/models/pos_payment.py
+++ b/addons/pos_viva_wallet/models/pos_payment.py
@@ -1,0 +1,7 @@
+from odoo import models, fields
+
+
+class PosPayment(models.Model):
+    _inherit = "pos.payment"
+
+    viva_wallet_session_id = fields.Char(help="Session ID of the transaction, stored so that it can be used to refund the payment.")

--- a/addons/pos_viva_wallet/models/pos_payment_method.py
+++ b/addons/pos_viva_wallet/models/pos_payment_method.py
@@ -150,6 +150,13 @@ class PosPaymentMethod(models.Model):
         endpoint = "transactions:sale"
         return self._call_viva_wallet(endpoint, 'post', data)
 
+    def viva_wallet_send_refund_request(self, data):
+        if not self.env.user.has_group('point_of_sale.group_pos_user'):
+            raise AccessError(_("Only 'group_pos_user' are allowed to send a Viva Wallet refund request"))
+
+        endpoint = "transactions:refund" if data.get("parentSessionId") else "transactions:unreferenced-refund"
+        return self._call_viva_wallet(endpoint, 'post', data)
+
     def viva_wallet_send_payment_cancel(self, data):
         if not self.env.user.has_group('point_of_sale.group_pos_user'):
             raise AccessError(_("Only 'group_pos_user' are allowed to cancel a Viva Wallet payment"))

--- a/addons/pos_viva_wallet/static/src/overrides/models/pos_payment.js
+++ b/addons/pos_viva_wallet/static/src/overrides/models/pos_payment.js
@@ -1,0 +1,9 @@
+import { PosPayment } from "@point_of_sale/app/models/pos_payment";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosPayment.prototype, {
+    updateRefundPaymentLine(refundedPaymentLine) {
+        super.updateRefundPaymentLine(refundedPaymentLine);
+        this.vivaWalletParentSessionId = refundedPaymentLine?.viva_wallet_session_id;
+    },
+});


### PR DESCRIPTION
Before this PR, refunds were not supported
for Viva Wallet, and trying to initiate a refund
transaction would result in an error.

After this PR, if the payment amount is
negative a refund is initiated via the Viva API
instead of a payment.

There are two types of refunds that can occur. A
regular refund occurs when the order originally
used a Viva wallet payment, and we are refunding
the same amount as was paid. In this case, we
directly refund the original Viva transaction.
This has the benefit of being quicker and also
refunding the processing fees.

In other cases, we use 'unreferenced' refunds,
meaning they are not linked to any previous
transaction and can therefore be any amount.
However, there must be enough money remaining
in the Viva account to process the refund, or an
error will occur.

task-3619622

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
