### PR TITLE
[FIX] website: fix scroll issues with header

### DIFF
--- a/addons/website/static/src/interactions/header/base_header.js
+++ b/addons/website/static/src/interactions/header/base_header.js
@@ -219,15 +219,6 @@ export class BaseHeader extends Interaction {
     //--------------------------------------------------------------
 
     getHeaderHeight() {
-        if (this.isSmall()) {
-            // Ensure we don't consider the hiddenOnScroll element on mobile
-            return this.el.getBoundingClientRect().height;
-        }
-        if (this.hideEl?.classList.contains("hidden")) {
-            // Ensure the header height stays the same on desktop
-            return this.hideElHeight + this.el.getBoundingClientRect().height;
-        }
-        this.hideElHeight = this.hideEl?.getBoundingClientRect().height || this.hideElHeight;
         return this.el.getBoundingClientRect().height;
     }
 

--- a/addons/website/static/src/interactions/header/base_header_special.js
+++ b/addons/website/static/src/interactions/header/base_header_special.js
@@ -78,6 +78,8 @@ export class BaseHeaderSpecial extends BaseHeader {
         }
 
         if (this.hideEl) {
+            this.hideEl.style.height = "";
+            this.hideEl.classList.remove("hidden");
             let elHeight = 0;
             if (this.cssAffixed) {
                 // Close the dropdowns if they are open when scrolling. 
@@ -110,8 +112,8 @@ export class BaseHeaderSpecial extends BaseHeader {
                 } else {
                     this.hideEl.style.paddingBlock = "";
                 }
-                this.adaptToHeaderChange();
             }
+            this.adaptToHeaderChange();
         }
 
         if (!this.cssAffixed && this.dropdownClickedEl) {

--- a/addons/website/static/src/interactions/header/header_standard.js
+++ b/addons/website/static/src/interactions/header/header_standard.js
@@ -71,6 +71,21 @@ export class HeaderStandard extends BaseHeader {
         this.toggleCSSAffixed(reachHeaderBottom);
         this.isScrolled = reachTransitionPoint;
     }
+
+    getHeaderHeight() {
+        if (this.hideEl) {
+            if (this.isSmall()) {
+                // Ensure we don't consider the hiddenOnScroll element on mobile
+                return this.el.getBoundingClientRect().height;
+            }
+            if (this.hideEl.classList.contains("hidden")) {
+                // Ensure the header height stays the same on desktop
+                return this.hideElHeight + this.el.getBoundingClientRect().height;
+            }
+            this.hideElHeight = this.hideEl?.getBoundingClientRect().height;
+        }
+        return this.el.getBoundingClientRect().height;
+    }
 }
 
 registry

--- a/addons/website/static/tests/interactions/header/header_disappears.test.js
+++ b/addons/website/static/tests/interactions/header/header_disappears.test.js
@@ -72,17 +72,17 @@ const behaviorWith = [{
     classList: "o_header_disappears o_top_fixed_element",
 }, {
     visibility: true,
-    paddingTop: "39px",
+    paddingTop: "40px",
     transform: "matrix(1, 0, 0, 1, 0, 0)",
     classList: "o_header_affixed o_header_disappears o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: true,
-    paddingTop: "39px",
+    paddingTop: "30px",
     transform: "matrix(1, 0, 0, 1, 0, 0)",
     classList: "o_header_affixed o_header_disappears o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: false,
-    paddingTop: "39px",
+    paddingTop: "30px",
     transform: "matrix(1, 0, 0, 1, 0, -30)",
     classList: "o_header_affixed o_header_disappears o_header_is_scrolled",
 }];

--- a/addons/website/static/tests/interactions/header/header_fade_out.test.js
+++ b/addons/website/static/tests/interactions/header/header_fade_out.test.js
@@ -72,17 +72,17 @@ const behaviorWith = [{
     classList: "o_header_fade_out o_top_fixed_element",
 }, {
     visibility: true,
-    paddingTop: "39px",
+    paddingTop: "40px",
     transform: "matrix(1, 0, 0, 1, 0, 0)",
     classList: "o_header_affixed o_header_fade_out o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: true,
-    paddingTop: "39px",
+    paddingTop: "30px",
     transform: "matrix(1, 0, 0, 1, 0, 0)",
     classList: "o_header_affixed o_header_fade_out o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: false,
-    paddingTop: "39px",
+    paddingTop: "30px",
     transform: "matrix(1, 0, 0, 1, 0, -30)",
     classList: "o_header_affixed o_header_fade_out o_header_is_scrolled",
 }];

--- a/addons/website/static/tests/interactions/header/header_fixed.test.js
+++ b/addons/website/static/tests/interactions/header/header_fixed.test.js
@@ -59,12 +59,12 @@ const behaviorWith = [{
     classList: "o_header_fixed o_top_fixed_element",
 }, {
     visibility: true,
-    paddingTop: "39px",
+    paddingTop: "40px",
     transform: "matrix(1, 0, 0, 1, 0, 0)",
     classList: "o_header_affixed o_header_fixed o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: true,
-    paddingTop: "39px",
+    paddingTop: "30px",
     transform: "matrix(1, 0, 0, 1, 0, 0)",
     classList: "o_header_affixed o_header_fixed o_header_is_scrolled o_top_fixed_element",
 }];

--- a/addons/website/static/tests/interactions/header/helpers.js
+++ b/addons/website/static/tests/interactions/header/helpers.js
@@ -34,10 +34,12 @@ export const getTemplateWithoutHideOnScroll = function (class_name) {
     `
 }
 
+// We use a class to set the height of the hide on scroll element because 
+// otherwise it would be override by the interaction.
 export const getTemplateWithHideOnScroll = function (class_name) {
     return `
     <header class="${class_name}" style="background-color:#CCFFCC">
-        <div class="o_header_hide_on_scroll" style="height: 20px; background-color:#CCFF33;"></div>
+        <div class="o_header_hide_on_scroll h20" style="background-color:#CCFF33;"></div>
         <div style="height: 30px; background-color:#33FFCC;"></div>
     </header>
     <main style="height:2000px;  background-color:#CCCCFF;">

--- a/addons/website/static/tests/interactions/snippets/helpers.js
+++ b/addons/website/static/tests/interactions/snippets/helpers.js
@@ -14,6 +14,7 @@ export const setupTest = async function (core, wrapwrap) {
     wrapwrap.style.overflow = "scroll";
     core.interactions[0].interaction.scrollingElement = wrapwrap;
     defineStyle(/* css */`.hidden { display: none !important; }`);
+    defineStyle(/* css */`.h20 { height: 20px; }`);
     await endTransition();
 }
 


### PR DESCRIPTION
Before this commit, the hide on scroll part of the header would not hide properly because its height was computed based on the new height instead of his origine height.

This commit solves the issue be resetting the values before computing the new height.