### PR TITLE
[FIX] website: prevent facebook snippet user input

### DIFF
--- a/addons/website/static/src/snippets/s_facebook_page/000.js
+++ b/addons/website/static/src/snippets/s_facebook_page/000.js
@@ -16,6 +16,11 @@ const FacebookPageWidget = publicWidget.Widget.extend({
         var def = this._super.apply(this, arguments);
         this.previousWidth = 0;
 
+        // Making the snippet non-editable.
+        // TODO adapt xml changes by adding "o_not_editable" class
+        // to s_facebook_page snippet in master.
+        this.el.classList.add("o_not_editable");
+
         const params = _.pick(this.$el[0].dataset, 'href', 'id', 'height', 'tabs', 'small_header', 'hide_cover');
         if (!params.href) {
             return def;


### PR DESCRIPTION
Steps to Reproduce:
-> Drag and Drop the Facebook Snippet.  
-> Click on the snippet.  
-> Enter any random text.
-> The snippet's content is editable.

Solution:
By adding the `o_not_editable` class to the Facebook Snippet, it prevent
user's input from affecting the snippet.

This PR ensures that the Facebook Snippet does not accept any
user input.

task-4517743