### PR TITLE
[IMP] point_of_sale: add error details when processing the order

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -146,7 +146,7 @@ class PosOrder(models.Model):
                 # do not hide transactional errors, the order(s) won't be saved!
                 raise
             except Exception as e:
-                _logger.error('Could not fully process the POS Order: %s', tools.ustr(e))
+                _logger.error('Could not fully process the POS Order: %s', tools.ustr(e), exc_info=True)
             pos_order._create_order_picking()
             pos_order._compute_total_cost_in_real_time()
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Additional information is needed in the error log to identify the method causing the error.

Current behavior before PR:

Prior to this change, the log received when an error occured was as follows but no information about the code was shown: `odoo.addons.point_of_sale.models.pos_order: Could not fully process the POS Order: Record cannot be modified right now: This cron task is currently being executed and may not be modified Please try again in a few minutes.

Desired behavior after PR is merged:

Information about the method causing the error must be displayed




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
