### PR TITLE
[FIX] pos_self_order: remove horizontal scrollbar

### DIFF
--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
@@ -16,7 +16,7 @@
                 }">
                 <div class="placeholder-glow o_self_order_item_card_no_image">
                     <div t-attf-class="{{ props.product.image_128 ? 'placeholder' : 'd-flex align-items-center justify-content-center h-100' }} bg-200 w-100 h-100 rounded">
-                        <span t-if="!props.product.image_128" t-esc="props.product.name" class="text-center text-white fs-2 fw-bold mb-1 mb-sm-2"/>
+                        <span t-if="!props.product.image_128" t-esc="props.product.name" class="text-center text-white fs-2 fw-bold mb-1 mb-sm-2 text-truncate w-100"/>
                     </div>
                 </div>
                 <img
@@ -27,8 +27,8 @@
                     loading="lazy"
                     onerror="this.remove()"/>
             </div>
-            <div class="product-infos d-flex flex-column justify-content-between text-start flex-grow-1 w-100 lh-1">
-                <span t-esc="props.product.name" class="fs-4 fw-bold mb-1 mb-sm-2"/>
+            <div class="product-infos d-flex flex-column justify-content-between text-start flex-grow-1 w-100 lh-1 overflow-hidden">
+                <span t-esc="props.product.name" class="fs-4 fw-bold mb-1 mb-sm-2 text-truncate w-100"/>
                 <div class="d-flex justify-content-between align-items-end gap-3">
                     <span t-esc="selfOrder.formatMonetary(selfOrder.getProductDisplayPrice(props.product))" class="o-so-tabular-nums fs-4 text-muted flex-grow-1" />
                     <div class="text-center ms-2 fs-lighter">


### PR DESCRIPTION
- Fix issue when in self order on mobile a weird horizontal scroll bar appears when a product with a long name (and no image) was sell.
- Now we just truncate the product name to avoid this issue.

task-id: 4510206

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
