### PR TITLE
[FIX] website_sale: shop product grid border

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -319,7 +319,7 @@ $input-border-color: $gray-400;
                 }
 
                 &::after {
-                    width: 100vw;
+                    width: calc(100% + var(--o-wsale-products-grid-gap));
                     height: $border-width;
                     bottom: calc(var(--line-offset-y) * -1);
                     left: calc(var(--line-offset-x) * -1);


### PR DESCRIPTION
Issue: in the /shop page, using the grid style if we change the size of a product on another column than the first one, the border of the grid will appear on the product or behind its image.

This is due to the width 100vw which extends behind the product's current width and overflowing on other products of the same row.

task-4513299
opw-4447224

| ![image](https://github.com/user-attachments/assets/f09e4233-f8da-441f-ba52-eefa139d0b75)|
|--------|



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
