### PR TITLE
[IMP] hr_recruitment: rearrange the attachments on the demo data

### DIFF
--- a/addons/hr_recruitment/data/hr_recruitment_demo.xml
+++ b/addons/hr_recruitment/data/hr_recruitment_demo.xml
@@ -85,6 +85,14 @@
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_sales')])]"/>
         <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
     </record>
+
+    <record id="hr_case_salesman0_cv" model="ir.attachment">
+        <field name="name">Enrique_Jones_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Enrique_Jones_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_salesman0"/>
+    </record>
+
     <record id="hr_case_salesman0" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_salesman0"/>
         <field name="job_id" ref="hr.job_marketing"/>
@@ -105,6 +113,14 @@
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_sales')])]"/>
         <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
     </record>
+
+    <record id="hr_case_salesman1_cv" model="ir.attachment">
+        <field name="name">Meldona_Thang_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Meldona_Thang_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_salesman1"/>
+    </record>
+
     <record id="hr_case_salesman1" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_salesman1"/>
         <field name="job_id" ref="hr.job_marketing"/>
@@ -122,6 +138,14 @@
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_it')])]"/>
         <field name="availability" eval="(DateTime.today() + timedelta(days=15)).strftime('%Y-%m-%d')"/>
     </record>
+
+    <record id="hr_case_dev0_cv" model="ir.attachment">
+        <field name="name">Johan_Duck_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Johan_Duck_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_dev0"/>
+    </record>
+
     <record id="hr_case_dev0" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_dev0"/>
         <field name="job_id" ref="hr.job_developer"/>
@@ -139,6 +163,14 @@
         <field name="type_id" ref="degree_graduate"/>
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_it')])]"/>
     </record>
+
+    <record id="hr_case_dev1_cv" model="ir.attachment">
+        <field name="name">Kelly_Wallant_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Kelly_Wallant_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_dev1"/>
+    </record>
+
     <record id="hr_case_dev1" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_dev1"/>
         <field name="job_id" ref="hr.job_developer"/>
@@ -155,6 +187,14 @@
         <field name="type_id" ref="degree_graduate"/>
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_it')])]"/>
     </record>
+
+    <record id="hr_case_dev2_cv" model="ir.attachment">
+        <field name="name">Cecile_Donth_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Cecile_Donth_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_dev2"/>
+    </record>
+
     <record id="hr_case_dev2" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_dev2"/>
         <field name="job_id" ref="hr.job_developer"/>
@@ -172,6 +212,14 @@
         <field name="type_id" ref="degree_graduate"/>
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_it')])]"/>
     </record>
+
+    <record id="hr_case_dev3_cv" model="ir.attachment">
+        <field name="name">Owen_James_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Ohen_Rizome_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_dev3"/>
+    </record>
+
     <record id="hr_case_dev3" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_dev3"/>
         <field name="job_id" ref="hr.job_developer"/>
@@ -189,6 +237,14 @@
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_manager')])]"/>
         <field name="availability" eval="(DateTime.today() + timedelta(days=15)).strftime('%Y-%m-%d')"/>
     </record>
+
+    <record id="hr_case_traineemca0_cv" model="ir.attachment">
+        <field name="name">Marie_Justine_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Marie_Justine_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_traineemca0"/>
+    </record>
+
     <record id="hr_case_traineemca0" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_traineemca0"/>
         <field name="job_id" ref="hr.job_trainee"/>
@@ -208,6 +264,14 @@
         <field name="type_id" ref="degree_bachelor"/>
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_it')])]"/>
     </record>
+
+    <record id="hr_case_fresher0_cv" model="ir.attachment">
+        <field name="name">Jose_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Jose_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_fresher0"/>
+    </record>
+
     <record id="hr_case_fresher0" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_fresher0"/>
         <field name="job_id" ref="hr.job_trainee"/>
@@ -223,6 +287,14 @@
         <field name="type_id" ref="degree_graduate"/>
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_manager')])]"/>
     </record>
