### PR TITLE
[FIX] website, web_editor: consider videos in `s_image_gallery`

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1798,12 +1798,14 @@ export class Wysiwyg extends Component {
                     await this.snippetsMenu.callPostSnippetDrop($element);
                 }
                 if (element.tagName !== 'IMG') {
+                    const event = $.Event("media_changed", { node: params.node });
+                    $element.trigger(event);
                     return;
                 }
                 return new Promise(resolve => {
                     this.snippetsMenu.trigger_up("snippet_edition_request", {exec: () => {
                         // TODO In master use a trigger parameter
-                        const event = $.Event("image_changed", {_complete: resolve});
+                        const event = $.Event("image_changed", { _complete: resolve, node: params.node });
                         $element.trigger(event);
                     }});
                 });

--- a/addons/web_editor/tools.py
+++ b/addons/web_editor/tools.py
@@ -147,7 +147,7 @@ def get_video_thumbnail_url(video_url):
     if platform == 'youtube':
         thumbnail_url = f'https://img.youtube.com/vi/{video_id}/0.jpg'
     elif platform == 'vimeo':
-        video_details_url = f'http://vimeo.com/api/oembed.json?url={video_url}'
+        video_details_url = f'https://vimeo.com/api/oembed.json?url={video_url}'
         res = requests.get(video_details_url, timeout=10)
         if res.ok:
             data = res.json()

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -31,6 +31,7 @@ from odoo.addons.http_routing.models.ir_http import slug, slugify, _guess_mimety
 from odoo.addons.portal.controllers.portal import pager as portal_pager
 from odoo.addons.portal.controllers.web import Home
 from odoo.addons.web.controllers.binary import Binary
+from odoo.addons.web_editor.tools import get_video_thumbnail_url
 from odoo.addons.website.tools import get_base_domain
 
 logger = logging.getLogger(__name__)
@@ -948,6 +949,16 @@ class Website(Home):
                     return action_res
 
         return request.redirect('/')
+
+    # ------------------------------------------------------
+    # Video information
+    # ------------------------------------------------------
+
+    @http.route('/website/get_video_thumbnail_url', type='json', auth='user', website=True)
+    def get_video_thumb_url(self, video_url):
+        if not request.env.user.has_group('website.group_website_restricted_editor'):
+            raise werkzeug.exceptions.Forbidden()
+        return get_video_thumbnail_url(video_url)
 
 
 class WebsiteBinary(Binary):

--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -241,6 +241,11 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
         if (snippetSaveOptionEl) {
             snippetSaveOptionEl.dataset.selector += ", .s_searchbar_input";
         }
