### PR TITLE
[IMP] web: hide default_group_by facet in kanban

### DIFF
--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1628,7 +1628,12 @@ export class SearchModel extends EventBus {
             facets.push(facet);
         }
         const hasAGroupByFacet = facets.some((f) => f.type === "groupBy");
-        if (!hasAGroupByFacet && !this.globalGroupBy.length && this.defaultGroupBy) {
+        if (
+            !hasAGroupByFacet &&
+            !this.globalGroupBy.length &&
+            this.defaultGroupBy &&
+            this.env.config.viewType !== "kanban"
+        ) {
             facets.push({
                 groupId: SPECIAL,
                 type: "groupBy",

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -5122,7 +5122,7 @@ test("prevent drag and drop of record if save fails", async () => {
 });
 
 test("kanban view with default_group_by", async () => {
-    expect.assertions(13);
+    expect.assertions(11);
 
     Partner._records[0].product_id = 1;
     Product._records.push({ id: 1, display_name: "third product" });
@@ -5162,8 +5162,7 @@ test("kanban view with default_group_by", async () => {
     if (queryAll(".o_control_panel_navigation > button").length) {
         await contains(".o_control_panel_navigation > button").click();
     }
-    expect(`.o_searchview_facet`).toHaveCount(1);
-    expect(`.o_searchview_facet`).toHaveText("Bar");
+    expect(`.o_searchview_facet`).toHaveCount(0);
 
     // simulate an update coming from the searchview, with another groupby given
     await toggleSearchBarMenu();
@@ -5175,8 +5174,7 @@ test("kanban view with default_group_by", async () => {
     // simulate an update coming from the searchview, removing the previously set groupby
     await contains(".o_searchview_facet .o_facet_remove").click();
     expect(".o_kanban_group").toHaveCount(2);
-    expect(`.o_searchview_facet`).toHaveCount(1);
-    expect(`.o_searchview_facet`).toHaveText("Bar");
+    expect(`.o_searchview_facet`).toHaveCount(0);
 });
 
 test.tags("desktop");


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/179887, the default_group_by is displayed inside the facets of the search bar. This feature has been deemed useless in the case of the kanban view since removing groupbys in this view doesn't make much sense functionally.

task-4489226