+
+    <record id="hr_case_mkt0_cv" model="ir.attachment">
+        <field name="name">Yin_Lee_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Yin_Lee_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_mkt0"/>
+    </record>
+
     <record id="hr_case_mkt0" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_mkt0"/>
         <field name="job_id" ref="hr.job_marketing"/>
@@ -238,6 +310,14 @@
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_manager')])]"/>
         <field name="availability" eval="(DateTime.today() + timedelta(days=15)).strftime('%Y-%m-%d')"/>
     </record>
+
+    <record id="hr_case_mkt1_cv" model="ir.attachment">
+        <field name="name">Hubert_Blank_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Hubert_Blank_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_mkt1"/>
+    </record>
+
     <record id="hr_case_mkt1" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_mkt1"/>
         <field name="job_id" ref="hr.job_marketing"/>
@@ -253,6 +333,14 @@
         <field name="type_id" ref="degree_graduate"/>
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_manager')])]"/>
     </record>
+
+    <record id="hr_case_yrsexperienceinphp0_cv" model="ir.attachment">
+        <field name="name">John_Bruno_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/John_Bruno_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_yrsexperienceinphp0"/>
+    </record>
+
     <record id="hr_case_yrsexperienceinphp0" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_yrsexperienceinphp0"/>
         <field eval="(datetime.now()+relativedelta(months=-2)).strftime('%Y-%m-03 01:00:00')" name="create_date"/>
@@ -270,6 +358,14 @@
         <field name="type_id" ref="degree_licenced"/>
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_reserve')])]"/>
     </record>
+
+    <record id="hr_case_marketingjob0_cv" model="ir.attachment">
+        <field name="name">Sandra_Elvis_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Sandra_Elvis_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_marketingjob0"/>
+    </record>
+
     <record id="hr_case_marketingjob0" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_marketingjob0"/>
         <field eval="(datetime.now()+relativedelta(months=-1)).strftime('%Y-%m-08 01:00:00')" name="create_date"/>
@@ -289,6 +385,14 @@
         <field name="partner_phone">33968745</field>
         <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
     </record>
+
+    <record id="hr_case_financejob0_cv" model="ir.attachment">
+        <field name="name">David_Armstrong_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/David_Armstrong_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_financejob0"/>
+    </record>
+
     <record id="hr_case_financejob0" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_financejob0"/>
         <field name="job_id" ref="hr.job_hrm"/>
@@ -305,6 +409,14 @@
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_reserve')])]"/>
         <field name="availability" eval="(DateTime.today() + timedelta(days=15)).strftime('%Y-%m-%d')"/>
     </record>
+
+    <record id="hr_case_financejob1_cv" model="ir.attachment">
+        <field name="name">Joren_Jacob_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Joren_Jacob_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_financejob1"/>
+    </record>
+
     <record id="hr_case_financejob1" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_financejob1"/>
         <field name="job_id" ref="hr.job_hrm"/>
@@ -323,6 +435,14 @@
         <field name="type_id" ref="degree_licenced"/>
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_sales')])]"/>
     </record>
+
+    <record id="hr_case_traineemca1_cv" model="ir.attachment">
+        <field name="name">Tina_Augustie_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Tina_Augustie_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_traineemca1"/>
+    </record>
+
     <record id="hr_case_traineemca1" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_traineemca1"/>
         <field name="job_id" ref="hr.job_trainee"/>
@@ -341,6 +461,14 @@
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_it')])]"/>
         <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
     </record>
+
+    <record id="hr_case_programmer_cv" model="ir.attachment">
+        <field name="name">Shane_Williams_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Shane_Williams_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_programmer"/>
+    </record>
+
     <record id="hr_case_programmer" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_programmer"/>
         <field name="job_id" ref="hr.job_developer"/>
@@ -360,6 +488,14 @@
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_it')])]"/>
         <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
     </record>
+
+    <record id="hr_case_advertisement_cv" model="ir.attachment">
+        <field name="name">David_Billy_CV.pdf</field>
+        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/David_Billy_CV.pdf"></field>
+        <field name="res_model">hr.candidate</field>
+        <field name="res_id" ref="hr_recruitment.hr_candidate_advertisement"/>
+    </record>
+
     <record id="hr_case_advertisement" model="hr.applicant">
         <field name="candidate_id" ref="hr_candidate_advertisement"/>
         <field name="job_id" ref="hr.job_consultant"/>
