### PR TITLE
[FIX] account: correct payment resequence

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -370,7 +370,7 @@ class AccountPayment(models.Model):
     @api.depends('move_id.name', 'state')
     def _compute_name(self):
         for payment in self:
-            if payment.id and not payment.name and payment.state in ('in_process', 'paid'):
+            if payment.id and (not payment.name or payment.move_id and payment.name != payment.move_id.name) and payment.state in ('in_process', 'paid'):
                 payment.name = (
                     payment.move_id.name
                     or self.env['ir.sequence'].with_company(payment.company_id).next_by_code(


### PR DESCRIPTION
- Configure an outstanding receipt account (e.g., Bank) for the Bank journal.

- Create an invoice and process the payment.

When attempting to resequence the journal entry corresponding to the `account.payment`, the journal entry is renamed, but the `account.payment` record is not updated accordingly.

https://github.com/odoo/odoo/commit/01b87f1230beac0568f4e3b1b76e547909506892 made the journal entry optional for payments, which broke the resequence.

opw-4437481


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
