### PR TITLE
[ADD] l10n_uy_website_sale: add Ecommerce module for Uruguay

### DIFF
--- a/addons/l10n_pe_website_sale/controllers/main.py
+++ b/addons/l10n_pe_website_sale/controllers/main.py
@@ -42,7 +42,7 @@ class L10nPEWebsiteSale(WebsiteSale):
                     and values["city_id"] != "" \
                     and request.env["res.city"].browse(int(values["city_id"]))
             to_include = {
-                "identification": kw.get("l10n_latam_identification_type_id"),
+                "identification": kw.get("l10n_latam_identification_type_id") or request.env.ref('l10n_pe.it_DNI').id,
                 "identification_types": request.env["l10n_latam.identification.type"].sudo().search(
                     ["|", ("country_id", "=", False), ("country_id.code", "=", "PE")]
                 ),

--- a/addons/l10n_pe_website_sale/static/tests/tours/website_sale_address.js
+++ b/addons/l10n_pe_website_sale/static/tests/tours/website_sale_address.js
@@ -74,6 +74,11 @@ registry.category("web_tour.tours").add('maintain_city_district_on_reload', {
             run: "text Lima",
         },
         {
+            content: "Set identification type to VAT",
+            trigger: 'select[name="l10n_latam_identification_type_id"]',
+            run: "text VAT",
+        },
+        {
             content: "Enter an invalid VAT value to trigger a potential reload",
             trigger: 'input[name="vat"]',
             run: 'text XAXX010101000',

--- a/addons/l10n_uy_website_sale/__init__.py
+++ b/addons/l10n_uy_website_sale/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import controllers

--- a/addons/l10n_uy_website_sale/__manifest__.py
+++ b/addons/l10n_uy_website_sale/__manifest__.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Uruguay Website',
+    'version': '1.0',
+    'category': 'Accounting/Localizations/Website',
+    'description': """ Add address Uruguay localisation fields in address page. """,
+    'depends': [
+        'l10n_uy',
+        'website_sale',
+    ],
+    'data': [
+        'data/ir_model_fields.xml',
+        'views/website_sales_templates.xml',
+    ],
+    'assets': {
+        'web.assets_tests': [
+            'l10n_uy_website_sale/static/tests/tours/*.js',
+        ],
+    },
+    'installable': True,
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_uy_website_sale/controllers/__init__.py
+++ b/addons/l10n_uy_website_sale/controllers/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import main
+from . import portal

--- a/addons/l10n_uy_website_sale/controllers/main.py
+++ b/addons/l10n_uy_website_sale/controllers/main.py
@@ -1,0 +1,35 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo.http import request
+
+
+class L10nUYWebsiteSale(WebsiteSale):
+
+    def _get_mandatory_fields_billing(self, country_id=False):
+        """ Extend mandatory fields to add new identification and responsibility fields when company is Uruguay. """
+        res = super()._get_mandatory_fields_billing(country_id)
+        if request.website.sudo().company_id.country_id.code == 'UY':
+            res += ['l10n_latam_identification_type_id', 'vat']
+        return res
+
+    def _get_country_related_render_values(self, kw, render_values):
+        res = super()._get_country_related_render_values(kw, render_values)
+        if request.website.sudo().company_id.country_id.code == 'UY':
+            res.update({
+                # Select CI identification type by default
+                'identification': kw.get('l10n_latam_identification_type_id') or request.env.ref('l10n_uy.it_ci').id,
+                'identification_types': request.env['l10n_latam.identification.type'].search(
+                    ['|', ('country_id', '=', False), ('country_id.code', '=', 'UY')]),
+            })
+        return res
+
+    def _get_vat_validation_fields(self, data):
+        res = super()._get_vat_validation_fields(data)
+        if request.website.sudo().company_id.country_id.code == 'UY':
+            latam_id_type_data = data.get('l10n_latam_identification_type_id')
+            res.update({
+                'l10n_latam_identification_type_id': latam_id_type_data and int(latam_id_type_data),
+                'name': data.get('name', False),
+            })
+        return res

--- a/addons/l10n_uy_website_sale/controllers/portal.py
+++ b/addons/l10n_uy_website_sale/controllers/portal.py
@@ -1,0 +1,44 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.portal.controllers.portal import CustomerPortal
+from odoo.http import request
+
+
+class CustomerPortalUruguay(CustomerPortal):
+
+    def _is_uruguay_company(self):
+        return request.env.company.country_code == 'UY'
+
+    def _get_mandatory_fields(self):
+        # EXTEND 'portal'
+        mandatory_fields = super()._get_mandatory_fields()
+
+        if self._is_uruguay_company():
+            mandatory_fields.extend(('l10n_latam_identification_type_id', 'vat'))
+
+        return mandatory_fields
+
+    def _prepare_portal_layout_values(self):
+        # EXTEND 'portal'
+        portal_layout_values = super()._prepare_portal_layout_values()
+
+        if self._is_uruguay_company():
+            partner = request.env.user.partner_id
+            portal_layout_values.update({
+                # Select CI identification type by default
+                'identification': partner.l10n_latam_identification_type_id or request.env.ref('l10n_uy.it_ci').id,
+                'identification_types': request.env['l10n_latam.identification.type'].search(
+                    ['|', ('country_id', '=', False), ('country_id.code', '=', 'UY')]),
+            })
+
+        return portal_layout_values
+
+    def details_form_validate(self, data, partner_creation=False):
+        # EXTEND 'portal'
+        error, error_message = super().details_form_validate(data, partner_creation)
+
+        # sanitize identification value to make sure it's correctly written on the partner
+        if self._is_uruguay_company() and data.get('l10n_latam_identification_type_id'):
+            data['l10n_latam_identification_type_id'] = int(data['l10n_latam_identification_type_id'])
+
+        return error, error_message

--- a/addons/l10n_uy_website_sale/data/ir_model_fields.xml
+++ b/addons/l10n_uy_website_sale/data/ir_model_fields.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <function model="ir.model.fields" name="formbuilder_whitelist">
+        <value>res.partner</value>
+        <value eval="['l10n_latam_identification_type_id']"/>
+    </function>
+
+</odoo>

--- a/addons/l10n_uy_website_sale/models/__init__.py
+++ b/addons/l10n_uy_website_sale/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import website

--- a/addons/l10n_uy_website_sale/models/website.py
+++ b/addons/l10n_uy_website_sale/models/website.py
@@ -1,0 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class Website(models.Model):
+    _inherit = 'website'
+
+    def _display_partner_b2b_fields(self):
+        """ Uruguay localization must always display b2b fields. """
+        return self.company_id.country_id.code == 'UY' or super()._display_partner_b2b_fields()

--- a/addons/l10n_uy_website_sale/static/tests/tours/website_sale_checkout_address.js
+++ b/addons/l10n_uy_website_sale/static/tests/tours/website_sale_checkout_address.js
@@ -1,0 +1,27 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import tourUtils from "@website_sale/js/tours/tour_utils";
+
+registry.category("web_tour.tours").add("shop_checkout_address_uy", {
+    test: true,
+    url: "/shop",
+    steps: () => [
+        ...tourUtils.addToCart({ productName: "product_a" }),
+        tourUtils.goToCart({ quantity: 1 }),
+        {
+            content: "Go to checkout",
+            trigger: "a:contains('Checkout')",
+        },
+        {
+            content: "Check that Id type field is present",
+            trigger: "label:contains('Identification Type')",
+            isCheck: true,
+        },
+        {
+            content: "Check that VAT field is present",
+            trigger: "label:contains('Identification Number')",
+            isCheck: true,
+        },
+    ],
+});

--- a/addons/l10n_uy_website_sale/tests/__init__.py
+++ b/addons/l10n_uy_website_sale/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_l10n_uy_website_sale

--- a/addons/l10n_uy_website_sale/tests/test_l10n_uy_website_sale.py
+++ b/addons/l10n_uy_website_sale/tests/test_l10n_uy_website_sale.py
@@ -1,0 +1,16 @@
+from odoo.tests.common import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingHttpCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUi(AccountTestInvoicingHttpCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref='uy'):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+    def test_checkout_address_uy(self):
+        self.env.company.country_id = self.env.ref('base.uy').id
+        self.env['website'].get_current_website().company_id = self.env.company.id
+        self.start_tour('/shop', 'shop_checkout_address_uy', login='accountman')

--- a/addons/l10n_uy_website_sale/views/website_sales_templates.xml
+++ b/addons/l10n_uy_website_sale/views/website_sales_templates.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="partner_info" name="Uruguay partner">
+
+        <!-- show identification type -->
+        <div t-attf-class="mb-3 #{error.get('l10n_latam_identification_type_id') and 'o_has_error' or ''} col-xl-6">
+            <label class="col-form-label" for="l10n_latam_identification_type_id">Identification Type</label>
+            <t t-if="partner.can_edit_vat()">
+                <select
+                    name="l10n_latam_identification_type_id"
+                    t-attf-class="form-select #{error.get('l10n_latam_identification_type_id') and 'is-invalid' or ''}"
+                >
+                    <option value="">Identification Type...</option>
+                    <t t-foreach="identification_types or []" t-as="id_type">
+                        <option
+                            t-att-value="id_type.id"
+                            t-att-selected="id_type.id == int(identification) if identification else id_type.id == partner.l10n_latam_identification_type_id.id"
+                        >
+                            <t t-out="id_type.name"/>
+                        </option>
+                    </t>
+                </select>
+            </t>
+            <t t-else="">
+                <p
+                    class="form-control"
+                    t-out="partner.l10n_latam_identification_type_id.name"
+                    readonly="1"
+                    title="Changing Identification type is not allowed once document(s) have been issued for your account. Please contact us directly for this operation."
+                />
+                <input
+                    name="l10n_latam_identification_type_id"
+                    class="form-control"
+                    t-att-value="partner.l10n_latam_identification_type_id.id"
+                    type='hidden'
+                />
+            </t>
+        </div>
+
+    </template>
+
+    <template id="address" inherit_id="website_sale.address">
+        <xpath expr="//input[@name='vat']/.." position="before">
+            <t t-if="mode[1] == 'billing'">
+                <t t-if="res_company.country_id.code == 'UY'">
+                    <div class="clearfix"/> <!-- Break the line to put Identifaction Type and Identifaction Number (vat) on the same line -->
+                    <t t-set="partner" t-value="website_sale_order.partner_id"/>
+                    <t t-call="l10n_uy_website_sale.partner_info"/>
+                </t>
+            </t>
+        </xpath>
+
+        <label for="vat" position="replace">
+            <t t-if="res_company.country_id.code != 'UY'">$0</t>
+            <t t-else="">
+                <label class="col-form-label label-optional" for="vat">
+                    Identification Number
+                </label>
+            </t>
+        </label>
+    </template>
+
+    <template
+        id="portal_my_details_fields"
+        name="portal_my_details_fields"
+        inherit_id="portal.portal_my_details_fields"
+    >
+        <xpath expr="//input[@name='vat']/.." position="before">
+            <t t-if="res_company.country_code == 'UY'">
+                <div class="clearfix"/>
+                <t t-call="l10n_uy_website_sale.partner_info"/>
+            </t>
+        </xpath>
+
+        <label for="vat" position="replace">
+            <t t-if="res_company.country_id.code != 'UY'">$0</t>
+            <t t-else="">
+                <label class="col-form-label label-optional" for="vat">
+                    Identification Number
+                </label>
+            </t>
+        </label>
+    </template>
+
+</odoo>


### PR DESCRIPTION
This commit add Ecommerce related bridge module for Uruguay
country to add Uruguay related field in address checkout
form and `my/account` page.

Also set DNI as default `ID type` for peru address.

task-4404637

upgrade PR - https://github.com/odoo/upgrade/pull/7930