### PR TITLE
[REF] various: use a dedicated warehouse in stock tests

### DIFF
--- a/addons/mrp/tests/common.py
+++ b/addons/mrp/tests/common.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from odoo import Command
 from odoo.tests import Form
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.stock.tests.common import TestStockCommon
@@ -40,8 +41,8 @@ class TestMrpCommon(TestStockCommon):
             'type': 'normal',
             'consumption': consumption if consumption else 'flexible',
             'bom_line_ids': [
-                (0, 0, {'product_id': product_to_use_2.id, 'product_qty': qty_base_2}),
-                (0, 0, {'product_id': product_to_use_1.id, 'product_qty': qty_base_1})
+                Command.create({'product_id': product_to_use_2.id, 'product_qty': qty_base_2}),
+                Command.create({'product_id': product_to_use_1.id, 'product_qty': qty_base_1}),
             ]})
         mo_form = Form(cls.env['mrp.production'])
         mo_form.product_id = product_to_build
@@ -101,6 +102,9 @@ class TestMrpCommon(TestStockCommon):
         # field `product_uom_id` must be set by many tests, and subviews of
         # `workorder_ids` must be present in many tests to create records.
         cls.env.user.group_ids += cls.env.ref('uom.group_uom') + cls.env.ref('mrp.group_mrp_routings')
+        cls.picking_type_manu = cls.warehouse_1.manu_type_id
+        cls.picking_type_manu.sequence = 5
+        cls.route_manufacture = cls.warehouse_1.manufacture_pull_id.route_id
 
         cls.workcenter_1 = cls.env['mrp.workcenter'].create({
             'name': 'Nuclear Workcenter',
@@ -138,8 +142,8 @@ class TestMrpCommon(TestStockCommon):
             ],
             'type': 'normal',
             'bom_line_ids': [
-                (0, 0, {'product_id': cls.product_2.id, 'product_qty': 2}),
-                (0, 0, {'product_id': cls.product_1.id, 'product_qty': 4})
+                Command.create({'product_id': cls.product_2.id, 'product_qty': 2}),
+                Command.create({'product_id': cls.product_1.id, 'product_qty': 4}),
             ]})
         cls.bom_2 = cls.env['mrp.bom'].create({
             'product_id': cls.product_5.id,
@@ -148,13 +152,13 @@ class TestMrpCommon(TestStockCommon):
             'consumption': 'flexible',
             'product_qty': 1.0,
             'operation_ids': [
-                (0, 0, {'name': 'Gift Wrap Maching', 'workcenter_id': cls.workcenter_1.id, 'time_cycle': 15, 'sequence': 1}),
+                Command.create({'name': 'Gift Wrap Maching', 'workcenter_id': cls.workcenter_1.id, 'time_cycle': 15, 'sequence': 1}),
             ],
             'type': 'phantom',
             'sequence': 2,
             'bom_line_ids': [
-                (0, 0, {'product_id': cls.product_4.id, 'product_qty': 2}),
-                (0, 0, {'product_id': cls.product_3.id, 'product_qty': 3})
+                Command.create({'product_id': cls.product_4.id, 'product_qty': 2}),
+                Command.create({'product_id': cls.product_3.id, 'product_qty': 3}),
             ]})
         cls.bom_3 = cls.env['mrp.bom'].create({
             'product_id': cls.product_6.id,
@@ -164,63 +168,65 @@ class TestMrpCommon(TestStockCommon):
             'consumption': 'flexible',
             'product_qty': 2.0,
             'operation_ids': [
-                (0, 0, {'name': 'Cutting Machine', 'workcenter_id': cls.workcenter_1.id, 'time_cycle': 12, 'sequence': 1}),
-                (0, 0, {'name': 'Weld Machine', 'workcenter_id': cls.workcenter_1.id, 'time_cycle': 18, 'sequence': 2}),
+                Command.create({'name': 'Cutting Machine', 'workcenter_id': cls.workcenter_1.id, 'time_cycle': 12, 'sequence': 1}),
+                Command.create({'name': 'Weld Machine', 'workcenter_id': cls.workcenter_1.id, 'time_cycle': 18, 'sequence': 2}),
             ],
             'type': 'normal',
             'bom_line_ids': [
-                (0, 0, {'product_id': cls.product_5.id, 'product_qty': 2}),
-                (0, 0, {'product_id': cls.product_4.id, 'product_qty': 8}),
-                (0, 0, {'product_id': cls.product_2.id, 'product_qty': 12})
+                Command.create({'product_id': cls.product_5.id, 'product_qty': 2}),
+                Command.create({'product_id': cls.product_4.id, 'product_qty': 8}),
+                Command.create({'product_id': cls.product_2.id, 'product_qty': 12}),
             ]})
         cls.bom_4 = cls.env['mrp.bom'].create({
             'product_id': cls.product_6.id,
             'product_tmpl_id': cls.product_6.product_tmpl_id.id,
             'consumption': 'flexible',
             'product_qty': 1.0,
-            'operation_ids': [
-                (0, 0, {'name': 'Rub it gently with a cloth', 'workcenter_id': cls.workcenter_2.id,
-                        'time_mode_batch': 1, 'time_mode': "auto", 'sequence': 1}),
-            ],
+            'operation_ids': [Command.create({
+                'name': 'Rub it gently with a cloth',
+                'workcenter_id': cls.workcenter_2.id,
+                'time_mode_batch': 1,
+                'time_mode': "auto",
+                'sequence': 1,
+            })],
             'type': 'normal',
             'bom_line_ids': [
-                (0, 0, {'product_id': cls.product_1.id, 'product_qty': 1}),
+                Command.create({'product_id': cls.product_1.id, 'product_qty': 1}),
             ]})
         cls.bom_5 = cls.env['mrp.bom'].create({
             'product_id': cls.product_6.id,
             'product_tmpl_id': cls.product_6.product_tmpl_id.id,
             'consumption': 'flexible',
             'product_qty': 1.0,
-            'operation_ids': [
-                (0, 0, {'name': 'Rub it gently with a cloth two at once', 'workcenter_id': cls.workcenter_3.id,
-                        'time_mode_batch': 2, 'time_mode': "auto", 'sequence': 1}),
-            ],
+            'operation_ids': [Command.create({
+                'name': 'Rub it gently with a cloth two at once',
+                'workcenter_id': cls.workcenter_3.id,
+                'time_mode_batch': 2,
+                'time_mode': "auto",
+                'sequence': 1,
+            })],
             'type': 'normal',
             'bom_line_ids': [
-                (0, 0, {'product_id': cls.product_1.id, 'product_qty': 1}),
+                Command.create({'product_id': cls.product_1.id, 'product_qty': 1}),
             ]})
         cls.bom_6 = cls.env['mrp.bom'].create({
             'product_id': cls.product_6.id,
             'product_tmpl_id': cls.product_6.product_tmpl_id.id,
             'consumption': 'flexible',
             'product_qty': 1.0,
-            'operation_ids': [
-                (0, 0, {'name': 'Rub it gently with a cloth two at once', 'workcenter_id': cls.workcenter_3.id,
-                        'time_mode_batch': 1, 'time_mode': "auto", 'sequence': 1}),
-            ],
+            'operation_ids': [Command.create({
+                'name': 'Rub it gently with a cloth two at once',
+                'workcenter_id': cls.workcenter_3.id,
+                'time_mode_batch': 1,
+                'time_mode': "auto",
+                'sequence': 1,
+            })],
             'type': 'normal',
             'bom_line_ids': [
-                (0, 0, {'product_id': cls.product_1.id, 'product_qty': 1}),
+                Command.create({'product_id': cls.product_1.id, 'product_qty': 1}),
             ]})
 
