### PR TITLE
[FIX] mail: non-accessible member's shouldn't displayed on ctrl+k by guest

### DIFF
--- a/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
@@ -1,4 +1,5 @@
 import { registry } from "@web/core/registry";
+import { contains } from "@web/../tests/utils";
 
 registry.category("web_tour.tours").add("discuss_channel_as_guest_tour.js", {
     steps: () => [
@@ -19,6 +20,18 @@ registry.category("web_tour.tours").add("discuss_channel_as_guest_tour.js", {
         {
             content: "Check that we are on channel page",
             trigger: ".o-mail-Thread",
+            run: "press ctrl+k",
+        },
+        {
+            trigger: ".o_command_palette_search input",
+            run: "fill @",
+        },
+        {
+            trigger: ".o-mail-DiscussCommand",
+            async run() {
+                await contains(".fa-hashtag");
+                await contains(".fa-user", { count: 0 });
+            },
         },
     ],
 });


### PR DESCRIPTION
**Current behavior before PR:**

when we are in public channel by guest and hit ctrl+k then click on partners which are not accessible by guest it shows access error.

**Desired behavior after PR is merged:**

now we are not displaying partners which removes the access error.

task-4518228

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
