### PR TITLE
[IMP] website_sale: mute unpublished products for admin

### DIFF
--- a/addons/sale/controllers/product_configurator.py
+++ b/addons/sale/controllers/product_configurator.py
@@ -358,6 +358,7 @@ class SaleProductConfiguratorController(Controller):
                 'description_sale': str|False,
                 'display_name': str,
                 'price': float,
+                'website_published': bool,
             }
         """
         basic_information = dict(
@@ -384,6 +385,7 @@ class SaleProductConfiguratorController(Controller):
             **basic_information,
             price=price,
             pricelist_rule_id=pricelist_rule_id,
+            website_published=product_or_template.website_published,
             **request.env['product.template']._get_additional_configurator_data(
                 product_or_template, pricelist=pricelist, **kwargs
             ),

--- a/addons/sale/static/src/js/product/product.js
+++ b/addons/sale/static/src/js/product/product.js
@@ -25,6 +25,7 @@ export class Product extends Component {
         parent_exclusions: Object,
         parent_product_tmpl_id: { type: Number, optional: true },
         price_info: { type: String, optional: true },
+        website_published: { type: Boolean, optional: true },
     };
 
     //--------------------------------------------------------------------------

--- a/addons/sale/static/src/js/product/product.xml
+++ b/addons/sale/static/src/js/product/product.xml
@@ -8,7 +8,7 @@
                 alt="Product Image"
             />
         </td>
-        <td class="p-3 product_name_description">
+        <td name="product_name_description" class="p-3 product_name_description">
             <div class="mb-4 text-break text-truncate" name="o_sale_product_configurator_name">
                 <span class="h5" t-out="this.props.display_name"/>
                 <div

--- a/addons/sale/static/src/js/product_list/product_list.xml
+++ b/addons/sale/static/src/js/product_list/product_list.xml
@@ -27,7 +27,13 @@
                 </tr>
             </thead>
             <tbody class="border-top-0">
-                <tr t-foreach="this.props.products" t-as="product" t-key="product.product_tmpl_id" t-att-class="{'non_optional_product_row_borders': !this.props.areProductsOptional}">
+                <tr
+                    name="product_row"
+                    t-foreach="this.props.products"
+                    t-as="product"
+                    t-key="product.product_tmpl_id"
+                    t-att-class="{'non_optional_product_row_borders': !this.props.areProductsOptional}"
+                >
                     <Product t-props="product" optional="this.props.areProductsOptional"/>
                 </tr>
                 <tr t-if="!this.props.areProductsOptional &amp;&amp; env.showPrice">

--- a/addons/website/models/models.py
+++ b/addons/website/models/models.py
@@ -15,3 +15,6 @@ class Base(models.AbstractModel):
         ):
             return True
         return super()._can_return_content(field_name, access_token)
+
+    def _get_snippet_filter_domain(self):
+        return [('is_published', '=', True)]

--- a/addons/website/models/website_snippet_filter.py
+++ b/addons/website/models/website_snippet_filter.py
@@ -101,7 +101,7 @@ class WebsiteSnippetFilter(models.Model):
                 website = self.env['website'].get_current_website()
                 domain = expression.AND([domain, [('company_id', 'in', [False, website.company_id.id])]])
             if 'is_published' in self.env[filter_sudo.model_id]:
-                domain = expression.AND([domain, [('is_published', '=', True)]])
+                domain = expression.AND([domain, self.env[filter_sudo.model_id]._get_snippet_filter_domain()])
             if search_domain:
                 domain = expression.AND([domain, search_domain])
             try:

--- a/addons/website_sale/data/data.xml
+++ b/addons/website_sale/data/data.xml
@@ -71,7 +71,6 @@
             <field name="name">Newest Products</field>
             <field name="model_id">product.product</field>
             <field name="user_ids" eval="False" />
-            <field name="domain">[('website_published', '=', True)]</field>
             <field name="context">{'display_default_code': False, 'add2cart_rerender': False}</field>
             <field name="sort">["create_date desc"]</field>
             <field name="action_id" ref="website.action_website"/>

--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -7,7 +7,11 @@
                 <t t-set="record" t-value="data['_record']"/>
                 <t t-set="product_template_id" t-value="record.id if not record.is_product_variant else record.product_tmpl_id.id"/>
                 <t t-set="product_id" t-value="record.id if record.is_product_variant else record.product_variant_id.id"/>
-                <div class="o_carousel_product_card card h-100 w-100" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
+                <div
+                    class="o_carousel_product_card card h-100 w-100"
+                    t-att-data-add2cart-rerender="data.get('_add2cart_rerender')"
+                    t-att-data-publish="record.website_published and 'on' or 'off'"
+                >
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <a class="o_carousel_product_img_link o_dynamic_product_hovered overflow-hidden" t-att-href="record.website_url">
                         <img class="card-img-top o_img_product_square o_img_product_cover h-auto" loading="lazy" t-att-src="data['image_512']"
@@ -27,6 +31,14 @@
                                 <t t-set="rating_avg" t-value="record.rating_avg"/>
                                 <t t-set="rating_count" t-value="record.rating_count"/>
                             </t>
+                            <a
+                                t-if="not record.website_published"
+                                role="button"
+                                class="btn btn-sm btn-danger"
+                                title="This product is unpublished."
+                            >
+                                Unpublished
+                            </a>
                         </div>
                         <div class="w-100 d-flex flex-wrap flex-md-column flex-lg-row align-items-center align-self-end justify-content-between">
                             <div class="py-2">
@@ -55,7 +67,11 @@
         <template id="dynamic_filter_template_product_product_view_detail" name="Classic Card - Detailed">
             <t t-foreach="records" t-as="data" data-number-of-elements="3" data-thumb="/website_sale/static/src/img/snippets_options/product_view_detail.svg">
                 <t t-set="record" t-value="data['_record']" data-arrow-position="bottom"/>
-                <div class="o_carousel_product_card card h-100 w-100" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
+                <div
+                    class="o_carousel_product_card card h-100 w-100"
+                    t-att-data-add2cart-rerender="data.get('_add2cart_rerender')"
+                    t-att-data-publish="record.website_published and 'on' or 'off'"
+                >
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <a class="o_carousel_product_img_link o_dynamic_product_hovered overflow-hidden" t-att-href="record.website_url">
                         <img class="card-img-top o_img_product_square o_img_product_cover h-auto" loading="lazy" t-att-src="data['image_512']" t-att-alt="record.display_name"/>
@@ -68,6 +84,14 @@
                                 <t t-set="rating_avg" t-value="record.rating_avg"/>
                                 <t t-set="rating_count" t-value="record.rating_count"/>
                             </t>
+                            <a
+                                t-if="not record.website_published"
+                                role="button"
+                                class="btn btn-sm btn-danger"
+                                title="This product is unpublished."
+                            >
+                                Unpublished
+                            </a>
                         </div>
                         <div class="d-flex justify-content-between flex-wrap flex-md-column flex-lg-row align-items-center align-self-end w-100 mt-2 pt-3 border-top">
                             <div class="pb-2">
@@ -85,7 +109,11 @@
         <template id="dynamic_filter_template_product_product_mini_image" name="Image only">
             <t t-foreach="records" t-as="data" data-number-of-elements="4" data-number-of-elements-sm="1" data-thumb="/website_sale/static/src/img/snippets_options/product_image_only.svg">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="card h-100 border-0 w-100 rounded-0 bg-transparent" t-att-data-url="record.website_url">
+                <div
+                    class="card h-100 border-0 w-100 rounded-0 bg-transparent"
+                    t-att-data-url="record.website_url"
+                    t-att-data-publish="record.website_published and 'on' or 'off'"
+                >
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <a class="o_carousel_product_img_link o_dynamic_product_hovered overflow-hidden" t-att-href="record.website_url">
                         <img class="card-img-top h-auto o_img_product_square o_img_product_cover rounded" loading="lazy" t-att-src="data['image_512']" t-att-alt="record.display_name"/>
@@ -97,7 +125,11 @@
         <template id="dynamic_filter_template_product_product_mini_price" name="Image with price">
             <t t-foreach="records" t-as="data" data-thumb="/website_sale/static/src/img/snippets_options/product_image_with_price.svg">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="card h-100 border-0 w-100 rounded-0 bg-transparent o_dynamic_product_hovered" t-att-data-url="record.website_url">
+                <div
+                    class="card h-100 border-0 w-100 rounded-0 bg-transparent o_dynamic_product_hovered"
+                    t-att-data-url="record.website_url"
+                    t-att-data-publish="record.website_published and 'on' or 'off'"
+                >
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <a class="o_carousel_product_img_link o_dynamic_product_hovered overflow-hidden" t-att-href="record.website_url">
                         <img class="card-img-top h-auto o_img_product_square o_img_product_cover rounded" loading="lazy" t-att-src="data['image_512']" t-att-alt="record.display_name"/>
@@ -109,6 +141,14 @@
                             <t t-set="rating_count" t-value="record.rating_count"/>
                         </t>
                         <div class="ms-auto">
+                            <a
+                                t-if="not record.website_published"
+                                role="button"
+                                class="btn btn-sm btn-danger"
+                                title="This product is unpublished."
+                            >
+                                Unpublished
+                            </a>
                             <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
                         </div>
                     </div>
@@ -119,7 +159,11 @@
         <template id="dynamic_filter_template_product_product_mini_name" name="Image with name">
             <t t-foreach="records" t-as="data" data-thumb="/website_sale/static/src/img/snippets_options/product_image_with_name.svg">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="card h-100 border-0 w-100 rounded-0 bg-transparent o_dynamic_product_hovered" t-att-data-url="record.website_url">
+                <div
+                    class="card h-100 border-0 w-100 rounded-0 bg-transparent o_dynamic_product_hovered"
+                    t-att-data-url="record.website_url"
+                    t-att-data-publish="record.website_published and 'on' or 'off'"
+                >
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <a class="o_carousel_product_img_link overflow-hidden" t-att-href="record.website_url">
                         <img class="card-img-top h-auto o_img_product_square o_img_product_cover rounded" loading="lazy" t-att-src="data['image_512']" t-att-alt="record.display_name"/>
@@ -130,6 +174,14 @@
                             <t t-set="rating_avg" t-value="record.rating_avg"/>
                             <t t-set="rating_count" t-value="record.rating_count"/>
                         </t>
+                            <a
+                                t-if="not record.website_published"
+                                role="button"
+                                class="btn btn-sm btn-danger"
+                                title="This product is unpublished."
+                            >
+                                Unpublished
+                            </a>
                     </div>
                 </div>
             </t>
@@ -138,7 +190,10 @@
         <template id="dynamic_filter_template_product_product_centered" name="Centered Product">
             <t t-foreach="records" t-as="data" data-arrow-position="bottom" data-thumb="/website_sale/static/src/img/snippets_options/product_centered.svg">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="o_carousel_product_card card w-100" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
+                <div
+                    class="o_carousel_product_card card w-100" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')"
+                    t-att-data-publish="record.website_published and 'on' or 'off'"
+                >
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <input type="hidden" name="product-id" t-att-data-product-id="record.id"/>
                     <a class="o_carousel_product_img_link position-absolute mx-auto" t-att-href="record.website_url">
@@ -158,6 +213,14 @@
                                     </t>
                                 </t>
                             </div>
+                            <a
+                                t-if="not record.website_published"
+                                role="button"
+                                class="btn btn-sm btn-danger"
+                                title="This product is unpublished."
+                            >
+                                Unpublished
+                            </a>
                         </div>
                     </div>
                     <div class="o_carousel_product_card_footer d-flex align-items-center justify-content-center pb-4">
@@ -172,7 +235,10 @@
         <template id="dynamic_filter_template_product_product_borderless_1" name="Borderless Product n°1">
             <t t-foreach="records" t-as="data" data-thumb="/website_sale/static/src/img/snippets_options/product_borderless_1.svg">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="o_carousel_product_card bg-transparent w-100 card border-0">
+                <div
+                    class="o_carousel_product_card bg-transparent w-100 card border-0"
+                    t-att-data-publish="record.website_published and 'on' or 'off'"
+                >
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <input type="hidden" name="product-id" t-att-data-product-id="record.id"/>
                     <a class="o_carousel_product_img_link o_dynamic_product_hovered stretched-link" t-att-href="record.website_url">
@@ -188,6 +254,14 @@
                                 <t t-set="rating_avg" t-value="record.rating_avg"/>
                                 <t t-set="rating_count" t-value="record.rating_count"/>
                             </t>
+                            <a
+                                t-if="not record.website_published"
+                                role="button"
+                                class="btn btn-sm btn-danger"
+                                title="This product is unpublished."
+                            >
+                                Unpublished
+                            </a>
                             <div class="mt-2">
                                 <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
                             </div>
@@ -200,7 +274,11 @@
         <template id="dynamic_filter_template_product_product_borderless_2" name="Borderless Product n°2">
             <t t-foreach="records" t-as="data" data-thumb="/website_sale/static/src/img/snippets_options/product_borderless_2.svg">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="o_carousel_product_card card w-100 border-0 bg-transparent" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
+                <div
+                    class="o_carousel_product_card card w-100 border-0 bg-transparent"
+                    t-att-data-add2cart-rerender="data.get('_add2cart_rerender')"
+                    t-att-data-publish="record.website_published and 'on' or 'off'"
+                >
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <a class="o_carousel_product_img_link o_dynamic_product_hovered" t-att-href="record.website_url">
                         <div class="overflow-hidden rounded">
@@ -222,6 +300,14 @@
                                     </t>
                                 </t>
                             </div>
+                            <a
+                                t-if="not record.website_published"
+                                role="button"
+                                class="btn btn-sm btn-danger"
+                                title="This product is unpublished."
+                            >
+                                Unpublished
+                            </a>
                         </div>
                         <div class="card-title h6 flex-grow-1 w-100 mt-2 mb-3" t-field="record.display_name"/>
                         <div class="text-end o_dynamic_snippet_btn_wrapper" t-if="record._website_show_quick_add()">
@@ -248,7 +334,11 @@
         <template id="dynamic_filter_template_product_product_banner" name="Large Banner">
             <t t-foreach="records" t-as="data" data-number-of-elements="1" data-number-of-elements-sm="1" data-thumb="/website_sale/static/src/img/snippets_options/product_banner.svg">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="o_carousel_product_card card w-100" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
+                <div
+                    class="o_carousel_product_card card w-100"
+                    t-att-data-add2cart-rerender="data.get('_add2cart_rerender')"
+                    t-att-data-publish="record.website_published and 'on' or 'off'"
+                >
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <div class="row flex-row-reverse">
                         <div class="col-lg-6 d-flex align-items-center justify-content-center justify-content-lg-end o_wrap_product_img position-relative">
@@ -266,6 +356,14 @@
                                         <t t-set="rating_count" t-value="record.rating_count"/>
                                     </t>
                                 </div>
+                                <a
+                                    t-if="not record.website_published"
+                                    role="button"
+                                    class="btn btn-sm btn-danger"
+                                    title="This product is unpublished."
+                                >
+                                    Unpublished
+                                </a>
                                 <div class="card-text text-muted" t-field="record.description_sale"/>
                                 <div class="mt-4">
                                     <t t-set="product_template_id" t-value="record.id if not record.is_product_variant else record.product_tmpl_id.id"/>
@@ -303,7 +401,11 @@
                 data-extra-classes="o_carousel_multiple_rows"
                 data-thumb="/website_sale/static/src/img/snippets_options/product_horizontal_card.svg">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="o_carousel_product_card card w-100 border-0 bg-light p-3" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
+                <div
+                    class="o_carousel_product_card card w-100 border-0 bg-light p-3"
+                    t-att-data-add2cart-rerender="data.get('_add2cart_rerender')"
+                    t-att-data-publish="record.website_published and 'on' or 'off'"
+                >
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <div class="row h-100 p-0">
                         <div class="col-lg-4 position-static">
@@ -321,6 +423,14 @@
                                         <t t-set="rating_avg" t-value="record.rating_avg"/>
                                         <t t-set="rating_count" t-value="record.rating_count"/>
                                     </t>
+                                <a
+                                    t-if="not record.website_published"
+                                    role="button"
+                                    class="btn btn-sm btn-danger"
+                                    title="This product is unpublished."
+                                >
+                                    Unpublished
+                                </a>
                                 </div>
                                 <div class="d-flex align-items-center flex-wrap">
                                     <div class="my-2">
@@ -358,7 +468,10 @@
                 data-extra-classes="o_carousel_multiple_rows"
                 data-thumb="/website_sale/static/src/img/snippets_options/product_horizontal_card_2.svg">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="o_carousel_product_card card w-100 border-0 o_dynamic_product_hovered o_cc o_cc5">
+                <div
+                    class="o_carousel_product_card card w-100 border-0 o_dynamic_product_hovered o_cc o_cc5"
+                    t-att-data-publish="record.website_published and 'on' or 'off'"
+                >
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <a class="stretched-link" t-att-href="record.website_url">
                         <img class="img img-fluid position-absolute w-100 h-100 o_img_product_cover" loading="lazy" t-att-src="data['image_512']" t-att-alt="record.display_name"/>
@@ -370,6 +483,14 @@
                                     <t t-set="rating_avg" t-value="record.rating_avg"/>
                                     <t t-set="rating_count" t-value="record.rating_count"/>
                                 </t>
+                            <a
+                                t-if="not record.website_published"
+                                role="button"
+                                class="btn btn-sm btn-danger"
+                                title="This product is unpublished."
+                            >
+                                Unpublished
+                            </a>
                         </div>
                         <div class="card-text h6 flex-grow-1" t-field="record.description_sale"/>
                         <div class="d-flex justify-content-between align-items-center flex-wrap mt-3">
@@ -407,13 +528,27 @@
                 data-extra-classes="o_card_group rounded"
                 data-thumb="/website_sale/static/src/img/snippets_options/product_card_group.svg">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="o_carousel_product_card card w-100 rounded-0 border-top-0 border-start-0" t-att-data-url="record.website_url">
+                <div
+                    class="o_carousel_product_card card w-100 rounded-0 border-top-0 border-start-0"
+                    t-att-data-url="record.website_url"
+                    t-att-data-publish="record.website_published and 'on' or 'off'"
+                >
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <input type="hidden" name="product-id" t-att-data-product-id="record.id"/>
                     <div class="o_carousel_product_card_body card-body justify-content-between h-100 p-3">
                         <div class="row h-100">
                             <div class="col-8 d-flex flex-column">
-                                <div class="card-title h5" t-field="record.display_name"/>
+                                <div class="d-flex card-title h5 justify-content-between">
+                                    <div t-field="record.display_name"/>
+                                    <a
+                                        t-if="not record.website_published"
+                                        role="button"
+                                        class="btn btn-sm btn-danger"
+                                        title="This product is unpublished."
+                                    >
+                                        Unpublished
+                                    </a>
+                                </div>
                                 <div class="card-text h6 text-muted" t-field="record.description_sale"/>
                                 <div class="d-flex justify-content-between align-items-center flex-wrap w-100 mt-auto">
                                     <div class="h5 text-primary mb-0 me-2">

--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -148,6 +148,12 @@ class ProductProduct(models.Model):
             return False
         return request.website.has_ecommerce_access()
 
+    def _get_snippet_filter_domain(self):
+        """override of website.models._get_snippet_filter_domain to show unpublished products on
+        snippets.
+        """
+        return []
+
     @api.onchange('public_categ_ids')
     def _onchange_public_categ_ids(self):
         if self.public_categ_ids:

--- a/addons/website_sale/static/src/js/product/product.xml
+++ b/addons/website_sale/static/src/js/product/product.xml
@@ -31,6 +31,16 @@
             position="attributes">
             <attribute name="class" remove="h5" add="h6" separator=" "/>
         </xpath>
+        <td name="product_name_description" position="inside">
+            <a
+                t-if="!this.props.website_published"
+                role="button"
+                class="btn btn-sm btn-danger"
+                title="This product is unpublished."
+            >
+                Unpublished
+            </a>
+        </td>
     </t>
 
     <t t-inherit="sale.product_price" t-inherit-mode="extension">

--- a/addons/website_sale/static/src/js/product_list/product_list.xml
+++ b/addons/website_sale/static/src/js/product_list/product_list.xml
@@ -7,5 +7,11 @@
         <span name="sale_product_configurator_list_total" position="attributes">
             <attribute name="class" remove="h4" add="h5" separator=" "/>
         </span>
+        <tr name="product_row" position="attributes">
+            <attribute
+                name="t-att-data-publish"
+                add="product.website_published and 'on' or 'off'"
+            />
+        </tr>
     </t>
 </templates>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2487,6 +2487,14 @@
                             </h6>
                         </div>
                         <div class="d-flex justify-content-md-end">
+                            <a
+                                t-if="not product.website_published"
+                                role="button"
+                                class="btn btn-sm btn-danger"
+                                title="This product is unpublished."
+                            >
+                                Unpublished
+                            </a>
                             <button
                                 role="button"
                                 class="js_add_suggested_products btn btn-primary text-nowrap"


### PR DESCRIPTION
prior this commit:
- When unpublished products are added to alternate product then they are shown unmuted on website for admin
- Unpublished products are not visible in any of the product carousel snippets

post this commit:
- unpublished products are muted with unpublished banner in alternate product snippet
- unpublished products are visible and muted to admin in product carousel snippet

task-4327865

related pr: https://github.com/odoo/upgrade/pull/7134

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
