### PR TITLE
[FIX] mail: msg/thread actions dropdown icon/label misaligned

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -120,7 +120,7 @@
 </t>
 
 <t t-name="mail.ChatWindow.dropdownAction">
-    <DropdownItem class="'o-mail-ChatWindow-command btn rounded-0 d-flex align-items-center p-2 m-0'" onSelected="() => action.onSelect()">
+    <DropdownItem class="'o-mail-ChatWindow-command btn rounded-0 d-flex align-items-baseline p-2 m-0'" onSelected="() => action.onSelect()">
         <i t-att-class="action.icon"/>
         <span class="mx-2" t-att-class="action.nameClass" t-out="action.name"/>
     </DropdownItem>

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -159,7 +159,7 @@
                         <t t-call="mail.Message.expandAction"/>
                         <t t-set-slot="content">
                             <t t-foreach="messageActions.actions.slice(quickActionCount - 1)" t-as="action" t-key="action.id">
-                                <DropdownItem class="'px-2 py-1 d-flex align-items-center rounded-0 ' + action.btnClass" onSelected="action.onClick" attrs="{ title: action.title}">
+                                <DropdownItem class="'px-2 py-1 d-flex align-items-baseline rounded-0 ' + action.btnClass" onSelected="action.onClick" attrs="{ title: action.title}">
                                     <t t-if="action.component" t-component="action.component" t-props="action.props"/>
                                     <t t-else="">
                                         <i class="fa-fw" t-att-class="action.icon"/>


### PR DESCRIPTION
They were slightly misaligned visually, which didn't look great.
This is fixes by replacing `.align-items-center` by `.align-items.baseline`

![Screenshot 2025-01-28 at 18 56 11](https://github.com/user-attachments/assets/91f371a3-07b8-46f2-9d51-44728af3bd10)
![Screenshot 2025-01-28 at 18 57 58](https://github.com/user-attachments/assets/8e6c1f25-bb96-4178-a8aa-a7ac955593a6)
![Screenshot 2025-01-28 at 19 01 37](https://github.com/user-attachments/assets/5861e704-81f5-418b-be49-9905f571f1a3)
![Screenshot 2025-01-28 at 19 01 29](https://github.com/user-attachments/assets/b601e30e-1a6c-4da9-a06d-a76a5e56accb)
