### PR TITLE
[IMP] pos, pos_restaurant: use pos config name as prefix for session names

### DIFF
--- a/addons/point_of_sale/data/orders_demo.xml
+++ b/addons/point_of_sale/data/orders_demo.xml
@@ -7,7 +7,7 @@
         <record id="pos_closed_session_1" model="pos.session" forcecreate="False" context="{'onboarding_creation': True}">
             <field name="config_id" ref="pos_config_main" />
             <field name="user_id" ref="base.user_admin" />
-            <field name="name">POS/DEMO/01</field>
+            <field name="name">Furniture Shop/Demo/01</field>
             <field name="start_at" eval="(DateTime.today() + relativedelta(days=-1)).strftime('%Y-%m-%d %H:%M:%S')" />
             <field name="stop_at"
                 eval="(DateTime.today() + relativedelta(days=-1, hours=1)).strftime('%Y-%m-%d %H:%M:%S')" />
@@ -94,7 +94,7 @@
         <record id="pos_closed_session_2" model="pos.session" forcecreate="False" context="{'onboarding_creation': True}">
             <field name="config_id" ref="pos_config_main" />
             <field name="user_id" ref="base.user_admin" />
-            <field name="name">POS/DEMO/02</field>
+            <field name="name">Furniture Shop/Demo/02</field>
             <field name="start_at" eval="(DateTime.today() + relativedelta(hours=-3)).strftime('%Y-%m-%d %H:%M:%S')" />
             <field name="stop_at" eval="(DateTime.today() + relativedelta(hours=-2)).strftime('%Y-%m-%d %H:%M:%S')" />
         </record>

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1694,7 +1694,7 @@ class PosSession(models.Model):
     def set_opening_control(self, cashbox_value: int, notes: str):
         self.state = 'opened'
         self.start_at = fields.Datetime.now()
-        self.name = self.env['ir.sequence'].with_context(
+        self.name = self.config_id.name + self.env['ir.sequence'].with_context(
             company_id=self.config_id.company_id.id
         ).next_by_code('pos.session') + (self.name if self.name != '/' else '')
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -616,6 +616,8 @@ class TestUi(TestPointOfSaleHttpCommon):
         last_order = self.env['pos.order'].search([], limit=1, order="id desc")
         self.assertEqual(last_order.lines[0].price_subtotal, 30.0)
         self.assertEqual(last_order.lines[0].price_subtotal_incl, 30.0)
+        # Check if session name contains config name as prefix
+        self.assertEqual(self.main_pos_config.name in last_order.session_id.name, True)
 
     def test_04_product_configurator(self):
         # Making one attribute inactive to verify that it doesn't show

--- a/addons/point_of_sale/views/point_of_sale_sequence.xml
+++ b/addons/point_of_sale/views/point_of_sale_sequence.xml
@@ -4,7 +4,7 @@
     <record id="seq_pos_session" model="ir.sequence">
         <field name="name">POS Session</field>
         <field name="code">pos.session</field>
-        <field name="prefix">POS/</field>
+        <field name="prefix">/</field>
         <field name="padding">5</field>
         <field name="company_id" eval="False" />
     </record>

--- a/addons/pos_restaurant/data/restaurant_session_floor.xml
+++ b/addons/pos_restaurant/data/restaurant_session_floor.xml
@@ -22,7 +22,7 @@
         <record id="pos_closed_session_3" model="pos.session" forcecreate="False">
             <field name="config_id" ref="pos_config_main_restaurant" />
             <field name="user_id" ref="base.user_admin" />
-            <field name="name">POS/DEMO/03</field>
+            <field name="name">Restaurant/Demo/03</field>
             <field name="start_at" eval="(DateTime.today() + relativedelta(days=-1)).strftime('%Y-%m-%d %H:%M:%S')" />
             <field name="stop_at"
                 eval="(DateTime.today() + relativedelta(days=-1, hours=1)).strftime('%Y-%m-%d %H:%M:%S')" />
@@ -97,7 +97,7 @@
         <record id="pos_closed_session_4" model="pos.session" forcecreate="False">
             <field name="config_id" ref="pos_config_main_restaurant" />
             <field name="user_id" ref="base.user_admin" />
-            <field name="name">POS/DEMO/04</field>
+            <field name="name">Restaurant/Demo/04</field>
             <field name="start_at" eval="(DateTime.today() + relativedelta(days=-1)).strftime('%Y-%m-%d %H:%M:%S')" />
             <field name="stop_at"
                 eval="(DateTime.today() + relativedelta(days=-1, hours=1)).strftime('%Y-%m-%d %H:%M:%S')" />


### PR DESCRIPTION
Before this commit:
- Session names were always prefixed with `POS`.

After this commit:
- Session names are now prefixed with the corresponding POS configuration name, making them more descriptive.
- For example:
  - `Furniture Shop/00001`
  - `Restaurant/00002`

Task: 4512713