-        cls.stock_location_14 = cls.env['stock.location'].create({
-            'name': 'Shelf 2',
-            'location_id': cls.env.ref('stock.warehouse0').lot_stock_id.id,
-        })
-        cls.stock_location_components = cls.env['stock.location'].create({
-            'name': 'Shelf 1',
-            'location_id': cls.env.ref('stock.warehouse0').lot_stock_id.id,
-        })
+        cls.stock_location_components = cls.shelf_1
         cls.laptop = cls.env['product.product'].create({
             'name': 'Acoustic Bloc Screens',
             'uom_id': cls.env.ref("uom.product_uom_unit").id,
@@ -255,7 +261,7 @@ class TestMrpCommon(TestStockCommon):
                 "type": "phantom",
                 "product_uom_id": cls.uom_unit.id,
                 "bom_line_ids": [
-                    (0, 0, {
+                    Command.create({
                         "product_id": c.id,
                         "product_qty": 1,
                         "product_uom_id": cls.uom_unit.id

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -15,8 +15,8 @@ class TestBoM(TestMrpCommon):
     def setUpClass(cls):
         super().setUpClass()
         cls.env.ref('base.group_user').write({'implied_ids': [
-            (4, cls.env.ref('product.group_product_variant').id),
-            (4, cls.env.ref('mrp.group_mrp_routings').id),
+            Command.link(cls.env.ref('product.group_product_variant').id),
+            Command.link(cls.env.ref('mrp.group_mrp_routings').id),
         ]})
 
     def test_01_explode(self):
@@ -161,11 +161,14 @@ class TestBoM(TestMrpCommon):
             'type': 'phantom'
         })
         test_bom_1.write({
-            'operation_ids': [
-                (0, 0, {'name': 'Gift Wrap Maching', 'workcenter_id': self.workcenter_1.id, 'time_cycle': 15, 'sequence': 1}),
-            ],
+            'operation_ids': [Command.create({
+                'name': 'Gift Wrap Maching',
+                'workcenter_id': self.workcenter_1.id,
+                'time_cycle': 15,
+                'sequence': 1,
+            })]
         })
-        test_bom_1.bom_line_ids = [(0, 0, {
+        test_bom_1.bom_line_ids = [Command.create({
             'product_id': self.product_3.id,
             'product_qty': 3,
         })]
@@ -178,25 +181,25 @@ class TestBoM(TestMrpCommon):
         })
         test_bom_2.write({
             'operation_ids': [
-                (0, 0, {'name': 'Cutting Machine', 'workcenter_id': self.workcenter_1.id, 'time_cycle': 12, 'sequence': 1}),
-                (0, 0, {'name': 'Weld Machine', 'workcenter_id': self.workcenter_1.id, 'time_cycle': 18, 'sequence': 2}),
+                Command.create({'name': 'Cutting Machine', 'workcenter_id': self.workcenter_1.id, 'time_cycle': 12, 'sequence': 1}),
+                Command.create({'name': 'Weld Machine', 'workcenter_id': self.workcenter_1.id, 'time_cycle': 18, 'sequence': 2}),
             ]
         })
-        test_bom_2.bom_line_ids = [(0, 0, {
+        test_bom_2.bom_line_ids = [Command.create({
             'product_id': self.product_2.id,
             'product_qty': 2,
         })]
-        test_bom_2.bom_line_ids = [(0, 0, {
+        test_bom_2.bom_line_ids = [Command.create({
             'product_id': self.product_5.id,
             'product_qty': 2,
-            'bom_product_template_attribute_value_ids': [(4, self.product_7_attr1_v1.id)],
+            'bom_product_template_attribute_value_ids': [Command.link(self.product_7_attr1_v1.id)],
         })]
-        test_bom_2.bom_line_ids = [(0, 0, {
+        test_bom_2.bom_line_ids = [Command.create({
             'product_id': self.product_5.id,
             'product_qty': 2,
-            'bom_product_template_attribute_value_ids': [(4, self.product_7_attr1_v2.id)],
+            'bom_product_template_attribute_value_ids': [Command.link(self.product_7_attr1_v2.id)],
         })]
-        test_bom_2.bom_line_ids = [(0, 0, {
+        test_bom_2.bom_line_ids = [Command.create({
             'product_id': self.product_4.id,
             'product_qty': 2,
         })]
@@ -214,7 +217,7 @@ class TestBoM(TestMrpCommon):
         self.assertEqual(set((test_bom_2_l1 | test_bom_2_l4 | test_bom_1.bom_line_ids).ids), set([l[0].id for l in lines]))
 
         # check with another picking_type
-        test_bom_1.write({'picking_type_id': self.warehouse_1.manu_type_id.id})
+        test_bom_1.write({'picking_type_id': self.picking_type_manu.id})
         self.bom_2.write({'picking_type_id': tmp_picking_type.id})
         test_bom_2.write({'picking_type_id': tmp_picking_type.id})
         boms, lines = test_bom_2.explode(self.product_7_1, 4)
@@ -244,12 +247,12 @@ class TestBoM(TestMrpCommon):
             'consumption': 'flexible',
             'type': 'phantom'
         })
-        test_bom_3.bom_line_ids = [(0, 0, {
+        test_bom_3.bom_line_ids = [Command.create({
             'product_id': self.product_10.id,
             'product_qty': 1.0,
         })]
         with self.assertRaises(exceptions.UserError):
-            test_bom_4.bom_line_ids = [(0, 0, {
+            test_bom_4.bom_line_ids = [Command.create({
                 'product_id': self.product_9.id,
                 'product_qty': 1.0,
             })]
@@ -276,11 +279,11 @@ class TestBoM(TestMrpCommon):
         product_template = self.env['product.template'].create({
             'name': 'Sofa',
             'attribute_line_ids': [
-                (0, 0, {
+                Command.create({
                     'attribute_id': att_color.id,
                     'value_ids': [(6, 0, [att_color_red.id, att_color_blue.id])]
                 }),
-                (0, 0, {
+                Command.create({
                     'attribute_id': att_size.id,
                     'value_ids': [(6, 0, [att_size_big.id, att_size_medium.id])]
                 })
@@ -305,16 +308,23 @@ class TestBoM(TestMrpCommon):
             'product_qty': 1.0,
             'type': 'normal',
             'bom_line_ids': [
-                (0, 0, {
+                Command.create({
                     'product_id': product_A.id,
                     'product_qty': 1,
-                    'bom_product_template_attribute_value_ids': [(4, sofa_red.id), (4, sofa_blue.id), (4, sofa_big.id)],
+                    'bom_product_template_attribute_value_ids': [
+                        Command.link(sofa_red.id),
+                        Command.link(sofa_blue.id),
+                        Command.link(sofa_big.id),
+                    ],
                 }),
-                (0, 0, {
+                Command.create({
                     'product_id': product_B.id,
                     'product_qty': 1,
-                    'bom_product_template_attribute_value_ids': [(4, sofa_red.id), (4, sofa_blue.id)]
-                })
+                    'bom_product_template_attribute_value_ids': [
+                        Command.link(sofa_red.id),
+                        Command.link(sofa_blue.id),
+                    ]
+                }),
             ]
         })
 
@@ -343,19 +353,18 @@ class TestBoM(TestMrpCommon):
             'product_qty': 4.0,
             'type': 'phantom',
             'bom_line_ids': [
-                (0, 0, {
+                Command.create({
                     'product_id': self.product_2.id,
                     'product_qty': 2,
                 }),
-                (0, 0, {
+                Command.create({
                     'product_id': self.product_3.id,
                     'product_qty': 2,
-                })
+                }),
             ]
         })
-        location = self.env.ref('stock.stock_location_stock')
-        self.env['stock.quant']._update_available_quantity(self.product_2, location, 4.0)
-        self.env['stock.quant']._update_available_quantity(self.product_3, location, 8.0)
+        self.env['stock.quant']._update_available_quantity(self.product_2, self.stock_location, 4.0)
+        self.env['stock.quant']._update_available_quantity(self.product_3, self.stock_location, 8.0)
         # Force the kit product available qty to be computed at the same time than its component quantities
         # Because `qty_available` of a bom kit "recurse" on `qty_available` of its component,
         # and this is a tricky thing for the ORM:
@@ -368,19 +377,17 @@ class TestBoM(TestMrpCommon):
         self.assertEqual(kit_product_qty, 8)
 
     def test_14_bom_kit_qty_multi_uom(self):
-        uom_dozens = self.env.ref('uom.product_uom_dozen')
-        uom_unit = self.env.ref('uom.product_uom_unit')
         product_unit = self.env['product.product'].create({
             'name': 'Test units',
             'type': 'consu',
             'is_storable': True,
-            'uom_id': uom_unit.id,
+            'uom_id': self.uom_unit.id,
         })
         product_dozens = self.env['product.product'].create({
             'name': 'Test dozens',
             'type': 'consu',
             'is_storable': True,
-            'uom_id': uom_dozens.id,
+            'uom_id': self.uom_dozen.id,
         })
 
         self.env['mrp.bom'].create({
@@ -389,15 +396,14 @@ class TestBoM(TestMrpCommon):
             'product_qty': 1.0,
             'type': 'phantom',
             'bom_line_ids': [
-                (0, 0, {
+                Command.create({
                     'product_id': product_dozens.id,
                     'product_qty': 1,
-                    'product_uom_id': uom_unit.id,
-                })
+                    'product_uom_id': self.uom_unit.id,
+                }),
             ]
         })
-        location = self.env.ref('stock.stock_location_stock')
-        self.env['stock.quant']._update_available_quantity(product_dozens, location, 1.0)
+        self.env['stock.quant']._update_available_quantity(product_dozens, self.stock_location, 1.0)
         self.assertEqual(product_unit.qty_available, 12.0)
 
     def test_13_negative_on_hand_qty(self):
@@ -407,23 +413,21 @@ class TestBoM(TestMrpCommon):
         precision = self.env.ref('uom.decimal_product_uom')
         precision.digits = 5
 
-        uom_unit = self.env.ref('uom.product_uom_unit')
-
         _ = self.env['mrp.bom'].create({
             'product_id': self.product_2.id,
             'product_tmpl_id': self.product_2.product_tmpl_id.id,
-            'product_uom_id': uom_unit.id,
+            'product_uom_id': self.uom_unit.id,
             'product_qty': 1.00,
             'type': 'phantom',
             'bom_line_ids': [
-                (0, 0, {
+                Command.create({
                     'product_id': self.product_3.id,
                     'product_qty': 1.000,
                 }),
             ]
         })
 
-        self.env['stock.quant']._update_available_quantity(self.product_3, self.env.ref('stock.stock_location_stock'), -384.0)
+        self.env['stock.quant']._update_available_quantity(self.product_3, self.stock_location, -384.0)
 
         kit_product_qty = self.product_2.qty_available  # Without product_3 in the prefetch
         # Use the float_repr to remove extra small decimal (and represent the front-end behavior)
@@ -446,14 +450,14 @@ class TestBoM(TestMrpCommon):
             'product_qty': 4.0,
             'type': 'phantom',
             'bom_line_ids': [
-                (0, 0, {
+                Command.create({
                     'product_id': self.product_2.id,
                     'product_qty': 2,
                 }),
-                (0, 0, {
+                Command.create({
                     'product_id': self.product_3.id,
                     'product_qty': 2,
-                })
+                }),
             ]
         })
         self.assertTrue(kit_products.is_kits)
@@ -500,14 +504,14 @@ class TestBoM(TestMrpCommon):
             'product_qty': 4.0,
             'type': 'phantom',
             'bom_line_ids': [
-                (0, 0, {
+                Command.create({
                     'product_id': self.product_2.id,
                     'product_qty': 2,
                 }),
-                (0, 0, {
+                Command.create({
                     'product_id': self.product_3.id,
                     'product_qty': 2,
-                })
+                }),
             ]
         })
         self.assertTrue(kit_products.is_kits)
@@ -718,24 +722,22 @@ class TestBoM(TestMrpCommon):
     def test_bom_report_dozens(self):
         """ Simulate a drawer bom with dozens as bom units
         """
-        uom_dozen = self.env.ref('uom.product_uom_dozen')
-        uom_unit = self.env.ref('uom.product_uom_unit')
         drawer = self.env['product.product'].create({
             'name': 'drawer',
             'is_storable': True,
-            'uom_id': uom_unit.id,
+            'uom_id': self.uom_unit.id,
         })
         screw = self.env['product.product'].create({
             'name': 'screw',
             'is_storable': True,
-            'uom_id': uom_unit.id,
+            'uom_id': self.uom_unit.id,
             'standard_price': 7.01
         })
 
         bom_form_drawer = Form(self.env['mrp.bom'])
         bom_form_drawer.product_tmpl_id = drawer.product_tmpl_id
         bom_form_drawer.product_qty = 11
-        bom_form_drawer.product_uom_id = uom_dozen
+        bom_form_drawer.product_uom_id = self.uom_dozen
         bom_drawer = bom_form_drawer.save()
 
         workcenter = self.env['mrp.workcenter'].create({
@@ -753,7 +755,7 @@ class TestBoM(TestMrpCommon):
         with Form(bom_drawer) as bom:
             with bom.bom_line_ids.new() as line:
                 line.product_id = screw
-                line.product_uom_id = uom_unit
+                line.product_uom_id = self.uom_unit
                 line.product_qty = 5
             with bom.operation_ids.new() as operation:
                 operation.workcenter_id = workcenter
@@ -991,27 +993,24 @@ class TestBoM(TestMrpCommon):
         Check the Price for 80 units of Finished -> 2.92$:
         """
         # Create a products templates
-        uom_unit = self.env.ref('uom.product_uom_unit')
-        uom_kg = self.env.ref('uom.product_uom_kgm')
-        uom_dozen = self.env.ref('uom.product_uom_dozen')
         uom_litre = self.env.ref('uom.product_uom_litre')
 
         finished = self.env['product.product'].create({
             'name': 'Finished',
             'is_storable': True,
-            'uom_id': uom_unit.id,
+            'uom_id': self.uom_unit.id,
         })
 
         semi_finished = self.env['product.product'].create({
             'name': 'Semi-Finished',
             'is_storable': True,
-            'uom_id': uom_kg.id,
+            'uom_id': self.uom_kg.id,
         })
 
         assembly = self.env['product.product'].create({
             'name': 'Assembly',
             'is_storable': True,
-            'uom_id': uom_dozen.id,
+            'uom_id': self.uom_dozen.id,
         })
 
         raw_material = self.env['product.product'].create({
@@ -1027,7 +1026,7 @@ class TestBoM(TestMrpCommon):
         bom_finished.product_qty = 100
         with bom_finished.bom_line_ids.new() as line:
             line.product_id = semi_finished
-            line.product_uom_id = uom_kg
+            line.product_uom_id = self.uom_kg
             line.product_qty = 5
         bom_finished = bom_finished.save()
 
@@ -1036,7 +1035,7 @@ class TestBoM(TestMrpCommon):
         bom_semi_finished.product_qty = 11
         with bom_semi_finished.bom_line_ids.new() as line:
             line.product_id = assembly
-            line.product_uom_id = uom_dozen
+            line.product_uom_id = self.uom_dozen
             line.product_qty = 2
         bom_semi_finished = bom_semi_finished.save()
 
@@ -1054,9 +1053,6 @@ class TestBoM(TestMrpCommon):
         self.assertAlmostEqual(report_values['lines']['bom_cost'], 2.92)
 
     def test_bom_report_capacity_with_quantity_of_0(self):
-        uom_unit = self.env.ref('uom.product_uom_unit')
-        location = self.env.ref('stock.stock_location_stock')
-
         target = self.env['product.product'].create({
             'name': 'Target',
             'is_storable': True,
@@ -1066,13 +1062,13 @@ class TestBoM(TestMrpCommon):
             'name': 'Component one',
             'is_storable': True,
         })
-        self.env['stock.quant']._update_available_quantity(product_one, location, 3.0)
+        self.env['stock.quant']._update_available_quantity(product_one, self.stock_location, 3.0)
 
         product_two = self.env['product.product'].create({
             'name': 'Component two',
             'is_storable': True,
         })
-        self.env['stock.quant']._update_available_quantity(product_two, location, 4.0)
+        self.env['stock.quant']._update_available_quantity(product_two, self.stock_location, 4.0)
 
         bom = self.env['mrp.bom'].create({
             'product_tmpl_id': target.product_tmpl_id.id,
@@ -1083,12 +1079,12 @@ class TestBoM(TestMrpCommon):
                 Command.create({
                     'product_id': product_one.id,
                     'product_qty': 0,
-                    'product_uom_id': uom_unit.id,
+                    'product_uom_id': self.uom_unit.id,
                 }),
                 Command.create({
                     'product_id': product_two.id,
                     'product_qty': 0.1,
-                    'product_uom_id': uom_unit.id,
+                    'product_uom_id': self.uom_unit.id,
                 })
             ]
         })
@@ -1100,8 +1096,7 @@ class TestBoM(TestMrpCommon):
         self.assertEqual(report_values["lines"]["producible_qty"], 40)
 
     def test_bom_report_capacity_with_duplicate_components(self):
-        location = self.env.ref('stock.stock_location_stock')
-        self.env['stock.quant']._update_available_quantity(self.product_2, location, 2.0)
+        self.env['stock.quant']._update_available_quantity(self.product_2, self.stock_location, 2.0)
         bom = self.env['mrp.bom'].create({
             'product_tmpl_id': self.product_3.product_tmpl_id.id,
             'product_qty': 1,
@@ -1124,12 +1119,10 @@ class TestBoM(TestMrpCommon):
     def test_bom_report_same_component(self):
         """ Test report bom structure with duplicated components.
         """
-        location = self.env.ref('stock.stock_location_stock')
-        uom_unit = self.env.ref('uom.product_uom_unit')
         final_product_tmpl = self.env['product.template'].create({'name': 'Final Product', 'is_storable': True})
         component_product = self.env['product.product'].create({'name': 'Compo 1', 'is_storable': True})
 
-        self.env['stock.quant']._update_available_quantity(component_product, location, 3.0)
+        self.env['stock.quant']._update_available_quantity(component_product, self.stock_location, 3.0)
 
         bom = self.env['mrp.bom'].create({
             'product_tmpl_id': final_product_tmpl.id,
@@ -1140,12 +1133,12 @@ class TestBoM(TestMrpCommon):
                 Command.create({
                     'product_id': component_product.id,
                     'product_qty': 3,
-                    'product_uom_id': uom_unit.id,
+                    'product_uom_id': self.uom_unit.id,
                 }),
                 Command.create({
                     'product_id': component_product.id,
                     'product_qty': 3,
-                    'product_uom_id': uom_unit.id,
+                    'product_uom_id': self.uom_unit.id,
                 })
             ]
         })
@@ -1158,7 +1151,7 @@ class TestBoM(TestMrpCommon):
         """
         Test that a bom with a child-bom set with a zero qty will still have have 0 qty for the child-bom on the report.
         """
-        self.bom_4.bom_line_ids = [(0, 0, {
+        self.bom_4.bom_line_ids = [Command.create({
             'product_id': self.bom_2.product_id.id,
             'product_qty': 1.0,
         })]
@@ -1171,18 +1164,17 @@ class TestBoM(TestMrpCommon):
         """
         Cannot set a BOM line on a BOM with the same product as the BOM itself
         """
-        uom_unit = self.env.ref('uom.product_uom_unit')
         finished = self.env['product.product'].create({
             'name': 'Finished',
             'is_storable': True,
-            'uom_id': uom_unit.id,
+            'uom_id': self.uom_unit.id,
         })
         bom_finished = Form(self.env['mrp.bom'])
         bom_finished.product_tmpl_id = finished.product_tmpl_id
         bom_finished.product_qty = 100
         with bom_finished.bom_line_ids.new() as line:
             line.product_id = finished
-            line.product_uom_id = uom_unit
+            line.product_uom_id = self.uom_unit
             line.product_qty = 5
         with self.assertRaises(exceptions.ValidationError):
             bom_finished = bom_finished.save()
@@ -1191,14 +1183,13 @@ class TestBoM(TestMrpCommon):
         """
         Cannot set a BOM line on a BOM with the same product variant as the BOM itself
         """
-        uom_unit = self.env.ref('uom.product_uom_unit')
         bom_finished = Form(self.env['mrp.bom'])
         bom_finished.product_tmpl_id = self.product_7_template
         bom_finished.product_id = self.product_7_3
         bom_finished.product_qty = 100
         with bom_finished.bom_line_ids.new() as line:
             line.product_id = self.product_7_3
-            line.product_uom_id = uom_unit
+            line.product_uom_id = self.uom_unit
             line.product_qty = 5
         with self.assertRaises(exceptions.ValidationError):
             bom_finished = bom_finished.save()
@@ -1209,14 +1200,13 @@ class TestBoM(TestMrpCommon):
         Usecase for example A black T-shirt made  from a white T-shirt and
         black color.
         """
-        uom_unit = self.env.ref('uom.product_uom_unit')
         bom_finished = Form(self.env['mrp.bom'])
         bom_finished.product_tmpl_id = self.product_7_template
         bom_finished.product_id = self.product_7_3
         bom_finished.product_qty = 100
         with bom_finished.bom_line_ids.new() as line:
             line.product_id = self.product_7_2
-            line.product_uom_id = uom_unit
+            line.product_uom_id = self.uom_unit
             line.product_qty = 5
         bom_finished = bom_finished.save()
 
@@ -1224,14 +1214,13 @@ class TestBoM(TestMrpCommon):
         """
         Can set a BOM line on a BOM with a product variant when the BOM has no variant selected
         """
-        uom_unit = self.env.ref('uom.product_uom_unit')
         bom_finished = Form(self.env['mrp.bom'])
         bom_finished.product_tmpl_id = self.product_6.product_tmpl_id
         # no product_id
         bom_finished.product_qty = 100
         with bom_finished.bom_line_ids.new() as line:
             line.product_id = self.product_7_2
-            line.product_uom_id = uom_unit
+            line.product_uom_id = self.uom_unit
             line.product_qty = 5
         bom_finished = bom_finished.save()
 
@@ -1241,27 +1230,23 @@ class TestBoM(TestMrpCommon):
             quantity of the BoM in the UoM of the product.
         """
 
-        uom_kg = self.env.ref('uom.product_uom_kgm')
-        uom_gram = self.env.ref('uom.product_uom_gram')
-        manufacturing_route_id = self.ref('mrp.route_warehouse0_manufacture')
-
         product_gram = self.env['product.product'].create({
             'name': 'Product sold in grams',
             'is_storable': True,
-            'uom_id': uom_gram.id,
-            'route_ids': [(4, manufacturing_route_id)],
+            'uom_id': self.uom_gm.id,
+            'route_ids': [Command.link(self.route_manufacture.id)],
         })
         # We create a BoM that manufactures 2kg of product
         self.env['mrp.bom'].create({
             'product_id': product_gram.id,
             'product_tmpl_id': product_gram.product_tmpl_id.id,
-            'product_uom_id': uom_kg.id,
+            'product_uom_id': self.uom_kg.id,
             'product_qty': 2.0,
             'type': 'normal',
         })
         # We create a delivery order of 2300 grams
         picking_form = Form(self.env['stock.picking'])
-        picking_form.picking_type_id = self.env.ref('stock.picking_type_out')
+        picking_form.picking_type_id = self.picking_type_out
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = product_gram
             move.product_uom_qty = 2300.0
@@ -1272,8 +1257,8 @@ class TestBoM(TestMrpCommon):
         self.env.flush_all()
         self.env['stock.warehouse.orderpoint']._get_orderpoint_action()
         orderpoint = self.env['stock.warehouse.orderpoint'].search([('product_id', '=', product_gram.id)])
-        orderpoint.replenishment_uom_id = uom_kg
-        self.assertEqual(orderpoint.route_id.id, manufacturing_route_id)
+        orderpoint.replenishment_uom_id = self.uom_kg
+        self.assertEqual(orderpoint.route_id.id, self.route_manufacture.id)
         self.assertEqual(orderpoint.qty_to_order, 3000.0)
 
     def test_bom_generated_from_mo(self):
@@ -1389,8 +1374,6 @@ class TestBoM(TestMrpCommon):
         Checks the generated BoM has the expected BoM lines UoM and quantity.
         """
         self.env.user.group_ids += self.env.ref('uom.group_uom')
-        uom_unit = self.env.ref('uom.product_uom_unit')
-        uom_dozen = self.env.ref('uom.product_uom_dozen')
         # Creates some products.
         common_vals = {'is_storable': True}
         finished_product = self.env['product.product'].create(dict(common_vals, name="CO² Molecule"))
@@ -1400,26 +1383,26 @@ class TestBoM(TestMrpCommon):
         mo_form = Form(self.env['mrp.production'])
         mo_form.product_id = finished_product
         mo_form.product_qty = 1
-        mo_form.product_uom_id = uom_dozen
+        mo_form.product_uom_id = self.uom_dozen
         with mo_form.move_raw_ids.new() as raw_move:
             raw_move.product_id = component_1
             raw_move.product_uom_qty = 12
-            raw_move.product_uom = uom_unit
+            raw_move.product_uom = self.uom_unit
         with mo_form.move_raw_ids.new() as raw_move:
             raw_move.product_id = component_2
             raw_move.product_uom_qty = 2
-            raw_move.product_uom = uom_dozen
+            raw_move.product_uom = self.uom_dozen
         mo = mo_form.save()
         mo.action_confirm()
         # Generates a BoM from the MO and checks its values.
         action_generate_new_bom = mo.action_generate_bom()
         bom_form = Form(self.env['mrp.bom'].with_context(action_generate_new_bom['context']))
         bom_from_mo = bom_form.save()
-        self.assertEqual(bom_from_mo.product_uom_id, uom_dozen)
+        self.assertEqual(bom_from_mo.product_uom_id, self.uom_dozen)
         self.assertEqual(bom_from_mo.product_qty, 1)
         self.assertRecordValues(bom_from_mo.bom_line_ids, [
-            {'product_id': component_1.id, 'product_qty': 12, 'product_uom_id': uom_unit.id},
-            {'product_id': component_2.id, 'product_qty': 2, 'product_uom_id': uom_dozen.id},
+            {'product_id': component_1.id, 'product_qty': 12, 'product_uom_id': self.uom_unit.id},
+            {'product_id': component_2.id, 'product_qty': 2, 'product_uom_id': self.uom_dozen.id},
         ])
 
     def test_bom_generated_from_mo_with_byproducts(self):
@@ -1475,13 +1458,12 @@ class TestBoM(TestMrpCommon):
         bom = self.make_bom(prod1, prod2)
         bom.product_qty = 100
 
-        loc = self.env.ref("stock.stock_location_stock")
-        self.env["stock.quant"]._update_available_quantity(p3, loc, 10)
-        self.env["stock.quant"]._update_available_quantity(p4, loc, 10)
-        self.env["stock.quant"]._update_available_quantity(p6, loc, 5.5)
-        self.env["stock.quant"]._update_available_quantity(p6, loc, -4.8)
-        self.env["stock.quant"]._update_available_quantity(prod2, loc, 5.57)
-        self.env["stock.quant"]._update_available_quantity(prod2, loc, -5)
+        self.env["stock.quant"]._update_available_quantity(p3, self.stock_location, 10)
+        self.env["stock.quant"]._update_available_quantity(p4, self.stock_location, 10)
+        self.env["stock.quant"]._update_available_quantity(p6, self.stock_location, 5.5)
+        self.env["stock.quant"]._update_available_quantity(p6, self.stock_location, -4.8)
+        self.env["stock.quant"]._update_available_quantity(prod2, self.stock_location, 5.57)
+        self.env["stock.quant"]._update_available_quantity(prod2, self.stock_location, -5)
 
         self.assertEqual(p1.qty_available, 5.0)
         self.assertEqual(p2.qty_available, 10.0)
@@ -1612,8 +1594,6 @@ class TestBoM(TestMrpCommon):
         Checks the MO's raw moves' quantities are correctly updated.
         """
         self.env.user.group_ids += self.env.ref('uom.group_uom')
-        uom_unit = self.env.ref('uom.product_uom_unit')
-        uom_dozen = self.env.ref('uom.product_uom_dozen')
         # Creates a BoM.
         common_vals = {'is_storable': True}
         finished_product = self.env['product.product'].create(dict(common_vals, name="Monster in Jar"))
@@ -1629,12 +1609,12 @@ class TestBoM(TestMrpCommon):
         mo_form = Form(self.env['mrp.production'])
         mo_form.bom_id = bom
         mo_form.product_qty = 4
-        mo_form.product_uom_id = uom_dozen
+        mo_form.product_uom_id = self.uom_dozen
         mo_1 = mo_form.save()
         self.assertRecordValues(mo_1.move_raw_ids, [{
-            'product_id': component_1.id, 'product_uom_qty': 24, 'product_uom': uom_unit.id,
+            'product_id': component_1.id, 'product_uom_qty': 24, 'product_uom': self.uom_unit.id,
         }, {
-            'product_id': component_2.id, 'product_uom_qty': 24, 'product_uom': uom_unit.id,
+            'product_id': component_2.id, 'product_uom_qty': 24, 'product_uom': self.uom_unit.id,
         }])
 
         ### Test draft MO ###
@@ -1644,19 +1624,19 @@ class TestBoM(TestMrpCommon):
             "BoM changed, it should be marked as updated.")
         mo_1.action_update_bom()
         self.assertRecordValues(mo_1,
-            [{'product_qty': 4, 'product_uom_id': uom_dozen.id}])
+            [{'product_qty': 4, 'product_uom_id': self.uom_dozen.id}])
         self.assertRecordValues(mo_1.move_raw_ids, [{
-            'product_id': component_1.id, 'product_uom_qty': 48, 'product_uom': uom_unit.id,
+            'product_id': component_1.id, 'product_uom_qty': 48, 'product_uom': self.uom_unit.id,
         }, {
-            'product_id': component_2.id, 'product_uom_qty': 48, 'product_uom': uom_unit.id,
+            'product_id': component_2.id, 'product_uom_qty': 48, 'product_uom': self.uom_unit.id,
         }])
 
         ### Test confirmed MO ###
         mo_1.product_qty = 1
         self.assertRecordValues(mo_1.move_raw_ids, [{
-            'product_id': component_1.id, 'product_uom_qty': 12, 'product_uom': uom_unit.id,
+            'product_id': component_1.id, 'product_uom_qty': 12, 'product_uom': self.uom_unit.id,
         }, {
-            'product_id': component_2.id, 'product_uom_qty': 12, 'product_uom': uom_unit.id,
+            'product_id': component_2.id, 'product_uom_qty': 12, 'product_uom': self.uom_unit.id,
         }])
         mo_1.action_confirm()
         # Updates the BoM by set the first BoM line's quantity to 2.
@@ -1670,26 +1650,26 @@ class TestBoM(TestMrpCommon):
         mo_1.action_update_bom()
         self.assertEqual(mo_1.is_outdated_bom, False)
         self.assertRecordValues(mo_1.move_raw_ids, [{
-            'product_id': component_1.id, 'product_uom_qty': 24, 'product_uom': uom_unit.id,
+            'product_id': component_1.id, 'product_uom_qty': 24, 'product_uom': self.uom_unit.id,
         }, {
-            'product_id': component_2.id, 'product_uom_qty': 12, 'product_uom': uom_unit.id,
+            'product_id': component_2.id, 'product_uom_qty': 12, 'product_uom': self.uom_unit.id,
         }])
 
         # Do the same but while changing the raw moves' UoM too.
         mo_form = Form(self.env['mrp.production'])
         mo_form.bom_id = bom
-        mo_form.product_uom_id = uom_dozen
+        mo_form.product_uom_id = self.uom_dozen
         with mo_form.move_raw_ids.edit(0) as move_raw:
             move_raw.product_uom_qty = 2
-            move_raw.product_uom = uom_dozen
+            move_raw.product_uom = self.uom_dozen
         with mo_form.move_raw_ids.edit(1) as move_raw:
             move_raw.product_uom_qty = 1
-            move_raw.product_uom = uom_dozen
+            move_raw.product_uom = self.uom_dozen
         mo_2 = mo_form.save()
         mo_2.action_confirm()
         self.assertRecordValues(mo_2.move_raw_ids, [
-            {'product_id': component_1.id, 'product_uom_qty': 2, 'product_uom': uom_dozen.id},
-            {'product_id': component_2.id, 'product_uom_qty': 1, 'product_uom': uom_dozen.id}
+            {'product_id': component_1.id, 'product_uom_qty': 2, 'product_uom': self.uom_dozen.id},
+            {'product_id': component_2.id, 'product_uom_qty': 1, 'product_uom': self.uom_dozen.id}
         ])
 
         # Updates the BoM by set the second BoM line's quantity to 2.
@@ -1776,7 +1756,7 @@ class TestBoM(TestMrpCommon):
         # Creates a MO.
         mo_form = Form(self.env['mrp.production'])
         mo_form.bom_id = self.bom_1
-        mo_form.picking_type_id = self.warehouse_1.manu_type_id
+        mo_form.picking_type_id = self.picking_type_manu
         mo_1 = mo_form.save()
         mo_1.action_confirm()
         picking = mo_1.picking_ids
@@ -1825,14 +1805,14 @@ class TestBoM(TestMrpCommon):
         product_template = self.env['product.template'].create({
             'name': 'Sofa',
             'attribute_line_ids': [
-                (0, 0, {
+                Command.create({
                     'attribute_id': att_color.id,
                     'value_ids': [(6, 0, [att_color_red.id, att_color_blue.id])]
                 }),
-                (0, 0, {
+                Command.create({
                     'attribute_id': att_size.id,
                     'value_ids': [(6, 0, [att_size_big.id, att_size_medium.id])]
-                })
+                }),
             ]
         })
         bom = self.env['mrp.bom'].create({
@@ -1840,8 +1820,17 @@ class TestBoM(TestMrpCommon):
             'product_uom_id': self.uom_unit.id,
             'product_qty': 1.0,
             'allow_operation_dependencies': True,
-            'operation_ids': [(0, 0, {'name': 'op1', 'workcenter_id': self.workcenter_1.id, 'time_cycle': 1.0, 'bom_product_template_attribute_value_ids': [(4, att_color_blue.pav_attribute_line_ids.product_template_value_ids[0].id)]}),
-                                (0, 0, {'name': 'op2', 'workcenter_id': self.workcenter_1.id, 'time_cycle': 1.0})],
+            'operation_ids': [
+                Command.create({
+                    'name': 'op1',
+                    'workcenter_id': self.workcenter_1.id,
+                    'time_cycle': 1.0,
+                    'bom_product_template_attribute_value_ids': [
+                        Command.link(att_color_blue.pav_attribute_line_ids.product_template_value_ids[0].id),
+                    ]
+                }),
+                Command.create({'name': 'op2', 'workcenter_id': self.workcenter_1.id, 'time_cycle': 1.0}),
+            ],
         })
         # Make 1st workorder depend on 2nd
         bom.operation_ids[1].blocked_by_operation_ids = [Command.link(bom.operation_ids[0].id)]
@@ -1873,10 +1862,10 @@ class TestBoM(TestMrpCommon):
         bom_2_finished_product = self.bom_2.product_id
         with self.assertRaises(exceptions.ValidationError):
             # finished product is one of the components:
-            self.bom_1.bom_line_ids = [(0, 0, {'product_id': bom_1_finished_product.id, 'product_qty': 1.0},)]
+            self.bom_1.bom_line_ids = [Command.create({'product_id': bom_1_finished_product.id, 'product_qty': 1.0})]
         with self.assertRaises(exceptions.ValidationError):
             # cycle:
-            self.bom_1.bom_line_ids = [(0, 0, {'product_id': bom_2_finished_product.id, 'product_qty': 1.0},)]
+            self.bom_1.bom_line_ids = [Command.create({'product_id': bom_2_finished_product.id, 'product_qty': 1.0})]
 
     def test_cycle_on_line_update(self):
         lines = self.bom_1.bom_line_ids
@@ -1895,7 +1884,7 @@ class TestBoM(TestMrpCommon):
             'product_qty': 1.0,
             'type': 'normal',
             'bom_line_ids': [
-                (0, 0, {'product_id': finished_product.id, 'product_qty': 1.0}),
+                Command.create({'product_id': finished_product.id, 'product_qty': 1.0}),
             ],
         })
         with self.assertRaises(exceptions.ValidationError):
@@ -1912,7 +1901,7 @@ class TestBoM(TestMrpCommon):
                 'product_qty': 1.0,
                 'type': 'normal',
                 'bom_line_ids': [
-                    (0, 0, {'product_id': finished_product.id, 'product_qty': 1.0}),
+                    Command.create({'product_id': finished_product.id, 'product_qty': 1.0}),
                 ],
             })
 
@@ -1937,7 +1926,7 @@ class TestBoM(TestMrpCommon):
             'product_qty': 1.0,
             'type': 'normal',
             'bom_line_ids': [
-                (0, 0, {'product_id': compo.id, 'product_qty': 1.0}),
+                Command.create({'product_id': compo.id, 'product_qty': 1.0}),
             ],
         } for finished, compo, in [
             (product_A, product_D),
@@ -1952,7 +1941,7 @@ class TestBoM(TestMrpCommon):
                 'product_qty': 1.0,
                 'type': 'normal',
                 'bom_line_ids': [
-                    (0, 0, {'product_id': product_A.id, 'product_qty': 1.0}),
+                    Command.create({'product_id': product_A.id, 'product_qty': 1.0}),
                 ],
             })
 
@@ -1980,7 +1969,7 @@ class TestBoM(TestMrpCommon):
             'product_qty': 1.0,
             'type': 'normal',
             'bom_line_ids': [
-                (0, 0, {'product_id': compo.id, 'product_qty': 1.0}),
+                Command.create({'product_id': compo.id, 'product_qty': 1.0}),
             ],
         } for finished, compo, in [
             (product_A, product_D),
@@ -2010,14 +1999,14 @@ class TestBoM(TestMrpCommon):
             'product_qty': 1.0,
             'type': 'normal',
             'bom_line_ids': [
-                (0, 0, {
+                Command.create({
                     'product_id': self.product_1.id,
-                    'product_qty': 1.0
+                    'product_qty': 1.0,
                 }),
-                (0, 0, {
+                Command.create({
                     'product_id': self.product_2.id,
                     'product_qty': 1.0,
-                    'bom_product_template_attribute_value_ids': [(4, self.product_7_attr1_v2.id)]
+                    'bom_product_template_attribute_value_ids': [Command.link(self.product_7_attr1_v2.id)],
                 }),
             ],
         })
@@ -2028,7 +2017,7 @@ class TestBoM(TestMrpCommon):
             'product_qty': 1.0,
             'type': 'normal',
             'bom_line_ids': [
-                (0, 0, {'product_id': self.product_7_1.id, 'product_qty': 1.0}),
+                Command.create({'product_id': self.product_7_1.id, 'product_qty': 1.0}),
             ],
         })
 
@@ -2131,19 +2120,17 @@ class TestBoM(TestMrpCommon):
 
     def test_availability_bom_type_kit(self):
         """ Product should only be available if bom type is kit """
-        uom_unit = self.env.ref('uom.product_uom_unit')
-        location = self.env.ref('stock.stock_location_stock')
         product_one = self.env['product.product'].create({
             'name': 'Product',
             'is_storable': True,
-            'uom_id': uom_unit.id,
+            'uom_id': self.uom_unit.id,
         })
         product_two = self.env['product.product'].create({
             'name': 'Component',
             'is_storable': True,
-            'uom_id': uom_unit.id,
+            'uom_id': self.uom_unit.id,
         })
-        self.env['stock.quant']._update_available_quantity(product_two, location, 4.0)
+        self.env['stock.quant']._update_available_quantity(product_two, self.stock_location, 4.0)
 
         bom_normal = self.env['mrp.bom'].create({
             'product_tmpl_id': product_one.product_tmpl_id.id,
@@ -2296,8 +2283,7 @@ class TestBoM(TestMrpCommon):
         """
         bom = self.bom_1
         product = bom.product_id
-        manufacturing_route_id = self.ref('mrp.route_warehouse0_manufacture')
-        product.route_ids = [Command.set([manufacturing_route_id])]
+        product.route_ids = [Command.set([self.route_manufacture.id])]
         notification = bom.action_compute_bom_days()
         self.assertEqual(bom.days_to_prepare_mo, 0.0)
         self.assertEqual((notification['type'], notification['tag']), ('ir.actions.client', 'display_notification'))

--- a/addons/mrp/tests/test_manual_consumption.py
+++ b/addons/mrp/tests/test_manual_consumption.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 # -*- coding: utf-8 -*-
 
+from odoo import Command
 from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo.tests import tagged, Form, HttpCase
 
@@ -56,8 +57,9 @@ class TestManualConsumption(TestMrpCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.stock_location = cls.env.ref('stock.stock_location_stock')
-        cls.env.ref('base.group_user').write({'implied_ids': [(4, cls.env.ref('stock.group_production_lot').id)]})
+        cls.env.ref('base.group_user').write({
+            'implied_ids': [Command.link(cls.env.ref('stock.group_production_lot').id)],
+        })
 
     def test_manual_consumption_with_different_component_price(self):
         """
@@ -231,7 +233,7 @@ class TestManualConsumption(TestMrpCommon):
         bom.bom_line_ids[-1].product_qty = 0.0
         self.env['stock.quant']._update_available_quantity(components[0], self.warehouse_1.lot_stock_id, 10.0)
         mo_form = Form(self.env['mrp.production'])
-        mo_form.picking_type_id = self.warehouse_1.manu_type_id
+        mo_form.picking_type_id = self.picking_type_manu
         mo_form.bom_id = bom
         mo_form.product_qty = 4
         mo = mo_form.save()

--- a/addons/mrp/tests/test_oee.py
+++ b/addons/mrp/tests/test_oee.py
@@ -18,7 +18,7 @@ class TestOee(TestMrpCommon):
             'description': loss_reason.name
         })
 
-    def test_wrokcenter_oee(self):
+    def test_workcenter_oee(self):
         """  Test case workcenter oee. """
         day = datetime.date(datetime.today())
         self.workcenter_1.resource_calendar_id.leave_ids.unlink()

--- a/addons/mrp/tests/test_replenish.py
+++ b/addons/mrp/tests/test_replenish.py
@@ -13,40 +13,38 @@ from odoo import fields, Command
 
 class TestMrpReplenish(TestMrpCommon):
 
-    def _create_wizard(self, product, wh):
+    def _create_wizard(self, product, warehouse):
         return self.env['product.replenish'].with_context(default_product_tmpl_id=product.product_tmpl_id.id).create({
                 'product_id': product.id,
                 'product_uom_id': self.uom_unit.id,
                 'quantity': 1,
-                'warehouse_id': wh.id,
+                'warehouse_id': warehouse.id,
             })
 
     def test_mrp_delay(self):
         """Open the replenish view and check if delay is taken into account
             in the base date computation
         """
-        route = self.env.ref('mrp.route_warehouse0_manufacture')
+        route = self.warehouse_1.manufacture_pull_id.route_id
         product = self.product_4
         product.route_ids = route
-        wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
         self.env.company.manufacturing_lead = 0
         self.env['ir.config_parameter'].sudo().set_param('mrp.use_manufacturing_lead', True)
 
         with freeze_time("2023-01-01"):
-            wizard = self._create_wizard(product, wh)
+            wizard = self._create_wizard(product, self.warehouse_1)
             self.assertEqual(fields.Datetime.from_string('2023-01-01 00:00:00'), wizard.date_planned)
             self.env.company.manufacturing_lead = 3
-            wizard2 = self._create_wizard(product, wh)
+            wizard2 = self._create_wizard(product, self.warehouse_1)
             self.assertEqual(fields.Datetime.from_string('2023-01-04 00:00:00'), wizard2.date_planned)
             route.rule_ids[0].delay = 2
-            wizard3 = self._create_wizard(product, wh)
+            wizard3 = self._create_wizard(product, self.warehouse_1)
             self.assertEqual(fields.Datetime.from_string('2023-01-06 00:00:00'), wizard3.date_planned)
 
     def test_mrp_orderpoint_leadtime(self):
-        self.warehouse = self.env.ref('stock.warehouse0')
-        route_manufacture = self.warehouse.manufacture_pull_id.route_id
-        route_manufacture.supplied_wh_id = self.warehouse
-        route_manufacture.supplier_wh_id = self.warehouse
+        route_manufacture = self.warehouse_1.manufacture_pull_id.route_id
+        route_manufacture.supplied_wh_id = self.warehouse_1
+        route_manufacture.supplier_wh_id = self.warehouse_1
         route_manufacture.rule_ids.delay = 2
         product_1 = self.env['product.product'].create({
             'name': 'Cake',
@@ -63,7 +61,7 @@ class TestMrpReplenish(TestMrpCommon):
         # setup orderpoint (reordering rule)
         rr = self.env['stock.warehouse.orderpoint'].create({
             'name': 'Cake RR',
-            'location_id': self.warehouse.lot_stock_id.id,
+            'location_id': self.stock_location.id,
             'product_id': product_1.id,
             'product_min_qty': 0,
             'product_max_qty': 5,
@@ -78,8 +76,8 @@ class TestMrpReplenish(TestMrpCommon):
         """Check manufacturing order take bom according to picking type of the rule triggered by an
         orderpoint."""
 
-        self.product_4.route_ids = self.env.ref('mrp.route_warehouse0_manufacture')
-        picking_type_2 = self.warehouse_1.manu_type_id.copy({'sequence': 100})
+        self.product_4.route_ids = self.warehouse_1.manufacture_pull_id.route_id
+        picking_type_2 = self.picking_type_manu.copy({'sequence': 100})
         self.product_4.bom_ids.picking_type_id = picking_type_2
         rr = self.env['stock.warehouse.orderpoint'].create({
             'name': 'Cake RR',
@@ -97,36 +95,34 @@ class TestMrpReplenish(TestMrpCommon):
         self.assertTrue(mo)
 
     def test_mrp_delay_bom(self):
-        route = self.env.ref('mrp.route_warehouse0_manufacture')
+        route = self.warehouse_1.manufacture_pull_id.route_id
         product = self.product_4
         bom = product.bom_ids
         product.route_ids = route
-        wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
         self.env.company.manufacturing_lead = 0
         with freeze_time("2023-01-01"):
-            wizard = self._create_wizard(product, wh)
+            wizard = self._create_wizard(product, self.warehouse_1)
             self.assertEqual(fields.Datetime.from_string('2023-01-01 00:00:00'), wizard.date_planned)
             bom.produce_delay = 2
-            wizard2 = self._create_wizard(product, wh)
+            wizard2 = self._create_wizard(product, self.warehouse_1)
             self.assertEqual(fields.Datetime.from_string('2023-01-03 00:00:00'), wizard2.date_planned)
             bom.days_to_prepare_mo = 4
-            wizard3 = self._create_wizard(product, wh)
+            wizard3 = self._create_wizard(product, self.warehouse_1)
             self.assertEqual(fields.Datetime.from_string('2023-01-07 00:00:00'), wizard3.date_planned)
 
     def test_replenish_from_scrap(self):
         """ Test that when ticking replenish on the scrap wizard of a MO, the new move
         is linked to the MO and validating it will automatically reserve the quantity
         on the MO. """
-        warehouse = self.env.ref('stock.warehouse0')
-        warehouse.manufacture_steps = 'pbm'
+        self.warehouse_1.manufacture_steps = 'pbm'
         basic_mo, dummy1, dummy2, product_to_scrap, other_product = self.generate_mo(qty_final=1, qty_base_1=1, qty_base_2=1)
         for product in (product_to_scrap, other_product):
             self.env['stock.quant'].create({
                 'product_id': product.id,
-                'location_id': warehouse.lot_stock_id.id,
+                'location_id': self.stock_location.id,
                 'quantity': 2
             })
-        self.assertEqual(basic_mo.move_raw_ids.location_id, warehouse.pbm_loc_id)
+        self.assertEqual(basic_mo.move_raw_ids.location_id, self.warehouse_1.pbm_loc_id)
         basic_mo.action_confirm()
         self.assertEqual(len(basic_mo.picking_ids), 1)
         basic_mo.picking_ids.action_assign()
@@ -136,7 +132,7 @@ class TestMrpReplenish(TestMrpCommon):
         scrap_form = Form.from_action(self.env, basic_mo.button_scrap())
         scrap_form.product_id = product_to_scrap
         scrap_form.should_replenish = True
-        self.assertEqual(scrap_form.location_id, warehouse.pbm_loc_id)
+        self.assertEqual(scrap_form.location_id, self.warehouse_1.pbm_loc_id)
         scrap_form.save().action_validate()
         self.assertNotEqual(basic_mo.move_raw_ids.mapped('state'), ['assigned', 'assigned'])
         self.assertEqual(len(basic_mo.picking_ids), 2)
@@ -147,16 +143,15 @@ class TestMrpReplenish(TestMrpCommon):
     def test_scrap_replenishment_reassigns_required_qty_to_component(self):
         """ Test that when validating the scrap replenishment transfer, the required quantity
         is re-assigned to the component for the final manufacturing product. """
-        warehouse = self.env.ref('stock.warehouse0')
-        warehouse.manufacture_steps = 'pbm'
+        self.warehouse_1.manufacture_steps = 'pbm'
         basic_mo, _, _, product_to_scrap, other_product = self.generate_mo(qty_final=1, qty_base_1=10, qty_base_2=10)
         for product in (product_to_scrap, other_product):
             self.env['stock.quant'].create({
                 'product_id': product.id,
-                'location_id': warehouse.lot_stock_id.id,
+                'location_id': self.stock_location.id,
                 'quantity': 20
             })
-        self.assertEqual(basic_mo.move_raw_ids.location_id, warehouse.pbm_loc_id)
+        self.assertEqual(basic_mo.move_raw_ids.location_id, self.warehouse_1.pbm_loc_id)
         basic_mo.action_confirm()
         self.assertEqual(len(basic_mo.picking_ids), 1)
         basic_mo.picking_ids.action_assign()
@@ -168,7 +163,7 @@ class TestMrpReplenish(TestMrpCommon):
         scrap_form.product_id = product_to_scrap
         scrap_form.scrap_qty = 5
         scrap_form.should_replenish = True
-        self.assertEqual(scrap_form.location_id, warehouse.pbm_loc_id)
+        self.assertEqual(scrap_form.location_id, self.warehouse_1.pbm_loc_id)
         scrap_form.save().action_validate()
 
         # Assert that the component quantity is reduced
@@ -191,22 +186,24 @@ class TestMrpReplenish(TestMrpCommon):
         """ Ensure global visibility days will only be captured one time in an orderpoint's
         lead_days/json_lead_days.
         """
-        wh = self.env.user._get_default_warehouse_id()
-        wh.manufacture_steps = 'pbm'
+        self.warehouse_1.manufacture_steps = 'pbm'
         finished_product = self.product_4
-        finished_product.route_ids = [(6, 0, self.env['stock.route'].search([('name', '=', 'Manufacture')], limit=1).ids)]
+        finished_product.route_ids = [Command.set(self.warehouse_1.manufacture_pull_id.route_id.ids)]
 
-        orderpoint = self.env['stock.warehouse.orderpoint'].create({'product_id': finished_product.id})
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({
+            'product_id': finished_product.id,
+            'location_id': self.stock_location.id,
+        })
         out_picking = self.env['stock.picking'].create({
-            'picking_type_id': self.env.ref('stock.picking_type_out').id,
-            'location_id': wh.lot_stock_id.id,
-            'location_dest_id': self.env.ref('stock.stock_location_customers').id,
+            'picking_type_id': self.picking_type_out.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
             'move_ids': [Command.create({
                 'name': 'TGVDALTMR out move',
                 'product_id': finished_product.id,
                 'product_uom_qty': 2,
-                'location_id': wh.lot_stock_id.id,
-                'location_dest_id': self.env.ref('stock.stock_location_customers').id,
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.customer_location.id,
             })],
         })
         out_picking.with_context(global_visibility_days=365).action_assign()

--- a/addons/mrp/tests/test_smp.py
+++ b/addons/mrp/tests/test_smp.py
@@ -184,9 +184,9 @@ class TestMrpSerialMassProduce(TestMrpCommon):
             'name': 'SN2',
             'product_id': tracked_product.id,
         })
-        self.env['stock.quant']._update_available_quantity(tracked_product, self.stock_location_14, 1, lot_id=sn_1)
-        self.env['stock.quant']._update_available_quantity(tracked_product, self.stock_location_14, 1, lot_id=sn_2)
-        self.env['stock.quant']._update_available_quantity(component, self.stock_location_14, 10)
+        self.env['stock.quant']._update_available_quantity(tracked_product, self.shelf_1, 1, lot_id=sn_1)
+        self.env['stock.quant']._update_available_quantity(tracked_product, self.shelf_1, 1, lot_id=sn_2)
+        self.env['stock.quant']._update_available_quantity(component, self.shelf_1, 10)
         # create an MO to use the tracked product available in stock
         mo_form = Form(self.env['mrp.production'])
         mo_form.product_id = self.product_1
@@ -340,7 +340,7 @@ class TestMrpSerialMassProduce(TestMrpCommon):
         self.env['res.config.settings'].write({
             'group_stock_adv_location': True,
         })
-        self.env.ref('stock.warehouse0').manufacture_steps = 'pbm'
+        self.warehouse_1.manufacture_steps = 'pbm'
         mo = self.generate_mo(tracking_final='lot', tracking_base_1='lot')[0]
         # Make some stock and reserve
         for product in mo.move_raw_ids.product_id:

--- a/addons/mrp/tests/test_traceability.py
+++ b/addons/mrp/tests/test_traceability.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo.exceptions import UserError
@@ -34,34 +35,33 @@ class TestTraceability(TestMrpCommon):
         consumed_no_track = self._create_product('none')
         consumed_lot = self._create_product('lot')
         consumed_serial = self._create_product('serial')
-        stock_id = self.env.ref('stock.stock_location_stock').id
         Lot = self.env['stock.lot']
         # create inventory
         quants = self.env['stock.quant'].create({
-            'location_id': stock_id,
+            'location_id': self.stock_location.id,
             'product_id': consumed_no_track.id,
             'inventory_quantity': 3
         })
         quants |= self.env['stock.quant'].create({
-            'location_id': stock_id,
+            'location_id': self.stock_location.id,
             'product_id': consumed_lot.id,
             'inventory_quantity': 3,
             'lot_id': Lot.create({'name': 'L1', 'product_id': consumed_lot.id}).id
         })
         quants |= self.env['stock.quant'].create({
-            'location_id': stock_id,
+            'location_id': self.stock_location.id,
             'product_id': consumed_serial.id,
             'inventory_quantity': 1,
             'lot_id': Lot.create({'name': 'S1', 'product_id': consumed_serial.id}).id
         })
         quants |= self.env['stock.quant'].create({
-            'location_id': stock_id,
+            'location_id': self.stock_location.id,
             'product_id': consumed_serial.id,
             'inventory_quantity': 1,
             'lot_id': Lot.create({'name': 'S2', 'product_id': consumed_serial.id}).id
         })
         quants |= self.env['stock.quant'].create({
-            'location_id': stock_id,
+            'location_id': self.stock_location.id,
             'product_id': consumed_serial.id,
             'inventory_quantity': 1,
             'lot_id': Lot.create({'name': 'S3', 'product_id': consumed_serial.id}).id
@@ -72,20 +72,20 @@ class TestTraceability(TestMrpCommon):
             bom = self.env['mrp.bom'].create({
                 'product_id': finished_product.id,
                 'product_tmpl_id': finished_product.product_tmpl_id.id,
-                'product_uom_id': self.env.ref('uom.product_uom_unit').id,
+                'product_uom_id': self.uom_unit.id,
                 'product_qty': 1.0,
                 'type': 'normal',
                 'bom_line_ids': [
-                    (0, 0, {'product_id': consumed_no_track.id, 'product_qty': 1}),
-                    (0, 0, {'product_id': consumed_lot.id, 'product_qty': 1}),
-                    (0, 0, {'product_id': consumed_serial.id, 'product_qty': 1}),
+                    Command.create({'product_id': consumed_no_track.id, 'product_qty': 1}),
+                    Command.create({'product_id': consumed_lot.id, 'product_qty': 1}),
+                    Command.create({'product_id': consumed_serial.id, 'product_qty': 1}),
                 ],
             })
 
             mo_form = Form(self.env['mrp.production'])
             mo_form.product_id = finished_product
             mo_form.bom_id = bom
-            mo_form.product_uom_id = self.env.ref('uom.product_uom_unit')
+            mo_form.product_uom_id = self.uom_unit
             mo_form.product_qty = 1
             mo = mo_form.save()
             mo.action_confirm()
@@ -175,12 +175,12 @@ class TestTraceability(TestMrpCommon):
             'consumption': 'flexible',
             'type': 'normal',
             'bom_line_ids': [
-                (0, 0, {'product_id': product_1.id, 'product_qty': 1}),
-                (0, 0, {'product_id': product_2.id, 'product_qty': 1})
+                Command.create({'product_id': product_1.id, 'product_qty': 1}),
+                Command.create({'product_id': product_2.id, 'product_qty': 1}),
             ],
             'byproduct_ids': [
-                (0, 0, {'product_id': byproduct_1.id, 'product_qty': 1, 'product_uom_id': byproduct_1.uom_id.id}),
-                (0, 0, {'product_id': byproduct_2.id, 'product_qty': 1, 'product_uom_id': byproduct_2.uom_id.id})
+                Command.create({'product_id': byproduct_1.id, 'product_qty': 1, 'product_uom_id': byproduct_1.uom_id.id}),
+                Command.create({'product_id': byproduct_2.id, 'product_qty': 1, 'product_uom_id': byproduct_2.uom_id.id}),
             ]})
         mo_form = Form(self.env['mrp.production'])
         mo_form.product_id = product_final
@@ -320,9 +320,8 @@ class TestTraceability(TestMrpCommon):
         Produce a new SN product with same lot
         """
         mo, bom, p_final, p1, p2 = self.generate_mo(qty_base_1=1, qty_base_2=1, qty_final=1, tracking_final='serial')
-        stock_location = self.env.ref('stock.stock_location_stock')
-        self.env['stock.quant']._update_available_quantity(p1, stock_location, 1)
-        self.env['stock.quant']._update_available_quantity(p2, stock_location, 1)
+        self.env['stock.quant']._update_available_quantity(p1, self.stock_location, 1)
+        self.env['stock.quant']._update_available_quantity(p2, self.stock_location, 1)
         mo.action_assign()
 
         lot = self.env['stock.lot'].create({
@@ -365,9 +364,6 @@ class TestTraceability(TestMrpCommon):
         Ensure that, when we already have some qty of productB (with different lots),
         the user can produce several productA and can then produce some productB again
         """
-        stock_location = self.env.ref('stock.stock_location_stock')
-        picking_type = self.env['stock.picking.type'].search([('code', '=', 'mrp_operation')])[0]
-
         productA, productB, productC = self.env['product.product'].create([{
             'name': 'Product A',
             'is_storable': True,
@@ -391,11 +387,11 @@ class TestTraceability(TestMrpCommon):
             'product_uom_id': self.uom_unit.id,
             'product_qty': 1.0,
             'type': 'normal',
-            'bom_line_ids': [(0, 0, {'product_id': component.id, 'product_qty': 1})],
+            'bom_line_ids': [Command.create({'product_id': component.id, 'product_qty': 1})],
         } for finished, component in [(productA, productB), (productB, productC)]])
 
-        self.env['stock.quant']._update_available_quantity(productB, stock_location, 10, lot_id=lot_B01)
-        self.env['stock.quant']._update_available_quantity(productB, stock_location, 5, lot_id=lot_B02)
+        self.env['stock.quant']._update_available_quantity(productB, self.stock_location, 10, lot_id=lot_B01)
+        self.env['stock.quant']._update_available_quantity(productB, self.stock_location, 5, lot_id=lot_B02)
 
         # Produce 15 x productA
         mo_form = Form(self.env['mrp.production'])
@@ -430,10 +426,6 @@ class TestTraceability(TestMrpCommon):
         for EndProduct A, all three lots' delivery_ids are set to
         Picking A.
         """
-
-        stock_location = self.env.ref('stock.stock_location_stock')
-        customer_location = self.env.ref('stock.stock_location_customers')
-
         # Create the three lot-tracked products.
         subcomponentA = self._create_product('lot')
         componentA = self._create_product('lot')
@@ -452,10 +444,10 @@ class TestTraceability(TestMrpCommon):
             'product_uom_id': self.uom_unit.id,
             'product_qty': 1.0,
             'type': 'normal',
-            'bom_line_ids': [(0, 0, {'product_id': component.id, 'product_qty': 1})],
+            'bom_line_ids': [Command.create({'product_id': component.id, 'product_qty': 1})],
         } for finished, component in [(endproductA, componentA), (componentA, subcomponentA)]])
 
-        self.env['stock.quant']._update_available_quantity(subcomponentA, stock_location, 1, lot_id=lot_subcomponentA)
+        self.env['stock.quant']._update_available_quantity(subcomponentA, self.stock_location, 1, lot_id=lot_subcomponentA)
 
         # Produce 1 component A
         mo_form = Form(self.env['mrp.production'])
@@ -485,9 +477,10 @@ class TestTraceability(TestMrpCommon):
 
         # Create out picking for EndProduct A
         pickingA_out = self.env['stock.picking'].create({
-            'picking_type_id': self.env.ref('stock.picking_type_out').id,
-            'location_id': stock_location.id,
-            'location_dest_id': customer_location.id})
+            'picking_type_id': self.picking_type_out.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+        })
 
         moveA = self.env['stock.move'].create({
             'name': 'Picking A move',
@@ -495,8 +488,9 @@ class TestTraceability(TestMrpCommon):
             'quantity': 1,
             'product_uom': endproductA.uom_id.id,
             'picking_id': pickingA_out.id,
-            'location_id': stock_location.id,
-            'location_dest_id': customer_location.id})
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+        })
 
         # Set move_line lot_id to the mrp.production lot_producing_id
         moveA.move_line_ids[0].write({
@@ -517,9 +511,6 @@ class TestTraceability(TestMrpCommon):
         Build a product P that uses C with SN, unbuild P, scrap SN, unscrap SN
         and rebuild a product with SN in the components
         """
-        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
-        stock_location = warehouse.lot_stock_id
-
         component = self.bom_4.bom_line_ids.product_id
         component.write({
             'is_storable': True,
@@ -529,7 +520,7 @@ class TestTraceability(TestMrpCommon):
             'product_id': component.id,
             'name': 'Super Serial',
         })
-        self.env['stock.quant']._update_available_quantity(component, stock_location, 1, lot_id=serial_number)
+        self.env['stock.quant']._update_available_quantity(component, self.stock_location, 1, lot_id=serial_number)
 
         # produce 1
         mo_form = Form(self.env['mrp.production'])
@@ -551,6 +542,7 @@ class TestTraceability(TestMrpCommon):
         scrap = self.env['stock.scrap'].create({
             'product_id': component.id,
             'product_uom_id': component.uom_id.id,
+            'location_id': self.stock_location.id,
             'scrap_qty': 1,
             'lot_id': serial_number.id,
         })
@@ -561,15 +553,15 @@ class TestTraceability(TestMrpCommon):
         internal_move = self.env['stock.move'].create({
             'name': component.name,
             'location_id': scrap_location.id,
-            'location_dest_id': stock_location.id,
+            'location_dest_id': self.stock_location.id,
             'product_id': component.id,
             'product_uom': component.uom_id.id,
             'product_uom_qty': 1.0,
             'picked': True,
-            'move_line_ids': [(0, 0, {
+            'move_line_ids': [Command.create({
                 'product_id': component.id,
                 'location_id': scrap_location.id,
-                'location_dest_id': stock_location.id,
+                'location_dest_id': self.stock_location.id,
                 'product_uom_id': component.uom_id.id,
                 'quantity': 1.0,
                 'lot_id': serial_number.id,
@@ -663,7 +655,6 @@ class TestTraceability(TestMrpCommon):
         Consume SN
         Consume SN -> Should raise an error as it has already been consumed
         """
-        stock_location = self.env.ref('stock.stock_location_stock')
         component = self.bom_4.bom_line_ids.product_id
         component.write({
             'is_storable': True,
@@ -675,7 +666,7 @@ class TestTraceability(TestMrpCommon):
             'name': name,
             'company_id': self.env.company.id,
         } for name in ['SN01', 'SN02']])
-        self.env['stock.quant']._update_available_quantity(component, stock_location, 1, lot_id=sn_lot02)
+        self.env['stock.quant']._update_available_quantity(component, self.stock_location, 1, lot_id=sn_lot02)
 
         mo = self.env['mrp.production'].create({
             'product_id': component.id,
@@ -786,7 +777,6 @@ class TestTraceability(TestMrpCommon):
         Consume SN
         -> We should not raise any UserError
         """
-        stock_location = self.env.ref('stock.stock_location_stock')
         component = self.bom_4.bom_line_ids.product_id
         component.write({
             'is_storable': True,
@@ -831,7 +821,7 @@ class TestTraceability(TestMrpCommon):
         unbuild_form.mo_id = mo_produce_sn
         unbuild_form.save().action_unbuild()
 
-        self.env['stock.quant']._update_available_quantity(component, stock_location, 1, lot_id=sn)
+        self.env['stock.quant']._update_available_quantity(component, self.stock_location, 1, lot_id=sn)
 
         mo_consume_sn_form = Form(self.env['mrp.production'])
         mo_consume_sn_form.bom_id = self.bom_4

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -18,7 +18,6 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         # Required for `manufacture_steps` to be visible in the view
         cls.env.user.group_ids += cls.env.ref('stock.group_adv_location')
         # Create warehouse
-        cls.customer_location = cls.env['ir.model.data']._xmlid_to_res_id('stock.stock_location_customers')
         warehouse_form = Form(cls.env['stock.warehouse'])
         warehouse_form.name = 'Test Warehouse'
         warehouse_form.code = 'TWH'
@@ -180,11 +179,11 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         with Form(self.warehouse) as warehouse:
             warehouse.manufacture_steps = 'pbm_sam'
         self.warehouse.flush_model()
-        self.env.ref('stock.route_warehouse0_mto').active = True
+        self.route_mto.active = True
         self.env['stock.quant']._update_available_quantity(self.raw_product, self.warehouse.lot_stock_id, 4.0)
         picking_customer = self.env['stock.picking'].create({
             'location_id': self.warehouse.wh_output_stock_loc_id.id,
-            'location_dest_id': self.customer_location,
+            'location_dest_id': self.customer_location.id,
             'partner_id': self.env['ir.model.data']._xmlid_to_res_id('base.res_partner_4'),
             'picking_type_id': self.warehouse.out_type_id.id,
             'state': 'draft',
@@ -197,7 +196,7 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
             'product_uom': self.uom_unit.id,
             'picking_id': picking_customer.id,
             'location_id': self.warehouse.lot_stock_id.id,
-            'location_dest_id': self.customer_location,
+            'location_dest_id': self.customer_location.id,
             'procure_method': 'make_to_order',
             'origin': 'SOURCEDOCUMENT',
             'state': 'draft',
@@ -264,7 +263,7 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         self.env['stock.quant']._update_available_quantity(self.raw_product, self.warehouse.lot_stock_id, 4.0)
         picking_customer = self.env['stock.picking'].create({
             'location_id': self.warehouse.lot_stock_id.id,
-            'location_dest_id': self.customer_location,
+            'location_dest_id': self.customer_location.id,
             'partner_id': self.env['ir.model.data']._xmlid_to_res_id('base.res_partner_4'),
             'picking_type_id': self.warehouse.out_type_id.id,
             'state': 'draft',
@@ -276,7 +275,7 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
             'picking_id': picking_customer.id,
             'product_uom': self.uom_unit.id,
             'location_id': self.warehouse.lot_stock_id.id,
-            'location_dest_id': self.customer_location,
+            'location_dest_id': self.customer_location.id,
             'procure_method': 'make_to_order',
         })
         picking_customer.action_confirm()
@@ -371,7 +370,7 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
 
         finished_product = self.env['product.product'].create({
             'name': 'Super Product',
-            'route_ids': [(4, self.ref('mrp.route_warehouse0_manufacture'))],
+            'route_ids': [Command.link(self.route_manufacture.id)],
             'is_storable': True,
         })
         secondary_product = self.env['product.product'].create({
@@ -762,7 +761,7 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         self.env.user.group_ids += self.env.ref('mrp.group_mrp_byproducts')
         demo = self.env['product.product'].create({
             'name': 'DEMO',
-            'route_ids': [(4, self.ref('mrp.route_warehouse0_manufacture'))],
+            'route_ids': [Command.link(self.route_manufacture.id)],
             'is_storable': True,
         })
         comp1 = self.env['product.product'].create({

--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -15,8 +15,7 @@ class TestMrpAccount(TestMrpCommon):
     @classmethod
     def setUpClass(cls):
         super(TestMrpAccount, cls).setUpClass()
-        cls.source_location_id = cls.stock_location_14.id
-        cls.warehouse = cls.env.ref('stock.warehouse0')
+        cls.source_location_id = cls.shelf_1.id
         # setting up alternative workcenters
         cls.wc_alt_1 = cls.env['mrp.workcenter'].create({
             'name': 'Nuclear Workcenter bis',
@@ -226,7 +225,7 @@ class TestMrpAccount(TestMrpCommon):
             'name': 'in 2 component',
             'product_id': component.id,
             'product_uom_qty': 2.0,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
+            'location_id': self.supplier_location.id,
             'location_dest_id': self.source_location_id,
             'price_unit': 1,
         })
@@ -279,7 +278,7 @@ class TestMrpAccount(TestMrpCommon):
             'product_id': final_product.id,
             'product_uom_qty': 1.0,
             'location_id': self.source_location_id,
-            'location_dest_id': self.env.ref('stock.stock_location_customers').id,
+            'location_dest_id': self.customer_location.id,
         })
         out_move._action_confirm()
         out_move._action_assign()

--- a/addons/mrp_repair/tests/test_tracability.py
+++ b/addons/mrp_repair/tests/test_tracability.py
@@ -99,14 +99,11 @@ class TestRepairTraceability(TestMrpCommon):
             mo.button_mark_done()
             return mo
 
-
-        stock_location = self.env.ref('stock.stock_location_stock')
-
         finished, component = self.env['product.product'].create([{
             'name': 'Finished Product',
             'is_storable': True,
         }, {
-            'name': 'SN Componentt',
+            'name': 'SN Component',
             'is_storable': True,
             'tracking': 'serial',
         }])
@@ -115,7 +112,7 @@ class TestRepairTraceability(TestMrpCommon):
             'product_id': component.id,
             'name': 'USN01',
         })
-        self.env['stock.quant']._update_available_quantity(component, stock_location, 1, lot_id=sn_lot)
+        self.env['stock.quant']._update_available_quantity(component, self.stock_location, 1, lot_id=sn_lot)
 
         mo = produce_one(finished, component)
         self.assertEqual(mo.state, 'done')
@@ -142,7 +139,7 @@ class TestRepairTraceability(TestMrpCommon):
         with ro_form.move_ids.new() as ro_line:
             ro_line.repair_line_type = 'recycle'
             ro_line.product_id = component
-            ro_line.location_dest_id = stock_location
+            ro_line.location_dest_id = self.stock_location
         ro = ro_form.save()
         ro.action_validate()
         ro.move_ids[0].lot_ids = sn_lot
@@ -155,7 +152,7 @@ class TestRepairTraceability(TestMrpCommon):
         with ro_form.move_ids.new() as ro_line:
             ro_line.repair_line_type = 'add'
             ro_line.product_id = component
-            ro_line.location_id = stock_location
+            ro_line.location_id = self.stock_location
         ro = ro_form.save()
         ro.action_validate()
         ro.move_ids[0].lot_ids = sn_lot
@@ -168,7 +165,7 @@ class TestRepairTraceability(TestMrpCommon):
         with ro_form.move_ids.new() as ro_line:
             ro_line.repair_line_type = 'recycle'
             ro_line.product_id = component
-            ro_line.location_dest_id = stock_location
+            ro_line.location_dest_id = self.stock_location
         ro = ro_form.save()
         ro.action_validate()
         ro.move_ids[0].lot_ids = sn_lot
@@ -212,8 +209,7 @@ class TestRepairTraceability(TestMrpCommon):
         ro.action_repair_start()
         ro.action_repair_end()
 
-        stock_location = self.env.ref('stock.stock_location_stock')
-        self.env['stock.quant']._update_available_quantity(component, stock_location, 1, lot_id=sn_lot)
+        self.env['stock.quant']._update_available_quantity(component, self.stock_location, 1, lot_id=sn_lot)
         self.assertEqual(component.qty_available, 1)
 
         # create a manufacturing order
@@ -258,7 +254,6 @@ class TestRepairTraceability(TestMrpCommon):
         Move the component back to the stock
         Use it in a MO
         """
-        stock_location = self.env.ref('stock.stock_location_stock')
         scrap_location = self.env['stock.location'].search([('company_id', '=', self.env.company.id), ('scrap_location', '=', True)], limit=1)
 
         finished = self.bom_4.product_id
@@ -273,7 +268,7 @@ class TestRepairTraceability(TestMrpCommon):
             'name': 'SN01',
             'company_id': self.env.company.id,
         })
-        self.env['stock.quant']._update_available_quantity(component, stock_location, 1, lot_id=sn_lot)
+        self.env['stock.quant']._update_available_quantity(component, self.stock_location, 1, lot_id=sn_lot)
 
         mo_form = Form(self.env['mrp.production'])
         mo_form.bom_id = self.bom_4
@@ -308,7 +303,7 @@ class TestRepairTraceability(TestMrpCommon):
             'product_uom_qty': 1,
             'product_uom': component.uom_id.id,
             'location_id': scrap_location.id,
-            'location_dest_id': stock_location.id,
+            'location_dest_id': self.stock_location.id,
         })
         sm._action_confirm()
         sm.move_line_ids.write({

--- a/addons/product_expiry/tests/test_stock_lot.py
+++ b/addons/product_expiry/tests/test_stock_lot.py
@@ -46,9 +46,9 @@ class TestStockLot(TestStockCommon):
         })
 
         picking_in = self.PickingObj.create({
-            'picking_type_id': self.picking_type_in,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'picking_type_id': self.picking_type_in.id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'state': 'draft',
         })
 
@@ -58,8 +58,8 @@ class TestStockLot(TestStockCommon):
             'product_uom_qty': 33,
             'product_uom': self.productAAA.uom_id.id,
             'picking_id': picking_in.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
         })
 
         self.assertEqual(picking_in.move_ids.state, 'draft', 'Wrong state of move line.')
@@ -143,10 +143,11 @@ class TestStockLot(TestStockCommon):
         })
 
         picking_in = self.PickingObj.create({
-            'picking_type_id': self.picking_type_in,
-            'location_id': self.supplier_location,
+            'picking_type_id': self.picking_type_in.id,
+            'location_id': self.supplier_location.id,
             'state': 'draft',
-            'location_dest_id': self.stock_location})
+            'location_dest_id': self.stock_location.id,
+        })
 
         move_b = self.MoveObj.create({
             'name': self.productBBB.name,
@@ -154,8 +155,9 @@ class TestStockLot(TestStockCommon):
             'product_uom_qty': 44,
             'product_uom': self.productBBB.uom_id.id,
             'picking_id': picking_in.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location})
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+        })
 
         self.assertEqual(picking_in.move_ids.state, 'draft', 'Wrong state of move line.')
         picking_in.action_confirm()
@@ -191,10 +193,11 @@ class TestStockLot(TestStockCommon):
         self.lot1_productCCC = self.LotObj.create({'name': 'Lot 1 ProductCCC', 'product_id': self.productCCC.id})
 
         picking_in = self.PickingObj.create({
-            'picking_type_id': self.picking_type_in,
-            'location_id': self.supplier_location,
+            'picking_type_id': self.picking_type_in.id,
+            'location_id': self.supplier_location.id,
             'state': 'draft',
-            'location_dest_id': self.stock_location})
+            'location_dest_id': self.stock_location.id,
+        })
 
         move_c = self.MoveObj.create({
             'name': self.productCCC.name,
@@ -202,8 +205,9 @@ class TestStockLot(TestStockCommon):
             'product_uom_qty': 44,
             'product_uom': self.productCCC.uom_id.id,
             'picking_id': picking_in.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location})
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+        })
 
         self.assertEqual(picking_in.move_ids.state, 'draft', 'Wrong state of move line.')
         picking_in.action_confirm()
@@ -299,7 +303,7 @@ class TestStockLot(TestStockCommon):
         # Receives a tracked production using expiration date.
         picking_form = Form(self.env['stock.picking'])
         picking_form.partner_id = partner
-        picking_form.picking_type_id = self.env.ref('stock.picking_type_in')
+        picking_form.picking_type_id = self.picking_type_in
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.apple_product
             move.product_uom_qty = 4
@@ -347,7 +351,7 @@ class TestStockLot(TestStockCommon):
         # Receives a tracked production using expiration date.
         picking_form = Form(self.env['stock.picking'])
         picking_form.partner_id = partner
-        picking_form.picking_type_id = self.env.ref('stock.picking_type_in')
+        picking_form.picking_type_id = self.picking_type_in
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.apple_product
             move.quantity = 4
@@ -403,7 +407,7 @@ class TestStockLot(TestStockCommon):
         # Case #1: make a delivery with no expired lot.
         picking_form = Form(self.env['stock.picking'])
         picking_form.partner_id = partner
-        picking_form.picking_type_id = self.env.ref('stock.picking_type_out')
+        picking_form.picking_type_id = self.picking_type_out
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.apple_product
             move.product_uom_qty = 4
@@ -428,7 +432,7 @@ class TestStockLot(TestStockCommon):
         # Case #2: make a delivery with one non-expired lot and one expired lot.
         picking_form = Form(self.env['stock.picking'])
         picking_form.partner_id = partner
-        picking_form.picking_type_id = self.env.ref('stock.picking_type_out')
+        picking_form.picking_type_id = self.picking_type_out
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.apple_product
             move.product_uom_qty = 8
@@ -463,7 +467,7 @@ class TestStockLot(TestStockCommon):
         # Case #3: make a delivery with only on expired lot.
         picking_form = Form(self.env['stock.picking'])
         picking_form.partner_id = partner
-        picking_form.picking_type_id = self.env.ref('stock.picking_type_out')
+        picking_form.picking_type_id = self.picking_type_out
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.apple_product
             move.product_uom_qty = 4
@@ -504,7 +508,7 @@ class TestStockLot(TestStockCommon):
 
         quant = self.StockQuantObj.with_context(inventory_mode=True).create({
             'product_id': self.apple_product.id,
-            'location_id': self.stock_location,
+            'location_id': self.stock_location.id,
             'quantity': 10,
             'lot_id': apple_lot.id,
         })
@@ -529,14 +533,14 @@ class TestStockLot(TestStockCommon):
 
         move = self.env['stock.move'].create({
             'name': 'move_test',
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'product_id': self.apple_product.id,
             'product_uom': self.apple_product.uom_id.id,
         })
         sml = self.env['stock.move.line'].create({
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'product_id': self.apple_product.id,
             'quantity': 3,
             'product_uom_id': self.apple_product.uom_id.id,
@@ -589,7 +593,7 @@ class TestStockLot(TestStockCommon):
 
         self.StockQuantObj.with_context(inventory_mode=True).create({
             'product_id': self.apple_product.id,
-            'location_id': self.stock_location,
+            'location_id': self.stock_location.id,
             'quantity': 100,
             'lot_id': apple_lot.id,
         })
@@ -597,9 +601,9 @@ class TestStockLot(TestStockCommon):
         self.assertEqual(self.apple_product.qty_available, 100, 'Wrong quantity.')
 
         picking_out = self.PickingObj.create({
-            'picking_type_id': self.picking_type_out,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'picking_type_id': self.picking_type_out.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
             'state': 'draft',
         })
 
@@ -609,8 +613,8 @@ class TestStockLot(TestStockCommon):
             'product_uom_qty': 10,
             'product_uom': self.apple_product.uom_id.id,
             'picking_id': picking_out.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
 
         self.assertEqual(picking_out.move_ids.state, 'draft', 'Wrong state of move line.')
@@ -634,17 +638,17 @@ class TestStockLot(TestStockCommon):
 
         self.StockQuantObj.with_context(inventory_mode=True).create([{
             'product_id': self.apple_product.id,
-            'location_id': self.stock_location,
+            'location_id': self.stock_location.id,
             'quantity': 100,
         }, {
             'product_id': self.apple_product.id,
-            'location_id': self.stock_location,
+            'location_id': self.stock_location.id,
             'quantity': 100,
             'lot_id': apple_lot.id,
         }])
 
         with Form(self.PickingObj) as picking_form:
-            picking_form.picking_type_id = self.env.ref('stock.picking_type_out')
+            picking_form.picking_type_id = self.picking_type_out
             with picking_form.move_ids_without_package.new() as move:
                 move.product_id = self.apple_product
                 move.product_uom_qty = 10
@@ -666,7 +670,7 @@ class TestStockLot(TestStockCommon):
         picking_form = Form(self.env['stock.picking'])
         picking_form.partner_id = partner
         picking_form.scheduled_date = new_date
-        picking_form.picking_type_id = self.env.ref('stock.picking_type_in')
+        picking_form.picking_type_id = self.picking_type_in
 
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.apple_product

--- a/addons/project_stock_account/tests/test_analytics.py
+++ b/addons/project_stock_account/tests/test_analytics.py
@@ -42,17 +42,17 @@ class TestAnalytics(TestStockCommon):
 
     def test_analytic_lines_generation_delivery(self):
         picking_out = self.PickingObj.create({
-            'picking_type_id': self.picking_type_out,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'picking_type_id': self.picking_type_out.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
             'project_id': self.project.id,
         })
         picking_out.picking_type_id.analytic_costs = True
         move_values = {
             'product_uom': self.uom_unit.id,
             'picking_id': picking_out.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         }
         self.MoveObj.create([
             {
@@ -91,17 +91,17 @@ class TestAnalytics(TestStockCommon):
             profitability' right side panel and displayed under the 'costs -> materials' section.
         """
         picking_in = self.PickingObj.create({
-            'picking_type_id': self.picking_type_in,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'picking_type_id': self.picking_type_in.id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'project_id': self.project.id,
         })
         picking_in.picking_type_id.analytic_costs = True
         move_values = {
             'product_uom': self.uom_unit.id,
             'picking_id': picking_in.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
         }
         self.MoveObj.create([
             {
@@ -150,9 +150,9 @@ class TestAnalytics(TestStockCommon):
             'applicability': 'mandatory',
         })
         picking_in = self.PickingObj.create({
-            'picking_type_id': self.picking_type_in,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'picking_type_id': self.picking_type_in.id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'project_id': self.project.id,
         })
         picking_in.picking_type_id.analytic_costs = True
@@ -161,8 +161,8 @@ class TestAnalytics(TestStockCommon):
             'name': 'Move',
             'product_uom': self.uom_unit.id,
             'picking_id': picking_in.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'product_id': self.product2.id,
             'product_uom_qty': 5,
         })

--- a/addons/purchase_repair/tests/test_repair_purchase_flow.py
+++ b/addons/purchase_repair/tests/test_repair_purchase_flow.py
@@ -2,11 +2,11 @@
 
 from odoo.fields import Command
 from odoo.tests import tagged
-from odoo.addons.stock.tests.common import TestStockCommon
+from odoo.addons.purchase_stock.tests.common import PurchaseTestCommon
 
 
 @tagged('post_install', '-at_install')
-class TestRepairPurchaseFlow(TestStockCommon):
+class TestRepairPurchaseFlow(PurchaseTestCommon):
 
     @classmethod
     def setUpClass(cls):
@@ -20,10 +20,8 @@ class TestRepairPurchaseFlow(TestStockCommon):
         Validates that a repair order triggers a purchase order with correct product
         and quantity, and ensures proper linking via the procurement group.
         """
-        self.env.ref('stock.route_warehouse0_mto').active = True
-        mto_route = self.env['stock.route'].search([('name', '=', 'Replenish on Order (MTO)')])
-        buy_route = self.env['stock.route'].search([('name', '=', 'Buy')])
-        rule = mto_route.rule_ids.filtered(lambda r: r.picking_type_id.code == 'repair_operation')
+        self.route_mto.active = True
+        rule = self.route_mto.rule_ids.filtered(lambda r: r.picking_type_id.code == 'repair_operation')
         rule.update({'procure_method': 'make_to_order'})
 
         seller = self.env['res.partner'].create({
@@ -32,7 +30,7 @@ class TestRepairPurchaseFlow(TestStockCommon):
 
         product = self.productA
         product.write({
-            'route_ids': [(4, mto_route.id), (4, buy_route.id)],
+            'route_ids': [Command.set([self.route_mto.id, self.route_buy.id])],
             'seller_ids': [
                 Command.create({
                     'partner_id': seller.id,

--- a/addons/purchase_stock/tests/common.py
+++ b/addons/purchase_stock/tests/common.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import timedelta
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.addons.stock.tests.common import TestStockCommon
 from odoo import tools
 
@@ -24,32 +24,31 @@ class PurchaseTestCommon(TestStockCommon):
     @classmethod
     def setUpClass(cls):
         super(PurchaseTestCommon, cls).setUpClass()
-        cls.env.ref('stock.route_warehouse0_mto').active = True
+        cls.route_mto.active = True
 
-        cls.route_buy = cls.warehouse_1.buy_pull_id.route_id.id
-        cls.route_mto = cls.warehouse_1.mto_pull_id.route_id.id
+        cls.route_buy = cls.warehouse_1.buy_pull_id.route_id
         cls.categ_id = cls.env.ref('product.product_category_goods').id
 
         # Update product_1 with type, route and Delivery Lead Time
         cls.product_1.write({
             'is_storable': True,
-            'route_ids': [(6, 0, [cls.route_buy, cls.route_mto])],
-            'seller_ids': [(0, 0, {'partner_id': cls.partner_1.id, 'delay': 5})],
+            'route_ids': [Command.set([cls.route_buy.id, cls.route_mto.id])],
+            'seller_ids': [Command.create({'partner_id': cls.partner_1.id, 'delay': 5})],
             'categ_id': cls.categ_id,
         })
 
         cls.t_shirt = cls.env['product.product'].create({
             'name': 'T-shirt',
             'description': 'Internal Notes',
-            'route_ids': [(6, 0, [cls.route_buy, cls.route_mto])],
-            'seller_ids': [(0, 0, {'partner_id': cls.partner_1.id, 'delay': 5})]
+            'route_ids': [Command.set([cls.route_buy.id, cls.route_mto.id])],
+            'seller_ids': [Command.create({'partner_id': cls.partner_1.id, 'delay': 5})]
         })
 
         # Update product_2 with type, route and Delivery Lead Time
         cls.product_2.write({
             'is_storable': True,
-            'route_ids': [(6, 0, [cls.route_buy, cls.route_mto])],
-            'seller_ids': [(0, 0, {'partner_id': cls.partner_1.id, 'delay': 2})],
+            'route_ids': [Command.set([cls.route_buy.id, cls.route_mto.id])],
+            'seller_ids': [Command.create({'partner_id': cls.partner_1.id, 'delay': 2})],
             'categ_id': cls.categ_id,
         })
 
@@ -58,5 +57,5 @@ class PurchaseTestCommon(TestStockCommon):
             'name': "Purchase User",
             'login': "pu",
             'email': "purchaseuser@yourcompany.com",
-            'group_ids': [(6, 0, [cls.env.ref('purchase.group_purchase_user').id])],
-            })
+            'group_ids': [Command.set([cls.env.ref('purchase.group_purchase_user').id])],
+        })

--- a/addons/purchase_stock/tests/test_purchase_delete_order.py
+++ b/addons/purchase_stock/tests/test_purchase_delete_order.py
@@ -47,17 +47,14 @@ class TestDeleteOrder(PurchaseTestCommon):
 
         partner = self.env['res.partner'].create({'name': 'My Partner'})
 
-        stock_location = self.env.ref('stock.warehouse0').out_type_id.default_location_src_id
-        cust_location = self.env.ref('stock.stock_location_customers')
-        picking_type_out = self.ref('stock.picking_type_out')
         move = self.env['stock.move'].create({
             'name': self.product_2.name,
             'product_id': self.product_2.id,
             'product_uom_qty': 1,
             'product_uom': self.product_2.uom_id.id,
-            'location_id': stock_location.id,
-            'location_dest_id': cust_location.id,
-            'picking_type_id': picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
         })
         move._action_confirm()
         self.assertEqual(move.state, 'confirmed', 'Move should be confirmed as there is no quantity in stock')

--- a/addons/purchase_stock/tests/test_purchase_lead_time.py
+++ b/addons/purchase_stock/tests/test_purchase_lead_time.py
@@ -4,7 +4,7 @@
 from datetime import datetime, timedelta, time
 from unittest.mock import patch
 
-from odoo import fields
+from odoo import Command, fields
 from .common import PurchaseTestCommon
 from odoo.tests import Form
 
@@ -100,8 +100,8 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
         # create a product with manufacture route
         product_1 = self.env['product.product'].create({
             'name': 'AAA',
-            'route_ids': [(4, self.route_buy)],
-            'seller_ids': [(0, 0, {'partner_id': self.partner_1.id, 'delay': 5})]
+            'route_ids': [Command.link(self.route_buy.id)],
+            'seller_ids': [Command.create({'partner_id': self.partner_1.id, 'delay': 5})]
         })
 
         # create a move for product_1 from stock to output and reserve to trigger the
@@ -109,9 +109,9 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
         move_1 = self.env['stock.move'].create({
             'name': 'move_1',
             'product_id': product_1.id,
-            'product_uom': self.ref('uom.product_uom_unit'),
-            'location_id': self.ref('stock.stock_location_stock'),
-            'location_dest_id': self.ref('stock.stock_location_output'),
+            'product_uom': self.uom_unit.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.output_location.id,
             'product_uom_qty': 10,
             'procure_method': 'make_to_order'
         })
@@ -126,9 +126,9 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
         move_2 = self.env['stock.move'].create({
             'name': 'move_2',
             'product_id': product_1.id,
-            'product_uom': self.ref('uom.product_uom_unit'),
-            'location_id': self.ref('stock.stock_location_stock'),
-            'location_dest_id': self.ref('stock.stock_location_output'),
+            'product_uom': self.uom_unit.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.output_location.id,
             'product_uom_qty': 5,
             'procure_method': 'make_to_order'
         })
@@ -225,7 +225,7 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
             'name': 'Carrot',
             'is_storable': True,
             'seller_ids': [
-                (0, 0, {'partner_id': vendor.id, 'delay': 1.0, 'company_id': company.id})
+                Command.create({'partner_id': vendor.id, 'delay': 1.0, 'company_id': company.id})
             ]
         })
 
@@ -237,7 +237,7 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
             'product_uom': prod.uom_id.id,
             'product_uom_qty': 5.0,
             'location_id': warehouse.lot_stock_id.id,
-            'location_dest_id': self.ref('stock.stock_location_customers'),
+            'location_dest_id': self.customer_location.id,
         })._action_confirm()
         self.env['stock.warehouse.orderpoint'].action_open_orderpoints()
         replenishment = self.env['stock.warehouse.orderpoint'].search([
@@ -250,8 +250,8 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
             'name': 'Chicory',
             'is_storable': True,
             'seller_ids': [
-                (0, 0, {'partner_id': vendor2.id, 'delay': 15.0, 'company_id': company2.id}),
-                (0, 0, {'partner_id': vendor.id, 'delay': 1.0, 'company_id': company.id})
+                Command.create({'partner_id': vendor2.id, 'delay': 15.0, 'company_id': company2.id}),
+                Command.create({'partner_id': vendor.id, 'delay': 1.0, 'company_id': company.id})
             ]
         })
         orderpoint_form = Form(self.env['stock.warehouse.orderpoint'])
@@ -274,7 +274,7 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
                 'product_uom': product.uom_id.id,
                 'product_uom_qty': 5.0,
                 'location_id': warehouse.lot_stock_id.id,
-                'location_dest_id': self.ref('stock.stock_location_customers'),
+                'location_dest_id': self.customer_location.id,
             })
         delivery_moves._action_confirm()
         self.env['procurement.group'].run_scheduler()

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -47,7 +47,7 @@ class TestReorderingRule(TransactionCase):
             - There should be one move supplier -> input and two moves input -> stock
         """
         warehouse_1 = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
-        warehouse_1.write({'reception_steps': 'two_steps'})
+        warehouse_1.reception_steps = 'two_steps'
         warehouse_2 = self.env['stock.warehouse'].create({'name': 'WH 2', 'code': 'WH2', 'company_id': self.env.company.id, 'partner_id': self.env.company.partner_id.id, 'reception_steps': 'one_step'})
 
         # Create and set specific buyer for partner
@@ -458,7 +458,7 @@ class TestReorderingRule(TransactionCase):
             'name': 'Tintin'
         })
         for wh in self.env['stock.warehouse'].search([]):
-            wh.write({'reception_steps': 'two_steps'})
+            wh.reception_steps = 'two_steps'
         route_buy = self.env.ref('purchase_stock.route_warehouse0_buy')
         route_mto = self.env.ref('stock.route_warehouse0_mto')
 

--- a/addons/purchase_stock/tests/test_replenish_wizard.py
+++ b/addons/purchase_stock/tests/test_replenish_wizard.py
@@ -2,12 +2,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from freezegun import freeze_time
 
-from odoo.addons.stock.tests.common import TestStockCommon
+from odoo import Command, fields
+from .common import PurchaseTestCommon
 
-from odoo import fields
 
-
-class TestReplenishWizard(TestStockCommon):
+class TestReplenishWizard(PurchaseTestCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -25,8 +24,8 @@ class TestReplenishWizard(TestStockCommon):
         cls.product1 = cls.env['product.product'].create({
             'name': 'product a',
             'is_storable': True,
-            'seller_ids': [(4, cls.supplierinfo.id, 0)],
-            'route_ids': [(4, cls.env.ref('purchase_stock.route_warehouse0_buy').id, 0)],
+            'seller_ids': [Command.link(cls.supplierinfo.id)],
+            'route_ids': [Command.link(cls.route_buy.id)],
         })
 
         # Additional Values required by the replenish wizard
@@ -72,7 +71,7 @@ class TestReplenishWizard(TestStockCommon):
         product_to_buy = self.env['product.product'].create({
             'name': "Furniture Service",
             'is_storable': True,
-            'route_ids': [(4, self.env.ref('purchase_stock.route_warehouse0_buy').id, 0)],
+            'route_ids': [Command.link(self.route_buy.id)],
         })
         vendor1 = self.env['res.partner'].create({'name': 'vendor1', 'email': 'from.test@example.com'})
 
@@ -122,7 +121,7 @@ class TestReplenishWizard(TestStockCommon):
         product_to_buy = self.env['product.product'].create({
             'name': "Furniture Service",
             'is_storable': True,
-            'route_ids': [(4, self.env.ref('purchase_stock.route_warehouse0_buy').id, 0)],
+            'route_ids': [Command.link(self.route_buy.id)],
         })
         vendor1 = self.env['res.partner'].create({'name': 'vendor1', 'email': 'from.test@example.com'})
         vendor2 = self.env['res.partner'].create({'name': 'vendor2', 'email': 'from.test2@example.com'})
@@ -179,7 +178,7 @@ class TestReplenishWizard(TestStockCommon):
         product_to_buy = self.env['product.product'].create({
             'name': "Furniture Service",
             'is_storable': True,
-            'route_ids': [(4, self.env.ref('purchase_stock.route_warehouse0_buy').id, 0)],
+            'route_ids': [Command.link(self.route_buy.id)],
         })
         vendor1 = self.env['res.partner'].create({'name': 'vendor1', 'email': 'from.test@example.com'})
         vendor2 = self.env['res.partner'].create({'name': 'vendor2', 'email': 'from.test2@example.com'})
@@ -228,7 +227,7 @@ class TestReplenishWizard(TestStockCommon):
         product_to_buy = self.env['product.product'].create({
             'name': "Furniture Service",
             'is_storable': True,
-            'route_ids': [(4, self.env.ref('purchase_stock.route_warehouse0_buy').id, 0)],
+            'route_ids': [Command.link(self.route_buy.id)],
         })
         vendor1 = self.env['res.partner'].create({'name': 'vendor1', 'email': 'from.test@example.com'})
         supplierinfo1 = self.env['product.supplierinfo'].create({
@@ -310,7 +309,7 @@ class TestReplenishWizard(TestStockCommon):
         product_to_buy = self.env['product.product'].create({
             'name': "Furniture Service",
             'is_storable': True,
-            'route_ids': [(4, self.env.ref('purchase_stock.route_warehouse0_buy').id, 0)],
+            'route_ids': [Command.link(self.route_buy.id)],
         })
         vendor1 = self.env['res.partner'].create({'name': 'vendor1', 'email': 'from.test@example.com'})
         supplier_delay = self.env['product.supplierinfo'].create({
@@ -334,7 +333,7 @@ class TestReplenishWizard(TestStockCommon):
                 'product_uom_id': self.uom_unit.id,
                 'quantity': 1,
                 'warehouse_id': self.wh.id,
-                'route_id': self.env.ref('purchase_stock.route_warehouse0_buy').id
+                'route_id': self.route_buy.id,
             })
             wizard.supplier_id = supplier_no_delay
             self.assertEqual(fields.Datetime.from_string('2023-01-01 00:00:00'), wizard.date_planned)
@@ -345,7 +344,7 @@ class TestReplenishWizard(TestStockCommon):
         product_to_buy = self.env['product.product'].create({
             'name': "Furniture Service",
             'is_storable': True,
-            'route_ids': [(4, self.env.ref('purchase_stock.route_warehouse0_buy').id, 0)],
+            'route_ids': [Command.link(self.route_buy.id)],
         })
         vendor = self.env['res.partner'].create({'name': 'vendor1', 'email': 'from.test@example.com'})
         supplier1 = self.env['product.supplierinfo'].create({
@@ -372,7 +371,7 @@ class TestReplenishWizard(TestStockCommon):
                 'product_uom_id': self.uom_unit.id,
                 'quantity': 1,
                 'warehouse_id': self.wh.id,
-                'route_id': self.env.ref('purchase_stock.route_warehouse0_buy').id
+                'route_id': self.route_buy.id,
             })
             wizard.supplier_id = supplier1
             self.assertEqual(fields.Datetime.from_string('2023-01-01 00:00:00'), wizard.date_planned)
@@ -385,7 +384,7 @@ class TestReplenishWizard(TestStockCommon):
         product_to_buy = self.env['product.product'].create({
             'name': "Furniture Service",
             'is_storable': True,
-            'route_ids': [(4, self.env.ref('purchase_stock.route_warehouse0_buy').id, 0)],
+            'route_ids': [Command.link(self.route_buy.id)],
         })
         vendor = self.env['res.partner'].create({'name': 'vendor1', 'email': 'from.test@example.com'})
         supplier = self.env['product.supplierinfo'].create({
@@ -405,7 +404,7 @@ class TestReplenishWizard(TestStockCommon):
                 'product_uom_id': self.uom_unit.id,
                 'quantity': 1,
                 'warehouse_id': self.wh.id,
-                'route_id': self.env.ref('purchase_stock.route_warehouse0_buy').id
+                'route_id': self.route_buy.id,
             })
             wizard.supplier_id = supplier
             self.assertEqual(fields.Datetime.from_string('2023-01-08 00:00:00'), wizard.date_planned)
@@ -423,9 +422,7 @@ class TestReplenishWizard(TestStockCommon):
                 'price': 1.0,
                 'date_end': '2019-01-01',
             })],
-            'route_ids': [(6, 0, [
-                self.env.ref('purchase_stock.route_warehouse0_buy').id
-            ])],
+            'route_ids': [Command.set([self.route_buy.id])],
         })
 
         replenish_wizard = self.env['product.replenish'].create({
@@ -434,7 +431,7 @@ class TestReplenishWizard(TestStockCommon):
             'product_uom_id': self.uom_unit.id,
             'quantity': 1,
             'warehouse_id': self.wh.id,
-            'route_id': self.env.ref('purchase_stock.route_warehouse0_buy').id
+            'route_id': self.route_buy.id,
         })
         replenish_wizard.launch_replenishment()
         last_po_id = self.env['purchase.order'].search([
@@ -448,9 +445,7 @@ class TestReplenishWizard(TestStockCommon):
         self.env['stock.warehouse'].search([], limit=1).reception_steps = 'two_steps'
         product = self.env['product.product'].create({
             'name': 'Product',
-            'route_ids': [(6, 0, [
-                self.env.ref('purchase_stock.route_warehouse0_buy').id
-            ])],
+            'route_ids': [Command.set([self.route_buy.id])],
         })
         partner_a, partner_b = self.env['res.partner'].create([
             {'name': "partner_a"},
@@ -476,7 +471,7 @@ class TestReplenishWizard(TestStockCommon):
             'product_uom_id': self.uom_unit.id,
             'quantity': 1,
             'warehouse_id': self.wh.id,
-            'route_id': self.env.ref('purchase_stock.route_warehouse0_buy').id,
+            'route_id': self.route_buy.id,
             'supplier_id': product.seller_ids[2].id  # partner_b price 100$
         })
         replenish_wizard.launch_replenishment()

--- a/addons/sale_mrp/tests/test_multistep_manufacturing.py
+++ b/addons/sale_mrp/tests/test_multistep_manufacturing.py
@@ -18,7 +18,7 @@ class TestMultistepManufacturing(TestMrpCommon):
         # Required for `product_id` to be visible in the view
         cls.env.user.group_ids += cls.env.ref('product.group_product_variant')
 
-        cls.env.ref('stock.route_warehouse0_mto').active = True
+        cls.route_mto.active = True
         cls.MrpProduction = cls.env['mrp.production']
         # Create warehouse
         warehouse_form = Form(cls.env['stock.warehouse'])
@@ -155,8 +155,8 @@ class TestMultistepManufacturing(TestMrpCommon):
         self.assertEqual(mo.action_view_sale_orders()['res_id'], self.sale_order.id)
 
     def test_sales_order_with_mto_manufacturing(self):
-        self.env.ref('stock.route_warehouse0_mto').active = True
-        warehouse = self.env.ref('stock.warehouse0')
+        self.route_mto.active = True
+        warehouse = self.warehouse_1
         warehouse.manufacture_steps = 'pbm_sam'
         prod1 = self.env['product.product'].create({
             'name': 'elct1',

--- a/addons/sale_mrp/tests/test_sale_mrp_lead_time.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_lead_time.py
@@ -14,7 +14,7 @@ class TestSaleMrpLeadTime(TestStockCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env.ref('stock.route_warehouse0_mto').active = True
+        cls.route_mto.active = True
         # Update the product_1 with type, route, Manufacturing Lead Time and Customer Lead Time
         with Form(cls.product_1) as p1:
             # `type` is invisible in the view,

--- a/addons/sale_project_stock/tests/test_reinvoice.py
+++ b/addons/sale_project_stock/tests/test_reinvoice.py
@@ -19,9 +19,9 @@ class TestReInvoice(TestStockCommon):
             'reinvoiced_sale_order_id': cls.sale_order.id,
         })
         cls.picking_out = cls.PickingObj.create({
-            'picking_type_id': cls.picking_type_out,
-            'location_id': cls.stock_location,
-            'location_dest_id': cls.customer_location,
+            'picking_type_id': cls.picking_type_out.id,
+            'location_id': cls.stock_location.id,
+            'location_dest_id': cls.customer_location.id,
             'project_id': cls.project.id,
         })
         cls.picking_out.picking_type_id.analytic_costs = True
@@ -44,8 +44,8 @@ class TestReInvoice(TestStockCommon):
             'name': 'Move',
             'product_uom': self.uom_unit.id,
             'picking_id': self.picking_out.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         }
         self.MoveObj.create([
             {

--- a/addons/sale_project_stock_account/tests/test_analytics_reinvoice.py
+++ b/addons/sale_project_stock_account/tests/test_analytics_reinvoice.py
@@ -12,9 +12,9 @@ class TestAnalyticsReinvoice(TestAnalytics):
             'expense_policy': 'cost',
         })
         picking_out = self.PickingObj.create({
-            'picking_type_id': self.picking_type_out,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'picking_type_id': self.picking_type_out.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
             'project_id': self.project.id,
         })
         picking_out.picking_type_id.analytic_costs = True
@@ -22,8 +22,8 @@ class TestAnalyticsReinvoice(TestAnalytics):
             'name': 'Move',
             'product_uom': self.uom_unit.id,
             'picking_id': picking_out.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
             'product_id': reinvoicable_product.id,
             'product_uom_qty': 3,
         })

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -16,9 +16,9 @@ from dateutil.relativedelta import relativedelta
 class TestPickShip(TestStockCommon):
     def create_pick_ship(self):
         picking_client = self.env['stock.picking'].create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
 
@@ -28,16 +28,16 @@ class TestPickShip(TestStockCommon):
             'product_uom_qty': 10,
             'product_uom': self.productA.uom_id.id,
             'picking_id': picking_client.id,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
             'state': 'waiting',
             'procure_method': 'make_to_order',
         })
 
         picking_pick = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.pack_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.pack_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
 
@@ -47,18 +47,18 @@ class TestPickShip(TestStockCommon):
             'product_uom_qty': 10,
             'product_uom': self.productA.uom_id.id,
             'picking_id': picking_pick.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.pack_location,
-            'move_dest_ids': [(4, dest.id)],
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.pack_location.id,
+            'move_dest_ids': [Command.link(dest.id)],
             'state': 'confirmed',
         })
         return picking_pick, picking_client
 
     def create_pick_pack_ship(self):
         picking_ship = self.env['stock.picking'].create({
-            'location_id': self.output_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.output_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
 
@@ -68,14 +68,14 @@ class TestPickShip(TestStockCommon):
             'product_uom_qty': 1,
             'product_uom': self.productA.uom_id.id,
             'picking_id': picking_ship.id,
-            'location_id': self.output_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.output_location.id,
+            'location_dest_id': self.customer_location.id,
         })
 
         picking_pack = self.env['stock.picking'].create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.output_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.output_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
 
@@ -85,15 +85,15 @@ class TestPickShip(TestStockCommon):
             'product_uom_qty': 1,
             'product_uom': self.productA.uom_id.id,
             'picking_id': picking_pack.id,
-            'location_id': self.pack_location,
-            'location_dest_id': self.output_location,
-            'move_dest_ids': [(4, ship.id)],
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.output_location.id,
+            'move_dest_ids': [Command.link(ship.id)],
         })
 
         picking_pick = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.pack_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.pack_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
 
@@ -103,9 +103,9 @@ class TestPickShip(TestStockCommon):
             'product_uom_qty': 1,
             'product_uom': self.productA.uom_id.id,
             'picking_id': picking_pick.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.pack_location,
-            'move_dest_ids': [(4, pack.id)],
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.pack_location.id,
+            'move_dest_ids': [Command.link(pack.id)],
             'state': 'confirmed',
         })
         return picking_pick, picking_pack, picking_ship
@@ -115,9 +115,8 @@ class TestPickShip(TestStockCommon):
             'name': 'product unreserve',
             'is_storable': True,
         })
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        self.env['stock.quant']._update_available_quantity(product_unreserve, stock_location, 4.0)
-        quants = self.env['stock.quant']._gather(product_unreserve, stock_location, strict=True)
+        self.env['stock.quant']._update_available_quantity(product_unreserve, self.stock_location, 4.0)
+        quants = self.env['stock.quant']._gather(product_unreserve, self.stock_location, strict=True)
         self.assertEqual(quants[0].reserved_quantity, 0)
         move = self.MoveObj.create({
             'name': product_unreserve.name,
@@ -125,8 +124,8 @@ class TestPickShip(TestStockCommon):
             'product_uom_qty': 3,
             'product_uom': product_unreserve.uom_id.id,
             'state': 'confirmed',
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         move._action_assign()
         self.assertEqual(quants[0].reserved_quantity, 3)
@@ -137,13 +136,13 @@ class TestPickShip(TestStockCommon):
             'quantity': 2,
             'product_uom': product_unreserve.uom_id.id,
             'state': 'confirmed',
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         move_2._action_assign()
         move_2.picked = True
         move_2._action_done()
-        quants = self.env['stock.quant']._gather(product_unreserve, stock_location, strict=True)
+        quants = self.env['stock.quant']._gather(product_unreserve, self.stock_location, strict=True)
         self.assertEqual(quants[0].reserved_quantity, 2)
 
 
@@ -152,10 +151,9 @@ class TestPickShip(TestStockCommon):
             10 in stock, do pick->ship and check ship is assigned when pick is done, then backorder of ship
         """
         picking_pick, picking_client = self.create_pick_ship()
-        location = self.env['stock.location'].browse(self.stock_location)
 
         # make some stock
-        self.env['stock.quant']._update_available_quantity(self.productA, location, 10.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 10.0)
         picking_pick.action_assign()
         picking_pick.move_ids[0].move_line_ids[0].quantity = 10.0
         picking_pick.move_ids[0].picked = True
@@ -177,7 +175,7 @@ class TestPickShip(TestStockCommon):
         picking_pick, picking_ship = self.create_pick_ship()
         self.env['stock.quant'].create({
             'product_id': self.productA.id,
-            'location_id': self.stock_location,
+            'location_id': self.stock_location.id,
             'quantity': 10
         })
         (picking_pick + picking_ship).action_assign()
@@ -191,7 +189,7 @@ class TestPickShip(TestStockCommon):
         self.assertEqual(picking_pick.state, 'done')
         self.assertEqual(picking_ship.state, 'confirmed')
         # ship source location remains unchanged
-        self.assertEqual(picking_ship.location_id.id, self.pack_location)
+        self.assertEqual(picking_ship.location_id.id, self.pack_location.id)
         self.assertEqual(picking_ship.move_ids.procure_method, 'make_to_stock')
 
     def test_mto_to_mts_2(self):
@@ -201,7 +199,7 @@ class TestPickShip(TestStockCommon):
         picking_pick, picking_ship = self.create_pick_ship()
         self.env['stock.quant'].create({
             'product_id': self.productA.id,
-            'location_id': self.stock_location,
+            'location_id': self.stock_location.id,
             'quantity': 10
         })
         (picking_pick + picking_ship).action_assign()
@@ -222,7 +220,7 @@ class TestPickShip(TestStockCommon):
         picking_pick, picking_ship = self.create_pick_ship()
         self.env['stock.quant'].create({
             'product_id': self.productA.id,
-            'location_id': self.stock_location,
+            'location_id': self.stock_location.id,
             'quantity': 10
         })
         (picking_pick + picking_ship).action_assign()
@@ -236,7 +234,7 @@ class TestPickShip(TestStockCommon):
         self.assertEqual(picking_pick.state, 'done')
         self.assertEqual(picking_ship.state, 'confirmed')
         # pick destination location remains unchanged
-        self.assertEqual(picking_pick.location_dest_id.id, self.pack_location)
+        self.assertEqual(picking_pick.location_dest_id.id, self.pack_location.id)
         self.assertEqual(picking_ship.move_ids.procure_method, 'make_to_stock')
 
     def test_mto_moves_transfer(self):
@@ -244,13 +242,11 @@ class TestPickShip(TestStockCommon):
             10 in stock, 5 in pack.  Make sure it does not assign the 5 pieces in pack
         """
         picking_pick, picking_client = self.create_pick_ship()
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 10.0)
-        pack_location = self.env['stock.location'].browse(self.pack_location)
-        self.env['stock.quant']._update_available_quantity(self.productA, pack_location, 5.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 10.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.pack_location, 5.0)
 
-        self.assertEqual(len(self.env['stock.quant']._gather(self.productA, stock_location)), 1.0)
-        self.assertEqual(len(self.env['stock.quant']._gather(self.productA, pack_location)), 1.0)
+        self.assertEqual(len(self.env['stock.quant']._gather(self.productA, self.stock_location)), 1.0)
+        self.assertEqual(len(self.env['stock.quant']._gather(self.productA, self.pack_location)), 1.0)
 
         (picking_pick + picking_client).action_assign()
 
@@ -260,8 +256,8 @@ class TestPickShip(TestStockCommon):
         self.assertEqual(picking_pick.state, 'assigned')
         self.assertEqual(move_cust.state, 'waiting')
         self.assertEqual(picking_client.state, 'waiting', 'The picking should not assign what it does not have')
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, stock_location), 0.0)
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 5.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.stock_location), 0.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location), 5.0)
 
         move_pick.move_line_ids[0].quantity = 10.0
         move_pick.picked = True
@@ -271,15 +267,14 @@ class TestPickShip(TestStockCommon):
         self.assertEqual(picking_pick.state, 'done')
         self.assertEqual(move_cust.state, 'assigned')
         self.assertEqual(picking_client.state, 'assigned', 'The picking should not assign what it does not have')
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, stock_location), 0.0)
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 5.0)
-        self.assertEqual(sum(self.env['stock.quant']._gather(self.productA, stock_location).mapped('quantity')), 0.0)
-        self.assertEqual(len(self.env['stock.quant']._gather(self.productA, pack_location)), 1.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.stock_location), 0.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location), 5.0)
+        self.assertEqual(sum(self.env['stock.quant']._gather(self.productA, self.stock_location).mapped('quantity')), 0.0)
+        self.assertEqual(len(self.env['stock.quant']._gather(self.productA, self.pack_location)), 1.0)
 
     def test_mto_moves_return(self):
         picking_pick, picking_client = self.create_pick_ship()
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 10.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 10.0)
 
         picking_pick.action_assign()
         picking_pick.move_ids[0].move_line_ids[0].quantity = 10.0
@@ -310,9 +305,8 @@ class TestPickShip(TestStockCommon):
         initial move.
         """
         picking_pick, picking_client = self.create_pick_ship()
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        self.productA.write({'route_ids': [(4, self.env.ref('stock.route_warehouse0_mto').id)]})
-        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 10.0)
+        self.productA.route_ids = [Command.link(self.route_mto.id)]
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 10.0)
         picking_pick.action_assign()
         picking_pick.move_ids[0].move_line_ids[0].quantity = 15.0
         picking_pick.move_ids[0].picked = True
@@ -331,8 +325,7 @@ class TestPickShip(TestStockCommon):
 
     def test_mto_moves_return_extra(self):
         picking_pick, picking_client = self.create_pick_ship()
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 10.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 10.0)
 
         picking_pick.action_assign()
         picking_pick.move_ids[0].move_line_ids[0].quantity = 10.0
@@ -363,21 +356,18 @@ class TestPickShip(TestStockCommon):
         activity).
         """
         picking_pick, picking_pack, picking_ship = self.create_pick_pack_ship()
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        warehouse_1 = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
-        warehouse_1.write({'delivery_steps': 'pick_pack_ship'})
+        warehouse_1 = self.warehouse_1
+        warehouse_1.delivery_steps = 'pick_pack_ship'
         warehouse_2 = self.env['stock.warehouse'].create({
             'name': 'Small Warehouse',
             'code': 'SWH'
         })
-        warehouse_1.write({
-            'resupply_wh_ids': [(6, 0, [warehouse_2.id])]
-        })
+        warehouse_1.resupply_wh_ids = [Command.set([warehouse_2.id])]
         resupply_route = self.env['stock.route'].search([('supplier_wh_id', '=', warehouse_2.id), ('supplied_wh_id', '=', warehouse_1.id)])
         self.assertTrue(resupply_route)
-        self.productA.write({'route_ids': [(4, resupply_route.id), (4, self.env.ref('stock.route_warehouse0_mto').id)]})
+        self.productA.route_ids = [Command.set([resupply_route.id, self.route_mto.id])]
 
-        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 10.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 10.0)
 
         picking_pick.action_assign()
         picking_pick.move_ids[0].move_line_ids[0].quantity = 10.0
@@ -390,7 +380,7 @@ class TestPickShip(TestStockCommon):
         picking_pack._action_done()
 
         picking_ship.action_cancel()
-        picking_ship.move_ids.write({'procure_method': 'make_to_order'})
+        picking_ship.move_ids.procure_method = 'make_to_order'
 
         self.env['procurement.group'].run_scheduler()
         next_activity = self.env['mail.activity'].search([('res_model', '=', 'product.template'), ('res_id', '=', self.productA.product_tmpl_id.id)])
@@ -407,10 +397,9 @@ class TestPickShip(TestStockCommon):
         ask the user will have to consider again if he wants to create a backorder or not.
         """
         picking_pick, picking_client = self.create_pick_ship()
-        location = self.env['stock.location'].browse(self.stock_location)
 
         # make some stock
-        self.env['stock.quant']._update_available_quantity(self.productA, location, 10.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 10.0)
         picking_pick.action_assign()
         picking_pick.move_ids[0].move_line_ids[0].quantity = 5.0
         picking_pick.move_ids[0].picked = True
@@ -432,10 +421,9 @@ class TestPickShip(TestStockCommon):
         Editing the move line of the first move should impact the reservation of the second one.
         """
         picking_pick, picking_client = self.create_pick_ship()
-        location = self.env['stock.location'].browse(self.stock_location)
 
         # make some stock
-        self.env['stock.quant']._update_available_quantity(self.productA, location, 10.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 10.0)
         picking_pick.action_assign()
         picking_pick.move_ids[0].move_line_ids[0].quantity = 10.0
         picking_pick.move_ids[0].picked = True
@@ -471,10 +459,9 @@ class TestPickShip(TestStockCommon):
             'product_id': self.productA.id,
         })
         picking_pick, picking_client = self.create_pick_ship()
-        location = self.env['stock.location'].browse(self.stock_location)
 
         # make some stock
-        self.env['stock.quant']._update_available_quantity(self.productA, location, 10.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 10.0)
         picking_pick.action_assign()
         picking_pick.move_ids[0].move_line_ids[0].write({
             'quantity': 10.0,
@@ -506,9 +493,9 @@ class TestPickShip(TestStockCommon):
         Check that reserved quantity and flow work correctly.
         """
         picking_client = self.env['stock.picking'].create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         dest = self.MoveObj.create({
@@ -517,15 +504,15 @@ class TestPickShip(TestStockCommon):
             'product_uom_qty': 5,
             'product_uom': self.uom_kg.id,
             'picking_id': picking_client.id,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
             'state': 'waiting',
         })
 
         picking_pick = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.pack_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.pack_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
 
@@ -535,25 +522,23 @@ class TestPickShip(TestStockCommon):
             'product_uom_qty': 5,
             'product_uom': self.uom_kg.id,
             'picking_id': picking_pick.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.pack_location,
-            'move_dest_ids': [(4, dest.id)],
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.pack_location.id,
+            'move_dest_ids': [Command.link(dest.id)],
             'state': 'confirmed',
         })
-        location = self.env['stock.location'].browse(self.stock_location)
-        pack_location = self.env['stock.location'].browse(self.pack_location)
 
         # make some stock
-        self.env['stock.quant']._update_available_quantity(self.gB, location, 10000.0)
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.gB, pack_location), 0.0)
+        self.env['stock.quant']._update_available_quantity(self.gB, self.stock_location, 10000.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.gB, self.pack_location), 0.0)
         picking_pick.action_assign()
         picking_pick.move_ids[0].move_line_ids[0].quantity = 5.0
         picking_pick.move_ids[0].picked = True
         picking_pick._action_done()
 
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.gB, location), 5000.0)
-        self.assertEqual(self.env['stock.quant']._gather(self.gB, pack_location).quantity, 5000.0)
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.gB, pack_location), 0.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.gB, self.stock_location), 5000.0)
+        self.assertEqual(self.env['stock.quant']._gather(self.gB, self.pack_location).quantity, 5000.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.gB, self.pack_location), 0.0)
         self.assertEqual(picking_client.state, 'assigned')
         self.assertEqual(picking_client.move_ids.quantity, 5.0)
 
@@ -565,15 +550,12 @@ class TestPickShip(TestStockCommon):
         """
         picking_pick, picking_ship = self.create_pick_ship()
         picking_ship.picking_type_id.return_picking_type_id = False
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        pack_location = self.env['stock.location'].browse(self.pack_location)
-        customer_location = self.env['stock.location'].browse(self.customer_location)
         self.productA.tracking = 'lot'
         lot = self.env['stock.lot'].create({
             'product_id': self.productA.id,
             'name': '123456789',
         })
-        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 10.0, lot_id=lot)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 10.0, lot_id=lot)
 
         picking_pick.action_assign()
         picking_pick.move_ids.picked = True
@@ -585,7 +567,7 @@ class TestPickShip(TestStockCommon):
         picking_ship.move_ids.picked = True
         picking_ship._action_done()
 
-        customer_quantity = self.env['stock.quant']._get_available_quantity(self.productA, customer_location, lot_id=lot)
+        customer_quantity = self.env['stock.quant']._get_available_quantity(self.productA, self.customer_location, lot_id=lot)
         self.assertEqual(customer_quantity, 10, 'It should be one product in customer')
 
         # First we create the return picking for pick picking.
@@ -630,10 +612,10 @@ class TestPickShip(TestStockCommon):
         self.assertEqual(return_ship_picking.state, 'done')
         self.assertEqual(return_pick_picking.state, 'assigned')
 
-        customer_quantity = self.env['stock.quant']._get_available_quantity(self.productA, customer_location, lot_id=lot)
+        customer_quantity = self.env['stock.quant']._get_available_quantity(self.productA, self.customer_location, lot_id=lot)
         self.assertEqual(customer_quantity, 0, 'It should be one product in customer')
 
-        pack_quantity = self.env['stock.quant']._get_available_quantity(self.productA, pack_location, lot_id=lot)
+        pack_quantity = self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location, lot_id=lot)
         self.assertEqual(pack_quantity, 0, 'It should be one product in pack location but is reserved')
 
         # Should use previous move lot.
@@ -642,7 +624,7 @@ class TestPickShip(TestStockCommon):
         return_pick_picking._action_done()
         self.assertEqual(return_pick_picking.state, 'done')
 
-        stock_quantity = self.env['stock.quant']._get_available_quantity(self.productA, stock_location, lot_id=lot)
+        stock_quantity = self.env['stock.quant']._get_available_quantity(self.productA, self.stock_location, lot_id=lot)
         self.assertEqual(stock_quantity, 10, 'The product is not back in stock')
 
     def test_pick_pack_ship_return(self):
@@ -652,13 +634,12 @@ class TestPickShip(TestStockCommon):
         if all the link orgini/destination between moves are correct.
         """
         picking_pick, picking_pack, picking_ship = self.create_pick_pack_ship()
-        stock_location = self.env['stock.location'].browse(self.stock_location)
         self.productA.tracking = 'serial'
         lot = self.env['stock.lot'].create({
             'product_id': self.productA.id,
             'name': '123456789',
         })
-        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 1.0, lot_id=lot)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 1.0, lot_id=lot)
 
         picking_pick.action_assign()
         picking_pick.move_ids[0].move_line_ids[0].quantity = 1.0
@@ -690,7 +671,7 @@ class TestPickShip(TestStockCommon):
         return_ship_picking.move_ids[0].picked = True
         return_ship_picking._action_done()
 
-        stock_quant = self.env['stock.quant']._gather(self.productA, stock_location, lot_id=lot)
+        stock_quant = self.env['stock.quant']._gather(self.productA, self.stock_location, lot_id=lot)
         self.assertEqual(stock_quant.quantity, 1)
 
         # Now that everything is returned we will check if the return moves are correctly linked between them.
@@ -729,8 +710,8 @@ class TestPickShip(TestStockCommon):
             'product_uom_qty': 3,
             'product_uom': self.productA.uom_id.id,
             'picking_id': picking_client.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
             'origin': 'MPS',
             'procure_method': 'make_to_stock',
         })
