### PR TITLE
[FIX] sms: correctly fetch number on linked partner

### DIFF
--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -120,7 +120,7 @@ class SendSMS(models.TransientModel):
                 composer.recipient_single_number_itf = ''
                 continue
             records.ensure_one()
-            res = records._sms_get_recipients_info(force_field=composer.number_field_name, partner_fallback=False)
+            res = records._sms_get_recipients_info(force_field=composer.number_field_name, partner_fallback=True)
             if not composer.recipient_single_number_itf:
                 composer.recipient_single_number_itf = res[records.id]['number'] or ''
             if not composer.number_field_name:

--- a/addons/test_mail_sms/tests/test_sms_composer.py
+++ b/addons/test_mail_sms/tests/test_sms_composer.py
@@ -3,8 +3,10 @@
 
 from odoo.addons.sms.tests.common import SMSCommon
 from odoo.addons.test_mail_sms.tests.common import TestSMSRecipients
+from odoo.tests import tagged
 
 
+@tagged('post_install', '-at_install', 'sms_composer')
 class TestSMSComposerComment(SMSCommon, TestSMSRecipients):
     """ TODO LIST
 
@@ -169,16 +171,21 @@ class TestSMSComposerComment(SMSCommon, TestSMSRecipients):
 
     def test_composer_nofield_w_customer(self):
         """ Test SMS composer without number field, the number on partner must be used instead"""
+        test_record = self.env['mail.test.sms.partner'].create({
+            'name': 'Test',
+            'customer_id': self.partner_1.id,
+        })
+
         with self.with_user('employee'):
             composer = self.env['sms.composer'].with_context(
-                    default_res_model='mail.test.sms', default_res_id=self.test_record.id,
+                    default_res_model=test_record._name, default_res_id=test_record.id,
                 ).create({
                     'body': self._test_body,
                 })
-
+        self.assertFalse(composer.number_field_name)
         self.assertTrue(composer.recipient_single_valid)
-        self.assertEqual(composer.recipient_single_number, self.test_numbers[1])
-        self.assertEqual(composer.recipient_single_number_itf, self.test_numbers[1])
+        self.assertEqual(composer.recipient_single_number, self.partner_1.mobile)
+        self.assertEqual(composer.recipient_single_number_itf, self.partner_1.mobile)
 
     def test_composer_internals(self):
         with self.with_user('employee'):


### PR DESCRIPTION
Followup of odoo/odoo#134682 but for code added notably during odoo/odoo@f685e70616e8fe357690cd8e6cfa4543c1d0df24

Also fix the test, as it was not testing the real issue (wrong model used in test).

Task-3743525