### PR TITLE
[FIX] stock: fix import lots dialog layout

### DIFF
--- a/addons/stock/static/src/widgets/lots_dialog.xml
+++ b/addons/stock/static/src/widgets/lots_dialog.xml
@@ -73,7 +73,7 @@
                 </t>
                 <t t-if="props.mode === 'import'" class="d-flex">
                     <div class="grid o_inner_group">
-                        <div class="d-flex d-sm-contents">
+                        <div class="d-flex">
                             <div class="o_cell flex-grow-0 flex-sm-grow-0 text-900 pe-3">
                                 <label class="o_form_label" for="next_serial_0">
                                     <t t-if="props.move.data.has_tracking==='lot'">Lot numbers</t>
@@ -88,7 +88,7 @@
                                     class="o_input" t-ref="lots" id="next_serial_0" type="text"/>
                             </div>
                         </div>
-                        <div class="d-flex d-sm-contents">
+                        <div class="d-flex">
                             <div class="o_cell flex-grow-0 flex-sm-grow-0 text-900 pe-3">
                                 <label class="o_form_label" for="keep_lines_0">Keep current lines</label>
                             </div>


### PR DESCRIPTION
Issue:
The grid elements on the import Lots dialog are placed in one column instead of two, which misses up the layout.

Reproduction steps:
1. install "purchase_stock"
2. create a product tracked by lots
3. make an RFQ for that product and confirm it
4. click on the generated receipt smart button
5. in "Operations" tab, click fa-list icon to open the dialog
6. in the dialog, click "Import Serials/Lots

Reason:
The bug was introduced in [239e75b1385fa023e97396baa0c8d46c50997dda](https://github.com/odoo/odoo/commit/239e75b1385fa023e97396baa0c8d46c50997dda#diff-1377579fdb76de80cd31ca67d798b752a90600ab4c82a3c8799786a130b7a46fR431-R433), where the following style was added
```css
.o_cell:first-child:last-child {
    grid-column: span 2;
}
```
which applies for the children of the first and the third grid elements; However, since the first and the third grid elements have `display: contents`, the `grid-column: span 2` of their children messes up the grid layout, and makes it 4x1 instead of 2x2.

The fix:
Remove `display: contents` on the first and third grid elements, as it seems to not be useful. Have tested on web and mobile layouts.

opw-4505725