### PR TITLE
[FIX] orm: domain with hierarchy should use ilike for str

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -699,6 +699,16 @@ class TestExpression(SavepointCaseWithUserDemo, TransactionExpressionCase):
         res_13 = self._search(Currency, [('rate_ids', 'not in', [])])
         self.assertEqual(res_10, res_13)
 
+    def test_15_hierarchy_ilike(self):
+        Company = self.env['res.company']
+        company1 = Company.create({'name': 'Hierarchy Parent'})
+        Company.create({'name': 'Child', 'parent_id': company1.id})
+        base_domain = Domain('id', 'child_of', company1.id)
+        companies = self._search(Company, base_domain)
+
+        self.assertEqual(companies, self._search(Company, base_domain & Domain('id', 'child_of', 'Parent')))
+        self.assertEqual(companies, self._search(Company, base_domain & Domain('id', 'parent_of', 'Chi')))
+
     def test_20_expression_parse(self):
         # TDE note: those tests have been added when refactoring the expression.parse() method.
         # They come in addition to the already existing tests; maybe some tests

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1335,7 +1335,8 @@ def _operator_hierarchy(condition, model):
         if field.type == 'many2one':
             field = model._fields['id']
     # Get the initial ids and bind them to comodel_sudo before resolving the hierarchy
-    coids = _value_to_ids(value, comodel, 'in')
+    cooperator = 'ilike' if isinstance(value, str) else 'in'
+    coids = _value_to_ids(value, comodel, cooperator)
     if field.type == 'many2many' or isinstance(coids, (SQL, Query)):
         # always search for many2many
         coids = comodel.search(Domain('id', 'in', coids), order='id').ids


### PR DESCRIPTION
Domains such as `[('id', 'child_of', 'some_str')]` should search the corecords using ilike before resolving the hierarchy. Adding tests for this use case.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
