### PR TITLE
[IMP] hr_attendance: hide refuse button if no extra hours

### DIFF
--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -126,7 +126,7 @@
                                     <button
                                         class="oe_stat_button"
                                         string="Refuse"
-                                        invisible="not is_manager or overtime_status not in ['to_approve', 'approved']"
+                                        invisible="not is_manager or overtime_status not in ['to_approve', 'approved'] or validated_overtime_hours == 0"
                                         name="action_refuse_overtime"
                                         icon="fa-times"
                                         type="object"


### PR DESCRIPTION
Since logging new attendance is approved by default, the refuse button for rejecting extra zero hours should be invisible.

task-4320142

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
