### PR TITLE
[FIX] website_sale: show order ref on all checkout states

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2387,6 +2387,19 @@
                     </h5>
                 </div>
             </t>
+            <t t-if="tx_sudo.state != 'done'">
+                <div class="mb-4">
+                    <h5>
+                        <em>
+                            <span>Order</span>
+                            <span t-field="order.name" />
+                            <t t-if="order.state == 'sale'">
+                                <i class="fa fa-check-circle ms-1"/>
+                            </t>
+                        </em>
+                    </h5>
+                </div>
+            </t>
             <t t-if="request.env['res.users']._get_signup_invitation_scope() == 'b2c' and request.website.is_public_user()">
                 <p class="alert alert-info mt-3" role="status">
                     <a role="button" t-att-href="order.partner_id.signup_prepare() and order.partner_id.with_context(relative_url=True).signup_url" class="btn btn-primary">Sign Up</a>


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Enable Wire Transfer as a payment provider;
2. in eCommerce, add an item to cart;
3. go to checkout;
4. pay via wire transfer.

Issue
-----
The order reference isn't shown below the "Thank you for your order" message because the payment transaction hasn't been approved yet.

Solution
--------
Show the order reference regardless of transaction status.

opw-3844583