+        // TODO remove in master: allow reordering videos in `s_image_gallery`.
+        const galleryElementOptionEl = $html.find("[data-js='GalleryElement']")[0];
+        if (galleryElementOptionEl) {
+            galleryElementOptionEl.dataset.selector += ", .s_image_gallery .media_iframe_video";
+        }
         // TODO remove in 18.0
         const navTabsStyleEl = $html.find(`[data-js="NavTabsStyle"]`)[0];
         if (navTabsStyleEl) {

--- a/addons/website/static/src/snippets/s_image_gallery/001.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/001.scss
@@ -78,7 +78,16 @@
                 padding-bottom: 64px;
             }
             ul.carousel-indicators li {
+                position: relative;
                 border: 1px solid #aaa;
+
+                // Play icon for video thumbnail indicators.
+                i.o_video_thumbnail {
+                    position: absolute;
+                    top: 50%;
+                    left: 50%;
+                    transform: translate(-50%, -50%);
+                }
             }
             .media_iframe_video {
                 // 70% because the carousel controls are each 15% and the user

--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -93,7 +93,7 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
                 let min = Infinity;
                 let smallestColEl;
                 for (const colEl of cols) {
-                    const imgEls = colEl.querySelectorAll("img");
+                    const imgEls = colEl.querySelectorAll("img, .media_iframe_video");
                     const lastImgRect = imgEls.length && imgEls[imgEls.length - 1].getBoundingClientRect();
                     const height = lastImgRect ? Math.round(lastImgRect.top + lastImgRect.height) : 0;
                     if (height < min) {
@@ -150,7 +150,7 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
 
         imgs.forEach((img, index) => {
             var wrapClass = 'col-lg-3';
-            if (img.width >= img.height * 2 || img.width > 600) {
+            if (img.width >= img.height * 2 || img.width > 600 || img.classList.contains("media_iframe_video")) {
                 wrapClass = 'col-lg-6';
             }
             var $wrap = $('<div/>', {class: wrapClass}).append(imgHolderEls[index]);
@@ -162,17 +162,31 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
      *
      * @private
      */
-    _slideshow() {
-        const imageEls = this._getItemsGallery();
-        const imgHolderEls = this._getImgHolderEls();
-        const images = Array.from(imageEls).map((img) => ({
-            // Use getAttribute to get the attribute value otherwise .src
-            // returns the absolute url.
-            src: img.getAttribute('src'),
+    async _slideshow() {
+        const mediaEls = this._getItemsGallery();
+        const mediaHolderEls = this._getImgHolderEls();
+        // Get the images src and the videos thumbnail urls.
+        const mediaSrc = await Promise.all(
+            mediaHolderEls.map(async (mediaEl) => {
+                if (mediaEl.tagName === "IMG") {
+                    // Use getAttribute to get the attribute value otherwise
+                    // .src returns the absolute url.
+                    return mediaEl.getAttribute("src");
+                } else if (mediaEl.classList.contains("media_iframe_video")) {
+                    // For videos, get the thumbnail image link.
+                    return this._getVideoThumbnailUrl(mediaEl.dataset.oeExpression);
+                } else if (mediaEl.tagName === "A") {
+                    return mediaEl.querySelector("img").getAttribute("src");
+                }
+            })
+        );
+
+        const images = mediaHolderEls.map((media, index) => ({
+            src: mediaSrc[index],
             // TODO: remove me in master. This is not needed anymore as the
             // images of the rendered `website.gallery.slideshow` are replaced
-            // by the elements of `imgHolderEls`.
-            alt: img.getAttribute('alt'),
+            // by the elements of `mediaHolderEls`.
+            alt: media.getAttribute("alt"),
         }));
         var currentInterval = this.$target.find('.carousel:first').attr('data-bs-interval');
         var params = {
@@ -184,9 +198,9 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
             // TODO: in master, remove `attrClass` and `attStyle` from `params`.
             // This is not needed anymore as the images of the rendered
             // `website.gallery.slideshow` are replaced by the elements of
-            // `imgHolderEls`.
-            attrClass: imageEls.length > 0 ? imageEls[0].className : '',
-            attrStyle: imageEls.length > 0 ? imageEls[0].style.cssText : '',
+            // `mediaHolderEls`.
+            attrClass: mediaEls.length > 0 ? mediaEls[0].className : "",
+            attrStyle: mediaEls.length > 0 ? mediaEls[0].style.cssText : "",
         },
         $slideshow = $(renderToElement('website.gallery.slideshow', params));
         const imgSlideshowEls = $slideshow[0].querySelectorAll("img[data-o-main-image]");
@@ -195,12 +209,16 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
             // order to keep the characteristics of the image such as the
             // filter, the width, the quality, the link on which the users are
             // redirected once they click on the image etc...
-            imgSlideshowEl.after(imgHolderEls[index]);
+            imgSlideshowEl.after(mediaHolderEls[index]);
             imgSlideshowEl.remove();
         });
         this._replaceContent($slideshow);
-        this.$("img").toArray().forEach((img, index) => {
-            $(img).attr({contenteditable: true, 'data-index': index});
+        const indicatorEls = [...this.$target[0].querySelectorAll("[data-bs-slide-to]")];
+        mediaEls.forEach((mediaEl, index) => {
+            $(mediaEl).attr({ contenteditable: true, "data-index": index });
+            if (mediaEl.classList.contains("media_iframe_video")) {
+                this._addVideoPlayIcon(indicatorEls[index]);
+            }
         });
 
         // Apply layout animation
@@ -212,9 +230,8 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
      * @override
      */
     _getItemsGallery() {
-        const imgs = this.$('img').get();
-        imgs.sort((a, b) => this._getIndex(a) - this._getIndex(b));
-        return imgs;
+        const mediaEls = this.$target.find("img, .media_iframe_video").get();
+        return mediaEls.sort((a, b) => this._getIndex(a) - this._getIndex(b));
     },
     /**
      * Returns the images, or the images holder if this holder is an anchor,
@@ -429,6 +446,7 @@ options.registry.GalleryImageList = options.registry.GalleryLayout.extend({
      * @override
      */
     init() {
+        this.videoThumbnailCache = new Map();
         this.rpc = this.bindService("rpc");
         return this._super.apply(this, arguments);
     },
@@ -436,12 +454,16 @@ options.registry.GalleryImageList = options.registry.GalleryLayout.extend({
      * @override
      */
     start() {
-        // Make sure image previews are updated if images are changed
-        this.$target.on('image_changed.gallery', 'img', ev => {
-            const $img = $(ev.currentTarget);
-            const index = this.$target.find('.carousel-item.active').index();
-            this.$('.carousel:first li[data-bs-target]:eq(' + index + ')')
-                .css('background-image', 'url(' + $img.attr('src') + ')');
+        // Make sure image and video previews are updated if they are replaced.
+        this.$target.on("image_changed.gallery", "img", (ev) => {
+            const mediaEl = ev.currentTarget;
+            const src = mediaEl.getAttribute("src");
+            this.onMediaChanged(ev, mediaEl, src, false);
+        });
+        this.$target.on("media_changed.gallery", ".media_iframe_video", async (ev) => {
+            const mediaEl = ev.currentTarget;
+            const thumbnailUrl = await this._getVideoThumbnailUrl(mediaEl.dataset.oeExpression);
+            this.onMediaChanged(ev, mediaEl, thumbnailUrl, true);
         });
 
         // When the snippet is empty, an edition button is the default content
@@ -461,6 +483,16 @@ options.registry.GalleryImageList = options.registry.GalleryLayout.extend({
                 });
             }
         });
+
+        // If some medias do not have the `data-index` attribute, reset the mode
+        // so everything is consistent. (Needed for already dropped snippets
+        // whose images have been previously replaced by other media types).
+        const mediaEls = this._getItemsGallery();
+        const indexedMediaEls = this.$target[0].querySelectorAll("[data-index]");
+        if (mediaEls.length !== indexedMediaEls.length) {
+            const _super = this._super.bind(this);
+            return this._relayout().then(() => _super.apply(this, arguments));
+        }
 
         return this._super.apply(this, arguments);
     },
@@ -591,6 +623,37 @@ options.registry.GalleryImageList = options.registry.GalleryLayout.extend({
     //--------------------------------------------------------------------------
 
     /**
+     * Updates the carousel indicator after a media item (image or video) is
+     * replaced.
+     *
+     * Synchronizes the media `data-index` provided, finds the active carousel
+     * item, and updates its corresponding indicator background. Adds a play
+     * icon when the media is a video.
+     *
+     * @param {Event} ev - Media change event
+     * @param {HTMLElement} mediaEl - Updated media element.
+     * @param {string} backgroundSrc - URL used as the indicator background.
+     * @param {boolean} isVideo - Whether the media element is a video.
+     */
+    onMediaChanged(ev, mediaEl, backgroundSrc, isVideo) {
+        if (ev.node) {
+            mediaEl.setAttribute("data-index", ev.node.dataset.index);
+        }
+
+        const index = this.$target.find(".carousel-item.active").index();
+        const $indicator = this.$(`.carousel:first li[data-bs-target]:eq(${index})`);
+        if (!$indicator.length) {
+            return;
+        }
+
+        $indicator.empty().css("background-image", `url(${backgroundSrc})`);
+        if (isVideo) {
+            this._addVideoPlayIcon($indicator[0]);
+        } else {
+            $indicator.removeClass("o_not_editable");
+        }
+    },
+    /**
      * Handles image removals and image index updates.
      *
      * @override
@@ -609,6 +672,40 @@ options.registry.GalleryImageList = options.registry.GalleryLayout.extend({
     // Private
     //--------------------------------------------------------------------------
 
+    /**
+     * Gets the thumbnail url of the given video.
+     *
+     * @private
+     * @param {String} videoUrl the video url
+     * @returns {String}
+     */
+    async _getVideoThumbnailUrl(videoUrl) {
+        // First, check if it was not already cached.
+        if (this.videoThumbnailCache.has(videoUrl)) {
+            return this.videoThumbnailCache.get(videoUrl);
+        }
+        let [platform, thumbnailUrl] = await this.rpc("/website/get_video_thumbnail_url", {
+            video_url: videoUrl,
+        });
+        if (!thumbnailUrl || platform === "instagram") {
+            thumbnailUrl = "/web/static/img/placeholder.png";
+        }
+
+        this.videoThumbnailCache.set(videoUrl, thumbnailUrl);
+        return thumbnailUrl;
+    },
+    /**
+     * Adds a play icon in the given carousel indicator element, in order to
+     * show that its corresponding slide contains a video.
+     *
+     * @param {HTMLElement} indicatorEl the carousel indicator
+     */
+    _addVideoPlayIcon(indicatorEl) {
+        const playIconEl = document.createElement("i");
+        playIconEl.className = "fa fa-2x fa-play-circle text-white o_video_thumbnail";
+        indicatorEl.append(playIconEl);
+        indicatorEl.classList.add("o_not_editable"); // So the icon is not editable.
+    },
     /**
      * @private
      */

--- a/addons/website/static/tests/tours/snippet_image_gallery.js
+++ b/addons/website/static/tests/tours/snippet_image_gallery.js
@@ -134,7 +134,53 @@ wTourUtils.registerWebsitePreviewTour("snippet_image_gallery_reorder", {
     trigger: "iframe .s_image_gallery .carousel-item.active img[data-index='2']",
 },
     wTourUtils.assertCssVariable("height", "400px", "iframe .s_image_gallery"),
-]);
+{
+    content: "Click on replace button in the selected image options",
+    trigger: ".snippet-option-ReplaceMedia we-button",
+}, {
+    content: "Go to the 'Videos' tab",
+    trigger: "a:contains('Videos')",
+}, {
+    content: "Enter a video link",
+    trigger: "#o_video_text",
+    run: "text https://youtu.be/nbso3NVz3p8",
+}, {
+    content: "Check that the video is previewed",
+    trigger: ".o_video_dialog_iframe",
+    run: () => {}, // This is a check.
+}, {
+    content: "Click on 'add' button",
+    trigger: ".modal-footer button:contains('Add')",
+}, {
+    content: "Check if the video thumbnail is added to the indicator.",
+    trigger: "iframe .s_image_gallery li.active",
+    run: function () {
+        const indicatorEl = this.$anchor[0];
+        // The background image must contain the video unique ID.
+        if (!indicatorEl.style.backgroundImage.includes("nbso3NVz3p8")) {
+            console.error("There is a problem with the video thumbnail.");
+        }
+    },
+}, {
+    content: "Slide back to the previous image.",
+    trigger: "iframe .s_image_gallery .carousel-control-prev",
+}, {
+    content: "Click on the image.",
+    trigger: "iframe .s_image_gallery img",
+}, {
+    content: "Use the 'Re-order' option to move the slide to the next position.",
+    trigger: ".snippet-option-GalleryElement we-button[data-position='next']",
+}, {
+    content: "Verify that the video slide and its indicator thumbnail are both retained in the image gallery.",
+    trigger: "iframe .s_image_gallery",
+    run: function () {
+        const mediaEl = this.$anchor[0].querySelector(".carousel-inner .media_iframe_video");
+        const indicatorEl = this.$anchor[0].querySelector(".carousel-indicators .o_video_thumbnail");
+        if (!mediaEl || !indicatorEl) {
+            console.error("The video slide or its indicator thumbnail is missing from the image gallery.");
+        }
+    },
+}]);
 
 wTourUtils.registerWebsitePreviewTour("snippet_image_gallery_thumbnail_update", {
     test: true,


### PR DESCRIPTION
> Commit 1:

This commit extracts the logic for computing a video's thumbnail URL into a new helper method, `get_video_thumbnail_url`. Previously, `get_video_thumbnail` returned only the final fetched (base64) thumbnail
content, making it impossible to access the underlying platform or the raw thumbnail URL directly.

By separating the two responsibilities:
* `get_video_thumbnail_url` now returns the platform and the computed thumbnail URL without performing any HTTP request. For Vimeo videos, this involves an HTTP request to retrieve the thumbnail metadata.
* `get_video_thumbnail` uses this URL to fetch the actual thumbnail image as before in binary context.

---
> Commit 2:

Steps to reproduce:
1. Go to the website and enter edit mode.
2. Drag and drop an `Image Gallery` or `Images Wall` snippet.
3. Replace any image with a video.
4. Try to reorder the images or videos.

Issue:
When reordering items, video elements are removed, leaving only images.

Cause:
The `s_image_gallery` logic is designed to handle images only. It does not account for other media elements, such as videos using the `media_iframe_video` class.

Expected behavior:
Images and videos should be treated the same and must remain in place when reordered, with correct thumbnails and indicator behavior.

Solution:
This commit updates the reordering logic to collect media elements (images and videos), ensuring videos are preserved during reordering. It also enables proper display of video thumbnails with an play icon in indicators. For Instagram videos and other videos without thumbnails, a placeholder image is used.

task-4487638