### PR TITLE
[FIX] web: prevent crash on website editor

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -479,7 +479,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/tests/legacy/legacy_tests/helpers/**/*',
             ('remove', 'web/static/tests/legacy/legacy_tests/helpers/test_utils_tests.js'),
 
-            'web/static/lib/jquery/jquery.js',
+            ('include', 'web._assets_jquery'),
 
             'web/static/lib/fullcalendar/core/index.global.js',
             'web/static/lib/fullcalendar/interaction/index.global.js',

--- a/addons/web/static/src/core/ensure_jquery.js
+++ b/addons/web/static/src/core/ensure_jquery.js
@@ -1,4 +1,4 @@
-import { loadBundle } from "./assets";
+import { loadBundle, loadJS } from "./assets";
 
 export async function ensureJQuery() {
     if (!window.jQuery) {
@@ -19,5 +19,7 @@ export async function ensureJQuery() {
                 };
             }
         }
+    } else if (!window.jQuery.fn.getScrollingElement) {
+        await loadJS("/web/static/src/legacy/js/libs/jquery.js");
     }
 }


### PR DESCRIPTION
__Current behavior before commit:__
jQuery has been removed from `web.assets_backend` in [`b8fc93e`][1], now it's dynamically added with the `ensureJQuery` method. A lot of customers put `web/static/lib/jquery/jquery.js` in `web.assets_backend` (using custom modules) but not `web/static/src/legacy/js/libs/jquery.js`. Therefore `ensureJQuery` doesn't fetch `web._assets_jquery` and therefore
`web/static/src/legacy/js/libs/jquery.js` is never included.

__Description of the fix:__
If jQuery is present, check if the method `getScrollingElement` is defined in jQuery.fn. If not load `/web/static/src/legacy/js/libs/jquery.js`.

__Steps to reproduce the issue in local:__
1. Add back "web/static/lib/jquery/jquery.js" in the `web.assets_backend` entry of `addons/web/\_\_manifest\_\_.py` to simulate that a customer added it in a custom module.
2. Open the database and Refresh Assets in the debug menu
3. Try to open the editor Crash: "TypeError: $(...).getScrollingElement is not a function"

opw-4499576

[1]: https://github.com/odoo/odoo/commit/b8fc93ea97b8
