### PR TITLE
Master fix columns count option dery

### DIFF
--- a/addons/website/views/snippets/s_cards_grid.xml
+++ b/addons/website/views/snippets/s_cards_grid.xml
@@ -4,10 +4,8 @@
 <template id="s_cards_grid" name="Cards Grid">
     <section class="s_cards_grid o_colored_level o_cc o_cc2 pt64 pb64">
         <div class="container">
-            <div class="row s_nb_column_fixed">
-                <div class="col-lg-12">
-                    <h3>Features that set us apart</h3>
-                </div>
+            <h3>Features that set us apart</h3>
+            <div class="row">
                 <div data-name="Card" class="col-lg-6">
                     <div class="s_card o_card_img_horizontal o_cc o_cc1 card flex-lg-row" data-vxml="001" data-snippet="s_card" data-name="Card" style="--card-img-size-h: 25%;">
                         <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">

--- a/addons/website/views/snippets/s_cards_soft.xml
+++ b/addons/website/views/snippets/s_cards_soft.xml
@@ -4,11 +4,9 @@
 <template id="s_cards_soft" name="Cards Soft">
     <section class="s_cards_soft o_cc o_cc1 pt48 pb32">
         <div class="container">
-            <div class="row s_nb_column_fixed">
-                <div class="col-lg-12">
-                    <h2 style="text-align: center;">Your Journey Begins Here</h2>
-                    <p class="lead" style="text-align: center;">We make every moment count with solutions designed just for you.</p>
-                </div>
+            <h2 style="text-align: center;">Your Journey Begins Here</h2>
+            <p class="lead" style="text-align: center;">We make every moment count with solutions designed just for you.</p>
+            <div class="row">
                 <div data-name="Card" class="col-lg-4 pt16 pb16">
                     <div class="s_card card o_cc o_cc2" data-vxml="001" data-snippet="s_card" data-name="Card" style="border-width: 0px !important;">
                         <div class="card-body">

--- a/addons/website/views/snippets/s_company_team.xml
+++ b/addons/website/views/snippets/s_company_team.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <h3>Meet our team</h3>
             <p class="lead">Dedicated professionals driving our success</p>
-            <div class="row s_nb_column_fixed">
+            <div class="row">
                 <div class="col-lg-6 pt32 pb32" data-name="Team Member">
                     <div class="row s_col_no_resize s_col_no_bgcolor">
                         <div class="col-lg-3 pb24 o_not_editable" contenteditable="false">

--- a/addons/website/views/snippets/s_company_team_basic.xml
+++ b/addons/website/views/snippets/s_company_team_basic.xml
@@ -2,36 +2,35 @@
 <odoo>
 
 <template id="s_company_team_basic" name="Team Basic">
-    <section class="s_company_team_basic o_cc o_cc1 pt64 pb64">
+    <section class="s_company_team_basic o_cc o_cc1 pt96 pb64">
         <div class="container">
-            <div class="row o_grid_mode" data-row-count="10">
-                <div class="o_grid_item g-col-lg-12 g-height-2 col-lg-12" style="grid-area: 1 / 1 / 3 / 13; --grid-item-padding-y: 32px; --grid-item-padding-x: 32px; z-index: 1;">
-                    <h3 style="text-align: center;">Discover our executive team</h3>
-                </div>
-                <div class="o_grid_item g-col-6 g-col-lg-3 g-height-8 col-6 col-lg-3" data-name="Team Member" style="grid-area: 3 / 1 / 11 / 4; --grid-item-padding-y: 16px; --grid-item-padding-x: 32px; z-index: 2;">
+            <h3 style="text-align: center;">Discover our executive team</h3>
+            <p><br/></p>
+            <div class="row">
+                <div class="col-lg-3 col-6 pb32" data-name="Team Member">
                     <p class="o_not_editable" contenteditable="false" style="text-align: center;">
