### PR TITLE
[FIX] resource : Remove date condition when computing avg hours per day

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -164,7 +164,6 @@ class ResourceCalendar(models.Model):
     def _get_global_attendances(self):
         return self.attendance_ids.filtered(lambda attendance:
             attendance.day_period != 'lunch'
-            and not attendance.date_from and not attendance.date_to
             and not attendance.resource_id and not attendance.display_type)
 
     def _get_hours_per_day(self, attendances):


### PR DESCRIPTION
### Steps to reproduce:
	- Go to Working schedule
	- Add the starting and ending dates for each line
	- Notice that the average hours per day will become 0

### Cause:
When computing 'hours_per_day' we are fetching the attendances sum all their duration and divide them by their count. When fetching those attendances we are filtering them on some conditions one of those is not getting the attendance line if it has start and end dates.

https://github.com/odoo/odoo/blob/74784c26b7cfcea13e75b2939f377521aa40a492/addons/resource/models/resource_calendar.py#L164-L168

### Fix:
As per discussed with GMF it is better to remove the date condition.

opw-4471522