### PR TITLE
[IMP] base: improve test_uncommented_invisible_field error message

### DIFF
--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -4568,19 +4568,20 @@ class TestInvisibleField(TransactionCaseWithUserDemo):
 
         modules_without_error = set(self.env['ir.module.module'].search([('state', '=', 'intalled'), ('name', 'in', only_log_modules)]).mapped('name'))
         module_log_views = defaultdict(list)
-        module_error_views = defaultdict(list)
+        module_error_views = defaultdict(lambda: defaultdict(list)) 
         uncommented_regexp = r'''(<field [^>]*invisible=['"](True|1)['"][^>]*>)[\s\t\n ]*(.*)'''
         views = self.env['ir.ui.view'].search([('type', 'in', ('tree', 'form')), '|', ('arch_db', 'like', 'invisible=_True_'), ('arch_db', 'like', 'invisible=_1_')])
-        for view in views:
+        for view in views.filtered('model_data_id'):
+            module_name = view.model_data_id.module
+            view_name = view.model_data_id.name
             for field, _val, comment in re.findall(uncommented_regexp, view.arch_db):
-                if (not comment or not comment.startswith('<!--')) and view.model_data_id:
-                    views = module = view.model_data_id.module
-                    if module in only_log_modules:
-                        modules_without_error.discard(module)
-                        module_log_views[module].append(view.model_data_id.name)
+                if (not comment or not comment.startswith('<!--')):
+                    if module_name in only_log_modules:
+                        modules_without_error.discard(module_name)
+                        module_log_views[module_name].append(view_name)
+                        break
                     else:
-                        module_error_views[module].append(view.model_data_id.name)
-                    break
+                        module_error_views[module_name][view_name].append(field)
 
         msg = 'Please indicate why the always invisible fields are present in the view, or remove the field tag.'
 
@@ -4589,8 +4590,13 @@ class TestInvisibleField(TransactionCaseWithUserDemo):
             _logger.info('%s\n%s', msg, msg_info)
 
         if module_error_views:
-            msg_info = '\n'.join(f'Addons: {module!r}   Views: {names}' for module, names in module_error_views.items())
-            _logger.error('%s\n%s', msg, msg_info)
+            error_lines = []
+            for module, view_errors in module_error_views.items():
+                error_lines.append(f"Addon: {module!r}")
+                for view, fields in view_errors.items():
+                    error_lines.extend([f"{' ' * 3}View: {view}\n{' ' * 6}Fields:"])
+                    error_lines.extend(["\n".join(f"{' ' * 9}{field}" for field in fields)])
+            _logger.error("%s\n%s", msg, "\n".join(error_lines))
 
         if modules_without_error:
             _logger.error('Please remove this module names from the white list of this current test: %r', sorted(modules_without_error))


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
Since this PR #162009, all uncommented invisible fields raise an error.
This commit improves the error message from the method `test_uncommented_invisible_field` by showing which line of the view should be removed/commented.

The error message before this commit :
```
Addons: 'module_name'   Views: ['view_name1', 'view_name2']
```

After:
```
Addon: 'module_name'
   View: view_name1
      Fields:
         <field name="field1" invisible="1">
         <field name="field2" invisible="1">
   View: view_name2
      Fields:
         <field name="field1" invisible="1">
```

The main benefit of this change is to display in a single test all uncommented fields that need to be fixed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
