### PR TITLE
[IMP] core: api.private

### DIFF
--- a/addons/web/controllers/dataset.py
+++ b/addons/web/controllers/dataset.py
@@ -4,7 +4,6 @@ from werkzeug.exceptions import NotFound
 
 from odoo import http
 from odoo.http import request
-from odoo.models import check_method_name
 from odoo.service.model import call_kw
 
 from .utils import clean_action
@@ -27,12 +26,10 @@ class DataSet(http.Controller):
 
     @http.route(['/web/dataset/call_kw', '/web/dataset/call_kw/<path:path>'], type='jsonrpc', auth="user", readonly=_call_kw_readonly)
     def call_kw(self, model, method, args, kwargs, path=None):
-        check_method_name(method)
         return call_kw(request.env[model], method, args, kwargs)
 
     @http.route(['/web/dataset/call_button', '/web/dataset/call_button/<path:path>'], type='jsonrpc', auth="user", readonly=_call_kw_readonly)
     def call_button(self, model, method, args, kwargs, path=None):
-        check_method_name(method)
         action = call_kw(request.env[model], method, args, kwargs)
         if isinstance(action, dict) and action.get('type') != '':
             return clean_action(action, env=request.env)

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -18,8 +18,8 @@ from markupsafe import Markup
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import ValidationError, AccessError, UserError
 from odoo.http import request
-from odoo.models import check_method_name
 from odoo.modules.module import get_resource_from_path
+from odoo.service.model import get_public_method
 from odoo.tools import config, lazy_property, frozendict, SQL
 from odoo.tools.convert import _fix_multiple_roots
 from odoo.tools.misc import file_path, get_diff, ConstantMapping
@@ -1614,8 +1614,8 @@ actual arch.
                     )
                     self._raise_view_error(msg, node)
                 try:
-                    check_method_name(name)
-                except AccessError:
+                    get_public_method(name_manager.model, name)
+                except (AttributeError, AccessError):
                     msg = _(
                         "%(method)s on %(model)s is private and cannot be called from a button",
                         method=name, model=name_manager.model._name,

--- a/odoo/addons/test_rpc/models.py
+++ b/odoo/addons/test_rpc/models.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class Test_RpcModel_A(models.Model):
@@ -11,6 +10,21 @@ class Test_RpcModel_A(models.Model):
     name = fields.Char(required=True)
     field_b1 = fields.Many2one("test_rpc.model_b", string="required field", required=True)
     field_b2 = fields.Many2one("test_rpc.model_b", string="restricted field", ondelete="restrict")
+
+    @api.private
+    def read_group(self, *a, **kw):
+        return super().read_group(*a, **kw)
+
+    @api.private
+    def private_method(self):
+        return "private"
+
+    def filtered(self, func):
+        return super().filtered(func)
+
+    @api.model
+    def not_depending_on_id(self, vals=None):
+        return f"got {vals}"
 
 
 class Test_RpcModel_B(models.Model):

--- a/odoo/addons/test_rpc/tests/test_error.py
+++ b/odoo/addons/test_rpc/tests/test_error.py
@@ -16,6 +16,16 @@ class TestError(common.HttpCase):
         # Reset the admin's lang to avoid breaking tests due to admin not in English
         self.rpc("res.users", "write", [uid], {"lang": False})
 
+    def test_01_private(self):
+        with self.assertRaisesRegex(Exception, r"Private method"), mute_logger('odoo.http'):
+            self.rpc('test_rpc.model_a', '_create')
+        with self.assertRaisesRegex(Exception, r"Private method"), mute_logger('odoo.http'):
+            self.rpc('test_rpc.model_a', 'private_method')
+        with self.assertRaisesRegex(Exception, r"Private method"), mute_logger('odoo.http'):
+            self.rpc('test_rpc.model_a', 'init')
+        with self.assertRaisesRegex(Exception, r"Private method"), mute_logger('odoo.http'):
+            self.rpc('test_rpc.model_a', 'filtered', ['id'])
+
     def test_01_create(self):
         """ Create: mandatory field not provided """
         self.rpc("test_rpc.model_b", "create", {"name": "B1"})
@@ -75,3 +85,7 @@ class TestError(common.HttpCase):
         self.patch(http, 'db_list', db_list)  # this is just to ensure that the request won't have a db, breaking monodb behaviour
 
         self.rpc("test_rpc.model_b", "create", {"name": "B1"})
+
+    def test_05_model(self):
+        res = self.rpc("test_rpc.model_a", "not_depending_on_id", [1])
+        self.assertEqual(res, "got [1]")

--- a/odoo/api/__init__.py
+++ b/odoo/api/__init__.py
@@ -11,6 +11,7 @@ from odoo.orm.decorators import (
     model_create_multi,
     onchange,
     ondelete,
+    private,
     readonly,
 )
 from odoo.orm.environments import Environment

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1638,6 +1638,7 @@ class BaseModel(metaclass=MetaModel):
         return self.search_fetch(domain, [], offset=offset, limit=limit, order=order)
 
     @api.model
+    @api.private
     @api.readonly
     def search_fetch(self, domain: DomainType, field_names: Sequence[str], offset=0, limit=None, order=None) -> Self:
         """ search_fetch(domain, field_names[, offset=0][, limit=None][, order=None])
@@ -3160,6 +3161,7 @@ class BaseModel(metaclass=MetaModel):
         if parent_path_compute:
             self._parent_store_compute()
 
+    @api.private
     def init(self):
         """ This method is called after :meth:`~._auto_init`, and may be
             overridden to create or modify a model's database schema.
@@ -3865,6 +3867,7 @@ class BaseModel(metaclass=MetaModel):
             fnames = [field.name]
         self.fetch(fnames)
 
+    @api.private
     def fetch(self, field_names):
         """ Make sure the given fields are in memory for the records in ``self``,
         by fetching what is necessary from the database.  Non-stored fields are
@@ -4176,6 +4179,7 @@ class BaseModel(metaclass=MetaModel):
                 })
             raise UserError("\n".join(lines))
 
+    @api.private  # use has_access
     def check_access(self, operation: str) -> None:
         """ Verify that the current user is allowed to perform ``operation`` on
         all the records in ``self``. The method raises an :class:`AccessError`
@@ -5642,6 +5646,7 @@ class BaseModel(metaclass=MetaModel):
             old_record.copy_translations(new_record, excluded=default or ())
         return new_records
 
+    @api.private
     def exists(self) -> Self:
         """  exists() -> records
 
@@ -5913,6 +5918,7 @@ class BaseModel(metaclass=MetaModel):
         self._ids = ids
         self._prefetch_ids = prefetch_ids
 
+    @api.private
     def browse(self, ids: int | typing.Iterable[IdType] = ()) -> Self:
         """ browse([ids]) -> records
 
@@ -5954,6 +5960,7 @@ class BaseModel(metaclass=MetaModel):
     # Conversion methods
     #
 
+    @api.private
     def ensure_one(self) -> Self:
         """Verify that the current recordset holds a single record.
 
@@ -5967,6 +5974,7 @@ class BaseModel(metaclass=MetaModel):
         except ValueError:
             raise ValueError("Expected singleton: %s" % self)
 
+    @api.private
     def with_env(self, env: api.Environment) -> Self:
         """Return a new version of this recordset attached to the provided environment.
 
@@ -5978,6 +5986,7 @@ class BaseModel(metaclass=MetaModel):
         """
         return self.__class__(env, self._ids, self._prefetch_ids)
 
+    @api.private
     def sudo(self, flag=True) -> Self:
         """ sudo([flag=True])
 
@@ -6006,6 +6015,7 @@ class BaseModel(metaclass=MetaModel):
             return self
         return self.with_env(self.env(su=flag))
 
+    @api.private
     def with_user(self, user) -> Self:
         """ with_user(user)
 
@@ -6017,6 +6027,7 @@ class BaseModel(metaclass=MetaModel):
             return self
         return self.with_env(self.env(user=user, su=False))
 
+    @api.private
     def with_company(self, company) -> Self:
         """ with_company(company)
 
@@ -6051,6 +6062,7 @@ class BaseModel(metaclass=MetaModel):
 
         return self.with_context(allowed_company_ids=allowed_company_ids)
 
+    @api.private
     def with_context(self, *args, **kwargs) -> Self:
         """ with_context([context][, **overrides]) -> Model
 
@@ -6090,6 +6102,7 @@ class BaseModel(metaclass=MetaModel):
             context['allowed_company_ids'] = self._context['allowed_company_ids']
         return self.with_env(self.env(context=context))
 
+    @api.private
     def with_prefetch(self, prefetch_ids=None) -> Self:
         """ with_prefetch([prefetch_ids]) -> records
 
@@ -6154,6 +6167,7 @@ class BaseModel(metaclass=MetaModel):
     # Record traversal and update
     #
 
+    @api.private
     def mapped(self, func):
         """Apply ``func`` on all records in ``self``, and return the result as a
         list or a recordset (if ``func`` return recordsets). In the latter
@@ -6213,6 +6227,7 @@ class BaseModel(metaclass=MetaModel):
             vals = func(self)
             return vals if isinstance(vals, BaseModel) else []
 
+    @api.private
     def filtered(self, func) -> Self:
         """Return the records in ``self`` satisfying ``func``.
 
@@ -6238,6 +6253,7 @@ class BaseModel(metaclass=MetaModel):
             func = self._fields[func].__get__
         return self.browse(rec.id for rec in self if func(rec))
 
+    @api.private
     def grouped(self, key):
         """Eagerly groups the records of ``self`` by the ``key``, returning a
         dict from the ``key``'s result to recordsets. All the resulting
@@ -6265,6 +6281,7 @@ class BaseModel(metaclass=MetaModel):
         browse = functools.partial(type(self), self.env, prefetch_ids=self._prefetch_ids)
         return {key: browse(tuple(ids)) for key, ids in collator.items()}
 
+    @api.private
     def filtered_domain(self, domain) -> Self:
         """Return the records in ``self`` satisfying the domain and keeping the same order.
 
@@ -6438,6 +6455,7 @@ class BaseModel(metaclass=MetaModel):
         [result_ids] = stack
         return self.browse(id_ for id_ in self._ids if id_ in result_ids)
 
+    @api.private
     def sorted(self, key=None, reverse=False) -> Self:
         """Return the recordset ``self`` ordered by ``key``.
 
@@ -6464,11 +6482,13 @@ class BaseModel(metaclass=MetaModel):
             ids = tuple(item.id for item in sorted(self, key=key, reverse=reverse))
         return self.__class__(self.env, ids, self._prefetch_ids)
 
+    @api.private  # use write instead
     def update(self, values):
         """ Update the records in ``self`` with ``values``. """
         for name, value in values.items():
             self[name] = value
 
+    @api.private
     def flush_model(self, fnames=None):
         """ Process the pending computations and database updates on ``self``'s
         model.  When the parameter is given, the method guarantees that at least
@@ -6480,6 +6500,7 @@ class BaseModel(metaclass=MetaModel):
         self._recompute_model(fnames)
         self._flush(fnames)
 
+    @api.private
     def flush_recordset(self, fnames=None):
         """ Process the pending computations and database updates on the records
         ``self``.   When the parameter is given, the method guarantees that at
@@ -6563,6 +6584,7 @@ class BaseModel(metaclass=MetaModel):
     #
 
     @api.model
+    @api.private
     def new(self, values=None, origin=None, ref=None) -> Self:
         """ new([values], [origin], [ref]) -> record
 
@@ -6645,6 +6667,7 @@ class BaseModel(metaclass=MetaModel):
         """ Return the concatenation of two recordsets. """
         return self.concat(other)
 
+    @api.private
     def concat(self, *args) -> Self:
         """ Return the concatenation of ``self`` with all the arguments (in
             linear time complexity).
@@ -6689,6 +6712,7 @@ class BaseModel(metaclass=MetaModel):
         """
         return self.union(other)
 
+    @api.private
     def union(self, *args) -> Self:
         """ Return the union of ``self`` with all the arguments (in linear time
             complexity, with first occurrence order preserved).
@@ -6800,6 +6824,7 @@ class BaseModel(metaclass=MetaModel):
         """ Return the cache of ``self``, mapping field names to values. """
         return RecordCache(self)
 
+    @api.private
     def invalidate_model(self, fnames=None, flush=True):
         """ Invalidate the cache of all records of ``self``'s model, when the
         cached values no longer correspond to the database values.  If the
@@ -6814,6 +6839,7 @@ class BaseModel(metaclass=MetaModel):
             self.flush_model(fnames)
         self._invalidate_cache(fnames)
 
+    @api.private
     def invalidate_recordset(self, fnames=None, flush=True):
         """ Invalidate the cache of the records in ``self``, when the cached
         values no longer correspond to the database values.  If the parameter
@@ -6842,6 +6868,7 @@ class BaseModel(metaclass=MetaModel):
                 spec.append((invf, None))
         self.env.cache.invalidate(spec)
 
+    @api.private
     def modified(self, fnames, create=False, before=False):
         """ Notify that fields will be or have been modified on ``self``. This
         invalidates the cache where necessary, and prepares the recomputation of

--- a/odoo/orm/utils.py
+++ b/odoo/orm/utils.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from collections.abc import Set as AbstractSet
 
 import dateutil.relativedelta
@@ -67,6 +68,7 @@ SQL_OPERATORS = {
 
 def check_method_name(name):
     """ Raise an ``AccessError`` if ``name`` is a private method name. """
+    warnings.warn("Since 19.0, use odoo.service.model.get_public_method", DeprecationWarning)
     if regex_private.match(name):
         raise AccessError('Private methods (such as %s) cannot be called remotely.' % name)
 

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -187,8 +187,8 @@ def _eval_xml(self, node, env):
         if 'context' in kwargs:
             model = model.with_context(**kwargs.pop('context'))
         method = getattr(model, method_name)
-        api = getattr(method, '_api', None)
-        if api and api.startswith('model'):
+        is_model_method = getattr(method, '_api_model', False)
+        if is_model_method:
             pass  # already bound to an empty recordset
         else:
             record_ids, *args = args


### PR DESCRIPTION
Explicitly prevent calling non-public ORM methods via RPC, without breaking the API

The ORM contains a series of API methods found on Models and recordsets, next to the main
CRUD methods. Those utility methods are very commonly used in server-side business logic
code, and were historically named without the usual underscore prefix that should mark
them as private (e.g. `_private_method()` vs `public_method()`).

Examples:
- the `browse()` method returns a recordset from a list of IDs, which is really just
  a proxy object prepared for other recordset operations ;
- the `fetch()` and `search_fetch()` methods populate the transactional in-memory cache
  for a set of fields and record ;
- and many more...

The lack of prefix makes writing business logic code a bit simpler, but causes confusion
because these methods look like they are public.

Of course, calling such internal methods over RPC doesn't make sense, and may crash or
cause unexpected results.

This commit marks those internal methods and prevents calling them over RPC. This is
preferred over renaming them with an underscore prefix, as that would break a lot of
existing code without a good reason.

All business logic code must still follow the best-practicce convention of prefixing
non-public method with underscores, by default and by design, to avoid mixing different
conventions. The `@api.private` decorator is reserved for exceptions for ORM methods.

task-4505030
odoo/enterprise#77961
odoo/documentation#11944


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
