### PR TITLE
[FIX] pos_restaurant: creation of floor plan with create button

### DIFF
--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -15,8 +15,8 @@
                             <span t-if="changeCount > 0" class="badge rounded-pill text-bg-danger ms-2 py-1 smaller fw-bolder" t-esc="changeCount"/>
                         </button>
                     </t>
-                    <button t-attf-class="{{editButtonClass}} btn-secondary lh-lg" t-if="pos.isEditMode or pos.config.floor_ids?.length === 0" >
-                        <i class="fa fa-plus fa-fw" role="img" aria-label="Add Floor" title="Add Floor" t-on-click="addFloor"/>
+                    <button t-attf-class="{{editButtonClass}} btn-secondary lh-lg" t-if="pos.isEditMode or pos.config.floor_ids?.length === 0" t-on-click="addFloor" >
+                        <i class="fa fa-plus fa-fw" role="img" aria-label="Add Floor" title="Add Floor" />
                     </button>
                 </div>
                 <!-- Right Side Div -->


### PR DESCRIPTION
Before this commit:
==========
- To create a new floor plan, the user must click the plus icon on the floor plan's create button; clicking anywhere else on the floor plan's create button was not working.

After this commit:
==========
- Users can click anywhere on the floor plan's create button to create a floor plan.

task-4517219