@@ -745,10 +726,9 @@ class TestPickShip(TestStockCommon):
         order to check again if the picking and state are updated.
         """
         picking_pick, picking_client = self.create_pick_ship()
-        location = self.env['stock.location'].browse(self.stock_location)
 
         # make some stock
-        self.env['stock.quant']._update_available_quantity(self.productA, location, 10.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 10.0)
         picking_pick.move_ids.quantity = 5.0
         picking_pick.move_ids.picked = True
         backorder_wizard_values = picking_pick.button_validate()
@@ -784,8 +764,7 @@ class TestPickShip(TestStockCommon):
         self.assertEqual(picking_pick.state, 'confirmed')
         picking_pick.do_unreserve()
         self.assertEqual(picking_pick.state, 'confirmed')
-        location = self.env['stock.location'].browse(self.stock_location)
-        self.env['stock.quant']._update_available_quantity(self.productA, location, 10.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 10.0)
         picking_pick.action_assign()
         self.assertEqual(picking_pick.state, 'assigned')
         picking_pick.do_unreserve()
@@ -798,17 +777,17 @@ class TestPickShip(TestStockCommon):
     def test_return_only_one_product(self):
         """ test returning only one product in a picking then return the leftovers"""
         picking_client = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
             'move_ids': [Command.create({
                 'name': p.name,
                 'product_id': p.id,
                 'product_uom_qty': 10 + i,
                 'product_uom': p.uom_id.id,
-                'location_id': self.stock_location,
-                'location_dest_id': self.customer_location,
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.customer_location.id,
                 'state': 'waiting',
                 'procure_method': 'make_to_order',
             }) for i, p in enumerate((self.productA, self.productB, self.productC))]
@@ -843,8 +822,6 @@ class TestPickShip(TestStockCommon):
         """ In a pick ship scenario, send two items to the customer, then return one in the ship
         location and one in a return location that is located in another warehouse.
         """
-        pick_location = self.env['stock.location'].browse(self.stock_location)
-
         return_warehouse = self.env['stock.warehouse'].create({'name': 'return warehouse', 'code': 'rw'})
         return_location = self.env['stock.location'].create({
             'name': 'return internal',
@@ -852,7 +829,7 @@ class TestPickShip(TestStockCommon):
             'location_id': return_warehouse.view_location_id.id
         })
 
-        self.env['stock.quant']._update_available_quantity(self.productA, pick_location, 10.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 10.0)
         picking_pick, picking_client = self.create_pick_ship()
 
         # send the items to the customer
@@ -891,7 +868,7 @@ class TestPickShip(TestStockCommon):
         return_to_return_picking.move_ids[0].picked = True
         return_to_return_picking._action_done()
 
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pick_location), 5.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.stock_location), 5.0)
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, return_location), 5.0)
         self.assertEqual(len(self.env['stock.quant'].search([('product_id', '=', self.productA.id), ('quantity', '!=', 0)])), 2)
 
@@ -912,11 +889,10 @@ class TestPickShip(TestStockCommon):
             'name': 'lot3',
             'product_id': self.productA.id,
         })
-        stock_location = self.env['stock.location'].browse(self.stock_location)
 
-        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 7.0, lot_id=lot1)
-        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 7.0, lot_id=lot2)
-        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 7.0, lot_id=lot3)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 7.0, lot_id=lot1)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 7.0, lot_id=lot2)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 7.0, lot_id=lot3)
 
         picking_pick, picking_client = self.create_pick_ship()
         picking_pick.action_confirm()
@@ -963,9 +939,9 @@ class TestSinglePicking(TestStockCommon):
         """ Check the good behavior of creating a backorder for an available stock move.
         """
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         self.MoveObj.create({
@@ -974,40 +950,39 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 2,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
         })
 
         # make some stock
-        pack_location = self.env['stock.location'].browse(self.pack_location)
-        self.env['stock.quant']._update_available_quantity(self.productA, pack_location, 2)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.pack_location, 2)
 
         # assign
         delivery_order.action_confirm()
         delivery_order.action_assign()
         self.assertEqual(delivery_order.state, 'assigned')
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 0.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location), 0.0)
 
         # valid with backorder creation
         delivery_order.move_ids[0].move_line_ids[0].quantity = 1
         delivery_order.move_ids[0].picked = True
         delivery_order._action_done()
         self.assertNotEqual(delivery_order.date_done, False)
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 1.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location), 1.0)
 
         backorder = self.env['stock.picking'].search([('backorder_id', '=', delivery_order.id)])
         self.assertEqual(backorder.state, 'confirmed')
         backorder.action_assign()
         self.assertEqual(backorder.state, 'assigned')
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 0.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location), 0.0)
 
     def test_backorder_2(self):
         """ Check the good behavior of creating a backorder for a partially available stock move.
         """
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         self.MoveObj.create({
@@ -1016,26 +991,25 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 2,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
         })
 
         # make some stock
-        pack_location = self.env['stock.location'].browse(self.pack_location)
-        self.env['stock.quant']._update_available_quantity(self.productA, pack_location, 1)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.pack_location, 1)
 
         # assign to partially available
         delivery_order.action_confirm()
         delivery_order.action_assign()
         self.assertEqual(delivery_order.state, 'assigned')
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 0.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location), 0.0)
 
         # valid with backorder creation
         delivery_order.move_ids[0].move_line_ids[0].quantity = 1
         delivery_order.move_ids[0].picked = True
         delivery_order._action_done()
         self.assertNotEqual(delivery_order.date_done, False)
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 0.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location), 0.0)
 
         backorder = self.env['stock.picking'].search([('backorder_id', '=', delivery_order.id)])
         self.assertEqual(backorder.state, 'confirmed')
@@ -1045,9 +1019,9 @@ class TestSinglePicking(TestStockCommon):
         two available moves.
         """
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         self.MoveObj.create({
@@ -1056,8 +1030,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 2,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         self.MoveObj.create({
             'name': self.productA.name,
@@ -1065,14 +1039,13 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 2,
             'product_uom': self.productB.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
         })
 
         # make some stock
-        pack_location = self.env['stock.location'].browse(self.pack_location)
-        self.env['stock.quant']._update_available_quantity(self.productA, pack_location, 2)
-        self.env['stock.quant']._update_available_quantity(self.productA, pack_location, 2)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.pack_location, 2)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.pack_location, 2)
 
         # assign to partially available
         delivery_order.action_confirm()
