### PR TITLE
[FIX] web_editor: fix code view check in commitChanges

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -397,8 +397,8 @@ export class HtmlField extends Component {
                     await this.updateValue();
                 }
                 await saveModifiedImagesPromise;
-                if (this.state.showCodeView) {
-                    const codeViewEl = this._getCodeViewEl();
+                const codeViewEl = this._getCodeViewEl();
+                if (codeViewEl) {
                     codeViewEl.value = this.wysiwyg.getValue();
                 }
                 if (this.props.isInlineStyle) {


### PR DESCRIPTION
**Problem**:
`this.state.showCodeView` cannot be relied upon because `toggleCodeView`
of `HtmlField` is never called in cases like mass mailing. Instead,
`MassMailingSnippetsMenu` forces code view without using the
`HtmlField` mechanism.

**Solution**:
Instead of checking `this.state.showCodeView`, directly check the
return value of `this._getCodeViewEl()` in `MassMailingHtmlField`.

**Steps to Reproduce**:
1. Add an Image-Text snippet.
2. Save the snippet.
3. Resize the image.
4. Switch to code view.
5. Save.
6. Observe that the class `o_modified_image_to_save` is not removed
   from the image.

opw-4406195

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
