### PR TITLE
[FIX] base: show all groups menu in group view


### DIFF
--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -125,7 +125,7 @@
         <record id="action_res_groups" model="ir.actions.act_window">
             <field name="name">Groups</field>
             <field name="res_model">res.groups</field>
-            <field name="context">{'search_default_filter_no_share': 1}</field>
+            <field name="context">{'search_default_filter_no_share': 1, 'ir.ui.menu.full_list': 1}</field>
             <field name="help">A group is a set of functional areas that will be assigned to the user in order to give them access and rights to specific applications and tasks in the system. You can create custom groups or edit the ones existing by default in order to customize the view of the menu that users will be able to see. Whether they can have a read, write, create and delete access right can be managed from here.</field>
         </record>
         <menuitem action="action_res_groups" id="menu_action_res_groups" parent="base.menu_users" groups="base.group_no_one" sequence="3"/>


### PR DESCRIPTION

Scenario: set a menu to be visible only to a group you don't have
Result: the menu is not shown in the list of menu on the group form view

Why: in 17.0, web_read was added that is adding a search for ordering
results of x2many according to order in specification. This is
interfering with custom code of ir.ui.menu that is filtering out menu
that are not visible (in the interface) to you.

Fix: add context key that bypass the ir.ui.menu filtering in the
res.groups window action.

opw-4376374
