### PR TITLE
[FIX] website: fix not available items in search results

### DIFF
--- a/addons/website/static/src/snippets/s_searchbar/000.xml
+++ b/addons/website/static/src/snippets/s_searchbar/000.xml
@@ -16,7 +16,7 @@
     </t>
     <a t-foreach="results" t-as="result"
         t-att-href="result['website_url']" class="dropdown-item p-2 text-wrap">
-        <div class="d-flex align-items-center o_search_result_item">
+        <div class="d-flex align-items-center flex-wrap o_search_result_item">
             <t t-if="widget.displayImage">
                 <img t-if="result['image_url']" t-att-src="result['image_url']" class="flex-shrink-0 o_image_64_contain"/>
                 <i t-else="" t-attf-class="o_image_64_contain text-center pt16 fa #{result['_fa']}" style="font-size: 34px;"/>
@@ -30,7 +30,7 @@
                 <button t-if="extra_link" class="extra_link btn btn-link btn-sm" t-att-data-target="result['extra_link_url']" t-out="extra_link"/>
                 <t t-if="extra_link_html" t-out="extra_link_html"/>
             </div>
-            <div t-if="parts['detail'] and widget.displayDetail" class="flex-shrink-0">
+            <div t-if="parts['detail'] and widget.displayDetail" class="flex-shrink-0 ms-auto">
                 <t t-if="result['detail_strike']">
                     <span class="text-danger text-nowrap" style="text-decoration: line-through;">
                         <t t-out="result['detail_strike']"/>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2566,7 +2566,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
 
 <template id="one_hybrid" name="Single any Search Results">
     <a t-att-href="result.get('website_url')" class="dropdown-item p-2 text-wrap">
-        <div class="d-flex align-items-center o_search_result_item">
+        <div class="d-flex align-items-center flex-wrap o_search_result_item">
             <img t-if="result.get('image_url')" t-att-src="result.get('image_url')" class="flex-shrink-0 o_image_64_contain"/>
             <i t-else="" t-att-class="'o_image_64_contain text-center pt16 fa %s' % result.get('_fa')" style="font-size: 34px;"/>
             <div class="o_search_result_item_detail px-3">
@@ -2579,7 +2579,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
                     t-attf-onclick="location.href='#{result.get('extra_link_url')}';return false;"/>
                 <t t-if="extra_link_html" t-out="extra_link_html"/>
             </div>
-            <div class="flex-shrink-0">
+            <div class="flex-shrink-0 ms-auto">
                 <t t-if="result.get('detail_strike')">
                     <span class="text-danger text-nowrap" style="text-decoration: line-through;">
                         <t t-out="result.get('detail_strike')"/>


### PR DESCRIPTION
This commit fixes the width of not available items inside the search results list and the search result dropdown.

We achieve the fix by using the same approach used in this commit: https://github.com/odoo/odoo/commit/9ffbc8720b84f51d5d03a7e11c74c19b62cf46c0

opw-4444222
task-4517564

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
