### PR TITLE
[FIX] point_of_sale: prevent duplicate lines for pos categories

### DIFF
--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -53,7 +53,7 @@ class PosOrderReport(models.Model):
                 LEFT JOIN pos_payment pm ON (pm.pos_order_id=po.id)
                 GROUP BY pol.id
             )
-            SELECT
+            SELECT DISTINCT ON (l.id)
                 l.id AS id,
                 1 AS nbr_lines, -- number of lines in order line is always 1
                 s.date_order AS date,


### PR DESCRIPTION
**Description:**
- If a product belongs to multiple POS categories and is added to a single order,
the order report may show duplicate lines based on the number of categories the product is assigned to.

**Steps to reproduce:**
- Install the 'point_of_sale' module.
- Create a product and assign it to multiple POS categories.
- Open the POS interface, add that product and validate the order.
- Check the order report for this order—the lines will be duplicated based on the number of POS categories the product belongs to.

**Screenshots for clarity:**
- Product configuration

![product_config](https://github.com/user-attachments/assets/942e2a55-9d92-4b6e-b2f0-685ea0f57f22)

- Add the product from any of the category.

![prod_add](https://github.com/user-attachments/assets/78b1037e-8514-4198-bc60-14803f57c123)


**Before FIX**
- Reporting view for **Orders** you may notice that the product is already double `2` even though we have added single quantity.

![order_pivot](https://github.com/user-attachments/assets/17b99163-9083-40a0-b357-8fce585fbcb3)


- Double line created with same `id` for both the categories.

![dup_lines](https://github.com/user-attachments/assets/f7d42585-d0a4-477d-b521-0ac9e8802d64)


**After FIX**
- Reporting view for **Orders** 

![after_fix](https://github.com/user-attachments/assets/75383e60-c317-4997-8927-a8ca55821b6a)


- Single line with same product quantity added on the order line.

![single_line](https://github.com/user-attachments/assets/dc2c8e75-aad7-4539-895f-b5f793d59179)






OPW - 4478667

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
