### PR TITLE
[FIX] iot_box_image: input acces for odoo user

### DIFF
--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -268,6 +268,7 @@ usermod -a -G usbusers odoo
 usermod -a -G video odoo
 usermod -a -G lp odoo
 usermod -a -G input lightdm
+usermod -a -G input odoo
 usermod -a -G pi odoo
 mkdir -v /var/log/odoo
 chown odoo:odoo /var/log/odoo


### PR DESCRIPTION
Currently, as the user "odoo" which runs Odoo service on the IoT Box on images >=25_01 is not in the group "input" it does not detect all of the connected USB devices and cannot properly detect keyboard input in KeyboardDriver_L.py

Note: the fix needs the build of a new image to apply it

This PR fixes the issue by adding "odoo" to the "input" group

task-4432802

Related PR:
https://github.com/odoo/odoo/pull/195306
