### PR TITLE
[FIX] *: tours

### DIFF
--- a/addons/hr_expense/static/src/js/tours/show_expense_receipt_tour.js
+++ b/addons/hr_expense/static/src/js/tours/show_expense_receipt_tour.js
@@ -19,6 +19,10 @@ registry.category("web_tour.tours").add("show_expense_receipt_tour", {
             run: "click",
         },
         {
+            content: "Wait chatter is loaded to avoid lost focus on the next step",
+            trigger: ".o-mail-Chatter:contains(the conversation is empty)",
+        },
+        {
             content: "Click on an expense line 2",
             trigger: '.o_data_row .o_data_cell[data-tooltip="expense_2"]',
             run: "click",

--- a/addons/mail/static/src/js/tours/discuss_channel_tour.js
+++ b/addons/mail/static/src/js/tours/discuss_channel_tour.js
@@ -52,24 +52,10 @@ registry.category("web_tour.tours").add("discuss_channel_tour", {
             run: "click",
         },
         {
-            trigger: ".o-mail-Message",
-            content: _t("Click on your message"),
+            trigger: ".o-mail-Message:contains(today at)",
+            content: _t("Hover on your message and mark as todo"),
             tooltipPosition: "top",
-            run: "click",
-        },
-        {
-            trigger: ".o-mail-Message [title='Expand']",
-            content: _t("Expand options"),
-            tooltipPosition: "top",
-            run: "click",
-        },
-        {
-            trigger: ".o-mail-Message [title='Mark as Todo']",
-            content: markup(
-                _t("Messages can be <b>starred</b> to remind you to check back later.")
-            ),
-            tooltipPosition: "bottom",
-            run: "click",
+            run: "hover && click .o-mail-Message [title='Mark as Todo']",
         },
         {
             trigger: "button:contains(Starred)",

--- a/addons/website/static/tests/tours/gray_color_palette.js
+++ b/addons/website/static/tests/tours/gray_color_palette.js
@@ -32,12 +32,12 @@ registerWebsitePreviewTour('website_gray_color_palette', {
     },
     {
         content: "Drag the hue slider",
-        trigger: '.o_we_slider_tint[data-param="gray-hue"]',
-        run() {
-            const slider = document.querySelector('.o_we_slider_tint[data-param="gray-hue"] input');
-            slider.value = 100;
-            slider.dispatchEvent(new InputEvent('change', {bubbles: true}));
-        },
+        trigger: '.o_we_slider_tint[data-param="gray-hue"] input',
+        run: "range 100",
+    },
+    {
+        content: "Wait for loading",
+        trigger: ":iframe body:has(.o_we_ui_loading)",
     },
     {
         content: "Check the preview of the gray 900 after hue change",
@@ -46,12 +46,12 @@ registerWebsitePreviewTour('website_gray_color_palette', {
     ...waitForCSSReload(),
     {
         content: "Drag the saturation slider",
-        trigger: '.o_we_user_value_widget[data-param="gray-extra-saturation"]',
-        run() {
-            const slider = document.querySelector('.o_we_user_value_widget[data-param="gray-extra-saturation"] input');
-            slider.value = 15;
-            slider.dispatchEvent(new InputEvent('change', {bubbles: true}));
-        }
+        trigger: '.o_we_user_value_widget[data-param="gray-extra-saturation"] input',
+        run: "range 15",
+    },
+    {
+        content: "Wait for loading",
+        trigger: ":iframe body:has(.o_we_ui_loading)",
     },
     {
         content: "Check the preview of the gray 900 after saturation change",

--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -150,8 +150,8 @@ registerWebsitePreviewTour("website_media_dialog_image_shape", {
     changeOption("ImageTools", "we-button[data-set-img-shape]"),
     {
         content: "Open MediaDialog from an image",
-        trigger: ":iframe .s_text_image img[data-shape]",
-        run: "dblclick",
+        trigger: "we-customizeblock-option:contains(media) we-button:contains(replace)",
+        run: "click",
     },
     {
         content: "Click on the 'Icons' tab",

--- a/addons/website/static/tests/tours/website_form_editor_frontend.js
+++ b/addons/website/static/tests/tours/website_form_editor_frontend.js
@@ -218,6 +218,10 @@ registry.category("web_tour.tours").add('website_form_contactus_submit', {
     // As the demo portal user, only two inputs needs to be filled to send
     // the email
     {
+        isActive: ["body:has(.o-livechat-root)"],
+        trigger: ":shadow span:contains(select an option above)",
+    },
+    {
         content: "Fill in the subject",
         trigger: 'input[name="subject"]',
         run: "edit Test",

--- a/addons/website_slides/static/tests/tours/slides_course_member.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member.js
@@ -151,15 +151,15 @@ registry.category("web_tour.tours").add("course_member", {
             run: "click",
         },
         {
-            trigger: ".modal .modal-body i.fa.fa-star:eq(2)",
+            trigger: ".modal.modal_shown .modal-body i.fa.fa-star:eq(2)",
             run: "click",
         },
         {
-            trigger: ".modal .modal-body textarea",
+            trigger: ".modal.modal_shown .modal-body textarea",
             run: "edit This is a great course. Top !",
         },
         {
-            trigger: ".modal button:contains(review)",
+            trigger: ".modal.modal_shown button:contains(review)",
             run: "click",
         },
         {


### PR DESCRIPTION
In this commit, we fix multiple tours on step that can cause non deterministic behaviors:

- show_expense_receipt_tour: Wait the chatter is loaded to prevent lost focus on the input targetted on the next step.
- discuss_channel_tour: use hover helper to concat three steps.
- website_gray_color_palette: use range hoot helper and wait ui loading appears before to wait it disappears... In the goal to change tour engine and base it on waitFor instead of MutationObserver, these additionnal steps are crucial.
- website_form_contactus_submit: wait livechat if module is installed.
- course_member: wait the modal is shown before click on element inside.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