-                        <img alt="" class="o_editable_media img-fluid rounded-circle" src="/web/image/website.s_company_team_image_1" style="width: 100% !important;"/>
+                        <img alt="" class="o_editable_media img-fluid rounded-circle me-auto float-start" src="/web/image/website.s_company_team_image_1" style="width: 100% !important; padding: 20px"/>
                     </p>
                     <h4 class="h5-fs" style="text-align: center;">Tony Fred, CEO</h4>
                     <p class="o_small-fs text-muted" style="text-align: center;">Chief Executive Officer</p>
                 </div>
-                <div class="o_grid_item g-col-6 g-col-lg-3 g-height-8 col-6 col-lg-3" data-name="Team Member" style="grid-area: 3 / 4 / 11 / 7; --grid-item-padding-y: 16px; --grid-item-padding-x: 32px; z-index: 3;">
+                <div class="col-lg-3 col-6 pb32" data-name="Team Member">
                     <p class="o_not_editable" contenteditable="false" style="text-align: center;">
-                        <img alt="" class="o_editable_media img-fluid rounded-circle" src="/web/image/website.s_company_team_image_2" style="width: 100% !important;"/>
+                        <img alt="" class="o_editable_media img-fluid rounded-circle me-auto float-start" src="/web/image/website.s_company_team_image_2" style="width: 100% !important; padding: 20px"/>
                     </p>
                     <h4 class="h5-fs" style="text-align: center;">Mich Stark, COO</h4>
                     <p class="o_small-fs text-muted" style="text-align: center;">Chief Operational Officer</p>
                 </div>
-                <div class="o_grid_item g-col-6 g-col-lg-3 g-height-8 col-6 col-lg-3" data-name="Team Member" style="grid-area: 3 / 7 / 11 / 10; --grid-item-padding-y: 16px; --grid-item-padding-x: 32px; z-index: 4;">
+                <div class="col-lg-3 col-6 pb32" data-name="Team Member">
                     <p class="o_not_editable" contenteditable="false" style="text-align: center;">
-                        <img alt="" class="o_editable_media img-fluid rounded-circle" src="/web/image/website.s_company_team_image_3" style="width: 100% !important;"/>
+                        <img alt="" class="o_editable_media img-fluid rounded-circle me-auto float-start" src="/web/image/website.s_company_team_image_3" style="width: 100% !important; padding: 20px"/>
                     </p>
                     <h4 class="h5-fs" style="text-align: center;">Aline Turner, CTO</h4>
                     <p class="o_small-fs text-muted" style="text-align: center;">Chief Technical Officer</p>
                 </div>
-                <div class="o_grid_item g-col-6 g-col-lg-3 g-height-8 col-6 col-lg-3" data-name="Team Member" style="grid-area: 3 / 10 / 11 / 13; --grid-item-padding-y: 16px; --grid-item-padding-x: 32px; z-index: 5;">
+                <div class="col-lg-3 col-6 pb32" data-name="Team Member">
                     <p class="o_not_editable" contenteditable="false" style="text-align: center;">
-                        <img alt="" class="o_editable_media img-fluid rounded-circle" src="/web/image/website.s_company_team_image_4" style="width: 100% !important;"/>
+                        <img alt="" class="o_editable_media img-fluid rounded-circle me-auto float-start" src="/web/image/website.s_company_team_image_4" style="width: 100% !important; padding: 20px"/>
                     </p>
                     <h4 class="h5-fs" style="text-align: center;">Iris Joe, CFO</h4>
                     <p class="o_small-fs text-muted" style="text-align: center;">Chief Financial Officer</p>

--- a/addons/website/views/snippets/s_company_team_detail.xml
+++ b/addons/website/views/snippets/s_company_team_detail.xml
@@ -4,11 +4,9 @@
 <template id="s_company_team_detail" name="Team Detail">
     <section class="s_company_team_detail o_cc o_cc1 pt64 pb64">
         <div class="container">
