### PR TITLE
[FIX] account: compute journal_id payment register

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -485,6 +485,8 @@ class AccountPaymentRegister(models.TransientModel):
     @api.depends('available_journal_ids')
     def _compute_journal_id(self):
         for wizard in self:
+            if wizard.journal_id in wizard.available_journal_ids:
+                continue
             move_payment_method_lines = wizard.line_ids.move_id.preferred_payment_method_line_id
             if move_payment_method_lines and len(move_payment_method_lines) == 1:
                 wizard.journal_id = move_payment_method_lines.journal_id
@@ -536,6 +538,9 @@ class AccountPaymentRegister(models.TransientModel):
                 available_payment_method_lines = wizard.journal_id._get_available_payment_method_lines(wizard.payment_type)
             else:
                 available_payment_method_lines = False
+
+            if available_payment_method_lines and wizard.payment_method_line_id in available_payment_method_lines:
+                continue
 
             # Select the first available one by default.
             if available_payment_method_lines:


### PR DESCRIPTION
Steps:

- Install `account_sepa_drect_debit`
- Duplicate the default bank journal and add a bank account
- Create an invoice for a partner with valid mandate
- Open the payment register wizard
- Change journal from default one to the duplicated one
- Select 'SEPA Direct Debit' as payment method
- Click on 'Create payments'
-> Validation Error: "The selected payment method is not available ..."

Cause:

In `account_sepa_direct_debit.action_create_payments`, the `journal_id` is recomputed when
calling the `write` method on the wizard.

Fix:

Dont recompute the `journal_id` if it is already in
`available_journal_ids`

Note:

We do the same for `payment_method_line_id`

opw-4485191
