### PR TITLE
[IMP] hr: update job title if it is not customized

### DIFF
--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -198,7 +198,7 @@ class HrEmployeeBase(models.AbstractModel):
             elif not employee.coach_id:
                 employee.coach_id = False
 
-    @api.depends('job_id')
+    @api.depends('job_id.name')
     def _compute_job_title(self):
         for employee in self.filtered('job_id'):
             employee.job_title = employee.job_id.name


### PR DESCRIPTION
Problem
----------
When a job position is set to an employee, the job title is updated once. If the name of the job changes, it will not be updated in each employee job title.

task-3710658