-            <div class="row s_nb_column_fixed">
-                <div class="col-lg-12">
-                    <h3>Meet our team</h3>
-                    <p class="lead">Dedicated professionals driving our success</p>
-                </div>
+            <h3>Meet our team</h3>
+            <p class="lead">Dedicated professionals driving our success</p>
+            <div class="row">
                 <div class="col-lg-4 pt32 pb32" data-name="Team Member">
                     <div class="o_not_editable" contenteditable="false">
                         <img class="o_editable_media img img-fluid rounded-circle" src="/web/image/website.s_company_team_image_1" alt="" style="width: 25% !important;"/>

--- a/addons/website/views/snippets/s_company_team_shapes.xml
+++ b/addons/website/views/snippets/s_company_team_shapes.xml
@@ -4,10 +4,9 @@
 <template id="s_company_team_shapes" name="Team Shapes">
     <section class="s_company_team_shapes o_cc o_cc2 pt48 pb48">
         <div class="o_container_small">
-            <div class="row s_nb_column_fixed">
-                <div class="col-lg-12 pb24">
-                    <h2 style="text-align: center;">Our talented crew</h2>
-                </div>
+            <h2 style="text-align: center;">Our talented crew</h2>
+            <p><br/></p>
+            <div class="row">
                 <div class="col-6 col-lg-4 pb24">
                     <p><img src="/web_editor/image_shape/website.s_company_team_image_1/web_editor/geometric_round/geo_round_square.svg" class="img img-fluid" alt="" data-shape="web_editor/geometric_round/geo_round_square" data-original-mimetype="image/jpeg" data-file-name="s_company_team_image_1.svg" data-shape-colors=";;;;" style="width: 100% !important;"/></p>
                     <h3 class="h5-fs" style="text-align: center;">Tony Fred</h3>

--- a/addons/website/views/snippets/s_company_team_spotlight.xml
+++ b/addons/website/views/snippets/s_company_team_spotlight.xml
@@ -4,10 +4,9 @@
 <template id="s_company_team_spotlight" name="Team Spotlight">
     <section class="s_company_team_spotlight o_colored_level o_cc o_cc1 pt48 pb48">
         <div class="container">
-            <div class="row s_nb_column_fixed">
-                <div class="col-lg-12 pb24">
-                    <h2 style="text-align: center;">Team spotlight</h2>
-                </div>
+            <h2 style="text-align: center;">Team spotlight</h2>
+            <p><br/></p>
+            <div class="row">
                 <div data-name="Team Member" class="col-6 col-lg-3">
                     <div class="s_card o_card_img_top card o_cc o_cc1" data-vxml="001" data-snippet="s_card" data-name="Card">
                         <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">

--- a/addons/website/views/snippets/s_faq_list.xml
+++ b/addons/website/views/snippets/s_faq_list.xml
@@ -2,13 +2,12 @@
 <odoo>
 
 <template id="s_faq_list" name="FAQ List">
-    <section class="s_faq_list pt56 pb56">
+    <section class="s_faq_list pt56 pb64">
         <div class="container">
-            <div class="row s_nb_column_fixed">
-                <div class="col-lg-12 pb24">
-                    <h3>Need help?</h3>
-                    <p class="lead">In this section, you can address common questions efficiently.</p>
-                </div>
+            <h3>Need help?</h3>
+            <p class="lead">In this section, you can address common questions efficiently.</p>
+            <p><br/></p>
+            <div class="row">
                 <div class="col-lg-4 pt16 pb16">
                     <h6><strong>What sets us apart?</strong></h6>
                     <p>We deliver personalized solutions, ensuring that every customer receives top-tier service tailored to their needs.</p>

--- a/addons/website/views/snippets/s_features.xml
+++ b/addons/website/views/snippets/s_features.xml
@@ -4,10 +4,8 @@
 <template id="s_features" name="Features">
     <section class="s_features pt64 pb64">
         <div class="container">
-            <div class="col-lg-12">
-                <h3>Everything you need</h3>
-                <p class="lead">List and describe the key features of your solution or service.</p>
-            </div>
+            <h3>Everything you need</h3>
+            <p class="lead">List and describe the key features of your solution or service.</p>
             <div class="row">
                 <div class="col-lg-4">
                     <div class="s_hr pt-4 pb32">

