### PR TITLE
[FIX] stock_account: avoid traceback when processing valuation lot

### DIFF
--- a/addons/purchase_mrp/models/stock_move.py
+++ b/addons/purchase_mrp/models/stock_move.py
@@ -35,7 +35,11 @@ class StockMove(models.Model):
         # Convert uom from bom_line_uom to product_uom for bom_line
         uom_factor = bom_line.product_id.uom_id._compute_quantity(uom_factor, bom_line.product_uom_id)
 
-        return {self.env['stock.lot']: (kit_price_unit * cost_share * uom_factor * bom.product_qty / bom_line.product_qty)}
+        price_unit = kit_price_unit * cost_share * uom_factor * bom.product_qty / bom_line.product_qty
+        if self.product_id.lot_valuated:
+            return {lot: price_unit for lot in self.lot_ids}
+        else:
+            return {self.env['stock.lot']: price_unit}
 
     def _get_valuation_price_and_qty(self, related_aml, to_curr):
         valuation_price_unit_total, valuation_total_qty = super()._get_valuation_price_and_qty(related_aml, to_curr)


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”:
    - Product category: “AVCO”
    - BoM:
        - Type: Kit
        - Components:
            - C1: Tracked by lot and valuated by lot
            - C2
- Create a purchase order:
    - 1 unit of P1 → Price: $10
- Confirm the PO

- Go to the reception:
    - Set a new lot (Lot_1) for C1
    - Validate the reception

Problem:
A traceback is triggered:
```
new_std_price = move_cost[lot]
~~~~~~~~~^^^^^ KeyError: stock.lot(19,)"
```

When validating the picking, the moves will first be validated, and then
the product price will be updated before the move is marked as done:
https://github.com/odoo/odoo/blob/168f4d75ef724ee99ffaf7884730facd8ed936bb/addons/stock_account/models/stock_move.py#L387-L388

The move cost is retrieved using the _get_price_unit function:
https://github.com/odoo/odoo/commit/2d933b83613ad52d76ab457201adecac6fcf184b#diff-ad6229e976ce0bd1592e805b88e9813ac4e3f6fb989d3dfb8dfb8b70af03cd58R403

However, since move.product_id is different from move.purchase_line,
the parent product will be treated as a kit, and the unit price of the
kit product will be used instead: https://github.com/odoo/odoo/blob/17.0/addons/purchase_mrp/models/stock_move.py#L19
Based on this, the unit price for each component is calculated using
the cost_share and the bom_lines quantities. This is then stored in a
dictionary with an empty record of the ```”stock.lot”``` model:

When attempting to access the dictionary using the lot key from the move,
no result is returned, leading to an error.
https://github.com/odoo/odoo/blob/2d933b83613ad52d76ab457201adecac6fcf184b/addons/stock_account/models/stock_move.py#L425

Solution:
The process should account for the fact that the move product is a
component of a kit. Therefore, the price should be directly retrieved
from the dictionary without requiring a key.

opw-4434390