### PR TITLE
[IMP] html_editor: custom selection for separator

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -1,4 +1,3 @@
-import { _t } from "@web/core/l10n/translation";
 import { Plugin } from "../plugin";
 import { closestBlock, isBlock } from "../utils/blocks";
 import {
@@ -27,7 +26,6 @@ import {
     isTangible,
     isUnprotecting,
     listElementSelector,
-    paragraphRelatedElementsSelector,
 } from "../utils/dom_info";
 import {
     childNodes,
@@ -72,27 +70,12 @@ export class DomPlugin extends Plugin {
         user_commands: [
             { id: "insertFontAwesome", run: this.insertFontAwesome.bind(this) },
             { id: "setTag", run: this.setTag.bind(this) },
-            {
-                id: "insertSeparator",
-                title: _t("Separator"),
-                description: _t("Insert a horizontal rule separator"),
-                icon: "fa-minus",
-                run: this.insertSeparator.bind(this),
-            },
         ],
-        powerbox_items: {
-            categoryId: "structure",
-            commandId: "insertSeparator",
-        },
         /** Handlers */
         clean_handlers: this.removeEmptyClassAndStyleAttributes.bind(this),
         clean_for_save_handlers: ({ root }) => {
             this.removeEmptyClassAndStyleAttributes(root);
-            for (const el of root.querySelectorAll("hr[contenteditable]")) {
-                el.removeAttribute("contenteditable");
-            }
         },
-        normalize_handlers: this.normalize.bind(this),
     };
     contentEditableToRemove = new Set();
 
@@ -601,20 +584,6 @@ export class DomPlugin extends Plugin {
         this.dependencies.history.addStep();
     }
 
-    insertSeparator() {
-        const selection = this.dependencies.selection.getEditableSelection();
-        const sep = this.document.createElement("hr");
-        const block = closestBlock(selection.startContainer);
-        const element =
-            closestElement(selection.startContainer, paragraphRelatedElementsSelector) ||
-            (block && !isListItemElement(block) ? block : null);
-
-        if (element && element !== this.editable) {
-            element.before(sep);
-        }
-        this.dependencies.history.addStep();
-    }
-
     removeEmptyClassAndStyleAttributes(root) {
         for (const node of [root, ...descendants(root)]) {
             if (node.classList && !node.classList.length) {
@@ -622,24 +591,6 @@ export class DomPlugin extends Plugin {
             }
             if (node.style && !node.style.length) {
                 node.removeAttribute("style");
-            }
-        }
-    }
-
-    normalize(el) {
-        if (el.tagName === "HR") {
-            el.setAttribute(
-                "contenteditable",
-                el.hasAttribute("contenteditable") ? el.getAttribute("contenteditable") : "false"
-            );
-        } else {
-            for (const separator of el.querySelectorAll("hr")) {
-                separator.setAttribute(
-                    "contenteditable",
-                    separator.hasAttribute("contenteditable")
-                        ? separator.getAttribute("contenteditable")
-                        : "false"
-                );
             }
         }
     }

--- a/addons/html_editor/static/src/main/separator_plugin.js
+++ b/addons/html_editor/static/src/main/separator_plugin.js
@@ -1,0 +1,85 @@
+import { _t } from "@web/core/l10n/translation";
+import { Plugin } from "../plugin";
+import { closestBlock } from "../utils/blocks";
+import { closestElement } from "../utils/dom_traversal";
+import { isListItemElement, paragraphRelatedElementsSelector } from "../utils/dom_info";
+import { removeClass } from "@html_editor/utils/dom";
+
+export class SeparatorPlugin extends Plugin {
+    static id = "separator";
+    static dependencies = ["selection", "history", "split", "delete", "lineBreak"];
+    resources = {
+        user_commands: [
+            {
+                id: "insertSeparator",
+                title: _t("Separator"),
+                description: _t("Insert a horizontal rule separator"),
+                icon: "fa-minus",
+                run: this.insertSeparator.bind(this),
+            },
+        ],
+        powerbox_items: {
+            categoryId: "structure",
+            commandId: "insertSeparator",
+        },
+        /** Handlers */
+        normalize_handlers: this.normalize.bind(this),
+        selectionchange_handlers: this.handleSelectionInHr.bind(this),
+        deselect_custom_selected_nodes_handlers: this.deselectHR.bind(this),
+        clean_handlers: this.deselectHR.bind(this),
+        clean_for_save_handlers: ({ root }) => {
+            for (const el of root.querySelectorAll("hr[contenteditable]")) {
+                el.removeAttribute("contenteditable");
+            }
+            this.deselectHR(root);
+        },
+    };
+
+    insertSeparator() {
+        const selection = this.dependencies.selection.getEditableSelection();
+        const sep = this.document.createElement("hr");
+        const block = closestBlock(selection.startContainer);
+        const element =
+            closestElement(selection.startContainer, paragraphRelatedElementsSelector) ||
+            (block && !isListItemElement(block) ? block : null);
+
+        if (element && element !== this.editable) {
+            element.before(sep);
+        }
+        this.dependencies.history.addStep();
+    }
+
+    normalize(el) {
+        if (el.tagName === "HR") {
+            el.setAttribute(
+                "contenteditable",
+                el.hasAttribute("contenteditable") ? el.getAttribute("contenteditable") : "false"
+            );
+        } else {
+            for (const separator of el.querySelectorAll("hr")) {
+                separator.setAttribute(
+                    "contenteditable",
+                    separator.hasAttribute("contenteditable")
+                        ? separator.getAttribute("contenteditable")
+                        : "false"
+                );
+            }
+        }
+    }
+
+    deselectHR(root = this.editable) {
+        for (const hr of root.querySelectorAll(".o_selected_hr")) {
+            removeClass(hr, "o_selected_hr");
+        }
+    }
+
+    handleSelectionInHr() {
+        this.deselectHR();
+        const traversedNodes = this.dependencies.selection.getTraversedNodes({ deep: true });
+        for (const node of traversedNodes) {
+            if (node.nodeName === "HR") {
+                node.classList.toggle("o_selected_hr", true);
+            }
+        }
+    }
+}

--- a/addons/html_editor/static/src/main/separator_selection.scss
+++ b/addons/html_editor/static/src/main/separator_selection.scss
@@ -1,0 +1,3 @@
+hr.o_selected_hr {
+    box-shadow: 5px 0px 0px 5px rgba(50, 151, 253, 1);
+}

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -776,6 +776,7 @@ export class TablePlugin extends Plugin {
                     table.classList.toggle("o_selected_table", true);
                     for (const td of getTableCells(table)) {
                         td.classList.toggle("o_selected_td", true);
+                        this.dispatchTo("deselect_custom_selected_nodes_handlers", td);
                     }
                 }
             }
@@ -971,6 +972,7 @@ export class TablePlugin extends Plugin {
                 (_, index) => index >= minColIndex && index <= maxColIndex
             )) {
                 td.classList.toggle("o_selected_td", true);
+                this.dispatchTo("deselect_custom_selected_nodes_handlers", td);
             }
         }
     }

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -4,6 +4,7 @@ import { CommentPlugin } from "./core/comment_plugin";
 import { DeletePlugin } from "./core/delete_plugin";
 import { DialogPlugin } from "./core/dialog_plugin";
 import { DomPlugin } from "./core/dom_plugin";