--- a/addons/website/views/snippets/s_features_wave.xml
+++ b/addons/website/views/snippets/s_features_wave.xml
@@ -2,14 +2,13 @@
 <odoo>
 
 <template id="s_features_wave" name="Features Wave">
-    <section class="s_features_wave o_cc o_cc5 pt64 pb64" data-oe-shape-data="{'shape':'web_editor/Wavy/11_001','colors':{'c5':'o-color-1'}, 'showOnMobile':true}">
+    <section class="s_features_wave o_cc o_cc5 pt64 pb88" data-oe-shape-data="{'shape':'web_editor/Wavy/11_001','colors':{'c5':'o-color-1'}, 'showOnMobile':true}">
         <div class="o_we_shape o_web_editor_Wavy_11_001 o_shape_show_mobile" style="background-image: url('/web_editor/shape/web_editor/Wavy/11_001.svg?c5=o-color-1');"/>
         <div class="container">
-            <div class="row s_nb_column_fixed">
-                <div class="col-lg-12 pb24">
-                    <h3 style="text-align: center;">Everything you need</h3>
-                    <p class="lead" style="text-align: center;">List and describe the key features of your solution or service.</p>
-                </div>
+            <h3 style="text-align: center;">Everything you need</h3>
+            <p class="lead" style="text-align: center;">List and describe the key features of your solution or service.</p>
+            <p><br/></p>
+            <div class="row">
                 <div class="col-lg-4 pt24 pb24">
                     <i class="fa fa-thumbs-o-up d-block mx-auto border rounded fa-2x" style="background-color: rgba(0, 0, 0, 0);" role="presentation"/>
                     <br/>

--- a/addons/website/views/snippets/s_key_benefits.xml
+++ b/addons/website/views/snippets/s_key_benefits.xml
@@ -5,13 +5,11 @@
     <section class="s_key_benefits pt48 pb48" data-oe-shape-data="{'shape': 'web_editor/Connections/14'}">
         <div class="o_we_shape o_web_editor_Connections_14"/>
         <div class="container">
-            <div class="row s_nb_column_fixed">
-                <div class="col-lg-12">
-                    <p class="lead">
-                        ✽&#160;&#160;What We Offer
-                    </p>
-                    <h2 class="display-3-fs">Discover our<br/>main three benefits</h2>
-                </div>
+            <p class="lead">
+                ✽&#160;&#160;What We Offer
+            </p>
+            <h2 class="display-3-fs">Discover our<br/>main three benefits</h2>
+            <div class="row">
                 <div class="col-lg-4 pt48 pb24">
                     <span class="display-3-fs text-o-color-1">1</span>
                     <div class="s_hr pt8 pb24" data-snippet="s_hr" data-name="Separator">

--- a/addons/website/views/snippets/s_key_images.xml
+++ b/addons/website/views/snippets/s_key_images.xml
@@ -4,11 +4,10 @@
 <template id="s_key_images" name="Key Images">
     <section class="s_key_images pt72 pb72">
         <div class="container">
-            <div class="row s_nb_column_fixed">
-                <div class="col-lg-12 pb32">
-                    <h2>What we propose to our customers</h2>
-                    <p class="lead">Dive deeper into our company’s abilities.</p>
-                </div>
+            <h2>What we propose to our customers</h2>
+            <p class="lead">Dive deeper into our company’s abilities.</p>
+            <p><br/></p>
+            <div class="row">
                 <div class="col-6 col-lg-3">
                     <p class="h1-fs">01</p>
                     <p><img src="/web/image/website.s_key_images_default_image_1" class="img img-fluid rounded" alt="" style="width: 100% !important;"/></p>

--- a/addons/website/views/snippets/s_product_list.xml
+++ b/addons/website/views/snippets/s_product_list.xml
@@ -5,10 +5,8 @@
     <t t-set="url" t-value="url or '#'"/>
     <section class="s_product_list pt64 pb64" data-vcss="001">
         <div class="container">
