### PR TITLE
[FIX] web: conserve keyboard nav after selecting an emoji category

### DIFF
--- a/addons/web/static/src/core/emoji_picker/emoji_picker.xml
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.xml
@@ -19,7 +19,7 @@
             </div>
             <t t-set="itemIndex" t-value="0"/>
             <t t-set="emojisFromSearch" t-value="getEmojisFromSearch()"/>
-            <div class="o-EmojiPicker-content overflow-auto d-flex flex-grow-1 w-100 flex-wrap align-items-center user-select-none mt-1" t-att-class="emojisFromSearch.length === 0 ? 'flex-column justify-content-center' : 'align-content-start'" t-ref="emoji-grid" t-on-scroll="highlightActiveCategory">
+            <div class="o-EmojiPicker-content overflow-auto d-flex flex-grow-1 w-100 flex-wrap align-items-center user-select-none mt-1" t-att-class="emojisFromSearch.length === 0 ? 'flex-column justify-content-center' : 'align-content-start'" t-ref="emoji-grid" t-on-scroll="highlightActiveCategory" tabindex="-1">
                 <t t-if="searchTerm and emojisFromSearch.length === 0" class="d-flex flex-column">
                     <span class="o-EmojiPicker-empty">😢</span>
                     <span class="fs-5 text-muted">No emoji matches your search</span>
@@ -73,13 +73,13 @@
 </t>
 
 <t t-name="web.EmojiPicker.tab">
-    <span class="o-Emoji text-center fs-5 rounded-3 cursor-pointer d-flex align-items-center align-self-stretch" t-att-class="{'o-active': category.sortId === state.categoryId}" t-att-title="category.name" t-att-data-id="category.sortId" t-on-click="() => this.selectCategory(category.sortId)">
+    <span class="o-Emoji text-center fs-5 rounded-3 cursor-pointer d-flex align-items-center align-self-stretch" tabindex="0" t-att-class="{'o-active': category.sortId === state.categoryId}" t-att-title="category.name" t-att-data-id="category.sortId" t-on-keydown.stop.capture="(ev) => this.onKeydownCategory(ev, category.sortId)" t-on-click="() => this.selectCategory(category.sortId)">
         <span t-esc="category.title"/>
     </span>
 </t>
 
 <t t-name="web.EmojiPicker.tabNext">
-    <span class="o-Emoji text-center fs-5 rounded-3 cursor-pointer d-flex align-items-center align-self-stretch" title="To previous categories" t-on-click="onClickToNextCategories">
+    <span class="o-Emoji text-center fs-5 rounded-3 cursor-pointer d-flex align-items-center align-self-stretch" title="To next categories" t-on-click="onClickToNextCategories" t-on-keydown.stop.capture="onClickToNextCategories" tabindex="0">
         <span class="position-relative">
             <i class="oi oi-chevron-right fa-fw smaller opacity-0"/>
             <i class="oi oi-chevron-right fa-fw smaller position-absolute opacity-75" style="left: 3px; transform: translateY(75%);"/>
@@ -89,7 +89,7 @@
 </t>
 
 <t t-name="web.EmojiPicker.tabPrev">
-    <span class="o-Emoji text-center fs-5 rounded-3 cursor-pointer d-flex align-items-center align-self-stretch" title="To next categories" t-on-click="onClickToPreviousCategories">
+    <span class="o-Emoji text-center fs-5 rounded-3 cursor-pointer d-flex align-items-center align-self-stretch" title="To previous categories" t-on-click="onClickToPreviousCategories" t-on-keydown.stop.capture="onClickToPreviousCategories" tabindex="0">
         <span class="position-relative">
             <i class="oi oi-chevron-left fa-fw smaller opacity-0"/>
             <i class="oi oi-chevron-left fa-fw smaller position-absolute opacity-75" style="left: 3px; transform: translateY(75%);"/>


### PR DESCRIPTION
Before this PR, the keyboard navigation capability was lost after clicking on a category.
This PR adds a tabindex to avoid losing focus on the emoji picker.
