### PR TITLE
[IMP] core: allow to fail fast test suite

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -288,7 +288,7 @@ def load_module_graph(cr, graph, status=None, perform_checks=True,
                 env['ir.http']._clear_routing_map()     # force routing map to be rebuilt
 
                 tests_t0, tests_q0 = time.time(), odoo.sql_db.sql_counter
-                test_results = loader.run_suite(suite, module_name)
+                test_results = loader.run_suite(suite, module_name, global_report=report)
                 report.update(test_results)
                 test_time = time.time() - tests_t0
                 test_queries = odoo.sql_db.sql_counter - tests_q0

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1346,7 +1346,7 @@ def preload_registries(dbnames):
                     with registry.cursor() as cr:
                         env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
                         env['ir.qweb']._pregenerate_assets_bundles()
-                result = loader.run_suite(post_install_suite)
+                result = loader.run_suite(post_install_suite, global_report=registry._assertion_report)
                 registry._assertion_report.update(result)
                 _logger.info("%d post-tests in %.2fs, %s queries",
                              registry._assertion_report.testsRun - tests_before,

--- a/odoo/tests/loader.py
+++ b/odoo/tests/loader.py
@@ -76,13 +76,13 @@ def make_suite(module_names, position='at_install'):
     return OdooSuite(sorted(tests, key=lambda t: t.test_sequence))
 
 
-def run_suite(suite, module_name=None):
+def run_suite(suite, module_name=None, global_report=None):
     # avoid dependency hell
     from ..modules import module
     module.current_test = True
     threading.current_thread().testing = True
 
-    results = OdooTestResult()
+    results = OdooTestResult(global_report=global_report)
     suite(results)
 
     threading.current_thread().testing = False

--- a/odoo/tests/result.py
+++ b/odoo/tests/result.py
@@ -1,10 +1,12 @@
 """Test result object"""
 
-import logging
 import collections
 import contextlib
 import inspect
+import logging
+import os
 import re
+import sys
 import time
 import traceback
 
@@ -18,6 +20,7 @@ __unittest = True
 STDOUT_LINE = '\nStdout:\n%s'
 STDERR_LINE = '\nStderr:\n%s'
 
+ODOO_TEST_MAX_FAILED_TESTS = max(1, int(os.environ.get('ODOO_TEST_MAX_FAILED_TESTS', sys.maxsize)))
 
 stats_logger = logging.getLogger('odoo.tests.stats')
 
@@ -68,7 +71,7 @@ class OdooTestResult(object):
     _previousTestClass = None
     _moduleSetUpFailed = False
 
-    def __init__(self, stream=None, descriptions=None, verbosity=None):
+    def __init__(self, stream=None, descriptions=None, verbosity=None, global_report=None):
         self.failures_count = 0
         self.errors_count = 0
         self.testsRun = 0
@@ -80,6 +83,24 @@ class OdooTestResult(object):
         self._soft_fail = False
         self.had_failure = False
         self.stats = collections.defaultdict(Stat)
+        self.global_report = global_report
+        self.shouldStop = False
+        
+    def total_errors_count(self):
+        result = self.errors_count + self.failures_count
+        if self.global_report:
+            result += self.global_report.total_errors_count()
+        return result
+
+    def _checkShouldStop(self):
+        if self.total_errors_count() >= ODOO_TEST_MAX_FAILED_TESTS:
+            global_report = self.global_report or self
+            if not global_report.shouldStop:
+                _logger.error(
+                    "Test suite halted: max failed tests already reached (%s). "
+                    "Remaining tests will be skipped.", ODOO_TEST_MAX_FAILED_TESTS)
+                global_report.shouldStop = True
+            self.shouldStop = True
 
     def printErrors(self):
         "Called by TestRunner after test run"
@@ -108,6 +129,7 @@ class OdooTestResult(object):
         else:
             self.errors_count += 1
         self.logError("ERROR", test, err)
+        self._checkShouldStop()
 
     def addFailure(self, test, err):
         """Called when an error has occurred. 'err' is a tuple of values as
@@ -117,6 +139,7 @@ class OdooTestResult(object):
         else:
             self.failures_count += 1
         self.logError("FAIL", test, err)
+        self._checkShouldStop()
 
     def addSubTest(self, test, subtest, err):
         if err is not None:

--- a/odoo/tests/suite.py
+++ b/odoo/tests/suite.py
@@ -24,7 +24,6 @@ from odoo.modules import module
 
 __unittest = True
 
-
 class TestSuite(BaseTestSuite):
     """A test suite is a composite test consisting of a number of TestCases.
     For use, create an instance of TestSuite, then add test case instances.
@@ -36,6 +35,8 @@ class TestSuite(BaseTestSuite):
 
     def run(self, result, debug=False):
         for test in self:
+            if result.shouldStop:
+                break
             assert isinstance(test, (TestCase))
             module.current_test = test
             self._tearDownPreviousClass(test, result)


### PR DESCRIPTION
Allow to limit to max failures or errors in odoo test suite
when environment variable ODOO_TEST_MAX_FAILED_TESTS is set.
Above that limit, skip all following tests

ODOO_TEST_MAX_FAILED_TESTS must be a non zero int

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
