### PR TITLE
[FIX] base: Fix a traceback with the partner merging wizard

### DIFF
--- a/doc/cla/individual/burkhaltery.md
+++ b/doc/cla/individual/burkhaltery.md
@@ -1,0 +1,11 @@
+Switzerland, 2024-12-16
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Yannis Burkhalter yannis@burkhalter.dev https://github.com/BurkhalterY

--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -264,7 +264,9 @@ class MergePartnerAutomatic(models.TransientModel):
             if field.type not in ('many2many', 'one2many') and field.compute is None:
                 for item in itertools.chain(src_partners, [dst_partner]):
                     if item[column]:
-                        if column in summable_fields and values.get(column):
+                        if field.type == 'reference':
+                            values[column] = item[column]
+                        elif column in summable_fields and values.get(column):
                             values[column] += write_serializer(item[column])
                         else:
                             values[column] = write_serializer(item[column])


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Fix a traceback with the partner merging wizard.

Current behavior before PR:

Currently, the partner merging wizard doesn't support fields of type `reference`, because this type of field is never used by Odoo on model `res.partner`.
This will never happend in native Odoo, but some external addons can trigger this traceback.

Desired behavior after PR is merged:

The traceback is fixed and reference fields are treated like any others field types.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
