### PR TITLE
[FIX] mail: avatar stack counter hidden by previous avatar

### DIFF
--- a/addons/mail/static/src/discuss/core/common/avatar_stack.xml
+++ b/addons/mail/static/src/discuss/core/common/avatar_stack.xml
@@ -7,7 +7,7 @@
                     <img t-att-src="persona.avatarUrl" t-att-title="persona.name" class="rounded-circle" t-attf-class="{{props.avatarClass(persona)}}" t-attf-style="{{getStyle(persona_index)}}"/>
                     <t t-slot="avatarExtraInfo" persona="persona"/>
                 </span>
-                <span t-if="props.personas.length > props.max" class="rounded-circle bg-secondary smaller d-flex justify-content-center align-items-center user-select-none" t-attf-style="{{getStyle(props.personas.length)}}">+<t t-esc="props.personas.length - props.max"/></span>
+                <span t-if="props.personas.length > props.max" class="z-1 rounded-circle bg-secondary smaller d-flex justify-content-center align-items-center user-select-none" t-attf-style="{{getStyle(props.personas.length)}}">+<t t-esc="props.personas.length - props.max"/></span>
             </div>
         </div>
     </t>


### PR DESCRIPTION
The avatar stack displays several avatar on top of each other. When there are too many avatars to display, a counter is shown. However, this counter is hidden by the previous avatar. In order for the stack to work, each item should have an higher z index than the previous one. It's correctly done for avatars but not for the counter. This pr fixes the issue.

| Before | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/665e160b-7105-447c-97e5-62032d45544b)  | ![image](https://github.com/user-attachments/assets/a6c4a7ac-c8db-4a82-bd46-3454d0a0a51e)  |