### PR TITLE
[FIX] website_sale: fix overlapping divs on mobile

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -816,6 +816,19 @@ publicWidget.registry.websiteSaleCart = publicWidget.Widget.extend({
         'click .js_delete_product': '_onClickDeleteProduct',
     },
 
+    /**
+     * @override
+     */
+    async start() {
+        document.querySelector('.o_cta_navigation_placeholder')?.classList.remove('d-none')
+        const ctaContainer = document.querySelector('.o_cta_navigation_container');
+        if (ctaContainer) {
+            const placeholder = document.querySelector('.o_cta_navigation_placeholder');
+            placeholder.style.height = `${ctaContainer.offsetHeight}px`;
+            ctaContainer.style.top = `calc(100% - ${ctaContainer.offsetHeight}px)`;
+        }
+    },
+
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------


### PR DESCRIPTION
The navigation buttons on the cart were repositioned on the screen for mobile view by setting position to absolute.
However this causes an issue if a user adds blocks from the editor below the checkout screen, since  disregards
the height of the element.
To fix this the height of the element is set on the placeholder element to which the navigation buttons are anchored.

opw-4498660



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