@@ -369,125 +505,6 @@
         <field name="salary_expected">11000.0</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=4)"/>
         <field name="date_last_stage_update" eval="(DateTime.today() - timedelta(days=2)).strftime('%Y-%m-%d')"/>
-    </record>
-
-    <record id="hr_case_dev2_cv" model="ir.attachment">
-        <field name="name">Cecile_Donth_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Cecile_Donth_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_dev2"/>
-    </record>
-
-    <record id="hr_case_financejob0_cv" model="ir.attachment">
-        <field name="name">David_Armstrong_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/David_Armstrong_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_financejob0"/>
-    </record>
-
-    <record id="hr_case_advertisement_cv" model="ir.attachment">
-        <field name="name">David_Billy_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/David_Billy_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_advertisement"/>
-    </record>
-
-    <record id="hr_case_salesman0_cv" model="ir.attachment">
-        <field name="name">Enrique_Jones_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Enrique_Jones_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_salesman0"/>
-    </record>
-
-        <record id="hr_case_mkt1_cv" model="ir.attachment">
-        <field name="name">Hubert_Blank_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Hubert_Blank_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_mkt1"/>
-    </record>
-
-    <record id="hr_case_dev0_cv" model="ir.attachment">
-        <field name="name">Johan_Duck_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Johan_Duck_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_dev0"/>
-    </record>
-
-    <record id="hr_case_yrsexperienceinphp0_cv" model="ir.attachment">
-        <field name="name">John_Bruno_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/John_Bruno_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_yrsexperienceinphp0"/>
-    </record>
-
-    <record id="hr_case_financejob1_cv" model="ir.attachment">
-        <field name="name">Joren_Jacob_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Joren_Jacob_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_financejob1"/>
-    </record>
-
-    <record id="hr_case_fresher0_cv" model="ir.attachment">
-        <field name="name">Jose_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Jose_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_fresher0"/>
-    </record>
-
-    <record id="hr_case_dev1_cv" model="ir.attachment">
-        <field name="name">Kelly_Wallant_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Kelly_Wallant_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_dev1"/>
-    </record>
-
-    <record id="hr_case_traineemca0_cv" model="ir.attachment">
-        <field name="name">Marie_Justine_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Marie_Justine_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_traineemca0"/>
-    </record>
-
-    <record id="hr_case_salesman1_cv" model="ir.attachment">
-        <field name="name">Meldona_Thang_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Meldona_Thang_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_salesman1"/>
-    </record>
-
-    <record id="hr_case_dev3_cv" model="ir.attachment">
-        <field name="name">Owen_James_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Ohen_Rizome_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_dev3"/>
-    </record>
-
-    <record id="hr_case_marketingjob0_cv" model="ir.attachment">
-        <field name="name">Sandra_Elvis_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Sandra_Elvis_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_marketingjob0"/>
-    </record>
-
-    <record id="hr_case_programmer_cv" model="ir.attachment">
-        <field name="name">Shane_Williams_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Shane_Williams_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_programmer"/>
-    </record>
-
-    <record id="hr_case_traineemca1_cv" model="ir.attachment">
-        <field name="name">Tina_Augustie_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Tina_Augustie_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_traineemca1"/>
-    </record>
-
-    <record id="hr_case_mkt0_cv" model="ir.attachment">
-        <field name="name">Yin_Lee_CV.pdf</field>
-        <field name="datas" type="base64" file="hr_recruitment/static/applicant_cvs/Yin_Lee_CV.pdf"></field>
-        <field name="res_model">hr.candidate</field>
-        <field name="res_id" ref="hr_recruitment.hr_candidate_mkt0"/>
     </record>
 
     <record id="message_application_demo" model="mail.message">


### PR DESCRIPTION
In this PR, the demo data for the attachments has been rearranged
so that we don't need to create it for the application.
Also, it will be disabled from the OCR in the candidate model.

Task-4438455

