### PR TITLE
[FIX] website_sale_loyalty: Decimal rounding comparison issue

### DIFF
--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -5,6 +5,7 @@ from werkzeug.urls import url_encode, url_parse
 from odoo import http, _
 from odoo.exceptions import UserError, ValidationError
 from odoo.http import request
+from odoo.tools import float_compare
 
 from odoo.addons.website_sale.controllers import main
 
@@ -158,7 +159,8 @@ class PaymentPortal(main.PaymentPortal):
             initial_amount = order_sudo.amount_total
             order_sudo._update_programs_and_rewards()
             order_sudo.validate_taxes_on_sales_order()  # re-applies taxcloud taxes if necessary
-            if initial_amount != order_sudo.amount_total:
+            rounding = order_sudo.currency_id.rounding
+            if float_compare(order_sudo.amount_total, initial_amount, precision_rounding=rounding) != 0:
                 raise ValidationError(
                     _("Cannot process payment: applied reward was changed or has expired.")
                 )


### PR DESCRIPTION
Steps
-----
1. Add an item to the cart (ensure the total price has decimals).
2. During checkout, apply a coupon (e.g., a 50% discount).
3. Attempt to validate the payment.


Issue
-----
The frontend user encounters the following error:
"Cannot process payment: applied reward was changed or has expired."

Cause
-----
In some cases, the comparison between initial_amount and the new amount_total fails due to a small decimal difference (e.g., 0.00002).

Solution
--------
Use the float_compare function to handle precise rounding.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
