### PR TITLE
[FIX] website: fix website form editor tour submit

### DIFF
--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -619,6 +619,21 @@ odoo.define('website.tour.form_editor', function (require) {
 
         ...wTourUtils.clickOnEditAndWaitEditMode(),
         {
+            content: "Select the 'Subject' field",
+            trigger: 'iframe .s_website_form_field.s_website_form_model_required:has(label:contains("Subject"))',
+        },
+        ...selectButtonByData("data-set-visibility='visible'"),
+        {
+            content: "Empty the default value of the 'Subject' field",
+            trigger: 'we-input[data-attribute-name="value"] input',
+            run: "remove_text",
+        },
+        {
+            content: "Select the 'Your Message' field",
+            trigger: 'iframe .s_website_form_field.s_website_form_required:has(label:contains("Your Message"))',
+        },
+        ...selectButtonByData("data-set-visibility='visible'"),
+        {
             content: 'Click on the submit button',
             trigger: 'iframe .s_website_form_send',
             run: 'click',


### PR DESCRIPTION
Since the "website_form_editor" tour was modified by this commit [1], the "Website Form Editor Tour" has been failing. This is due to the "Subject" field being hidden, while the "Website Form Editor Tour" expected it to be visible.

[1]: https://github.com/odoo/odoo/commit/243a4c1eb6523ba5d458f8cf8df5d696e40ccc8e

runbot-113783