### PR TITLE
[FIX] account: basic user report rights

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Invoicing',
     'version': '1.4',
-    'summary': 'Invoices, Payments, Follow-ups & Bank Synchronization',
+    'summary': 'Invoices & Payments',
     'sequence': 10,
     'description': """
 Invoicing & Payments

--- a/addons/l10n_in/data/l10n_in_chart_data.xml
+++ b/addons/l10n_in/data/l10n_in_chart_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-        <menuitem id="account_reports_in_statements_menu" name="India" parent="account.menu_finance_reports" sequence="5"/>
+        <menuitem id="account_reports_in_statements_menu" name="India" parent="account.menu_finance_reports" sequence="5" groups="account.group_account_readonly"/>
 
         <record id="sgst_tag_account" model="account.account.tag">
             <field name="name">SGST</field>

--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -18,8 +18,8 @@ class TestPerfSessionInfo(common.HttpCase):
         self.authenticate(user.login, "info")
 
         self.env.registry.clear_all_caches()
-        # cold ormcache (only web: 37, all module: 119)
-        with self.assertQueryCount(119):
+        # cold ormcache (only web: 37, all module: 120)
+        with self.assertQueryCount(120):
             self.url_open(
                 "/web/session/get_session_info",
                 data=json.dumps({'jsonrpc': "2.0", 'method': "call", 'id': str(uuid4())}),


### PR DESCRIPTION
With the introduction of Invoicing Enterprise (access to bank recon etc) a new user group was created "Invoicing & Banks" (`group_account_basic`)
This group should also be able to access the customer statement / partner ledger (from the partner smart button)

Implications: The module dependencies change because account_reports are now available with just Invoicing.

Old dependencies
----------------
- `account_asset` ... (and other accounting features)
    - `account_reports` (auto installed)
        - `accountant` **[Accounting]**
            - `account_accountant` (auto installed)
                - `account` **[Invoicing]**

New
---
- `account_asset` ... (and other accounting features)
    - `accountant` **[Accounting]**
        - `account_reports` (auto install)
            - `account_accountant` (auto install)
                - `account` **[Invoicing]**

Also, since the Accounting Reports menu is also only available to `group_no_one` with `group_account_readonly` rights, this is hidden and changes the session info query count.

Task-4465208