### PR TITLE
[FIX] web: close form dialog with escape without bluring

### DIFF
--- a/addons/web/static/src/core/ui/ui_service.js
+++ b/addons/web/static/src/core/ui/ui_service.js
@@ -75,7 +75,13 @@ export function useActiveElement(refName) {
                 if (!el.contains(document.activeElement)) {
                     firstTabableEl.focus();
                 }
-                return () => {
+                return async () => {
+                    // Components are destroyed from top to bottom, meaning that this cleanup is
+                    // called before the ones of children. As a consequence, event handlers added on
+                    // the current active element in children aren't removed yet, and can thus be
+                    // executed if we deactivate that active element right away (e.g. the blur and
+                    // change events could be triggered). For that reason, we wait for a micro-tick.
+                    await Promise.resolve();
                     uiService.deactivateElement(el);
                     el.removeEventListener("keydown", trapFocus);
 

--- a/addons/web/static/tests/core/confirmation_dialog_tests.js
+++ b/addons/web/static/tests/core/confirmation_dialog_tests.js
@@ -34,117 +34,129 @@ QUnit.module("Components", (hooks) => {
 
     QUnit.module("ConfirmationDialog");
 
-    QUnit.test("Without dismiss callback pressing escape to close the dialog", async function (assert) {
-        const env = await makeDialogTestEnv();
-        await mount(ConfirmationDialog, target, {
-            env,
-            props: {
-                body: "Some content",
-                title: "Confirmation",
-                close: () => {
-                    assert.step("Close action");
+    QUnit.test(
+        "Without dismiss callback pressing escape to close the dialog",
+        async function (assert) {
+            const env = await makeDialogTestEnv();
+            await mount(ConfirmationDialog, target, {
+                env,
+                props: {
+                    body: "Some content",
+                    title: "Confirmation",
+                    close: () => {
+                        assert.step("Close action");
+                    },
+                    confirm: () => {
+                        throw new Error("should not be called");
+                    },
+                    cancel: () => {
+                        assert.step("Cancel action");
+                    },
                 },
-                confirm: () => {
-                    throw new Error("should not be called");
-                },
-                cancel: () => {
-                    assert.step("Cancel action");
-                },
-            },
-        });
-        assert.verifySteps([]);
-        triggerHotkey("escape");
-        await nextTick();
-        assert.verifySteps(
-            ["Cancel action", "Close action"],
-            "dialog has called its cancel method before its closure"
-        );
-    });
+            });
+            assert.verifySteps([]);
+            triggerHotkey("escape");
+            await nextTick();
+            assert.verifySteps(
+                ["Cancel action", "Close action"],
+                "dialog has called its cancel method before its closure"
+            );
+        }
+    );
 
-    QUnit.test("With dismiss callback: pressing escape to close the dialog", async function (assert) {
-        const env = await makeDialogTestEnv();
-        await mount(ConfirmationDialog, target, {
-            env,
-            props: {
-                body: "Some content",
-                title: "Confirmation",
-                close: () => {
-                    assert.step("Close action");
+    QUnit.test(
+        "With dismiss callback: pressing escape to close the dialog",
+        async function (assert) {
+            const env = await makeDialogTestEnv();
+            await mount(ConfirmationDialog, target, {
+                env,
+                props: {
+                    body: "Some content",
+                    title: "Confirmation",
+                    close: () => {
+                        assert.step("Close action");
+                    },
+                    confirm: () => {
+                        throw new Error("should not be called");
+                    },
+                    cancel: () => {
+                        throw new Error("should not be called");
+                    },
+                    dismiss: () => {
+                        assert.step("Dismiss action");
+                    },
                 },
-                confirm: () => {
-                    throw new Error("should not be called");
-                },
-                cancel: () => {
-                    throw new Error("should not be called");
-                },
-                dismiss: () => {
-                    assert.step("Dismiss action");
-                },
-            },
-        });
-        assert.verifySteps([]);
-        triggerHotkey("escape");
-        await nextTick();
-        assert.verifySteps(
-            ["Dismiss action", "Close action"],
-            "dialog has called its dismiss method before its closure"
-        );
-    });
+            });
+            assert.verifySteps([]);
+            triggerHotkey("escape");
+            await nextTick();
+            assert.verifySteps(
+                ["Dismiss action", "Close action"],
+                "dialog has called its dismiss method before its closure"
+            );
+        }
+    );
 
-    QUnit.test("Without dismiss callback: clicking on 'X' to close the dialog", async function (assert) {
-        const env = await makeDialogTestEnv();
-        await mount(ConfirmationDialog, target, {
-            env,
-            props: {
-                body: "Some content",
-                title: "Confirmation",
-                close: () => {
-                    assert.step("Close action");
+    QUnit.test(
+        "Without dismiss callback: clicking on 'X' to close the dialog",
+        async function (assert) {
+            const env = await makeDialogTestEnv();
+            await mount(ConfirmationDialog, target, {
+                env,
+                props: {
+                    body: "Some content",
+                    title: "Confirmation",
+                    close: () => {
+                        assert.step("Close action");
+                    },
+                    confirm: () => {
+                        throw new Error("should not be called");
+                    },
+                    cancel: () => {
+                        assert.step("Cancel action");
+                    },
                 },
-                confirm: () => {
-                    throw new Error("should not be called");
-                },
-                cancel: () => {
-                    assert.step("Cancel action");
-                },
-            },
-        });
-        assert.verifySteps([]);
-        await click(target, ".modal-header .btn-close");
-        assert.verifySteps(
-            ["Cancel action", "Close action"],
-            "dialog has called its cancel method before its closure"
-        );
-    });
+            });
+            assert.verifySteps([]);
+            await click(target, ".modal-header .btn-close");
+            assert.verifySteps(
+                ["Cancel action", "Close action"],
+                "dialog has called its cancel method before its closure"
+            );
+        }
+    );
 
-    QUnit.test("With dismiss callback: clicking on 'X' to close the dialog", async function (assert) {
-        const env = await makeDialogTestEnv();
-        await mount(ConfirmationDialog, target, {
-            env,
-            props: {
-                body: "Some content",
-                title: "Confirmation",
-                close: () => {
-                    assert.step("Close action");
+    QUnit.test(
+        "With dismiss callback: clicking on 'X' to close the dialog",
+        async function (assert) {
+            const env = await makeDialogTestEnv();
+            await mount(ConfirmationDialog, target, {
+                env,
+                props: {
+                    body: "Some content",
+                    title: "Confirmation",
+                    close: () => {
+                        assert.step("Close action");
+                    },
+                    confirm: () => {
+                        throw new Error("should not be called");
+                    },
+                    cancel: () => {
+                        throw new Error("should not be called");
+                    },
+                    dismiss: () => {
+                        assert.step("Dismiss action");
+                    },
                 },
-                confirm: () => {
-                    throw new Error("should not be called");
-                },
-                cancel: () => {
-                    throw new Error("should not be called");
-                },
-                dismiss: () => {
-                    assert.step("Dismiss action");
-                },
-            },
-        });
-        assert.verifySteps([]);
-        await click(target, ".modal-header .btn-close");
-        assert.verifySteps(
-            ["Dismiss action", "Close action"],
-            "dialog has called its dismiss method before its closure"
-        );
-    });
+            });
+            assert.verifySteps([]);
+            await click(target, ".modal-header .btn-close");
+            assert.verifySteps(
+                ["Dismiss action", "Close action"],
+                "dialog has called its dismiss method before its closure"
+            );
+        }
+    );
 
     QUnit.test("clicking on 'Ok'", async function (assert) {
         const env = await makeDialogTestEnv();
@@ -326,6 +338,7 @@ QUnit.module("Components", (hooks) => {
             "As the button is disabled, the focus is now on the body"
         );
         destroy(comp);
+        await Promise.resolve();
         assert.strictEqual(
             document.activeElement,
             target.querySelector(".my-input"),

--- a/addons/web/static/tests/core/dialog_tests.js
+++ b/addons/web/static/tests/core/dialog_tests.js
@@ -346,6 +346,7 @@ QUnit.module("Components", (hooks) => {
 
         const parent = await mount(Parent, target, { env });
         destroy(parent);
+        await Promise.resolve();
 
         assert.strictEqual(
             env.services.ui.activeElement,

--- a/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
+++ b/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
@@ -736,6 +736,7 @@ QUnit.test("registrations and elements belong to the correct UI owner", async (a
     await nextTick();
 
     destroy(comp2);
+    await Promise.resolve();
     triggerHotkey("a");
     triggerHotkey("b", true);
     await nextTick();


### PR DESCRIPTION
Have a form view opened in a dialog and edit the value of an input field (with onchange='1'), without bluring the input (i.e. such that the "change" event isn't fired yet). Press "Escape".

Before this commit, it crashed with error "Component is destroyed". The reason is that when the dialog closes itself, the ui service focusses the previously active element (an element that was behind the dialog), which in turn blurs the current active element (the input that we edited), which fires the "change" event. However, at that point, the form controller is already destroyed, hence the error.

In that flow, we don't want to perform the onchange as we're discarding the form. Actually, we don't want the field to listen to the "change" event anymore. We delay for a micro-tick the activation of the previously active element, to wait for owl to have called destroy on the whole component hierarchy, and thus for the "change" handler to be removed (in input_field_hook).

The issue could be reproduced in Studio:
 - click on Edit menu
 - open a menu to edit it
 - change its name but to not blur/click out
 - press Esc

This is a backport of odoo/odoo#195238, where we add a test (hoot). The faulty scenario could not be reproduced in the QUnit suite because we do not precisely enough mock events that occur when focusing/bluring elements.

opw-4490577

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
