### PR TITLE
[FIX] mail: harmonize background of emoji picker and quick reactions

### DIFF
--- a/addons/mail/static/src/core/common/quick_reaction_menu.scss
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.scss
@@ -117,11 +117,18 @@ $quick-reaction-menu-picker-grow-duration: 0.25s;
     & .popover-arrow {
         z-index: 1 !important;
         transform: translateY(var(--arrowTranslateY));
+
+        &::after {
+            border-bottom-color: $gray-100!important;
+        }
+        &::before {
+            border-bottom-color: var(--secondary)!important;
+        }
     }
 
     & .o-EmojiPicker {
         opacity: 0;
-        border: var(--popover-border-width) solid var(--popover-border-color);
+        border: var(--popover-border-width) solid var(--secondary);
         transform: scale(0.8);
         transform-origin: var(--originY);
         animation: qrm-pickerGrowAnimation $quick-reaction-menu-picker-grow-duration cubic-bezier(0.25, 0.8, 0.25, 1) forwards;

--- a/addons/mail/static/src/core/common/quick_reaction_menu.xml
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.xml
@@ -6,7 +6,7 @@
                 <i class="fa-lg" t-att-class="props.action.icon"/>
             </button>
             <t t-set-slot="content">
-                <div class="o-mail-QuickReactionMenu d-flex align-items-center px-1 bg-view border rounded-pill shadow-sm" t-ref="toggle">
+                <div class="o-mail-QuickReactionMenu d-flex align-items-center px-1 bg-100 border border-secondary rounded-pill shadow-sm" t-ref="toggle">
                     <button t-foreach="mostFrequentEmojis" t-as="emoji" t-key="emoji" class="o-mail-QuickReactionMenu-emoji o-mail-QuickReactionMenu-popEffect o-navigable d-flex justify-content-center align-items-center rounded-circle btn lh-1 p-1" t-att-class="{ 'bg-secondary': reactedBySelf(emoji) }" t-att-title="getEmojiShortcode(emoji)" t-on-click="() => this.toggleReaction(emoji)">
                         <span class="fs-2" t-esc="emoji"/>
                     </button>

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="discuss.GifPicker">
-        <div class="o-discuss-GifPicker bg-view d-flex flex-column" t-attf-class="{{ props.className }}" t-att-class="{ 'h-100': props.mobile }">
+        <div class="o-discuss-GifPicker d-flex flex-column" t-attf-class="{{ props.className }}" t-att-class="{ 'h-100': props.mobile }">
             <div t-if="!store.hasGifPickerFeature and store.self.isAdmin" class="d-flex flex-column align-items-center justify-content-center m-3 h-100">
                 <span class="o-discuss-GifPicker-bigEmoji">🧑‍🍳🌶️</span>
                 <span class="fs-5 text-muted">Want to spice up your conversations with GIFs? Activate the feature in the settings!</span>

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -479,7 +479,11 @@ export function usePicker(PickerComponent, ref, props, options = {}) {
             options.onClose?.();
         },
     };
-    const popover = usePopover(PickerComponent, { ...newOptions, animation: false });
+    const popover = usePopover(PickerComponent, {
+        ...newOptions,
+        animation: false,
+        popoverClass: options.popoverClass ?? "" + " bg-100 border border-secondary",
+    });
     props.storeScroll = {
         scrollValue: 0,
         set: (value) => {


### PR DESCRIPTION
The emoji picker bg is `bg-100` and the quick reaction menu bg is `bg-view` which seems odd. This PR harmonizes the two backgrounds.

| Before | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/38b80d7a-c4ed-4abf-aad8-616480431d64) | ![image](https://github.com/user-attachments/assets/a77ddb66-b69c-4613-831d-9204a1c81d86)  |
