### PR TITLE
[IMP] sale_{project,timesheet}: rename label in input search bar in portal

### DIFF
--- a/addons/sale_project/controllers/portal.py
+++ b/addons/sale_project/controllers/portal.py
@@ -24,7 +24,7 @@ class SaleProjectCustomerPortal(ProjectCustomerPortal):
             del values['partner_id']
         if not project or project.sudo().allow_billable:
             values |= {
-                'sale_order':  {'input': 'sale_order', 'label': _('Search in Sales Order'), 'sequence': 90},
+                'sale_order':  {'input': 'sale_order', 'label': _('Search in Sales Order Item'), 'sequence': 90},
                 'invoice': {'input': 'invoice', 'label': _('Search in Invoice'), 'sequence': 100},
             }
         return values

--- a/addons/sale_timesheet/controllers/portal.py
+++ b/addons/sale_timesheet/controllers/portal.py
@@ -61,7 +61,7 @@ class SaleTimesheetCustomerPortal(TimesheetCustomerPortal):
 
     def _get_searchbar_inputs(self):
         return super()._get_searchbar_inputs() | {
-            'so': {'input': 'so', 'label': _('Search in Sales Order'), 'sequence': 50},
+            'so': {'input': 'so', 'label': _('Search in Sales Order Item'), 'sequence': 50},
             'invoice': {'input': 'invoice', 'label': _('Search in Invoice'), 'sequence': 80},
         }
 


### PR DESCRIPTION
This commit renames the label `Search in Sale Order` into `Search in Sales Order Item` in timesheets and tasks portal views to be consistent with the label displayed in the groupby for instance.

task-4260389