-            <div class="row s_nb_column_fixed">
-                <div class="col-lg-12">
-                    <h2 class="h3-fs">Our finest selection</h2>
-                </div>
+            <h2 class="h3-fs">Our finest selection</h2>
+            <div class="row">
                 <div data-name="Card" class="col-lg-2 col-6">
                     <div class="s_card o_card_img_top card o_cc o_cc1" data-snippet="s_card" data-vxml="001" data-name="Card">
                         <figure class="o_card_img_wrapper ratio ratio-4x3 mb-0">

--- a/addons/website/views/snippets/s_references.xml
+++ b/addons/website/views/snippets/s_references.xml
@@ -4,14 +4,13 @@
 <template id="s_references" name="References">
     <section class="s_references o_cc o_cc1 pt80 pb80">
         <div class="container">
-            <div class="row s_nb_column_fixed">
-                <div class="col-12 col-lg-12 pb24">
-                    <h2 style="text-align: center;">Partners and references</h2>
-                    <p class="lead" style="text-align: center;">Use this section to boost your company's credibility.</p>
-                    <p style="text-align: center;">
-                        <a href="#">See our case studies <i class="fa fa-long-arrow-right ms-2"/></a>
-                    </p>
-                </div>
+            <h2 style="text-align: center;">Partners and references</h2>
+            <p class="lead" style="text-align: center;">Use this section to boost your company's credibility.</p>
+            <p style="text-align: center;">
+                <a href="#">See our case studies <i class="fa fa-long-arrow-right ms-2"/></a>
+            </p>
+            <p><br/></p>
+            <div class="row">
                 <div class="col-6 col-lg-2 pt16 pb16">
                     <img src="/web/image/website.s_reference_demo_image_1" class="img img-fluid mx-auto" alt=""/>
                 </div>

--- a/addons/website/views/snippets/s_references_social.xml
+++ b/addons/website/views/snippets/s_references_social.xml
@@ -4,11 +4,9 @@
 <template id="s_references_social" name="References Social">
     <section class="s_references_social o_cc o_cc1 pt64 pb64">
         <div class="container">
-            <div class="row s_nb_column_fixed">
-                <div class="col-lg-12">
-                    <h2 style="text-align: center;">Our valued partners</h2>
-                    <p class="lead" style="text-align: center;">We are in good company.</p>
-                </div>
+            <h2 style="text-align: center;">Our valued partners</h2>
+            <p class="lead" style="text-align: center;">We are in good company.</p>
+            <div class="row">
                 <div class="col-lg-3 pt16 pb16">
                     <img class="img img-fluid mx-auto" src="/web/image/website.s_reference_demo_image_1" alt=""/>
                     <h3 class="h5-fs" style="text-align: center;"><br/>Amsterdam</h3>

--- a/addons/website/views/snippets/s_striped.xml
+++ b/addons/website/views/snippets/s_striped.xml
@@ -2,14 +2,13 @@
 <odoo>
 
 <template id="s_striped" name="Striped section">
-    <section class="s_striped o_cc o_cc5 pt56 pb96" style="position: relative;" data-oe-shape-data="{'shape':'web_editor/Connections/20','colors':{'c5': 'o-color-4'},'flip':[], 'showOnMobile':true}">
+    <section class="s_striped o_cc o_cc5 pt80 pb96" style="position: relative;" data-oe-shape-data="{'shape':'web_editor/Connections/20','colors':{'c5': 'o-color-4'},'flip':[], 'showOnMobile':true}">
         <div class="o_we_shape o_web_editor_Connections_20 o_shape_show_mobile" style="background-image: url('/web_editor/shape/web_editor/Connections/20.svg?c5=o-color-4'); background-position: 50% 100%;"/>
         <div class="container">
+            <h2 style="text-align: center;">The evolution of our company</h2>
+            <p class="lead" style="text-align: center;">Learn about the key decisions that have shaped our identity.</p>
+            <p><br/></p>
             <div class="row">
