### PR TITLE
[IMP] pos_loyalty: highlight action button when reward is available

### DIFF
--- a/addons/pos_loyalty/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -1,3 +1,4 @@
+import { useState, onWillRender } from "@odoo/owl";
 import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { TextInputPopup } from "@point_of_sale/app/components/popups/text_input_popup/text_input_popup";
@@ -7,6 +8,16 @@ import { makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
 import { patch } from "@web/core/utils/patch";
 
 patch(ControlButtons.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.state = useState({
+            nbrRewards: [],
+        });
+
+        onWillRender(() => {
+            this.state.nbrRewards = this.getPotentialRewards().length;
+        });
+    },
     _getEWalletRewards(order) {
         const claimableRewards = order.getClaimableRewards();
         return claimableRewards.filter((reward_line) => {

--- a/addons/pos_loyalty/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -26,7 +26,7 @@
             <t t-if="pos.models['loyalty.program'].length and this.pos.cashier._role !== 'minimal'">
                 <button class="control-button"
                     t-att-class="buttonClass"
-                    t-attf-class="{{getPotentialRewards().length ? 'highlight text-action' : 'disabled'}}"
+                    t-attf-class="{{state.nbrRewards ? 'highlight text-action' : 'disabled'}}"
                     t-on-click="() => this.clickRewards()">
                     <i class="fa fa-star me-1"/>Reward
                 </button>
@@ -39,6 +39,9 @@
                     <i class="fa fa-star me-1"/>Reset Programs
                 </button>
             </t>
+        </xpath>
+        <xpath expr="//button[hasclass('more-btn')]" position="attributes">
+            <attribute name="t-attf-class">{{ state.nbrRewards ? 'active text-action' : '' }}</attribute>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
In this commit:
===
- When a reward is available, the "More" action button is visually highlighted .

task-4519592
