### PR TITLE
[FIX] point_of_sale: fix CustomerDisplayPosAdapter bad var reference

### DIFF
--- a/addons/point_of_sale/static/src/customer_display/customer_display_adapter.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display_adapter.js
@@ -23,9 +23,9 @@ export class CustomerDisplayPosAdapter {
 
         if (pos.config.customer_display_type === "remote") {
             pos.data.call("pos.config", "update_customer_display", [
-                [this.pos.config.id],
+                [pos.config.id],
                 this.data,
-                this.pos.config.access_token,
+                pos.config.access_token,
             ]);
         }
 


### PR DESCRIPTION
Steps to reproduce:
- Set the customer display feature on "another device" in the settings
- Open the POS and add products

Reason:
The refactor in 59700feb8fb6e4ca993ffdd1eef6951b9203ca06 badly kept referencing `pos` as a class field instead of a function parameter.

opw-4508838