### PR TITLE
[FIX] website_blog, *: allow editable headers in side bars

### DIFF
--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -188,7 +188,9 @@ Options:
 <template id="opt_sidebar_blog_index_follow_us" name="Follow Us" priority="1" inherit_id="website_blog.sidebar_blog_index" active="True">
     <xpath expr="//div[@id='o_wblog_sidebar']" position="inside">
         <div class="o_wblog_sidebar_block pb-5">
-            <h6 class="text-uppercase pb-2 mb-4 border-bottom fw-bold">Follow Us</h6>
+            <div>
+                <h6 class="text-uppercase pb-2 mb-4 border-bottom fw-bold">Follow Us</h6>
+            </div>
             <div class="o_wblog_social_links d-flex flex-wrap mx-n1 o_not_editable">
                 <t t-set="classes" t-translation="off">bg-100 border mx-1 mb-2 rounded-circle d-flex align-items-center justify-content-center text-decoration-none</t>
                 <a t-if="website.social_facebook" t-att-href="website.social_facebook" aria-label="Facebook" title="Facebook" t-att-class="classes"><i class="fa fa-facebook-square text-facebook"/></a>
@@ -214,8 +216,9 @@ Options:
 <template id="opt_sidebar_blog_index_archives" name="Archives" priority="2" inherit_id="website_blog.sidebar_blog_index" active="True">
     <xpath expr="//div[@id='o_wblog_sidebar']" position="inside">
         <div class="o_wblog_sidebar_block pb-5">
-            <h6 class="text-uppercase pb-2 mb-4 border-bottom fw-bold">Archives</h6>
-
+            <div>
+                <h6 class="text-uppercase pb-2 mb-4 border-bottom fw-bold">Archives</h6>
+            </div>
             <t t-call="website_blog.date_selector"/>
         </div>
         <div class="oe_structure" id="oe_structure_blog_sidebar_index_4"/>
@@ -227,7 +230,9 @@ Options:
     <xpath expr="//div[@id='o_wblog_sidebar']" position="inside">
 
         <div t-if="other_tags or tag_category" class="o_wblog_sidebar_block pb-5">
-            <h6 class="text-uppercase pb-2 mb-4 border-bottom fw-bold">Tags</h6>
+            <div>
+                <h6 class="text-uppercase pb-2 mb-4 border-bottom fw-bold">Tags</h6>
+            </div>
             <div class="h5">
                 <t t-foreach="tag_category" t-as="nav_tag_category">
                     <t t-call="website_blog.tags_list">
@@ -280,7 +285,9 @@ Display a sidebar beside the post content.
 <template id="opt_blog_post_share_links_display" name="Share Links" inherit_id="website_blog.blog_post_sidebar" active="True" priority="2">
     <xpath expr="//div[@id='o_wblog_post_sidebar']" position="inside">
         <div class="o_wblog_sidebar_block pb-5">
-            <h6 class="text-uppercase pb-3 mb-4 border-bottom fw-bold">Share this post</h6>
+            <div>
+                <h6 class="text-uppercase pb-3 mb-4 border-bottom fw-bold">Share this post</h6>
+            </div>
 
             <div class="o_wblog_social_links d-flex flex-wrap mx-n1 o_not_editable">
                 <t t-set="classes" t-translation="off">bg-100 border mx-1 mb-2 rounded-circle d-flex align-items-center justify-content-center text-decoration-none</t>
@@ -298,7 +305,9 @@ Display a sidebar beside the post content.
 <template id="opt_blog_post_tags_display" name="Tags" inherit_id="website_blog.blog_post_sidebar" active="True" priority="3">
     <xpath expr="//div[@id='o_wblog_post_sidebar']" position="inside">
         <div class="o_wblog_sidebar_block pb-5">
-            <h6 class="text-uppercase pb-3 mb-4 border-bottom fw-bold">Tags</h6>
+            <div>
+                <h6 class="text-uppercase pb-3 mb-4 border-bottom fw-bold">Tags</h6>
+            </div>
             <t t-if="blog_post.tag_ids">
                 <div class="h5">
                     <t t-foreach="blog_post.tag_ids" t-as="one_tag">
@@ -322,7 +331,9 @@ Display a sidebar beside the post content.
 <template id="opt_blog_post_blogs_display" name="Blogs List" inherit_id="website_blog.blog_post_sidebar" active="True" priority="4">
     <xpath expr="//div[@id='o_wblog_post_sidebar']" position="inside">
         <div t-if="len(blogs) > 1" class="o_wblog_sidebar_block pb-5">
-            <h6 class="text-uppercase pb-3 mb-4 border-bottom fw-bold">Our blogs</h6>
+            <div>
+                <h6 class="text-uppercase pb-3 mb-4 border-bottom fw-bold">Our blogs</h6>
+            </div>
             <ul class="list-unstyled">
                 <li t-foreach="blogs" t-as="nav_blog" class="mb-2">
                     <a t-attf-href="#{blog_url(blog=nav_blog, tag=False, date_begin=False, date_end=False)}"><b t-field="nav_blog.name"/></a>
@@ -337,8 +348,9 @@ Display a sidebar beside the post content.
 <template id="opt_blog_post_archive_display" name="Archive" inherit_id="website_blog.blog_post_sidebar" active="True" priority="5">
     <xpath expr="//div[@id='o_wblog_post_sidebar']" position="inside">
         <div class="o_wblog_sidebar_block pb-5">
-            <h6 class="text-uppercase pb-3 mb-4 border-bottom fw-bold">Archive</h6>
-
+            <div>
+                <h6 class="text-uppercase pb-3 mb-4 border-bottom fw-bold">Archive</h6>
+            </div>
             <t t-call="website_blog.date_selector"/>
         </div>
         <div class="oe_structure" id="oe_structure_blog_post_sidebar_6"/>

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -449,7 +449,9 @@
 <template id="index_sidebar_follow_us" inherit_id="website_event.index_sidebar" active="False" name="Follow us" priority="30">
     <xpath expr="//div[@id='o_wevent_index_sidebar']" position="inside">
         <div class="o_wevent_sidebar_block">
-            <h6 class="o_wevent_sidebar_title">Follow Us</h6>
+            <div>
+                <h6 class="o_wevent_sidebar_title">Follow Us</h6>
+            </div>
             <div class="o_wevent_sidebar_social mx-n1">
                 <a t-if="website.social_facebook" t-att-href="website.social_facebook" class="o_wevent_social_link"><i class="fa fa-facebook text-facebook" aria-label="Facebook" title="Facebook"/></a>
                 <a t-if="website.social_twitter" t-att-href="website.social_twitter" class="o_wevent_social_link"><i class="fa fa-twitter text-twitter" aria-label="X" title="X"/></a>
@@ -467,7 +469,9 @@
 <!-- Index - Sidebar - Photos -->
 <template id="index_sidebar_photos" inherit_id="website_event.index_sidebar" active="True" name="Photos" priority="40">
     <xpath expr="//div[@id='o_wevent_index_sidebar']" position="inside">
-        <h6 class="o_wevent_sidebar_title">Photos</h6>
+        <div>
+            <h6 class="o_wevent_sidebar_title">Photos</h6>
+        </div>
         <a href="/event">
             <figure class="o_wevent_sidebar_block o_wevent_sidebar_figure figure">
                 <img class="figure-img img-fluid rounded oe_unremovable" src="/website_event/static/src/img/event_past_0.jpg" alt=""/>

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -102,7 +102,9 @@
                         <!-- Location -->
                         <meta itemprop="eventAttendanceMode" t-attf-content="https://schema.org/{{'Offline' if event.address_id else 'Online'}}EventAttendanceMode"/>
                         <div t-if="event.address_id" class="o_wevent_sidebar_block border-bottom pb-3 mb-4" itemprop="location" itemscope="itemscope" itemtype="https://schema.org/Place">
-                            <h6 class="o_wevent_sidebar_title">Location</h6>
+                            <div>
+                                <h6 class="o_wevent_sidebar_title">Location</h6>
+                            </div>
                             <div itemprop="name" class="mb-1" t-field="event.address_id"/>
                             <small class="d-block mb-2" t-field="event.address_id" t-options='{
                                 "widget": "contact",
@@ -128,14 +130,18 @@
                         </div>
                         <!-- Organizer -->
                         <div t-if="event.organizer_id" class="o_wevent_sidebar_block border-bottom pb-3 mb-4" itemprop="organizer" itemscope="itemscope" itemtype="http://schema.org/Organization">
-                            <h6 class="o_wevent_sidebar_title">Organizer</h6>
+                            <div>
+                                <h6 class="o_wevent_sidebar_title">Organizer</h6>
+                            </div>
                             <div itemprop="name" class="mb-1" t-field="event.organizer_id"/>
                             <small t-field="event.organizer_id" t-options="{'widget': 'contact', 'fields': ['phone', 'mobile', 'email'], 'with_microdata': True,}"/>
                         </div>
                         <!-- Social -->
                         <div class="o_wevent_sidebar_block">
-                            <h6 class="o_wevent_sidebar_title">Share</h6>
-                            <p>Find out what people see and say about this event, and join the conversation.</p>
+                            <div>
+                                <h6 class="o_wevent_sidebar_title">Share</h6>
+                                <p>Find out what people see and say about this event, and join the conversation.</p>
+                            </div>
                             <t t-snippet-call="website.s_share">
                                 <t t-set="_no_title" t-value="True"/>
                                 <t t-set="_classes" t-valuef="o_wevent_sidebar_social mx-n1"/>

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -437,7 +437,9 @@
         <div class="row o_wslides_home_aside_title">
             <div class="col">
                 <a t-if="users" href="/profile/users" class="float-end">View all</a>
-                <h5 class="m-0">Leaderboard</h5>
+                <div>
+                    <h5 class="m-0">Leaderboard</h5>
+                </div>
                 <hr class="mt-2 mb-2"/>
             </div>
         </div>


### PR DESCRIPTION
*: website_event, website_slides

Steps to reproduce:

- Go to /blogs, open any blog post
- launch the web editor and activate "Sidebar"
- Attempt to modify the format of the titles in the sidebar
- Observe that this action is not possible
- The same issue occurs in /slides and /events

The <hx> elements in the blog/event/slides sidebar template were treated as "unremovable" and "unbreakable" by the editor, preventing users from changing its tag (e.g., from h6 to h2).

This commit wraps the <hx> element in a div to ensure that editable attributes (e.g., oe-id) are applied to the div instead, allowing the editor to handle modifications without triggering a rollback.

opw-4458011
