### PR TITLE
[FIX] stock: fix stock report accessing non-existent field

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -123,10 +123,10 @@
                                             <span t-field="ml.product_uom_id" groups="uom.group_uom">units</span>
                                             <span t-if="ml.move_id.packaging_uom_id">
                                                 <span t-if="o.state != 'done'">
-                                                    (<span t-field="ml.packaging_uom_qty" t-options='{"widget": "integer"}'/> <span t-field="ml.move_id.packaging_uom_id.name"/>)
+                                                    (<span t-field="ml.move_id.packaging_uom_qty" t-options='{"widget": "integer"}'/> <span t-field="ml.move_id.packaging_uom_id.name"/>)
                                                 </span>
                                                 <span t-if="o.state == 'done'">
-                                                    (<span t-field="ml.packaging_uom_qty" t-options='{"widget": "integer"}'/> <span t-field="ml.move_id.packaging_uom_id.name"/>)
+                                                    (<span t-field="ml.move_id.packaging_uom_qty" t-options='{"widget": "integer"}'/> <span t-field="ml.move_id.packaging_uom_id.name"/>)
                                                 </span>
                                             </span>
                                         </td>


### PR DESCRIPTION
This commit fixes accessing `stock_move_line.packaging_uom_qty` field
which doesn't exist and changes it to access
`stock_move.packaging_uom_qty` instead.

Runbot : 111967

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
