### PR TITLE
[FIX] web: add a few emoji shortcodes

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -241,7 +241,7 @@
             <t t-esc="option.emoji.codepoints"/>
         </strong>
         <em class="text-600 text-truncate align-self-center">
-            <t t-esc="option.emoji.shortcodes.join(', ')"/>
+            <t t-esc="option.emoji.shortcodes.join(' ')"/>
         </em>
     </t>
 </templates>

--- a/addons/web/static/src/core/emoji_picker/emoji_data.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_data.js
@@ -1912,6 +1912,7 @@ const _getEmojisData1 = () => `{
     ],
     "name": "` + _t("see-no-evil monkey") + `",
     "shortcodes": [
+        ":see_no_evil:",
         ":see-no-evil_monkey:"
     ]
 },
@@ -1931,6 +1932,7 @@ const _getEmojisData1 = () => `{
     ],
     "name": "` + _t("hear-no-evil monkey") + `",
     "shortcodes": [
+        ":hear_no_evil:",
         ":hear-no-evil_monkey:"
     ]
 },
@@ -1950,6 +1952,7 @@ const _getEmojisData1 = () => `{
     ],
     "name": "` + _t("speak-no-evil monkey") + `",
     "shortcodes": [
+        ":speak_no_evil:",
         ":speak-no-evil_monkey:"
     ]
 },
@@ -2464,6 +2467,7 @@ const _getEmojisData2 = () => `{
     ],
     "name": "` + _t("waving hand") + `",
     "shortcodes": [
+        ":wave:",
         ":waving_hand:"
     ]
 },
@@ -2927,6 +2931,7 @@ const _getEmojisData2 = () => `{
     ],
     "name": "` + _t("folded hands") + `",
     "shortcodes": [
+        ":pray:",
         ":folded_hands:"
     ]
 },
@@ -10360,6 +10365,7 @@ const _getEmojisData4 = () => `{
     ],
     "name": "` + _t("hot beverage") + `",
     "shortcodes": [
+        ":coffee:",
         ":hot_beverage:"
     ]
 },
@@ -13799,6 +13805,7 @@ const _getEmojisData5 = () => `{
     ],
     "name": "` + _t("water wave") + `",
     "shortcodes": [
+        ":ocean:",
         ":water_wave:"
     ]
 },`;


### PR DESCRIPTION
This commit adds a few shortcodes to emojis that felt missing such as `:coffee:`.

Also use single space in the emoji suggestion when an emoji has more than 1 shortcode, for consistency with emoji picker search placeholder and also `,` is distracting: emoji shortcodes have no whitespace so whitespace is enough of a separator.