### PR TITLE
[FIX] web: filter duplicate selected records from the list view

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -1,5 +1,6 @@
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
+import { unique } from "@web/core/utils/arrays";
 import { DataPoint } from "./datapoint";
 import { Record } from "./record";
 import { resequence } from "./utils";
@@ -115,7 +116,7 @@ export class DynamicList extends DataPoint {
         } else {
             resIds = this.records.map((r) => r.resId);
         }
-        return resIds;
+        return unique(resIds);
     }
 
     async leaveEditMode({ discard } = {}) {
@@ -217,7 +218,7 @@ export class DynamicList extends DataPoint {
     async _duplicateRecords(records) {
         let resIds;
         if (records.length) {
-            resIds = records.map((r) => r.resId);
+            resIds = unique(records.map((r) => r.resId));
         } else {
             resIds = await this.getResIds(true);
         }
@@ -236,7 +237,7 @@ export class DynamicList extends DataPoint {
     async _deleteRecords(records) {
         let resIds;
         if (records.length) {
-            resIds = records.map((r) => r.resId);
+            resIds = unique(records.map((r) => r.resId));
         } else {
             resIds = await this.getResIds(true);
             records = this.records.filter((r) => resIds.includes(r.resId));
@@ -296,7 +297,7 @@ export class DynamicList extends DataPoint {
             });
             return false;
         } else {
-            const resIds = validSelection.map((r) => r.resId);
+            const resIds = unique(validSelection.map((r) => r.resId));
             const context = this.context;
             try {
                 await this.model.orm.write(this.resModel, resIds, changes, { context });

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -1912,6 +1912,47 @@ test(`enabling archive in list when groupby m2m field`, async () => {
     });
 });
 
+test(`enabling archive in list when groupby m2m field and multi selecting the same record`, async () => {
+    onRpc("has_group", () => false);
+    onRpc("action_archive", ({ args }) => {
+        expect.step("action_archive");
+        expect(args[0]).toEqual([1], {
+            message: "the archive action rpc should only contain unique ids in arguments",
+        });
+    });
+    // add active field on foo model and make all records active
+    Foo._fields.active = fields.Boolean({ default: true });
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <tree>
+                <field name="foo"/>
+                <field name="m2m" widget="many2many_tags"/>
+            </tree>
+        `,
+        actionMenus: {},
+        groupBy: ["m2m"],
+    });
+    await contains(`.o_group_name:eq(0)`).click(); // open group "Value 1"
+    await contains(`.o_group_name:eq(1)`).click(); // open group "Value 2"
+    // Check for the initial number of records
+    expect(`.o_data_row`).toHaveCount(5, { message: "Checking initial number of records" });
+
+    await contains(`.o_data_row:eq(0) .o_list_record_selector input`).click(); // select first record
+    await contains(`.o_data_row:eq(3) .o_list_record_selector input`).click(); // select the same record in another group
+    await contains(`div.o_control_panel .o_cp_action_menus .dropdown-toggle`).click(); // click on actions
+
+    await toggleMenuItem("Archive"); // toggle archive action
+    await contains(`.modal-footer .btn-primary`).click(); // confirm the archive action
+    // check that after archive the record is removed from both 2nd and 3rd groups
+    expect(`.o_data_row`).toHaveCount(3, {
+        message: "record should be archived from both the groups",
+    });
+    expect.verifySteps(["action_archive"]);
+});
+
 test(`enabling duplicate in list when groupby m2m field`, async () => {
     onRpc("has_group", () => false);
     // add active field on foo model and make all records active
@@ -1946,6 +1987,46 @@ test(`enabling duplicate in list when groupby m2m field`, async () => {
     expect(`.o_data_row`).toHaveCount(7, {
         message: "record should be duplicated in both the groups",
     });
+});
+
+test(`enabling duplicate in list when groupby m2m field and multi selecting the same record`, async () => {
+    onRpc("has_group", () => false);
+    onRpc("copy", ({ args }) => {
+        expect.step("copy");
+        expect(args[0]).toEqual([1], {
+            message: "the copy rpc should only contain unique ids in arguments",
+        });
+    });
+    // add active field on foo model and make all records active
+    Foo._fields.active = fields.Boolean({ default: true });
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <tree>
+                <field name="foo"/>
+                <field name="m2m" widget="many2many_tags"/>
+            </tree>
+        `,
+        actionMenus: {},
+        groupBy: ["m2m"],
+    });
+    await contains(`.o_group_name:eq(0)`).click(); // open group "Value 1"
+    await contains(`.o_group_name:eq(1)`).click(); // open group "Value 2"
+    // Check for the initial number of records
+    expect(`.o_data_row`).toHaveCount(5, { message: "Checking initial number of records" });
+
+    await contains(`.o_data_row:eq(0) .o_list_record_selector input`).click(); // select first record
+    await contains(`.o_data_row:eq(3) .o_list_record_selector input`).click(); // select the same record in another group
+    await contains(`div.o_control_panel .o_cp_action_menus .dropdown-toggle`).click(); // click on actions
+
+    await toggleMenuItem("Duplicate"); // toggle duplicate action
+    // check that after duplicate the record is duplicated in both 2nd and 3rd groups
+    expect(`.o_data_row`).toHaveCount(7, {
+        message: "record should be duplicated in both the groups",
+    });
+    expect.verifySteps(["copy"]);
 });
 
 test(`enabling delete in list when groupby m2m field`, async () => {
@@ -1983,6 +2064,47 @@ test(`enabling delete in list when groupby m2m field`, async () => {
     expect(`.o_data_row`).toHaveCount(3, {
         message: "record should be deleted from both the groups",
     });
+});
+
+test(`enabling delete in list when groupby m2m field and multi selecting the same record`, async () => {
+    onRpc("has_group", () => false);
+    onRpc("unlink", ({ args }) => {
+        expect.step("unlink");
+        expect(args[0]).toEqual([1], {
+            message: "the unlink rpc should only contain unique ids in arguments",
+        });
+    });
+    // add active field on foo model and make all records active
+    Foo._fields.active = fields.Boolean({ default: true });
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <tree>
+                <field name="foo"/>
+                <field name="m2m" widget="many2many_tags"/>
+            </tree>
+        `,
+        actionMenus: {},
+        groupBy: ["m2m"],
+    });
+    await contains(`.o_group_name:eq(0)`).click(); // open group "Value 1"
+    await contains(`.o_group_name:eq(1)`).click(); // open group "Value 2"
+    // Check for the initial number of records
+    expect(`.o_data_row`).toHaveCount(5, { message: "Checking initial number of records" });
+
+    await contains(`.o_data_row:eq(0) .o_list_record_selector input`).click(); // select first record
+    await contains(`.o_data_row:eq(3) .o_list_record_selector input`).click(); // select the same record in another group
+    await contains(`div.o_control_panel .o_cp_action_menus .dropdown-toggle`).click(); // click on actions
+
+    await toggleMenuItem("Delete"); // toggle delete action
+    await contains(`.modal-footer .btn-primary`).click(); // confirm the delete action
+    // check that after delete the record is deleted in both 2nd and 3rd groups
+    expect(`.o_data_row`).toHaveCount(3, {
+        message: "record should be deleted from both the groups",
+    });
+    expect.verifySteps(["unlink"]);
 });
 
 test(`enabling unarchive in list when groupby m2m field`, async () => {
@@ -2027,6 +2149,54 @@ test(`enabling unarchive in list when groupby m2m field`, async () => {
     expect(`.o_data_row`).toHaveCount(2, {
         message: "record should be unarchived from both the groups",
     });
+});
+
+test(`enabling unarchive in list when groupby m2m field and multi selecting the same record`, async () => {
+    onRpc("has_group", () => false);
+    onRpc("action_unarchive", ({ args }) => {
+        expect.step("action_unarchive");
+        expect(args[0]).toEqual([1], {
+            message: "the unarchive action rpc should only contain unique ids in arguments",
+        });
+    });
+    // add active field on foo model and make all records active
+    Foo._fields.active = fields.Boolean({ default: true });
+    // creating archived records
+    Foo._records = [
+        { id: 1, foo: "First record", m2m: [1, 2], active: false },
+        { id: 2, foo: "Second record", m2m: [1, 2], active: false },
+    ];
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <tree>
+                <field name="foo"/>
+                <field name="m2m" widget="many2many_tags"/>
+            </tree>
+        `,
+        actionMenus: {},
+        groupBy: ["m2m"],
+        // apply the filter to show only records with active = false
+        domain: [["active", "=", false]],
+    });
+
+    await contains(`.o_group_name:eq(0)`).click(); // open first group
+    await contains(`.o_group_name:eq(1)`).click(); // open second group
+    // Check for the initial number of records
+    expect(`.o_data_row`).toHaveCount(4, { message: "Checking initial number of records" });
+
+    await contains(`.o_data_row:eq(0) .o_list_record_selector input`).click(); // select first record
+    await contains(`.o_data_row:eq(2) .o_list_record_selector input`).click(); // select the same record in another group
+    await contains(`div.o_control_panel .o_cp_action_menus .dropdown-toggle`).click(); // click on actions
+
+    await toggleMenuItem("Unarchive"); // toggle unarchive action
+    // check that after unarchive the record is unarchived in both 1st and 2nd groups
+    expect(`.o_data_row`).toHaveCount(2, {
+        message: "record should be unarchived from both the groups",
+    });
+    expect.verifySteps(["action_unarchive"]);
 });
 
 test(`add record in list grouped by m2m`, async () => {
@@ -2086,6 +2256,43 @@ test(`editing a record should change same record in other groups when grouped by
     await contains(`.o_data_row .o_list_char input`).edit("xyz");
     await contains(`.o_list_view`).click();
     expect(queryAllTexts(`.o_list_char`)).toEqual(["xyz", "blip", "blip", "xyz", "blip"]);
+});
+
+test(`selecting the same record on different groups and editing it when grouping by m2m field`, async () => {
+    onRpc("write", ({ args }) => {
+        expect.step("write");
+        expect(args[0]).toEqual([1], {
+            message: "the write rpc should only contain unique ids in arguments",
+        });
+    });
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <tree multi_edit="1">
+                <field name="foo"/>
+                <field name="m2m" widget="many2many_tags"/>
+            </tree>
+        `,
+        groupBy: ["m2m"],
+    });
+
+    await contains(`.o_group_header`).click(); // open Value 1 group
+    await contains(`.o_group_header:eq(1)`).click(); // open Value 2 group
+    expect(queryAllTexts(`.o_list_char`)).toEqual(["yop", "blip", "blip", "yop", "blip"]);
+
+    await contains(`.o_data_row:eq(0) .o_list_record_selector input`).click(); // select first record
+    await contains(`.o_data_row:eq(3) .o_list_record_selector input`).click(); // select the same record in another group
+    await contains(`.o_data_row .o_data_cell`).click();
+    await contains(`.o_data_row .o_list_char input`).edit("xyz");
+    await contains(`.o_list_view`).click();
+    expect(`.modal`).toHaveCount(1);
+
+    await contains(`.modal .modal-footer .btn-primary`).click();
+    expect(`.modal`).toHaveCount(0);
+    expect(queryAllTexts(`.o_list_char`)).toEqual(["xyz", "blip", "blip", "xyz", "blip"]);
+    expect.verifySteps(["write"]);
 });
 
 test(`change a record field in readonly should change same record in other groups when grouped by m2m field`, async () => {


### PR DESCRIPTION
In the context of grouping records on a Many2Many field (e.g. tags of tasks) in the list view, it's possible to select the same record multiple times. In such case, when modifying the selected records, there could be duplicated ids in the arguments of the different RPCs (write, unlink, call). Processing the same record multiple times in backend could cause unexpected issues. 
So in this PR, we filter out the duplicated records ids before each call, to work with a clean recordset in backend.

version-17.4

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
