### PR TITLE
[16.0] [FIX] l10n_es_edi_sii: sudo to access ir.model.data

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -589,7 +589,7 @@ class AccountEdiFormat(models.Model):
         return results
 
     def _has_oss_taxes(self, invoice):
-        oss_tax_groups = self.env['ir.model.data'].search([
+        oss_tax_groups = self.env['ir.model.data'].sudo().search([
             ('module', '=', 'l10n_eu_oss'),
             ('model', '=', 'account.tax.group')])
         lines = invoice.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_section', 'line_note'))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

l10n_es_edi_sii: sudo to access ir.model.data

Current behavior before PR:

If user does not have Administration/Access Rights permission, an error is raised when calling to _has_oss_taxes method

Desired behavior after PR is merged:

No error of permission is raised.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