@@ -1091,9 +1064,9 @@ class TestSinglePicking(TestStockCommon):
         for a picking with a missing product.
         """
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         self.MoveObj.create({
@@ -1102,8 +1075,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 2,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         self.MoveObj.create({
             'name': self.productA.name,
@@ -1111,14 +1084,13 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 2,
             'product_uom': self.productB.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
         })
 
         # Update available quantities for each products
-        pack_location = self.env['stock.location'].browse(self.pack_location)
-        self.env['stock.quant']._update_available_quantity(self.productA, pack_location, 2)
-        self.env['stock.quant']._update_available_quantity(self.productB, pack_location, 2)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.pack_location, 2)
+        self.env['stock.quant']._update_available_quantity(self.productB, self.pack_location, 2)
 
         delivery_order.action_confirm()
         delivery_order.action_assign()
@@ -1141,9 +1113,9 @@ class TestSinglePicking(TestStockCommon):
     def test_assign_deadline(self):
         """ Check if similar items with shorter deadline are prioritized. """
         delivery_order = self.PickingObj.create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         # Avoid to merge move3 and move4 for the test case
@@ -1157,8 +1129,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 4,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
             'date_deadline': datetime.now() + relativedelta(days=1)
         })
         move2 = self.MoveObj.create({
@@ -1167,8 +1139,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 4,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
             'date_deadline': datetime.now() + relativedelta(days=2)
         })
         move3 = self.MoveObj.create({
@@ -1177,8 +1149,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 1,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
             'date': datetime.now() + relativedelta(days=10)
         })
         move4 = self.MoveObj.create({
@@ -1187,14 +1159,13 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 1,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
             'date': datetime.now() + relativedelta(days=0)
         })
 
         # make some stock
-        pack_location = self.env['stock.location'].browse(self.pack_location)
-        self.StockQuantObj._update_available_quantity(self.productA, pack_location, 2)
+        self.StockQuantObj._update_available_quantity(self.productA, self.pack_location, 2)
 
         # assign to partially available
         delivery_order.action_confirm()
@@ -1204,19 +1175,19 @@ class TestSinglePicking(TestStockCommon):
         self.assertEqual(move2.quantity, 0, "Later deadline should not have reserved quantity")
 
         # add new stock
-        self.StockQuantObj._update_available_quantity(self.productA, pack_location, 2)
+        self.StockQuantObj._update_available_quantity(self.productA, self.pack_location, 2)
         delivery_order.action_assign()
         self.assertEqual(move1.quantity, 4, "Earlier deadline should have reserved quantity")
         self.assertEqual(move2.quantity, 0, "Later deadline should not have reserved quantity")
 
-        self.StockQuantObj._update_available_quantity(self.productA, pack_location, 1)
+        self.StockQuantObj._update_available_quantity(self.productA, self.pack_location, 1)
         delivery_order.action_assign()
         self.assertEqual(move1.quantity, 4, "Earlier deadline should have reserved quantity")
         self.assertEqual(move2.quantity, 1, "Move with deadline should take priority")
         self.assertEqual(move3.quantity, 0, "Move without deadline should not have reserved quantity")
         self.assertEqual(move4.quantity, 0, "Move without deadline should not have reserved quantity")
 
-        self.StockQuantObj._update_available_quantity(self.productA, pack_location, 4)
+        self.StockQuantObj._update_available_quantity(self.productA, self.pack_location, 4)
         delivery_order.action_assign()
         self.assertEqual(move1.quantity, 4, "Earlier deadline should have reserved quantity")
         self.assertEqual(move2.quantity, 4, "Move with deadline should take priority")
@@ -1229,9 +1200,9 @@ class TestSinglePicking(TestStockCommon):
         only 1 in stock.
         """
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         move1 = self.MoveObj.create({
@@ -1240,28 +1211,27 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 1,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
         })
 
         # make some stock
