### PR TITLE
[FIX] mail: no crash Object.groupBy is not a function

### DIFF
--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -1,3 +1,4 @@
+import { Object_groupBy } from "@mail/utils/common/misc";
 import { toRaw, useComponent, useEffect, useRef, useState } from "@odoo/owl";
 import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 
@@ -225,7 +226,7 @@ export function useComposerActions() {
         },
         get partition() {
             const actions = transformedActions.filter((action) => action.condition);
-            const groupedPickers = Object.groupBy(
+            const groupedPickers = Object_groupBy(
                 actions.filter((a) => a.isPicker),
                 (a) => (a.sequenceQuick ? "quick" : "other")
             );

--- a/addons/mail/static/src/utils/common/misc.js
+++ b/addons/mail/static/src/utils/common/misc.js
@@ -191,3 +191,25 @@ export function convertToEmbedURL(url) {
     }
     return { url: null, provider: null };
 }
+
+/**
+ * Function that is equivalent to Object.groupBy().
+ * All evergreen browsers in 2024 have it implemented, but some users
+ * upgrade their browsers every 2 years it seems.
+ *
+ * @deprecated
+ */
+export function Object_groupBy() {
+    if (Object.groupBy && typeof Object.groupBy === "function") {
+        return Object.groupBy;
+    } else {
+        return (arr, callback) => {
+            return arr.reduce((acc = {}, ...args) => {
+                const key = callback(...args);
+                acc[key] ??= [];
+                acc[key].push(args[0]);
+                return acc;
+            }, {});
+        };
+    }
+}


### PR DESCRIPTION
This happened when opening the composer in chatter on a outdated browser from as late as november 2023.

This commit adds a function that polyfills when the function is not implemented by the browser.