+import { SeparatorPlugin } from "./main/separator_plugin";
 import { FormatPlugin } from "./core/format_plugin";
 import { HistoryPlugin } from "./core/history_plugin";
 import { InputPlugin } from "./core/input_plugin";
@@ -126,6 +127,7 @@ export const MAIN_PLUGINS = [
     BannerPlugin,
     ChatGPTPlugin,
     ColorPlugin,
+    SeparatorPlugin,
     ColumnPlugin,
     EmojiPlugin,
     HintPlugin,

--- a/addons/html_editor/static/tests/insert/separator.test.js
+++ b/addons/html_editor/static/tests/insert/separator.test.js
@@ -2,6 +2,8 @@ import { describe, expect, test } from "@odoo/hoot";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { getContent } from "../_helpers/selection";
 import { execCommand } from "../_helpers/userCommands";
+import { simulateArrowKeyPress } from "../_helpers/user_actions";
+import { animationFrame } from "@odoo/hoot-dom";
 
 async function insertSeparator(editor) {
     execCommand(editor, "insertSeparator");
@@ -68,5 +70,32 @@ describe("insert separator", () => {
         expect(getContent(el)).toBe(
             `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p><div><hr contenteditable="false"></div>`
         );
+    });
+
+    test("should apply custom selection on separator when selected", async () => {
+        const { el, editor } = await setupEditor("<p>abc</p><p>x[]yz</p>");
+        await insertSeparator(editor);
+        expect(getContent(el)).toBe(`<p>abc</p><hr contenteditable="false"><p>x[]yz</p>`);
+
+        simulateArrowKeyPress(editor, ["Shift", "ArrowUp"]);
+        await animationFrame();
+
+        expect(getContent(el)).toBe(
+            `<p>a]bc</p><hr contenteditable="false" class="o_selected_hr"><p>x[yz</p>`
+        );
+    });
+
+    test("should remove custom selection on separator when not selected", async () => {
+        const { el, editor } = await setupEditor(
+            '<p>[abc</p><hr contenteditable="false"><p>xyz]</p>'
+        );
+        expect(getContent(el)).toBe(
+            `<p>[abc</p><hr contenteditable="false" class="o_selected_hr"><p>xyz]</p>`
+        );
+
+        simulateArrowKeyPress(editor, ["Shift", "ArrowUp"]);
+        await animationFrame();
+
+        expect(getContent(el)).toBe(`<p>[abc]</p><hr contenteditable="false"><p>xyz</p>`);
     });
 });


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

- Selecting a separator didn’t apply any visual highlight, unlike text which was highlighted upon selection.
  Current behavior before PR:

**Desired behavior after PR is merged:**

-  A custom highlight is now applied when a separator is selected, ensuring it behaves like a text selection.

task:3332560