### PR TITLE
[IMP] mail: move init store data out of session info

### DIFF
--- a/addons/im_livechat/static/src/core/common/chat_window_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/chat_window_model_patch.js
@@ -13,7 +13,7 @@ const chatWindowPatch = {
         super.setup(...arguments);
         this.livechatStep = CW_LIVECHAT_STEP.NONE;
     },
-    close(options = {}) {
+    async close(options = {}) {
         if (this.thread?.channel_type !== "livechat") {
             return super.close(...arguments);
         }
@@ -21,7 +21,8 @@ const chatWindowPatch = {
             this.livechatStep = CW_LIVECHAT_STEP.NONE;
             return super.close(...arguments);
         }
-        const isSelfVisitor = this.thread.livechatVisitorMember?.persona?.eq(this.store.self);
+        const self = await this.store.getSelf();
+        const isSelfVisitor = this.thread.livechatVisitorMember?.persona?.eq(self);
         switch (this.livechatStep) {
             case CW_LIVECHAT_STEP.NONE: {
                 if (this.thread.isTransient) {
@@ -47,7 +48,7 @@ const chatWindowPatch = {
             }
             case CW_LIVECHAT_STEP.CONFIRM_CLOSE: {
                 this.actionsDisabled = false;
-                if (this.thread.livechatVisitorMember?.persona?.eq(this.store.self)) {
+                if (this.thread.livechatVisitorMember?.persona?.eq(self)) {
                     this.open({ focus: true, notifyState: this.thread?.state !== "open" });
                     this.livechatStep = CW_LIVECHAT_STEP.FEEDBACK;
                 } else {

--- a/addons/im_livechat/static/src/core/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/core/common/chat_window_patch.xml
@@ -8,7 +8,7 @@
             </t>
         </xpath>
         <xpath expr="//Composer" position="replace">
-            <t t-if="thread?.composerDisabled and store.self.notEq(thread?.livechatVisitorMember?.persona)">$0</t>
+            <t t-if="thread?.composerDisabled and store.self?.notEq(thread?.livechatVisitorMember?.persona)">$0</t>
             <div t-if="thread?.composerDisabled" class="bg-200 py-1 text-center d-flex fst-italic fw-bold text-muted" t-ref="composerDisabledContainer">
                 <span class="flex-grow-1"/>
                 <span t-esc="thread.composerDisabledText"/>

--- a/addons/im_livechat/static/src/core/public_web/chat_window_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/chat_window_model_patch.js
@@ -1,11 +1,13 @@
 import { ChatWindow } from "@mail/core/common/chat_window_model";
 import { patch } from "@web/core/utils/patch";
 
-patch(ChatWindow.prototype, {
-    _onClose(options = {}) {
+/** @type {import("models").ChatWindow} */
+const chatWindowPatch = {
+    async _onClose(options = {}) {
+        const self = await this.store.getSelf();
         if (
             this.thread?.channel_type === "livechat" &&
-            this.thread.livechatVisitorMember?.persona?.notEq(this.store.self)
+            this.thread.livechatVisitorMember?.persona?.notEq(self)
         ) {
             const thread = this.thread; // save ref before delete
             super._onClose();
@@ -17,4 +19,5 @@ patch(ChatWindow.prototype, {
             super._onClose();
         }
     },
-});
+};
+patch(ChatWindow.prototype, chatWindowPatch);

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
@@ -42,7 +42,8 @@ export class ChatBotService {
      * Start the chatbot script.
      */
     async start() {
-        if (this.chatbot.thread.isLastMessageFromCustomer) {
+        await this.store.getSelf();
+        if (this.chatbot.thread.newestPersistentOfAllMessage?.isSelfAuthored) {
             await this.chatbot?.processAnswer(
                 this.livechatService.thread.newestPersistentOfAllMessage
             );

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -61,10 +61,6 @@ patch(Thread.prototype, {
         this.requested_by_operator = false;
     },
 
-    get isLastMessageFromCustomer() {
-        return this.newestPersistentOfAllMessage?.isSelfAuthored;
-    },
-
     get membersThatCanSeen() {
         return super.membersThatCanSeen.filter((member) => !member.is_bot);
     },

--- a/addons/im_livechat/static/src/embed/cors/persona_model_patch.js
+++ b/addons/im_livechat/static/src/embed/cors/persona_model_patch.js
@@ -13,7 +13,7 @@ patch(Persona.prototype, {
                 unique: this.write_date,
             }
         );
-        if (!this.store.self.isInternalUser) {
+        if (!this.store.self?.isInternalUser) {
             params.access_token = this.avatar_128_access_token;
         }
         if (this.type === "partner") {

--- a/addons/im_livechat/static/tests/messaging_service_patch.test.js
+++ b/addons/im_livechat/static/tests/messaging_service_patch.test.js
@@ -2,13 +2,10 @@ import { contains, start, startServer } from "@mail/../tests/mail_test_helpers";
 import { withGuest } from "@mail/../tests/mock_server/mail_mock_server";
 import { describe, test } from "@odoo/hoot";
 import {
-    asyncStep,
     Command,
     mockService,
-    onRpc,
     patchWithCleanup,
     serverState,
-    waitForSteps,
 } from "@web/../tests/web_test_helpers";
 
 import { rpc } from "@web/core/network/rpc";
@@ -41,26 +38,8 @@ test("push notifications are Odoo toaster on Android", async () => {
             Command.create({ guest_id: guestId }),
         ],
     });
-    onRpc("/mail/data", async (request) => {
-        const { params } = await request.json();
-        if (params.fetch_params.includes("init_messaging")) {
-            asyncStep(`/mail/data - ${JSON.stringify(params)}`);
-        }
-    });
     mockService("presence", { isOdooFocused: () => false });
     await start();
-    await waitForSteps([
-        `/mail/data - ${JSON.stringify({
-            fetch_params: ["failures", "systray_get_activities", "init_messaging"],
-            context: {
-                lang: "en",
-                tz: "taht",
-                uid: serverState.userId,
-                allowed_company_ids: [1],
-            },
-        })}`,
-    ]);
-    // send after init_messaging because bus subscription is done after init_messaging
     await withGuest(guestId, () =>
         rpc("/mail/message/post", {
             post_data: {

--- a/addons/mail/models/ir_http.py
+++ b/addons/mail/models/ir_http.py
@@ -1,9 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo
-from odoo import api, models, fields
+from odoo import models
 from odoo.http import request
-from odoo.addons.mail.tools.discuss import Store
 
 
 class IrHttp(models.AbstractModel):
@@ -12,16 +11,6 @@ class IrHttp(models.AbstractModel):
     def session_info(self):
         """Override to add the current user data (partner or guest) if applicable."""
         result = super().session_info()
-        store = Store()
-        ResUsers = self.env["res.users"]
-        if cids := request.cookies.get("cids", False):
-            allowed_company_ids = []
-            for company_id in [int(cid) for cid in cids.split("-")]:
-                if company_id in self.env.user.company_ids.ids:
-                    allowed_company_ids.append(company_id)
-            ResUsers = self.with_context(allowed_company_ids=allowed_company_ids).env["res.users"]
-        ResUsers._init_store_data(store)
-        result["storeData"] = store.get_result()
         guest = self.env['mail.guest']._get_guest_from_context()
         if not request.session.uid and guest:
             user_context = {'lang': guest.lang}

--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -67,13 +67,12 @@ Object.assign(Chatter.defaultProps, {
     isChatterAside: false,
     isInFormSheetBg: true,
 });
-
 /**
- * @type {import("@mail/chatter/web_portal/chatter").Chatter }
+ * @type {Chatter}
  * @typedef {Object} Props
  * @property {function} [close]
  */
-patch(Chatter.prototype, {
+const chatterPatch = {
     setup() {
         this.messageHighlight = useMessageHighlight();
         super.setup(...arguments);
@@ -119,7 +118,7 @@ patch(Chatter.prototype, {
                     );
                     this.state.isAttachmentBoxOpened = true;
                 }
-            }
+            },
         });
         useEffect(
             () => {
@@ -244,8 +243,9 @@ patch(Chatter.prototype, {
     },
 
     async _follow(thread) {
+        const self = await this.store.getSelf();
         await this.orm.call(thread.model, "message_subscribe", [[thread.id]], {
-            partner_ids: [this.store.self.id],
+            partner_ids: [self.id],
         });
         this.onFollowerChanged(thread);
     },
@@ -407,4 +407,5 @@ patch(Chatter.prototype, {
     popoutAttachment() {
         this.attachmentPopout.popout();
     },
-});
+};
+patch(Chatter.prototype, chatterPatch);

--- a/addons/mail/static/src/chatter/web/scheduled_message_model.js
+++ b/addons/mail/static/src/chatter/web/scheduled_message_model.js
@@ -33,11 +33,11 @@ export class ScheduledMessage extends Record {
     thread = Record.one("Thread");
     // Editors of the records can delete scheduled messages
     get deletable() {
-        return this.store.self.isAdmin || this.thread.hasWriteAccess;
+        return this.store.self?.isAdmin || this.thread.hasWriteAccess;
     }
 
     get editable() {
-        return this.store.self.isAdmin || this.isSelfAuthored;
+        return this.store.self?.isAdmin || this.isSelfAuthored;
     }
 
     get isSelfAuthored() {

--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -72,18 +72,20 @@ export class Chatter extends Component {
     changeThread(threadModel, threadId) {
         this.state.thread = this.store.Thread.insert({ model: threadModel, id: threadId });
         if (threadId === false) {
-            if (this.state.thread.messages.length === 0) {
-                this.state.thread.messages.push({
-                    id: this.store.getNextTemporaryId(),
-                    author: this.store.self,
-                    body: _t("Creating a new record..."),
-                    message_type: "notification",
-                    thread: this.state.thread,
-                    trackingValues: [],
-                    res_id: threadId,
-                    model: threadModel,
-                });
-            }
+            this.store.getSelf().then((self) => {
+                if (this.state.thread.messages.length === 0) {
+                    this.state.thread.messages.push({
+                        id: this.store.getNextTemporaryId(),
+                        author: self,
+                        body: _t("Creating a new record..."),
+                        message_type: "notification",
+                        thread: this.state.thread,
+                        trackingValues: [],
+                        res_id: threadId,
+                        model: threadModel,
+                    });
+                }
+            });
         }
     }
 

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -39,7 +39,7 @@ export class Attachment extends FileModelMixin(Record) {
     create_date = Record.attr(undefined, { type: "datetime" });
 
     get isDeletable() {
-        if (this.message && !this.store.self.isInternalUser) {
+        if (this.message && !this.store.self?.isInternalUser) {
             return this.message.editable;
         }
         return true;

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -165,9 +165,10 @@ export class ChatWindow extends Component {
     }
 
     async renameGuest(name) {
+        const self = await this.store.getSelf();
         const newName = name.trim();
-        if (this.store.self.name !== newName) {
-            await this.store.self.updateGuestName(newName);
+        if (self.name !== newName) {
+            await self.updateGuestName(newName);
         }
         this.state.editingGuestName = false;
     }

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -83,16 +83,16 @@
                     <t t-if="action_last" t-set="itemClass" t-value="ui.isSmall ? 'mx-2' : ''"/>
                 </t>
             </div>
-            <t t-if="this.store.inPublicPage and this.store.self.type === 'guest'">
+            <t t-if="this.store.inPublicPage and this.store.self?.type === 'guest'">
                 <button class="btn ps-1" t-if="!state.editingGuestName">
-                    <img class="o-mail-Discuss-selfAvatar rounded-circle o_object_fit_cover flex-shrink-0" alt="Avatar" t-att-src="store.self.avatarUrl" t-on-click="() => state.editingGuestName = true"/>
+                    <img class="o-mail-Discuss-selfAvatar rounded-circle o_object_fit_cover flex-shrink-0" alt="Avatar" t-att-src="store.self?.avatarUrl" t-on-click="() => state.editingGuestName = true"/>
                 </button>
                 <AutoresizeInput
                     t-if="state.editingGuestName"
                     className="'py-1 me-2'"
                     autofocus="true"
                     onValidate.bind="renameGuest"
-                    value="store.self.name"
+                    value="store.self?.name"
                 />
             </t>
         </div>

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -457,11 +457,12 @@ export class Composer extends Component {
         }
     }
 
-    onKeydown(ev) {
+    async onKeydown(ev) {
         const composer = toRaw(this.props.composer);
         switch (ev.key) {
             case "ArrowUp":
                 if (this.props.messageEdition && composer.text === "") {
+                    await this.store.getSelf();
                     const messageToEdit = composer.thread.lastEditableMessageOfSelf;
                     if (messageToEdit) {
                         this.props.messageEdition.editingMessage = messageToEdit;
@@ -530,7 +531,8 @@ export class Composer extends Component {
             mentionedChannels: this.props.composer.mentionedChannels,
             mentionedPartners: this.props.composer.mentionedPartners,
         });
-        const signature = this.store.self.signature;
+        const self = await this.store.getSelf();
+        const signature = self.signature;
         const default_body =
             (await prettifyMessageContent(body, validMentions)) +
             (this.props.composer.emailAddSignature && signature ? "<br>" + signature : "");
@@ -771,8 +773,8 @@ export class Composer extends Component {
     restoreContent() {
         const composer = toRaw(this.props.composer);
         try {
-            const config = JSON.parse(browser.localStorage.getItem(composer.localId));
-            if (config.text) {
+            const config = JSON.parse(browser.localStorage.getItem(composer.localId) ?? "{}");
+            if (config?.text) {
                 composer.emailAddSignature = config.emailAddSignature;
                 composer.text = config.text;
             }

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -29,7 +29,7 @@
                 </t>
             </FileUploader>
             <div t-if="showComposerAvatar" class="o-mail-Composer-sidebarMain flex-shrink-0">
-                <img class="o-mail-Composer-avatar o_avatar rounded" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>
+                <img class="o-mail-Composer-avatar o_avatar rounded" t-att-src="store.self?.avatarUrl" alt="Avatar of user"/>
             </div>
             <div class="o-mail-Composer-coreHeader text-truncate small p-2" t-if="props.composer.thread and props.messageToReplyTo?.thread?.eq(props.composer.thread)">
                 <span class="cursor-pointer" t-on-click="() => env.messageHighlight?.highlightMessage(props.messageToReplyTo.message, props.composer.thread)">

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -30,13 +30,14 @@ messageActionsRegistry
                 el: component.root?.el?.querySelector(`[name="${action.id}"]`),
             }),
         setup() {
+            /** @type {import("@mail/core/common/message").Message} */
             const component = useComponent();
             component.reactionPicker = useEmojiPicker(undefined, {
-                onSelect: (emoji) => {
+                onSelect: async (emoji) => {
+                    const self = await component.store.getSelf();
                     const reaction = component.props.message.reactions.find(
                         ({ content, personas }) =>
-                            content === emoji &&
-                            personas.find((persona) => persona.eq(component.store.self))
+                            content === emoji && personas.find((persona) => persona.eq(self))
                     );
                     if (!reaction) {
                         component.props.message.react(emoji);
@@ -158,7 +159,7 @@ messageActionsRegistry
     })
     .add("download_files", {
         condition: (component) =>
-            component.message.attachment_ids.length > 1 && component.store.self.isInternalUser,
+            component.message.attachment_ids.length > 1 && component.store.self?.isInternalUser,
         icon: "fa fa-download",
         title: _t("Download Files"),
         onClick: (component) =>

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -156,7 +156,7 @@ export class Message extends Record {
      * @returns {boolean}
      */
     get allowsEdition() {
-        return this.store.self.isAdmin || this.isSelfAuthored;
+        return this.store.self?.isAdmin || this.isSelfAuthored;
     }
 
     get bubbleColor() {
@@ -226,7 +226,7 @@ export class Message extends Record {
     }
 
     get isSelfMentioned() {
-        return this.store.self.in(this.recipients);
+        return this.store.self?.in(this.recipients);
     }
 
     get isHighlightedFromMention() {
@@ -360,8 +360,8 @@ export class Message extends Record {
         return Boolean(
             !this.is_transient &&
                 this.thread &&
-                this.store.self.type === "partner" &&
-                this.store.self.isInternalUser
+                this.store.self?.type === "partner" &&
+                this.store.self?.isInternalUser
         );
     }
 

--- a/addons/mail/static/src/core/common/message_reaction_list.js
+++ b/addons/mail/static/src/core/common/message_reaction_list.js
@@ -80,7 +80,7 @@ export class MessageReactionList extends Component {
     }
 
     hasSelfReacted(reaction) {
-        return this.store.self.in(reaction.personas);
+        return this.store.self?.in(reaction.personas);
     }
 
     onClickReaction(reaction) {

--- a/addons/mail/static/src/core/common/message_reactions.js
+++ b/addons/mail/static/src/core/common/message_reactions.js
@@ -15,10 +15,11 @@ export class MessageReactions extends Component {
         this.ui = useService("ui");
         this.addRef = useRef("add");
         this.emojiPicker = useEmojiPicker(this.addRef, {
-            onSelect: (emoji) => {
+            onSelect: async (emoji) => {
+                const self = await this.store.getSelf();
                 const reaction = this.props.message.reactions.find(
                     ({ content, personas }) =>
-                        content === emoji && personas.find((persona) => persona.eq(this.store.self))
+                        content === emoji && personas.find((persona) => persona.eq(self))
                 );
                 if (!reaction) {
                     this.props.message.react(emoji);

--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -84,8 +84,9 @@ export class Persona extends Record {
     userId;
     /** @type {ImStatus} */
     im_status = Record.attr(null, {
-        onUpdate() {
-            if (this.eq(this.store.self) && this.im_status === "offline") {
+        async onUpdate() {
+            const self = await this.store.getSelf();
+            if (this.eq(self) && this.im_status === "offline") {
                 this.store.env.services.im_status.updateBusPresence();
             }
         },
@@ -113,7 +114,7 @@ export class Persona extends Record {
 
     get avatarUrl() {
         const accessTokenParam = {};
-        if (!this.store.self.isInternalUser) {
+        if (!this.store.self?.isInternalUser) {
             accessTokenParam.access_token = this.avatar_128_access_token;
         }
         if (this.type === "partner") {

--- a/addons/mail/static/src/core/common/quick_reaction_menu.js
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.js
@@ -70,9 +70,10 @@ export class QuickReactionMenu extends Component {
         }
     }
 
-    toggleReaction(emoji) {
+    async toggleReaction(emoji) {
+        const self = await this.store.getSelf();
         const reaction = this.props.message.reactions.find(
-            (r) => r.content === emoji && this.store.self.in(r.personas)
+            (r) => r.content === emoji && self.in(r.personas)
         );
         if (reaction) {
             reaction.remove();
@@ -95,7 +96,7 @@ export class QuickReactionMenu extends Component {
 
     reactedBySelf(emoji) {
         return this.props.message.reactions.some(
-            (r) => r.content === emoji && this.store.self.in(r.personas)
+            (r) => r.content === emoji && this.store.self?.in(r.personas)
         );
     }
 

--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -185,7 +185,8 @@ export class Settings extends Record {
      * @param {number} param0.volume
      */
     async saveVolumeSetting({ partnerId, guestId, volume }) {
-        if (this.store.self.type !== "partner") {
+        const self = await this.store.getSelf();
+        if (self.type !== "partner") {
             return;
         }
         const key = `${partnerId}_${guestId}`;
@@ -324,7 +325,8 @@ export class Settings extends Record {
      * @private
      */
     async _saveSettings() {
-        if (this.store.self.type !== "partner") {
+        const self = await this.store.getSelf();
+        if (self.type !== "partner") {
             return;
         }
         browser.clearTimeout(this.globalSettingsTimeout);

--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -9,20 +9,22 @@ class UseSuggestion {
         this.fetchSuggestions = useDebounced(this.fetchSuggestions.bind(this), 250);
         useEffect(
             () => {
-                this.update();
-                if (this.search.position === undefined || !this.search.delimiter) {
-                    return; // nothing else to fetch
-                }
-                if (this.composer.store.self.type !== "partner") {
-                    return; // guests cannot access fetch suggestion method
-                }
-                if (
-                    this.lastFetchedSearch?.count === 0 &&
-                    (!this.search.delimiter || this.isSearchMoreSpecificThanLastFetch)
-                ) {
-                    return; // no need to fetch since this is more specific than last and last had no result
-                }
-                this.fetchSuggestions();
+                this.composer.store.getSelf().then((self) => {
+                    this.update();
+                    if (this.search.position === undefined || !this.search.delimiter) {
+                        return; // nothing else to fetch
+                    }
+                    if (
+                        this.lastFetchedSearch?.count === 0 &&
+                        (!this.search.delimiter || this.isSearchMoreSpecificThanLastFetch)
+                    ) {
+                        return; // no need to fetch since this is more specific than last and last had no result
+                    }
+                    if (self.type !== "partner") {
+                        return; // guests cannot access fetch suggestion method
+                    }
+                    this.fetchSuggestions();
+                });
             },
             () => [this.search.delimiter, this.search.position, this.search.term]
         );

--- a/addons/mail/static/src/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/core/public_web/@types/models.d.ts
@@ -10,7 +10,7 @@ declare module "models" {
     export interface Thread {
         setAsDiscussThread: (pushState: boolean) => void,
         unpin: () => Promise<void>,
-        askLeaveConfirmation: (body: string) => void,
+        askLeaveConfirmation: (body: string) => Promise<void>,
         leaveChannel: () => Promise<void>,
     }
     export interface Models {

--- a/addons/mail/static/src/core/public_web/discuss.js
+++ b/addons/mail/static/src/core/public_web/discuss.js
@@ -139,9 +139,10 @@ export class Discuss extends Component {
     }
 
     async renameGuest(name) {
+        const self = await this.store.getSelf();
         const newName = name.trim();
-        if (this.store.self.name !== newName) {
-            await this.store.self.updateGuestName(newName);
+        if (self.name !== newName) {
+            await self.updateGuestName(newName);
         }
     }
 }

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -72,14 +72,14 @@
                             <span t-if="!group_last" class="text-muted align-self-stretch ms-2 me-1"/>
                         </t>
                         <div t-if="store.inPublicPage and !ui.isSmall" class="d-flex align-items-center">
-                            <img class="o-mail-Discuss-selfAvatar mx-1 rounded-circle o_object_fit_cover flex-shrink-0" alt="Avatar" t-att-src="store.self.avatarUrl"/>
+                            <img class="o-mail-Discuss-selfAvatar mx-1 rounded-circle o_object_fit_cover flex-shrink-0" alt="Avatar" t-att-src="store.self?.avatarUrl"/>
                             <div class="lead fw-bold flex-shrink-1 text-dark">
-                                <t t-if="store.self.type === 'partner'" t-esc="store.self.name"/>
+                                <t t-if="store.self?.type === 'partner'" t-esc="store.self?.name"/>
                                 <t t-else="">
                                     <AutoresizeInput
                                         className="'py-1'"
                                         onValidate.bind="renameGuest"
-                                        value="store.self.name"
+                                        value="store.self?.name"
                                     />
                                 </t>
                             </div>

--- a/addons/mail/static/src/core/public_web/store_service_patch.js
+++ b/addons/mail/static/src/core/public_web/store_service_patch.js
@@ -3,7 +3,8 @@ import { Record } from "@mail/core/common/record";
 import { router } from "@web/core/browser/router";
 import { patch } from "@web/core/utils/patch";
 
-patch(Store.prototype, {
+/** @type {import("models").Store} */
+const storePatch = {
     setup() {
         super.setup(...arguments);
         this.discuss = Record.one("DiscussApp");
@@ -14,7 +15,8 @@ patch(Store.prototype, {
         this.discuss = { activeTab: "main" };
         this.env.bus.addEventListener(
             "discuss.channel/new_message",
-            ({ detail: { channel, message, silent } }) => {
+            async ({ detail: { channel, message, silent } }) => {
+                await this.store.getSelf();
                 if (this.env.services.ui.isSmall || message.isSelfAuthored || silent) {
                     return;
                 }
@@ -22,7 +24,8 @@ patch(Store.prototype, {
             }
         );
     },
-});
+};
+patch(Store.prototype, storePatch);
 
 patch(storeService, {
     start(env, services) {

--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -48,6 +48,7 @@ patch(MessagingMenu.prototype, {
     beforeOpen() {
         this.state.searchOpen = false;
         this.store.discuss.searchTerm = "";
+        // check of inbox counter against messages requires init counter to be fetched
         this.store.isReady.then(() => {
             if (
                 !this.store.inbox.isLoaded &&
@@ -82,7 +83,7 @@ patch(MessagingMenu.prototype, {
             onClick: () => {
                 this.pwa.show();
             },
-            iconSrc: this.store.odoobot.avatarUrl,
+            iconSrc: this.store.odoobot?.avatarUrl,
             partner: this.store.odoobot,
             isShown: this.store.discuss.activeTab === "main" && this.canPromptToInstall,
         };
@@ -91,7 +92,7 @@ patch(MessagingMenu.prototype, {
         return {
             body: _t("Stay tuned! Enable push notifications to never miss a message."),
             displayName: _t("Turn on notifications"),
-            iconSrc: this.store.odoobot.avatarUrl,
+            iconSrc: this.store.odoobot?.avatarUrl,
             partner: this.store.odoobot,
             isShown: this.store.discuss.activeTab === "main" && this.shouldAskPushPermission,
         };

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -30,9 +30,11 @@ const StorePatch = {
         this.history = Record.one("Thread");
     },
     async initialize() {
-        this.fetchStoreData("failures");
-        this.fetchStoreData("systray_get_activities");
-        await super.initialize(...arguments);
+        await Promise.all([
+            this.fetchStoreData("failures"),
+            this.fetchStoreData("systray_get_activities"),
+            super.initialize(...arguments),
+        ]);
     },
     onStarted() {
         super.onStarted(...arguments);

--- a/addons/mail/static/src/core/web/thread_patch.xml
+++ b/addons/mail/static/src/core/web/thread_patch.xml
@@ -4,7 +4,7 @@
         <xpath expr="//*[@name='empty-message']" position="replace">
             <t t-if="props.thread.isEmpty and props.thread.model === 'mail.box'">
                 <t t-if="props.thread.id === 'inbox' and state.mountedAndLoaded">
-                    <div t-if="store.self.notification_preference !== 'inbox'" class="align-items-center text-center">
+                    <div t-if="store.self and store.self.notification_preference !== 'inbox'" class="align-items-center text-center">
                         <h4 class="mb-3 fw-bolder">Your inbox is empty</h4>
                         <t t-esc="preferenceButtonText.before"/>
                         <button class="btn btn-link m-0 p-0 align-baseline o-hover-text-underline" t-on-click="onClickPreferences" t-esc="preferenceButtonText.inside"/>

--- a/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
+++ b/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
@@ -14,7 +14,7 @@ export const pttExtensionHookService = {
         const versionPromise =
             window.chrome?.runtime?.sendMessage(EXT_ID, { type: "ask-version" }) ??
             Promise.resolve("1.0.0.0");
-        const self = reactive({
+        const state = reactive({
             isEnabled: undefined,
             voiceActivated: undefined,
             notifyIsTalking(isTalking) {
@@ -24,7 +24,7 @@ export const pttExtensionHookService = {
                 sendMessage("subscribe");
             },
             unsubscribe() {
-                self.voiceActivated = false;
+                state.voiceActivated = false;
                 sendMessage("unsubscribe");
             },
             downloadURL: `https://chromewebstore.google.com/detail/discuss-push-to-talk/${EXT_ID}`,
@@ -54,7 +54,7 @@ export const pttExtensionHookService = {
             switch (data.type) {
                 case "push-to-talk-pressed":
                     {
-                        self.voiceActivated = false;
+                        state.voiceActivated = false;
                         const isFirstPress = !rtc.selfSession?.isTalking;
                         rtc.onPushToTalk();
                         if (rtc.selfSession?.isTalking) {
@@ -68,16 +68,16 @@ export const pttExtensionHookService = {
                     break;
                 case "toggle-voice":
                     {
-                        if (self.voiceActivated) {
+                        if (state.voiceActivated) {
                             rtc.setPttReleaseTimeout(0);
                         } else {
                             rtc.onPushToTalk();
                         }
-                        self.voiceActivated = !self.voiceActivated;
+                        state.voiceActivated = !state.voiceActivated;
                     }
                     break;
                 case "answer-is-enabled":
-                    self.isEnabled = true;
+                    state.isEnabled = true;
                     break;
             }
         });
@@ -89,7 +89,7 @@ export const pttExtensionHookService = {
          * @param {*} value
          */
         async function sendMessage(type, value) {
-            if (!self.isEnabled && type !== "ask-is-enabled") {
+            if (!state.isEnabled && type !== "ask-is-enabled") {
                 return;
             }
             const version = parseVersion(await versionPromise);
@@ -102,7 +102,7 @@ export const pttExtensionHookService = {
 
         sendMessage("ask-is-enabled");
 
-        return self;
+        return state;
     },
 };
 

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -36,13 +36,15 @@ export class ChannelInvitation extends Component {
             searchStr: "",
         });
         onWillStart(() => {
-            if (this.store.self.type === "partner") {
-                this.fetchPartnersToInvite();
-            }
+            this.store.getSelf().then((self) => {
+                if (self.type === "partner") {
+                    this.fetchPartnersToInvite();
+                }
+            });
         });
         onMounted(() => {
-            if (this.store.self.type === "partner" && this.props.thread) {
-                this.inputRef.el.focus();
+            if (this.props.thread) {
+                this.inputRef.el?.focus();
             }
         });
         useEffect(

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -10,7 +10,7 @@
 
     <t t-name="discuss.ChannelInvitation.main">
         <div class="d-flex flex-column flex-grow-1 bg-inherit" t-att-class="{ 'o-mail-Discuss-threadActionPopover w-100': props.hasSizeConstraints, 'px-1': !props.thread }">
-            <t t-if="store.self.type === 'partner'">
+            <t t-if="store.self?.type === 'partner'">
                 <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-white" t-att-value="searchStr" t-ref="input" placeholder="Search people to invite" t-on-input="onInput"/>
                 <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': selectablePartners.length === 0 }">
                     <div t-if="selectablePartners.length === 0" class="small text-muted mx-1 fst-italic">
@@ -35,7 +35,7 @@
                 </ul>
             </t>
             <div class="o-discuss-ChannelInvitation-invitationBox pt-0 pb-1 bg-inherit">
-                <t t-if="store.self.type === 'partner'" >
+                <t t-if="store.self?.type === 'partner'" >
                     <div t-if="selectedPartners.length > 0" class="pt-2">
                         <div class="o-discuss-ChannelInvitation-selectedList d-flex flex-wrap overflow-auto">
                             <t t-foreach="selectedPartners" t-as="selectedPartner" t-key="selectedPartner.id">

--- a/addons/mail/static/src/discuss/core/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/store_service_patch.js
@@ -69,9 +69,8 @@ const storeServicePatch = {
             const chat = await this.joinChat(partners_to[0], true);
             chat.open({ focus: true });
         } else if (partners_to.length === 2) {
-            const correspondentId = partners_to.find(
-                (partnerId) => partnerId !== this.store.self.id
-            );
+            const self = await this.store.getSelf();
+            const correspondentId = partners_to.find((partnerId) => partnerId !== self.id);
             const chat = await this.joinChat(correspondentId, true);
             chat.open({ focus: true });
         } else {

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -14,7 +14,7 @@ threadActionsRegistry
         condition(component) {
             return (
                 component.thread?.model === "discuss.channel" &&
-                component.store.self.type !== "guest" &&
+                component.store.self?.type === "partner" &&
                 (!component.props.chatWindow || component.props.chatWindow.isOpen)
             );
         },

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -303,8 +303,9 @@ const threadPatch = {
         return super.importantCounter;
     },
     /** @override */
-    isDisplayedOnUpdate() {
+    async isDisplayedOnUpdate() {
         super.isDisplayedOnUpdate(...arguments);
+        await this.store.getSelf();
         if (this.selfMember && !this.isDisplayed) {
             this.selfMember.syncUnread = true;
         }
@@ -318,8 +319,9 @@ const threadPatch = {
      * @param {boolean} [options.sync] Whether to sync the unread message
      * state with the server values.
      */
-    markAsRead({ sync } = {}) {
-        super.markAsRead(...arguments);
+    async markAsRead({ sync } = {}) {
+        await super.markAsRead(...arguments);
+        await Promise.all([this.store.Thread.getOrFetch(this), this.store.getSelf()]);
         if (!this.selfMember) {
             return;
         }
@@ -360,7 +362,8 @@ const threadPatch = {
             : super.needactionCounter;
     },
     /** @override */
-    onNewSelfMessage(message) {
+    async onNewSelfMessage(message) {
+        await this.store.getSelf();
         if (!this.selfMember || message.id < this.selfMember.seen_message_id?.id) {
             return;
         }

--- a/addons/mail/static/src/discuss/core/public/welcome_page.js
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.js
@@ -15,10 +15,15 @@ export class WelcomePage extends Component {
         this.store = useService("mail.store");
         this.ui = useService("ui");
         this.state = useState({
-            userName: this.store.self.name || _t("Guest"),
+            userName: this.store.self?.name || "",
             audioStream: null,
             videoStream: null,
         });
+        this.store
+            .getSelf()
+            .then(
+                (self) => (this.state.userName = this.state.userName || self.name || _t("Guest"))
+            );
         this.audioRef = useRef("audio");
         this.videoRef = useRef("video");
         onMounted(() => {
@@ -35,9 +40,10 @@ export class WelcomePage extends Component {
         }
     }
 
-    joinChannel() {
-        if (this.store.self.type === "guest") {
-            this.store.self.updateGuestName(this.state.userName.trim());
+    async joinChannel() {
+        const self = await this.store.getSelf();
+        if (self.type === "guest") {
+            await self.updateGuestName(this.state.userName.trim());
         }
         browser.localStorage.setItem("discuss_call_preview_join_mute", !this.state.audioStream);
         browser.localStorage.setItem(
@@ -126,6 +132,6 @@ export class WelcomePage extends Component {
         }
     }
     getLoggedInAsText() {
-        return sprintf(_t("Logged in as %s"), this.store.self.name);
+        return sprintf(_t("Logged in as %s"), this.store.self?.name);
     }
 }

--- a/addons/mail/static/src/discuss/core/public/welcome_page.xml
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.xml
@@ -28,12 +28,12 @@
                 <audio autoplay="" t-ref="audio"/>
             </div>
             <div class="d-flex flex-column justify-content-center">
-                <t t-if="store.self.type === 'guest'">
+                <t t-if="store.self?.type === 'guest'">
                     <label class="text-center fs-4" >What's your name?</label>
                     <input class="form-control mb-3 bg-white rounded" type="text" placeholder="Your name" t-model="state.userName" t-on-keydown="onKeydownInput"/>
                 </t>
-                <p t-if="store.self.type === 'partner'" class="fs-4" t-esc="getLoggedInAsText()"/>
-                <button class="btn btn-success fa-stack align-self-end p-0 rounded-circle fs-1 shadow" title="Join Channel" t-att-disabled="store.self.type === 'guest' and state.userName.trim() === ''" t-on-click="joinChannel">
+                <p t-if="store.self?.type === 'partner'" class="fs-4" t-esc="getLoggedInAsText()"/>
+                <button class="btn btn-success fa-stack align-self-end p-0 rounded-circle fs-1 shadow" title="Join Channel" t-att-disabled="store.self?.type === 'guest' and state.userName.trim() === ''" t-on-click="joinChannel">
                     <i class="oi oi-arrow-right"/>
                 </button>
             </div>

--- a/addons/mail/static/src/discuss/core/public_web/message_actions.js
+++ b/addons/mail/static/src/discuss/core/public_web/message_actions.js
@@ -5,7 +5,7 @@ messageActionsRegistry.add("create-or-view-thread", {
     condition: (component) =>
         component.message.thread?.eq(component.props.thread) &&
         component.message.thread.hasSubChannelFeature &&
-        component.store.self.isInternalUser,
+        component.store.self?.isInternalUser,
     icon: "fa fa-comments-o",
     onClick: (component) => {
         if (component.message.linkedSubChannel) {

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.js
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.js
@@ -56,6 +56,7 @@ export class SubChannelList extends Component {
     }
 
     async onClickSubThread(subThread) {
+        await this.store.getSelf();
         if (!subThread.hasSelfAsMember) {
             await rpc("/discuss/channel/join", { channel_id: subThread.id });
         }

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
@@ -14,7 +14,7 @@
                             <i t-if="!state.loading" class="o_searchview_icon oi oi-search" role="img" aria-label="Search Sub Channels" title="Search Sub Channels"/>
                             <i t-else="" class="fa fa-circle-o-notch fa-spin" aria-label="Search in progress" title="Search in progress"/>
                         </button>
-                        <button t-if="store.self.isInternalUser" class="ms-1 btn btn-primary smaller" aria-label="Create Thread" t-on-click="onClickCreate">Create</button>
+                        <button t-if="store.self?.isInternalUser" class="ms-1 btn btn-primary smaller" aria-label="Create Thread" t-on-click="onClickCreate">Create</button>
                     </div>
                 </div>
             </t>

--- a/addons/mail/static/src/discuss/core/web/discuss_command_palette_patch.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_command_palette_patch.js
@@ -13,7 +13,7 @@ commandCategoryRegistry
     .add(DISCUSS_RECENT, { namespace: "@", name: _t("Recent") }, { sequence: 20 });
 
 patch(DiscussCommandPalette.prototype, {
-    buildResults() {
+    async buildResults() {
         const importantChannels = this.store.getSelfImportantChannels();
         const recentChannels = this.store.getSelfRecentChannels();
         const mentionedSet = new Set();
@@ -41,6 +41,6 @@ patch(DiscussCommandPalette.prototype, {
                 }
             }
         }
-        super.buildResults(new Set([...mentionedSet, ...recentSet]));
+        await super.buildResults(new Set([...mentionedSet, ...recentSet]));
     },
 });

--- a/addons/mail/static/src/discuss/gif_picker/common/composer_actions_patch.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/composer_actions_patch.js
@@ -10,7 +10,7 @@ import { useGifPicker } from "./gif_picker";
 
 composerActionsRegistry.add("add-gif", {
     condition: (component) =>
-        (component.store.hasGifPickerFeature || component.store.self.isAdmin) &&
+        (component.store.hasGifPickerFeature || component.store.self?.isAdmin) &&
         !component.env.inChatter &&
         !component.props.composer.message,
     isPicker: true,

--- a/addons/mail/static/src/discuss/gif_picker/common/composer_patch.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/composer_patch.js
@@ -25,7 +25,7 @@ const composerPatch = {
     },
     get hasGifPicker() {
         return (
-            (this.store.hasGifPickerFeature || this.store.self.isAdmin) &&
+            (this.store.hasGifPickerFeature || this.store.self?.isAdmin) &&
             !this.env.inChatter &&
             !this.props.composer.message
         );

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.js
@@ -106,11 +106,13 @@ export class GifPicker extends Component {
         onWillStart(() => {
             this.loadCategories();
         });
-        if (this.store.self.type === "partner") {
-            onWillStart(() => {
-                this.loadFavorites();
+        onWillStart(() => {
+            this.store.getSelf().then((self) => {
+                if (self.type === "partner") {
+                    this.loadFavorites();
+                }
             });
-        }
+        });
         useEffect(
             () => {
                 if (this.props.state?.picker !== this.props.PICKERS?.GIF) {

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="discuss.GifPicker">
         <div class="o-discuss-GifPicker d-flex flex-column" t-attf-class="{{ props.className }}" t-att-class="{ 'h-100': props.mobile }">
-            <div t-if="!store.hasGifPickerFeature and store.self.isAdmin" class="d-flex flex-column align-items-center justify-content-center m-3 h-100">
+            <div t-if="!store.hasGifPickerFeature and store.self?.isAdmin" class="d-flex flex-column align-items-center justify-content-center m-3 h-100">
                 <span class="o-discuss-GifPicker-bigEmoji">🧑‍🍳🌶️</span>
                 <span class="fs-5 text-muted">Want to spice up your conversations with GIFs? Activate the feature in the settings!</span>
             </div>
@@ -23,7 +23,7 @@
                         <span class="fs-5 text-muted d-block">Failed to load gifs...</span>
                     </div>
                     <div t-if="state.showCategories and !state.loadingError" class="row row-cols-2 gy-2 gx-2" aria-label="list">
-                        <div t-if="store.self.type === 'partner'" class="col">
+                        <div t-if="store.self?.type === 'partner'" class="col">
                             <div class="position-relative ratio ratio-16x9 cursor-pointer rounded overflow-hidden" t-on-click="onClickFavoritesCategory" aria-label="list-item">
                                 <img
                                     t-if="state.favorites.gifs.length > 0"
@@ -88,7 +88,7 @@
     <t t-name="discuss.Gif">
         <div class="o-discuss-Gif position-relative mt-1 fs-5 cursor-pointer rounded overflow-hidden">
             <i
-                t-if="store.self.type === 'partner'"
+                t-if="store.self?.type === 'partner'"
                 class="position-absolute top-0 end-0 me-3 mt-3 p-2 o-bg-black bg-opacity-75 fa cursor-pointer opacity-0"
                 t-att-class="{ 'o-text-white fa-star-o': !isFavorite(gif_value), 'fa-star o-starred': isFavorite(gif_value) }"
                 t-on-click="() => this.onClickFavorite(gif_value)"

--- a/addons/mail/static/src/discuss/message_pin/common/message_actions.js
+++ b/addons/mail/static/src/discuss/message_pin/common/message_actions.js
@@ -3,7 +3,7 @@ import { messageActionsRegistry } from "@mail/core/common/message_actions";
 
 messageActionsRegistry.add("pin", {
     condition: (component) =>
-        component.store.self.type === "partner" &&
+        component.store.self?.type === "partner" &&
         component.props.thread?.model === "discuss.channel",
     icon: "fa fa-thumb-tack",
     title: (component) => (component.props.message.pinned_at ? _t("Unpin") : _t("Pin")),

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -126,7 +126,7 @@ test("Ordering of chat bubbles is consistent and seems logical.", async () => {
     await click(".o-mail-ChatWindow-command[title='Fold']");
     await contains(".o-mail-ChatWindow", { count: 0 });
     // no reorder on receiving new message
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/mail/message/post", {
             post_data: { body: "test", message_type: "comment" },
             thread_id: channelId,

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -3,7 +3,6 @@ import {
     contains,
     defineMailModels,
     mockGetMedia,
-    onRpcBefore,
     openDiscuss,
     patchUiSize,
     SIZES,
@@ -166,11 +165,6 @@ test("should display invitations", async () => {
         channel_member_id: memberId,
         channel_id: channelId,
     });
-    onRpcBefore("/mail/data", (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep(`/mail/data - ${JSON.stringify(args)}`);
-        }
-    });
     mockService("mail.sound_effects", {
         play(name) {
             asyncStep(`play - ${name}`);
@@ -180,14 +174,7 @@ test("should display invitations", async () => {
         },
     });
     await start();
-    await waitForSteps([
-        `/mail/data - ${JSON.stringify({
-            fetch_params: ["failures", "systray_get_activities", "init_messaging"],
-            context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
-        })}`,
-    ]);
     const [partner] = pyEnv["res.partner"].read(serverState.partnerId);
-    // send after init_messaging because bus subscription is done after init_messaging
     pyEnv["bus.bus"]._sendone(
         partner,
         "mail.record/insert",

--- a/addons/mail/static/tests/discuss/call/ptt_ad_banner.test.js
+++ b/addons/mail/static/tests/discuss/call/ptt_ad_banner.test.js
@@ -23,6 +23,9 @@ test("display banner when ptt extension is not enabled", async () => {
         get isEnabled() {
             return false;
         },
+        set isEnabled(value) {
+            // ignore value if the extension is actually installed on the current browser
+        },
     });
     patchUiSize({ size: SIZES.SM });
     await start();

--- a/addons/mail/static/tests/discuss/call/web/call.test.js
+++ b/addons/mail/static/tests/discuss/call/web/call.test.js
@@ -10,13 +10,13 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, test } from "@odoo/hoot";
+import { test } from "@odoo/hoot";
 import { mockUserAgent } from "@odoo/hoot-mock";
 import { mockService } from "@web/../tests/web_test_helpers";
 
-describe.current.tags("desktop");
 defineMailModels();
 
+test.tags("desktop");
 test("no auto-call on joining chat", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Mario" });
@@ -31,6 +31,7 @@ test("no auto-call on joining chat", async () => {
     await contains(".o-discuss-Call", { count: 0 });
 });
 
+test.tags("desktop");
 test("no auto-call on joining group chat", async () => {
     const pyEnv = await startServer();
     const [partnerId_1, partnerId_2] = pyEnv["res.partner"].create([
@@ -59,6 +60,9 @@ test("show Push-to-Talk button on mobile", async () => {
     mockService("discuss.ptt_extension", {
         get isEnabled() {
             return false;
+        },
+        set isEnabled(value) {
+            // ignore value if the extension is actually installed on the current browser
         },
     });
     patchUiSize({ size: SIZES.SM });

--- a/addons/mail/static/tests/discuss/core/crosstab.test.js
+++ b/addons/mail/static/tests/discuss/core/crosstab.test.js
@@ -45,7 +45,7 @@ test("Remove member from channel", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-discuss-ChannelMember", { text: "Harry" });
-    withUser(userId, () =>
+    await withUser(userId, () =>
         getService("orm").call("discuss.channel", "action_unfollow", [channelId])
     );
     await contains(".o-discuss-ChannelMember", { count: 0, text: "Harry" });

--- a/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
+++ b/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
@@ -170,7 +170,7 @@ test("channel preview ignores messages from the past", async () => {
     await contains(".o-mail-Message-content", { text: "last message", count: 0 });
     await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
     await contains(".o-mail-NotificationItem-text", { text: "You: last message" });
-    withUser(serverState.userId, () =>
+    await withUser(serverState.userId, () =>
         rpc("/mail/message/post", {
             post_data: { body: "it's a good idea", message_type: "comment" },
             thread_id: channelId,
@@ -230,7 +230,7 @@ test("counter is updated on receiving message on non-fetched channels", async ()
     expect(
         Boolean(getService("mail.store").Thread.get({ model: "discuss.channel", id: channelId }))
     ).toBe(false);
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/mail/message/post", {
             post_data: { body: "good to know", message_type: "comment" },
             thread_id: channelId,

--- a/addons/mail/static/tests/discuss/typing/typing.test.js
+++ b/addons/mail/static/tests/discuss/typing/typing.test.js
@@ -41,7 +41,7 @@ test('receive other member typing status "is typing"', async () => {
     await contains(".o-discuss-Typing");
     await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
     // simulate receive typing notification from demo
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: true,
@@ -66,7 +66,7 @@ test('receive other member typing status "is typing" then "no longer is typing"'
     await contains(".o-discuss-Typing");
     await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
     // simulate receive typing notification from demo "is typing"
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: true,
@@ -74,7 +74,7 @@ test('receive other member typing status "is typing" then "no longer is typing"'
     );
     await contains(".o-discuss-Typing", { text: "Demo is typing..." });
     // simulate receive typing notification from demo "is no longer typing"
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: false,
@@ -101,7 +101,7 @@ test('assume other member typing status becomes "no longer is typing" after long
     await contains(".o-discuss-Typing");
     await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
     // simulate receive typing notification from demo "is typing"
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: true,
@@ -129,7 +129,7 @@ test('other member typing status "is typing" refreshes of assuming no longer typ
     await contains(".o-discuss-Typing");
     await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
     // simulate receive typing notification from demo "is typing"
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: true,
@@ -176,7 +176,7 @@ test('receive several other members typing status "is typing"', async () => {
     await contains(".o-discuss-Typing");
     await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
     // simulate receive typing notification from other 10 (is typing)
-    withUser(userId_1, () =>
+    await withUser(userId_1, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: true,
@@ -184,7 +184,7 @@ test('receive several other members typing status "is typing"', async () => {
     );
     await contains(".o-discuss-Typing", { text: "Other 10 is typing..." });
     // simulate receive typing notification from other 11 (is typing)
-    withUser(userId_2, () =>
+    await withUser(userId_2, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: true,
@@ -192,7 +192,7 @@ test('receive several other members typing status "is typing"', async () => {
     );
     await contains(".o-discuss-Typing", { text: "Other 10 and Other 11 are typing..." });
     // simulate receive typing notification from other 12 (is typing)
-    withUser(userId_3, () =>
+    await withUser(userId_3, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: true,
@@ -200,7 +200,7 @@ test('receive several other members typing status "is typing"', async () => {
     );
     await contains(".o-discuss-Typing", { text: "Other 10, Other 11 and more are typing..." });
     // simulate receive typing notification from other 10 (no longer is typing)
-    withUser(userId_1, () =>
+    await withUser(userId_1, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: false,
@@ -208,7 +208,7 @@ test('receive several other members typing status "is typing"', async () => {
     );
     await contains(".o-discuss-Typing", { text: "Other 11 and Other 12 are typing..." });
     // simulate receive typing notification from other 10 (is typing again)
-    withUser(userId_1, () =>
+    await withUser(userId_1, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: true,
@@ -310,7 +310,7 @@ test("chat: correspondent is typing", async () => {
     await contains(".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-threadIcon");
     await contains(".fa-circle.text-success");
     // simulate receive typing notification from demo "is typing"
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: true,
@@ -318,7 +318,7 @@ test("chat: correspondent is typing", async () => {
     );
     await contains(".o-discuss-Typing-icon[title='Demo is typing...']");
     // simulate receive typing notification from demo "no longer is typing"
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: false,
@@ -347,7 +347,7 @@ test("chat: correspondent is typing in chat window", async () => {
     await click(".o-mail-NotificationItem");
     await contains("[title='Demo is typing...']", { count: 0 });
     // simulate receive typing notification from demo "is typing"
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: true,
@@ -355,7 +355,7 @@ test("chat: correspondent is typing in chat window", async () => {
     );
     await contains("[title='Demo is typing...']", { count: 2 }); // icon in header & text above composer
     // simulate receive typing notification from demo "no longer is typing"
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: false,
@@ -378,14 +378,14 @@ test("show typing in member list", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-discuss-ChannelMember", { count: 2 });
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: true,
         })
     );
     await contains(".o-discuss-ChannelMemberList [title='Other 10 is typing...']");
-    withUser(serverState.userId, () =>
+    await withUser(serverState.userId, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: true,

--- a/addons/mail/static/tests/discuss_app/inbox.test.js
+++ b/addons/mail/static/tests/discuss_app/inbox.test.js
@@ -666,7 +666,7 @@ test("Counter should be incremented by 1 when receiving a message with a mention
     await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
     const mention = [serverState.partnerId];
     const mentionName = serverState.partnerName;
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/mail/message/post", {
             post_data: {
                 body: `<a href="https://www.hoot.test/odoo/res.partner/17" class="o_mail_redirect" data-oe-id="${mention[0]}" data-oe-model="res.partner" target="_blank" contenteditable="false">@${mentionName}</a> mention`,

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -798,19 +798,7 @@ test("channel - states: open from the bus", async () => {
         user_id: serverState.userId,
         is_discuss_sidebar_category_channel_open: false,
     });
-    onRpcBefore("/mail/data", (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep(`/mail/data - ${JSON.stringify(args)}`);
-        }
-    });
     await start();
-    await waitForSteps([
-        `/mail/data - ${JSON.stringify({
-            fetch_params: ["failures", "systray_get_activities", "init_messaging"],
-            context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
-        })}`,
-    ]);
-    // send after init_messaging because bus subscription is done after init_messaging
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-channel .oi-chevron-right");
     const [partner] = pyEnv["res.partner"].read(serverState.partnerId);
@@ -948,19 +936,7 @@ test("chat - states: open from the bus", async () => {
         user_id: serverState.userId,
         is_discuss_sidebar_category_chat_open: false,
     });
-    onRpcBefore("/mail/data", (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep(`/mail/data - ${JSON.stringify(args)}`);
-        }
-    });
     await start();
-    await waitForSteps([
-        `/mail/data - ${JSON.stringify({
-            fetch_params: ["failures", "systray_get_activities", "init_messaging"],
-            context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
-        })}`,
-    ]);
-    // send after init_messaging because bus subscription is done after init_messaging
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
     await contains(".o-mail-DiscussSidebar button", { count: 0, text: "Mitchell Admin" });

--- a/addons/mail/static/tests/gif_picker/gif_picker.test.js
+++ b/addons/mail/static/tests/gif_picker/gif_picker.test.js
@@ -123,6 +123,7 @@ test("Not loading of GIF categories when feature is not available", async () => 
     await start();
     await openDiscuss(channelId);
     const store = getService("mail.store");
+    await store.isReady;
     store.hasGifPickerFeature = false;
     isFeatureEnabled = false;
     await click("button[title='Add GIFs']");
@@ -166,25 +167,23 @@ test("Open a GIF category trigger the search for the category", async () => {
 test("Can have GIF categories with same name", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "" });
-    onRpc("/discuss/gif/categories", () => {
-        return {
-            locale: "en",
-            tags: [
-                {
-                    searchterm: "duplicate",
-                    path: "/v2/search?q=duplicate&locale=en&component=categories&contentfilter=low",
-                    image: "https://media.tenor.com/BiseY2UXovAAAAAM/duplicate.gif",
-                    name: "#duplicate",
-                },
-                {
-                    searchterm: "duplicate",
-                    path: "/v2/search?q=duplicate&locale=en&component=categories&contentfilter=low",
-                    image: "https://media.tenor.com/BiseY2UXovAAAAAM/duplicate.gif",
-                    name: "#duplicate",
-                },
-            ],
-        };
-    });
+    onRpc("/discuss/gif/categories", () => ({
+        locale: "en",
+        tags: [
+            {
+                searchterm: "duplicate",
+                path: "/v2/search?q=duplicate&locale=en&component=categories&contentfilter=low",
+                image: "https://media.tenor.com/BiseY2UXovAAAAAM/duplicate.gif",
+                name: "#duplicate",
+            },
+            {
+                searchterm: "duplicate",
+                path: "/v2/search?q=duplicate&locale=en&component=categories&contentfilter=low",
+                image: "https://media.tenor.com/BiseY2UXovAAAAAM/duplicate.gif",
+                name: "#duplicate",
+            },
+        ],
+    }));
     onRpc("/discuss/gif/search", () => rpc.search);
     await start();
     await openDiscuss(channelId);

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -31,15 +31,10 @@ import { registry } from "@web/core/registry";
 import { MEDIAS_BREAKPOINTS, utils as uiUtils } from "@web/core/ui/ui_service";
 import { useServiceProtectMethodHandling } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
-import { session } from "@web/session";
 import { WebClient } from "@web/webclient/webclient";
 export { SIZES } from "@web/core/ui/ui_service";
 
-import {
-    DISCUSS_ACTION_ID,
-    authenticateGuest,
-    mailDataHelpers,
-} from "./mock_server/mail_mock_server";
+import { DISCUSS_ACTION_ID, authenticateGuest } from "./mock_server/mail_mock_server";
 import { Base } from "./mock_server/mock_models/base";
 import { DEFAULT_MAIL_VIEW_ID } from "./mock_server/mock_models/constants";
 import { DiscussChannel } from "./mock_server/mock_models/discuss_channel";
@@ -326,16 +321,6 @@ export async function start(options) {
             const adminUser = pyEnv["res.users"].search_read([["id", "=", serverState.userId]])[0];
             authenticate(adminUser.login, adminUser.password);
         }
-    }
-    if ("res.users" in pyEnv) {
-        /** @type {import("mock_models").ResUsers} */
-        const ResUsers = pyEnv["res.users"];
-        const store = new mailDataHelpers.Store();
-        ResUsers._init_store_data(store);
-        patchWithCleanup(session, {
-            storeData: store.get_result(),
-        });
-        registerDebugInfo("session.storeData", session.storeData);
     }
     let env;
     if (options?.asTab) {

--- a/addons/mail/static/tests/messaging/messaging.test.js
+++ b/addons/mail/static/tests/messaging/messaging.test.js
@@ -2,20 +2,13 @@ import {
     contains,
     defineMailModels,
     insertText,
-    onRpcBefore,
     openDiscuss,
     openFormView,
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
-import {
-    asyncStep,
-    Command,
-    serverState,
-    waitForSteps,
-    withUser,
-} from "@web/../tests/web_test_helpers";
+import { Command, serverState, withUser } from "@web/../tests/web_test_helpers";
 import { press } from "@odoo/hoot-dom";
 
 import { rpc } from "@web/core/network/rpc";
@@ -34,21 +27,9 @@ test("Receiving a new message out of discuss app should open a chat bubble", asy
         ],
         channel_type: "chat",
     });
-    onRpcBefore("/mail/data", (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep(`/mail/data - ${JSON.stringify(args)}`);
-        }
-    });
     await start();
-    await waitForSteps([
-        `/mail/data - ${JSON.stringify({
-            fetch_params: ["failures", "systray_get_activities", "init_messaging"],
-            context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
-        })}`,
-    ]);
-    // send after init_messaging because bus subscription is done after init_messaging
     // simulate receving new message
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/mail/message/post", {
             post_data: { body: "Magic!", message_type: "comment" },
             thread_id: channelId,
@@ -69,19 +50,7 @@ test("Receiving a new message in discuss app should open a chat bubble after lea
         ],
         channel_type: "chat",
     });
-    onRpcBefore("/mail/data", (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep(`/mail/data - ${JSON.stringify(args)}`);
-        }
-    });
     await start();
-    await waitForSteps([
-        `/mail/data - ${JSON.stringify({
-            fetch_params: ["failures", "systray_get_activities", "init_messaging"],
-            context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
-        })}`,
-    ]);
-    // send after init_messaging because bus subscription is done after init_messaging
     await openDiscuss();
     // simulate receiving new message
     await withUser(userId, () =>

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -604,7 +604,7 @@ test("Counter is updated when receiving new message", async () => {
     });
     await start();
     await openDiscuss();
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/mail/message/post", {
             thread_id: channelId,
             thread_model: "discuss.channel",

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -93,7 +93,7 @@ export function registerRoute(route, handler) {
             return res;
         }
         const response = handler.call(this, request);
-        res = await beforeCallableHandler.after?.(response);
+        res = await beforeCallableHandler.after?.({ params: args, response });
         if (res !== undefined) {
             return res;
         }
@@ -940,6 +940,7 @@ async function processRequest(request) {
                 ? [fetchParam, undefined]
                 : fetchParam;
         if (name === "init_messaging") {
+            ResUsers._init_store_data(store);
             if (!MailGuest._get_guest_from_context() || !ResUsers._is_public(this.env.uid)) {
                 ResUsers._init_messaging([this.env.uid], store, args.context);
             }

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -288,11 +288,6 @@ test("mark channel as fetched when a new message is loaded", async () => {
         ],
         channel_type: "chat",
     });
-    onRpcBefore("/mail/data", (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep(`/mail/data - ${JSON.stringify(args)}`);
-        }
-    });
     onRpcBefore("/discuss/channel/mark_as_read", (args) => {
         expect(args.channel_id).toBe(channelId);
         asyncStep("rpc:mark_as_read");
@@ -303,20 +298,7 @@ test("mark channel as fetched when a new message is loaded", async () => {
     });
     setupChatHub({ opened: [channelId] });
     await start();
-    await contains(".o_menu_systray i[aria-label='Messages']");
-    await waitForSteps([
-        `/mail/data - ${JSON.stringify({
-            fetch_params: [
-                "failures",
-                "systray_get_activities",
-                "init_messaging",
-                ["discuss.channel", [channelId]],
-            ],
-            context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
-        })}`,
-    ]);
-    // send after init_messaging because bus subscription is done after init_messaging
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/mail/message/post", {
             post_data: { body: "Hello!", message_type: "comment" },
             thread_id: channelId,
@@ -395,7 +377,7 @@ test("should scroll to bottom on receiving new message if the list is initially 
     await scroll(".o-mail-Thread", "bottom");
     await contains(".o-mail-Thread", { scroll: "bottom" });
     // simulate receiving a message
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/mail/message/post", {
             post_data: { body: "hello", message_type: "comment" },
             thread_id: channelId,
@@ -429,7 +411,7 @@ test("should not scroll on receiving new message if the list is initially scroll
     await contains(".o-mail-Message", { count: 11 });
     await contains(".o-mail-Thread", { scroll: 0 });
     // simulate receiving a message
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/mail/message/post", {
             post_data: { body: "hello", message_type: "comment" },
             thread_id: channelId,
@@ -656,7 +638,7 @@ test("first unseen message should be directly preceded by the new message separa
     // composer is focused by default, we remove that focus
     queryFirst(".o-mail-Composer-input").blur();
     // simulate receiving a message
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/mail/message/post", {
             post_data: { body: "test", message_type: "comment" },
             thread_id: channelId,

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -78,7 +78,8 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             async run() {
                 /** @type {import("models").Store} */
                 const store = odoo.__WOWL_DEBUG__.root.env.services["mail.store"];
-                if (store.self.type === "guest") {
+                const self = await store.getSelf();
+                if (self.type === "guest") {
                     const src = this.anchor.querySelector("img").src;
                     const token = store["ir.attachment"].get(
                         (src.match("/web/image/([0-9]+)") || []).at(-1)

--- a/addons/portal_rating/static/src/chatter/frontend/message_patch.xml
+++ b/addons/portal_rating/static/src/chatter/frontend/message_patch.xml
@@ -13,7 +13,7 @@
                 is link to the message (because publisher comment data
                 is on the rating.rating model - one comment max) -->
             <div t-if="message.rating and message.rating.id" class="o_wrating_publisher_container">
-                <button t-if="store.self.is_user_publisher"
+                <button t-if="store.self?.is_user_publisher"
                     t-attf-class="btn px-2 my-2 btn-sm border o_wrating_js_publisher_comment_btn {{ message.rating.publisher_comment !== '' ? 'd-none' : '' }}"
                     t-att-data-mes_index="message.rating.mes_index"
                     t-on-click="onClikEditComment">
@@ -34,7 +34,7 @@
                             <div class="o-mail-Message-header d-flex flex-wrap align-items-baseline mb-1 lh-1">
                                 <strong class="me-1 text-truncate"><t t-esc="message.rating.publisher_name"/></strong>
                                 <small class="text-muted opacity-50 me-2">Published on <t t-esc="message.rating.publisher_datetime"/></small>
-                                <div t-if="store.self.is_user_publisher" class="d-flex rounded-0">
+                                <div t-if="store.self?.is_user_publisher" class="d-flex rounded-0">
                                     <Dropdown>
                                         <button class="bg-transparent border-0">
                                             <i class="btn px-1 py-0 fa fa-ellipsis-v"/>

--- a/addons/web/static/tests/_framework/async_step.js
+++ b/addons/web/static/tests/_framework/async_step.js
@@ -12,6 +12,7 @@ import { Deferred } from "@odoo/hoot-dom";
  * @typedef {{
  *  timeout?: number;
  *  ignoreOrder?: boolean;
+ *  required?: boolean;
  * }} WaitForStepsOptions
  */
 
@@ -114,7 +115,14 @@ export async function waitForSteps(steps, options = {}) {
     stepState.expectedSteps = steps;
     stepState.deferred = new Deferred();
     stepState.ignoreOrder = options.ignoreOrder;
-    stepState.timeout = setTimeout(() => checkStepState(true), options.timeout ?? 2000);
+    stepState.timeout = setTimeout(() => {
+        if (options.required) {
+            checkStepState(true);
+        } else {
+            checkStepState(false);
+            clearStepState();
+        }
+    }, options.timeout ?? 2000);
 
     // Soft check with current steps
     checkStepState(false);


### PR DESCRIPTION
\* = im_livechat

The goal is to have the webclient load as fast as possible, and even better if the page can be fully cached.

Retrieve all dynamic info in the initial RPC.

https://github.com/odoo/enterprise/pull/77982