### PR TITLE
[FIX] point_of_sale: prevent archiving products in use during an open session

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -3308,6 +3308,14 @@ msgid ""
 msgstr ""
 
 #. module: point_of_sale
+#. odoo-python
+#: code:addons/point_of_sale/models/product_template.py:0
+msgid ""
+"Hold up! Archiving products while POS sessions are active is like pulling a plate mid-meal.\n"
+"Make sure to close all sessions first to avoid any issues."
+msgstr ""
+
+#. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_order__preset_time
 msgid "Hour"
 msgstr ""

--- a/addons/point_of_sale/models/product_product.py
+++ b/addons/point_of_sale/models/product_product.py
@@ -39,3 +39,7 @@ class ProductProduct(models.Model):
         if field_name == "image_128" and self.sudo().available_in_pos:
             return True
         return super()._can_return_content(field_name, access_token)
+
+    def action_archive(self):
+        self.product_tmpl_id._ensure_unused_in_pos()
+        return super().action_archive()

--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -161,6 +161,19 @@ class ProductTemplate(models.Model):
                     "Deleting a product available in a session would be like attempting to snatch a hamburger from a customer’s hand mid-bite; chaos will ensue as ketchup and mayo go flying everywhere!",
                 ))
 
+    def _ensure_unused_in_pos(self):
+        open_pos_sessions = self.env['pos.session'].search([('state', '!=', 'closed')])
+        used_products = open_pos_sessions.order_ids.filtered(lambda o: o.state == "draft").lines.product_id.product_tmpl_id
+        if used_products & self:
+            raise UserError(_(
+                "Hold up! Archiving products while POS sessions are active is like pulling a plate mid-meal.\n"
+                "Make sure to close all sessions first to avoid any issues.",
+            ))
+
+    def action_archive(self):
+        self._ensure_unused_in_pos()
+        return super().action_archive()
+
     @api.onchange('sale_ok')
     def _onchange_sale_ok(self):
         if not self.sale_ok:

--- a/addons/stock/tests/test_report_tours.py
+++ b/addons/stock/tests/test_report_tours.py
@@ -12,7 +12,7 @@ class TestStockReportTour(HttpCase):
     def test_stock_route_diagram_report(self):
         """ Open the route diagram report."""
         # Do not make the test rely on demo data
-        self.env['product.template'].search([('type', '!=', 'service')]).action_archive()
+        self.env['product.template'].search([('type', '!=', 'service')]).write({'active': False})
         self.env['product.template'].create({
             'name': 'Test Storable Product',
             'is_storable': True,


### PR DESCRIPTION
Before this commit:
====================
Archiving a product that is part of draft orderlines in an open session caused an error in the Indian localization. Specifically, the system threw a "l10n_in_hsn_code" error when attempting to reopen the session, as the archived product was no longer accessible.

After this commit:
====================
A user-friendly error message is displayed to notify the user about the archiving products when the session is open and products are in use, ensuring data consistency and preventing errors when reopening sessions.

Task-4518025


