### PR TITLE
[IMP] pos*: minimal rights shouldn't edit product

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -9,13 +9,12 @@ import {
     SaleDetailsButton,
     handleSaleDetails,
 } from "@point_of_sale/app/components/navbar/sale_details_button/sale_details_button";
-import { Component, onMounted, useState, useExternalListener } from "@odoo/owl";
+import { Component, useState, useExternalListener } from "@odoo/owl";
 import { Input } from "@point_of_sale/app/components/inputs/input/input";
 import { isBarcodeScannerSupported } from "@web/core/barcode/barcode_video_scanner";
 import { barcodeService } from "@barcodes/barcode_service";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
-import { user } from "@web/core/user";
 import { OrderTabs } from "@point_of_sale/app/components/order_tabs/order_tabs";
 import { PresetSlotsPopup } from "@point_of_sale/app/components/popups/preset_slots_popup/preset_slots_popup";
 import { makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
@@ -51,9 +50,6 @@ export class Navbar extends Component {
         this.isBarcodeScannerSupported = isBarcodeScannerSupported;
         this.timeout = null;
         this.bufferedInput = "";
-        onMounted(async () => {
-            this.isSystemUser = await user.hasGroup("base.group_system");
-        });
         useExternalListener(document, "keydown", this.handleKeydown.bind(this));
     }
 
@@ -152,7 +148,7 @@ export class Navbar extends Component {
     }
 
     get showCreateProductButton() {
-        return this.isSystemUser;
+        return this.pos.allowProductCreation();
     }
 
     get shouldDisplayPresetTime() {

--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
@@ -26,6 +26,6 @@ export class ProductInfoPopup extends Component {
         this.props.close();
     }
     get allowProductEdition() {
-        return true; // Overrided in pos_hr
+        return this.pos.allowProductCreation();
     }
 }

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -136,6 +136,8 @@ export class PosStore extends WithLazyGetterTrap {
         });
         this.scale = pos_scale;
 
+        this.isProductCreation = await user.hasGroup("product.group_product_manager");
+        this.isPOSManager = await user.hasGroup("point_of_sale.group_pos_manager");
         this.orderCounter = new Counter(0);
 
         // FIXME POSREF: the hardwareProxy needs the pos and the pos needs the hardwareProxy. Maybe
@@ -1821,8 +1823,8 @@ export class PosStore extends WithLazyGetterTrap {
             }
         );
     }
