### PR TITLE
[FIX] point_of_sale: fix duplicate report line

### DIFF
--- a/addons/point_of_sale/tests/test_report_pos_order.py
+++ b/addons/point_of_sale/tests/test_report_pos_order.py
@@ -14,6 +14,8 @@ class TestReportPoSOrder(TestPoSCommon):
     def test_report_pos_order_0(self):
         """Test the margin and price_total of a PoS Order with no taxes."""
         product1 = self.create_product('Product 1', self.categ_basic, 150)
+        self.categ_all = self.env['pos.category'].search([])
+        product1.write({'pos_categ_ids': [odoo.Command.set(self.categ_all.ids)]})
 
         self.open_new_session()
         session = self.pos_session
@@ -38,6 +40,7 @@ class TestReportPoSOrder(TestPoSCommon):
         # PoS Orders have negative IDs to avoid conflict, so reports[0] will correspond to the newest order
         reports = self.env['report.pos.order'].sudo().search([('product_id', '=', product1.id)], order='id')
 
+        self.assertEqual(len(reports.ids), 1)
         self.assertEqual(reports[0].margin, 150)
         self.assertEqual(reports[0].price_total, 150)
 


### PR DESCRIPTION
If you sell a product that has multiple pos categories, the report would contain as many lines as the number of categories.

Steps to reproduce:
-------------------
* Create product A with atleast 2 pos categories
* Make a sale in PoS with this product
* Go to PoS order report and click on the graph
* This will open a view containing all the lines of the report
> Observation: You have multiple lines for the same order

Why the fix:
------------
To avoid this issue, we select only the first category of the product.

opw-4451101