### PR TITLE
[IMP] calendar: add time dot indicator

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -123,6 +123,11 @@ export class CalendarCommonRenderer extends Component {
             longPressDelay: 500,
             navLinks: false,
             nowIndicator: true,
+            nowIndicatorContent: {
+                html: `
+                    <div class="o_calendar_time_indicator_now"></div>
+                `,
+            },
             select: this.onSelect,
             selectAllow: this.isSelectionAllowed,
             selectMinDistance: 5, // needed to not trigger select when click

--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -131,6 +131,11 @@
             --fc-today-bg-color: none;
         }
 
+        // Remove time indicator arrow
+        .fc-timegrid-now-indicator-arrow {
+            display: none;
+        }
+
         // ===  Adapt calendar table borders and general layout ===
         // ========================================================
         --fc-page-bg-color: #{$o-view-background-color};
@@ -224,6 +229,9 @@
         // ====== Both Day and Week agenda
         .fc-timeGridDay-view,
         .fc-timeGridWeek-view {
+            --o-cw-bg: #{$o-cw-color-today-accent};
+            --o-cw-color: #{color-contrast($o-cw-color-today-accent)};
+
             .fc-scrollgrid-section-body {
                 &:not(.fc-scrollgrid-section-liquid) .fc-scroller-harness {
                     background-color: $o-view-background-color;
@@ -240,16 +248,11 @@
                     align-items: center;
                 }
 
-                &.fc-day-today {
-                    --o-cw-color: #{color-contrast($o-cw-color-today-accent)};
-                    --o-cw-bg: #{$o-cw-color-today-accent};
-
-                    .o_cw_day_number {
-                        color: var(--o-cw-color);
-                        background-color: var(--o-cw-bg);
-                        border-radius: 50%;
-                        aspect-ratio: 1;
-                    }
+                &.fc-day-today .o_cw_day_number {
+                    color: var(--o-cw-color);
+                    background-color: var(--o-cw-bg);
+                    border-radius: 50%;
+                    aspect-ratio: 1;
                 }
             }
 
@@ -352,15 +355,38 @@
             }
         }
 
+        .fc-timegrid-now-indicator-container {
+            pointer-events: none;
+            overflow: visible;
+            border: none;
+        }
+
         // ====== Week only
         .fc-timeGridWeek-view {
             // Reset position to keep the "nowIndicator" line visible
             @for $i from 1 through 7 {
-                .fc-timegrid-col:not(.fc-timegrid-axis):nth-child(#{$i + 1}) .fc-timegrid-now-indicator-container {
+                .fc-timegrid-col:not(.fc-timegrid-axis):nth-child(#{$i + 1}) .o_calendar_time_indicator_now {
                     $left: ($i - 1) * -100;
                     $right: (7 - $i) * -100;
                     left: #{$left + '%'};
                     right: #{$right + '%'};
+                    position: absolute;
+                    height: 1px;
+                    background-color: var(--o-cw-bg);
+                    opacity: 0.3;
+                    transform: translateY(-100%);
+                }
+
+                // Add a dot shape at the start of the "Now Indicator" line
+                .fc-timegrid-now-indicator-line::before {
+                    content: "";
+                    position: absolute;
+                    height: .75rem;
+                    width: .75rem;
+                    border: $border-width solid $o-view-background-color;
+                    border-radius: $border-radius-pill;
+                    background-color: var(--o-cw-bg);
+                    transform: translate(-50%, -50%);
                 }
             }
         }


### PR DESCRIPTION
This commit adds a time dot indicator in the "today" col.

It also removes the fullCalendar default time arrow that is not useful anymore.

task-3919248

| Before | After |
|--------|--------|
| <img width="278" alt="Screenshot 2025-01-29 at 10 24 59" src="https://github.com/user-attachments/assets/03c92fc6-4cae-4144-ba45-8ee7ddb56dd2" /> | <img width="284" alt="Screenshot 2025-02-14 at 11 54 28" src="https://github.com/user-attachments/assets/2cefcf88-82dd-4116-acb9-e9e87f66f25c" /> | 
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
