### PR TITLE
[FIX] project_timesheet_holidays: prevent deletion of public holiday timesheets

### DIFF
--- a/addons/project_timesheet_holidays/models/account_analytic.py
+++ b/addons/project_timesheet_holidays/models/account_analytic.py
@@ -29,7 +29,9 @@ class AccountAnalyticLine(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_linked_leave(self):
-        if any(line.holiday_id for line in self):
+        if any(line.global_leave_id for line in self):
+            raise UserError(_('You cannot delete timesheets that are linked to global time off.'))
+        elif any(line.holiday_id for line in self):
             if not self.env.user.has_group('hr_holidays.group_hr_holidays_user') and self.env.user not in self.holiday_id.sudo().user_id:
                 raise UserError(_('You cannot delete timesheets that are linked to time off requests. Please cancel your time off request from the Time Off application instead.'))
             warning_msg = _('You cannot delete timesheets linked to time off. Please, cancel the time off instead.')


### PR DESCRIPTION
**Issue:**

Users are able to delete timesheets associated with public holidays, unlike regular time off requests

**Steps to Reproduce:**

   - Ensure "Time Off" is enabled in the Timesheet settings.
  - Time Off > Configurations > Public Holidays.
  - Create a new public holiday.
  - Timesheet > My Timesheet (list view).
  - Attempt to delete the timesheet entry corresponding to the public holiday.

The entry is deleted without any warning.

opw-4464411

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
