### PR TITLE
[FIX] mrp: assert time value with a delta

### DIFF
--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4449,8 +4449,8 @@ class TestMrpOrder(TestMrpCommon):
 
         production.button_mark_done()
 
-        self.assertEqual(production.workorder_ids[0].date_finished, production.date_finished)
-        self.assertEqual(production.workorder_ids[0].leave_id.date_to, production.date_finished)
+        self.assertAlmostEqual(production.workorder_ids[0].date_finished, production.date_finished, delta=timedelta(seconds=2))
+        self.assertAlmostEqual(production.workorder_ids[0].leave_id.date_to, production.date_finished, delta=timedelta(seconds=2))
 
     def test_child_mo_after_qty_parent_mo_update(self):
         """


### PR DESCRIPTION
Comparing times may give false error because of the precision and time to run a test. This commit adds a delta into which two datetime are considered the same in order to not make the test failing by mistake.

runbot : 112119

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
