### PR TITLE
[FIX] partner_autocomple: partner autocomplete partner_gid field

### DIFF
--- a/addons/account/views/res_company_views.xml
+++ b/addons/account/views/res_company_views.xml
@@ -52,7 +52,6 @@
                     </div>
                     <group>
                         <group>
-                            <field name="partner_gid" invisible="1"/>
                             <field name="vat"/>
                             <label for="street" string="Address"/>
                             <div class="o_address_format">

--- a/addons/partner_autocomplete/models/res_company.py
+++ b/addons/partner_autocomplete/models/res_company.py
@@ -5,6 +5,8 @@ import json
 import logging
 import threading
 
+from lxml.builder import E
+
 from odoo.addons.iap.tools import iap_tools
 from odoo import api, fields, models, _
 from odoo.tools.mail import email_domain_extract, url_domain_extract
@@ -37,7 +39,10 @@ class ResCompany(models.Model):
         arch, view = super()._get_view(view_id, view_type, **options)
 
         if view_type == 'form':
-            for node in arch.xpath("//field[@name='name' or @name='vat']"):
+            for i, node in enumerate(arch.xpath("//field[@name='name' or @name='vat']")):
+                if i == 0:
+                    node.addnext(E.field(name='partner_gid', invisible='1'))
+
                 node.set('widget', 'field_partner_autocomplete')
 
         return arch, view


### PR DESCRIPTION
`partner_gid` was missing from `res_company_form_view_onboarding` view which was creating a bug when applying the partner autocomplete.

Rollback of odoo/195000 as it created issues if you uninstalled `partner_autocomplete`. The field will still be present in the view, but it wouldn't exist in the database.

opw-4489441

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
