### PR TITLE
[FIX] hr_holidays : Calculate duration of leave when flexible hours

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -425,7 +425,10 @@ class HolidaysRequest(models.Model):
                 continue
             hours, days = (0, 0)
             if leave.employee_id:
-                if leave.leave_type_request_unit == 'day' and check_leave_type:
+                if leave.employee_id.is_flexible and leave.leave_type_request_unit in ['day','half_day']:
+                    duration = leave.date_to - leave.date_from
+                    days = ceil(duration.total_seconds() / (24 * 3600))
+                elif leave.leave_type_request_unit == 'day' and check_leave_type:
                     # list of tuples (day, hours)
                     work_time_per_day_list = work_time_per_day_mapped[(leave.date_from, leave.date_to, calendar)][leave.employee_id.id]
                     days = len(work_time_per_day_list)

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1133,7 +1133,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'date_to': '2024-12-31',
         })
         allocation.action_validate()
-        self.env['hr.leave'].with_user(self.user_employee_id).create({
+        leave = self.env['hr.leave'].with_user(self.user_employee_id).create({
             'name': 'Holiday Request',
             'employee_id': employee.id,
             'holiday_status_id': self.holidays_type_4.id,
@@ -1141,7 +1141,8 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'request_date_to': '2024-01-27',
         })
         holiday_status = self.holidays_type_4.with_user(self.user_employee_id)
-        self._check_holidays_status(holiday_status, employee, 20.0, 0.0, 20.0, 16.0)
+        self._check_holidays_status(holiday_status, employee, 20.0, 0.0, 20.0, 15.0)
+        self.assertEqual(leave.duration_display, '5 days')
 
     def test_default_request_date_timezone(self):
         """


### PR DESCRIPTION
### Steps to reproduce:
	- Create a working schedule that is flexible
	- Assign this working schedule to an Employee
	- Create a time off type and set the request unit to be 'half day'
	- Create an allocation for the created time off type for the employee with the flexible working schedule
	- Create a leave for the mentioned employee with the created time off type for 1 day
	- Notice the duration of the leave is 2 days not 1

### Cause:
When creating a working schedule we compute the duration of the periods and since 'attendance.calendar_id.hours_per_day' won't have a value each period will be 1 day. https://github.com/odoo/odoo/blob/18.0/addons/resource/models/resource_calendar_attendance.py#L82

So, when getting the duration of the leave where its request_unit is not 'day' the duration will be the summation of the periods' duration of the working schedule for the employee which in this case will be 1 for each period -each day has 2 periods with the value of 1-

### Fix:
Check if the employee if on flexible hours we calcualte the duration as the difference between the date_to and date_from rounded up in days

opw-4309551