### PR TITLE
[IMP] release: update to PEP440 identifier

### DIFF
--- a/odoo/release.py
+++ b/odoo/release.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 RELEASE_LEVELS = [ALPHA, BETA, RELEASE_CANDIDATE, FINAL] = ['alpha', 'beta', 'candidate', 'final']
-RELEASE_LEVELS_DISPLAY = {ALPHA: ALPHA,
-                          BETA: BETA,
+RELEASE_LEVELS_DISPLAY = {ALPHA: 'a',
+                          BETA: 'b',
                           RELEASE_CANDIDATE: 'rc',
                           FINAL: ''}
 
@@ -14,8 +13,8 @@ RELEASE_LEVELS_DISPLAY = {ALPHA: ALPHA,
 #  (6,1,0,'candidate',2) < (6,1,0,'final',0) < (6,1,2,'final',0)
 # NOTE: during release, the MAJOR version can become an arbitrary string ('saas~xx')
 version_info = (18, 2, 0, ALPHA, 1, '')
-version = '.'.join(str(s) for s in version_info[:2]) + RELEASE_LEVELS_DISPLAY[version_info[3]] + str(version_info[4] or '') + version_info[5]
 series = serie = major_version = '.'.join(str(s) for s in version_info[:2])
+version = series + RELEASE_LEVELS_DISPLAY[version_info[3]] + str(version_info[4] or '') + version_info[5]
 
 product_name = 'Odoo'
 description = 'Odoo Server'


### PR DESCRIPTION
The release levels are specified in PEP440 as "a|b|rc".
https://peps.python.org/pep-0440/

odoo/documentation#11863


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
