### PR TITLE
[IMP] payment: disable post-processing cron when no provider enabled

### DIFF
--- a/addons/payment/data/payment_cron.xml
+++ b/addons/payment/data/payment_cron.xml
@@ -10,6 +10,7 @@
         <field name="interval_number">10</field>
         <field name="interval_type">minutes</field>
         <field name="numbercall">-1</field>
+        <field name="active" eval="False"/>
     </record>
 
 </odoo>

--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -342,6 +342,8 @@ class PaymentProvider(models.Model):
     def create(self, values_list):
         providers = super().create(values_list)
         providers._check_required_if_provider()
+        if any(provider.state != 'disabled' for provider in providers):
+            self._toggle_post_processing_cron()
         return providers
 
     def write(self, values):
@@ -363,6 +365,8 @@ class PaymentProvider(models.Model):
 
         deactivated_providers._deactivate_unsupported_payment_methods()
         activated_providers._activate_default_pms()
+        if activated_providers or deactivated_providers:
+            self._toggle_post_processing_cron()
 
         return result
 
@@ -392,6 +396,22 @@ class PaymentProvider(models.Model):
             raise ValidationError(
                 _("The following fields must be filled: %s", ", ".join(field_names))
             )
+
+    def _toggle_post_processing_cron(self):
+        """ Enable the post-processing cron if some providers are enabled; disable it otherwise.
+
+        This allows for saving resources on the cron's wake-up overhead when it has nothing to do.
+
+        :return: None
+        """
+        post_processing_cron = self.env.ref(
+            'payment.cron_post_process_payment_tx', raise_if_not_found=False
+        )
+        if post_processing_cron:
+            any_active_provider = bool(
+                self.sudo().search_count([('state', '!=', 'disabled')], limit=1)
+            )
+            post_processing_cron.active = any_active_provider
 
     def _archive_linked_tokens(self):
         """ Archive all the payment tokens linked to the providers.

--- a/addons/payment/tests/test_payment_provider.py
+++ b/addons/payment/tests/test_payment_provider.py
@@ -47,6 +47,26 @@ class TestPaymentProvider(PaymentCommon):
                 self.provider.state = 'disabled'
                 self.assertFalse(self.payment_methods.active)
 
+    def test_enabling_provider_activates_processing_cron(self):
+        """ Test that the post-processing cron is activated when a provider is enabled. """
+        self.env['payment.provider'].search([]).state = 'disabled'  # Reset providers' state.
+        post_processing_cron = self.env.ref('payment.cron_post_process_payment_tx')
+        for enabled_state in ('enabled', 'test'):
+            post_processing_cron.active = False  # Reset the cron's active field.
+            self.provider.state = 'disabled'  # Prepare the dummy provider for enabling.
+            self.provider.state = enabled_state
+            self.assertTrue(post_processing_cron.active)
+
+    def test_disabling_provider_deactivates_processing_cron(self):
+        """ Test that the post-processing cron is deactivated when a provider is disabled. """
+        self.env['payment.provider'].search([]).state = 'disabled'  # Reset providers' state.
+        post_processing_cron = self.env.ref('payment.cron_post_process_payment_tx')
+        for enabled_state in ('enabled', 'test'):
+            post_processing_cron.active = True  # Reset the cron's active field.
+            self.provider.state = enabled_state  # Prepare the dummy provider for disabling.
+            self.provider.state = 'disabled'
+            self.assertFalse(post_processing_cron.active)
+
     def test_published_provider_compatible_with_all_users(self):
         """ Test that a published provider is always available to all users. """
         for user in (self.public_user, self.portal_user):


### PR DESCRIPTION
The payment post-processing cron is run every 10 minutes to ensure smooth operations, but waking up crons incurs a non-negligible performance cost.

Since the `payment` module is automatically installed with the `account` module, most databases have the `payment` module installed with its cron, even if they didn't enable any provider.

This commit disables the cron until a provider is enabled.

task-4467217
