### PR TITLE
[IMP] point_of_sale, pos_restaurant: tour for testing synchronisation

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -163,8 +163,6 @@
             ('remove', 'point_of_sale/static/src/customer_display/**/*'),
             # main.js boots the pos app, it is only included in the prod bundle as tests mount the app themselves
             ('remove', 'point_of_sale/static/src/app/main.js'),
-            # tour system FIXME: can this be added only in test mode? Are there any onboarding tours in PoS?
-            "web_tour/static/src/tour_pointer/**/*",
             ("include", "point_of_sale.base_tests"),
             # account
             'account/static/src/helpers/*.js',
@@ -207,6 +205,15 @@
             "barcodes/static/tests/helpers.js",
             "web/static/tests/legacy/helpers/utils.js",
             "web/static/tests/legacy/helpers/cleanup.js",
+        ],
+        'point_of_sale.assets_debug': [
+            'web_tour/static/src/tour_pointer/**/*',
+            'web_tour/static/src/tour_service/**/*',
+            ('remove', 'web_tour/static/src/tour_pointer/**/*.scss'),
+            'web/static/tests/legacy/helpers/utils.js',
+            'web/static/tests/legacy/helpers/cleanup.js',
+            'barcodes/static/tests/helpers.js',
+            'point_of_sale/static/tests/tours/**/*',
         ],
     },
     'license': 'LGPL-3',

