### PR TITLE
[FIX] html_editor: correctly position close icon on file upload notification

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.scss
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.scss
@@ -7,3 +7,20 @@
         }
     }
 }
+
+$o-notification-max-width-sm: calc(400px - 3rem);
+$button-width: 3rem;
+
+.editor_notification_manager {
+    width: calc(100% - #{$button-width});
+    @include media-breakpoint-up(sm) {
+        width: calc(#{$o-notification-max-width-sm} + #{$button-width});
+    }
+}
+
+.editor_notification_body {
+    width: calc(100% - #{$button-width});
+    @include media-breakpoint-up(sm) {
+        width: $o-notification-max-width-sm;
+    }
+}

--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.xml
@@ -9,17 +9,16 @@
         <span t-if="props.uploaded" class="text-success"><i class="fa fa-check my-1 me-1"/> File has been uploaded</span>
         <span t-else="" class="text-danger"><i class="fa fa-times float-start my-1 me-1"/> <span class="o_we_error_text" t-esc="props.errorMessage ? props.errorMessage : 'File could not be saved'"/></span>
     </small>
-    <div t-else="" class="progress">
+    <div t-else="" class="progress mt-2">
         <div class="progress-bar bg-info progress-bar-striped progress-bar-animated" role="progressbar" t-attf-style="width: {{this.progress}}%;" aria-label="Progress bar"><span t-esc="this.progress + '%'"/></div>
     </div>
     <hr/>
 </t>
 
 <t t-name="html_editor.UploadProgressToast">
-    <div class="o_notification_manager o_upload_progress_toast">
-        <div t-if="state.isVisible" class="o_notification position-relative show fade mb-2 border border-info bg-white" role="alert" aria-live="assertive" aria-atomic="true">
-            <button type="button" class="btn btn-close o_notification_close p-2" aria-label="Close" t-on-click="props.close"/>
-            <div class="o_notification_body ps-2 pe-4 py-2">
+    <div class="editor_notification_manager o_notification_manager o_upload_progress_toast">
+        <div t-if="state.isVisible" class="o_notification position-relative show fade mb-2 border border-info bg-white d-flex justify-content-between" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="editor_notification_body o_notification_body ps-2 py-2">
                 <div class="me-auto o_notification_content">
                     <div t-foreach="state.files" t-as="file" t-key="file" class="o_we_progressbar">
                         <ProgressBar progress="file_value.progress"
@@ -31,6 +30,7 @@
                     </div>
                 </div>
             </div>
+            <button type="button" class="btn btn-close o_notification_close p-2" aria-label="Close" t-on-click="props.close"/>
         </div>
     </div>
 </t>


### PR DESCRIPTION
**Problem**:
The close icon on the file upload notification is misplaced, appearing at the top-left instead of the expected position on the right.

Before fix:
![image](https://github.com/user-attachments/assets/206defd6-f7ff-4f17-9816-9c4450827070)

After fix:
![image](https://github.com/user-attachments/assets/fc3d84e1-821c-4c51-906b-55c057bd33ae)

**Solution**:
Adjust the button's position to appear on the right side of the notification.

**Steps to Reproduce**:
1. Open the Editor.
2. Upload a file.
3. Observe that the close button appears on the top-left instead of the right.

opw-4512322

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
