### PR TITLE
[FIX] account_check_printing: specify which journal_id column to use

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -171,8 +171,8 @@ class AccountPayment(models.Model):
             self.env.cr.execute("""
                   SELECT payment.id
                     FROM account_payment payment
-                    JOIN account_move move ON movE.id = payment.move_id
-                   WHERE journal_id = %(journal_id)s
+                    JOIN account_move move ON move.id = payment.move_id
+                   WHERE move.journal_id = %(journal_id)s
                    AND payment.check_number IS NOT NULL
                 ORDER BY payment.check_number::BIGINT DESC
                    LIMIT 1

--- a/doc/cla/corporate/rooteam.md
+++ b/doc/cla/corporate/rooteam.md
@@ -1,0 +1,16 @@
+United States of America, 2025-01-28
+
+Rooteam agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Gabriel Grinspan gabriel@rooteam.net https://github.com/gabe-grinspan
+
+List of contributors:
+
+Gabriel Grinspan gabriel@rooteam.net https://github.com/gabe-grinspan
+Gabriel Grinspan grinspan.gabriel@gmail.com https://github.com/gabe-grinspan


### PR DESCRIPTION
This issue is not directly an Odoo issue, but it can create an issue if a custom module adds a field called journal_id to the account.payment model. There are no knock-on effects of this, because anyway the original developer should have specified the table. Additionally, it seems that there was a mild typo in the line before it that didn't affect anything. I see no harm in fixing it.

Description of the issue/feature this PR addresses:

Current behavior before PR:
No change in behavior.

Desired behavior after PR is merged:
No change in behavior.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
