### PR TITLE
[FIX] stock: fix traceback when the user tries to create a new putawaay rules

### DIFF
--- a/addons/stock/models/product_strategy.py
+++ b/addons/stock/models/product_strategy.py
@@ -80,7 +80,7 @@ class StockPutawayRule(models.Model):
     @api.onchange('location_in_id')
     def _onchange_location_in(self):
         loc_in, loc_out = self.location_in_id, self.location_out_id
-        if not loc_out or not (loc_out._child_of(loc_in)):
+        if not loc_out or (loc_in and not loc_out._child_of(loc_in)):
             self.location_out_id = self.location_in_id
 
     @api.model_create_multi


### PR DESCRIPTION
Currently, a traceback is occurring when the user tries to create
a new put-away record and remove the `location_in_id`.

To reproduce this issue:

1) Install Inventory
2) Enable multi-step routes from inventory settings 
3) Create a new putaway rules record from inventory configuration 
4) Remove the `when product arrives in` value

Error:-
```
TypeError: startswith first arg must be str or a tuple of str, not bool
```

When the user removes the `location_in_id`, an onchange method `_onchange_location_in` triggers.

https://github.com/odoo/odoo/blob/239d18c8689d38e11783716b7e14a5204daed98a/addons/stock/models/product_strategy.py#L80-L83

We get the `loc_in` value as an empty recordset, because the user removed the `location_in_id` value.

So it will lead to the above traceback from the below line

https://github.com/odoo/odoo/blob/239d18c8689d38e11783716b7e14a5204daed98a/addons/stock/models/stock_location.py#L453-L455

sentry-6210564390
