### PR TITLE
[IMP] *: add dropzones for controller pages

### DIFF
--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -6,13 +6,22 @@
 <template id="index" name="Blog Navigation">
     <t t-call="website.layout">
         <div id="wrap" class="js_blog website_blog">
+            <!-- Droppable-area shared across all blog's pages -->
+            <t t-set="oe_structure_description">Visible in all blogs' pages</t>
+            <t t-set="tooltip_message">Shared between all blog pages</t>
+            <div class="oe_structure oe_empty oe_structure_not_nearest"
+                id="oe_structure_above_blog_header"
+                t-att-data-editor-sub-message="oe_structure_description"
+                t-att-data-tooltip-message="tooltip_message"
+            />
             <t t-out="0"/>
 
             <!-- Droppable-area shared across all blog's pages -->
-            <t t-set="oe_structure_blog_footer_description">Visible in all blogs' pages</t>
             <div class="oe_structure oe_empty oe_structure_not_nearest"
                 id="oe_structure_blog_footer"
-                t-att-data-editor-sub-message="oe_structure_blog_footer_description"/>
+                t-att-data-editor-sub-message="oe_structure_description"
+                t-att-data-tooltip-message="tooltip_message"
+            />
         </div>
     </t>
 </template>
@@ -93,6 +102,7 @@ list of filtered posts (by date or tag).
 <template id="opt_blog_cover_post" name="Top banner - Name / Latest Post" inherit_id="website_blog.blog_post_short" active="True" priority="17">
     <xpath expr="//div[@id='o_wblog_blog_top_droppable']" position="replace">
         <div class="container">
+            <div class="oe_structure" id="oe_structure_top_of_title"/>
             <div class="row py-4">
                 <t t-if="blog">
                     <div t-attf-class="mb-3 mb-md-0 #{'col-md-5' if (not opt_blog_list_view and not opt_blog_sidebar_show) else 'col-md-6'}">
@@ -137,6 +147,7 @@ list of filtered posts (by date or tag).
             </div>
         </t>
         <t t-else="">
+            <div class="oe_structure" id="oe_structure_top_of_title_2"/>
             <div class="h1 my-4 o_not_editable" style="text-align:center;">Our Latest Posts</div>
         </t>
     </xpath>
@@ -179,7 +190,7 @@ list of filtered posts (by date or tag).
         <t t-set="opt_blog_post_sidebar" t-value="is_view_active('website_blog.opt_blog_post_sidebar')"/>
         <t t-set="opt_blog_post_regular_cover" t-value="is_view_active('website_blog.opt_blog_post_regular_cover')"/>
         <t t-set="opt_blog_post_breadcrumb" t-value="is_view_active('website_blog.opt_blog_post_breadcrumb')"/>
-        
+
         <section id="o_wblog_post_top">
             <div id="title" class="blog_header" t-ignore="True">
                 <t t-call="website.record_cover">

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -12,6 +12,8 @@
             <!-- Options -->
             <t t-set="opt_events_list_cards" t-value="is_view_active('website_event.opt_events_list_cards')"/>
             <t t-set="opt_events_list_columns" t-value="is_view_active('website_event.opt_events_list_columns')"/>
+            <!-- Dropzone -->
+            <div id="oe_structure_we_index" class="oe_structure"/>
             <!-- Topbar -->
             <t t-call="website_event.index_topbar">
                 <t t-set="search" t-value="original_search or search or searches['search']"/>

--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -7,9 +7,15 @@
         <!-- Options -->
         <t t-set="opt_events_list_categories" t-value="is_view_active('website_event.opt_events_list_categories')"/>
         <div id="wrap" t-attf-class="o_wevent_event js_event d-flex flex-column h-100 #{'o_wevent_hide_sponsors' if hide_sponsors else ''}">
+            <t t-set="editor_sub_message">Following content will appear on all events.</t>
+            <t t-set="tooltip_message">Shared between all events</t>
+            <div class="oe_structure oe_empty"
+                id="oe_structure_website_event_layout_top"
+                t-att-data-editor-sub-message="editor_sub_message"
+                t-att-data-tooltip-message="tooltip_message"
+            />
             <t t-if="not hide_submenu" t-call="website_event.navbar"/>
             <t t-out="0"/>
-            <t t-set="editor_sub_message">Following content will appear on all events.</t>
             <div class="oe_structure oe_empty" id="oe_structure_website_event_layout_1" t-att-data-editor-sub-message="editor_sub_message"/>
         </div>
 

--- a/addons/website_event/views/event_templates_page_misc.xml
+++ b/addons/website_event/views/event_templates_page_misc.xml
@@ -12,13 +12,11 @@
 <template id="template_intro">
     <t t-call="website_event.layout">
         <div class="oe_structure oe_empty" id="oe_structure_website_event_intro_1"/>
