### PR TITLE
[FIX] im_livechat: auto popup always open

### DIFF
--- a/addons/im_livechat/static/src/embed/common/autopopup_service.js
+++ b/addons/im_livechat/static/src/embed/common/autopopup_service.js
@@ -35,7 +35,7 @@ export class AutopopupService {
             if (this.allowAutoPopup && livechatService.state === SESSION_STATE.NONE) {
                 browser.setTimeout(async () => {
                     if (!this.storeService.ChatWindow.get({ thread: livechatService.thread })) {
-                        expirableStorage.setItem(AutopopupService.STORAGE_KEY, false);
+                        expirableStorage.setItem(AutopopupService.STORAGE_KEY, true);
                         livechatService.open();
                     }
                 }, livechatService.rule.auto_popup_timer * 1000);


### PR DESCRIPTION
Livechats can be configured to automatically open a chat window when a visitor opens a page. This should only occur once per visitor not to bother visitors.

Before this PR, this occured each time the visitor accessed the page. The information on whether the popup was donce once is stored in the local storage but is incorrectly checked. This PR fixes the issue.

opw-4503667