-        pack_location = self.env['stock.location'].browse(self.pack_location)
-        self.env['stock.quant']._update_available_quantity(self.productA, pack_location, 1)
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 1.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.pack_location, 1)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location), 1.0)
 
         # assign to available
         delivery_order.action_confirm()
         delivery_order.action_assign()
         self.assertEqual(delivery_order.state, 'assigned')
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 0.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location), 0.0)
 
         # valid with backorder creation
         delivery_order.move_ids[0].move_line_ids[0].quantity = 2
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 0.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location), 0.0)
         delivery_order.move_ids[0].picked = True
         delivery_order._action_done()
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 0.0)
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location, allow_negative=True), -1.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location), 0.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location, allow_negative=True), -1.0)
 
         self.assertEqual(move1.product_qty, 1.0)
         self.assertEqual(move1.quantity, 2.0)
@@ -1273,9 +1243,9 @@ class TestSinglePicking(TestStockCommon):
         only 1 in stock.
         """
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         move1 = self.MoveObj.create({
@@ -1284,28 +1254,27 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 1,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
         })
 
         # make some stock
-        pack_location = self.env['stock.location'].browse(self.pack_location)
-        self.env['stock.quant']._update_available_quantity(self.productA, pack_location, 1)
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 1.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.pack_location, 1)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location), 1.0)
 
         # assign to available
         delivery_order.action_confirm()
         delivery_order.action_assign()
         self.assertEqual(delivery_order.state, 'assigned')
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 0.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location), 0.0)
 
         # valid with backorder creation
         delivery_order.move_ids[0].move_line_ids[0].quantity = 3
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 0.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location), 0.0)
         delivery_order.move_ids[0].picked = True
         delivery_order._action_done()
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 0.0)
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location, allow_negative=True), -2.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location), 0.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location, allow_negative=True), -2.0)
 
         self.assertEqual(move1.product_qty, 1.0)
         self.assertEqual(move1.quantity, 3.0)
@@ -1316,9 +1285,9 @@ class TestSinglePicking(TestStockCommon):
          the receipt of 2 item while the initial stock move had to move 1.
         """
         receipt = self.env['stock.picking'].create({
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
-            'picking_type_id': self.picking_type_in,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.picking_type_in.id,
             'state': 'draft',
         })
         move1 = self.MoveObj.create({
@@ -1327,10 +1296,9 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 1,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
         })
