### PR TITLE
[IMP] stock_account: improve stock valuation adjustment pop-up

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -273,7 +273,7 @@ will update the cost of every lot/serial number in stock."),
         self.ensure_one()
         ctx = dict(self._context, default_product_id=self.id, default_company_id=self.env.company.id)
         return {
-            'name': _("Product Revaluation"),
+            'name': _('Product Revaluation - %s', self.display_name),
             'view_mode': 'form',
             'res_model': 'stock.valuation.layer.revaluation',
             'view_id': self.env.ref('stock_account.stock_valuation_layer_revaluation_form_view').id,

--- a/addons/stock_account/models/stock_lot.py
+++ b/addons/stock_account/models/stock_lot.py
@@ -128,9 +128,9 @@ class StockLot(models.Model):
         elif all(float_is_zero(layer.remaining_qty, precision_rounding=self.product_id.uom_id.rounding) for layer in self.stock_valuation_layer_ids):
             raise UserError(_("You cannot adjust the valuation of a layer with zero quantity"))
         self.ensure_one()
-        ctx = dict(self._context, default_lot_id=self.id, default_company_id=self.env.company.id)
+        ctx = dict(self._context, default_lot_ids=self.ids, default_company_id=self.env.company.id)
         return {
-            'name': _("Lot/Serial number Revaluation"),
+            'name': _('Lot/Serial number Revaluation - %s', self.product_id.display_name),
             'view_mode': 'form',
             'res_model': 'stock.valuation.layer.revaluation',
             'view_id': self.env.ref('stock_account.stock_valuation_layer_revaluation_form_view').id,

--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -132,6 +132,24 @@ class StockValuationLayer(models.Model):
             "context": context,
         }
 
+    def action_stock_adjust_valuation(self):
+        """Perform Stock Valuation Adjustment from the stock valuation layer list view."""
+        if len(self.product_id) > 1:
+            raise UserError(_("You cannot revalue multiple products at once"))
+
+        return {
+            'name': _('Adjust Valuation - %s', self.product_id.display_name),
+            'view_mode': 'form',
+            'res_model': 'stock.valuation.layer.revaluation',
+            'view_id': self.env.ref('stock_account.stock_valuation_layer_revaluation_form_view').id,
+            'type': 'ir.actions.act_window',
+            'context': {
+                'active_model': 'stock.valuation.layer',
+                'active_ids': self.ids,
+            },
+            'target': 'new'
+        }
+
     def action_open_reference(self):
         self.ensure_one()
         if self.stock_move_id:

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -430,7 +430,8 @@ class TestLotValuation(TestStockValuationCommon):
             'default_product_id': self.product1.id,
             'default_company_id': self.env.company.id,
             'default_added_value': 8.0,
-            'default_lot_id': self.lot1.id,
+            'active_ids': self.lot1.ids,
+            'active_model': 'stock.lot',
         })).save().action_validate_revaluation()
 
         layers = self.lot1.stock_valuation_layer_ids

--- a/addons/stock_account/views/stock_valuation_layer_views.xml
+++ b/addons/stock_account/views/stock_valuation_layer_views.xml
@@ -193,6 +193,17 @@
         </field>
     </record>
 
+    <record id="action_stock_adjust_valuation" model="ir.actions.server">
+        <field name="name">Adjust Valuation</field>
+        <field name="model_id" ref="stock_account.model_stock_valuation_layer"/>
+        <field name="binding_model_id" ref="stock_account.model_stock_valuation_layer"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">
+            action = records.action_stock_adjust_valuation()
+        </field>
+    </record>
+
     <menuitem id="menu_valuation" name="Valuation" parent="stock.menu_warehouse_report" sequence="250" action="stock_valuation_layer_action"/>
 
     <record id="stock_valuation_layer_picking" model="ir.ui.view">

--- a/addons/stock_account/wizard/stock_valuation_layer_revaluation_views.xml
+++ b/addons/stock_account/wizard/stock_valuation_layer_revaluation_views.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <record id="action_revalue_layers" model="ir.actions.act_window">
-        <field name="name">Adjust Valuation</field>
-        <field name="res_model">stock.valuation.layer.revaluation</field>
-        <field name="view_mode">form</field>
-        <field name="binding_model_id" ref="stock_account.model_stock_valuation_layer"/>
-        <!-- Not available in form view because clicking a layer only opens its form view if it's already an adjustment layer, the action would always fail with a UserError because the quantity is 0 -->
-        <field name="binding_view_types">list,kanban</field>
-        <field name="target">new</field>
-    </record>
-
     <record id="stock_valuation_layer_revaluation_form_view" model="ir.ui.view">
         <field name="name">stock.valuation.layer.revaluation.form</field>
         <field name="model">stock.valuation.layer.revaluation</field>
@@ -24,15 +14,15 @@
                             <field name="current_value_svl" class="oe_inline" widget="monetary"/> for <field name="current_quantity_svl" class="oe_inline"/> <field name="product_uom_name" class="oe_inline"/>
                             </span>
                         </div>
+                        <field name="lot_ids" string="Lots/SN" invisible="not lot_ids" widget="many2many_tags"/>
                         <label for="added_value" string="Added Value"/>
                         <div class="o_row">
-                            <span><field name="added_value" class="oe_inline"/> = <field name="new_value" class="oe_inline"/> (<field name="new_value_by_qty" class="oe_inline ms-1"/> by <field name="product_uom_name" class="oe_inline me-1"/>)
+                            <span><field name="added_value" class="oe_inline"/>(<field name="added_value_by_qty" class="oe_inline ms-1"/> by <field name="product_uom_name" class="oe_inline me-1"/>) = <field name="new_value" class="oe_inline"/> (<field name="new_value_by_qty" class="oe_inline ms-1"/> by <field name="product_uom_name" class="oe_inline me-1"/>)
                             <small class="mx-2 fst-italic">Use a negative added value to record a decrease in the product value</small></span>
                         </div>
                         <field name="company_id" invisible="1"/>
                         <field name="currency_id" invisible="1"/>
                         <field name="product_id" invisible="1"/>
-                        <field name="lot_id" invisible="1"/>
                     </group>
                     <group>
                         <field name="property_valuation" invisible="1"/>


### PR DESCRIPTION
Before this commit:
======================

The valuation adjustment pop-up was misleading, making users think the adjustment applied to all stock on hand instead of only the selected valuation layer. This confused how stock valuation was being updated.

After this commit:
======================

- The pop-up now explicitly highlights the specific valuation layer being adjusted, so users can clearly see which valuation layer is affected, preventing any misinterpretation.

- All lots concerned with the selected valuation layer are now displayed, providing better visibility of the affected stock.

- The "Adjusted Value per Unit" field is now displayed in the pop-up, providing users with clear insight into the valuation adjustment.

These updates enhance transparency and ensure that users have the information needed to make accurate decisions regarding stock valuation.

Task - [4453885](https://www.odoo.com/odoo/my-tasks/4453885)

