### PR TITLE
[IMP] web: display emoji shortcodes inside the emoji picker

### DIFF
--- a/addons/mail/static/tests/emoji/emoji.test.js
+++ b/addons/mail/static/tests/emoji/emoji.test.js
@@ -157,12 +157,12 @@ test("search matches only frequently used emojis", async () => {
     await click(".o-EmojiPicker-content .o-Emoji", { text: "🥦" });
     await click("button[title='Add Emojis']");
     await contains(".o-EmojiPicker-navbar [title='Frequently used']");
-    await insertText("input[placeholder='Search emoji']", "brocoli");
+    await insertText(".o-EmojiPicker-search input", "brocoli");
     await contains(".o-EmojiPicker-sectionIcon", { count: 0 }); // await search performed
     await contains(".o-EmojiPicker-content .o-Emoji:eq(0)", { text: "🥦" });
     await contains(".o-EmojiPicker-content .o-Emoji", { count: 1 });
     await contains(".o-EmojiPicker-content", { text: "No emoji matches your search", count: 0 });
-    await insertText("input[placeholder='Search emoji']", "2");
+    await insertText(".o-EmojiPicker-search input", "2");
     await contains(".o-EmojiPicker-content", { text: "No emoji matches your search" });
 });
 

--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -1943,7 +1943,6 @@ msgstr ""
 
 #. module: web
 #. odoo-javascript
-#: code:addons/web/static/src/views/fields/image/image_field.js:0
 #: code:addons/web/static/src/views/fields/signature/signature_field.js:0
 msgid "Could not display the selected image"
 msgstr ""
@@ -1958,12 +1957,6 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/web/static/src/views/fields/google_slide_viewer/google_slide_viewer.js:0
 msgid "Could not display the selected spreadsheet"
-msgstr ""
-
-#. module: web
-#. odoo-javascript
-#: code:addons/web/static/src/views/fields/image_url/image_url_field.js:0
-msgid "Could not display the specified image url."
 msgstr ""
 
 #. module: web
@@ -3874,6 +3867,12 @@ msgstr ""
 
 #. module: web
 #. odoo-javascript
+#: code:addons/web/static/src/views/graph/graph_controller.xml:0
+msgid "Load everything anyway."
+msgstr ""
+
+#. module: web
+#. odoo-javascript
 #: code:addons/web/static/src/search/search_bar/search_bar.js:0
 msgid "Load more"
 msgstr ""
@@ -5762,7 +5761,7 @@ msgstr ""
 
 #. module: web
 #. odoo-javascript
-#: code:addons/web/static/src/core/emoji_picker/emoji_picker.xml:0
+#: code:addons/web/static/src/core/emoji_picker/emoji_picker.js:0
 msgid "Search emoji"
 msgstr ""
 
@@ -6488,6 +6487,14 @@ msgid ""
 "The style compilation failed. This is an administrator or developer error "
 "that must be fixed for the entire database before continuing working. See "
 "browser console or server logs for details."
+msgstr ""
+
+#. module: web
+#. odoo-javascript
+#: code:addons/web/static/src/views/graph/graph_controller.xml:0
+msgid ""
+"There are too many data. The graph only shows a sample. Use the filters to "
+"refine the scope."
 msgstr ""
 
 #. module: web

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -26,6 +26,16 @@ import { Deferred } from "../utils/concurrency";
 import { Dialog } from "../dialog/dialog";
 import { getTemplate } from "@web/core/templates";
 
+/**
+ * @typedef Emoji
+ * @property {string} category
+ * @property {string} codepoints the emoji itself to be displayed
+ * @property {string[]} emoticons string substitution (eg: ":p")
+ * @property {string[]} keywords
+ * @property {string} name
+ * @property {string[]} shortcodes
+ */
+
 export function useEmojiPicker(...args) {
     return usePicker(EmojiPicker, ...args);
 }
@@ -41,7 +51,7 @@ export const loader = {
     },
 };
 
