### PR TITLE
[FIX] mail: mentions in channel threads respect channel group

### DIFF
--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -82,11 +82,12 @@ class ResPartner(models.Model):
             [('user_ids.active', '=', True)],
             [('partner_share', '=', False)]
         ])
-        if channel.group_public_id.id:
+        allowed_group = (channel.parent_channel_id or channel).group_public_id
+        if allowed_group:
             extra_domain = expression.AND(
                 [
                     extra_domain,
-                    [("user_ids.groups_id", "in", channel.group_public_id.id)],
+                    [("user_ids.groups_id", "in", allowed_group.id)],
                 ]
             )
         partners = self._search_mention_suggestions(domain, limit, extra_domain)
@@ -97,7 +98,7 @@ class ResPartner(models.Model):
             ]
         )
         store = Store(members, fields={"channel": [], "persona": []})
-        if channel.group_public_id:
+        if allowed_group:
             for p in partners:
-                store.add(p, {"groups_id": [("ADD", (channel.group_public_id & p.user_ids.groups_id).ids)]})
+                store.add(p, {"groups_id": [("ADD", (allowed_group & p.user_ids.groups_id).ids)]})
         return store.get_result()

--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -165,7 +165,8 @@ export class SuggestionService {
             thread &&
             (thread.channel_type === "group" ||
                 thread.channel_type === "chat" ||
-                (thread.channel_type === "channel" && thread.authorizedGroupFullName));
+                (thread.channel_type === "channel" &&
+                    (thread.parent_channel_id || thread).group_public_id));
         if (isNonPublicChannel) {
             // Only return the channel members when in the context of a
             // group restricted channel. Indeed, the message with the mention
@@ -176,7 +177,8 @@ export class SuggestionService {
                 .map((member) => member.persona)
                 .filter((persona) => persona.type === "partner");
             if (thread.channel_type === "channel") {
-                partners = new Set([...partners, ...(thread.group_public_id?.personas ?? [])]);
+                const group = (thread.parent_channel_id || thread).group_public_id;
+                partners = new Set([...partners, ...(group?.personas ?? [])]);
             }
         } else {
             partners = Object.values(this.store.Persona.records).filter((persona) => {

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -113,8 +113,10 @@ export class ResPartner extends webModels.ResPartner {
             ["active", "=", true],
             ["partner_share", "=", false],
         ];
-        if (channel.group_public_id) {
-            extraDomain.push(["groups_id", "in", channel.group_public_id]);
+        const parent_channel = this.browse(channel.parent_channel_id);
+        const allowed_group = parent_channel?.group_public_id ?? channel.group_public_id;
+        if (allowed_group) {
+            extraDomain.push(["groups_id", "in", allowed_group]);
         }
         const baseDomain = search
             ? ["|", ["name", "ilike", searchLower], ["email", "ilike", searchLower]]
@@ -146,8 +148,8 @@ export class ResPartner extends webModels.ResPartner {
         for (const partnerId of partners) {
             const data = {
                 name: users[partnerId]?.name,
-                groups_id: users[partnerId]?.groups_id.includes(channel.group_public_id)
-                    ? channel.group_public_id
+                groups_id: users[partnerId]?.groups_id.includes(allowed_group)
+                    ? allowed_group
                     : undefined,
             };
             store.add(this.browse(partnerId), data);


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/176758

Commit above adds elligible partners in `@` mention suggestions, when the channel is restricted.

However, channel threads could mention anyone, which is unintended.

Steps to reproduce:
- open a restricted channel, e.g. `#general`
- open or make a sub-thread on this channel
- type `@` in composer

=> non-internal users are shows in suggestion list.

This happens because when the channel is restricted, this limits the amount of partners in the mention list. Problem is that channel threads do not set their `group_public_id`, and instead the parent value should be checked. This was not taken into account, which lead to unrestricted list of suggestions in these channels.

This commit fixes the issue by checking the parent channel `group_public_id` for listing the elligible people that can be mentioned.

Before
![Screenshot 2025-01-24 at 15 11 23](https://github.com/user-attachments/assets/fe4ff3ad-b223-439a-bf0a-61dd3a85523f)

After
![Screenshot 2025-01-24 at 15 10 50](https://github.com/user-attachments/assets/ac75d0af-d13b-4a5c-9b7d-aa7fe16c5792)

