### PR TITLE
[FIX] web_editor: apply `font-size` on highest non-block ancestor

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1153,12 +1153,20 @@ const removeStyle = (node, styleName, item) => {
 };
 const getOrCreateSpan = (node, ancestors) => {
     const span = ancestors.find((element) => element.tagName === 'SPAN' && element.isConnected);
+    const lastInlineAncestor = ancestors.findLast((element) => !isBlock(element) && element.isConnected);
     if (span) {
         return span;
     } else {
         const span = document.createElement('span');
-        node.after(span);
-        span.append(node);
+        // Apply font span above current inline top ancestor so that 
+        // the font style applies to the other style tags as well.
+        if (lastInlineAncestor) {
+            lastInlineAncestor.after(span);
+            span.append(lastInlineAncestor);
+        } else {
+            node.after(span);
+            span.append(node);
+        }
         return span;
     }
 }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
@@ -1045,6 +1045,20 @@ describe('Format', () => {
                 contentAfter: `<h1><span t="unbreakable">some <span style="font-size: 18px;">[text]</span></span></h1>`,
             });
         });
+        it('should apply font size on top of `u` and `s` tags', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: `<p>a<u>[b]</u>c</p>`,
+                stepFunction: setFontSize('18px'),
+                contentAfter: `<p>a<span style="font-size: 18px;"><u>[b]</u></span>c</p>`,
+            });
+        });
+        it('should apply font size on topmost `u` or `s` tags if multiple applied', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: `<p>a<s><u>[b]</u></s>c</p>`,
+                stepFunction: setFontSize('18px'),
+                contentAfter: `<p>a<span style="font-size: 18px;"><s><u>[b]</u></s></span>c</p>`,
+            });
+        });
     });
 
     it('should add style to a span parent of an inline', async () => {


### PR DESCRIPTION
**Problem**:
When `u` or `s` tags are applied, changing the `font-size` wraps the text inside these tags instead of applying it to the tags themselves. For example,
`a<u>b</u>c` → `a<u><font>b</font></u>c`,
which results in an inconsistent appearance.

**Solution**:
Ensure that the `span` for font size is applied to the highest non-block ancestor to maintain proper styling.

**Steps to Reproduce**:
1. Add text.
2. Apply underline.
3. Increase font size.
4. Observe that the underline remains the original size instead of scaling with the text.

opw-3086072

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
