### PR TITLE
[FIX] account: avoid too much repetition in line name

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -516,7 +516,7 @@ class AccountMoveLine(models.Model):
             if line.display_type == 'payment_term':
                 term_lines = term_by_move.get(line.move_id, self.env['account.move.line'])
                 n_terms = len(line.move_id.invoice_payment_term_id.line_ids)
-                if line.move_id.payment_reference and line.move_id.ref:
+                if line.move_id.payment_reference and line.move_id.ref and line.move_id.payment_reference != line.move_id.ref:
                     name = f'{line.move_id.ref} - {line.move_id.payment_reference}'
                 else:
                     name = line.move_id.payment_reference or ''


### PR DESCRIPTION
### Steps to reproduce:
- Go to Accounting > Reports > Aged Receivable
- Unfold any customer shown, click on the three dots next to an invoice, and select "View Journal Entry"
- On the Journal Entry, add the invoice sequence to Customer Reference and Payment Reference
- Go back to the report, you should see the invoice name is now shown 4 times

### Cause:
The bug appeared in this commit (https://github.com/odoo/odoo/commit/eb872c09897eb9edd5b6e5b9e8171fa6764be3dc). When computing the line `display_name`, if there is a name, a reference and `line_name`. The variable line_name already include the reference: 
`name = f'{line.move_id.ref} - {line.move_id.payment_reference}'` (https://github.com/odoo/odoo/commit/a6cbb7c2d3538d57dc8498f0dacf4566ea1492e7) 

So `line_name` is different from `move_name` and the result is: 
`line.move_id.name (line.move_id.ref) line.move_id.ref - line.move_id.payment_reference`

### Solution:
Check if the move_ref and the payment ref are the same, in that case only put one of the two as line_name. Then when computing the display_name, line_name will equal to move_name so line_name will not be included.

opw-4492298