### PR TITLE
[FIX] iap_account,sms: fix traceback when acessing iap accounts

### DIFF
--- a/addons/iap/models/iap_account.py
+++ b/addons/iap/models/iap_account.py
@@ -113,19 +113,17 @@ class IapAccount(models.Model):
             balance = f"{balance_amount} {account_id.service_id.unit_name}"
 
             information.pop('link_to_service_page', None)
-            account_info = {
-                'balance': balance,
-                'warning_threshold': information['warning_threshold'],
-                'state': information['registered'],
-                'service_locked': True,  # The account exist on IAP, prevent the edition of the service
-            }
-
-            if account_id.service_name == 'sms':
-                account_info.update({
-                    'sender_name': information.get('sender_name')
-                })
+            account_info = self._get_account_info(account_id, balance, information)
 
             account_id.with_context(disable_iap_update=True, tracking_disable=True).write(account_info)
+
+    def _get_account_info(self, account_id, balance, information):
+        return {
+            'balance': balance,
+            'warning_threshold': information['warning_threshold'],
+            'state': information['registered'],
+            'service_locked': True,  # The account exist on IAP, prevent the edition of the service
+        }
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/sms/models/iap_account.py
+++ b/addons/sms/models/iap_account.py
@@ -27,3 +27,9 @@ class IapAccount(models.Model):
             'res_model': 'sms.account.sender',
             'context': {'default_account_id': self.id},
         }
+
+    def _get_account_info(self, account_id, balance, information):
+        res = super()._get_account_info(account_id, balance, information)
+        if account_id.service_name == 'sms':
+            res['sender_name'] = information.get('sender_name')
+        return res


### PR DESCRIPTION
A traceback occurs when the user tries to open IAP accounts after uninstalling the SMS module.

To reproduce:
1) Install hr
2) open IAP accounts from settings/technical/iap/iap accounts 
3) Create a new iap account with service as `SMS`
4) Uninstall `SMS` module
5) Try to open the iap accounts again

Error:-
```
ValueError: Invalid field 'sender_name' in 'iap.account'
```

This error occurs from the below line

https://github.com/odoo/odoo/blob/1e7c2ca8c929d15c9015b960f7fcbe4560413e98/addons/iap/models/iap_account.py#L128

Because when the user creates an iap account with service_name as `SMS`,
We include `sender_name` in the dict of updating fields.

https://github.com/odoo/odoo/blob/1e7c2ca8c929d15c9015b960f7fcbe4560413e98/addons/iap/models/iap_account.py#L123-L126

But, the `sender_name` field is defined in the SMS module, 
So it will lead to the above traceback as the `SMS` module is uninstalled.

https://github.com/odoo/odoo/blob/1e7c2ca8c929d15c9015b960f7fcbe4560413e98/addons/sms/models/iap_account.py#L9

sentry-6249864173