-        stock_location = self.env['stock.location'].browse(self.stock_location)
 
         # assign to available
         receipt.action_confirm()
@@ -1341,7 +1309,7 @@ class TestSinglePicking(TestStockCommon):
         receipt.move_ids[0].move_line_ids[0].quantity = 2
         receipt.move_ids[0].picked = True
         receipt._action_done()
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, stock_location), 2.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.stock_location), 2.0)
 
         self.assertEqual(move1.product_qty, 1.0)
         self.assertEqual(move1.quantity, 2.0)
@@ -1353,9 +1321,9 @@ class TestSinglePicking(TestStockCommon):
         quantity and only merge extra moves in their original moves.
         """
         delivery = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         self.MoveObj.create({
@@ -1365,16 +1333,15 @@ class TestSinglePicking(TestStockCommon):
             'quantity': 10,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 5)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 5)
         delivery.action_confirm()
         delivery.action_assign()
 
         delivery.write({
-            'move_ids': [(0, 0, {
+            'move_ids': [Command.create({
                 'name': self.productA.name,
                 'product_id': self.productA.id,
                 'product_uom_qty': 0,
@@ -1382,8 +1349,8 @@ class TestSinglePicking(TestStockCommon):
                 'state': 'assigned',
                 'product_uom': self.productA.uom_id.id,
                 'picking_id': delivery.id,
-                'location_id': self.stock_location,
-                'location_dest_id': self.customer_location,
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.customer_location.id,
             })]
         })
         delivery.move_ids.picked = True
@@ -1398,11 +1365,11 @@ class TestSinglePicking(TestStockCommon):
         product with one move line. After adding a second unit in stock and recheck availability.
         The DO should have 2 reserved unit, be in available state and have only one move line.
         """
