### PR TITLE
[IMP] core: onchange should compute fields without dependencies

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -581,7 +581,7 @@ class AccountAccount(models.Model):
         for record in self:
             record.related_taxes_amount = self.env['account.tax'].search_count([
                 *self.env['account.tax']._check_company_domain(self.env.company),
-                ('repartition_line_ids.account_id', '=', record.id),
+                ('repartition_line_ids.account_id', 'in', record.ids),
             ])
 
     @api.depends_context('company')

--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -206,7 +206,7 @@ class AccountBankStatementLine(models.Model):
                     ORDER BY first_line_index DESC
                     LIMIT 1
                 """,
-                [min_index, journal.id],
+                [min_index or '', journal.id],
             )
             current_running_balance = 0.0
             extra_clause = SQL()
@@ -236,7 +236,7 @@ class AccountBankStatementLine(models.Model):
                         %s
                     ORDER BY st_line.internal_index
                 """,
-                max_index,
+                max_index or '',
                 journal.id,
                 company2children[journal.company_id].ids,
                 extra_clause,

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -486,7 +486,7 @@ class ResPartner(models.Model):
     def _compute_journal_item_count(self):
         AccountMoveLine = self.env['account.move.line']
         for partner in self:
-            partner.journal_item_count = AccountMoveLine.search_count([('partner_id', '=', partner.id)])
+            partner.journal_item_count = AccountMoveLine.search_count([('partner_id', 'in', partner.ids)])
 
     def _compute_available_invoice_template_pdf_report_ids(self):
         moves = self.env['account.move']

--- a/addons/auth_totp/models/res_users.py
+++ b/addons/auth_totp/models/res_users.py
@@ -178,6 +178,9 @@ class ResUsers(models.Model):
 
     def _compute_totp_secret(self):
         for user in self:
+            if not user.id:
+                user.totp_secret = user._origin.totp_secret
+                continue
             self.env.cr.execute('SELECT totp_secret FROM res_users WHERE id=%s', (user.id,))
             user.totp_secret = self.env.cr.fetchone()[0]
 

--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -155,7 +155,7 @@ class FleetVehicle(models.Model):
     def _get_odometer(self):
         FleetVehicalOdometer = self.env['fleet.vehicle.odometer']
         for record in self:
-            vehicle_odometer = FleetVehicalOdometer.search([('vehicle_id', '=', record.id)], limit=1, order='value desc')
+            vehicle_odometer = FleetVehicalOdometer.search([('vehicle_id', 'in', record.ids)], limit=1, order='value desc')
             if vehicle_odometer:
                 record.odometer = vehicle_odometer.value
             else:

--- a/addons/hr_recruitment/models/hr_candidate.py
+++ b/addons/hr_recruitment/models/hr_candidate.py
@@ -83,6 +83,9 @@ class HrCandidate(models.Model):
 
     _email_partner_phone_mobile = models.Index("(email_normalized, partner_phone_sanitized)")
 
+    def _phone_get_number_fields(self):
+        return super()._phone_get_number_fields() + ['partner_phone']
+
     @api.depends('partner_name')
     def _compute_display_name(self):
         for candidate in self:

--- a/addons/hr_skills/models/hr_employee_skill_log.py
+++ b/addons/hr_skills/models/hr_employee_skill_log.py
@@ -12,7 +12,7 @@ class HrEmployeeSkillLog(models.Model):
 
     employee_id = fields.Many2one('hr.employee', required=True, ondelete='cascade')
     department_id = fields.Many2one('hr.department')
-    skill_id = fields.Many2one('hr.skill', compute='_compute_skill_id', store=True, domain="[('skill_type_id', '=', skill_type_id)]", readonly=False, required=True, ondelete='cascade')
+    skill_id = fields.Many2one('hr.skill', domain="[('skill_type_id', '=', skill_type_id)]", required=True, ondelete='cascade')
     skill_level_id = fields.Many2one('hr.skill.level', compute='_compute_skill_level_id', domain="[('skill_type_id', '=', skill_type_id)]", store=True, readonly=False, required=True, ondelete='cascade')
     skill_type_id = fields.Many2one('hr.skill.type', required=True, ondelete='cascade')
     level_progress = fields.Integer(related='skill_level_id.level_progress', store=True, aggregator="avg")

