### PR TITLE
[FIX] pos_restaurant,product: prevent parseerror when user deletes combo choices

### DIFF
--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -106,7 +106,7 @@ class PosConfig(models.Model):
     def load_onboarding_restaurant_scenario(self):
         ref_name = 'pos_restaurant.pos_config_main_restaurant'
         if not self.env.ref(ref_name, raise_if_not_found=False):
-            self._load_restaurant_data()
+            self.with_context(load_data=True)._load_restaurant_data()
 
         journal, payment_methods_ids = self._create_journal_and_payment_methods(cash_journal_vals={'name': 'Cash Restaurant', 'show_on_dashboard': False})
         restaurant_categories = self.get_record_by_ref([

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -458,7 +458,7 @@ class ProductTemplate(models.Model):
     @api.constrains('type', 'combo_ids')
     def _check_combo_ids_not_empty(self):
         for template in self:
-            if template.type == 'combo' and not template.combo_ids:
+            if template.type == 'combo' and not template.combo_ids and not self.env.context.get('load_data'):
                 raise ValidationError(_("A combo product must contain at least 1 combo choice."))
 
     @api.constrains('type', 'combo_ids', 'sale_ok')


### PR DESCRIPTION
Currently a Traceback occurs when the user deletes the combo choices.

Error: `ParseError: while parsing /home/odoo/src/odoo/saas-18.1/addons/pos_restaurant/data/scenarios/restaurant_data.xml:607 A combo product must contain at least 1 combo choice.`

Steps to reproduce above error :-
- Install 'Point of Sale' application.
- Open POS and click 'Restaurant' button.
- POS > Products > Combo Choices, delete the combo choices.
- Now archive the 'Restaurant' in POS, again click 'Restaurant' and delete it.
- Open POS again and click 'Restaurant' button.
- The error appears in the log.

The error occurs because the user deleted combo choices, and when 'Restaurant' is clicked again, it tries to access the deleted combo choices.

This commit fixes the error by checking if the master data is loaded again through the `context`.

sentry-6233666117