### PR TITLE
[FIX] account: prevent syntax error on receivable  and payable account type

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4623,7 +4623,7 @@ class AccountMove(models.Model):
     def _get_all_reconciled_invoice_partials(self):
         self.ensure_one()
         reconciled_lines = self.line_ids.filtered(lambda line: line.account_id.account_type in ('asset_receivable', 'liability_payable'))
-        if not reconciled_lines:
+        if not reconciled_lines.ids:
             return {}
 
         self.env['account.partial.reconcile'].flush_model([

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -2755,3 +2755,12 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         action = credit_note_wizard.reverse_moves()
         credit_note = self.env['account.move'].browse(action['res_id'])
         self.assertEqual(credit_note.amount_total, invoice.amount_total)
+
+    def test_journal_item_on_payable_account(self):
+        move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
+
+        with move_form.line_ids.new() as line_form:
+            line_form.account_id = self.company_data['default_account_payable']
+
+        with self.assertRaisesRegex(UserError, 'Any journal item on a payable account must have a due date and vice versa.'):
+            move_form.save()


### PR DESCRIPTION
This error occurs when the user tries to create a new vendor bill
with a `Chart of Account` having type as `receivable` or `payable`
`when Allow Reconciliation` enabled.

Steps to reproduce:

- Install the `accountant` module.
- Create a new vendor bill record from accounting/vendor
- Create a new journal item with the type of `asset_receivable` or 
 `liability_payable`.
- Check that `Allow Reconciliation` must be enabled.
---
Error:
`SyntaxError:  WHERE part.debit_move_id IN ()`

This error occurs because code refactors with commit [1] allow compute to 
reconcile the bank account in a draft move but since the move/line is not saved
it returns as virtual_id and it causes an error.

This commit will fix the above issue by checking whether the reconciled contains
ids or not, if it does not contain an ids it returns an empty dictionary.

[1] - https://github.com/odoo/odoo/commit/52903687e136bd3327409aedbda568b60b3428c3

Sentry - 6250883109