--- a/addons/hr_timesheet/models/hr_employee.py
+++ b/addons/hr_timesheet/models/hr_employee.py
@@ -4,6 +4,7 @@ from ast import literal_eval
 
 from odoo import api, models, fields, _
 from odoo.exceptions import UserError
+from odoo.tools import SQL
 
 
 class HrEmployee(models.Model):
@@ -12,16 +13,21 @@ class HrEmployee(models.Model):
     has_timesheet = fields.Boolean(compute='_compute_has_timesheet', groups="hr.group_hr_user,base.group_system", export_string_translation=False)
 
     def _compute_has_timesheet(self):
-        self.env.cr.execute("""
-        SELECT id, EXISTS(SELECT 1 FROM account_analytic_line WHERE project_id IS NOT NULL AND employee_id = e.id limit 1)
-          FROM hr_employee e
-         WHERE id in %s
-        """, (tuple(self.ids), ))
-
-        result = {eid[0]: eid[1] for eid in self.env.cr.fetchall()}
+        if self.ids:
+            result = dict(self.env.execute_query(SQL(
+                """ SELECT id, EXISTS(
+                            SELECT 1 FROM account_analytic_line
+                             WHERE project_id IS NOT NULL AND employee_id = e.id
+                             LIMIT 1)
+                      FROM hr_employee e
+                     WHERE id in %s """,
+                tuple(self.ids),
+            )))
+        else:
+            result = {}
 
         for employee in self:
-            employee.has_timesheet = result.get(employee.id, False)
+            employee.has_timesheet = result.get(employee._origin.id, False)
 
     @api.depends('company_id', 'user_id')
     @api.depends_context('allowed_company_ids')

--- a/addons/hr_work_entry/models/hr_employee.py
+++ b/addons/hr_work_entry/models/hr_employee.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields, _
+from odoo.tools import SQL
 
 
 class HrEmployee(models.Model):
@@ -10,16 +11,18 @@ class HrEmployee(models.Model):
     has_work_entries = fields.Boolean(compute='_compute_has_work_entries', groups="base.group_system,hr.group_hr_user")
 
     def _compute_has_work_entries(self):
-        self.env.cr.execute("""
-        SELECT id, EXISTS(SELECT 1 FROM hr_work_entry WHERE employee_id = e.id limit 1)
-          FROM hr_employee e
-         WHERE id in %s
-        """, (tuple(self.ids), ))
-
-        result = {eid[0]: eid[1] for eid in self.env.cr.fetchall()}
+        if self.ids:
+            result = dict(self.env.execute_query(SQL(
+                """ SELECT id, EXISTS(SELECT 1 FROM hr_work_entry WHERE employee_id = e.id LIMIT 1)
+                      FROM hr_employee e
+                     WHERE id in %s """,
+                tuple(self.ids),
+            )))
+        else:
+            result = {}
 
         for employee in self:
-            employee.has_work_entries = result.get(employee.id, False)
+            employee.has_work_entries = result.get(employee._origin.id, False)
 
     def action_open_work_entries(self, initial_date=False):
         self.ensure_one()

--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -83,7 +83,7 @@ class LinkTracker(models.Model):
 
     def _compute_code(self):
         for tracker in self:
-            record = self.env['link.tracker.code'].search([('link_id', '=', tracker.id)], limit=1, order='id DESC')
+            record = self.env['link.tracker.code'].search([('link_id', 'in', tracker.ids)], limit=1, order='id DESC')
             tracker.code = record.code
 
     def _inverse_code(self):

--- a/addons/lunch/models/lunch_cashmove.py
+++ b/addons/lunch/models/lunch_cashmove.py
@@ -20,7 +20,7 @@ class LunchCashmove(models.Model):
 
     def _compute_display_name(self):
         for cashmove in self:
