### PR TITLE
[FIX] core: deprecated type='json' alias for type='jsonrpc'

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -715,7 +715,15 @@ def route(route=None, **routing):
         fname = f"<function {endpoint.__module__}.{endpoint.__name__}>"
 
         # Sanitize the routing
-        assert routing.get('type', 'http') in _dispatchers.keys()
+        if routing.get('type') == 'json':
+            warnings.warn(
+                "Since 19.0, @route(type='json') is a deprecated alias to @route(type='jsonrpc')",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            routing['type'] = 'jsonrpc'
+        assert routing.get('type', 'http') in _dispatchers.keys(), \
+            f"@route(type={routing['type']!r}) is not one of {_dispatchers.keys()}"
         if route:
             routing['routes'] = [route] if isinstance(route, str) else route
         wrong = routing.pop('method', None)


### PR DESCRIPTION
Commit 67b6ef3 changed `@route(type='json')` for `@route(type='jsonrpc')` but with no deprecation warning. Using `@route(type='json')` resulted in a (not so obvious) AssertionError.

In this work, we restored `type='json'` as a deprecated alias to `type='jsonrpc'`, the warning is only logged once. We also improved the assertion message so it lists the valid types.

If you need cross-version compatibility (down to 16.0) you might also do:

	from odoo.http import JsonRPCDispatcher
	@route(..., type=JsonRPCDispatcher.routing_type)

There's also a upgrade-code script to help you change all `type='json'` to `type='jsonrpc'`:

	odoo-bin upgrade_code --help
	odoo-bin upgrade_code --script route-jsonrpc

task-4257153
