### PR TITLE
[FIX] web: add a fallback if there is no previous controller

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -420,17 +420,15 @@ export function makeActionManager(env, router = _router) {
     function _getBreadcrumbs(stack) {
         return stack
             .filter((controller) => controller.action.tag !== "menu")
-            .map((controller) => {
-                return {
-                    jsId: controller.jsId,
-                    get name() {
-                        return controller.displayName;
-                    },
-                    get url() {
-                        return stateToUrl(controller.state);
-                    },
-                };
-            });
+            .map((controller) => ({
+                jsId: controller.jsId,
+                get name() {
+                    return controller.displayName;
+                },
+                get url() {
+                    return stateToUrl(controller.state);
+                },
+            }));
     }
 
     /**
@@ -786,11 +784,15 @@ export function makeActionManager(env, router = _router) {
             }
         };
         controller.config.historyBack = () => {
-            const previousController = controllerStack[controllerStack.length - 2];
-            if (previousController && !dialog) {
-                restore(previousController.jsId);
-            } else {
+            if (dialog) {
                 _executeCloseAction();
+            } else {
+                const previousController = controllerStack[controllerStack.length - 2];
+                if (previousController) {
+                    restore(previousController.jsId);
+                } else {
+                    env.bus.trigger("WEBCLIENT:LOAD_DEFAULT_APP");
+                }
             }
         };
 

--- a/addons/web/static/src/webclient/webclient.js
+++ b/addons/web/static/src/webclient/webclient.js
@@ -43,6 +43,7 @@ export class WebClient extends Component {
                 this.state.fullscreen = mode === "fullscreen";
             }
         });
+        useBus(this.env.bus, "WEBCLIENT:LOAD_DEFAULT_APP", this._loadDefaultApp);
         onMounted(() => {
             this.loadRouterState();
             // the chat window and dialog services listen to 'web_client_ready' event in

--- a/addons/web/static/tests/legacy/views/form/form_view_tests.js
+++ b/addons/web/static/tests/legacy/views/form/form_view_tests.js
@@ -59,6 +59,8 @@ import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field"
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { FormController } from "@web/views/form/form_controller";
 import { companyService } from "@web/webclient/company_service";
+import { redirect } from "@web/core/utils/urls";
+import { WebClient } from "@web/webclient/webclient";
 
 const fieldRegistry = registry.category("fields");
 const serviceRegistry = registry.category("services");
@@ -6582,6 +6584,27 @@ QUnit.module("Views", (hooks) => {
         assert.containsNone(document.body, ".modal", "no confirm modal should be displayed");
 
         assert.verifySteps(["get_views", "web_read", "unlink", "history-back"]);
+    });
+
+    QUnit.test("delete the last record (without previous action)", async function (assert) {
+        serverData.views = {
+            "partner,false,form": `
+                    <form>
+                        <field name="display_name"/>
+                    </form>`,
+            "partner,false,search": "<search></search>",
+        };
+        redirect("/odoo/m-partner/1");
+        patchWithCleanup(WebClient.prototype, {
+            _loadDefaultApp() {
+                assert.step("__DEFAULT_ACTION__ called");
+            },
+        });
+        await createWebClient({ serverData });
+        await toggleActionMenu(target);
+        await toggleMenuItem(target, "Delete");
+        await click(document.body.querySelector(".modal-footer button.btn-primary"));
+        assert.verifySteps(["__DEFAULT_ACTION__ called"]);
     });
 
     QUnit.test("empty required fields cannot be saved", async function (assert) {


### PR DESCRIPTION
- open a record with an URL: `/{model}/{id}`;
- delete or archive the record;

Before this commit, an empty form view was displayed, with an incorrect URL: `/{model}/new`. This form view was inconsistent, and would throw an error in some applications (such as accounting). Even if no error was thrown, an error would be thrown if the user clicked on the 'back' button.

This is not the correct behaviour, when deleting or archiving a record, the correct behaviour is :
- if a pager exists, display the next record;
- if not, return to the previous controller (the previous action, usually the multi-record view);

The issue here is that we don't have a previous action or a multi-record view.

Now, in this particular case, we will fallback to the default application.

opw-4354129