-            cashmove.display_name = '{} {}'.format(_('Lunch Cashmove'), '#%d' % cashmove.id)
+            cashmove.display_name = '{} {}'.format(_('Lunch Cashmove'), '#%s' % (cashmove.id or "_"))
 
     @api.model
     def get_wallet_balance(self, user, include_config=True):

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -252,7 +252,7 @@ class MrpWorkcenter(models.Model):
     @api.depends('routing_line_ids')
     def _compute_has_routing_lines(self):
         for workcenter in self:
-            workcenter.has_routing_lines = self.env['mrp.routing.workcenter'].search_count([('workcenter_id', '=', workcenter.id)], limit=1)
+            workcenter.has_routing_lines = self.env['mrp.routing.workcenter'].search_count([('workcenter_id', 'in', workcenter.ids)], limit=1)
 
     @api.constrains('default_capacity')
     def _check_capacity(self):

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -34,7 +34,9 @@ class ProductTemplate(models.Model):
 
     def _compute_bom_count(self):
         for product in self:
-            product.bom_count = self.env['mrp.bom'].search_count(['|', ('product_tmpl_id', '=', product.id), ('byproduct_ids.product_id.product_tmpl_id', '=', product.id)])
+            product.bom_count = self.env['mrp.bom'].search_count(
+                ['|', ('product_tmpl_id', 'in', product.ids), ('byproduct_ids.product_id.product_tmpl_id', 'in', product.ids)]
+            )
 
     @api.depends_context('company')
     def _compute_is_kits(self):
@@ -64,7 +66,7 @@ class ProductTemplate(models.Model):
     def _compute_used_in_bom_count(self):
         for template in self:
             template.used_in_bom_count = self.env['mrp.bom'].search_count(
-                [('bom_line_ids.product_tmpl_id', '=', template.id)])
+                [('bom_line_ids.product_tmpl_id', 'in', template.ids)])
 
     def write(self, values):
         if 'active' in values:
@@ -138,7 +140,10 @@ class ProductProduct(models.Model):
 
     def _compute_bom_count(self):
         for product in self:
-            product.bom_count = self.env['mrp.bom'].search_count(['|', '|', ('byproduct_ids.product_id', '=', product.id), ('product_id', '=', product.id), '&', ('product_id', '=', False), ('product_tmpl_id', '=', product.product_tmpl_id.id)])
+            product.bom_count = self.env['mrp.bom'].search_count([
+                '|', '|', ('byproduct_ids.product_id', 'in', product.ids), ('product_id', 'in', product.ids),
+                '&', ('product_id', '=', False), ('product_tmpl_id', 'in', product.product_tmpl_id.ids),
+            ])
 
     @api.depends_context('company')
     def _compute_is_kits(self):
@@ -185,7 +190,8 @@ class ProductProduct(models.Model):
 
     def _compute_used_in_bom_count(self):
         for product in self:
-            product.used_in_bom_count = self.env['mrp.bom'].search_count([('bom_line_ids.product_id', '=', product.id)])
+            product.used_in_bom_count = self.env['mrp.bom'].search_count(
+                [('bom_line_ids.product_id', 'in', product.ids)])
 
     @api.depends_context('order_id')
     def _compute_product_is_in_bom_and_mo(self):

--- a/addons/point_of_sale/models/pos_preset.py
+++ b/addons/point_of_sale/models/pos_preset.py
@@ -53,13 +53,13 @@ class PosPreset(models.Model):
 
     def _compute_count_linked_orders(self):
         for record in self:
-            record.count_linked_orders = self.env['pos.order'].search_count([('preset_id', '=', record.id)])
+            record.count_linked_orders = self.env['pos.order'].search_count([('preset_id', 'in', record.ids)])
 
     def _compute_count_linked_config(self):
         for record in self:
             record.count_linked_config = self.env['pos.config'].search_count([
-                '|', ('default_preset_id', '=', record.id),
-                ('available_preset_ids', 'in', record.id)
+                '|', ('default_preset_id', 'in', record.ids),
+                ('available_preset_ids', 'in', record.ids)
             ])
 
     # Slots are created directly here in the form of dates, to avoid polluting

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -261,8 +261,8 @@ class PosSession(models.Model):
     @api.depends('picking_ids', 'picking_ids.state')
     def _compute_picking_count(self):
         for session in self:
