### PR TITLE
[FIX] l10n_es_edi_tbai_multi_refund: enable selecting refunded vendor bills

### DIFF
--- a/addons/l10n_es_edi_tbai_multi_refund/i18n/es.po
+++ b/addons/l10n_es_edi_tbai_multi_refund/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-02 09:47+0000\n"
-"PO-Revision-Date: 2025-01-02 09:50+0000\n"
+"POT-Creation-Date: 2025-01-28 11:20+0000\n"
+"PO-Revision-Date: 2025-01-28 11:21+0000\n"
 "Last-Translator: Jairo Llopis <jairo@moduon.team>\n"
 "Language-Team: \n"
 "Language: es_ES\n"
@@ -27,11 +27,11 @@ msgstr "Formato EDI"
 #: model:ir.model.fields,help:l10n_es_edi_tbai_multi_refund.field_account_move__l10n_es_tbai_reversed_ids
 #: model:ir.model.fields,help:l10n_es_edi_tbai_multi_refund.field_account_payment__l10n_es_tbai_reversed_ids
 msgid ""
-"In the case where a vendor refund has multiple original invoices, you can "
-"set them here. "
+"In the case where a refund has multiple original invoices, you can set them "
+"here. "
 msgstr ""
 "Si una rectificación de facturas de proveedor tiene múltiples facturas "
-"originales, puede indicarlas aquí."
+"originales, puede indicarlas aquí. "
 
 #. module: l10n_es_edi_tbai_multi_refund
 #: model:ir.model,name:l10n_es_edi_tbai_multi_refund.model_account_move
@@ -42,5 +42,5 @@ msgstr "Asiento contable"
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai_multi_refund.field_account_bank_statement_line__l10n_es_tbai_reversed_ids
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai_multi_refund.field_account_move__l10n_es_tbai_reversed_ids
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai_multi_refund.field_account_payment__l10n_es_tbai_reversed_ids
-msgid "Refunded Vendor Bills"
-msgstr "Facturas de proveedor rectificadas"
+msgid "Refunded Invoices"
+msgstr "Facturas rectificadas"

--- a/addons/l10n_es_edi_tbai_multi_refund/i18n/l10n_es_edi_tbai_multi_refund.pot
+++ b/addons/l10n_es_edi_tbai_multi_refund/i18n/l10n_es_edi_tbai_multi_refund.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-17 12:42+0000\n"
-"PO-Revision-Date: 2025-01-17 12:42+0000\n"
+"POT-Creation-Date: 2025-01-28 11:20+0000\n"
+"PO-Revision-Date: 2025-01-28 11:20+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -25,8 +25,8 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_es_edi_tbai_multi_refund.field_account_move__l10n_es_tbai_reversed_ids
 #: model:ir.model.fields,help:l10n_es_edi_tbai_multi_refund.field_account_payment__l10n_es_tbai_reversed_ids
 msgid ""
-"In the case where a vendor refund has multiple original invoices, you can "
-"set them here. "
+"In the case where a refund has multiple original invoices, you can set them "
+"here. "
 msgstr ""
 
 #. module: l10n_es_edi_tbai_multi_refund
@@ -35,13 +35,8 @@ msgid "Journal Entry"
 msgstr ""
 
 #. module: l10n_es_edi_tbai_multi_refund
-#: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai_multi_refund.view_move_form
-msgid "Refunded Invoices"
-msgstr ""
-
-#. module: l10n_es_edi_tbai_multi_refund
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai_multi_refund.field_account_bank_statement_line__l10n_es_tbai_reversed_ids
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai_multi_refund.field_account_move__l10n_es_tbai_reversed_ids
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai_multi_refund.field_account_payment__l10n_es_tbai_reversed_ids
-msgid "Refunded Vendor Bills"
+msgid "Refunded Invoices"
 msgstr ""

--- a/addons/l10n_es_edi_tbai_multi_refund/models/account_move.py
+++ b/addons/l10n_es_edi_tbai_multi_refund/models/account_move.py
@@ -6,7 +6,7 @@ class AccountMove(models.Model):
 
     l10n_es_tbai_reversed_ids = fields.Many2many(
         'account.move', 'account_move_tbai_reversed_moves', 'refund_id', 'reversed_move_id',
-        string="Refunded Vendor Bills",
-        domain="[('move_type', '=', 'in_invoice'), ('commercial_partner_id', '=', commercial_partner_id)]",
-        help="In the case where a vendor refund has multiple original invoices, you can set them here. ",
+        string="Refunded Invoices",
+        domain="[('move_type', '=', 'in_invoice' if move_type == 'in_refund' else 'out_invoice'), ('commercial_partner_id', '=', commercial_partner_id)]",
+        help="In the case where a refund has multiple original invoices, you can set them here. ",
     )

--- a/addons/l10n_es_edi_tbai_multi_refund/views/account_move_view.xml
+++ b/addons/l10n_es_edi_tbai_multi_refund/views/account_move_view.xml
@@ -6,8 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <field name="l10n_es_tbai_refund_reason" position='after'>
-                <field name="l10n_es_tbai_reversed_ids" attrs="{'invisible': [('move_type', '!=', 'in_refund')]}" widget="many2many_tags"/>
-                <field name="l10n_es_tbai_reversed_ids" attrs="{'invisible': [('move_type', '!=', 'out_refund')]}" widget="many2many_tags" string="Refunded Invoices" domain="[('move_type', '=', 'out_invoice'), ('commercial_partner_id', '=', commercial_partner_id)]" />
+                <field name="l10n_es_tbai_reversed_ids" attrs="{'invisible': [('move_type', 'not in', ['in_refund', 'out_refund'])]}" widget="many2many_tags" options="{'no_create': True}" />
             </field>
         </field>
     </record>


### PR DESCRIPTION

When trying to select refunded vendor bills with this module, only customer invoices were searchable:


https://github.com/user-attachments/assets/e6b01236-780c-45d9-b03a-0cae83a6f37b



It turns out that the web client has a bug. When there's a field defined twice in the same form, to make it conditionally visible with different properties, and each of the field instances has a different domain, only the last one will be used always.

I couldn't find the fix for that bug, but with this fix I can avoid defining the field twice:
- The field name and help doesn't involve anything specific to customer or vendor invoices.
- The domain itself contains the condition.

Now both customer and vendor refunds allow selecting their corresponding invoices before posting. This makes the feature from https://github.com/odoo/odoo/pull/194130 actually usable.

@moduon MT-8778 OPW-4509823 @RicGR98 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
