### PR TITLE
[FIX] web: improve naming of recent new emoji picker methods

### DIFF
--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -144,7 +144,7 @@ export class EmojiPicker extends Component {
             if (this.props.storeScroll) {
                 this.gridRef.el.scrollTop = this.props.storeScroll.get();
             }
-            this.state.hoveredEmoji = this.currentSelectedEmoji;
+            this.state.hoveredEmoji = this.activeEmoji;
         });
         onPatched(() => {
             if (this.emojis.length === 0) {
@@ -181,7 +181,7 @@ export class EmojiPicker extends Component {
                     activeEl.scrollIntoView({ block: "center", behavior: "instant" });
                     this.keyboardNavigated = false;
                 }
-                this.state.hoveredEmoji = this.currentSelectedEmoji;
+                this.state.hoveredEmoji = this.activeEmoji;
             },
             () => [this.state.activeEmojiIndex, this.gridRef?.el]
         );
@@ -297,12 +297,12 @@ export class EmojiPicker extends Component {
         return this.state.hoveredEmoji?.shortcodes.join(" ") ?? _t("Search emoji");
     }
 
-    onMouseEnter(ev, emoji) {
+    onMouseenterEmoji(ev, emoji) {
         this.state.hoveredEmoji = emoji;
     }
 
-    onMouseLeave(ev) {
-        this.state.hoveredEmoji = this.currentSelectedEmoji;
+    onMouseleaveEmoji(ev) {
+        this.state.hoveredEmoji = this.activeEmoji;
     }
 
     onClick(ev) {
@@ -396,11 +396,11 @@ export class EmojiPicker extends Component {
         this.state.activeEmojiIndex = newIdx ?? this.state.activeEmojiIndex;
     }
 
-    get currentSelectedEmoji() {
-        const currentCodepoints = this.gridRef.el.querySelector(
+    get activeEmoji() {
+        const activeCodepoints = this.gridRef.el.querySelector(
             `.o-EmojiPicker-content .o-Emoji[data-index="${this.state.activeEmojiIndex}"]`
         )?.dataset.codepoints;
-        return currentCodepoints ? this.emojiByCodepoints[currentCodepoints] : undefined;
+        return activeCodepoints ? this.emojiByCodepoints[activeCodepoints] : undefined;
     }
 
     onKeydown(ev) {

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.xml
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.xml
@@ -110,7 +110,7 @@
 </t>
 
 <t t-name="web.EmojiPicker.emoji">
-    <span class="o-Emoji cursor-pointer d-flex justify-content-center rounded-3 align-items-center align-self-stretch" t-att-class="{ 'o-active': state.activeEmojiIndex === itemIndex, 'fs-2': !ui.isSmall, 'fs-1': ui.isSmall }" t-att-title="emoji.name" t-att-data-codepoints="emoji.codepoints" t-att-data-index="itemIndex" t-att-data-category="inRecent ? recentCategory.sortId : categories.find(c => c.name === emoji.category).sortId" t-on-click="selectEmoji" t-on-mouseenter="() => this.onMouseEnter(ev, emoji)" t-on-mouseleave="() => this.onMouseLeave(ev, emoji)">
+    <span class="o-Emoji cursor-pointer d-flex justify-content-center rounded-3 align-items-center align-self-stretch" t-att-class="{ 'o-active': state.activeEmojiIndex === itemIndex, 'fs-2': !ui.isSmall, 'fs-1': ui.isSmall }" t-att-title="emoji.name" t-att-data-codepoints="emoji.codepoints" t-att-data-index="itemIndex" t-att-data-category="inRecent ? recentCategory.sortId : categories.find(c => c.name === emoji.category).sortId" t-on-click="selectEmoji" t-on-mouseenter="(ev) => this.onMouseenterEmoji(ev, emoji)" t-on-mouseleave="(ev) => this.onMouseleaveEmoji(ev, emoji)">
         <span t-esc="emoji.codepoints"/>
     </span>
 </t>


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/195236

PR above add new methods to emoji picker for nice little feature. Commit had minor issues that this PR fixes:
- names were poor: onMouseEnter => onMouseenterEmoji (mouseenter event on an emoji) onMouseLeave => onMouseleaveEmoji (mouseleave event on an emoji) currentSelectedEmoji => activeEmoji (simpler and consistent with existing attributes on this component)
- ev of mouseenter and mouseleave were not propagated correctly to the handler methods (even if not used... yet?)