--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -64,6 +64,7 @@ class PosController(PortalAccount):
         session_info = pos_session._update_session_info(request.env['ir.http'].session_info())
         context = {
             'from_backend': 1 if from_backend else 0,
+            'use_pos_fake_tours': True if k.get('tours', False) else False,
             'session_info': session_info,
             'login_number': pos_session.with_company(pos_session.company_id).login(),
             'pos_session_id': pos_session.id,

--- a/addons/point_of_sale/static/src/app/components/tour_selector_popup/tour_selector_popup.js
+++ b/addons/point_of_sale/static/src/app/components/tour_selector_popup/tour_selector_popup.js
@@ -1,0 +1,33 @@
+import { Dialog } from "@web/core/dialog/dialog";
+import { Component, useState } from "@odoo/owl";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { registry } from "@web/core/registry";
+
+export class TourSelectorPopup extends Component {
+    static components = { Dialog };
+    static template = "point_of_sale.TourSelectorPopup";
+    static props = ["close", "getPayload"];
+
+    setup() {
+        this.pos = usePos();
+        this.state = useState({
+            selectedTours: new Set(),
+        });
+    }
+
+    get tours() {
+        const tourNames = Object.keys(registry.subRegistries["web_tour.tours"].content);
+        return tourNames.filter((name) => name.includes("PoSFakeTour"));
+    }
+
+    onCheck(ev) {
+        return ev.target.checked
+            ? this.state.selectedTours.add(ev.target.id)
+            : this.state.selectedTours.delete(ev.target.id);
+    }
+
+    confirm() {
+        this.props.getPayload([...this.state.selectedTours]);
+        this.props.close();
+    }
+}

--- a/addons/point_of_sale/static/src/app/components/tour_selector_popup/tour_selector_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/tour_selector_popup/tour_selector_popup.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="point_of_sale.TourSelectorPopup">
+        <Dialog>
+            <t t-set-slot="header">
+                <h4 class="modal-title">Launch fake tours</h4>
+            </t>
+            <div class="alert alert-warning" role="alert">
+                Running a fake tour will create random orders. Use at your own risk.
+            </div>
+            <div class="payment-methods-overview overflow-auto w-100 d-flex flex-wrap gap-1">
+                <div t-foreach="this.tours" t-as="name" t-key="name">
+                    <input class="form-check-input d-none" type="checkbox" t-att-name="name" t-att-id="name" t-on-change="onCheck" />
+                    <label class="btn btn-secondary btn d-flex" t-att-for="name" t-att-class="{'active': this.state.selectedTours.has(name)}">
+                        <span t-esc="name" />
+                    </label>
+                </div>
+            </div>
+            <t t-set-slot="footer">
+                <div class="modal-footer-left d-flex gap-2">
+                    <div class="modal-footer-left d-flex gap-2">
+                        <button class="button highlight btn btn btn-primary" t-on-click="confirm">Confirm</button>
+                        <button class="button btn btn btn-secondary" t-on-click="props.close">Close</button>
+                    </div>
+                </div>
+            </t>
+        </Dialog>
+    </t>
+
+</templates>

--- a/addons/point_of_sale/static/src/app/hooks/use_tours.js
+++ b/addons/point_of_sale/static/src/app/hooks/use_tours.js
@@ -1,0 +1,62 @@
+import { tourState } from "@web_tour/tour_service/tour_state";
+import { TourSelectorPopup } from "../components/tour_selector_popup/tour_selector_popup";
+import { makeAwaitable } from "../store/make_awaitable_dialog";
+import { useService } from "@web/core/utils/hooks";
+
+export default function useTours() {
+    const tour = useService("tour_service");
+    const dialog = useService("dialog");
+    const states = {
+        selectedTours: new Set(),
+        running: false,
+        index: 0,
+    };
+
+    let fakeTourInterval = null;
+
+    tourState.clear();
+
+    const toggle = async () => {
+        states.index = 0;
+        states.running = !states.running;
+        clearInterval(fakeTourInterval);
+
+        if (!states.running) {
+            tourState.clear();
+            return;
+        }
+
+        const tours = await makeAwaitable(dialog, TourSelectorPopup, {});
+        if (!tours || !tours.length) {
+            tourState.clear();
+            states.running = false;
+            return;
+        }
+
+        states.selectedTours = tours;
+        fakeTourInterval = setInterval(() => {
+            const state = tourState.getCurrentTour();
+            if (!state) {
+                runTour();
+            }
+        }, 500);
+    };
+
+    const runTour = async () => {
+        try {
+            if (states.index >= states.selectedTours.length) {
+                states.index = 0;
+            }
+            await tour.startTour(states.selectedTours[states.index], {
+                stepDelay: 150,
+                throw: false,
+            });
+
+            states.index++;
+        } catch (error) {
+            console.warn("Error in tour", error);
+        }
+    };
+
+    return { toggle };
+}

--- a/addons/point_of_sale/static/src/app/pos_app.js
+++ b/addons/point_of_sale/static/src/app/pos_app.js
@@ -8,6 +8,7 @@ import { batched } from "@web/core/utils/timing";
 import { deduceUrl } from "@point_of_sale/utils";
 import { useOwnDebugContext } from "@web/core/debug/debug_context";
 import { useIdleTimer } from "./utils/use_idle_timer";
+import useTours from "./hooks/use_tours";
 
 /**
  * Chrome is the root component of the PoS App.
@@ -24,6 +25,9 @@ export class Chrome extends Component {
         window.posmodel = reactivePos;
         useOwnDebugContext();
 
+        if (odoo.use_pos_fake_tours) {
+            window.pos_fake_tour = useTours();
+        }
         // prevent backspace from performing a 'back' navigation
         document.addEventListener("keydown", (ev) => {
             if (ev.key === "Backspace" && !ev.target.matches("input, textarea")) {

--- a/addons/point_of_sale/static/tests/tours/fake_tours.js
+++ b/addons/point_of_sale/static/tests/tours/fake_tours.js
@@ -1,0 +1,16 @@
+import { registry } from "@web/core/registry";
+import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/tours/utils/receipt_screen_util";
+
+registry.category("web_tour.tours").add("PoSFakeTourSimpleOrder", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            ProductScreen.clickDisplayedProduct("Desk Pad"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+        ].flat(),
+});

--- a/addons/point_of_sale/views/pos_assets_index.xml
+++ b/addons/point_of_sale/views/pos_assets_index.xml
@@ -22,6 +22,7 @@
                 'pos_session_id': pos_session_id,
                 'pos_config_id': pos_config_id,
                 'access_token': access_token,
+                'use_pos_fake_tours': use_pos_fake_tours,
                 'debug': debug,
             })"/>;
             // Prevent the menu_service to load anything. In an ideal world, POS assets would only contain
@@ -33,6 +34,9 @@
             <t t-set="ignore_missing_deps" t-value="True"/>
         </t>
         <t t-call-assets="point_of_sale.assets_prod" />
+        <t t-if="use_pos_fake_tours">
+            <t t-call-assets="point_of_sale.assets_debug" />
+        </t>
     </head>
     <body class="pos">
     </body>

--- a/addons/pos_restaurant/__manifest__.py
+++ b/addons/pos_restaurant/__manifest__.py
@@ -40,6 +40,9 @@ This module adds several features to the Point of Sale that are specific to rest
         'web.assets_tests': [
             'pos_restaurant/static/tests/tours/**/*',
         ],