-/** @returns {Promise<{ categories: Object[], emojis: Object[] }>")} */
+/** @returns {Promise<{ categories: Object[], emojis: Emoji[] }>")} */
 export async function loadEmoji() {
     const res = { categories: [], emojis: [] };
     try {
@@ -86,6 +96,7 @@ export class EmojiPicker extends Component {
     static template = "web.EmojiPicker";
 
     categories = null;
+    /** @type {Emoji[]|null} */
     emojis = null;
     shouldScrollElem = null;
     lastSearchTerm;
@@ -100,6 +111,8 @@ export class EmojiPicker extends Component {
             activeEmojiIndex: 0,
             categoryId: null,
             searchTerm: "",
+            /** @type {Emoji|undefined} */
+            hoveredEmoji: undefined,
         });
         this.frequentEmojiService = useService("web.frequent.emoji");
         useAutofocus();
@@ -131,6 +144,7 @@ export class EmojiPicker extends Component {
             if (this.props.storeScroll) {
                 this.gridRef.el.scrollTop = this.props.storeScroll.get();
             }
+            this.state.hoveredEmoji = this.currentSelectedEmoji;
         });
         onPatched(() => {
             if (this.emojis.length === 0) {
@@ -167,6 +181,7 @@ export class EmojiPicker extends Component {
                     activeEl.scrollIntoView({ block: "center", behavior: "instant" });
                     this.keyboardNavigated = false;
                 }
+                this.state.hoveredEmoji = this.currentSelectedEmoji;
             },
             () => [this.state.activeEmojiIndex, this.gridRef?.el]
         );
@@ -278,6 +293,18 @@ export class EmojiPicker extends Component {
         return recent.slice(0, 42);
     }
 
+    get placeholder() {
+        return this.state.hoveredEmoji?.shortcodes.join(" ") ?? _t("Search emoji");
+    }
+
+    onMouseEnter(ev, emoji) {
+        this.state.hoveredEmoji = emoji;
+    }
+
+    onMouseLeave(ev) {
+        this.state.hoveredEmoji = this.currentSelectedEmoji;
+    }
+
     onClick(ev) {
         markEventHandled(ev, "emoji.selectEmoji");
     }
@@ -367,6 +394,13 @@ export class EmojiPicker extends Component {
             }
         }
         this.state.activeEmojiIndex = newIdx ?? this.state.activeEmojiIndex;
+    }
+
+    get currentSelectedEmoji() {
+        const currentCodepoints = this.gridRef.el.querySelector(
+            `.o-EmojiPicker-content .o-Emoji[data-index="${this.state.activeEmojiIndex}"]`
+        )?.dataset.codepoints;
+        return currentCodepoints ? this.emojiByCodepoints[currentCodepoints] : undefined;
     }
 
     onKeydown(ev) {

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.xml
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.xml
@@ -110,13 +110,13 @@
 </t>
 
 <t t-name="web.EmojiPicker.emoji">
-    <span class="o-Emoji cursor-pointer d-flex justify-content-center rounded-3 align-items-center align-self-stretch" t-att-class="{ 'o-active': state.activeEmojiIndex === itemIndex, 'fs-2': !ui.isSmall, 'fs-1': ui.isSmall }" t-att-title="emoji.name" t-att-data-codepoints="emoji.codepoints" t-att-data-index="itemIndex" t-att-data-category="inRecent ? recentCategory.sortId : categories.find(c => c.name === emoji.category).sortId" t-on-click="selectEmoji">
+    <span class="o-Emoji cursor-pointer d-flex justify-content-center rounded-3 align-items-center align-self-stretch" t-att-class="{ 'o-active': state.activeEmojiIndex === itemIndex, 'fs-2': !ui.isSmall, 'fs-1': ui.isSmall }" t-att-title="emoji.name" t-att-data-codepoints="emoji.codepoints" t-att-data-index="itemIndex" t-att-data-category="inRecent ? recentCategory.sortId : categories.find(c => c.name === emoji.category).sortId" t-on-click="selectEmoji" t-on-mouseenter="() => this.onMouseEnter(ev, emoji)" t-on-mouseleave="() => this.onMouseLeave(ev, emoji)">
         <span t-esc="emoji.codepoints"/>
     </span>
 </t>
 
 <t t-name="web.EmojiPicker.searchInput">
-    <input class="form-control border-0 flex-grow-1 rounded-3 rounded-end-0 o-active lh-1" placeholder="Search emoji" t-model="localState.searchTerm" t-ref="autofocus" t-att-model="localState.searchTerm" t-on-input="() => this.state.activeEmojiIndex = 0" t-att-tabindex="isMobileOS ? -1 : 0"/>
+    <input class="form-control border-0 flex-grow-1 rounded-3 rounded-end-0 o-active lh-1" t-att-placeholder="placeholder" t-model="localState.searchTerm" t-ref="autofocus" t-att-model="localState.searchTerm" t-on-input="() => this.state.activeEmojiIndex = 0" t-att-tabindex="isMobileOS ? -1 : 0"/>
 </t>
 
 </templates>


### PR DESCRIPTION
This PR introduces a way for users to see the emoji shortcodes and use them later with the ":" shortcut.

Task-4516909

![Screenshot 2025-01-28 at 11 17 35](https://github.com/user-attachments/assets/422042aa-688f-4703-8192-bcb9b70e540b)
