### PR TITLE
[FIX] mrp: compute correctly bom cost in MO overview

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -188,4 +188,5 @@ class MrpRoutingWorkcenter(models.Model):
         return workcenter._get_expected_duration(product) + cycle_number * self.time_cycle * 100.0 / workcenter.time_efficiency
 
     def _compute_operation_cost(self):
-        return (self.time_cycle / 60.0) * (self.workcenter_id.costs_hour)
+        duration = self.env.context.get('op_duration', self.time_cycle)
+        return (duration / 60.0) * (self.workcenter_id.costs_hour)

--- a/addons/mrp/report/mrp_report_mo_overview.py
+++ b/addons/mrp/report/mrp_report_mo_overview.py
@@ -273,9 +273,8 @@ class ReportMoOverview(models.AbstractModel):
         operations = production.bom_id.operation_ids + kit_operation if kit_operation else production.bom_id.operation_ids
         if workorder.operation_id not in operations:
             return False
-        capacity = workorder.operation_id.workcenter_id._get_capacity(production.product_id)
-        operation_cycle = float_round(production.product_uom_qty / capacity, precision_rounding=1, rounding_method='UP')
-        return workorder.operation_id._compute_operation_cost() * operation_cycle
+        duration = workorder.operation_id._get_duration_expected(production.product_id, production.product_qty)
+        return self.env.company.currency_id.round(workorder.operation_id.with_context(op_duration=duration)._compute_operation_cost())
 
     def _get_operations_data(self, production, level=0, current_index=False):
         if production.state == "done":


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a workcenter “WC1”:
    - Cost by hour: 60
    - Setup time: 10 min
    - Cleanup time: 10 min
    - Time Efficiency: 85

- Create a storable product “P1” with the following BoM:
    - Operation: OP1 -> 60 min in WC1

- Create a MO to produce one unit of P1:
    - Confirm the MO
    - Go to the MO overview

Problem:
Time Efficiency, setup, and cleanup times are not taken into account in
the BoM Cost calculation.
The calculation should be the same as in the BoM overview. The purpose
of the BoM cost in the MO overview is to provide information for
comparison with the real cost, in case the user has modified certain
parameters during production.

Attention: There may be a slight difference in the calculation of
"mo_cost" and "bom_cost" because the expected duration is rounded to
two digits in the work order. This affects the mo_cost calculation
since it relies directly on this field,


opw-4478070
