### PR TITLE
[FIX] l10n_sa_edi_pos: prevent error when validating zero total orders

### DIFF
--- a/addons/l10n_sa_edi_pos/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi_pos/models/account_edi_xml_ubl_21_zatca.py
@@ -9,6 +9,6 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
             Return payment means code to be used to set the value on the XML file
         """
         res = super()._l10n_sa_get_payment_means_code(invoice)
-        if invoice._l10n_sa_is_simplified() and invoice.pos_order_ids:
+        if invoice._l10n_sa_is_simplified() and invoice.pos_order_ids.payment_ids:
             res = invoice.pos_order_ids.payment_ids[0].payment_method_id.type
         return res


### PR DESCRIPTION
Before this commit, attempting to validate an order with a zero total (such as when fully paid using an eWallet) would result in an error.

opw-4487591

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
