### PR TITLE
[FIX] point_of_sale: payment update not reflected on backend after return

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_payment.js
+++ b/addons/point_of_sale/static/src/app/models/pos_payment.js
@@ -23,10 +23,12 @@ export class PosPayment extends Base {
 
     set_amount(value) {
         this.pos_order_id.assert_editable();
-        this.amount = roundDecimals(
-            parseFloat(value) || 0,
-            this.pos_order_id.currency.decimal_places
-        );
+        this.update({
+            amount: roundDecimals(
+                parseFloat(value) || 0,
+                this.pos_order_id.currency.decimal_places
+            ),
+        });
     }
 
     get_amount() {
@@ -38,7 +40,7 @@ export class PosPayment extends Base {
     }
 
     set_payment_status(value) {
-        this.payment_status = value;
+        this.update({ payment_status: value });
     }
 
     is_done() {


### PR DESCRIPTION
Before this commit:
==========
- When the user returns to the payment screen from the floor screen and updates the payment line, the changes are not reflected in the backend.

After this commit:
==========
- Payment line changes will reflect in the backend after returning to the payment screen.

task- 4512036
