### PR TITLE
[FIX] account: outbound shouldnt require validated bank account

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -981,8 +981,16 @@ class AccountPayment(models.Model):
         ''' draft -> posted '''
         # Do not allow to post if the account is required but not trusted
         for payment in self:
-            if payment.require_partner_bank_account and not payment.partner_bank_id.allow_out_payment:
-                raise UserError(_('To record payments with %s, the recipient bank account must be manually validated. You should go on the partner bank account in order to validate it.', payment.partner_id.display_name))
+            if (
+                payment.require_partner_bank_account
+                and not payment.partner_bank_id.allow_out_payment
+                and payment.payment_type == 'outbound'
+            ):
+                raise UserError(_(
+                    'To record payments with %s, the recipient bank account must be manually '
+                    'validated. You should go on the partner bank account in order to validate it.',
+                    payment.partner_id.display_name
+                ))
 
         self.move_id._post(soft=False)
 


### PR DESCRIPTION
The `require_partner_bank_account` flag on the payment shouldn't require the `allow_out_payment` flag on it when the payment type is `inbound` as it leads to confusion.

This generates an issue with the `l10n_it_riba` RiBa payment method. It requires the bank account, but the money is incoming, not outgoing.

Enterprise PR: odoo/enterprise#77901

Task [link](https://www.odoo.com/odoo/project/967/tasks/4497749)
task-4497749