### PR TITLE
[FIX] hr_timesheet: prevent keyerror when company is unarchived

### DIFF
--- a/addons/hr_timesheet/models/ir_http.py
+++ b/addons/hr_timesheet/models/ir_http.py
@@ -16,6 +16,9 @@ class IrHttp(models.AbstractModel):
             company_ids = self.env.user.company_ids
 
             for company in company_ids:
+                if company.id not in result["user_companies"]["allowed_companies"]:
+                    result["user_companies"]["allowed_companies"][company.id] = {}
+
                 result["user_companies"]["allowed_companies"][company.id].update({
                     "timesheet_uom_id": company.timesheet_encode_uom_id.id,
                     "timesheet_uom_factor": company.project_time_mode_id._compute_quantity(


### PR DESCRIPTION
Currently a `KeyError` appears when the user unarchives the company.

Error: `Keyerror: 2`

Steps to reproduce above error :-
- Install `hr_timesheet` module.
- Settings > Users & Companies > Companies. create a company.
- Archive the company, now Unarchive the company.
- The error appears in the log.

The error occurs because on urachiving the company, the new company was not found.

This commit fixes the error, if company does not exist, it still returns an empty dictionary.

sentry-6251348500