### PR TITLE
[FIX] l10n_es_edi_tbai fix total_amount calculation in TBAI xml.

### DIFF
--- a/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
+++ b/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
@@ -537,7 +537,10 @@ class L10n_Es_Edi_TbaiDocument(models.Model):
             if values['grouping_key'] and values['grouping_key']['l10n_es_type'] == 'retencion':
                 total_retention += values['tax_amount']
             else:
-                total_amount += values['base_amount'] + values['tax_amount']
+                total_amount += values['tax_amount']
+
+        for line in base_lines:
+            total_amount += line['price_subtotal']
 
         tax_details_info = self._build_tax_details_info(values_per_grouping_key.values())
         invoice_info = {
@@ -578,7 +581,10 @@ class L10n_Es_Edi_TbaiDocument(models.Model):
             if values['grouping_key'] and values['grouping_key']['l10n_es_type'] == 'retencion':
                 total_retention += values['tax_amount']
             else:
-                total_amount += values['base_amount'] + values['tax_amount']
+                total_amount += values['tax_amount']
+
+        for line in base_lines:
+            total_amount += line['price_subtotal']
 
         invoice_info = {}
         for scope, target_key in (('service', 'PrestacionServicios'), ('consu', 'Entrega')):


### PR DESCRIPTION
Steps to reproduce:
-------------------
- in a Spanish company, make sure l10n_es_edi_tbai is installed.
- create an invoice with one product and add 2 taxes for that line (for example, the 21% goods and the 5.2 ES tax).
- confirm and send the invoice with TBAI.
- in the TBAI xml you will find the total amount wrong as the base amount was calculated twice, one time for each tax.

Cause:
-----
Since (#180062), the tax details calculation process was reworked.
So now the total amount is calculated inside a loop with this formula
```
for values in values_per_grouping_key.values():
    total_amount += values['base_amount'] + values['tax_amount']
```
in our case the one invoice line will generate 2 tax groups (one for each tax) so this code will add the base_amount twice in the total_amount calculation.

Fix
---
move the base amount aggregation outside the loop, in a separate loop over the base_lines.

opw-4501051