### PR TITLE
[FIX] hr_expense: prevent parseerror when product category is missing

### DIFF
--- a/addons/hr_expense/data/hr_expense_data.xml
+++ b/addons/hr_expense/data/hr_expense_data.xml
@@ -12,7 +12,7 @@
             <field name="can_be_expensed" eval="True"/>
             <field name="sale_ok" eval="False"/>
             <field name="purchase_ok" eval="False"/>
-            <field name="categ_id" ref="product.product_category_expenses"/>
+            <field name="categ_id" eval="ref('product.product_category_expenses', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="hr_expense/static/img/food.svg"/>
         </record>
         <record id="expense_product_travel_accommodation" model="product.product">
@@ -25,7 +25,7 @@
             <field name="can_be_expensed" eval="True"/>
             <field name="sale_ok" eval="False"/>
             <field name="purchase_ok" eval="False"/>
-            <field name="categ_id" ref="product.product_category_expenses"/>
+            <field name="categ_id" eval="ref('product.product_category_expenses', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="hr_expense/static/img/transport.svg"/>
         </record>
         <record id="uom.product_uom_km" model="uom.uom">
@@ -40,7 +40,7 @@
             <field name="can_be_expensed" eval="True"/>
             <field name="sale_ok" eval="False"/>
             <field name="purchase_ok" eval="False"/>
-            <field name="categ_id" ref="product.product_category_expenses"/>
+            <field name="categ_id" eval="ref('product.product_category_expenses', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="hr_expense/static/img/mileage.svg"/>
         </record>
         <record id="expense_product_gift" model="product.product">
@@ -53,7 +53,7 @@
             <field name="can_be_expensed" eval="True"/>
             <field name="sale_ok" eval="False"/>
             <field name="purchase_ok" eval="False"/>
-            <field name="categ_id" ref="product.product_category_expenses"/>
+            <field name="categ_id" eval="ref('product.product_category_expenses', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="hr_expense/static/img/gift.svg"/>
         </record>
         <record id="expense_product_communication" model="product.product">
@@ -66,7 +66,7 @@
             <field name="can_be_expensed" eval="True"/>
             <field name="sale_ok" eval="False"/>
             <field name="purchase_ok" eval="False"/>
-            <field name="categ_id" ref="product.product_category_expenses"/>
+            <field name="categ_id" eval="ref('product.product_category_expenses', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="hr_expense/static/img/communication.svg"/>
         </record>
         <record id="product_product_no_cost" model="product.product">
@@ -74,7 +74,7 @@
             <field name="standard_price">0.0</field>
             <field name="type">service</field>
             <field name="default_code">EXP_GEN</field>
-            <field name="categ_id" ref="product.product_category_expenses"/>
+            <field name="categ_id" eval="ref('product.product_category_expenses', raise_if_not_found=False)"/>
             <field name="can_be_expensed" eval="True"/>
             <field name="image_1920" type="base64" file="hr_expense/static/img/other.svg"/>
         </record>


### PR DESCRIPTION
Currently a Traceback appears when the user delete the `Expense` category in `Invoicing`.

**Error:**
```
ValueError: External ID not found in the system: product.product_category_expenses

ParseError
while parsing /home/odoo/src/odoo/saas-18.1/addons/hr_expense/data/hr_expense_data.xml:5, somewhere inside <record id="expense_product_meal" model="product.product">
            <field name="name">Meals</field>
            <field name="description">Restaurants, business lunches, etc.</field>
            <field name="standard_price">0.0</field>
            <field name="type">service</field>
            <field name="uom_id" ref="uom.product_uom_unit"/>
            <field name="default_code">FOOD</field>
            <field name="can_be_expensed" eval="True"/>
            <field name="sale_ok" eval="False"/>
            <field name="purchase_ok" eval="False"/>
            <field name="categ_id" ref="product.product_category_expenses"/>
            <field name="image_1920" type="base64" file="hr_expense/static/img/food.svg"/>
        </record>
 ```

### Steps to reproduce above error :-
- Install `Invoicing` application (without demo data).
- Invoicing > Configuration > Categories > Delete `Expense`
- Install `Expenses` application

The error occurs because the user deleted the category, then installed `Expenses` module, which reference the missing product category.

This commit resolves the error by providing a False value for the field if the product category is missing.

sentry-6235143606