### PR TITLE
[FIX] point_of_sale: allow validation of zero-total orders

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -475,7 +475,10 @@ export class PaymentScreen extends Component {
         }
 
         if (
-            this.currentOrder.get_total_with_tax() != 0 &&
+            !floatIsZero(
+                this.currentOrder.get_total_with_tax(),
+                this.pos.currency.decimal_places
+            ) &&
             this.currentOrder.payment_ids.length === 0
         ) {
             this.notification.add(_t("Select a payment method to validate the order."));


### PR DESCRIPTION
Before this commit, a rounding error could leading to scenarios where
orders with a zero total could not be validated. For instance, adding
a product priced at $70 with a 15% tax included and then applying an
eWallet payment in PoS would result in a zero total. However, during
the payment step, the system erroneously prompted for an additional
zero-amount payment line, causing confusion and preventing order
validation.

opw-4487591

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
