### PR TITLE
[FIX] point_of_sale: avoid creating change payment with amount = 0

### DIFF
--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -65,7 +65,7 @@ class PosPayment(models.Model):
 
     def _create_payment_moves(self, is_reverse=False):
         result = self.env['account.move']
-        change_payment = self.filtered(lambda p: p.is_change and p.payment_method_id.type == 'cash')
+        change_payment = self.filtered(lambda p: p.is_change and p.payment_method_id.type == 'cash' and p.amount > 0)
         payment_to_change = self.filtered(lambda p: not p.is_change and p.payment_method_id.type == 'cash')[:1]
         normal_payments = (self - payment_to_change) - change_payment if change_payment else self
 
@@ -91,6 +91,7 @@ class PosPayment(models.Model):
             self.write({'account_move_id': payment_move.id})
             payment_move._post()
             return payment_move
+        return self.env['account.move']
 
     def _create_payment_move_entry(self, is_reverse=False):
         self.ensure_one()


### PR DESCRIPTION
Issue from commit
https://github.com/odoo/odoo/commit/91a943b2655efcc45dfa865d61aaeff77060e8f7





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