-                <div class="col-lg-12 pt24 pb24">
-                    <h2 style="text-align: center;">The evolution of our company</h2>
-                    <p class="lead" style="text-align: center;">Learn about the key decisions that have shaped our identity.</p>
-                </div>
                 <div class="col-lg-8 offset-lg-2 pt24 pb24">
                     <img class="img img-fluid" src="/web/image/website.s_text_cover_default_image" style="width: 100% !important;" alt=""/>
                 </div>

--- a/addons/website/views/snippets/s_timeline.xml
+++ b/addons/website/views/snippets/s_timeline.xml
@@ -4,12 +4,9 @@
 <template name="Timeline" id="s_timeline">
     <section class="s_timeline pt48 pb48" data-vcss="002">
         <div class="o_container_small">
-            <div class="row">
-                <div class="col-lg-12 pb24 text-center" data-name="Heading">
-                    <h2 class="h3-fs">Latest news</h2>
-                    <p class="lead">Highlight your history, showcase growth and key milestones.</p>
-                </div>
-            </div>
+            <h2 style="text-align: center;" class="h3-fs">Latest news</h2>
+            <p style="text-align: center;" class="lead">Highlight your history, showcase growth and key milestones.</p>
+            <p><br/></p>
             <div class="position-relative pt-3">
                 <div class="s_timeline_row position-relative d-flex gap-md-5 flex-column flex-md-row pb-4" data-name="Milestone">
                     <div class="o_dot_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>

--- a/addons/website/views/snippets/s_timeline_list.xml
+++ b/addons/website/views/snippets/s_timeline_list.xml
@@ -4,12 +4,9 @@
 <template id="s_timeline_list" name="Timeline List">
     <section class="s_timeline_list pt32 pb88">
         <div class="o_container_small">
-            <div class="row">
-                <div class="col-lg-12 pb24 text-center" data-name="Heading">
-                    <h2 class="h3-fs">What's new</h2>
-                    <p class="lead">Highlight your history, showcase growth and key milestones.</p>
-                </div>
-            </div>
+            <h2 style="text-align: center;" class="h3-fs">What's new</h2>
+            <p style="text-align: center;" class="lead">Highlight your history, showcase growth and key milestones.</p>
+            <p><br/></p>
             <div class="s_timeline_list_wrapper d-flex justify-content-center pt-3">
                 <div>
                     <div class="s_timeline_list_row position-relative pb-4" data-name="Milestone">

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -983,7 +983,7 @@
     <div data-js="layout_column"
         data-selector="section, section.s_carousel_wrapper .carousel-item, .s_carousel_intro_item"
         data-target="> *:has(> .row), > .s_allow_columns"
-        data-exclude=".s_dynamic, .s_dynamic_snippet_content, .s_dynamic_snippet_title, .s_masonry_block, .s_framed_intro, .s_features_grid, .s_media_list, .s_table_of_content, .s_process_steps, .s_image_gallery, .s_timeline, .s_pricelist_boxed, .s_quadrant, .s_pricelist_cafe, .s_faq_horizontal, .s_image_frame, .s_card_offset, .s_contact_info">
+        data-exclude=".s_dynamic, .s_dynamic_snippet_content, .s_dynamic_snippet_title, .s_masonry_block, .s_framed_intro, .s_features_grid, .s_media_list, .s_table_of_content, .s_process_steps, .s_image_gallery, .s_pricelist_boxed, .s_quadrant, .s_pricelist_cafe, .s_faq_horizontal, .s_image_frame, .s_card_offset, .s_contact_info">
         <we-row>
             <we-button-group string="Layout" data-no-preview="true">
                 <we-button data-select-layout="grid" data-name="grid_mode">Grid</we-button>


### PR DESCRIPTION
[FIX] website: Correct the column count option behavior

Previously, in multiple widgets, changing the number of columns
caused the snippet title to be counted as a column.
This update ensures that the #columns option now works as intended.

To ensure that the modification made to the structure of the snippet 
were consistent even when switching the grid and column layout 
this process has also been modified.

Task-4310468