-            session.picking_count = self.env['stock.picking'].search_count([('pos_session_id', '=', session.id)])
-            session.failed_pickings = bool(self.env['stock.picking'].search([('pos_session_id', '=', session.id), ('state', '!=', 'done')], limit=1))
+            session.picking_count = self.env['stock.picking'].search_count([('pos_session_id', 'in', session.ids)])
+            session.failed_pickings = bool(self.env['stock.picking'].search([('pos_session_id', 'in', session.ids), ('state', '!=', 'done')], limit=1))
 
     def action_stock_picking(self):
         self.ensure_one()

--- a/addons/pos_sale/models/crm_team.py
+++ b/addons/pos_sale/models/crm_team.py
@@ -16,7 +16,7 @@ class CrmTeam(models.Model):
 
     def _compute_pos_sessions_open_count(self):
         for team in self:
-            team.pos_sessions_open_count = self.env['pos.session'].search_count([('config_id.crm_team_id', '=', team.id), ('state', '=', 'opened')])
+            team.pos_sessions_open_count = self.env['pos.session'].search_count([('config_id.crm_team_id', 'in', team.ids), ('state', '=', 'opened')])
 
     def _compute_pos_order_amount_total(self):
         data = self.env['report.pos.order']._read_group([

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -182,7 +182,7 @@ class ProductTemplate(models.Model):
             # Pricelist item count counts the rules applicable on current template or on its variants.
             template.pricelist_item_count = template.env['product.pricelist.item'].search_count([
                 '&',
-                '|', ('product_tmpl_id', '=', template.id), ('product_id', 'in', template.product_variant_ids.ids),
+                '|', ('product_tmpl_id', 'in', template.ids), ('product_id', 'in', template.product_variant_ids.ids),
                 ('pricelist_id.active', '=', True),
                 ('compute_price', '=', 'fixed'),
             ])
@@ -191,7 +191,7 @@ class ProductTemplate(models.Model):
         for template in self:
             template.product_document_count = template.env['product.document'].search_count([
                 '|',
-                    '&', ('res_model', '=', 'product.template'), ('res_id', '=', template.id),
+                    '&', ('res_model', '=', 'product.template'), ('res_id', 'in', template.ids),
                     '&',
                         ('res_model', '=', 'product.product'),
                         ('res_id', 'in', template.product_variant_ids.ids),

--- a/addons/product_margin/models/product_product.py
+++ b/addons/product_margin/models/product_product.py
@@ -90,6 +90,12 @@ class ProductProduct(models.Model):
         return result
 
     def _compute_product_margin_fields_values(self):
+        if not self.ids:
+            for field_name, field in self._fields.items():
+                if field.compute == '_compute_product_margin_fields_values':
+                    self[field_name] = False
+            return
+
         date_from = self.env.context.get('date_from', time.strftime('%Y-01-01'))
         date_to = self.env.context.get('date_to', time.strftime('%Y-12-31'))
         invoice_state = self.env.context.get('invoice_state', 'open_paid')

--- a/addons/purchase/models/analytic_account.py
+++ b/addons/purchase/models/analytic_account.py
@@ -13,7 +13,7 @@ class AccountAnalyticAccount(models.Model):
     def _compute_purchase_order_count(self):
         for account in self:
             account.purchase_order_count = self.env['purchase.order'].search_count([
-                ('order_line.invoice_lines.analytic_line_ids.account_id', '=', account.id)
+                ('order_line.invoice_lines.analytic_line_ids.account_id', 'in', account.ids)
             ])
 
     def action_view_purchase_orders(self):

--- a/addons/rating/models/rating.py
+++ b/addons/rating/models/rating.py
@@ -61,7 +61,10 @@ class RatingRating(models.Model):
     @api.depends('res_model', 'res_id')
     def _compute_res_name(self):
         for rating in self:
-            name = self.env[rating.res_model].sudo().browse(rating.res_id).display_name
+            if rating.res_model and rating.res_id:
+                name = self.env[rating.res_model].sudo().browse(rating.res_id).display_name
+            else:
+                name = False
             rating.res_name = name or f'{rating.res_model}/{rating.res_id}'
 
     @api.depends('res_model', 'res_id')

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -910,9 +910,15 @@ class StockPicking(models.Model):
             picking.move_ids.write({'date': picking.scheduled_date})
 
     def _has_scrap_move(self):
+        result = {
+            picking
+            for [picking] in self.env['stock.move']._read_group(
+                [('picking_id', 'in', self.ids), ('scrapped', '=', True)],
+                ['picking_id'],
+            )
+        }
         for picking in self:
-            # TDE FIXME: better implementation
-            picking.has_scrap_move = bool(self.env['stock.move'].search_count([('picking_id', '=', picking.id), ('scrapped', '=', True)]))
+            picking.has_scrap_move = picking._origin in result
 
     def _compute_move_line_exist(self):
         for picking in self:

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -904,9 +904,15 @@ class Base(models.AbstractModel):
             missing_names = [fname for fname in fields_spec if fname not in values]
             defaults = self.default_get(missing_names)
             for field_name in missing_names:
-                values[field_name] = defaults.get(field_name, False)
                 if field_name in defaults:
+                    values[field_name] = defaults[field_name]
                     field_names.append(field_name)
+                else:
+                    field = self._fields[field_name]
+                    if not field.compute or self.pool.field_depends[field]:
+                        # don't assign computed fields without dependencies,
+                        # otherwise they don't get computed
+                        values[field_name] = False
 
         # prefetch x2many lines: this speeds up the initial snapshot by avoiding
         # computing fields on new records as much as possible, as that can be

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -50,7 +50,7 @@ class IrUiView(models.Model):
 
     def _compute_first_page_id(self):
         for view in self:
-            view.first_page_id = self.env['website.page'].search([('view_id', '=', view.id)], limit=1)
+            view.first_page_id = self.env['website.page'].search([('view_id', 'in', view.ids)], limit=1)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -92,6 +92,9 @@ class WebsiteVisitor(models.Model):
     def _compute_partner_id(self):
         # The browse in the loop is fine, there is no SQL Query on partner here
         for visitor in self:
+            if not visitor.id:
+                visitor.partner_id = visitor._origin.partner_id
+                continue
             # If the access_token is not a 32 length hexa string, it means that
             # the visitor is linked to a logged in user, in which case its
             # partner_id is used instead as the token.

--- a/addons/website_livechat/models/im_livechat.py
+++ b/addons/website_livechat/models/im_livechat.py
@@ -13,7 +13,10 @@ class Im_LivechatChannel(models.Model):
     def _compute_website_url(self):
         super()._compute_website_url()
         for channel in self:
-            channel.website_url = "/livechat/channel/%s" % (self.env['ir.http']._slug(channel),)
+            if channel.id:
+                channel.website_url = "/livechat/channel/%s" % (self.env['ir.http']._slug(channel),)
+            else:
+                channel.website_url = channel._origin.website_url
 
     website_description = fields.Html(
         "Website description", default=False, translate=html_translate,

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -238,11 +238,9 @@ class IrModel(models.Model):
     def _inherited_models(self):
         self.inherited_model_ids = False
         for model in self:
-            parent_names = list(self.env[model.model]._inherits)
-            if parent_names:
-                model.inherited_model_ids = self.search([('model', 'in', parent_names)])
-            else:
-                model.inherited_model_ids = False
+            records = self.env.get(model.model)
+            if records is not None:
+                model.inherited_model_ids = self.search([('model', 'in', list(records._inherits))])
 
     @api.depends()
     def _in_modules(self):
@@ -262,8 +260,8 @@ class IrModel(models.Model):
     def _compute_count(self):
         self.count = 0
         for model in self:
-            records = self.env[model.model]
-            if not records._abstract and records._auto:
+            records = self.env.get(model.model)
+            if records is not None and not records._abstract and records._auto:
                 [[count]] = self.env.execute_query(SQL("SELECT COUNT(*) FROM %s", SQL.identifier(records._table)))
                 model.count = count
 

--- a/odoo/addons/base/models/ir_profile.py
+++ b/odoo/addons/base/models/ir_profile.py
@@ -48,6 +48,7 @@ class IrProfile(models.Model):
         domain = [('create_date', '<', fields.Datetime.now() - datetime.timedelta(days=30))]
         return self.sudo().search(domain).unlink()
 
+    @api.depends('init_stack_trace')
     def _compute_speedscope(self):
         for execution in self:
             sp = Speedscope(init_stack_trace=json.loads(execution.init_stack_trace))
@@ -61,6 +62,7 @@ class IrProfile(models.Model):
             result = json.dumps(sp.add_default().make())
             execution.speedscope = base64.b64encode(result.encode('utf-8'))
 
+    @api.depends('speedscope')
     def _compute_speedscope_url(self):
         for profile in self:
             profile.speedscope_url = f'/web/speedscope/{profile.id}'

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -840,6 +840,7 @@ class Test_New_ApiComputeOnchange(models.Model):
     foo = fields.Char()
     bar = fields.Char(compute='_compute_bar', store=True)
     baz = fields.Char(compute='_compute_baz', store=True, readonly=False)
+    quux = fields.Char(compute='_compute_quux')
     count = fields.Integer(default=0)
     line_ids = fields.One2many(
         'test_new_api.compute.onchange.line', 'record_id',
@@ -864,6 +865,10 @@ class Test_New_ApiComputeOnchange(models.Model):
         for record in self:
             if record.active:
                 record.baz = (record.foo or "") + "z"
+
+    # special case: this field has no dependency
+    def _compute_quux(self):
+        self.quux = "quux"
 
     @api.depends('foo')
     def _compute_line_ids(self):

--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -1093,6 +1093,7 @@ class TestComputeOnchange2(TransactionCase):
         form = Form(self.env['test_new_api.compute.onchange'])
         self.assertEqual(form.bar, "r")
         self.assertEqual(form.baz, False)
+        self.assertEqual(form.quux, "quux")
         form.active = True
         self.assertEqual(form.bar, "r")
         self.assertEqual(form.baz, "z")
@@ -1123,10 +1124,12 @@ class TestComputeOnchange2(TransactionCase):
         record = form.save()
         self.assertEqual(record.bar, "foo3r")
         self.assertEqual(record.baz, "foo3z")
+        self.assertEqual(record.quux, "quux")
 
         form = Form(record)
         self.assertEqual(form.bar, "foo3r")
         self.assertEqual(form.baz, "foo3z")
+        self.assertEqual(form.quux, "quux")
         form.foo = "foo4"
         self.assertEqual(form.bar, "foo4r")
         self.assertEqual(form.baz, "foo4z")
@@ -1142,13 +1145,14 @@ class TestComputeOnchange2(TransactionCase):
 
     def test_onchange_default(self):
         form = Form(self.env['test_new_api.compute.onchange'].with_context(
-            default_active=True, default_foo="foo", default_baz="baz",
+            default_active=True, default_foo="foo", default_baz="baz", default_quux="no",
         ))
         # 'baz' is computed editable, so when given a default value it should
         # 'not be recomputed, even if a dependency also has a default value
         self.assertEqual(form.foo, "foo")
         self.assertEqual(form.bar, "foor")
         self.assertEqual(form.baz, "baz")
+        self.assertEqual(form.quux, "no")
 
     def test_onchange_once(self):
         """ Modifies `foo` field which will trigger an onchange method and


### PR DESCRIPTION
When creating a new record from a form view, a computed field without dependencies will be initialized to `False` instead of being computed.  We simply make sure that such a field is computed instead.