### PR TITLE
[FIX] account: Traceback when downloading Original bills

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -34,7 +34,7 @@ class IrActionsReport(models.Model):
                 if stream:
                     record = self.env[attachment.res_model].browse(attachment.res_id)
                     try:
-                        stream = pdf.add_banner(stream, record.name, logo=True)
+                        stream = pdf.add_banner(stream, record.name or '', logo=True)
                     except (ValueError, PdfStreamError, PdfReadError, TypeError, zlib_error, NotImplementedError):
                         record._message_log(body=_(
                             "There was an error when trying to add the banner to the original PDF.\n"


### PR DESCRIPTION
Users currently cannot retrieve original bills attached to
newly created draft moves, because an error is blocking the action

Steps to reproduce:
- Go to Accounting > Vendor > Bills
- Upload a pdf
- Back in list view, select the created bill, Download > Original Bills

Issue: Traceback will raise
`AttributeError: 'bool' object has no attribute 'decode'`

This occurs because, after https://github.com/odoo/odoo/commit/ce73ed61bcf293953bc0c821ceaef3ddb9a47e3c,
draft moves are not named '/' anymore, the name field will be just `False`.
However reportlab expects a string and it crashes

opw-4502791