### PR TITLE
[FIX] account: prevent cancelled moves also from posting

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -426,7 +426,7 @@ class AccountBankStatement(models.Model):
                 statement._set_next_sequence()
 
         self.write({'state': 'posted'})
-        lines_of_moves_to_post = self.line_ids.filtered(lambda line: line.move_id.state != 'posted')
+        lines_of_moves_to_post = self.line_ids.filtered(lambda line: line.move_id.state not in ['posted', 'cancel'])
         if lines_of_moves_to_post:
             lines_of_moves_to_post.move_id._post(soft=False)
 


### PR DESCRIPTION
**Description:**
- From Version saas~13.4, bank statements are fetched and posted automatically [here](https://github.com/odoo/upgrade/blob/fad33ae4912cc4e50a7dbd4694a549ebb0bf736a/migrations/account/saas~13.4.1.1/end-09-payment-refactoring.py#L626) for the respective [domain](https://github.com/odoo/upgrade/blob/fad33ae4912cc4e50a7dbd4694a549ebb0bf736a/migrations/account/saas~13.4.1.1/end-09-payment-refactoring.py#L620) using the [button_post() method](https://github.com/odoo/odoo/tree/14.0/addons/account/models#L417) where ensures no deprecated accounts are used. Through this [commit](https://github.com/odoo/odoo/commit/80c28189ae6b10ad17c4de2a781233a8ffe663a6#diff-96c5c4fc954f9deb57474d052d9c59b68cc41b610205d342949727ece08ac404R409), the state of the moves is checked before posting, where this process posts all moves that are not in the "posted" state, including those in the "cancel" state.

- During the upgrade from V13, when bank statements transition from "draft" to "posted", this issue causes moves in the "cancel" state to be posted, which is not the intended behavior.

**Steps to Reproduce (V13.0)**
- Install Accounting > Goto overview 
- Create Bank statement > set date[eg: 2020-07-04] <= rc.fiscalyear_lock_date > Add transaction [[domain conditions](https://github.com/odoo/upgrade/blob/fad33ae4912cc4e50a7dbd4694a549ebb0bf736a/migrations/account/saas~13.4.1.1/end-09-payment-refactoring.py#L620)] > Reconcile > Validate
- Goto respective Journal Entries > Cancel it.
- Upgrade to >= V14.0 

**Solution**

- To resolve this issue, this commit ensures that only moves in the "draft" state are fetched and posted, excluding moves in the "cancel" state also along with the "posted" state.


**Current behavior before this PR :** 

**Original db :**

```sql
vrbh_2408781=> select move.id as move_id, move.state as move_state, move.name,aml.parent_state as move_line_state, move.date as move_date,statement.state as statement_state,statement.difference,rc.fiscalyear_lock_date from account_move move join account_move_line aml on aml.move_id=move.id join account_bank_statement statement on statement.id=aml.statement_id join account_bank_statement_line line on line.id=aml.statement_line_id join account_account aa on aa.id=aml.account_id join res_company rc on rc.id=aml.company_id where move.id=1884 and move.date <= rc.fiscalyear_lock_date;
 move_id | move_state |      name       | move_line_state | move_date  | statement_state | difference | fiscalyear_lock_date 
---------+------------+-----------------+-----------------+------------+-----------------+------------+----------------------
    1884 | cancel     | NAB-A/2020/0209 | cancel          | 2020-06-29 | open            |       0.00 | 2023-06-30
    1884 | cancel     | NAB-A/2020/0209 | cancel          | 2020-06-29 | open            |       0.00 | 2023-06-30
```

**Upgraded DB :**

```sql
vrbh_2408781_14.0=> select move.id as move_id, move.state as move_state, move.name,aml.parent_state as move_line_state, move.date as move_date,statement.state as statement_state,statement.difference,rc.fiscalyear_lock_date from account_move move join account_move_line aml on aml.move_id=move.id join account_bank_statement statement on statement.id=aml.statement_id join account_bank_statement_line line on line.id=aml.statement_line_id join account_account aa on aa.id=aml.account_id join res_company rc on rc.id=aml.company_id where move.id=1884 and move.date <= rc.fiscalyear_lock_date;
 move_id | move_state |      name       | move_line_state | move_date  | statement_state | difference | fiscalyear_lock_date 
---------+------------+-----------------+-----------------+------------+-----------------+------------+----------------------
    1884 | posted     | NAB-A/2020/0209 | posted          | 2020-06-29 | posted          |       0.00 | 2023-06-30
    1884 | posted     | NAB-A/2020/0209 | posted          | 2020-06-29 | posted          |       0.00 | 2023-06-30
```

**After this PR :** 

```sql
vrbh_2408781_14.0=> select move.id as move_id, move.state as move_state, move.name,aml.parent_state as move_line_state, move.date as move_date,statement.state as statement_state,statement.difference,rc.fiscalyear_lock_date from account_move move join account_move_line aml on aml.move_id=move.id join account_bank_statement statement on statement.id=aml.statement_id join account_bank_statement_line line on line.id=aml.statement_line_id join account_account aa on aa.id=aml.account_id join res_company rc on rc.id=aml.company_id where move.id=1884 and move.date <= rc.fiscalyear_lock_date;
 move_id | move_state |      name       | move_line_state | move_date  | statement_state | difference | fiscalyear_lock_date 
---------+------------+-----------------+-----------------+------------+-----------------+------------+----------------------
    1884 | cancel     | NAB-A/2020/0209 | cancel          | 2020-06-29 | posted          |       0.00 | 2023-06-30
    1884 | cancel     | NAB-A/2020/0209 | cancel          | 2020-06-29 | posted          |       0.00 | 2023-06-30
```

opw-4415662
upg-2408781

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
