### PR TITLE
[FIX] account: sudo get commercial partner

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -576,6 +576,7 @@ class ResPartner(models.Model):
         selection=[],  # to extend
         compute='_compute_invoice_edi_format',
         inverse='_inverse_invoice_edi_format',
+        compute_sudo=True,
     )
     invoice_edi_format_store = fields.Char(company_dependent=True)
     display_invoice_edi_format = fields.Boolean(default=lambda self: len(self._fields['invoice_edi_format'].selection), store=False)


### PR DESCRIPTION
Relevant conversation: https://github.com/odoo/upgrade/pull/7113

The error happens when a partner record doesn't have a company_id, making him accessible for the user, but its commercial_partner_id has a company_id that is different from the user's current company, causing an issue here:

https://github.com/odoo/odoo/blob/18.0/addons/account/models/partner.py#L643

```
   File "/home/odoo/src/odoo/18.0/addons/account_edi_ubl_cii/models/res_partner.py", line 190, in _compute_invoice_edi_format
    super()._compute_invoice_edi_format()
   File "/home/odoo/src/odoo/18.0/addons/account/models/partner.py", line 643, in _compute_invoice_edi_format
    if partner.commercial_partner_id.invoice_edi_format_store == 'none':
   File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 1266, in __get__
    recs._fetch_field(self)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 4058, in _fetch_field
    self.fetch(fnames)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 4101, in fetch
    raise self.env['ir.rule']._make_access_error('read', forbidden)
 odoo.exceptions.AccessError: Uh-oh! Looks like you have stumbled upon some top-secret records.

Sorry, Omar Ahmed Omar Al Himyari (id=2) doesn't have 'read' access to:
- Contact (res.partner)

If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies.

This seems to be a multi-company issue, you might be able to access the record by switching to the company: Overseas Warehouse Management.
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