-        self.env['stock.quant']._update_available_quantity(self.productA, self.env['stock.location'].browse(self.stock_location), 1.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 1.0)
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         move1 = self.MoveObj.create({
@@ -1411,8 +1378,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 2,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         delivery_order.action_confirm()
         delivery_order.action_assign()
@@ -1425,7 +1392,7 @@ class TestSinglePicking(TestStockCommon):
         self.assertEqual(len(move1.move_line_ids), 1)
 
         inventory_quant = self.env['stock.quant'].create({
-            'location_id': self.stock_location,
+            'location_id': self.stock_location.id,
             'product_id': self.productA.id,
             'inventory_quantity': 2
         })
@@ -1449,12 +1416,11 @@ class TestSinglePicking(TestStockCommon):
             'name': 'lot1',
             'product_id': self.productA.id,
         })
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 1.0, lot_id=lot1)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 1.0, lot_id=lot1)
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         move1 = self.MoveObj.create({
@@ -1463,8 +1429,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 2,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         delivery_order.action_confirm()
         delivery_order.action_assign()
@@ -1477,7 +1443,7 @@ class TestSinglePicking(TestStockCommon):
         self.assertEqual(len(move1.move_line_ids), 1)
 
         inventory_quant = self.env['stock.quant'].create({
-            'location_id': self.stock_location,
+            'location_id': self.stock_location.id,
             'product_id': self.productA.id,
             'inventory_quantity': 2,
             'lot_id': lot1.id
@@ -1505,12 +1471,11 @@ class TestSinglePicking(TestStockCommon):
             'name': 'lot2',
             'product_id': self.productA.id,
         })
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 1.0, lot_id=lot1)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 1.0, lot_id=lot1)
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         move1 = self.MoveObj.create({
@@ -1519,8 +1484,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 2,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         delivery_order.action_confirm()
         delivery_order.action_assign()
@@ -1533,7 +1498,7 @@ class TestSinglePicking(TestStockCommon):
         self.assertEqual(len(move1.move_line_ids), 1)
 
         inventory_quant = self.env['stock.quant'].create({
-            'location_id': self.stock_location,
+            'location_id': self.stock_location.id,
             'product_id': self.productA.id,
             'inventory_quantity': 1,
             'lot_id': lot2.id
@@ -1563,12 +1528,11 @@ class TestSinglePicking(TestStockCommon):
             'name': 'serial2',
             'product_id': self.productA.id,
         })
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 1.0, lot_id=serial1)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 1.0, lot_id=serial1)
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         move1 = self.MoveObj.create({
@@ -1577,8 +1541,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 2,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         delivery_order.action_confirm()
         delivery_order.action_assign()
@@ -1591,7 +1555,7 @@ class TestSinglePicking(TestStockCommon):
         self.assertEqual(len(move1.move_line_ids), 1)
 
         inventory_quant = self.env['stock.quant'].create({
-            'location_id': self.stock_location,
+            'location_id': self.stock_location.id,
             'product_id': self.productA.id,
             'inventory_quantity': 1,
             'lot_id': serial2.id
@@ -1612,18 +1576,16 @@ class TestSinglePicking(TestStockCommon):
         """ Check the behavior of a picking when `use_create_lot` and `use_existing_lot` are
         set to False and there's a move for a tracked product.
         """
-        self.env['stock.picking.type']\
-            .browse(self.picking_type_out)\
-            .write({
-                'use_create_lots': False,
-                'use_existing_lots': False,
-            })
+        self.picking_type_out.write({
+            'use_create_lots': False,
+            'use_existing_lots': False,
+        })
         self.productA.tracking = 'lot'
 
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         self.MoveObj.create({
@@ -1632,9 +1594,9 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 2,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'picking_type_id': self.picking_type_out,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'picking_type_id': self.picking_type_out.id,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
         })
 
         delivery_order.action_confirm()
@@ -1647,18 +1609,16 @@ class TestSinglePicking(TestStockCommon):
         """ Check the behavior of a picking when `use_create_lot` and `use_existing_lot` are
         set to True and there's a move for a tracked product.
         """
-        self.env['stock.picking.type']\
-            .browse(self.picking_type_out)\
-            .write({
-                'use_create_lots': True,
-                'use_existing_lots': True,
-            })
+        self.picking_type_out.write({
+            'use_create_lots': True,
+            'use_existing_lots': True,
+        })
         self.productA.tracking = 'lot'
 
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         self.MoveObj.create({
@@ -1667,9 +1627,9 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 2,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'picking_type_id': self.picking_type_out,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'picking_type_id': self.picking_type_out.id,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
         })
 
         delivery_order.action_confirm()
@@ -1689,18 +1649,16 @@ class TestSinglePicking(TestStockCommon):
         """ Check the behavior of a picking when `use_create_lot` is set to True and
         `use_existing_lot` is set to False and there's a move for a tracked product.
         """
-        self.env['stock.picking.type']\
-            .browse(self.picking_type_out)\
-            .write({
-                'use_create_lots': True,
-                'use_existing_lots': False,
-            })
+        self.picking_type_out.write({
+            'use_create_lots': True,
+            'use_existing_lots': False,
+        })
         self.productA.tracking = 'lot'
 
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         self.MoveObj.create({
@@ -1709,9 +1667,9 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 2,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'picking_type_id': self.picking_type_out,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'picking_type_id': self.picking_type_out.id,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
         })
 
         delivery_order.action_confirm()
@@ -1731,18 +1689,16 @@ class TestSinglePicking(TestStockCommon):
         """ Check the behavior of a picking when `use_create_lot` is set to False and
         `use_existing_lot` is set to True and there's a move for a tracked product.
         """
-        self.env['stock.picking.type']\
-            .browse(self.picking_type_out)\
-            .write({
-                'use_create_lots': False,
-                'use_existing_lots': True,
-            })
+        self.picking_type_out.write({
+            'use_create_lots': False,
+            'use_existing_lots': True,
+        })
         self.productA.tracking = 'lot'
 
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         self.MoveObj.create({
@@ -1751,9 +1707,9 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 2,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'picking_type_id': self.picking_type_out,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'picking_type_id': self.picking_type_out.id,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
         })
 
         delivery_order.action_confirm()
@@ -1785,18 +1741,16 @@ class TestSinglePicking(TestStockCommon):
     def test_use_create_lot_use_existing_lot_5(self):
         """Check if a quant without lot exist, it will be decrease even if a
         quant with the right lot exists but is empty"""
-        self.env['stock.picking.type']\
-            .browse(self.picking_type_in)\
-            .write({
-                'use_create_lots': False,
-                'use_existing_lots': False,
-            })
+        self.picking_type_in.write({
+            'use_create_lots': False,
+            'use_existing_lots': False,
+        })
         self.productA.tracking = 'lot'
 
         receipt = self.env['stock.picking'].create({
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
-            'picking_type_id': self.picking_type_in,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.picking_type_in.id,
         })
         self.MoveObj.create({
             'name': self.productA.name,
@@ -1804,9 +1758,9 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 2,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt.id,
-            'picking_type_id': self.picking_type_in,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'picking_type_id': self.picking_type_in.id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
         })
 
         receipt.action_confirm()
@@ -1816,7 +1770,7 @@ class TestSinglePicking(TestStockCommon):
         receipt._action_done()
         quant = self.env['stock.quant'].search([
             ('product_id', '=', self.productA.id),
-            ('location_id', '=', self.stock_location),
+            ('location_id', '=', self.stock_location.id),
             ('lot_id', '=', False),
         ])
         self.assertTrue(quant, 'A quant without lot should exist')
@@ -1828,7 +1782,7 @@ class TestSinglePicking(TestStockCommon):
         })
         new_quant = self.env['stock.quant'].create({
             'product_id': self.productA.id,
-            'location_id': self.stock_location,
+            'location_id': self.stock_location.id,
             'lot_id': lot.id,
         })
         out_move = self.MoveObj.create({
@@ -1836,9 +1790,9 @@ class TestSinglePicking(TestStockCommon):
             'product_id': self.productA.id,
             'product_uom_qty': 1,
             'product_uom': self.productA.uom_id.id,
-            'picking_type_id': self.picking_type_out,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'picking_type_id': self.picking_type_out.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         out_move._action_confirm()
         out_move._action_assign()
@@ -1851,9 +1805,9 @@ class TestSinglePicking(TestStockCommon):
 
     def test_merge_moves_1(self):
         receipt = self.env['stock.picking'].create({
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
-            'picking_type_id': self.picking_type_in,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.picking_type_in.id,
             'state': 'draft',
         })
         self.MoveObj.create({
@@ -1862,8 +1816,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 3,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
         })
         self.MoveObj.create({
             'name': self.productA.name,
@@ -1871,8 +1825,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 5,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
         })
         self.MoveObj.create({
             'name': self.productA.name,
@@ -1880,8 +1834,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 1,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
         })
         self.MoveObj.create({
             'name': self.productB.name,
@@ -1889,8 +1843,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 5,
             'product_uom': self.productB.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
         })
         receipt.action_confirm()
         self.assertEqual(len(receipt.move_ids), 2, 'Moves were not merged')
@@ -1899,9 +1853,9 @@ class TestSinglePicking(TestStockCommon):
 
     def test_merge_moves_2(self):
         receipt = self.env['stock.picking'].create({
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
-            'picking_type_id': self.picking_type_in,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.picking_type_in.id,
             'state': 'draft',
         })
         self.MoveObj.create({
@@ -1910,8 +1864,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 3,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'origin': 'MPS'
         })
         self.MoveObj.create({
@@ -1920,8 +1874,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 5,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'origin': 'PO0001'
         })
         self.MoveObj.create({
@@ -1930,8 +1884,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 3,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'origin': 'MPS'
         })
         receipt.action_confirm()
@@ -1945,9 +1899,9 @@ class TestSinglePicking(TestStockCommon):
         validation.
         """
         receipt = self.env['stock.picking'].create({
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
-            'picking_type_id': self.picking_type_in,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.picking_type_in.id,
             'state': 'draft',
         })
         move_1 = self.MoveObj.create({
@@ -1956,8 +1910,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 0,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'origin': 'MPS'
         })
         move_2 = self.MoveObj.create({
@@ -1966,8 +1920,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 0,
             'product_uom': self.productB.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'origin': 'PO0001'
         })
         move_1.quantity = 5
@@ -1993,12 +1947,12 @@ class TestSinglePicking(TestStockCommon):
         tmpl_attr_lines = self.env['product.template.attribute.line'].create({
             'attribute_id': product_attribute.id,
             'product_tmpl_id': self.productA.product_tmpl_id.id,
-            'value_ids': [(6, 0, product_attribute.value_ids.ids)],
+            'value_ids': [Command.set(product_attribute.value_ids.ids)],
         })
         receipt = self.env['stock.picking'].create({
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
-            'picking_type_id': self.picking_type_in,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.picking_type_in.id,
             'state': 'draft',
         })
         self.MoveObj.create({
@@ -2007,8 +1961,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 3,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'never_product_template_attribute_value_ids': tmpl_attr_lines.product_template_value_ids[0],
         })
         self.MoveObj.create({
@@ -2017,8 +1971,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 5,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'never_product_template_attribute_value_ids': tmpl_attr_lines.product_template_value_ids[1],
         })
         self.MoveObj.create({
@@ -2027,8 +1981,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 1,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'never_product_template_attribute_value_ids': tmpl_attr_lines.product_template_value_ids[1],
         })
         self.MoveObj.create({
@@ -2037,8 +1991,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 1,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
         })
         receipt.action_confirm()
         self.assertEqual(len(receipt.move_ids), 3, 'Moves were not merged')
@@ -2058,7 +2012,7 @@ class TestSinglePicking(TestStockCommon):
             'reception_steps': 'three_steps',
         })
         receipt1 = self.env['stock.picking'].create({
-            'location_id': self.supplier_location,
+            'location_id': self.supplier_location.id,
             'location_dest_id': warehouse.wh_input_stock_loc_id.id,
             'picking_type_id': warehouse.in_type_id.id,
             'state': 'draft',
@@ -2069,11 +2023,11 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 5,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt1.id,
-            'location_id': self.supplier_location,
+            'location_id': self.supplier_location.id,
             'location_dest_id': warehouse.wh_input_stock_loc_id.id,
         })
         receipt2 = self.env['stock.picking'].create({
-            'location_id': self.supplier_location,
+            'location_id': self.supplier_location.id,
             'location_dest_id': warehouse.wh_input_stock_loc_id.id,
             'picking_type_id': warehouse.in_type_id.id,
             'state': 'draft',
@@ -2084,7 +2038,7 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 3,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt2.id,
-            'location_id': self.supplier_location,
+            'location_id': self.supplier_location.id,
             'location_dest_id': warehouse.wh_input_stock_loc_id.id,
         })
         receipt1.action_confirm()
@@ -2123,7 +2077,7 @@ class TestSinglePicking(TestStockCommon):
             'reception_steps': 'three_steps',
         })
         receipt1 = self.env['stock.picking'].create({
-            'location_id': self.supplier_location,
+            'location_id': self.supplier_location.id,
             'location_dest_id': warehouse.wh_input_stock_loc_id.id,
             'picking_type_id': warehouse.in_type_id.id,
             'state': 'draft',
@@ -2134,7 +2088,7 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 5,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt1.id,
-            'location_id': self.supplier_location,
+            'location_id': self.supplier_location.id,
             'location_dest_id': warehouse.wh_input_stock_loc_id.id,
         })
         receipt2 = self.env['stock.picking'].create({
@@ -2186,9 +2140,9 @@ class TestSinglePicking(TestStockCommon):
         impossible and raise a usererror.
         """
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         self.MoveObj.create({
@@ -2197,8 +2151,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 0,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         self.MoveObj.create({
             'name': self.productB.name,
@@ -2206,8 +2160,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 0,
             'product_uom': self.productB.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         delivery_order.action_confirm()
         delivery_order.action_assign()
@@ -2221,9 +2175,9 @@ class TestSinglePicking(TestStockCommon):
         other.
         """
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         move_a = self.MoveObj.create({
@@ -2232,8 +2186,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 0,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         move_b = self.MoveObj.create({
             'name': self.productB.name,
@@ -2241,8 +2195,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 0,
             'product_uom': self.productB.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         delivery_order.action_confirm()
         delivery_order.action_assign()
@@ -2257,8 +2211,7 @@ class TestSinglePicking(TestStockCommon):
 
     def test_unlink_move_1(self):
         picking = Form(self.env['stock.picking'])
-        ptout = self.env['stock.picking.type'].browse(self.picking_type_out)
-        picking.picking_type_id = ptout
+        picking.picking_type_id = self.picking_type_out
         with picking.move_ids_without_package.new() as move:
             move.product_id = self.productA
             move.quantity = 10
@@ -2276,9 +2229,9 @@ class TestSinglePicking(TestStockCommon):
         """
         # Make some stock for productA and productB.
         receipt = self.env['stock.picking'].create({
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
-            'picking_type_id': self.picking_type_in,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.picking_type_in.id,
             'state': 'draft',
         })
         move_1 = self.MoveObj.create({
@@ -2287,8 +2240,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 10,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
         })
         move_2 = self.MoveObj.create({
             'name': self.productB.name,
@@ -2296,8 +2249,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 10,
             'product_uom': self.productB.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
         })
         receipt.action_confirm()
         move_1.quantity = 10
@@ -2309,9 +2262,9 @@ class TestSinglePicking(TestStockCommon):
 
         # Create a delivery for 1 productA, reserve, check the picking is ready
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'move_type': 'one',
             'state': 'draft',
         })
@@ -2321,8 +2274,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 10,
             'product_uom': self.productA.uom_id.id,
             'picking_id': delivery_order.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         delivery_order.action_confirm()
         delivery_order.action_assign()
@@ -2343,9 +2296,8 @@ class TestSinglePicking(TestStockCommon):
         self.assertEqual(delivery_order.state, 'assigned')
         self.assertEqual(delivery_order.show_check_availability, False)
 
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        self.assertEqual(self.env['stock.quant']._gather(self.productA, stock_location).reserved_quantity, 10.0)
-        self.assertEqual(self.env['stock.quant']._gather(self.productB, stock_location).reserved_quantity, 10.0)
+        self.assertEqual(self.env['stock.quant']._gather(self.productA, self.stock_location).reserved_quantity, 10.0)
+        self.assertEqual(self.env['stock.quant']._gather(self.productB, self.stock_location).reserved_quantity, 10.0)
 
     def test_additional_move_2(self):
         """ On an immediate trasfer, add a stock move when the picking is already ready. Check that
@@ -2353,15 +2305,15 @@ class TestSinglePicking(TestStockCommon):
         """
         # Create a delivery for 1 productA, check the picking is ready
         delivery_order = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
-            'move_ids_without_package': [(0, 0, {
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
+            'move_ids_without_package': [Command.create({
                 'name': self.productA.name,
                 'product_id': self.productA.id,
                 'product_uom': self.productA.uom_id.id,
-                'location_id': self.stock_location,
-                'location_dest_id': self.customer_location,
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.customer_location.id,
                 'quantity': 5,
             })],
         })
@@ -2382,9 +2334,9 @@ class TestSinglePicking(TestStockCommon):
         """Make a receipt, set an owner and validate"""
         owner1 = self.env['res.partner'].create({'name': 'owner'})
         receipt = self.env['stock.picking'].create({
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
-            'picking_type_id': self.picking_type_in,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.picking_type_in.id,
             'state': 'draft',
         })
         move1 = self.env['stock.move'].create({
@@ -2393,8 +2345,8 @@ class TestSinglePicking(TestStockCommon):
             'product_uom_qty': 1,
             'product_uom': self.productA.uom_id.id,
             'picking_id': receipt.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
         })
         receipt.action_confirm()
         receipt = Form(receipt)
@@ -2402,10 +2354,8 @@ class TestSinglePicking(TestStockCommon):
         receipt = receipt.save()
         receipt.button_validate()
 
-        supplier_location = self.env['stock.location'].browse(self.supplier_location)
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        supplier_quant = self.env['stock.quant']._gather(self.productA, supplier_location)
-        stock_quant = self.env['stock.quant']._gather(self.productA, stock_location)
+        supplier_quant = self.env['stock.quant']._gather(self.productA, self.supplier_location)
+        stock_quant = self.env['stock.quant']._gather(self.productA, self.stock_location)
 
         self.assertEqual(supplier_quant.owner_id, owner1)
         self.assertEqual(supplier_quant.quantity, -1)
@@ -2417,33 +2367,26 @@ class TestSinglePicking(TestStockCommon):
         to define the `location_dest_id`.
         """
         partner = self.env['res.partner'].create({'name': 'Partner'})
-        supplier_location = self.env['stock.location'].browse(self.supplier_location)
-        stock_location = self.env['stock.location'].create({
-            'name': 'test-stock',
-            'usage': 'internal',
-        })
         shelf_location = self.env['stock.location'].create({
             'name': 'shelf1',
             'usage': 'internal',
-            'location_id': stock_location.id,
+            'location_id': self.stock_location.id,
         })
 
         # We need to activate multi-locations to use putaway rules.
         grp_multi_loc = self.env.ref('stock.group_stock_multi_locations')
-        self.env.user.write({'group_ids': [(4, grp_multi_loc.id)]})
+        self.env.user.group_ids = [Command.link(grp_multi_loc.id)]
         putaway_product = self.env['stock.putaway.rule'].create({
             'product_id': self.productA.id,
-            'location_in_id': stock_location.id,
+            'location_in_id': self.stock_location.id,
             'location_out_id': shelf_location.id,
         })
         # Changes config of receipt type to allow to edit move lines directly.
-        picking_type = self.env['stock.picking.type'].browse(self.picking_type_in)
-
         receipt_form = Form(self.env['stock.picking'], view='stock.view_picking_form')
         receipt_form.partner_id = partner
-        receipt_form.picking_type_id = picking_type
+        receipt_form.picking_type_id = self.picking_type_in
         # <field name="location_id" invisible="picking_type_code' == 'incoming'"
-        receipt_form.location_dest_id = stock_location
+        receipt_form.location_dest_id = self.stock_location
         receipt = receipt_form.save()
 
         with receipt_form.move_ids_without_package.new() as move:
@@ -2453,24 +2396,24 @@ class TestSinglePicking(TestStockCommon):
         receipt = receipt_form.save()
         # Checks receipt has still its destination location and checks its move
         # line took the one from the putaway rule.
-        self.assertEqual(receipt.location_dest_id.id, stock_location.id)
+        self.assertEqual(receipt.location_dest_id.id, self.stock_location.id)
         self.assertEqual(receipt.move_line_ids.location_dest_id.id, shelf_location.id)
 
     def test_cancel_plan_transfer(self):
         """ Test canceling plan transfer """
         # Create picking with stock move.
         picking = self.env['stock.picking'].create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
-            'move_ids': [(0, 0, {
+            'move_ids': [Command.create({
                 'name': self.productA.name,
                 'product_id': self.productA.id,
                 'product_uom_qty': 10,
                 'product_uom': self.productA.uom_id.id,
-                'location_id': self.pack_location,
-                'location_dest_id': self.customer_location,
+                'location_id': self.pack_location.id,
+                'location_dest_id': self.customer_location.id,
             })]
         })
         # Confirm the outgoing picking, state should be changed.
@@ -2486,15 +2429,15 @@ class TestSinglePicking(TestStockCommon):
             Test picking cancelation with immediate transfer and done quantity"""
         # create picking with stock move line
         picking = self.env['stock.picking'].create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
-            'move_line_ids': [(0, 0, {
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
+            'move_line_ids': [Command.create({
                 'product_id': self.productA.id,
                 'quantity': 10,
                 'product_uom_id': self.productA.uom_id.id,
-                'location_id': self.pack_location,
-                'location_dest_id': self.customer_location,
+                'location_id': self.pack_location.id,
+                'location_dest_id': self.customer_location.id,
             })]
         })
 
@@ -2507,14 +2450,14 @@ class TestSinglePicking(TestStockCommon):
     def test_immediate_picking_with_lot(self):
         self.productA.tracking = 'serial'
         picking = self.env['stock.picking'].create({
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
-            'picking_type_id': self.picking_type_in,
-            'move_line_ids': [(0, 0, {
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.picking_type_in.id,
+            'move_line_ids': [Command.create({
                 'product_id': self.productA.id,
                 'product_uom_id': self.productA.uom_id.id,
-                'location_id': self.supplier_location,
-                'location_dest_id': self.stock_location,
+                'location_id': self.supplier_location.id,
+                'location_dest_id': self.stock_location.id,
                 'quantity': 1,
                 'lot_name': '12345',
             })]
@@ -2530,27 +2473,26 @@ class TestSinglePicking(TestStockCommon):
         are reserved by the scheduler
         """
         product = self.productA
-        picking_type_out = self.env['stock.picking.type'].browse(self.picking_type_out)
-        picking_type_out.reservation_method = 'at_confirm'
+        self.picking_type_out.reservation_method = 'at_confirm'
         picking = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'move_ids': [Command.create({
                 'name': product.name,
                 'product_id': product.id,
                 'product_uom_qty': 10,
                 'product_uom': product.uom_id.id,
-                'location_id': self.stock_location,
-                'location_dest_id': self.customer_location,
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.customer_location.id,
             })],
         })
         picking.action_confirm()
         self.assertFalse(picking.move_line_ids)
-        self.env['stock.quant']._update_available_quantity(product, self.env['stock.location'].browse(self.stock_location), 5)
+        self.env['stock.quant']._update_available_quantity(product, self.stock_location, 5)
         self.env['procurement.group'].run_scheduler()
         self.assertRecordValues(picking.move_line_ids, [{'state': 'partially_available', 'quantity': 5.0}])
-        self.env['stock.quant']._update_available_quantity(product, self.env['stock.location'].browse(self.stock_location), 10)
+        self.env['stock.quant']._update_available_quantity(product, self.stock_location, 10)
         self.env['procurement.group'].run_scheduler()
         self.assertRecordValues(picking.move_line_ids, [{'state': 'assigned', 'quantity': 10.0}])
 
@@ -2559,27 +2501,26 @@ class TestSinglePicking(TestStockCommon):
         Check that a move line created and auto assigned to a picked move will also be picked
         """
         product = self.productA
-        picking_type_out = self.env['stock.picking.type'].browse(self.picking_type_out)
-        picking_type_out.reservation_method = 'at_confirm'
+        self.picking_type_out.reservation_method = 'at_confirm'
         picking = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'move_ids': [Command.create({
                 'name': product.name,
                 'product_id': product.id,
                 'product_uom_qty': 10,
                 'product_uom': product.uom_id.id,
-                'location_id': self.stock_location,
-                'location_dest_id': self.customer_location,
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.customer_location.id,
             })],
         })
         picking.action_confirm()
         picking.move_ids.quantity = 5
         picking.move_ids.picked = True
         sml = self.env['stock.move.line'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
             'product_id': product.id,
             'picking_id': picking.id,
             'quantity': 1.0,
@@ -2613,7 +2554,7 @@ class TestSinglePicking(TestStockCommon):
             {
                 'name': f'Shell {lot_count - i}',
                 'usage': 'internal',
-                'location_id': self.stock_location,
+                'location_id': self.stock_location.id,
             }
             for i in range(lot_count)
         ])
@@ -2621,16 +2562,16 @@ class TestSinglePicking(TestStockCommon):
             self.env['stock.quant']._update_available_quantity(tracked_product, locations[i], 10.0, lot_id=lots[i])
         delivery = self.env['stock.picking'].create({
             'name': 'Lovely Delivery',
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'move_ids': [
                 Command.create({
                     'name': 'Lovely Move',
                     'product_id': tracked_product.id,
                     'product_uom_qty': 50,
-                    'location_id': self.stock_location,
-                    'location_dest_id': self.customer_location,
+                    'location_id': self.stock_location.id,
+                    'location_dest_id': self.customer_location.id,
                     'product_uom': tracked_product.uom_id.id,
                 })
             ]
@@ -2682,12 +2623,12 @@ class TestSinglePicking(TestStockCommon):
             {
                 'name': f'Super location',
                 'usage': 'internal',
-                'location_id': self.stock_location,
+                'location_id': self.stock_location.id,
             },
             {
                 'name': f'Super destination',
                 'usage': 'internal',
-                'location_id': self.stock_location,
+                'location_id': self.stock_location.id,
             }
         ])
         with Form(self.env['stock.picking'].with_context(restricted_picking_type_code='internal')) as picking_form:
@@ -2706,16 +2647,16 @@ class TestSinglePicking(TestStockCommon):
         Check that validating an already validated picking bypasses the call.
         """
         picking = self.env['stock.picking'].create({
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'move_ids': [
                 Command.create({
                     'name': 'Lovely Move',
                     'product_id': self.productA.id,
                     'product_uom_qty': 50,
-                    'location_id': self.stock_location,
-                    'location_dest_id': self.customer_location,
+                    'location_id': self.stock_location.id,
+                    'location_dest_id': self.customer_location.id,
                     'product_uom': self.productA.uom_id.id,
                 }),
             ],
@@ -2754,14 +2695,14 @@ class TestStockUOM(TestStockCommon):
         T_TEST = self.env['product.product'].create({
             'name': 'T_TEST',
             'is_storable': True,
-            'uom_ids': [(4, T_LBS.id)],
+            'uom_ids': [Command.link(T_LBS.id)],
             'tracking': 'lot',
         })
 
         picking_in = self.env['stock.picking'].create({
-            'picking_type_id': self.picking_type_in,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'picking_type_id': self.picking_type_in.id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'state': 'draft',
         })
         move = self.env['stock.move'].create({
@@ -2770,8 +2711,8 @@ class TestStockUOM(TestStockCommon):
             'product_uom_qty': 60,
             'product_uom': T_GT.id,
             'picking_id': picking_in.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
         })
         picking_in.action_confirm()
         picking_in.do_unreserve()
@@ -2784,8 +2725,8 @@ class TestStockUOM(TestStockCommon):
             'move_id': move.id,
             'product_id': T_TEST.id,
             'product_uom_id': T_LBS.id,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'quantity': 42760.00,
             'lot_id': lot.id,
         })
@@ -2817,23 +2758,22 @@ class TestStockUOM(TestStockCommon):
             'uom_id': self.uom_gm.id,
         })
 
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        self.env['stock.quant']._update_available_quantity(product_G, stock_location, 149.88)
+        self.env['stock.quant']._update_available_quantity(product_G, self.stock_location, 149.88)
         self.assertEqual(len(product_G.stock_quant_ids), 1, 'One quant should exist for the product.')
         quant = product_G.stock_quant_ids
 
         # transfer 1kg of product_G
         picking = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.env.ref('stock.picking_type_out').id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
 
         move = self.env['stock.move'].create({
             'name': 'test_reserve_product_G',
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
             'picking_id': picking.id,
             'product_id': product_G.id,
             'product_uom': self.uom_kg.id,
@@ -2862,15 +2802,12 @@ class TestRoutes(TestStockCommon):
             'name': 'product a',
             'is_storable': True,
         })
-        cls.uom_unit = cls.env.ref('uom.product_uom_unit')
         cls.partner = cls.env['res.partner'].create({'name': 'Partner'})
 
     def _enable_pick_ship(self):
-        self.wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
-
         # create and get back the pick ship route
-        self.wh.write({'delivery_steps': 'pick_ship'})
-        self.pick_ship_route = self.wh.route_ids.filtered(lambda r: '(pick + ship)' in r.name)
+        self.warehouse_1.delivery_steps = 'pick_ship'
+        self.pick_ship_route = self.warehouse_1.route_ids.filtered(lambda r: '(pick + ship)' in r.name)
 
     def test_replenish_pick_ship_1(self):
         """ Creates 2 warehouses and make a replenish using one warehouse
@@ -2878,25 +2815,22 @@ class TestRoutes(TestStockCommon):
         """
         self.product_uom_qty = 42
 
-        warehouse_1 = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        warehouse_1 = self.warehouse_1
         warehouse_2 = self.env['stock.warehouse'].create({
             'name': 'Small Warehouse',
             'code': 'SWH'
         })
-        warehouse_1.write({
-            'resupply_wh_ids': [(6, 0, [warehouse_2.id])]
-        })
+        warehouse_1.resupply_wh_ids = [Command.set([warehouse_2.id])]
         resupply_route = self.env['stock.route'].search([('supplier_wh_id', '=', warehouse_2.id), ('supplied_wh_id', '=', warehouse_1.id)])
         self.assertTrue(resupply_route, "Ressuply route not found")
-        self.product1.write({'route_ids': [(4, resupply_route.id), (4, self.env.ref('stock.route_warehouse0_mto').id)]})
-        self.wh = warehouse_1
+        self.product1.route_ids = [Command.set([resupply_route.id, self.route_mto.id])]
 
         replenish_wizard = self.env['product.replenish'].with_context(default_product_tmpl_id=self.product1.product_tmpl_id.id).create({
             'product_id': self.product1.id,
             'product_tmpl_id': self.product1.product_tmpl_id.id,
             'product_uom_id': self.uom_unit.id,
             'quantity': self.product_uom_qty,
-            'warehouse_id': self.wh.id,
+            'warehouse_id': self.warehouse_1.id,
         })
 
         genrated_picking = replenish_wizard.launch_replenishment()
@@ -2963,20 +2897,20 @@ class TestRoutes(TestStockCommon):
         # Create sublocation of Customer
         subloc = self.env['stock.location'].create({
             'name': 'Fancy Spot',
-            'location_id': self.env.ref('stock.stock_location_customers').id,
+            'location_id': self.customer_location.id,
             'usage': 'internal',
         })
 
         pick_move = self.env['stock.move'].create({
             'name': 'pick',
-            'picking_type_id': self.wh.pick_type_id.id,
-            'location_id': self.wh.lot_stock_id.id,
+            'picking_type_id': self.warehouse_1.pick_type_id.id,
+            'location_id': self.warehouse_1.lot_stock_id.id,
             'product_id': self.product1.id,
             'product_uom_qty': 1,
             'location_final_id': subloc.id,
         })
         pick_move._action_confirm()
-        self.assertEqual(pick_move.location_dest_id, self.wh.wh_output_stock_loc_id)
+        self.assertEqual(pick_move.location_dest_id, self.warehouse_1.wh_output_stock_loc_id)
 
         # Validate the picking
         pick_move.write({'quantity': 1, 'picked': True})
@@ -2990,34 +2924,33 @@ class TestRoutes(TestStockCommon):
         """ Create a route with a push rule, force it on a move, check that it is applied.
         """
         self._enable_pick_ship()
-        stock_location = self.env.ref('stock.stock_location_stock')
 
         push_location = self.env['stock.location'].create({
-            'location_id': stock_location.location_id.id,
+            'location_id': self.stock_location.location_id.id,
             'name': 'push location',
         })
 
         # TODO: maybe add a new type on the "applicable on" fields?
         route = self.env['stock.route'].create({
             'name': 'new route',
-            'rule_ids': [(0, False, {
+            'rule_ids': [Command.create({
                 'name': 'create a move to push location',
-                'location_src_id': stock_location.id,
+                'location_src_id': self.stock_location.id,
                 'location_dest_id': push_location.id,
                 'company_id': self.env.company.id,
                 'action': 'push',
                 'auto': 'manual',
-                'picking_type_id': self.env.ref('stock.picking_type_in').id,
+                'picking_type_id': self.picking_type_in.id,
             })],
         })
         move1 = self.env['stock.move'].create({
             'name': 'move with a route',
-            'location_id': stock_location.id,
-            'location_dest_id': stock_location.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.stock_location.id,
             'product_id': self.product1.id,
             'product_uom': self.uom_unit.id,
             'product_uom_qty': 1.0,
-            'route_ids': [(4, route.id)]
+            'route_ids': [Command.link(route.id)],
         })
         move1._action_confirm()
         # Need to complete the move to trigger the push rules
@@ -3032,7 +2965,6 @@ class TestRoutes(TestStockCommon):
         with auto field set to transparent is done correctly. The stock_move
         is create with the move line directly to pass into action_confirm() via
         action_done(). """
-        self.wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
         new_loc = self.env['stock.location'].create({
             'name': 'New_location',
             'usage': 'internal',
@@ -3042,15 +2974,15 @@ class TestRoutes(TestStockCommon):
             'name': 'new_picking_type',
             'code': 'internal',
             'sequence_code': 'NPT',
-            'default_location_src_id': self.env.ref('stock.stock_location_stock').id,
+            'default_location_src_id': self.stock_location.id,
             'default_location_dest_id': new_loc.id,
-            'warehouse_id': self.wh.id,
+            'warehouse_id': self.warehouse_1.id,
         })
         route = self.env['stock.route'].create({
             'name': 'new route',
-            'rule_ids': [(0, False, {
+            'rule_ids': [Command.create({
                 'name': 'create a move to push location',
-                'location_src_id': self.env.ref('stock.stock_location_stock').id,
+                'location_src_id': self.stock_location.id,
                 'location_dest_id': new_loc.id,
                 'company_id': self.env.company.id,
                 'action': 'push',
@@ -3061,20 +2993,20 @@ class TestRoutes(TestStockCommon):
         product = self.env['product.product'].create({
             'name': 'new_product',
             'is_storable': True,
-            'route_ids': [(4, route.id)]
+            'route_ids': [Command.link(route.id)],
         })
         move1 = self.env['stock.move'].create({
             'name': 'move with a route',
-            'location_id': self.supplier_location,
-            'location_dest_id': self.env.ref('stock.stock_location_stock').id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'product_id': product.id,
             'product_uom_qty': 1.0,
             'product_uom': self.uom_unit.id,
-            'move_line_ids': [(0, 0, {
+            'move_line_ids': [Command.create({
                 'product_id': product.id,
                 'product_uom_id': self.uom_unit.id,
-                'location_id': self.supplier_location,
-                'location_dest_id': self.env.ref('stock.stock_location_stock').id,
+                'location_id': self.supplier_location.id,
+                'location_dest_id': self.stock_location.id,
                 'quantity': 1.00,
             })],
         })
@@ -3140,12 +3072,11 @@ class TestRoutes(TestStockCommon):
 
 class TestAutoAssign(TestStockCommon):
     def create_pick_ship(self):
-        warehouse = self.env['stock.location'].browse(self.stock_location).warehouse_id
-        warehouse.delivery_route_id.rule_ids.action = 'pull'
+        self.warehouse_1.delivery_route_id.rule_ids.action = 'pull'
         picking_client = self.env['stock.picking'].create({
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
 
@@ -3155,16 +3086,16 @@ class TestAutoAssign(TestStockCommon):
             'product_uom_qty': 10,
             'product_uom': self.productA.uom_id.id,
             'picking_id': picking_client.id,
-            'location_id': self.pack_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.pack_location.id,
+            'location_dest_id': self.customer_location.id,
             'state': 'waiting',
             'procure_method': 'make_to_order',
         })
 
         picking_pick = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.pack_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.pack_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
 
@@ -3174,9 +3105,9 @@ class TestAutoAssign(TestStockCommon):
             'product_uom_qty': 10,
             'product_uom': self.productA.uom_id.id,
             'picking_id': picking_pick.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.pack_location,
-            'move_dest_ids': [(4, dest.id)],
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.pack_location.id,
+            'move_dest_ids': [Command.link(dest.id)],
             'state': 'confirmed',
         })
         return picking_pick, picking_client
@@ -3186,43 +3117,41 @@ class TestAutoAssign(TestStockCommon):
         validate a incoming move to check if the outgoing move is automatically
         assigned.
         """
-        pack_location = self.env['stock.location'].browse(self.pack_location)
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        self.env['stock.picking.type'].browse(self.picking_type_out).reservation_method = 'at_confirm'
+        self.picking_type_out.reservation_method = 'at_confirm'
 
         # create customer picking and move
         customer_picking = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         customer_move = self.env['stock.move'].create({
             'name': 'customer move',
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
             'product_id': self.productA.id,
             'product_uom': self.productA.uom_id.id,
             'product_uom_qty': 10.0,
             'picking_id': customer_picking.id,
-            'picking_type_id': self.picking_type_out,
+            'picking_type_id': self.picking_type_out.id,
         })
         customer_picking.action_confirm()
         customer_picking.action_assign()
         self.assertEqual(customer_move.state, 'confirmed')
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, stock_location), 0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.stock_location), 0)
 
         # create supplier picking and move
         supplier_picking = self.env['stock.picking'].create({
-            'location_id': self.customer_location,
-            'location_dest_id': self.stock_location,
-            'picking_type_id': self.picking_type_in,
+            'location_id': self.customer_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.picking_type_in.id,
             'state': 'draft',
         })
         supplier_move = self.env['stock.move'].create({
             'name': 'test_transit_1',
-            'location_id': self.customer_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.customer_location.id,
+            'location_dest_id': self.stock_location.id,
             'product_id': self.productA.id,
             'product_uom': self.productA.uom_id.id,
             'product_uom_qty': 10.0,
@@ -3235,7 +3164,7 @@ class TestAutoAssign(TestStockCommon):
 
         # customer move should be automatically assigned and no more available product in stock
         self.assertEqual(customer_move.state, 'assigned')
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, stock_location), 0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.stock_location), 0)
 
     def test_auto_assign_1(self):
         """Create a outgoing MTO move without enough products, then validate a
@@ -3243,18 +3172,16 @@ class TestAutoAssign(TestStockCommon):
         automatically assigned.
         """
         picking_pick, picking_client = self.create_pick_ship()
-        pack_location = self.env['stock.location'].browse(self.pack_location)
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        self.env['stock.picking.type'].browse(self.picking_type_out).reservation_method = 'at_confirm'
+        self.picking_type_out.reservation_method = 'at_confirm'
 
         # make some stock
-        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 10.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 10.0)
 
         # create another move to make product available in pack_location
         picking_pick_2 = self.env['stock.picking'].create({
-            'location_id': self.stock_location,
-            'location_dest_id': self.pack_location,
-            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.pack_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'state': 'draft',
         })
         self.MoveObj.create({
@@ -3263,8 +3190,8 @@ class TestAutoAssign(TestStockCommon):
             'product_uom_qty': 10,
             'product_uom': self.productA.uom_id.id,
             'picking_id': picking_pick_2.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.pack_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.pack_location.id,
             'state': 'confirmed',
         })
         picking_pick_2.action_assign()
@@ -3273,7 +3200,7 @@ class TestAutoAssign(TestStockCommon):
         picking_pick_2._action_done()
 
         self.assertEqual(picking_client.state, 'waiting', "MTO moves can't be automatically assigned.")
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 10.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.pack_location), 10.0)
 
     def test_auto_assign_reservation_method(self):
         """Test different stock.picking.type reservation methods by:
@@ -3286,9 +3213,8 @@ class TestAutoAssign(TestStockCommon):
         Also check reservation_dates are as expected
         """
 
-        stock_location = self.env['stock.location'].browse(self.stock_location)
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, stock_location), 0)
-        picking_type_out1 = self.env['stock.picking.type'].browse(self.picking_type_out).copy()
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.stock_location), 0)
+        picking_type_out1 = self.picking_type_out.copy()
         picking_type_out2 = picking_type_out1.copy()
         picking_type_out3 = picking_type_out1.copy()
         picking_type_out4 = picking_type_out1.copy()
@@ -3302,8 +3228,8 @@ class TestAutoAssign(TestStockCommon):
         # 'manual' assign picking => should never auto-assign
         customer_picking1 = self.env['stock.picking'].create({
             'name': "Delivery 1",
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
             'picking_type_id': picking_type_out1.id,
             'state': 'draft',
         })
@@ -3363,15 +3289,15 @@ class TestAutoAssign(TestStockCommon):
 
         # create supplier picking and move
         supplier_picking = self.env['stock.picking'].create({
-            'location_id': self.customer_location,
-            'location_dest_id': self.stock_location,
-            'picking_type_id': self.picking_type_in,
+            'location_id': self.customer_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.picking_type_in.id,
             'state': 'draft',
         })
         supplier_move = self.env['stock.move'].create({
             'name': 'test_transit_1',
-            'location_id': self.customer_location,
-            'location_dest_id': self.stock_location,
+            'location_id': self.customer_location.id,
+            'location_dest_id': self.stock_location.id,
             'product_id': self.productA.id,
             'product_uom': self.productA.uom_id.id,
             'product_uom_qty': 50.0,
@@ -3384,7 +3310,7 @@ class TestAutoAssign(TestStockCommon):
         self.assertEqual(customer_picking1.move_ids.quantity, 0, "Reservation Method: 'manual' shouldn't ever auto-assign")
         self.assertEqual(customer_picking2.move_ids.quantity, 0, "Reservation Method: 'by_date' shouldn't auto-assign when not within reservation date range")
         self.assertEqual(customer_picking3.move_ids.quantity, 10, "Reservation Method: 'by_date' should auto-assign when within reservation date range")
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, stock_location), 40)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.stock_location), 40)
 
         customer_picking4.action_confirm()
         customer_picking5.action_confirm()
@@ -3392,10 +3318,6 @@ class TestAutoAssign(TestStockCommon):
         self.assertEqual(customer_picking5.move_ids.quantity, 10, "Reservation Method: 'at_confirm' should auto-assign at confirmation")
 
     def test_serial_lot_ids(self):
-        self.stock_location = self.env.ref('stock.stock_location_stock')
-        self.customer_location = self.env.ref('stock.stock_location_customers')
-        self.supplier_location = self.env.ref('stock.stock_location_suppliers')
-        self.uom_unit = self.env.ref('uom.product_uom_unit')
         self.product_serial = self.env['product.product'].create({
             'name': 'PSerial',
             'is_storable': True,
@@ -3408,7 +3330,7 @@ class TestAutoAssign(TestStockCommon):
             'location_dest_id': self.stock_location.id,
             'product_id': self.product_serial.id,
             'product_uom': self.uom_unit.id,
-            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'picking_type_id': self.picking_type_in.id,
         })
         self.assertEqual(move.state, 'draft')
         lot1 = self.env['stock.lot'].create({
@@ -3423,25 +3345,24 @@ class TestAutoAssign(TestStockCommon):
             'name': 'serial3',
             'product_id': self.product_serial.id,
         })
-        move.lot_ids = [(4, lot1.id)]
-        move.lot_ids = [(4, lot2.id)]
-        move.lot_ids = [(4, lot3.id)]
+        move.lot_ids = [Command.link(lot1.id)]
+        move.lot_ids = [Command.link(lot2.id)]
+        move.lot_ids = [Command.link(lot3.id)]
         self.assertEqual(move.quantity, 3.0)
-        move.lot_ids = [(3, lot2.id)]
+        move.lot_ids = [Command.unlink(lot2.id)]
         self.assertEqual(move.quantity, 2.0)
 
-        self.uom_dozen = self.env.ref('uom.product_uom_dozen')
         move = self.env['stock.move'].create({
             'name': 'TestReceiveDozen',
             'location_id': self.supplier_location.id,
             'location_dest_id': self.stock_location.id,
             'product_id': self.product_serial.id,
             'product_uom': self.uom_dozen.id,
-            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'picking_type_id': self.picking_type_in.id,
         })
-        move.lot_ids = [(4, lot1.id)]
-        move.lot_ids = [(4, lot2.id)]
-        move.lot_ids = [(4, lot3.id)]
+        move.lot_ids = [Command.link(lot1.id)]
+        move.lot_ids = [Command.link(lot2.id)]
+        move.lot_ids = [Command.link(lot3.id)]
         self.assertEqual(move.quantity, 3.0/12.0)
 
     def test_do_not_merge_deliveries_with_different_partner(self):
@@ -3523,13 +3444,12 @@ class TestAutoAssign(TestStockCommon):
         Ensure the description_picking of a move matches the product template's
         description in a multi-step reception process.
         """
-        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
-        warehouse.reception_steps = 'two_steps'
+        self.warehouse_1.reception_steps = 'two_steps'
 
         self.productA.product_tmpl_id.description_picking = 'transfer'
         receipt = self.env['stock.picking'].create({
-            'picking_type_id': self.picking_type_in,
-            'location_id': self.supplier_location,
+            'picking_type_id': self.picking_type_in.id,
+            'location_id': self.supplier_location.id,
             'move_line_ids': [Command.create({
                 'product_id': self.productA.id,
                 'quantity': 1,

--- a/addons/stock/tests/test_old_rules.py
+++ b/addons/stock/tests/test_old_rules.py
@@ -139,9 +139,9 @@ class TestOldRules(TestStockCommon):
         self.env['stock.quant']._update_available_quantity(self.productA, self.warehouse_3_steps.lot_stock_id, 4.0)
 
         # We alter one rule and we set it to 'mts_else_mto'
-        self.warehouse_3_steps.delivery_route_id.rule_ids.filtered(lambda r: r.procure_method == "make_to_order").write({
-            'procure_method': 'mts_else_mto',
-        })
+        self.warehouse_3_steps.delivery_route_id.rule_ids.filtered(
+            lambda r: r.procure_method == "make_to_order"
+        ).procure_method = 'mts_else_mto'
 
         pg = self.env['procurement.group'].create({'name': 'Test-pg-mtso-mto'})
 
@@ -193,9 +193,7 @@ class TestOldRules(TestStockCommon):
         # We alter one rule and we set it to 'mts_else_mto'
         self.warehouse_3_steps.delivery_route_id.rule_ids.filtered(
             lambda r: r.procure_method == "make_to_order"
-        ).write({
-            'procure_method': 'mts_else_mto',
-        })
+        ).procure_method = 'mts_else_mto'
 
         pg1 = self.env['procurement.group'].create({'name': 'Test-pg-mtso-mts-1'})
         pg2 = self.env['procurement.group'].create({'name': 'Test-pg-mtso-mts-2'})
@@ -335,7 +333,7 @@ class TestOldRules(TestStockCommon):
             'product_uom_qty': 5.0,
             'product_uom': prod.uom_id.id,
             'location_id': self.warehouse_3_steps.wh_output_stock_loc_id.id,
-            'location_dest_id': self.env.ref('stock.stock_location_customers').id,
+            'location_dest_id': self.customer_location.id,
             'warehouse_id':  self.warehouse_3_steps.id,
             'picking_type_id':  self.warehouse_3_steps.out_type_id.id,
             'procure_method': 'make_to_order',
@@ -518,7 +516,7 @@ class TestOldRules(TestStockCommon):
             'product_uom_qty': 5.0,
             'product_uom': self.product.uom_id.id,
             'location_id': warehouse.wh_output_stock_loc_id.id,
-            'location_dest_id': self.env.ref('stock.stock_location_customers').id,
+            'location_dest_id': self.customer_location.id,
             'warehouse_id': warehouse.id,
             'picking_type_id': warehouse.out_type_id.id,
             'procure_method': 'make_to_order',

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -14,7 +14,7 @@ class TestPackingCommon(TransactionCase):
         super(TestPackingCommon, cls).setUpClass()
         cls.stock_location = cls.env.ref('stock.stock_location_stock')
         cls.warehouse = cls.env['stock.warehouse'].search([('lot_stock_id', '=', cls.stock_location.id)], limit=1)
-        cls.warehouse.write({'delivery_steps': 'pick_pack_ship'})
+        cls.warehouse.delivery_steps = 'pick_pack_ship'
         cls.warehouse.int_type_id.reservation_method = 'manual'
         cls.pack_location = cls.warehouse.wh_pack_stock_loc_id
         cls.ship_location = cls.warehouse.wh_output_stock_loc_id
@@ -1816,7 +1816,7 @@ class TestPacking(TestPackingCommon):
         Ensure it results with the two first package reserved. The first and the third package
         should be picked.
         """
-        self.warehouse.write({'delivery_steps': 'ship_only'})
+        self.warehouse.delivery_steps = 'ship_only'
 
         pack1, pack2, pack3 = self.env['stock.quant.package'].create([
             {'name': 'pack1'},

--- a/addons/stock/tests/test_replenish.py
+++ b/addons/stock/tests/test_replenish.py
@@ -5,7 +5,7 @@ from freezegun import freeze_time
 
 from odoo.addons.stock.tests.common import TestStockCommon
 from odoo.tests import Form
-from odoo import fields
+from odoo import Command, fields
 
 
 
@@ -15,47 +15,45 @@ class TestStockReplenish(TestStockCommon):
         """Open the replenish view and check if delay is taken into account
             in the base date computation
         """
-        stock_location = self.env.ref('stock.stock_location_stock')
-
         push_location = self.env['stock.location'].create({
-            'location_id': stock_location.location_id.id,
+            'location_id': self.stock_location.location_id.id,
             'name': 'push location',
         })
 
         route_no_delay = self.env['stock.route'].create({
             'name': 'new route',
-            'rule_ids': [(0, False, {
+            'rule_ids': [Command.create({
                 'name': 'create a move to push location',
-                'location_src_id': stock_location.id,
+                'location_src_id': self.stock_location.id,
                 'location_dest_id': push_location.id,
                 'company_id': self.env.company.id,
                 'action': 'push',
                 'auto': 'manual',
-                'picking_type_id': self.env.ref('stock.picking_type_in').id,
+                'picking_type_id': self.picking_type_in.id,
                 'delay': 0,
             })],
         })
 
         route_delay = self.env['stock.route'].create({
             'name': 'new route',
-            'rule_ids': [(0, False, {
+            'rule_ids': [Command.create({
                 'name': 'create a move to push location',
-                'location_src_id': stock_location.id,
+                'location_src_id': self.stock_location.id,
                 'location_dest_id': push_location.id,
                 'company_id': self.env.company.id,
                 'action': 'push',
                 'auto': 'manual',
-                'picking_type_id': self.env.ref('stock.picking_type_in').id,
+                'picking_type_id': self.picking_type_in.id,
                 'delay': 2,
             }),
             (0, False, {
                 'name': 'create a move to push location',
                 'location_src_id': push_location.id,
-                'location_dest_id': stock_location.id,
+                'location_dest_id': self.stock_location.id,
                 'company_id': self.env.company.id,
                 'action': 'push',
                 'auto': 'manual',
-                'picking_type_id': self.env.ref('stock.picking_type_in').id,
+                'picking_type_id': self.picking_type_in.id,
                 'delay': 4,
             })],
         })

--- a/addons/stock/tests/test_stock_lot.py
+++ b/addons/stock/tests/test_stock_lot.py
@@ -96,13 +96,13 @@ class TestLotSerial(TestStockCommon):
         linked to a company"""
         picking1 = self.env['stock.picking'].create({
             'name': 'Picking 1',
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
-            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.picking_type_in.id,
             'move_ids': [Command.create({
                 'name': self.productB.name,
-                'location_id': self.supplier_location,
-                'location_dest_id': self.stock_location,
+                'location_id': self.supplier_location.id,
+                'location_dest_id': self.stock_location.id,
                 'product_id': self.productB.id,
                 'product_uom_qty': 1.0,
             })]
@@ -169,21 +169,20 @@ class TestLotSerial(TestStockCommon):
         customer = self.PartnerObj.create({'name': 'bob'})
         delivery_picking = self.env['stock.picking'].create({
             'partner_id': customer.id,
-            'picking_type_id': self.picking_type_out,
+            'picking_type_id': self.picking_type_out.id,
             'move_ids': [Command.create({
                 'name': self.productC.name,
                 'product_id': self.productC.id,
                 'product_uom_qty': 5,
                 'quantity': 5,
-                'location_id': self.stock_location,
-                'location_dest_id': self.customer_location,
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.customer_location.id,
             })]
         })
-        stock = self.env['stock.location'].browse(self.stock_location)
         additional_product = self.productA
         lot = self.lot_p_a
-        lot.location_id = stock
-        quant = additional_product.stock_quant_ids.filtered(lambda q: q.location_id == stock)
+        lot.location_id = self.stock_location
+        quant = additional_product.stock_quant_ids.filtered(lambda q: q.location_id == self.stock_location)
         self.assertRecordValues(quant, [{'quantity': 10.0, 'reserved_quantity': 0.0}])
         delivery_picking.button_validate()
         delivery_picking.is_locked = False
@@ -210,7 +209,7 @@ class TestLotSerial(TestStockCommon):
         move = self.env["stock.move"].create({
             'name': 'test_move',
             'location_id': self.locationA.id,
-            'location_dest_id': self.customer_location,
+            'location_dest_id': self.customer_location.id,
             'product_id': self.productB.id,
             'product_uom_qty': 1.0,
         })
@@ -223,11 +222,11 @@ class TestLotSerial(TestStockCommon):
         # check that the quantity of starting quant is moved to a new quant
         self.assertEqual(starting_quant.quantity, 0)
         # check that the sn is in customer location
-        self.assertEqual(self.lot_p_b.location_id.id, self.customer_location)
+        self.assertEqual(self.lot_p_b.location_id.id, self.customer_location.id)
         # create a return
         move = self.env['stock.move'].create({
             'name': 'test_move',
-            'location_id': self.customer_location,
+            'location_id': self.customer_location.id,
             'location_dest_id': self.locationA.id,
             'product_id': self.productB.id,
             'lot_ids': self.lot_p_b,
@@ -255,13 +254,13 @@ class TestLotSerial(TestStockCommon):
         # create a receipt and confirm it
         picking1 = self.env['stock.picking'].create({
             'name': 'Picking 1',
-            'location_id': self.supplier_location,
+            'location_id': self.supplier_location.id,
             'location_dest_id': branch_a_warehouse.lot_stock_id.id,
             'picking_type_id': branch_receipt_type.id,
         })
         move = self.env["stock.move"].with_company(branch_a).create({
             'name': 'test_move',
-            'location_id': self.supplier_location,
+            'location_id': self.supplier_location.id,
             'location_dest_id': branch_a_warehouse.lot_stock_id.id,
             'product_id': self.productB.id,
             'product_uom_qty': 1.0,
@@ -286,12 +285,12 @@ class TestLotSerial(TestStockCommon):
             'name': 'Picking 1',
             'partner_id': customer.id,
             'location_id': self.locationA.id,
-            'location_dest_id': self.customer_location,
-            'picking_type_id': self.picking_type_out,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
             'move_ids': [Command.create({
                 'name': self.productA.name,
                 'location_id': self.locationA.id,
-                'location_dest_id': self.customer_location,
+                'location_dest_id': self.customer_location.id,
                 'product_id': self.productA.id,
                 'product_uom_qty': 1.0,
                 'quantity': 1.0,

--- a/addons/stock/tests/test_stock_return_picking.py
+++ b/addons/stock/tests/test_stock_return_picking.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from odoo import Command
 from odoo.addons.stock.tests.common import TestStockCommon
 from odoo.tests import Form
 
@@ -9,25 +10,28 @@ class TestReturnPicking(TestStockCommon):
         StockReturnObj = self.env['stock.return.picking']
 
         picking_out = self.PickingObj.create({
-            'picking_type_id': self.picking_type_out,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location})
+            'picking_type_id': self.picking_type_out.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+        })
         move_1 = self.MoveObj.create({
             'name': self.productA.name,
             'product_id': self.productA.id,
             'product_uom_qty': 2,
             'product_uom': self.uom_unit.id,
             'picking_id': picking_out.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location})
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+        })
         move_2 = self.MoveObj.create({
             'name': self.productA.name,
             'product_id': self.productA.id,
             'product_uom_qty': 1,
             'product_uom': self.uom_dozen.id,
             'picking_id': picking_out.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location})
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+        })
         picking_out.action_confirm()
         picking_out.action_assign()
         move_1.quantity = 2
@@ -54,9 +58,6 @@ class TestReturnPicking(TestStockCommon):
         """
             Test returns of pickings with serial tracked products put in packs
         """
-        wh_stock = self.env['stock.location'].browse(self.stock_location)
-        customer_location = self.env['stock.location'].browse(self.customer_location)
-
         product_serial = self.env['product.product'].create({
             'name': 'Tracked by SN',
             'is_storable': True,
@@ -66,12 +67,12 @@ class TestReturnPicking(TestStockCommon):
             'name': 'serial1',
             'product_id': product_serial.id,
         })
-        self.env['stock.quant']._update_available_quantity(product_serial, wh_stock, 1.0, lot_id=serial1)
+        self.env['stock.quant']._update_available_quantity(product_serial, self.stock_location, 1.0, lot_id=serial1)
 
         picking = self.PickingObj.create({
-            'picking_type_id': self.picking_type_out,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'picking_type_id': self.picking_type_out.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         self.MoveObj.create({
             'name': product_serial.name,
@@ -79,8 +80,8 @@ class TestReturnPicking(TestStockCommon):
             'product_uom_qty': 1,
             'product_uom': self.uom_unit.id,
             'picking_id': picking.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
 
         picking.action_confirm()
@@ -89,7 +90,7 @@ class TestReturnPicking(TestStockCommon):
         picking.action_put_in_pack()
         picking.move_ids.picked = True
         picking.button_validate()
-        customer_stock = self.env['stock.quant']._gather(product_serial, customer_location, lot_id=serial1)
+        customer_stock = self.env['stock.quant']._gather(product_serial, self.customer_location, lot_id=serial1)
         self.assertEqual(len(customer_stock), 1)
         self.assertEqual(customer_stock.quantity, 1)
 
@@ -106,27 +107,26 @@ class TestReturnPicking(TestStockCommon):
         picking2.move_ids.move_line_ids.quantity = 1
         picking2.move_ids.picked = True
         picking2.button_validate()
-        self.assertFalse(self.env['stock.quant']._gather(product_serial, customer_location, lot_id=serial1))
+        self.assertFalse(self.env['stock.quant']._gather(product_serial, self.customer_location, lot_id=serial1))
 
     def test_return_location(self):
         """ test default return location are taken into account
         """
         # Make a delivery
-        wh_stock = self.env['stock.location'].browse(self.stock_location)
-        self.env['stock.quant']._update_available_quantity(self.productA, wh_stock, 100)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 100)
 
         delivery_picking = self.PickingObj.create({
-            'picking_type_id': self.picking_type_out,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'picking_type_id': self.picking_type_out.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         out_move = self.MoveObj.create({
             'name': "OUT move",
             'product_id':self.productA.id,
             'product_uom_qty': 1,
             'picking_id': delivery_picking.id,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
         })
         out_move.quantity = 1
         delivery_picking.button_validate()
@@ -144,17 +144,17 @@ class TestReturnPicking(TestStockCommon):
         """
         partner = self.env['res.partner'].create({'name': 'Jean'})
         receipt = self.env['stock.picking'].create({
-            'picking_type_id': self.picking_type_in,
-            'location_id': self.supplier_location,
-            'location_dest_id': self.stock_location,
+            'picking_type_id': self.picking_type_in.id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
             'partner_id': partner.id,
-            'move_ids': [(0, 0, {
+            'move_ids': [Command.create({
                 'name': self.productA.name,
                 'product_id': self.productA.id,
                 'product_uom_qty': 1,
                 'product_uom': self.uom_unit.id,
-                'location_id': self.supplier_location,
-                'location_dest_id': self.stock_location,
+                'location_id': self.supplier_location.id,
+                'location_dest_id': self.stock_location.id,
             })],
         })
         receipt.button_validate()
@@ -182,14 +182,14 @@ class TestReturnPicking(TestStockCommon):
         })
         # Create a stock picking with moves
         original_picking = self.PickingObj.create({
-            'picking_type_id': self.picking_type_in,
-            'location_id': self.stock_location,
-            'location_dest_id': self.customer_location,
-            'move_ids': [(0, 0, {
+            'picking_type_id': self.picking_type_in.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'move_ids': [Command.create({
                 'name': product_serial.name,
                 'product_id': product_serial.id,
-                'location_id': self.supplier_location,
-                'location_dest_id': self.stock_location,
+                'location_id': self.supplier_location.id,
+                'location_dest_id': self.stock_location.id,
                 'product_uom_qty': 10,
                 'product_uom': self.uom_unit.id,
             })],
@@ -218,15 +218,15 @@ class TestReturnPicking(TestStockCommon):
 
         # Original: one return (return picking), type in, 10 items
         self.assertEqual(original_picking.return_count, 1)
-        self.assertEqual(original_picking.picking_type_id.id, self.picking_type_in)
+        self.assertEqual(original_picking.picking_type_id, self.picking_type_in)
         self.assertEqual(len(original_picking.move_line_ids), 10)
 
         # Return: one return (exchange picking), type out, 1 item
         self.assertEqual(return_picking.return_count, 1)
-        self.assertEqual(return_picking.picking_type_id.id, self.picking_type_out)
+        self.assertEqual(return_picking.picking_type_id, self.picking_type_out)
         self.assertEqual(len(return_picking.move_line_ids), 1)
 
         # Exchange: no returns, type in, 1 item
         self.assertEqual(exchange_picking.return_count, 0)
-        self.assertEqual(exchange_picking.picking_type_id.id, self.picking_type_in)
+        self.assertEqual(exchange_picking.picking_type_id, self.picking_type_in)
         self.assertEqual(len(exchange_picking.move_line_ids), 1)


### PR DESCRIPTION
The end goal of Logistics tests refactoring is to use dedicated
resources (companies, users, warehouses etc.) in all stock tests. This
is part 1 of these changes, focusing on a dedicated warehouse, but also
introducting some small improvements.

After this PR is merged, we will:
* use a dedicated warehouse in all stock tests
* use locations, picking types, routes etc. associated with that warehouse, instead of global ones
* consistently use test resources naming convention:
  * StockLocationObj -> the Odoo Model
  * stock_location -> a specific instance
  * stock_location.id -> the ID of that instance
* use Command class instead of command triple
* fix a few typos

Please note that not all tests in stock module (and related ones) have
been updated. The main reason is that not all of stock tests inherit
from TestStockCommon. This will be changed in the future.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
