### PR TITLE
[FIX] point_of_sale, pos_settle_due: prevent creation of empty orders

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -1097,6 +1097,12 @@ export class PosOrder extends Base {
             change: this.get_change() && formatCurrency(this.get_change()),
         };
     }
+    get hasItemsOrPayLater() {
+        return (
+            this.lines.length > 0 ||
+            this.payment_ids.some((p) => p.payment_method_id.type === "pay_later")
+        );
+    }
 }
 
 registry.category("pos_available_models").add(PosOrder.pythonModel, PosOrder);

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1063,13 +1063,11 @@ export class PosStore extends Reactive {
                 order.finalized &&
                 typeof order.id === "string" &&
                 !this.pendingOrder.create.has(order.id) &&
-                !this.pendingOrder.write.has(order.id)
+                !this.pendingOrder.write.has(order.id) &&
+                order.hasItemsOrPayLater
         );
         const orderToCreate = this.models["pos.order"].filter(
-            (order) =>
-                this.pendingOrder.create.has(order.id) &&
-                (order.lines.length > 0 ||
-                    order.payment_ids.some((p) => p.payment_method_id.type === "pay_later"))
+            (order) => this.pendingOrder.create.has(order.id) && order.hasItemsOrPayLater
         );
         const orderToUpdate = this.models["pos.order"].filter((order) =>
             this.pendingOrder.write.has(order.id)


### PR DESCRIPTION
Before this commit, depositing money for a customer with a zero balance could result in the creation of an empty order upon refreshing the browser. This issue arose because empty orders without payments were being synchronized, leading to unintended empty orders in the system.

This commit addresses the problem by ensuring that empty orders without payments are not synchronized and prevents the creation of such empty orders during the deposit process.

opw-4483049

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
