### PR TITLE
[FIX] stock: show barcode instead of lot for dymo labels

### DIFF
--- a/addons/product/report/product_label_report.py
+++ b/addons/product/report/product_label_report.py
@@ -57,4 +57,7 @@ class ReportProductTemplateLabelDymo(models.AbstractModel):
     _description = 'Product Label Report'
 
     def _get_report_values(self, docids, data):
+        custom_barcodes = data.pop('custom_barcodes', None)
+        if custom_barcodes:
+            data['quantity_by_product'].update({p: 1 for p in custom_barcodes})
         return _prepare_data(self.env, data)


### PR DESCRIPTION
**Steps to reproduce:**
1. Product A with lot, barcode, UoM as UNITs.
2. Product B with lot, barcode, UoM as METERs (or any other, not UNITs)
3. Create a Transfer for A and another one for B (need to provide Lot numbers while doing so, since the products are tracked by Lot)
4. Print the dymo labels for each of these transfers, by:
   - clicking "Print Labels"
   - selecting "Product Labels" and "Confirm"
   - selecting "dymo" and "Confirm"

**Observation:**
- The printed dymo label of A shows the Lot number provided in step 3, intead of the barcode -> UNDESIRED.
- The printed dymo label of B however, as expected, shows the barcode and not the Lot.

**Reason:**
ac145a7eaa00b36877fc7bdd8f3f05b232e44d1a overrides the barcode value by the Lot value when it exists, if the product's unit of measure is `uom_unit`. This change is not desired for the 'dymo' print format however.

**Fix:**
For the 'dymo' format labels, we remove any custom barcodes from the data to process, so basically reverting the changes of https://github.com/odoo/odoo/commit/ac145a7eaa00b36877fc7bdd8f3f05b232e44d1a.

opw-4461156