### PR TITLE
[FIX] point_of_sale: prevent error when loading demo data of furniture or cloth

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -8477,6 +8477,18 @@ msgstr ""
 #. module: point_of_sale
 #. odoo-python
 #: code:addons/point_of_sale/models/pos_config.py:0
+msgid "You must have 'Administration Settings' access to load clothes data."
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-python
+#: code:addons/point_of_sale/models/pos_config.py:0
+msgid "You must have 'Administration Settings' access to load furniture data."
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-python
+#: code:addons/point_of_sale/models/pos_config.py:0
 msgid ""
 "You must have at least one payment method configured to launch a session."
 msgstr ""

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -943,6 +943,8 @@ class PosConfig(models.Model):
 
     @api.model
     def _load_furniture_data(self):
+        if not self.env.user.has_group('base.group_system'):
+            raise AccessError(_("You must have 'Administration Settings' access to load furniture data."))
         product_module = self.env['ir.module.module'].search([('name', '=', 'product')])
         if not product_module.demo:
             convert.convert_file(self.env, 'product', 'data/product_category_demo.xml', None, noupdate=True, mode='init', kind='data')
@@ -957,6 +959,8 @@ class PosConfig(models.Model):
 
     @api.model
     def load_onboarding_clothes_scenario(self):
+        if not self.env.user.has_group('base.group_system'):
+            raise AccessError(_("You must have 'Administration Settings' access to load clothes data."))
         ref_name = 'point_of_sale.pos_config_clothes'
         if not self.env.ref(ref_name, raise_if_not_found=False):
             convert.convert_file(self.env, 'point_of_sale', 'data/scenarios/clothes_data.xml', None, noupdate=True, mode='init', kind='data')

--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
@@ -64,20 +64,32 @@ export class PosKanbanRenderer extends KanbanRenderer {
         this.posState.show_predefined_scenarios = this.props.list.count === 0;
     }
 
+    showAccessDeniedDialog(body) {
+        this.dialog.add(AlertDialog, {
+            title: _t("Access Denied"),
+            body: body,
+        });
+    }
+
     async callWithViewUpdate(func) {
         try {
             const isPosManager = await user.hasGroup("point_of_sale.group_pos_manager");
             if (!isPosManager) {
-                this.dialog.add(AlertDialog, {
-                    title: _t("Access Denied"),
-                    body: _t(
+                this.showAccessDeniedDialog(
+                    _t(
                         "It seems like you don't have enough rights to create point of sale configurations."
-                    ),
-                });
+                    )
+                );
                 return;
             }
             await func();
             await updatePosKanbanViewState(this.orm, this.posState);
+        } catch (e) {
+            if (e.exceptionName === "odoo.exceptions.AccessError") {
+                this.showAccessDeniedDialog(e.data.message);
+            } else {
+                throw e;
+            }
         } finally {
             this.env.searchModel.clearQuery();
         }


### PR DESCRIPTION
We encountered an error when trying to open `Furniture` or `Clothes` from the 
`Dashboard` if the Administrator has been assigned Admin rights to a new user.

Step to Reproduce:
- Install the Point of Sale module without demo data.
- Navigate to `Settings` > `Users` and `create` a new user with `Admin rights` of POS.
- Log in with the newly created admin user.
- Try to load sample data for `Furniture` or `Clothes`.

Traceback:
```
while parsing /home/odoo/src/odoo/saas-18.1/addons/product/data/product_demo.xml:5, somewhere inside
<record id="base.group_user" model="res.groups">
            <field name="implied_ids" eval="[(4, ref('product.group_product_variant'))]"/>
        </record>
```

Error[2]  generated when solving above problem :

Traceback :
```
while parsing /home/odoo/odoo/community/addons/point_of_sale/data/orders_demo.xml:86, 
somewhere inside <function model="pos.session" name="update_closing_control_state_session" eval="[[ref('pos_closed_session_1')], '']"/>
```

This issue was occuring since new users does not have access right of `res.groups`.

This commit will fix the above errors by using Superuser environment to load data..

sentry-6239966848

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
