### PR TITLE
[FIX] event_sale: prevent error on upgrading module

### DIFF
--- a/addons/event_sale/data/event_sale_data.xml
+++ b/addons/event_sale/data/event_sale_data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
-        <record id="event_product.product_product_event" model="product.product">
+        <record id="event_product.product_product_event" model="product.product" forcecreate="False">
             <field name="invoice_policy">order</field>
         </record>
     </data>


### PR DESCRIPTION
Currently a ``ParseError`` is arising when the user upgrades the ``event_sale`` module after deleting the ``Event Registration`` product from sales.

Steps to reproduce:
---
- Install ``Sale_management`` and ``event`` module (without demo data)
- Open ``Products`` in Sales > Delete ``Event Registration``
- Now upgrade ``event_sale`` module
- The error appears in the log.

Traceback:
---
```
Exception: Cannot update missing record 'event_product.product_product_event'

ParseError: while parsing /home/odoo/src/odoo/saas-18.1/addons/event_sale/data/event_sale_data.xml:4, somewhere inside <record id="event_product.product_product_event" model="product.product">
            <field name="invoice_policy">order</field>
        </record>
```

This commit resolves the issue by preventing the creation of a product using ``forcecreate="False"``.

sentry-5731062091

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
