### PR TITLE
[FIX] mrp: prevent error when adding new work order in MO

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -150,10 +150,10 @@ class MrpWorkorder(models.Model):
                                      domain="[('allow_workorder_dependencies', '=', True), ('id', '!=', id), ('production_id', '=', production_id)]",
                                      copy=False)
 
-    @api.depends('production_availability', 'blocked_by_workorder_ids.state', 'qty_ready')
+    @api.depends('production_availability', 'blocked_by_workorder_ids.state', 'qty_ready', 'product_uom_id')
     def _compute_state(self):
         for workorder in self:
-            if workorder.state not in ('pending', 'waiting', 'ready'):
+            if not workorder.product_uom_id or workorder.state not in ('pending', 'waiting', 'ready'):
                 continue
             blocked = any(w.state not in ('done', 'cancel') for w in workorder.blocked_by_workorder_ids)
             has_qty_ready = float_compare(workorder.qty_ready, 0, precision_rounding=workorder.product_uom_id.rounding) > 0

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5022,6 +5022,28 @@ class TestMrpOrder(TestMrpCommon):
         with self.assertRaises(UserError):
             self.workcenter_1.resource_calendar_id, = resource_calendar
 
+    def test_workorder_without_product(self):
+        mo_form = Form(self.env['mrp.production'])
+
+        with mo_form.workorder_ids.new() as wo:
+            wo.name = "Cutting"
+            wo.workcenter_id = self.workcenter_1
+
+        mo_form.product_id = self.product_1
+        mo_form.product_qty = 1.0
+        mo = mo_form.save()
+
+        self.assertFalse(mo.workorder_ids)
+
+        with mo_form.workorder_ids.new() as wo:
+            wo.name = "Cutting"
+            wo.workcenter_id = self.workcenter_1
+        mo = mo_form.save()
+
+        self.assertTrue(mo.workorder_ids)
+        self.assertEqual(len(mo.workorder_ids), 1)
+        self.assertEqual(mo.product_id, wo.product_id)
+
 @tagged('-at_install', 'post_install')
 class TestTourMrpOrder(HttpCase):
     def test_mrp_order_product_catalog(self):


### PR DESCRIPTION
Currently, an error occurs when adding a new work order line in a manufacturing order without specifying a product.

Steps to produce:
- Install the `mrp` module.
- Enable `Unit of measure` and `Work Orders` from the settings.
- Create a new manufacturing order.
- Do not specify a product in the record and attempt to add a work order.
- Observe the error.

Error: `AssertionError: precision_rounding must be positive, got 0.0`

An error occurs when attempting to access `product_uom_id.rounding` - [1]. However, if no product is defined, the `product_uom_id` remains an empty recordset, which generates an error.

[1] - https://github.com/odoo/odoo/blob/9922e570acdf695a0101a7a0c28d57a2708ea050/addons/mrp/models/mrp_workorder.py#L159

This commit resolves the issue by ensuring the product is specified, if no product is defined, the method skips the further computation to avoid errors.

sentry-6236848517

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr