### PR TITLE
[FIX] sale: round discount floats display

### DIFF
--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 from odoo import Command, _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools import float_repr
 
 
 class SaleOrderDiscount(models.TransientModel):
@@ -107,6 +108,7 @@ class SaleOrderDiscount(models.TransientModel):
                 discounted_price = line.price_unit * (1 - (line.discount or 0.0)/100)
                 total_price_per_tax_groups[line.tax_id] += (discounted_price * line.product_uom_qty)
 
+            discount_dp = self.env['decimal.precision'].precision_get('Discount')
             if not total_price_per_tax_groups:
                 # No valid lines on which the discount can be applied
                 return
@@ -121,7 +123,7 @@ class SaleOrderDiscount(models.TransientModel):
                         taxes=taxes,
                         description=_(
                             "Discount: %(percent)s%%",
-                            percent=self.discount_percentage*100
+                            percent=float_repr(self.discount_percentage * 100, discount_dp),
                         ),
                     ),
                 }]
@@ -134,8 +136,8 @@ class SaleOrderDiscount(models.TransientModel):
                         description=_(
                             "Discount: %(percent)s%%"
                             "- On products with the following taxes %(taxes)s",
-                            percent=self.discount_percentage*100,
-                            taxes=", ".join(taxes.mapped('name'))
+                            percent=float_repr(self.discount_percentage * 100, discount_dp),
+                            taxes=", ".join(taxes.mapped('name')),
                         ),
                     ) for taxes, subtotal in total_price_per_tax_groups.items()
                 ]


### PR DESCRIPTION
## Versions:
17.0+
No fix needed in 16.0 as the discount was not displayed this way.

## Issue:
Discount descriptions contain long string floats while it should be truncated for human reading.

## Steps to reproduce:
- Activate `Discounts` through settings;
- Create a new sale order for any client with at least 1 product;
- Click the `Discount` button on the form;
- Apply a 7% `Global Discount`;
- Read the `Discount` product's description.

## Cause:
Some numbers cannot be represented correctly in Python (including 7, 3.3 etc.).

opw-4485316