### PR TITLE
[FIX] account: prevent error on opening catalog

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3094,6 +3094,7 @@ class AccountMove(models.Model):
         fields = fields or self._get_default_read_fields()
         return super().read(fields, load)
 
+    @api.model
     def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None, **read_kwargs):
         fields = fields or self._get_default_read_fields()
         return super().search_read(domain, fields, offset, limit, order, **read_kwargs)

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1329,6 +1329,7 @@ class AccountMoveLine(models.Model):
         fields = fields or self._get_default_read_fields()
         return super().read(fields, load)
 
+    @api.model
     def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None, **read_kwargs):
         fields = fields or self._get_default_read_fields()
         return super().search_read(domain, fields, offset, limit, order, **read_kwargs)

--- a/addons/account/static/tests/tours/account_product_catalog_tests.js
+++ b/addons/account/static/tests/tours/account_product_catalog_tests.js
@@ -1,0 +1,29 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_use_product_catalog_on_invoice", {
+    steps: () => [
+        {
+            content: "Click Catalog Button",
+            trigger: "button[name=action_add_from_catalog]",
+            run: "click",
+        },
+        {
+            content: "Add a Product",
+            trigger: ".o_kanban_record:contains(Test Product)",
+            run: "click",
+        },
+        {
+            content: "Wait for it",
+            trigger: ".o_product_added",
+        },
+        {
+            content: "Back to Invoice",
+            trigger: ".o-kanban-button-back",
+            run: "click",
+        },
+        {
+            content: "Ensure product is added",
+            trigger: ".o_field_product_label_section_and_note_cell:contains(Test Product)",
+        },
+    ],
+});

--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -88,3 +88,10 @@ class TestUi(AccountTestInvoicingHttpCommon):
         product.supplier_taxes_id = new_tax
 
         self.start_tour("/odoo", 'account_tax_group', login="admin")
+
+    def test_use_product_catalog_on_invoice(self):
+        self.product.write({
+            'is_favorite': True,
+            'default_code': '0',
+        })
+        self.start_tour("/odoo/customer-invoices/new", 'test_use_product_catalog_on_invoice', login="admin")


### PR DESCRIPTION
This error occurs when we click on the ``Catalog`` button in move lines.

Steps to reproduce:
---
- Install ``Invoicing`` module
- Open NEW invoice > Click on ``Catalog`` in Invoice lines

Traceback:
---
```
IndexError: list index out of range
  File "odoo/http.py", line 2406, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1934, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1997, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1964, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2214, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 334, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 733, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 31, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/service/model.py", line 51, in call_kw
    ids, args = args[0], args[1:]
```

The issue arises because the absence of the ``@api.model`` decorator in the original implementation prevents Odoo's ORM from properly recognizing the method as a ``model method``. To resolve this, the ``@api.model`` decorator was added above the ``search_read`` method.

sentry-6232832214

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