-        <div class="oe_structure">
             <section class="s_title pt32 pb32" data-vcss="001" data-snippet="s_title" data-name="Title">
                 <div class="container s_allow_columns">
                     <h1 class="display-3" style="text-align: center;">Introduction</h1>
                 </div>
             </section>
-        </div>
         <div class="oe_structure oe_empty" id="oe_structure_website_event_intro_2"/>
     </t>
 </template>

--- a/addons/website_forum/views/forum_forum_templates_forum_all.xml
+++ b/addons/website_forum/views/forum_forum_templates_forum_all.xml
@@ -12,6 +12,7 @@
     <t t-call="website.layout">
         <t t-set="pageName" t-value="'website_forum'"/>
         <div id="wrap">
+            <div class="oe_structure" id="oe_structure_above_title_forum"/>
             <div class="oe_structure oe_empty" id="oe_structure_forum_all_top"/>
             <div id="o_wforum_forums_index_list" class="container pt-lg-4 pb-5">
                 <div class="row justify-content-center">

--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -210,7 +210,13 @@
             </div>
         </t>
         <t t-else="">
-            <div class="oe_structure" id="oe_structure_website_forum_header_1"/>
+            <t t-set="editor_message">DROP BUILDING BLOCKS HERE TO MAKE THE AVAILABLE ACROSS ALL FORUMS.</t>
+            <t t-set="tooltip_message">Shared between all forums</t>
+            <div class="oe_structure"
+                id="oe_structure_website_forum_header_1"
+                t-att-data-editor-message="editor_message"
+                t-att-data-tooltip-message="tooltip_message"
+            />
             <div id="wrap" t-attf-class="o_wforum_wrapper position-relative container row mx-auto px-0 #{ 'h-100' if forum_welcome_message else ''} #{website_forum_action}">
                 <t t-set="_forum_slug" t-value="slug(forum) if forum else 'all'"/>
                 <t t-set="_forum_path" t-value="url_for('/forum') + '/' + _forum_slug"/>
@@ -353,8 +359,8 @@
 </template>
 
 <template id="header_welcome_message" inherit_id="website_forum.header" name="Forum Welcome Message (oe_structure_forum_top)">
-    <xpath expr="//*[hasclass('oe_structure')][@id='oe_structure_website_forum_header_1']" position="replace">
-        <div t-if="forum" class="oe_structure oe_empty" id="oe_structure_website_forum_header_1">
+    <xpath expr="//*[hasclass('oe_structure')][@id='oe_structure_website_forum_header_1']" position="inside">
+        <div t-if="forum" class="oe_structure oe_empty" t-ignore="true">
             <section t-if="editable or (is_public_user and not forum_welcome_message)" t-attf-class="s_cover parallax s_parallax_is_fixed bg-black-50 pt48 pb48 #{'css_non_editable_mode_hidden' if editable else 'forum_intro'}" data-scroll-background-ratio="1" data-snippet="s_cover">
                 <span t-if="forum.image_1920" class="s_parallax_bg oe_img_bg" t-attf-style="background-image: url('#{request.website.image_url(forum, 'image_1920')}'); background-position: center;"/>
                 <div t-if="forum.image_1920" class="o_we_bg_filter bg-black-50"/>

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -19,6 +19,7 @@
                 </div>
             </nav>
 
+            <div class="oe_structure" id="oe_structure_hr_recruitment_index_below_title"/>
             <!-- Content -->
             <div class="container oe_website_jobs">
                 <div class="row pt48 pb16">
@@ -123,6 +124,13 @@
         </nav>
         <!-- Content -->
         <div id="wrap" class="js_hr_recruitment">
+            <t t-set="editor_message">DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL JOBS</t>
+            <t t-set="tooltip_message">Shared between all jobs</t>
+            <div class="oe_structure oe_empty"
+                id="oe_structure_hr_recruitment_index_above_title"
+                t-att-data-editor-message="editor_message"
+                t-att-data-tooltip-message="tooltip_message"
+            />
             <div itemscope="itemscope" itemtype="https://schema.org/JobPosting">
                 <meta t-if="job.contract_type_id" itemprop="employmentType" t-att-content="job.contract_type_id.sudo().name"/>
                 <meta t-if="job.published_date" itemprop="datePosted" t-att-content="job.published_date"/>


### PR DESCRIPTION
*= website_blog, website_forum, website_hr_recruitment, website_event

This commit introduces dropzones above the title on certain pages, such as 'Blog', 'Help', 'Job', etc. Additionally, dropzones are added to internal pages (e.g., /blog/{page}). These dropzones are intended to contain shared elements across the content.
    
The attribute `data-tooltip-message` is also introduced to display tooltips, as specified in [1].
    
 [1]: https://www.odoo.com/odoo/project.task/4430496
    
task-4430461

