### PR TITLE
[FIX] l10n_it: do not allow xml as main attachment by default

### DIFF
--- a/addons/l10n_it/models/account_move.py
+++ b/addons/l10n_it/models/account_move.py
@@ -6,7 +6,7 @@ from odoo import models
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    def _message_set_main_attachment_id(self, attachments, force=False, filter_xml=False):
+    def _message_set_main_attachment_id(self, attachments, force=False, filter_xml=True):
         if self.message_main_attachment_id.mimetype == "application/pkcs7-mime":
             force = True
         super()._message_set_main_attachment_id(attachments, force, filter_xml)


### PR DESCRIPTION
**Issue:**
When "l10n_it" is installed, an override of "_message_set_main_attachment_id" method is changing the default value of "filter_xml" param from True to False, which is impacting the general behavior when the module is installed. As a consequence, xml files can be set as main attachment of a bill, which generates unreadable PDF files when using "Print > Original Bills" action on a bill.

opw-4439034


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