+        'point_of_sale.assets_debug': [
+            'pos_restaurant/static/tests/tours/**/*',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/pos_restaurant/static/tests/tours/fake_tours.js
+++ b/addons/pos_restaurant/static/tests/tours/fake_tours.js
@@ -1,0 +1,69 @@
+/* global posmodel */
+
+import { registry } from "@web/core/registry";
+import * as ProductScreenPos from "@point_of_sale/../tests/tours/utils/product_screen_util";
+import * as ProductScreenResto from "@pos_restaurant/../tests/tours/utils/product_screen_util";
+import * as FloorScreen from "@pos_restaurant/../tests/tours/utils/floor_screen_util";
+import * as ChromePos from "@point_of_sale/../tests/tours/utils/chrome_util";
+import * as ChromeRestaurant from "@pos_restaurant/../tests/tours/utils/chrome";
+import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/tours/utils/receipt_screen_util";
+
+const Chrome = { ...ChromePos, ...ChromeRestaurant };
+const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
+
+const getRandomTable = () => {
+    const tables = posmodel.currentFloor.table_ids;
+    return tables[Math.floor(Math.random() * tables.length)].table_number;
+};
+
+const getRandomTableWithOrder = () => {
+    const tables = posmodel.currentFloor.table_ids.filter(
+        (table) => table["<-pos.order.table_id"].length > 0
+    );
+    return tables[Math.floor(Math.random() * tables.length)].table_number;
+};
+
+const getRandomProduct = () => {
+    const products = posmodel.models["product.product"].filter(
+        (p) =>
+            !p.isConfigurable() &&
+            !p.isCombo() &&
+            !p.isTracked() &&
+            p.id !== posmodel.config.tip_product_id?.id &&
+            !posmodel.session._pos_special_products_ids?.includes(p.id)
+    );
+    return products[Math.floor(Math.random() * products.length)].name;
+};
+
+registry.category("web_tour.tours").add("PoSFakeTourRestaurant", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            FloorScreen.clickTable(getRandomTable()),
+            ProductScreen.clickDisplayedProduct(getRandomProduct()),
+            ProductScreen.clickDisplayedProduct(getRandomProduct()),
+            ProductScreen.clickDisplayedProduct(getRandomProduct()),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable(getRandomTable()),
+            ProductScreen.clickDisplayedProduct(getRandomProduct()),
+            ProductScreen.clickDisplayedProduct(getRandomProduct()),
+            ProductScreen.clickDisplayedProduct(getRandomProduct()),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PoSFakeTourTransferOrder", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            FloorScreen.clickTable(getRandomTableWithOrder()),
+            ProductScreen.clickControlButton("Transfer"),
+            FloorScreen.clickTable(getRandomTable()),
+            ProductScreen.clickDisplayedProduct(getRandomProduct()),
+            Chrome.clickPlanButton(),
+        ].flat(),
+});


### PR DESCRIPTION
Before we had no solution to test the synchronisation of the pos. In classic tours websocket are not supported. And we cannot launch two tours in parallel.

This commit add the possibility to load test assets in the PoS during our development. That's allow us to launch tour in loop in two different browser and test the synchronisation by creating orders, payment etc.

Tour assets are only added by adding `&tours=True` in the URL of the PoS interface.




