### PR TITLE
[FIX] web: prevent error when user clicks the call icon while creating a record

### DIFF
--- a/addons/web/static/src/views/fields/phone/phone_field.xml
+++ b/addons/web/static/src/views/fields/phone/phone_field.xml
@@ -4,7 +4,7 @@
     <t t-name="web.PhoneField">
         <div class="o_phone_content d-inline-flex w-100">
             <t t-if="props.readonly">
-                <a t-if="props.record.data[props.name]" class="o_form_uri" t-att-href="phoneHref" t-esc="props.record.data[props.name]"/>
+                <a t-if="props.record.data[props.name]" class="o_form_uri" target="_blank" t-att-href="phoneHref" t-esc="props.record.data[props.name]"/>
             </t>
             <t t-else="">
                 <input
@@ -24,6 +24,7 @@
             <a
                 t-if="props.record.data[props.name]"
                 t-att-href="phoneHref"
+                target="_blank"
                 class="o_phone_form_link ms-3 d-inline-flex align-items-center"
             >
                 <i class="fa fa-phone"></i><small class="fw-bold ms-1">Call</small>

--- a/addons/web/static/tests/views/fields/phone_field_tests.js
+++ b/addons/web/static/tests/views/fields/phone_field_tests.js
@@ -264,4 +264,49 @@ QUnit.module("Fields", (hooks) => {
         );
         assert.hasAttrValue(phone, "href", "tel:+12345678900", "href should not contain any space");
     });
+
+    QUnit.test(
+        "New record, fill in phone field, then click on call icon and save",
+        async function (assert) {
+            await makeView({
+                serverData,
+                type: "form",
+                resModel: "partner",
+                arch: `
+                    <form>
+                        <sheet>
+                            <group>
+                                <field name="display_name" required="1"/>
+                                <field name="foo" widget="phone"/>
+                            </group>
+                        </sheet>
+                    </form>`,
+            });
+
+            await editInput(target, "div[name='display_name'] input[type='text']", "TEST");
+            await editInput(target, "div[name='foo'] input[type='tel']", "+12345678900");
+            target.querySelector(".o_field_widget[name=foo] input").focus();
+            await click(target.querySelector(".o_phone_form_link"));
+            assert.doesNotHaveClass(
+                target.querySelector(".o_form_status_indicator_buttons"),
+                "invisible",
+                "save button should be visible"
+            );
+            await clickSave(target);
+
+            assert.deepEqual(
+                target.querySelector(".o_field_widget[name=display_name] input").value,
+                "TEST"
+            );
+            assert.strictEqual(
+                target.querySelector(".o_field_widget[name=foo] input").value,
+                "+12345678900"
+            );
+            assert.hasClass(
+                target.querySelector(".o_form_status_indicator_buttons"),
+                "invisible",
+                "save button should be invisible"
+            );
+        }
+    );
 });


### PR DESCRIPTION
Currently an exception was generated when the user tries to save the new employee record after clicking on call icon.

Steps to reproduce:
1) Install HR module
2) Create a new employee record by giving employee name 
3) Click on the call icon of work phone
4) Now tries to save the new employee record

Error: `KeyError:  name`

This issue occurs because, while clicking the call widget, it creates the record but does not update it in the browser.

As a result, when the user tries to save manually, It again  creates the record with an empty vals_list.

So it will leads to the above traceback from the below lines

https://github.com/odoo/odoo/blob/2d64d94487d24278dc3c6615343a793e1ec94daf/addons/hr/models/hr_employee.py#L386

This fix resolves the issue by ensuring that clicking the call icon before saving retains the user input. Additionally, I have added a test to verify this behavior.

sentry-6234873849

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
