### PR TITLE
[REF] spreadsheet*: test util createModelWithDataSource now returns env

### DIFF
--- a/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin.test.js
+++ b/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin.test.js
@@ -253,7 +253,7 @@ test("Data reloaded strictly upon domain update", async () => {
 });
 
 test("Can import/export an Odoo chart", async () => {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     insertChartInSpreadsheet(model, "odoo_line");
     const data = model.exportData();
     const figures = data.sheets[0].figures;
@@ -261,7 +261,7 @@ test("Can import/export an Odoo chart", async () => {
     const figure = figures[0];
     expect(figure.tag).toBe("chart");
     expect(figure.data.type).toBe("odoo_line");
-    const m1 = await createModelWithDataSource({ spreadsheetData: data });
+    const { model: m1 } = await createModelWithDataSource({ spreadsheetData: data });
     const sheetId = m1.getters.getActiveSheetId();
     expect(m1.getters.getChartIds(sheetId).length).toBe(1);
     const chartId = m1.getters.getChartIds(sheetId)[0];
@@ -303,7 +303,7 @@ test("can import (export) contextual domain", async function () {
             },
         ],
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, args) {
             if (args.method === "web_read_group") {
@@ -322,7 +322,7 @@ test("can import (export) contextual domain", async function () {
 });
 
 test("Can undo/redo an Odoo chart creation", async () => {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     insertChartInSpreadsheet(model, "odoo_line");
     const sheetId = model.getters.getActiveSheetId();
     const chartId = model.getters.getChartIds(sheetId)[0];
@@ -613,7 +613,7 @@ test("cumulative line chart with past data before domain period", async () => {
 });
 
 test("Can insert odoo chart from a different model", async () => {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     insertListInSpreadsheet(model, { model: "product", columns: ["name"] });
     await addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER);
     const sheetId = model.getters.getActiveSheetId();
@@ -918,7 +918,7 @@ test("import/export action xml id", async () => {
     const exported = model.exportData();
     expect(exported.sheets[0].figures[0].data.actionXmlId).toBe("test.my_action");
 
-    const model2 = await createModelWithDataSource({ spreadsheetData: exported });
+    const { model: model2 } = await createModelWithDataSource({ spreadsheetData: exported });
     const sheetId = model2.getters.getActiveSheetId();
     const chartId = model2.getters.getChartIds(sheetId)[0];
     expect(model2.getters.getChartDefinition(chartId).actionXmlId).toBe("test.my_action");

--- a/addons/spreadsheet/static/tests/charts/ui/link_chart_figure.test.js
+++ b/addons/spreadsheet/static/tests/charts/ui/link_chart_figure.test.js
@@ -115,7 +115,7 @@ beforeEach(async () => {
 });
 
 test("icon external link isn't on the chart when its not linked to an odoo menu", async function () {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         serverData,
     });
     const fixture = await mountSpreadsheet(model);
@@ -129,7 +129,7 @@ test("icon external link isn't on the chart when its not linked to an odoo menu"
 });
 
 test("icon external link is on the chart when its linked to an odoo menu", async function () {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         serverData,
     });
     await mountSpreadsheet(model);
@@ -146,7 +146,7 @@ test("icon external link is on the chart when its linked to an odoo menu", async
 });
 
 test("icon external link is not on the chart when its linked to a wrong odoo menu", async function () {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         serverData,
     });
     await mountSpreadsheet(model);
@@ -162,7 +162,7 @@ test("icon external link is not on the chart when its linked to a wrong odoo men
 });
 
 test("icon external link isn't on the chart in dashboard mode", async function () {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         serverData,
     });
     await mountSpreadsheet(model);
@@ -182,7 +182,7 @@ test("click on icon external link on chart redirect to the odoo menu", async fun
     const doActionStep = "doAction";
     mockActionService(doActionStep);
 
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         serverData,
     });
     const fixture = await mountSpreadsheet(model);
@@ -204,7 +204,7 @@ test("click on icon external link on chart redirect to the odoo menu", async fun
 test("Click on chart in dashboard mode redirect to the odoo menu", async function () {
     const doActionStep = "doAction";
     mockActionService(doActionStep);
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         serverData,
     });
     const fixture = await mountSpreadsheet(model);
@@ -233,7 +233,7 @@ test("Click on chart in dashboard mode redirect to the odoo menu", async functio
 
 test("can use menus xmlIds instead of menu ids", async function () {
     mockActionService("doAction");
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         serverData,
     });
     const fixture = await mountSpreadsheet(model);
@@ -259,7 +259,7 @@ test("Trying to open a menu without an action sends a notification to the user",
         },
     });
 
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         serverData,
     });
     const fixture = await mountSpreadsheet(model);

--- a/addons/spreadsheet/static/tests/command_palette.test.js
+++ b/addons/spreadsheet/static/tests/command_palette.test.js
@@ -14,7 +14,7 @@ defineSpreadsheetModels();
 
 test("Command palette is active on spreadsheet", async function () {
     await mountWithCleanup(WebClient);
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         serverData,
     });
     await mountSpreadsheet(model);
@@ -25,7 +25,7 @@ test("Command palette is active on spreadsheet", async function () {
 
 test("First item of command palette is insert link", async function () {
     await mountWithCleanup(WebClient);
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         serverData,
     });
     await mountSpreadsheet(model);

--- a/addons/spreadsheet/static/tests/currency/currency_plugin.test.js
+++ b/addons/spreadsheet/static/tests/currency/currency_plugin.test.js
@@ -9,7 +9,7 @@ describe.current.tags("headless");
 defineSpreadsheetModels();
 
 test("get default currency format when it's in the config", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         modelConfig: { defaultCurrency: { position: "after", symbol: "θ", decimalPlaces: 2 } },
         mockRPC: async function (route, args) {
             throw new Error("Should not make any RPC");
@@ -19,7 +19,7 @@ test("get default currency format when it's in the config", async () => {
 });
 
 test("get default currency format when it's not in the config", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "get_company_currency_for_spreadsheet") {
                 return {
@@ -39,7 +39,7 @@ test("get default currency format when it's not in the config", async () => {
 });
 
 test("get specific currency format", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         modelConfig: { defaultCurrency: { position: "after", symbol: "θ", decimalPlaces: 2 } },
         mockRPC: async function (route, args) {
             if (args.method === "get_company_currency_for_spreadsheet" && args.args[0] === 42) {

--- a/addons/spreadsheet/static/tests/currency/currency_rate_function.test.js
+++ b/addons/spreadsheet/static/tests/currency/currency_rate_function.test.js
@@ -12,7 +12,7 @@ defineSpreadsheetModels();
 defineSpreadsheetActions();
 
 test("Basic exchange formula", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "get_rates_for_spreadsheet") {
                 const info = args.args[0][0];
@@ -32,7 +32,7 @@ test("Basic exchange formula", async () => {
 });
 
 test("rate formula at a given date(time)", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "get_rates_for_spreadsheet") {
                 const [A1, A2] = args.args[0];
@@ -53,7 +53,7 @@ test("rate formula at a given date(time)", async () => {
 });
 
 test("invalid date", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "get_rates_for_spreadsheet") {
                 throw new Error("Should not be called");
@@ -69,7 +69,7 @@ test("invalid date", async () => {
 });
 
 test("rate formula at a given company", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "get_rates_for_spreadsheet") {
                 const [A1, A2] = args.args[0];
@@ -92,7 +92,7 @@ test("rate formula at a given company", async () => {
 });
 
 test("invalid company id", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "get_rates_for_spreadsheet") {
                 const error = new RPCError();
@@ -108,7 +108,7 @@ test("invalid company id", async () => {
 });
 
 test("Currency rate throw with unknown currency", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "get_rates_for_spreadsheet") {
                 const info = args.args[0][0];
@@ -122,7 +122,7 @@ test("Currency rate throw with unknown currency", async () => {
 });
 
 test("Currency rates are only loaded once", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "get_rates_for_spreadsheet") {
                 expect.step("FETCH");
@@ -140,7 +140,7 @@ test("Currency rates are only loaded once", async () => {
 });
 
 test("Currency rates are loaded once by clock", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "get_rates_for_spreadsheet") {
                 expect.step("FETCH:" + args.args[0].length);

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -400,7 +400,7 @@ test("Can import/export filters", async function () {
         },
         globalFilters: [LAST_YEAR_LEGACY_FILTER, LAST_YEAR_GLOBAL_FILTER],
     };
-    const model = await createModelWithDataSource({ spreadsheetData });
+    const { model } = await createModelWithDataSource({ spreadsheetData });
 
     expect(model.getters.getGlobalFilters().length).toBe(2);
     let [filter1, filter2] = model.getters.getGlobalFilters();
@@ -525,7 +525,7 @@ test("Relational filter default to current user", async function () {
 });
 
 test("Get active filters with multiple filters", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, {
         id: "42",
         type: "text",
@@ -552,7 +552,7 @@ test("Get active filters with multiple filters", async function () {
 });
 
 test("Get active filters with text filter enabled", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, {
         id: "42",
         type: "text",
@@ -568,7 +568,7 @@ test("Get active filters with text filter enabled", async function () {
 });
 
 test("restrict text filter to a range of values", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     const sheetId = model.getters.getActiveSheetId();
     setCellContent(model, "A1", "Hello");
     setCellContent(model, "A2", "World");
@@ -586,7 +586,7 @@ test("restrict text filter to a range of values", async function () {
 });
 
 test("duplicated values appear once in text filter with range", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     const sheetId = model.getters.getActiveSheetId();
     setCellContent(model, "A1", "3");
     setCellContent(model, "A2", "=3");
@@ -601,7 +601,7 @@ test("duplicated values appear once in text filter with range", async function (
 });
 
 test("numbers and dates are formatted in text filter with range", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     const sheetId = model.getters.getActiveSheetId();
     setCellContent(model, "A1", "2");
     setCellContent(model, "A2", "2");
@@ -621,7 +621,7 @@ test("numbers and dates are formatted in text filter with range", async function
 });
 
 test("falsy values appears (but not empty string) in text filter with range", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     const sheetId = model.getters.getActiveSheetId();
     setCellContent(model, "A1", "0");
     setCellContent(model, "A2", "FALSE");
@@ -640,7 +640,7 @@ test("falsy values appears (but not empty string) in text filter with range", as
 });
 
 test("default value appears in text filter with range", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     const sheetId = model.getters.getActiveSheetId();
     setCellContent(model, "A1", "Hello");
     await addGlobalFilter(model, {
@@ -658,7 +658,7 @@ test("default value appears in text filter with range", async function () {
 });
 
 test("current value appears in text filter with range", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     const sheetId = model.getters.getActiveSheetId();
     setCellContent(model, "A1", "Hello");
     setCellContent(model, "A2", "World");
@@ -682,7 +682,7 @@ test("current value appears in text filter with range", async function () {
 });
 
 test("default value appears once if the same value is in the text filter range", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     const sheetId = model.getters.getActiveSheetId();
     setCellContent(model, "A1", "Hello");
     await addGlobalFilter(model, {
@@ -698,7 +698,7 @@ test("default value appears once if the same value is in the text filter range",
 });
 
 test("formatted default value appears once if the same value is in the text filter range", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     const sheetId = model.getters.getActiveSheetId();
     setCellContent(model, "A1", "0.3");
     setCellFormat(model, "A1", "0.00%");
@@ -719,7 +719,7 @@ test("formatted default value appears once if the same value is in the text filt
 });
 
 test("errors and empty cells if the same value is in the text filter range", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     const sheetId = model.getters.getActiveSheetId();
     setCellContent(model, "A1", "Hello");
     setCellContent(model, "A2", "=1/0");
@@ -737,7 +737,7 @@ test("errors and empty cells if the same value is in the text filter range", asy
 });
 
 test("add column before a text filter range", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     const sheetId = model.getters.getActiveSheetId();
     await addGlobalFilter(model, {
         id: "42",
@@ -751,7 +751,7 @@ test("add column before a text filter range", async function () {
 });
 
 test("delete a text filter range", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     const sheetId = model.getters.getActiveSheetId();
     await addGlobalFilter(model, {
         id: "42",
@@ -765,7 +765,7 @@ test("delete a text filter range", async function () {
 });
 
 test("import/export a text filter range", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     const sheetId = model.getters.getActiveSheetId();
     await addGlobalFilter(model, {
         id: "42",
@@ -784,7 +784,7 @@ test("import/export a text filter range", async function () {
 });
 
 test("Get active filters with relation filter enabled", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, {
         id: "42",
         type: "relation",
@@ -800,7 +800,7 @@ test("Get active filters with relation filter enabled", async function () {
 });
 
 test("Get active filters with date filter enabled", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, {
         id: "42",
         type: "date",
@@ -835,7 +835,7 @@ test("Get active filters with date filter enabled", async function () {
 });
 
 test("ODOO.FILTER.VALUE text filter", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     setCellContent(model, "A10", `=ODOO.FILTER.VALUE("Text Filter")`);
     await animationFrame();
     expect(getCellValue(model, "A10")).toBe("#ERROR");
@@ -856,7 +856,7 @@ test("ODOO.FILTER.VALUE text filter", async function () {
 });
 
 test("ODOO.FILTER.VALUE date filter", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     setCellContent(model, "A10", `=ODOO.FILTER.VALUE("Date Filter")`);
     await animationFrame();
     await addGlobalFilter(model, {
@@ -905,7 +905,7 @@ test("ODOO.FILTER.VALUE date filter", async function () {
 });
 
 test("ODOO.FILTER.VALUE date from/to without values", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, {
         id: "42",
         type: "date",
@@ -918,7 +918,7 @@ test("ODOO.FILTER.VALUE date from/to without values", async function () {
 });
 
 test("ODOO.FILTER.VALUE date from/to with only from defined", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     setCellContent(model, "A1", `=ODOO.FILTER.VALUE("Date Filter")`);
     await addGlobalFilter(model, {
         id: "42",
@@ -939,7 +939,7 @@ test("ODOO.FILTER.VALUE date from/to with only from defined", async function () 
 });
 
 test("ODOO.FILTER.VALUE date from/to with only to defined", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     setCellContent(model, "A1", `=ODOO.FILTER.VALUE("Date Filter")`);
     await addGlobalFilter(model, {
         id: "42",
@@ -960,7 +960,7 @@ test("ODOO.FILTER.VALUE date from/to with only to defined", async function () {
 });
 
 test("ODOO.FILTER.VALUE date from/to with from and to defined", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     setCellContent(model, "A1", `=ODOO.FILTER.VALUE("Date Filter")`);
     await addGlobalFilter(model, {
         id: "42",
@@ -984,7 +984,7 @@ test("ODOO.FILTER.VALUE date from/to with from and to defined", async function (
 });
 
 test("ODOO.FILTER.VALUE relation filter", async function () {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: function (route, { method, args }) {
             if (method === "read") {
                 const resId = args[0][0];
@@ -1037,7 +1037,7 @@ test("ODOO.FILTER.VALUE relation filter", async function () {
 });
 
 test("ODOO.FILTER.VALUE with escaped quotes in the filter label", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, {
         id: "42",
         type: "text",
@@ -1049,7 +1049,7 @@ test("ODOO.FILTER.VALUE with escaped quotes in the filter label", async function
 });
 
 test("ODOO.FILTER.VALUE formulas are updated when filter label is changed", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, {
         id: "42",
         type: "date",
@@ -1073,7 +1073,7 @@ test("ODOO.FILTER.VALUE formulas are updated when filter label is changed", asyn
 });
 
 test("Exporting data does not remove value from model", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, {
         id: "42",
         type: "text",
@@ -1090,7 +1090,7 @@ test("Exporting data does not remove value from model", async function () {
 });
 
 test("Can undo-redo a ADD_GLOBAL_FILTER", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, {
         id: "42",
         type: "text",
@@ -1104,7 +1104,7 @@ test("Can undo-redo a ADD_GLOBAL_FILTER", async function () {
 });
 
 test("Can undo-redo a REMOVE_GLOBAL_FILTER", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, {
         id: "42",
         type: "text",
@@ -1119,7 +1119,7 @@ test("Can undo-redo a REMOVE_GLOBAL_FILTER", async function () {
 });
 
 test("Can undo-redo a EDIT_GLOBAL_FILTER", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, {
         id: "42",
         type: "text",
@@ -1138,7 +1138,7 @@ test("Can undo-redo a EDIT_GLOBAL_FILTER", async function () {
 });
 
 test("Can undo-redo a MOVE_GLOBAL_FILTER", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     addGlobalFilter(model, LAST_YEAR_GLOBAL_FILTER, {});
     addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER, {});
     addGlobalFilter(model, NEXT_YEAR_GLOBAL_FILTER, {});
@@ -1213,7 +1213,7 @@ test("load data only once if filter is not active (without default value)", asyn
             },
         ],
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method, kwargs }) {
             if (model === "partner" && method === "read_group") {
@@ -1263,7 +1263,7 @@ test("load data only once if filter is active (with a default value)", async fun
             },
         ],
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method, kwargs }) {
             if (model === "partner" && method === "read_group") {
@@ -1298,7 +1298,7 @@ test("don't reload data if an empty filter is added", async function () {
             },
         },
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method, kwargs }) {
             if (model === "partner" && method === "read_group") {
@@ -1340,7 +1340,7 @@ test("don't load data if a filter is added but the data is not needed", async fu
             },
         },
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method, kwargs }) {
             if (model === "partner" && method === "read_group") {
@@ -1393,7 +1393,7 @@ test("don't load data if a filter is activated but the data is not needed", asyn
             },
         ],
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method, kwargs }) {
             if (model === "partner" && method === "read_group") {
@@ -1471,7 +1471,7 @@ test("Export global filters for excel", async function () {
 });
 
 test("Export from/to global filters for excel", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, {
         id: "42",
         type: "date",
@@ -1500,7 +1500,9 @@ test("Export from/to global filters for excel", async function () {
     expect(filterSheet.formats["B2"]).toBe(1);
     expect(filterSheet.formats["C2"]).toBe(1);
     expect(exportData.formats[1]).toBe("m/d/yyyy");
-    const exportedModel = await createModelWithDataSource({ spreadsheetData: exportData });
+    const { model: exportedModel } = await createModelWithDataSource({
+        spreadsheetData: exportData,
+    });
     const sheetId = exportData.sheets.at(-1).id;
     expect(getCell(exportedModel, "B2", sheetId).format).toBe("m/d/yyyy");
     expect(getCell(exportedModel, "C2", sheetId).format).toBe("m/d/yyyy");
@@ -2018,7 +2020,7 @@ test("getFiltersMatchingPivot return correctly matching filter according to cell
 });
 
 test("getFiltersMatchingPivot return an empty array if there is no pivot formula", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     const result = getFiltersMatchingPivot(model, "=1");
     expect(result).toEqual([]);
 });
@@ -2497,10 +2499,15 @@ test("Updating the pivot should keep the global filter domain", async () => {
 
 test("Updating a non-odoo pivot should not crash on global filter", async () => {
     const grid = {
-        A1: "Customer",   B1: "Price", C1: `=PIVOT(1)`,
-        A2: "Alice",      B2: "10",
-        A3: "",           B3: "20",
-        A4: "Olaf",       B4: "30",
+        A1: "Customer",
+        B1: "Price",
+        C1: `=PIVOT(1)`,
+        A2: "Alice",
+        B2: "10",
+        A3: "",
+        B3: "20",
+        A4: "Olaf",
+        B4: "30",
     };
     const model = createModelFromGrid(grid);
     const pivot = {

--- a/addons/spreadsheet/static/tests/helpers/chart.js
+++ b/addons/spreadsheet/static/tests/helpers/chart.js
@@ -41,12 +41,10 @@ export function insertChartInSpreadsheet(
  * @returns { Promise<{ model: OdooSpreadsheetModel, env: Object }>}
  */
 export async function createSpreadsheetWithChart(params = {}) {
-    const model = await createModelWithDataSource(params);
+    const { model, env } = await createModelWithDataSource(params);
 
     insertChartInSpreadsheet(model, params.type, params.definition);
 
-    const env = model.config.custom.env;
-    env.model = model;
     await animationFrame();
     return { model, env };
 }

--- a/addons/spreadsheet/static/tests/helpers/list.js
+++ b/addons/spreadsheet/static/tests/helpers/list.js
@@ -47,7 +47,7 @@ export function insertListInSpreadsheet(model, params) {
  * @returns { Promise<{ model: OdooSpreadsheetModel, env: Object }>}
  */
 export async function createSpreadsheetWithList(params = {}) {
-    const model = await createModelWithDataSource({
+    const { model, env } = await createModelWithDataSource({
         mockRPC: params.mockRPC,
         serverData: params.serverData,
         modelConfig: params.modelConfig,
@@ -61,8 +61,6 @@ export async function createSpreadsheetWithList(params = {}) {
         sheetId: params.sheetId,
     });
 
-    const env = model.config.custom.env;
-    env.model = model;
     await waitForDataLoaded(model);
     return { model, env };
 }

--- a/addons/spreadsheet/static/tests/helpers/model.js
+++ b/addons/spreadsheet/static/tests/helpers/model.js
@@ -27,7 +27,7 @@ export function setupDataSourceEvaluation(model) {
  * @param {object} [params.modelConfig]
  * @param {ServerData} [params.serverData] Data to be injected in the mock server
  * @param {function} [params.mockRPC] Mock rpc function
- * @returns {Promise<OdooSpreadsheetModel>}
+ * @returns {Promise<{ model: OdooSpreadsheetModel, env: Object }>}
  */
 export async function createModelWithDataSource(params = {}) {
     const env = await makeSpreadsheetMockEnv(params);
@@ -41,12 +41,13 @@ export async function createModelWithDataSource(params = {}) {
             ...config?.custom,
         },
     });
+    env.model = model;
     // if (params.serverData) {
     //     await addRecordsFromServerData(params.serverData);
     // }
     setupDataSourceEvaluation(model);
     await animationFrame(); // initial async formulas loading
-    return model;
+    return { model, env };
 }
 
 /**
@@ -82,11 +83,11 @@ export async function makeSpreadsheetMockEnv(params = {}) {
 }
 
 export function createModelFromGrid(grid) {
-  const model = new Model();
-  for (let xc in grid) {
-    if (grid[xc] !== undefined) {
-      setCellContent(model, xc, grid[xc]);
+    const model = new Model();
+    for (const xc in grid) {
+        if (grid[xc] !== undefined) {
+            setCellContent(model, xc, grid[xc]);
+        }
     }
-  }
-  return model;
+    return model;
 }

--- a/addons/spreadsheet/static/tests/helpers/pivot.js
+++ b/addons/spreadsheet/static/tests/helpers/pivot.js
@@ -96,15 +96,13 @@ export async function insertPivotInSpreadsheet(model, pivotId, params) {
  * @returns {Promise<{ model: OdooSpreadsheetModel, env: object, pivotId: string}>}
  */
 export async function createSpreadsheetWithPivot(params = {}) {
-    const model = await createModelWithDataSource({
+    const { model, env } = await createModelWithDataSource({
         mockRPC: params.mockRPC,
         serverData: params.serverData,
     });
     const arch = params.arch || getBasicPivotArch();
     const pivotId = "PIVOT#1";
     await insertPivotInSpreadsheet(model, pivotId, { arch });
-    const env = model.config.custom.env;
-    env.model = model;
     await waitForDataLoaded(model);
     return { model, env, pivotId };
 }

--- a/addons/spreadsheet/static/tests/helpers/stores.js
+++ b/addons/spreadsheet/static/tests/helpers/stores.js
@@ -21,7 +21,7 @@ const { ModelStore, NotificationStore, DependencyContainer } = stores;
  * @return {Promise<{ store: T, container: InstanceType<DependencyContainer>, model: OdooSpreadsheetModel }>}
  */
 export async function makeStore(Store, ...args) {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     return makeStoreWithModel(model, Store, ...args);
 }
 

--- a/addons/spreadsheet/static/tests/lists/list_plugin.test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin.test.js
@@ -290,7 +290,7 @@ test("don't fetch list data if no formula use it", async function () {
             },
         },
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method }) {
             if (!["partner", "ir.model"].includes(model)) {
@@ -355,7 +355,7 @@ test("user context is combined with list context to fetch data", async function 
         lang: "FR",
         uid: serverState.userId,
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method, kwargs }) {
             if (model !== "partner") {
@@ -856,7 +856,7 @@ test("List record limit is computed during the import and UPDATE_CELL", async fu
             },
         },
     };
-    const model = await createModelWithDataSource({ spreadsheetData });
+    const { model } = await createModelWithDataSource({ spreadsheetData });
     const ds = model.getters.getListDataSource("1");
     expect(ds.maxPosition).toBe(1);
     expect(ds.maxPositionFetched).toBe(1);
@@ -879,7 +879,7 @@ test("Spec of web_search_read is minimal", async function () {
             },
         },
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, args) {
             if (args.method === "web_search_read") {
@@ -920,7 +920,7 @@ test("can import (export) contextual domain", async function () {
             },
         },
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, args) {
             if (args.method === "web_search_read") {
@@ -947,11 +947,11 @@ test("can import (export) action xml id", async function () {
                 domain: [],
                 model: "partner",
                 orderBy: [],
-                actionXmlId: "spreadsheet.test_action"
+                actionXmlId: "spreadsheet.test_action",
             },
         },
     };
-    const model = await createModelWithDataSource({ spreadsheetData });
+    const { model } = await createModelWithDataSource({ spreadsheetData });
     expect(model.getters.getListDefinition(listId).actionXmlId).toBe("spreadsheet.test_action");
     expect(model.exportData().lists[listId].actionXmlId).toBe("spreadsheet.test_action");
 });

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -322,7 +322,7 @@ test("user context is combined with pivot context to fetch data", async function
         lang: "FR",
         uid: serverState.userId,
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method, kwargs }) {
             if (model !== "partner") {
@@ -371,7 +371,7 @@ test("Context is purged from PivotView related keys", async function (assert) {
         },
     };
 
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method, kwargs }) {
             if (model === "partner" && method === "read_group") {
@@ -421,7 +421,7 @@ test("fetch metadata only once per model", async function () {
             },
         },
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method, kwargs }) {
             if (model === "partner" && method === "fields_get") {
@@ -470,7 +470,7 @@ test("don't fetch pivot data if no formula use it", async function () {
             },
         },
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method, kwargs }) {
             if (!["partner", "ir.model"].includes(model)) {
@@ -531,7 +531,7 @@ test("evaluates only once when two pivots are loading", async function () {
             },
         },
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
     });
     model.config.custom.odooDataProvider.addEventListener("data-source-updated", () =>
@@ -562,7 +562,7 @@ test("concurrently load the same pivot twice", async function () {
             },
         },
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
     });
     // the data loads first here, when we insert the first pivot function
@@ -613,7 +613,7 @@ test("display loading while data is not fully available", async function () {
         }
         return parent();
     });
-    const model = await createModelWithDataSource({ spreadsheetData });
+    const { model } = await createModelWithDataSource({ spreadsheetData });
     expect(getCellValue(model, "A1")).toBe("Loading...");
     expect(getCellValue(model, "A2")).toBe("Loading...");
     expect(getCellValue(model, "A3")).toBe("Loading...");
@@ -820,7 +820,7 @@ test("can import (export) contextual domain", async () => {
             },
         },
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, args) {
             if (args.method === "read_group") {
@@ -850,7 +850,7 @@ test("Adding a measure should trigger a reload", async () => {
             },
         },
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, args) {
             if (args.method === "read_group") {
@@ -900,7 +900,7 @@ test("Updating dimensions with undefined values does not trigger a new rpc", asy
             },
         },
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, args) {
             if (args.method === "read_group") {
@@ -1497,7 +1497,7 @@ test("can import a pivot with a calculated field", async function () {
             },
         },
     };
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData,
         mockRPC: function (route, { model, method, kwargs }) {
             if (model === "partner" && method === "read_group") {

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_positional_formula.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_positional_formula.test.js
@@ -129,7 +129,7 @@ test("sort first pivot column (ascending)", async () => {
             },
         },
     };
-    const model = await createModelWithDataSource({ spreadsheetData });
+    const { model } = await createModelWithDataSource({ spreadsheetData });
     setCellContent(model, "A1", `=PIVOT.HEADER(1,"#bar",1)`);
     setCellContent(model, "A2", `=PIVOT.HEADER(1,"#bar",2)`);
     setCellContent(model, "B1", `=PIVOT.VALUE(1,"probability:sum","#bar",1,"#foo",1)`);
@@ -167,7 +167,7 @@ test("sort first pivot column (descending)", async () => {
             },
         },
     };
-    const model = await createModelWithDataSource({ spreadsheetData });
+    const { model } = await createModelWithDataSource({ spreadsheetData });
     setCellContent(model, "A1", `=PIVOT.HEADER(1,"#bar",1)`);
     setCellContent(model, "A2", `=PIVOT.HEADER(1,"#bar",2)`);
     setCellContent(model, "B1", `=PIVOT.VALUE(1,"probability:sum","#bar",1,"#foo",1)`);
@@ -206,7 +206,7 @@ test("sort second pivot column (ascending)", async () => {
             },
         },
     };
-    const model = await createModelWithDataSource({ spreadsheetData });
+    const { model } = await createModelWithDataSource({ spreadsheetData });
     setCellContent(model, "A1", `=PIVOT.HEADER(1,"#bar",1)`);
     setCellContent(model, "A2", `=PIVOT.HEADER(1,"#bar",2)`);
     setCellContent(model, "B1", `=PIVOT.VALUE(1,"probability:sum","#bar",1,"#foo",1)`);
@@ -245,7 +245,7 @@ test("sort second pivot column (descending)", async () => {
             },
         },
     };
-    const model = await createModelWithDataSource({ spreadsheetData });
+    const { model } = await createModelWithDataSource({ spreadsheetData });
     setCellContent(model, "A1", `=PIVOT.HEADER(1,"#bar",1)`);
     setCellContent(model, "A2", `=PIVOT.HEADER(1,"#bar",2)`);
     setCellContent(model, "B1", `=PIVOT.VALUE(1,"probability:sum","#bar",1,"#foo",1)`);
@@ -286,7 +286,7 @@ test("sort second pivot measure (ascending)", async () => {
             },
         },
     };
-    const model = await createModelWithDataSource({ spreadsheetData });
+    const { model } = await createModelWithDataSource({ spreadsheetData });
     setCellContent(model, "A10", `=PIVOT.HEADER(1,"#product_id",1)`);
     setCellContent(model, "A11", `=PIVOT.HEADER(1,"#product_id",2)`);
     setCellContent(model, "B10", `=PIVOT.VALUE(1,"probability:sum","#product_id",1)`);
@@ -323,7 +323,7 @@ test("sort second pivot measure (descending)", async () => {
             },
         },
     };
-    const model = await createModelWithDataSource({ spreadsheetData });
+    const { model } = await createModelWithDataSource({ spreadsheetData });
     setCellContent(model, "A10", `=PIVOT.HEADER(1,"#product_id",1)`);
     setCellContent(model, "A11", `=PIVOT.HEADER(1,"#product_id",2)`);
     setCellContent(model, "B10", `=PIVOT.VALUE(1,"probability:sum","#product_id",1)`);

--- a/addons/spreadsheet/static/tests/public_spreadsheet/freeze.test.js
+++ b/addons/spreadsheet/static/tests/public_spreadsheet/freeze.test.js
@@ -63,7 +63,7 @@ test("Pivot with a type different of ODOO is not converted", async function () {
             },
         },
     };
-    const model = await createModelWithDataSource({ spreadsheetData });
+    const { model } = await createModelWithDataSource({ spreadsheetData });
     setCellContent(model, "A1", `=PIVOT.VALUE(1, "probability:avg")`);
     setCellContent(model, "A2", `=PIVOT.HEADER(1, "measure", "probability:avg")`);
     const data = await freezeOdooData(model);
@@ -89,7 +89,7 @@ test("values are not exported formatted", async function () {
     expect(getEvaluatedCell(model, "C4").value).toBe(46);
     expect(getEvaluatedCell(model, "C4").formattedValue).toBe("February 1900");
     const data = await freezeOdooData(model);
-    const sharedModel = await createModelWithDataSource({ spreadsheetData: data });
+    const { model: sharedModel } = await createModelWithDataSource({ spreadsheetData: data });
     expect(getEvaluatedCell(sharedModel, "C3").value).toBe(15);
     expect(getEvaluatedCell(sharedModel, "C3").formattedValue).toBe("January 1900");
     expect(getEvaluatedCell(sharedModel, "C4").value).toBe(46);
@@ -130,7 +130,7 @@ test("computed format is exported", async function () {
     const formatId = data.sheets[0].formats.A1;
     const format = data.formats[formatId];
     expect(format).toBe("#,##0.00[$€]");
-    const sharedModel = await createModelWithDataSource({ spreadsheetData: data });
+    const { model: sharedModel } = await createModelWithDataSource({ spreadsheetData: data });
     expect(getCell(sharedModel, "A1").format).toBe("#,##0.00[$€]");
 });
 
@@ -164,7 +164,7 @@ test("geo charts are replaced with an image", async function () {
 });
 
 test("translation function are replaced with their value", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     setCellContent(model, "A1", `=_t("example")`);
     setCellContent(model, "A2", `=CONCATENATE("for",_t(" example"))`);
     expect(getEvaluatedCell(model, "A1").value).toBe("example");
@@ -180,7 +180,7 @@ test("translation function are replaced with their value", async function () {
 });
 
 test("a new sheet is added for global filters", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER);
     const data = await freezeOdooData(model);
     expect(data.sheets.length).toBe(2);
@@ -189,7 +189,7 @@ test("a new sheet is added for global filters", async function () {
 });
 
 test("global filters and their display value are exported", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER);
     const data = await freezeOdooData(model);
     expect(data.globalFilters.length).toBe(1);
@@ -198,7 +198,7 @@ test("global filters and their display value are exported", async function () {
 });
 
 test("from/to global filters are exported", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, {
         id: "42",
         type: "date",
@@ -225,7 +225,7 @@ test("from/to global filters are exported", async function () {
 });
 
 test("from/to global filter without value is exported", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, {
         id: "42",
         type: "date",
@@ -268,7 +268,7 @@ test("odoo links are replaced with their label", async function () {
         ],
     };
 
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         spreadsheetData: data,
         serverData: getMenuServerData(),
     });

--- a/addons/spreadsheet/static/tests/public_spreadsheet/public_spreadsheet.test.js
+++ b/addons/spreadsheet/static/tests/public_spreadsheet/public_spreadsheet.test.js
@@ -21,7 +21,7 @@ mockService("http", {
 });
 
 test("show spreadsheet in readonly mode", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER);
     data = await freezeOdooData(model);
     const fixture = await mountPublicSpreadsheet("dashboardDataUrl", "spreadsheet");
@@ -30,7 +30,7 @@ test("show spreadsheet in readonly mode", async function () {
 });
 
 test("show dashboard in dashboard mode when there are global filters", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER);
     data = await freezeOdooData(model);
     const fixture = await mountPublicSpreadsheet("dashboardDataUrl", "dashboard");
@@ -39,7 +39,7 @@ test("show dashboard in dashboard mode when there are global filters", async fun
 });
 
 test("show dashboard in dashboard mode when there are no global filters", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     data = await freezeOdooData(model);
     const fixture = await mountPublicSpreadsheet("dashboardDataUrl", "dashboard");
     const filterButton = fixture.querySelector(".o-public-spreadsheet-filter-button");
@@ -47,7 +47,7 @@ test("show dashboard in dashboard mode when there are no global filters", async 
 });
 
 test("click filter button can show all filters", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER);
     data = await freezeOdooData(model);
     const fixture = await mountPublicSpreadsheet("dashboardDataUrl", "dashboard");
@@ -57,7 +57,7 @@ test("click filter button can show all filters", async function () {
 });
 
 test("click close button in filter panel will close the panel", async function () {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER);
     data = await freezeOdooData(model);
     const fixture = await mountPublicSpreadsheet("dashboardDataUrl", "dashboard");

--- a/addons/spreadsheet_account/static/tests/model/account_groups.test.js
+++ b/addons/spreadsheet_account/static/tests/model/account_groups.test.js
@@ -14,21 +14,21 @@ defineSpreadsheetAccountModels();
 const serverData = getAccountingData();
 
 test("get no account", async () => {
-    const model = await createModelWithDataSource({ serverData });
+    const { model } = await createModelWithDataSource({ serverData });
     setCellContent(model, "A1", `=ODOO.ACCOUNT.GROUP("test")`);
     await waitForDataLoaded(model);
     expect(getCellValue(model, "A1")).toBe("");
 });
 
 test("get one account", async () => {
-    const model = await createModelWithDataSource({ serverData });
+    const { model } = await createModelWithDataSource({ serverData });
     setCellContent(model, "A1", `=ODOO.ACCOUNT.GROUP("income_other")`);
     await waitForDataLoaded(model);
     expect(getCellValue(model, "A1")).toBe("100105");
 });
 
 test("get multiple accounts", async () => {
-    const model = await createModelWithDataSource({ serverData });
+    const { model } = await createModelWithDataSource({ serverData });
     setCellContent(model, "A1", `=ODOO.ACCOUNT.GROUP("income")`);
     await waitForDataLoaded(model);
     expect(getCellValue(model, "A1")).toBe("100104,200104");

--- a/addons/spreadsheet_account/static/tests/model/accounting.test.js
+++ b/addons/spreadsheet_account/static/tests/model/accounting.test.js
@@ -22,7 +22,7 @@ const { DEFAULT_LOCALE: locale } = spreadsheet.constants;
 const serverData = getAccountingData();
 
 test("Basic evaluation", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "spreadsheet_fetch_debit_credit") {
                 expect.step("spreadsheet_fetch_debit_credit");
@@ -41,7 +41,7 @@ test("Basic evaluation", async () => {
 });
 
 test("evaluation with reference to a month period", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "spreadsheet_fetch_debit_credit") {
                 expect(args.args[0]).toEqual([
@@ -74,7 +74,7 @@ test("evaluation with reference to a month period", async () => {
 });
 
 test("Functions are correctly formatted", async () => {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     setCellContent(model, "A1", `=ODOO.CREDIT("100", "2022")`);
     setCellContent(model, "A2", `=ODOO.DEBIT("100", "2022")`);
     setCellContent(model, "A3", `=ODOO.BALANCE("100", "2022")`);
@@ -85,7 +85,7 @@ test("Functions are correctly formatted", async () => {
 });
 
 test("Functions with a wrong company id is correctly in error", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "get_company_currency_for_spreadsheet") {
                 return false;
@@ -98,7 +98,7 @@ test("Functions with a wrong company id is correctly in error", async () => {
 });
 
 test("formula with invalid date", async () => {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     setCellContent(model, "A1", `=ODOO.CREDIT("100",)`);
     setCellContent(model, "A2", `=ODOO.DEBIT("100", 0)`);
     setCellContent(model, "A3", `=ODOO.BALANCE("100", -1)`);
@@ -118,7 +118,7 @@ test("formula with invalid date", async () => {
 });
 
 test("Evaluation with multiple account codes", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "spreadsheet_fetch_debit_credit") {
                 expect.step("spreadsheet_fetch_debit_credit");
@@ -147,7 +147,7 @@ test("Evaluation with multiple account codes", async () => {
 });
 
 test("Handle error evaluation", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "spreadsheet_fetch_debit_credit") {
                 throw makeServerError({ description: "a nasty error" });
@@ -162,7 +162,7 @@ test("Handle error evaluation", async () => {
 });
 
 test("Server requests", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "spreadsheet_fetch_debit_credit") {
                 const blobs = args.args[0];
@@ -244,7 +244,7 @@ test("Server requests", async () => {
 });
 
 test("Server requests with multiple account codes", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "spreadsheet_fetch_debit_credit") {
                 expect.step("spreadsheet_fetch_debit_credit");
@@ -272,7 +272,7 @@ test("Server requests with multiple account codes", async () => {
 });
 
 test("account group formula as input to balance formula", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         serverData,
         mockRPC: async function (route, args) {
             if (args.method === "spreadsheet_fetch_debit_credit") {
@@ -303,7 +303,7 @@ test("account group formula as input to balance formula", async () => {
 });
 
 test("two concurrent requests on different accounts", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         serverData,
         mockRPC: async function (route, args) {
             if (args.method === "spreadsheet_fetch_debit_credit") {
@@ -348,7 +348,7 @@ test("two concurrent requests on different accounts", async () => {
 });
 
 test("date with non-standard locale", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, { method, args }) {
             if (method === "spreadsheet_fetch_debit_credit") {
                 expect.step("spreadsheet_fetch_debit_credit");

--- a/addons/spreadsheet_account/static/tests/model/fiscal_year.test.js
+++ b/addons/spreadsheet_account/static/tests/model/fiscal_year.test.js
@@ -14,7 +14,7 @@ defineSpreadsheetModels();
 const { DEFAULT_LOCALE } = spreadsheet.constants;
 
 test("Basic evaluation", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "get_fiscal_dates") {
                 expect.step("get_fiscal_dates");
@@ -39,7 +39,7 @@ test("Basic evaluation", async () => {
 });
 
 test("with a given company id", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "get_fiscal_dates") {
                 expect.step("get_fiscal_dates");
@@ -64,7 +64,7 @@ test("with a given company id", async () => {
 });
 
 test("with a wrong company id", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "get_fiscal_dates") {
                 expect.step("get_fiscal_dates");
@@ -93,7 +93,7 @@ test("with a wrong company id", async () => {
 });
 
 test("with wrong input arguments", async () => {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     setCellContent(model, "A1", `=ODOO.FISCALYEAR.START("not a number")`);
     setCellContent(model, "A2", `=ODOO.FISCALYEAR.END("11/11/2020", "not a number")`);
     expect(getEvaluatedCell(model, "A1").message).toBe(
@@ -105,7 +105,7 @@ test("with wrong input arguments", async () => {
 });
 
 test("Date format is locale dependant", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "get_fiscal_dates") {
                 return [{ start: "2020-01-01", end: "2020-12-31" }];

--- a/addons/spreadsheet_account/static/tests/model/partner_balance.test.js
+++ b/addons/spreadsheet_account/static/tests/model/partner_balance.test.js
@@ -2,27 +2,21 @@ import { describe, expect, test } from "@odoo/hoot";
 import { setCellContent } from "@spreadsheet/../tests/helpers/commands";
 import { getCellValue, getEvaluatedCell } from "@spreadsheet/../tests/helpers/getters";
 import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
-import {
-    defineSpreadsheetAccountModels,
-} from "@spreadsheet_account/../tests/accounting_test_data";
+import { defineSpreadsheetAccountModels } from "@spreadsheet_account/../tests/accounting_test_data";
 import { waitForDataLoaded } from "@spreadsheet/helpers/model";
 
 describe.current.tags("headless");
 defineSpreadsheetAccountModels();
 
 test("Basic evaluation", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "spreadsheet_fetch_partner_balance") {
                 expect.step("spreadsheet_fetch_partner_balance");
                 expect(args.args[0]).toEqual([
                     {
-                        partner_ids: [
-                            14, 16
-                        ],
-                        codes: [
-                            "112",
-                        ],
+                        partner_ids: [14, 16],
+                        codes: ["112"],
                         date_range: {
                             range_type: "year",
                             year: 2023,
@@ -42,27 +36,27 @@ test("Basic evaluation", async () => {
 });
 
 test("with wrong date format", async () => {
-    const model = await createModelWithDataSource();
-    setCellContent(model, "A1", `=ODOO.PARTNER.BALANCE("14, 16", "112", "This is not a valid date")`);
+    const { model } = await createModelWithDataSource();
+    setCellContent(
+        model,
+        "A1",
+        `=ODOO.PARTNER.BALANCE("14, 16", "112", "This is not a valid date")`
+    );
     await waitForDataLoaded(model);
     expect(getEvaluatedCell(model, "A1").message).toBe(
-        "'This is not a valid date' is not a valid period. Supported formats are \"21/12/2022\", \"Q1/2022\", \"12/2022\", and \"2022\"."
+        '\'This is not a valid date\' is not a valid period. Supported formats are "21/12/2022", "Q1/2022", "12/2022", and "2022".'
     );
 });
 
 test("with no date", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "spreadsheet_fetch_partner_balance") {
                 expect.step("spreadsheet_fetch_partner_balance");
                 expect(args.args[0]).toEqual([
                     {
-                        partner_ids: [
-                            14, 16
-                        ],
-                        codes: [
-                            "112",
-                        ],
+                        partner_ids: [14, 16],
+                        codes: ["112"],
                         date_range: {
                             range_type: "year",
                             year: new Date().getFullYear(),

--- a/addons/spreadsheet_account/static/tests/model/residual_amount.test.js
+++ b/addons/spreadsheet_account/static/tests/model/residual_amount.test.js
@@ -2,24 +2,20 @@ import { describe, expect, test } from "@odoo/hoot";
 import { setCellContent } from "@spreadsheet/../tests/helpers/commands";
 import { getCellValue, getEvaluatedCell } from "@spreadsheet/../tests/helpers/getters";
 import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
-import {
-    defineSpreadsheetAccountModels,
-} from "@spreadsheet_account/../tests/accounting_test_data";
+import { defineSpreadsheetAccountModels } from "@spreadsheet_account/../tests/accounting_test_data";
 import { waitForDataLoaded } from "@spreadsheet/helpers/model";
 
 describe.current.tags("headless");
 defineSpreadsheetAccountModels();
 
 test("Basic evaluation", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "spreadsheet_fetch_residual_amount") {
                 expect.step("spreadsheet_fetch_residual_amount");
                 expect(args.args[0]).toEqual([
                     {
-                        codes: [
-                            "112",
-                        ],
+                        codes: ["112"],
                         date_range: {
                             range_type: "year",
                             year: 2023,
@@ -39,24 +35,22 @@ test("Basic evaluation", async () => {
 });
 
 test("with wrong date format", async () => {
-    const model = await createModelWithDataSource();
+    const { model } = await createModelWithDataSource();
     setCellContent(model, "A1", `=ODOO.RESIDUAL("112", "This is not a valid date")`);
     await waitForDataLoaded(model);
     expect(getEvaluatedCell(model, "A1").message).toBe(
-        "'This is not a valid date' is not a valid period. Supported formats are \"21/12/2022\", \"Q1/2022\", \"12/2022\", and \"2022\"."
+        '\'This is not a valid date\' is not a valid period. Supported formats are "21/12/2022", "Q1/2022", "12/2022", and "2022".'
     );
 });
 
 test("with no date", async () => {
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         mockRPC: async function (route, args) {
             if (args.method === "spreadsheet_fetch_residual_amount") {
                 expect.step("spreadsheet_fetch_residual_amount");
                 expect(args.args[0]).toEqual([
                     {
-                        codes: [
-                            "112",
-                        ],
+                        codes: ["112"],
                         date_range: {
                             range_type: "year",
                             year: new Date().getFullYear(),

--- a/addons/spreadsheet_account/static/tests/ui/accounting_drilldown.test.js
+++ b/addons/spreadsheet_account/static/tests/ui/accounting_drilldown.test.js
@@ -38,7 +38,7 @@ test("Create drill down domain", async () => {
     };
     mockService("action", fakeActionService);
 
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         serverData,
         mockRPC: async function (route, args) {
             if (args.method === "spreadsheet_move_line_action") {
@@ -89,7 +89,7 @@ test("Create drill down domain", async () => {
 
 test("Create drill down domain when month date is a reference", async () => {
     mockService("action", { doAction: () => {} });
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         serverData,
         mockRPC: async function (route, args) {
             if (args.method === "spreadsheet_move_line_action") {
@@ -122,7 +122,7 @@ test("Create drill down domain when month date is a reference", async () => {
 
 test("Create drill down domain when date uses a non-standard locale", async () => {
     mockService("action", { doAction: () => {} });
-    const model = await createModelWithDataSource({
+    const { model } = await createModelWithDataSource({
         serverData,
         mockRPC: async function (route, args) {
             if (args.method === "spreadsheet_move_line_action") {


### PR DESCRIPTION
With this commit, the `env` is now returned by `createModelWithDataSource` in addition to the `model`.
It avoids to have to get the `env` from `model.config.custom.env`.

Task: 4525938

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
