### PR TITLE
[IMP] web: escape translated strings that contain markup

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -28,7 +28,7 @@ import {
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { FileUploader } from "@web/views/fields/file_handler";
-import { escape, sprintf } from "@web/core/utils/strings";
+import { escape } from "@web/core/utils/strings";
 import { isDisplayStandalone, isIOS, isMobileOS } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
@@ -249,49 +249,48 @@ export class Composer extends Component {
 
     get CANCEL_OR_SAVE_EDIT_TEXT() {
         if (this.ui.isSmall) {
-            return markup(
-                sprintf(
-                    escape(
-                        _t(
-                            "%(open_button)s%(icon)s%(open_em)sDiscard editing%(close_em)s%(close_button)s"
-                        )
+            return _t(
+                "%(open_button)s%(icon)s%(open_em)sDiscard editing%(close_em)s%(close_button)s",
+                {
+                    open_button: markup(
+                        `<button class='btn px-1 py-0' data-type="${escape(
+                            EDIT_CLICK_TYPE.CANCEL
+                        )}">`
                     ),
-                    {
-                        open_button: `<button class='btn px-1 py-0' data-type="${escape(
+                    close_button: markup("</button>"),
+                    icon: markup(
+                        `<i class='fa fa-times-circle pe-1' data-type="${escape(
                             EDIT_CLICK_TYPE.CANCEL
-                        )}">`,
-                        close_button: "</button>",
-                        icon: `<i class='fa fa-times-circle pe-1' data-type="${escape(
-                            EDIT_CLICK_TYPE.CANCEL
-                        )}"></i>`,
-                        open_em: `<em data-type="${escape(EDIT_CLICK_TYPE.CANCEL)}">`,
-                        close_em: "</em>",
-                    }
-                )
+                        )}"></i>`
+                    ),
+                    open_em: markup(`<em data-type="${escape(EDIT_CLICK_TYPE.CANCEL)}">`),
+                    close_em: markup("</em>"),
+                }
             );
         } else {
-            const translation1 = _t(
-                "%(open_samp)sEscape%(close_samp)s %(open_em)sto %(open_cancel)scancel%(close_cancel)s%(close_em)s, %(open_samp)sCTRL-Enter%(close_samp)s %(open_em)sto %(open_save)ssave%(close_save)s%(close_em)s"
-            );
-            const translation2 = _t(
-                "%(open_samp)sEscape%(close_samp)s %(open_em)sto %(open_cancel)scancel%(close_cancel)s%(close_em)s, %(open_samp)sEnter%(close_samp)s %(open_em)sto %(open_save)ssave%(close_save)s%(close_em)s"
-            );
-            return markup(
-                sprintf(escape(this.props.mode === "extended" ? translation1 : translation2), {
-                    open_samp: "<samp>",
-                    close_samp: "</samp>",
-                    open_em: "<em>",
-                    close_em: "</em>",
-                    open_cancel: `<a role="button" href="#" data-type="${escape(
-                        EDIT_CLICK_TYPE.CANCEL
-                    )}">`,
-                    close_cancel: "</a>",
-                    open_save: `<a role="button" href="#" data-type="${escape(
-                        EDIT_CLICK_TYPE.SAVE
-                    )}">`,
-                    close_save: "</a>",
-                })
-            );
+            const tags = {
+                open_samp: markup("<samp>"),
+                close_samp: markup("</samp>"),
+                open_em: markup("<em>"),
+                close_em: markup("</em>"),
+                open_cancel: markup(
+                    `<a role="button" href="#" data-type="${escape(EDIT_CLICK_TYPE.CANCEL)}">`
+                ),
+                close_cancel: markup("</a>"),
+                open_save: markup(
+                    `<a role="button" href="#" data-type="${escape(EDIT_CLICK_TYPE.SAVE)}">`
+                ),
+                close_save: markup("</a>"),
+            };
+            return this.props.mode === "extended"
+                ? _t(
+                      "%(open_samp)sEscape%(close_samp)s %(open_em)sto %(open_cancel)scancel%(close_cancel)s%(close_em)s, %(open_samp)sCTRL-Enter%(close_samp)s %(open_em)sto %(open_save)ssave%(close_save)s%(close_em)s",
+                      tags
+                  )
+                : _t(
+                      "%(open_samp)sEscape%(close_samp)s %(open_em)sto %(open_cancel)scancel%(close_cancel)s%(close_em)s, %(open_samp)sEnter%(close_samp)s %(open_em)sto %(open_save)ssave%(close_save)s%(close_em)s",
+                      tags
+                  );
         }
     }
 

--- a/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
+++ b/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
@@ -3,7 +3,6 @@ import { markup, reactive } from "@odoo/owl";
 import { parseVersion } from "@mail/utils/common/misc";
 import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
