### PR TITLE
[FIX] web: view_service: mark loadViews as async

### DIFF
--- a/addons/web/static/src/views/view_service.js
+++ b/addons/web/static/src/views/view_service.js
@@ -41,6 +41,7 @@ import { UPDATE_METHODS } from "@web/core/orm_service";
 
 export const viewService = {
     dependencies: ["orm"],
+    async: ["loadViews"],
     start(env, { orm }) {
         let cache = {};
 

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -12054,7 +12054,7 @@ QUnit.module("Views", (hooks) => {
                 if (obj.display_name === "first line") {
                     if (onChangeCount === 0) {
                         onChangeCount += 1;
-                        assert.step("resequence onChange crash")
+                        assert.step("resequence onChange crash");
                         throw makeErrorFromResponse({
                             code: 200,
                             message: "Odoo Server Error",
@@ -12098,8 +12098,9 @@ QUnit.module("Views", (hooks) => {
         await click(target.querySelector(".o_form_button_save"));
         await nextTick();
 
-        let getNames = () => [...target.querySelectorAll(".o_list_char")].map((el) => el.textContent)
-        assert.deepEqual(getNames(), ["first line", "second line"])
+        const getNames = () =>
+            [...target.querySelectorAll(".o_list_char")].map((el) => el.textContent);
+        assert.deepEqual(getNames(), ["first line", "second line"]);
 
         // drag and drop first line to the second, should crash because of onchange
         await dragAndDrop(
@@ -12107,7 +12108,7 @@ QUnit.module("Views", (hooks) => {
             "tbody.ui-sortable tr:nth-child(2)"
         );
         await nextTick();
-        assert.deepEqual(getNames(), ["first line", "second line"])
+        assert.deepEqual(getNames(), ["first line", "second line"]);
 
         // drag and drop first line to the second, should work
         await dragAndDrop(
@@ -12115,7 +12116,7 @@ QUnit.module("Views", (hooks) => {
             "tbody.ui-sortable tr:nth-child(2)"
         );
         await nextTick();
-        assert.deepEqual(getNames(), ["second line", "first line"])
+        assert.deepEqual(getNames(), ["second line", "first line"]);
 
         assert.verifySteps(["resequence onChange crash", "resequence onChange ok"]);
     });
@@ -15231,6 +15232,51 @@ QUnit.module("Views", (hooks) => {
             await click(target.querySelector(".btn[name='lovely action']"));
             // the record should have been saved and the action performed.
             assert.verifySteps(["Check/prepare record datas", "web_save", "Perform Action"]);
+        }
+    );
+
+    QUnit.test(
+        "open x2many with non inline form view, delayed get_views, form destroyed",
+        async function (assert) {
+            serverData.models.partner.records[0].product_ids = [37];
+            serverData.views = {
+                "product,false,form": `<form><field name="display_name"/></form>`,
+            };
+
+            let def;
+            const form = await makeView({
+                type: "form",
+                resModel: "partner",
+                serverData,
+                arch: `
+                    <form>
+                        <field name="product_ids">
+                            <tree>
+                                <field name="display_name"/>
+                            </tree>
+                        </field>
+                    </form>`,
+                resId: 1,
+                async mockRPC(route, { method }) {
+                    if (method === "get_views") {
+                        assert.step("get_views");
+                        await def;
+                    }
+                },
+            });
+
+            // click on an x2many record to open it in dialog (get_views delayed)
+            def = makeDeferred();
+            await click(target, ".o_data_row .o_data_cell");
+            assert.containsNone(target, ".o_dialog");
+
+            // destroy the form view while get_views is pending
+            form.__owl__.destroy();
+            def.resolve();
+            await nextTick();
+
+            // everything should have gone smoothly, nothing should have happened as the view is destroyed
+            assert.verifySteps(["get_views", "get_views"]);
         }
     );
 });


### PR DESCRIPTION
Before this commit, loadViews didn't benefit from the "async" protection of services. Indeed, when used in a component (via useService), the promise returned by loadViews could be resolved (when the rpc returned), even if the component had been destroyed meanwhile. This could lead to code in a destroyed component being executed, and eventually doing an rpc, which would lead to the crash `Error: Component is destroyed`.

This could be reproduced in a form view with an x2many field, whose form view isn't inline (i.e. needs to be fetched when a record is clicked). In such a form view, click on a record in the x2many, then, during the call to get_views, toggle the home menu (for instance).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
