### PR TITLE
[FIX] l10n_in: backporting of fiscal position commits

### DIFF
--- a/addons/l10n_in/tests/test_l10n_in_fiscal_position.py
+++ b/addons/l10n_in/tests/test_l10n_in_fiscal_position.py
@@ -1,3 +1,4 @@
+from odoo import Command, fields
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
 
@@ -32,6 +33,7 @@ class TestFiscal(AccountTestInvoicingCommon):
         })
         cls.partner_foreign = cls.env['res.partner'].create({
             'name': 'Partner Outside India',
+            'state_id': cls.env.ref('base.state_us_1').id,
             'country_id': cls.env.ref('base.us').id,
         })
 
@@ -49,15 +51,16 @@ class TestFiscal(AccountTestInvoicingCommon):
                 }]
             )
 
-    def _assert_invoice_fiscal_position(self, fiscal_position_ref, partner, tax_ref='igst_sale_18'):
+    def _assert_invoice_fiscal_position(self, fiscal_position_ref, partner, tax_ref='igst_sale_18', move_type='out_invoice', post=True):
         test_invoice = self.init_invoice(
-            move_type="out_invoice",
+            move_type=move_type,
             partner=partner,
-            post=True,
+            post=post,
             amounts=[110, 500],
             taxes=self.env['account.chart.template'].ref(tax_ref)
         )
         self.assertEqual(test_invoice.fiscal_position_id, self.env['account.chart.template'].ref(fiscal_position_ref))
+        return test_invoice
 
     def test_l10n_in_setting_up_company(self):
         company = self.setup_company_data(company_name='Fiscal Setup Test Company', chart_template=chart_template_ref)['company']
@@ -124,3 +127,125 @@ class TestFiscal(AccountTestInvoicingCommon):
             fiscal_position_ref='fiscal_position_in_export_sez_in',
             partner=self.partner_foreign
         )
+
+    def test_l10n_in_fiscal_in_bill_to_ship_to(self):
+        self.env.company = self.default_company
+        # Inter State
+        out_invoice = self._assert_invoice_fiscal_position(
+            fiscal_position_ref='fiscal_position_in_inter_state',
+            partner=self.partner_inter_state,
+            tax_ref='sgst_sale_18',
+            post=False,
+        )
+        # Intra State
+        out_invoice.write({
+            'l10n_in_state_id': self.env.ref('base.state_in_gj').id,
+        })
+        self.assertEqual(
+            out_invoice.fiscal_position_id,
+            self.env['account.chart.template'].ref('fiscal_position_in_intra_state')
+        )
+        # Outside India (Export/SEZ)
+        out_invoice.write({
+            'l10n_in_state_id': self.env.ref('l10n_in.state_in_oc').id,  # Other Country State
+        })
+        self.assertEqual(
+            out_invoice.fiscal_position_id,
+            self.env['account.chart.template'].ref('fiscal_position_in_export_sez_in')
+        )
+
+    def test_l10n_in_fiscal_in_vendor_bills(self):
+        '''
+        In Purchase Document: Compare place of supply with vendor state
+        '''
+
+        self.env.company = self.default_company
+        template = self.env['account.chart.template']
+        company_state = self.env.company.state_id
+        other_state = self.env['res.country.state'].search([
+            ('id', '!=', company_state.id),
+            ('country_id', '=', company_state.country_id.id)
+        ], limit=1)
+
+        # Sub-test: Intra-State
+        with self.subTest(scenario="Intra-State"):
+            self.partner_a.write({'state_id': company_state.id})
+            self.partner_a.write({'country_id': company_state.country_id.id})
+            vendor_bill = self._assert_invoice_fiscal_position(
+                fiscal_position_ref='fiscal_position_in_intra_state',
+                partner=self.partner_a,
+                move_type='in_invoice',
+                post=False,
+            )
+            self.partner_a.write({'state_id': other_state.id})
+            vendor_bill.write({'l10n_in_state_id': other_state.id})
+            self.assertEqual(
+                vendor_bill.fiscal_position_id,
+                template.ref('fiscal_position_in_intra_state')
+            )
+
+        # Sub-test: Inter-State
+        with self.subTest(scenario="Inter-State"):
+            self.partner_a.write({'state_id': other_state.id})
+            vendor_bill = self._assert_invoice_fiscal_position(
+                fiscal_position_ref='fiscal_position_in_inter_state',
+                partner=self.partner_a,
+                move_type='in_invoice',
+                post=False,
+            )
+            self.partner_a.write({'state_id': company_state.id})
+            vendor_bill.write({'l10n_in_state_id': other_state.id})
+            self.assertEqual(
+                vendor_bill.fiscal_position_id,
+                template.ref('fiscal_position_in_inter_state')
+            )
+
+        # Sub-test: Export/SEZ (Outside India)
+        with self.subTest(scenario="Export/SEZ"):
+            vendor_bill = self._assert_invoice_fiscal_position(
+                fiscal_position_ref='fiscal_position_in_export_sez_in',
+                partner=self.partner_foreign,
+                move_type='in_invoice',
+                post=False,
+            )
+            vendor_bill.write({'l10n_in_state_id': self.env.ref('l10n_in.state_in_oc').id})  # Other Country State
+            self.assertEqual(
+                vendor_bill.fiscal_position_id,
+                template.ref('fiscal_position_in_export_sez_in')
+            )
+            # Here fpos should Inter-State. But due to `l10n_in_gst_treatment` it will be Export/SEZ
+            self.partner_a.write({'state_id': other_state.id})
+            vendor_bill.write({
+                'partner_id': self.partner_a.id,  # Inter-State Partner
+                'l10n_in_state_id': company_state.id,  # Company State
+                'l10n_in_gst_treatment': 'special_economic_zone',
+            })
+            self.assertEqual(
+                vendor_bill.fiscal_position_id,
+                template.ref('fiscal_position_in_export_sez_in')
+            )
+
+        # Sub-test: Manual Partner Fiscal Check
+        with self.subTest(scenario="Manual Partner Fiscal Check"):
+            # Here fpos should Inter-State. But due to `property_account_position_id` it will be Export/SEZ
+            self.partner_a.write({
+                'state_id': company_state.id,  # Intra-State Partner
+                'property_account_position_id': template.ref('fiscal_position_in_export_sez_in').id
+            })
+            vendor_bill = self.env['account.move'].with_company(self.env.company).create({
+                'move_type': 'in_invoice',
+                'invoice_date': fields.Date.from_string('2019-01-01'),
+                'partner_id': self.partner_a.id,
+                'invoice_line_ids': [Command.create({
+                    'product_id': self.product_a.id,
+                    'quantity': 10,
+                    'name': 'product test 1',
+                    'price_unit': 40,
+                })]
+            })
+            vendor_bill.action_post()
+    
+            self.assertEqual(
+                vendor_bill.fiscal_position_id,
+                self.env['account.chart.template'].ref('fiscal_position_in_export_sez_in')
+            )


### PR DESCRIPTION
This PR is backporting of these commits:

[1] Commit https://github.com/odoo/odoo/commit/a1b7d8aba255ec477a030d44897b8ea73d1f37e7
[2] Commit https://github.com/odoo/odoo/commit/3653131d32997392b2170ce542bfc544fd96bef2

These commits introduce the computation of fiscal positions for sales and
purchase documents based on the place of supply. While these changes are
already merged into version 18.1, they are now required in version 17.0.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
