### PR TITLE
[IMP] hr_hourly_cost: change hourly_cost precision

### DIFF
--- a/addons/hr_hourly_cost/__manifest__.py
+++ b/addons/hr_hourly_cost/__manifest__.py
@@ -13,6 +13,7 @@ This module assigns an hourly wage to employees to be used by other modules.
     'depends': ['hr'],
     'data': [
         'views/hr_employee_views.xml',
+        'data/hr_hourly_cost_data.xml',
     ],
     'demo': [
         'data/hr_hourly_cost_demo.xml',

--- a/addons/hr_hourly_cost/data/hr_hourly_cost_data.xml
+++ b/addons/hr_hourly_cost/data/hr_hourly_cost_data.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>    
+    <record forcecreate="True" id="decimal_hourly_cost" model="decimal.precision">
+        <field name="name">Hourly Cost</field>
+        <field name="digits">4</field>
+    </record>
+</odoo>

--- a/addons/hr_hourly_cost/models/hr_employee.py
+++ b/addons/hr_hourly_cost/models/hr_employee.py
@@ -6,5 +6,5 @@ from odoo import fields, models
 class HrEmployee(models.Model):
     _inherit = 'hr.employee'
 
-    hourly_cost = fields.Monetary('Hourly Cost', currency_field='currency_id',
+    hourly_cost = fields.Float(string='Hourly Cost', digits='Hourly Cost',
         groups="hr.group_hr_user", default=0.0, tracking=True)

--- a/addons/hr_hourly_cost/views/hr_employee_views.xml
+++ b/addons/hr_hourly_cost/views/hr_employee_views.xml
@@ -11,9 +11,9 @@
             </group>
             <group name="application_group" position="inside">
                 <label for="hourly_cost"/>
-                <div name="hourly_cost">
-                    <field name="hourly_cost" class="oe_inline"/>
-                    <field name="currency_id" invisible="1"/>
+                <div name="hourly_cost" class="d-flex">
+                    <field name="hourly_cost"/>
+                    <field name="currency_id"/>
                 </div>
             </group>
         </field>


### PR DESCRIPTION
- As LU law state a 4 digit hourly wage, the `hourly_cost` must be modified into float and
have a decimal accurecy to able to adapt
to anyother regulations

Task: 3382221


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
