### PR TITLE
[FIX] l10n_sa_edi: InvoiceTypeCode for Individuals Exports

### DIFF
--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -29,7 +29,7 @@ class AccountMove(models.Model):
         :return:
         """
         self.ensure_one()
-        return self.partner_id.company_type == 'person'
+        return self.partner_id.company_type == 'person' and self.partner_id.country_code == 'SA'
 
     @api.depends('amount_total_signed', 'amount_tax_signed', 'l10n_sa_confirmation_datetime', 'company_id',
                  'company_id.vat', 'journal_id', 'journal_id.l10n_sa_production_csid_json', 'edi_document_ids',

--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -215,3 +215,44 @@ class TestEdiZatca(TestSaEdiCommon):
         errors = self.edi_format.with_user(self.user_saudi.id)._check_move_configuration(move)
         msg = '- Please, make sure the invoice date is set to either the same as or before Today.'
         self.assertTrue(msg in errors)
+        
+    def test_invoice_type_code(self):
+        move_us_company = self._create_invoice(
+            name='INV/2024/00014',
+            date='2024-02-20',
+            date_due='2024-02-28',
+            partner_id=self.partner_us,
+            product_id=self.product_a,
+            price=320.0,
+            user=self.user_saudi,
+        )
+        
+        invoice_type_code = self.env['account.edi.xml.ubl_21.zatca']._l10n_sa_get_invoice_transaction_code(move_us_company)
+        # Not a simplified invoice since the partner is not from saudi arabia and a company
+        self.assertEqual(invoice_type_code, "0100100")
+
+        move_sa = self._create_invoice(
+            name='INV/2024/00015',
+            date='2024-02-20',
+            date_due='2024-02-28',
+            partner_id=self.partner_sa,
+            product_id=self.product_a,
+            price=320.0,
+            user=self.user_saudi,
+        )
+        invoice_type_code = self.env['account.edi.xml.ubl_21.zatca']._l10n_sa_get_invoice_transaction_code(move_sa)
+        # Not a simplified invoice since the partner is from saudi arabia but a company
+        self.assertEqual(invoice_type_code, "0100000")
+
+        move_sa_simplified = self._create_invoice(
+            name='INV/2024/00016',
+            date='2024-02-20',
+            date_due='2024-02-28',
+            partner_id=self.partner_sa_simplified,
+            product_id=self.product_a,
+            price=320.0,
+            user=self.user_saudi,
+        )
+        invoice_type_code = self.env['account.edi.xml.ubl_21.zatca']._l10n_sa_get_invoice_transaction_code(move_sa_simplified)
+        # Simplified invoice since the partner is from saudi arabia and an individual
+        self.assertEqual(invoice_type_code, "0200000")


### PR DESCRIPTION
When doing an export, a lot of information are computed depending on the
partner, the company and the transaction.
This commit will modify the field Invoice Type Transaction which is defined in a
structure of 7-digit code: Standard Invoice must have 01 as the first 2 digits
and 02 for simplified tax invoice.
Other 5 digits depend on nature of the transaction.

Before this commit we used to send for Individual contacts, 0200000 for all
invoices, where the country of the Customer is not Saudi Arabia. But it's
actually wrong and we should send 0100100 which is a simple export invoice.

To fix that issues we added a condition for an invoice to be simplified that the
partner need to be an individual from Saudi Arabia.

task-4504987




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
