### PR TITLE
[FIX] mail: align avatar with composer

### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -11,7 +11,7 @@
     }
 
     .o-mail-Composer-sidebarMain {
-        padding-top: 0.4375rem; // avatar centered with composer text input: 36px (avatar) + 2*7px (this value) = 20px + 2 * { 10px (padding) + 1px (border) + 4px (margin) }
+        padding-top: 0.1875rem; // avatar centered with composer text input: 36px (avatar) + 2*3px (this value) = 20px + 2 * { 10px (padding) + 1px (border) }
         width: 48px;
     }
 


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/195364

PR above made several small UI adjustments, from similar PR made in 18.0. One of the change was to fix avatar alignment with composer. However the alignment fix made sense in 18.0 but not in 18.1.

This commit reverts this part of the improvements, so that the alignment is correct.

Before 
![Screenshot 2025-01-28 at 13 43 35](https://github.com/user-attachments/assets/22896495-ea35-418c-8533-83689a89cd74)

After
![Screenshot 2025-01-28 at 13 43 18](https://github.com/user-attachments/assets/31352d83-f006-48ed-a4b3-e6fa662a53cd)