-    async allowProductCreation() {
-        return await user.hasGroup("base.group_system");
+    allowProductCreation() {
+        return this.isPOSManager ? true : this.isProductCreation;
     }
     orderDetailsProps(order) {
         return {

--- a/addons/pos_hr/static/src/app/components/navbar/navbar.js
+++ b/addons/pos_hr/static/src/app/components/navbar/navbar.js
@@ -3,10 +3,8 @@ import { patch } from "@web/core/utils/patch";
 
 patch(Navbar.prototype, {
     get showCreateProductButton() {
-        if (!this.pos.config.module_pos_hr || this.pos.employeeIsAdmin) {
-            return super.showCreateProductButton;
-        } else {
-            return false;
-        }
+        return this.pos.config.module_pos_hr
+            ? this.pos.cashier._role === "manager" && super.showCreateProductButton
+            : super.showCreateProductButton;
     },
 });

--- a/addons/pos_hr/static/src/app/components/popups/product_info_popup/product_info_popup.js
+++ b/addons/pos_hr/static/src/app/components/popups/product_info_popup/product_info_popup.js
@@ -3,6 +3,8 @@ import { patch } from "@web/core/utils/patch";
 
 patch(ProductInfoPopup.prototype, {
     get allowProductEdition() {
-        return !this.pos.config.module_pos_hr || this.pos.employeeIsAdmin;
+        return this.pos.config.module_pos_hr
+            ? this.pos.cashier._role === "manager" && super.allowProductEdition
+            : super.allowProductEdition;
     },
 });

--- a/addons/pos_hr/static/src/app/services/pos_store.js
+++ b/addons/pos_hr/static/src/app/services/pos_store.js
@@ -137,10 +137,9 @@ patch(PosStore.prototype, {
         }
         return super.shouldShowOpeningControl(...arguments);
     },
-    async allowProductCreation() {
-        if (this.config.module_pos_hr) {
-            return this.employeeIsAdmin;
-        }
-        return await super.allowProductCreation();
+    allowProductCreation() {
+        return this.config.module_pos_hr
+            ? this.cashier._role === "manager" && super.allowProductCreation()
+            : super.allowProductCreation();
     },
 });

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -181,3 +181,33 @@ registry.category("web_tour.tours").add("test_change_on_rights_reflected_directl
             Utils.negateStep(...SelectionPopup.has("Pos Employee1")),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("UserEditOrCreateProduct", {
+    steps: () =>
+        [
+            Chrome.clickBtn("Open Register"),
+            PosHr.loginScreenIsShown(),
+            PosHr.clickLoginButton(),
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+            Dialog.confirm("Open Register"),
+            ...PosHr.editCreateProductFlow(true),
+            ...PosHr.testUserAccess("Pos Employee1", false),
+            ...PosHr.testUserAccess("Test Employee 3", false),
+            ProductScreen.isShown(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("UserEditOrCreateProduct2", {
+    steps: () =>
+        [
+            Chrome.clickBtn("Open Register"),
+            PosHr.loginScreenIsShown(),
+            PosHr.clickLoginButton(),
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+            Dialog.confirm("Open Register"),
+            ...PosHr.editCreateProductFlow(false),
+            ...PosHr.testUserAccess("Pos Employee1", false),
+            ...PosHr.testUserAccess("Test Employee 3", false),
+            ProductScreen.isShown(),
+        ].flat(),
+});

--- a/addons/pos_hr/static/tests/tours/utils/pos_hr_helpers.js
+++ b/addons/pos_hr/static/tests/tours/utils/pos_hr_helpers.js
@@ -1,6 +1,9 @@
 import * as SelectionPopup from "@point_of_sale/../tests/generic_helpers/selection_popup_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as NumberPopup from "@point_of_sale/../tests/generic_helpers/number_popup_util";
+import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
 
 export function clickLoginButton() {
     return [
@@ -55,5 +58,31 @@ export function refreshPage() {
                 window.location.reload();
             },
         },
+    ];
+}
+
+export function editCreateProductFlow(access = true) {
+    return [
+        ProductScreen.clickInfoProduct("Desk Pad", "1"),
+        {
+            trigger: access
+                ? `.modal .modal-footer .btn-secondary:contains("Edit")`
+                : negate(`.modal .modal-footer .btn-secondary:contains("Edit")`),
+        },
+        Dialog.cancel(),
+        Chrome.clickMenuButton(),
+        {
+            trigger: access
+                ? `span.dropdown-item:contains("Create Product")`
+                : negate(`span.dropdown-item:contains("Create Product")`),
+        },
+    ];
+}
+
+export function testUserAccess(employeeName, hasAccess) {
+    return [
+        clickCashierName(),
+        SelectionPopup.has(employeeName, { run: "click" }),
+        ...editCreateProductFlow(hasAccess),
     ];
 }

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -133,3 +133,28 @@ class TestUi(TestPosHrHttpCommon):
             "test_change_on_rights_reflected_directly",
             login="pos_admin",
         )
+
+    def setup_employees_roles(self):
+        # all backend users
+        self.admin.pin = False
+        self.emp1.pin = False
+        self.emp3.pin = False
+        self.main_pos_config.advanced_employee_ids = [Command.link(self.admin.id)]
+        self.main_pos_config.basic_employee_ids = [Command.link(self.emp1.id)]
+        self.main_pos_config.minimal_employee_ids = [Command.link(self.emp3.id)]
+
+    def test_edit_or_create_product_backend_admin(self):
+        # backend admin
+        self.setup_employees_roles()
+        self.start_pos_tour("UserEditOrCreateProduct", login="pos_admin")
+
+    def test_edit_or_create_product_backend_user_no_product(self):
+        # pos user has no write access on product
+        self.setup_employees_roles()
+        self.start_pos_tour("UserEditOrCreateProduct2", login="pos_user")
+
+    def test_edit_or_create_product_backend_user_product(self):
+        # pos user has write access on product
+        self.setup_employees_roles()
+        self.pos_user.groups_id += self.env.ref('product.group_product_manager')
+        self.start_pos_tour("UserEditOrCreateProduct", login="pos_user")

--- a/addons/pos_self_order/static/src/overrides/components/product_info_popup/product_info_popup.js
+++ b/addons/pos_self_order/static/src/overrides/components/product_info_popup/product_info_popup.js
@@ -7,4 +7,12 @@ patch(ProductInfoPopup.prototype, {
             self_order_available: !this.props.productTemplate.self_order_available,
         });
     },
+    showSelfOrderToggle() {
+        return (
+            this.pos.config.self_ordering_mode != "nothing" &&
+            (this.pos.config.module_pos_hr
+                ? this.pos.cashier._role === "manager" && this.pos.allowProductCreation()
+                : this.pos.allowProductCreation())
+        );
+    },
 });

--- a/addons/pos_self_order/static/src/overrides/components/product_info_popup/product_info_popup.xml
+++ b/addons/pos_self_order/static/src/overrides/components/product_info_popup/product_info_popup.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.ProductInfoPopup" t-inherit="point_of_sale.ProductInfoPopup" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('section-inventory')]" position="before">
-            <div t-if="this.pos.cashier._role !== 'minimal' and this.pos.config.self_ordering_mode != 'nothing'" class="section-self-order-availability mt-3 mb-4 pb-4 border-bottom text-start d-flex align-items-center">
+            <div t-if="showSelfOrderToggle()" class="section-self-order-availability mt-3 mb-4 pb-4 border-bottom text-start d-flex align-items-center">
                 <h3 class="section-title">Self-ordering:</h3>
                 <div class="section-self-order-availability-body d-flex ms-auto">
                     <div class="form-check form-switch">


### PR DESCRIPTION
Before:
===
- Users with minimal rights could edit products and enable/disable self-ordering.

After:
===
- Restricted users with minimal rights from editing products and toggling self-ordering.

Task: 4509050