-import { escape, sprintf } from "@web/core/utils/strings";
 import { _t } from "@web/core/l10n/translation";
 
 export const pttExtensionHookService = {
@@ -30,14 +29,14 @@ export const pttExtensionHookService = {
             },
             downloadURL: `https://chromewebstore.google.com/detail/discuss-push-to-talk/${EXT_ID}`,
             get downloadText() {
-                const translation = _t(
-                    `The Push-to-Talk feature is only accessible within tab focus. To enable the Push-to-Talk functionality outside of this tab, we recommend downloading our %(anchor_start)sextension%(anchor_end)s.`
-                );
-                return markup(
-                    sprintf(escape(translation), {
-                        anchor_start: `<a href="${this.downloadURL}" target="_blank" class="text-reset text-decoration-underline">`,
-                        anchor_end: "</a>",
-                    })
+                return _t(
+                    "The Push-to-Talk feature is only accessible within tab focus. To enable the Push-to-Talk functionality outside of this tab, we recommend downloading our %(anchor_start)sextension%(anchor_end)s.",
+                    {
+                        anchor_start: markup(
+                            `<a href="${this.downloadURL}" target="_blank" class="text-reset text-decoration-underline">`
+                        ),
+                        anchor_end: markup("</a>"),
+                    }
                 );
             },
         });

--- a/addons/web/static/src/views/fields/many2one/many2one_field.js
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.js
@@ -6,7 +6,7 @@ import { _t } from "@web/core/l10n/translation";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
 import { useChildRef, useOwnedDialogs, useService } from "@web/core/utils/hooks";
-import { escape, sprintf } from "@web/core/utils/strings";
+import { escape } from "@web/core/utils/strings";
 import { Many2XAutocomplete, useOpenMany2XRecord } from "@web/views/fields/relational_utils";
 import * as BarcodeScanner from "@web/core/barcode/barcode_dialog";
 import { isBarcodeScannerSupported } from "@web/core/barcode/barcode_video_scanner";
@@ -30,12 +30,10 @@ class CreateConfirmationDialog extends Component {
     }
 
     get dialogContent() {
-        return markup(
-            sprintf(escape(_t("Create %(value)s as a new %(field)s?")), {
-                value: `<strong>${escape(this.props.value)}</strong>`,
-                field: escape(this.props.name),
-            })
-        );
+        return _t("Create %(value)s as a new %(field)s?", {
+            value: markup(`<strong>${escape(this.props.value)}</strong>`),
+            field: this.props.name,
+        });
     }
 
     async onCreate() {

--- a/addons/website/static/src/components/fullscreen_indication/fullscreen_indication.js
+++ b/addons/website/static/src/components/fullscreen_indication/fullscreen_indication.js
@@ -1,6 +1,5 @@
 import { useBus } from "@web/core/utils/hooks";
 import { EventBus, Component, useState, markup } from "@odoo/owl";
-import { escape, sprintf } from "@web/core/utils/strings";
 import { _t } from "@web/core/l10n/translation";
 
 export class FullscreenIndication extends Component {
@@ -28,6 +27,6 @@ export class FullscreenIndication extends Component {
     }
 
     get fullScreenIndicationText() {
-        return markup(sprintf(escape(_t("Press %(key)s to exit full screen")), {key: "<span>esc</span>"}));
+        return _t("Press %(key)s to exit full screen", { key: markup("<span>esc</span>") });
     }
 }


### PR DESCRIPTION
Automatically escape source terms and non-markup values passed to `_t` if at least one of the inserted values is a markup.

This approach is believed to have the following benefits:

- More XSS-proof
    - Any piece of HTML that needs to be inserted has to be wrapped in a call to markup. This will increase the number of lines requiring special attention that will be caught by the CI/Security check.
    - Any part of the translated string that's not markup is escaped
 - Better syntax
    - It eliminates the need for the sprintf function to insert markup into the safely escaped translated string, as well as the need for the escape function to escape the string itself and the interpolated non-markup values.
  - API consistency (i.e. it matches the behavior of gettext with markups [as it currently exists](https://github.com/odoo/odoo/blob/bd6789ee4fd749d308e3715899ca2fc0e0ce005f/odoo/tools/translate.py#L457-L468) on the Python side)

## Before
```js
return markup(
    sprintf(escape(_t("Create %(value)s as a new %(field)s?")), {
        value: `<strong>${escape(this.props.value)}</strong>`,
        field: escape(this.props.name),
    })
);
```
## After
```js
return _t("Create %(value)s as a new %(field)s?", {
    value: markup(`<strong>${escape(this.props.value)}</strong>`),
    field: this.props.name,
});
```

Task-4519529