### PR TITLE
[FIX] l10n_es_edi_tbai: the number sent in vendor bills should be the…

### DIFF
--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -71,6 +71,9 @@ class AccountEdiFormat(models.Model):
         if self.code != 'es_tbai' or invoice.country_code != 'ES':
             return errors
 
+        if invoice.is_purchase_document() and not invoice.ref:
+            errors.append(_("You need to fill in the Reference field as the invoice number from your vendor."))
+
         # Ensure a certificate is available.
         if not invoice.company_id.l10n_es_edi_certificate_id:
             errors.append(_("Please configure the certificate for TicketBAI/SII."))

--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -658,7 +658,10 @@ class AccountEdiFormat(models.Model):
         lroe_values = self._l10n_es_tbai_prepare_values_bi(invoice, invoice_xml, cancel=cancel)
         if invoice.is_purchase_document():
             lroe_str = env['ir.qweb']._render('l10n_es_edi_tbai.template_LROE_240_main_recibidas', lroe_values)
-            invoice.l10n_es_tbai_post_xml = b64encode(lroe_str.encode())
+            if cancel:
+                invoice.l10n_es_tbai_cancel_xml = b64encode(lroe_str.encode())
+            else:
+                invoice.l10n_es_tbai_post_xml = b64encode(lroe_str.encode())
         else:
             lroe_str = env['ir.qweb']._render('l10n_es_edi_tbai.template_LROE_240_main', lroe_values)
 

--- a/addons/l10n_es_edi_tbai/models/account_move.py
+++ b/addons/l10n_es_edi_tbai/models/account_move.py
@@ -128,17 +128,31 @@ class AccountMove(models.Model):
     def _get_l10n_es_tbai_sequence_and_number(self):
         """Get the TicketBAI sequence a number values for this invoice."""
         self.ensure_one()
+        if self.is_purchase_document(): # Batuz
+            # Check if we are cancelling or not
+            doc = self.env['account.edi.document'].search([('state', '=', 'to_cancel'),
+                                                           ('edi_format_id.code', '=', 'es_tbai')], limit=1)
+            if doc and self.l10n_es_tbai_post_xml:
+                vals = self._get_l10n_es_tbai_values_from_xml({
+                    'sequence': './/CabeceraFactura/SerieFactura',
+                    'number': './/CabeceraFactura/NumFactura',
+                })
+                if vals['sequence'] and vals['number']:
+                    return vals['sequence'], vals['number']
 
-        sequence = self.sequence_prefix.rstrip('/')
+            number = self.ref
+            sequence = "TEST" if self.company_id.l10n_es_edi_test_env else ""
+        else:
+            sequence = self.sequence_prefix.rstrip('/')
 
-        # NOTE non-decimal characters should not appear in the number
-        seq_length = self._get_sequence_format_param(self.name)[1]['seq_length']
-        number = f"{self.sequence_number:0{seq_length}d}"
+            # NOTE non-decimal characters should not appear in the number
+            seq_length = self._get_sequence_format_param(self.name)[1]['seq_length']
+            number = f"{self.sequence_number:0{seq_length}d}"
 
-        sequence = regex_sub(r"[^0-9A-Za-z.\_\-\/]", "", sequence)  # remove forbidden characters
-        sequence = regex_sub(r"\s+", " ", sequence)  # no more than one consecutive whitespace allowed
-        # NOTE (optional) not recommended to use chars out of ([0123456789ABCDEFGHJKLMNPQRSTUVXYZ.\_\-\/ ])
-        sequence += "TEST" if self.company_id.l10n_es_edi_test_env else ""
+            sequence = regex_sub(r"[^0-9A-Za-z.\_\-\/]", "", sequence)  # remove forbidden characters
+            sequence = regex_sub(r"\s+", " ", sequence)  # no more than one consecutive whitespace allowed
+            # NOTE (optional) not recommended to use chars out of ([0123456789ABCDEFGHJKLMNPQRSTUVXYZ.\_\-\/ ])
+            sequence += "TEST" if self.company_id.l10n_es_edi_test_env else ""
         return sequence, number
 
     def _get_l10n_es_tbai_signature_and_date(self):

--- a/addons/l10n_es_edi_tbai/tests/common.py
+++ b/addons/l10n_es_edi_tbai/tests/common.py
@@ -236,13 +236,14 @@ class TestEsEdiTbaiCommon(AccountEdiTestCommon):
                     <ApellidosNombreRazonSocial>&amp;@àÁ$£€èêÈÊöÔÇç¡⅛™³</ApellidosNombreRazonSocial>
                 </EmisorFacturaRecibida>
                 <CabeceraFactura>
-                    <SerieFactura>INVTEST</SerieFactura>
-                    <NumFactura>01</NumFactura>
+                    <SerieFactura>TEST</SerieFactura>
+                    <NumFactura>INV/5234</NumFactura>
                     <FechaExpedicionFactura>01-01-2022</FechaExpedicionFactura>
                     <FechaRecepcion>01-01-2022</FechaRecepcion>
                     <TipoFactura>F1</TipoFactura>
                 </CabeceraFactura>
                 <DatosFactura>
+                    <DescripcionOperacion>INV/5234</DescripcionOperacion>
                     <Claves>
                         <IDClave>
                             <ClaveRegimenIvaOpTrascendencia>01</ClaveRegimenIvaOpTrascendencia>
@@ -285,13 +286,14 @@ class TestEsEdiTbaiCommon(AccountEdiTestCommon):
                     <ApellidosNombreRazonSocial>partner_b</ApellidosNombreRazonSocial>
                 </EmisorFacturaRecibida>
                 <CabeceraFactura>
-                    <SerieFactura>INVTEST</SerieFactura>
-                    <NumFactura>01</NumFactura>
+                    <SerieFactura>TEST</SerieFactura>
+                    <NumFactura>INV/5234</NumFactura>
                     <FechaExpedicionFactura>01-01-2022</FechaExpedicionFactura>
                     <FechaRecepcion>01-01-2022</FechaRecepcion>
                     <TipoFactura>F1</TipoFactura>
                 </CabeceraFactura>
                 <DatosFactura>
+                    <DescripcionOperacion>INV/5234</DescripcionOperacion>
                     <Claves>
                         <IDClave>
                             <ClaveRegimenIvaOpTrascendencia>09</ClaveRegimenIvaOpTrascendencia>

--- a/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
@@ -149,6 +149,7 @@ class TestEdiTbaiXmls(TestEsEdiTbaiCommon):
             self.in_invoice = self.env['account.move'].create({
                 'name': 'INV/01',
                 'move_type': 'in_invoice',
+                'ref': 'INV/5234',
                 'invoice_date': datetime.now(),
                 'partner_id': self.partner_a.id,
                 'invoice_line_ids': [(0, 0, {
@@ -169,6 +170,7 @@ class TestEdiTbaiXmls(TestEsEdiTbaiCommon):
             self.in_invoice = self.env['account.move'].create({
                 'name': 'INV/01',
                 'move_type': 'in_invoice',
+                'ref': 'INV/5234',
                 'invoice_date': datetime.now(),
                 'partner_id': self.partner_b.id,
                 'invoice_line_ids': [(0, 0, {


### PR DESCRIPTION
… ref, not the name

For Bizkaia, when we send the invoices, the numfactura and seriefactura should be the name of the vendor and the one of the customer.

In order to make it possible to correct it and to cancel an invoice with the previous way of doing, we check in the original XML what the dates sent were.

opw-4498833

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
