### PR TITLE
[IMP] mail: Move technical fields on channel form view

### DIFF
--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -65,15 +65,7 @@
                         </div>
                         <group class="o_label_nowrap">
                             <field name="active" invisible="1"/>
-                            <field name="channel_type" groups="base.group_no_one"/>
                             <field name="description" placeholder="Topics discussed in this group..." readonly="not is_editable"/>
-                            <field name="parent_channel_id" groups="base.group_no_one"/>
-                            <field name="sub_channel_ids" groups="base.group_no_one"/>
-                            <field name="from_message_id" groups="base.group_no_one"/>
-                        </group>
-                        <group class="o_label_nowrap" groups="base.group_no_one">
-                            <field name="sfu_channel_uuid"/>
-                            <field name="sfu_server_url"/>
                         </group>
                         <notebook>
                             <page string="Privacy" name="privacy">
@@ -93,6 +85,16 @@
                                         <field name="guest_id" readonly="id or partner_id" required="not partner_id"/>
                                     </list>
                                 </field>
+                            </page>
+                            <page string="Extra info" name="extra_info" groups="base.group_no_one">
+                                <group class="o_label_nowrap">
+                                    <field name="channel_type"/>
+                                    <field name="parent_channel_id"/>
+                                    <field name="sub_channel_ids"/>
+                                    <field name="from_message_id"/>
+                                    <field name="sfu_channel_uuid"/>
+                                    <field name="sfu_server_url"/>
+                                </group>
                             </page>
                             <page string="Integrations" invisible="1" name="discuss_channel_integrations"></page>
                         </notebook>


### PR DESCRIPTION
**Current behavior before PR:**

prior to this PR the technical fields are mixed with other fields.

**Desired behavior after PR is merged:**

now it is reorganized into new notebook page called `Extra info`.

task-4510260

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
