### PR TITLE
[IMP] account, *: change name of Journal to Sales and Purchases

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -1033,7 +1033,7 @@ class AccountChartTemplate(models.AbstractModel):
     def _get_account_journal(self, template_code):
         return {
             "sale": {
-                'name': _('Customer Invoices'),
+                'name': _('Sales'),
                 'type': 'sale',
                 'code': _('INV'),
                 'show_on_dashboard': True,
@@ -1041,7 +1041,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'sequence': 5,
             },
             "purchase": {
-                'name': _('Vendor Bills'),
+                'name': _('Purchases'),
                 'type': 'purchase',
                 'code': _('BILL'),
                 'show_on_dashboard': True,

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -275,7 +275,7 @@ class TestAccountJournalAlias(AccountTestInvoicingCommon, MailCommon):
         # assert base test data
         company_name = 'company_1_data'
         journal_code = 'BILL'
-        journal_name = 'Vendor Bills'
+        journal_name = 'Purchases'
         journal_alias = journal.alias_id
         self.assertEqual(journal.code, journal_code)
         self.assertEqual(journal.company_id.name, company_name)
@@ -295,7 +295,7 @@ class TestAccountJournalAlias(AccountTestInvoicingCommon, MailCommon):
         self.assertFalse(journal_alias.alias_force_thread_id, 'Journal alias should create new moves')
         self.assertEqual(journal_alias.alias_model_id, self.env['ir.model']._get('account.move'),
                          'Journal alias targets moves')
-        self.assertEqual(journal_alias.alias_name, f'vendor-bills-{company_name}')
+        self.assertEqual(journal_alias.alias_name, f'purchases-{company_name}')
         self.assertEqual(journal_alias.alias_parent_model_id, self.env['ir.model']._get('account.journal'),
                          'Journal alias owned by journal itself')
         self.assertEqual(journal_alias.alias_parent_thread_id, journal.id,
@@ -305,10 +305,10 @@ class TestAccountJournalAlias(AccountTestInvoicingCommon, MailCommon):
         for alias_name, expected in [
             (False, False),
             ('', False),
-            (' ', f'vendor-bills-{company_name}'),  # error recuperation
-            ('.', f'vendor-bills-{company_name}'),  # error recuperation
-            ('😊', f'vendor-bills-{company_name}'),  # resets, unicode not supported
-            ('ぁ', f'vendor-bills-{company_name}'),  # resets, non ascii not supported
+            (' ', f'purchases-{company_name}'),  # error recuperation
+            ('.', f'purchases-{company_name}'),  # error recuperation
+            ('😊', f'purchases-{company_name}'),  # resets, unicode not supported
+            ('ぁ', f'purchases-{company_name}'),  # resets, non ascii not supported
             ('Youpie Boum', 'youpie-boum'),
         ]:
             with self.subTest(alias_name=alias_name):

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -44,7 +44,7 @@
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                         <div class="oe_title">
                             <label for="name"/>
-                            <h1><field name="name" placeholder="e.g. Customer Invoices"/></h1>
+                            <h1><field name="name" placeholder="e.g. Sales"/></h1>
                         </div>
                         <group>
                             <group>

--- a/addons/l10n_fr_account/tests/test_fec_export.py
+++ b/addons/l10n_fr_account/tests/test_fec_export.py
@@ -18,9 +18,9 @@ class TestFECExport(AccountTestInvoicingCommon):
             'JournalCode|JournalLib|EcritureNum|EcritureDate|CompteNum|CompteLib|CompAuxNum|CompAuxLib|PieceRef|PieceDate|EcritureLib|Debit|Credit|EcritureLet|DateLet|ValidDate|Montantdevise|Idevise\r\n'
             'OUV|Balance initiale|OUVERTURE/2020|20200101|999999|Undistributed Profits/Losses|||-|20200101|/|0,00| 000000000003000,00|||20200101||\r\n'
             f'OUV|Balance initiale|OUVERTURE/2020|20200101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20200101|/| 000000000003000,00|0,00|||20200101||\r\n'
-            'INV|Customer Invoices|INV/2020/00001|20200101|400000|Product Sales|||-|20200101|test line|0,00| 000000000001000,00|||20200101|-000000000001000,00|USD\r\n'
-            'INV|Customer Invoices|INV/2020/00001|20200101|400000|Product Sales|||-|20200101|test line|0,00| 000000000002000,00|||20200101|-000000000002000,00|USD\r\n'
-            f'INV|Customer Invoices|INV/2020/00001|20200101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20200101|INV/2020/00001| 000000000003000,00|0,00|||20200101| 000000000003000,00|USD'
+            'INV|Sales|INV/2020/00001|20200101|400000|Product Sales|||-|20200101|test line|0,00| 000000000001000,00|||20200101|-000000000001000,00|USD\r\n'
+            'INV|Sales|INV/2020/00001|20200101|400000|Product Sales|||-|20200101|test line|0,00| 000000000002000,00|||20200101|-000000000002000,00|USD\r\n'
+            f'INV|Sales|INV/2020/00001|20200101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20200101|INV/2020/00001| 000000000003000,00|0,00|||20200101| 000000000003000,00|USD'
         )
 
     def test_fec_sub_companies(self):
@@ -57,14 +57,14 @@ class TestFECExport(AccountTestInvoicingCommon):
         self.assertEqual(
             result['file_content'].decode(),
             "JournalCode|JournalLib|EcritureNum|EcritureDate|CompteNum|CompteLib|CompAuxNum|CompAuxLib|PieceRef|PieceDate|EcritureLib|Debit|Credit|EcritureLet|DateLet|ValidDate|Montantdevise|Idevise\r\n"
-            "INV|Customer Invoices|INV/2021/00001|20210101|400000|Product Sales|||-|20210101|test line|0,00| 000000000000100,00|||20210101|-000000000000100,00|USD\r\n"
-            f"INV|Customer Invoices|INV/2021/00001|20210101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20210101|INV/2021/00001| 000000000000100,00|0,00|||20210101| 000000000000100,00|USD\r\n"
-            "INV|Customer Invoices|INV/2021/00002|20210101|400000|Product Sales|||-|20210101|test line|0,00| 000000000000200,00|||20210101|-000000000000200,00|USD\r\n"
-            f"INV|Customer Invoices|INV/2021/00002|20210101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20210101|INV/2021/00002| 000000000000200,00|0,00|||20210101| 000000000000200,00|USD\r\n"
-            "INV|Customer Invoices|INV/2021/00003|20210101|400000|Product Sales|||-|20210101|test line|0,00| 000000000000300,00|||20210101|-000000000000300,00|USD\r\n"
-            f"INV|Customer Invoices|INV/2021/00003|20210101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20210101|INV/2021/00003| 000000000000300,00|0,00|||20210101| 000000000000300,00|USD\r\n"
-            "INV|Customer Invoices|INV/2021/00004|20210101|400000|Product Sales|||-|20210101|test line|0,00| 000000000000400,00|||20210101|-000000000000400,00|USD\r\n"
-            f"INV|Customer Invoices|INV/2021/00004|20210101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20210101|INV/2021/00004| 000000000000400,00|0,00|||20210101| 000000000000400,00|USD"
+            "INV|Sales|INV/2021/00001|20210101|400000|Product Sales|||-|20210101|test line|0,00| 000000000000100,00|||20210101|-000000000000100,00|USD\r\n"
+            f"INV|Sales|INV/2021/00001|20210101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20210101|INV/2021/00001| 000000000000100,00|0,00|||20210101| 000000000000100,00|USD\r\n"
+            "INV|Sales|INV/2021/00002|20210101|400000|Product Sales|||-|20210101|test line|0,00| 000000000000200,00|||20210101|-000000000000200,00|USD\r\n"
+            f"INV|Sales|INV/2021/00002|20210101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20210101|INV/2021/00002| 000000000000200,00|0,00|||20210101| 000000000000200,00|USD\r\n"
+            "INV|Sales|INV/2021/00003|20210101|400000|Product Sales|||-|20210101|test line|0,00| 000000000000300,00|||20210101|-000000000000300,00|USD\r\n"
+            f"INV|Sales|INV/2021/00003|20210101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20210101|INV/2021/00003| 000000000000300,00|0,00|||20210101| 000000000000300,00|USD\r\n"
+            "INV|Sales|INV/2021/00004|20210101|400000|Product Sales|||-|20210101|test line|0,00| 000000000000400,00|||20210101|-000000000000400,00|USD\r\n"
+            f"INV|Sales|INV/2021/00004|20210101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20210101|INV/2021/00004| 000000000000400,00|0,00|||20210101| 000000000000400,00|USD"
         )
 
         # Select only parent company
@@ -81,6 +81,6 @@ class TestFECExport(AccountTestInvoicingCommon):
         self.assertEqual(
             result['file_content'].decode(),
             "JournalCode|JournalLib|EcritureNum|EcritureDate|CompteNum|CompteLib|CompAuxNum|CompAuxLib|PieceRef|PieceDate|EcritureLib|Debit|Credit|EcritureLet|DateLet|ValidDate|Montantdevise|Idevise\r\n"
-            "INV|Customer Invoices|INV/2021/00001|20210101|400000|Product Sales|||-|20210101|test line|0,00| 000000000000100,00|||20210101|-000000000000100,00|USD\r\n"
-            f"INV|Customer Invoices|INV/2021/00001|20210101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20210101|INV/2021/00001| 000000000000100,00|0,00|||20210101| 000000000000100,00|USD"
+            "INV|Sales|INV/2021/00001|20210101|400000|Product Sales|||-|20210101|test line|0,00| 000000000000100,00|||20210101|-000000000000100,00|USD\r\n"
+            f"INV|Sales|INV/2021/00001|20210101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20210101|INV/2021/00001| 000000000000100,00|0,00|||20210101| 000000000000100,00|USD"
         )

--- a/addons/l10n_uy/models/template_uy.py
+++ b/addons/l10n_uy/models/template_uy.py
@@ -41,13 +41,13 @@ class AccountChartTemplate(models.AbstractModel):
     def _get_uy_account_journal(self):
         return {
             'sale': {
-                "name": _("Customer Invoices"),
+                "name": _("Sales"),
                 "code": "0001",
                 "l10n_latam_use_documents": True,
                 "refund_sequence": False,
             },
             'purchase': {
-                "name": _("Vendor Bills"),
+                "name": _("Purchases"),
                 "code": "0002",
                 "l10n_latam_use_documents": True,
                 "refund_sequence": False,

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -1252,5 +1252,5 @@ stepUtils.toggleHomeMenu()[0],
 {
     isActive: ["auto", "desktop", "enterprise"],
     content: "check that we're back on the dashboard",
-    trigger: 'a:contains("Customer Invoices")',
+    trigger: 'a:contains("Sales")',
 }]});

--- a/odoo/addons/test_main_flows/tests/test_flow.py
+++ b/odoo/addons/test_main_flows/tests/test_flow.py
@@ -62,7 +62,7 @@ class BaseTestUi(AccountTestMockOnlineSyncCommon):
         IrDefault.set('res.partner', 'property_account_position_id', False, company_id=self.env.company.id)
 
         self.expenses_journal = self.env['account.journal'].create({
-            'name': 'Vendor Bills - Test',
+            'name': 'Purchases - Test',
             'code': 'TEXJ',
             'type': 'purchase',
             'refund_sequence': True,
@@ -78,7 +78,7 @@ class BaseTestUi(AccountTestMockOnlineSyncCommon):
         self.bank_journal.inbound_payment_method_line_ids.payment_account_id = a_sale
 
         self.sales_journal = self.env['account.journal'].create({
-            'name': 'Customer Invoices - Test',
+            'name': 'Sales - Test',
             'code': 'TINV',
             'type': 'sale',
             'default_account_id': a_sale.id,


### PR DESCRIPTION
The journal have a name that implies that you should only have Customer Invoices or Vendor Bills but you can also get refunds and credit notes.

task-4427096




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
