### PR TITLE
[FIX] website: fix drag inner snippet in snippets_all_drag_and_drop test

### DIFF
--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -108,6 +108,13 @@ tour.register("snippets_all_drag_and_drop", {
         content: "check setting are loaded, wait panel is visible",
         trigger: ".o_we_customize_panel"
     },
+    // We hide the header before starting to drop snippets. This prevents
+    // situations where the header's drop zones overlap with those of the #wrap,
+    // ensuring that a snippet is dropped in the #wrap as expected instead of
+    // the header.
+    websiteTourUtils.clickOnSnippet({id: "o_header_standard", name: "Header"}),
+    websiteTourUtils.changeOption("TopMenuVisibility", "we-select:has([data-visibility]) we-toggler"),
+    websiteTourUtils.changeOption("TopMenuVisibility", 'we-button[data-visibility="hidden"]'),
     {
         content: "click on 'BLOCKS' tab",
         trigger: ".o_we_add_snippet_btn"


### PR DESCRIPTION
Since commit [1], the test "snippets_all_drag_and_drop" is failing randomly on the runbot. This is due to the fact that it is now possible to drop an "inner snippet" next to the "phone number" in the "header". Since the "phone number" is in the middle of the "header" (horizontally), its drop zone overlaps with the one of the "#wrap" during the test. As a result, "inner snippet" is being dropped in the "header" instead of the "#wrap". This happens because the "drag_and_drop" function in the test by default drops at the middle and top of the drop zones.

To avoid this kind of situation, in this commit, we add a step at the beginning of the test to hide the header.

[1]: https://github.com/odoo/odoo/commit/e0c16bb9a90dfb378b75e0de059e71f0aebd84fb

opw-4494945