### PR TITLE
[FIX] l10n_in_ewaybill_irn: Add missing JSON payload preparation for transportation details

### DIFF
--- a/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py
@@ -27,6 +27,21 @@ class L10nInEwaybill(models.Model):
                 )
             )
 
+    def _prepare_ewaybill_transportation_json_payload(self):
+        if self.is_process_through_irn:
+            return dict(
+                filter(lambda kv: kv[1], {
+                    "TransId": self.transporter_id.vat,
+                    "TransName": self.transporter_id.name,
+                    "TransMode": self.mode,
+                    "TransDocNo": self.transportation_doc_no,
+                    "TransDocDt": self.transportation_doc_date and self.transportation_doc_date.strftime("%d/%m/%Y"),
+                    "VehNo": self.vehicle_no,
+                    "VehType": self.vehicle_type,
+                }.items())
+            )
+        return super()._prepare_ewaybill_transportation_json_payload()
+
     def _ewaybill_generate_irn_json(self):
         return {
             'Irn': self.account_move_id._get_l10n_in_edi_response_json().get('Irn'),

--- a/addons/l10n_in_ewaybill_irn/tests/__init__.py
+++ b/addons/l10n_in_ewaybill_irn/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_ewaybill_irn

--- a/addons/l10n_in_ewaybill_irn/tests/test_ewaybill_irn.py
+++ b/addons/l10n_in_ewaybill_irn/tests/test_ewaybill_irn.py
@@ -1,0 +1,44 @@
+from freezegun import freeze_time
+from odoo.addons.l10n_in.tests.common import L10nInTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestEwaybillJson(L10nInTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.invoice = cls.init_invoice("out_invoice", post=True, products=cls.product_a)
+        attachment = cls.env['ir.attachment'].create({
+            'name': 'einvoice.json',
+            'res_model': 'account.move',
+            'res_id': cls.invoice.id,
+            'raw': b'{"Irn": "1234567890"}',
+        })
+        cls.invoice.edi_document_ids = cls.env['account.edi.document'].create({
+            'edi_format_id': cls.env.ref('l10n_in_edi.edi_in_einvoice_json_1_03').id,
+            'state': 'sent',
+            'attachment_id': attachment.id,
+            'move_id': cls.invoice.id,
+        })
+
+    def test_ewaybill_irn(self):
+        ewaybill = self.env['l10n.in.ewaybill'].create({
+            'account_move_id': self.invoice.id,
+            'distance': 20,
+            'mode': "1",
+            'vehicle_no': "GJ11AA1234",
+            'vehicle_type': "R",
+        })
+        self.assertTrue(ewaybill.is_process_through_irn)
+        self.assertDictEqual(
+            ewaybill._ewaybill_generate_irn_json(),
+            {
+                'Irn': "1234567890",
+                'Distance': '20',
+                'TransMode': '1',
+                'VehNo': 'GJ11AA1234',
+                'VehType': 'R'
+            }
+        )


### PR DESCRIPTION
Implemented _prepare_ewaybill_transportation_json_payload to address a missed
requirement for generating e-way bill transportation details when processed through IRN.

Added corresponding tests to ensure proper functionality and coverage.

This fixes gaps in the integration with the e-invoice and EDI workflows.