### PR TITLE
[FIX] html_editor: qweb and toolbar overlay

### DIFF
--- a/addons/html_editor/static/tests/qweb.test.js
+++ b/addons/html_editor/static/tests/qweb.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { click, queryAll, queryAllTexts, queryOne, select } from "@odoo/hoot-dom";
+import { click, dblclick, queryAll, queryAllTexts, queryOne, select } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
@@ -230,6 +230,10 @@ test("select text inside t-out", async () => {
 
     await tick();
     expect(getContent(el)).toBe(
+        `<div><t t-out="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">H[]ello</t></div>`
+    );
+    await dblclick("t");
+    expect(getContent(el)).toBe(
         `<div>[<t t-out="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>]</div>`
     );
 });
@@ -246,6 +250,10 @@ test("select text inside t-esc", async () => {
 
     await tick();
     expect(getContent(el)).toBe(
+        `<div><t t-esc="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">H[]ello</t></div>`
+    );
+    await dblclick("t");
+    expect(getContent(el)).toBe(
         `<div>[<t t-esc="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>]</div>`
     );
 });
@@ -261,6 +269,10 @@ test("select text inside t-field", async () => {
     setSelection({ anchorNode: el.querySelector("t[t-field]").childNodes[0], anchorOffset: 1 });
 
     await tick();
+    expect(getContent(el)).toBe(
+        `<div><t t-field="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">H[]ello</t></div>`
+    );
+    await dblclick("t");
     expect(getContent(el)).toBe(
         `<div>[<t t-field="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>]</div>`
     );


### PR DESCRIPTION
**Current behavior before PR:**

- When clicking on a dynamic field, both the qweb overlay and the toolbar would appear simultaneously, causing an overlap.

**Desired behavior after PR is merged:**

- The qweb overlay will now only be shown when the selection is collapsed, ensuring that it does not overlap with the toolbar when it is visible.

task:4243987
