### PR TITLE
[FIX] base_import_module: ignore unset module_type

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -338,7 +338,7 @@ class IrModule(models.Model):
     def web_read(self, specification):
         fields = list(specification.keys())
         module_type = self.env.context.get('module_type', 'official')
-        if module_type != 'official':
+        if module_type == 'industries':
             modules_list = self._get_modules_from_apps(fields, module_type, self.env.context.get('module_name'))
             return modules_list
         else:


### PR DESCRIPTION
`module_type` is not required. This leads to some code-modules to have
null value in the column. When this happens an error occurs if we try to
open the form view of the module in Apps.

Steps to reproduce:
1. Install a custom module.
2. Modify the `module_type` to `NULL` via SQL (note that the column is
   not required)
3. Try to open the module in the Apps menu. We get an error like:
```
Can't fetch records(s) ... They might have been deleted.
```

This issue is impacting multiple DBs post upgrade. Since this is a new
field the value is not filled in some cases. It is also possible that
due to misconfiguration the value is set to something other than
`official`.

In this patch we propose to fetch the information only for modules that
are already marked as `industry`. 

opw-4516992

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
