### PR TITLE
[FIX] point_of_sale: fix error using .trim() on undefined

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -351,7 +351,9 @@ export class PosOrder extends Base {
         // was last sent to the preparation tools or updated. If so we delete older changes.
         for (const [key, change] of Object.entries(this.last_order_preparation_change.lines)) {
             const orderline = this.models["pos.order.line"].getBy("uuid", change.uuid);
-            if (!orderline || change.note.trim() !== orderline.note.trim()) {
+            const lineNote = orderline?.note;
+            const changeNote = change?.note;
+            if (!orderline || (lineNote && changeNote && changeNote.trim() !== lineNote.trim())) {
                 delete this.last_order_preparation_change.lines[key];
             }
         }

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1560,7 +1560,7 @@ export class PosStore extends Reactive {
         order = this.get_order(),
         printBillActionTriggered = false,
     } = {}) {
-        await this.printer.print(
+        const result = await this.printer.print(
             OrderReceipt,
             {
                 data: this.orderExportForPrinting(order),
@@ -1569,7 +1569,7 @@ export class PosStore extends Reactive {
             },
             { webPrintFallback: true }
         );
-        if (!printBillActionTriggered) {
+        if (!printBillActionTriggered && result) {
             const nbrPrint = order.nb_print;
             await this.data.write("pos.order", [order.id], { nb_print: nbrPrint + 1 });
         }


### PR DESCRIPTION
The error was caused by calling .trim() on a variable that could be undefined.

This commit adds a check to ensure the variable is defined before calling .trim()

