### PR TITLE
[FIX] l10n_in_pos: correctly fetch company from backend

### DIFF
--- a/addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js
+++ b/addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js
@@ -13,7 +13,7 @@ patch(PaymentScreen.prototype, {
             }
         });
     },
-    toggleIsToInvoice() {
+    async toggleIsToInvoice() {
         if (this.checkIsToInvoice()) {
             this.dialog.add(AlertDialog, {
                 title: _t("This order needs to be invoiced"),
@@ -22,7 +22,7 @@ patch(PaymentScreen.prototype, {
                 ),
             });
         } else {
-            super.toggleIsToInvoice(...arguments);
+            await super.toggleIsToInvoice(...arguments);
         }
     },
     checkIsToInvoice() {

--- a/addons/l10n_in_pos/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
+++ b/addons/l10n_in_pos/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
@@ -5,6 +5,7 @@ import { companyStateDialog } from "@l10n_in_pos/app/components/popups/company_s
 
 patch(CashMovePopup.prototype, {
     async confirm() {
+        await this.pos.data.read("res.company", [this.pos.company.id]);
         if (this.pos.company.country_id?.code === "IN" && !this.pos.company.state_id) {
             this.dialog.add(companyStateDialog);
             return;

--- a/addons/l10n_in_pos/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/l10n_in_pos/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -5,6 +5,7 @@ import { companyStateDialog } from "@l10n_in_pos/app/components/popups/company_s
 
 patch(ClosePosPopup.prototype, {
     async confirm() {
+        await this.pos.data.read("res.company", [this.pos.company.id]);
         if (this.pos.company.country_id?.code === "IN" && !this.pos.company.state_id) {
             this.dialog.add(companyStateDialog);
             return;

--- a/addons/l10n_in_pos/static/src/app/models/invoice_button.js
+++ b/addons/l10n_in_pos/static/src/app/models/invoice_button.js
@@ -4,11 +4,12 @@ import { patch } from "@web/core/utils/patch";
 import { companyStateDialog } from "@l10n_in_pos/app/components/popups/company_state_dialog/company_state_dialog";
 
 patch(InvoiceButton.prototype, {
-    click() {
+    async click() {
+        await this.pos.data.read("res.company", [this.pos.company.id]);
         if (this.pos.company.country_id?.code === "IN" && !this.pos.company.state_id) {
             this.dialog.add(companyStateDialog);
             return;
         }
-        return super.click();
+        return await super.click();
     },
 });

--- a/addons/l10n_in_pos/static/src/app/models/payment_screen.js
+++ b/addons/l10n_in_pos/static/src/app/models/payment_screen.js
@@ -4,11 +4,12 @@ import { patch } from "@web/core/utils/patch";
 import { companyStateDialog } from "@l10n_in_pos/app/components/popups/company_state_dialog/company_state_dialog";
 
 patch(PaymentScreen.prototype, {
-    toggleIsToInvoice() {
+    async toggleIsToInvoice() {
+        await this.pos.data.read("res.company", [this.pos.company.id]);
         if (this.pos.company.country_id?.code === "IN" && !this.pos.company.state_id) {
             this.dialog.add(companyStateDialog);
             return;
         }
-        return super.toggleIsToInvoice();
+        return await super.toggleIsToInvoice();
     },
 });

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -205,7 +205,7 @@ export class PaymentScreen extends Component {
             this.selectedPaymentLine.setAmount(amount);
         }
     }
-    toggleIsToInvoice() {
+    async toggleIsToInvoice() {
         this.currentOrder.setToInvoice(!this.currentOrder.isToInvoice());
     }
     openCashbox() {

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -385,12 +385,15 @@ export class PosStore extends WithLazyGetterTrap {
         return this.data.models["pos.session"].getFirst();
     }
 
+    get company() {
+        return this.data.models["res.company"].getFirst();
+    }
+
     async processServerData() {
         // These fields should be unique for the pos_config
         // and should not change during the session, so we can
         // safely take the first element.this.models
         this.config = this.data.models["pos.config"].getFirst();
-        this.company = this.data.models["res.company"].getFirst();
         this.user = this.data.models["res.users"].getFirst();
         this.currency = this.config.currency_id;
         this.pickingType = this.data.models["stock.picking.type"].getFirst();


### PR DESCRIPTION
Before this commit:
===
- If the company had no state set, attempting to close the POS session would trigger a company state dialog, redirecting to the company settings page.
- After adding the state and reopening the session, the same dialog would appear again, despite the state being present.

After this commit:
===
- The system correctly fetches the company state from the backend, preventing unnecessary redirections.

related-https://github.com/odoo/enterprise/pull/78507
task-4517944
