### PR TITLE
[IMP] mail: remove tenor content filter options

### DIFF
--- a/addons/mail/controllers/discuss/gif.py
+++ b/addons/mail/controllers/discuss/gif.py
@@ -5,6 +5,8 @@ import werkzeug.urls
 
 from odoo.http import request, route, Controller
 
+TENOR_CONTENT_FILTER = "medium"
+TENOR_GIF_LIMIT = 8
 
 class DiscussGifController(Controller):
     def _request_gifs(self, endpoint):
@@ -23,8 +25,8 @@ class DiscussGifController(Controller):
                 "q": search_term,
                 "key": ir_config.get_param("discuss.tenor_api_key"),
                 "client_key": request.env.cr.dbname,
-                "limit": ir_config.get_param("discuss.tenor_gif_limit"),
-                "contentfilter": ir_config.get_param("discuss.tenor_content_filter"),
+                "limit": TENOR_GIF_LIMIT,
+                "contentfilter": TENOR_CONTENT_FILTER,
                 "locale": locale,
                 "country": country,
                 "media_filter": "tinygif",
@@ -43,8 +45,8 @@ class DiscussGifController(Controller):
             {
                 "key": ir_config.get_param("discuss.tenor_api_key"),
                 "client_key": request.env.cr.dbname,
-                "limit": ir_config.get_param("discuss.tenor_gif_limit"),
-                "contentfilter": ir_config.get_param("discuss.tenor_content_filter"),
+                "limit": TENOR_GIF_LIMIT,
+                "contentfilter": TENOR_CONTENT_FILTER,
                 "locale": locale,
                 "country": country,
             }

--- a/addons/mail/models/ir_config_parameter.py
+++ b/addons/mail/models/ir_config_parameter.py
@@ -73,8 +73,7 @@ class IrConfig_Parameter(models.Model):
     #     configuration parameters when using web push notifications;
     #   * 'mail.use_twilio_rtc_servers', 'mail.sfu_server_url' and 'mail.
     #     sfu_server_key': rtc server usage and configuration;
-    #   * 'discuss.tenor_api_key', 'discuss.tenor_gif_limit' and 'discuss.
-    #     tenor_content_filter' used for gif fetch service;
+    #   * 'discuss.tenor_api_key': used for gif fetch service;
     _inherit = 'ir.config_parameter'
 
     @api.model

--- a/addons/mail/models/res_config_settings.py
+++ b/addons/mail/models/res_config_settings.py
@@ -50,21 +50,6 @@ class ResConfigSettings(models.TransientModel):
         config_parameter='discuss.tenor_api_key',
         help="Add a Tenor GIF API key to enable GIFs support. https://developers.google.com/tenor/guides/quickstart#setup",
     )
-    tenor_content_filter = fields.Selection(
-        [('high', 'High'),
-        ('medium', 'Medium'),
-        ('low', 'Low'),
-        ('off', 'Off')],
-        string='Tenor content filter',
-        help="https://developers.google.com/tenor/guides/content-filtering",
-        config_parameter='discuss.tenor_content_filter',
-        default='low',
-    )
-    tenor_gif_limit = fields.Integer(
-        default=8,
-        config_parameter='discuss.tenor_gif_limit',
-        help="Fetch up to the specified number of GIF.",
-    )
     google_translate_api_key = fields.Char(
         "Message Translation API Key",
         help="A valid Google API key is required to enable message translation. https://cloud.google.com/translate/docs/setup",

--- a/addons/mail/views/res_config_settings_views.xml
+++ b/addons/mail/views/res_config_settings_views.xml
@@ -102,12 +102,6 @@
                         <setting id="tenor_api_key" string="Tenor GIF API key" help="Add a Tenor GIF API key to enable GIFs support." documentation="https://developers.google.com/tenor/guides/quickstart#setup">
                             <field name="tenor_api_key" placeholder="Paste your API key"/>
                         </setting>
-                        <setting id="tenor_content_filter" string="Tenor GIF content filter" help="Select the content filter used for filtering GIFs" documentation="https://developers.google.com/tenor/guides/content-filtering">
-                            <field name="tenor_content_filter"/>
-                        </setting>
-                        <setting id="tenor_gif_limit" string="Tenor GIF limits" help="Fetch up to the specified number of GIF.">
-                            <field name="tenor_gif_limit"/>
-                        </setting>
                         <setting string="Message Translation" help="Google Translate Integration" id="message_translation_setting" documentation="https://cloud.google.com/translate/docs/setup">
                             <field name="google_translate_api_key" placeholder="Paste your API key"/>
                         </setting>


### PR DESCRIPTION
This commit removes the `tenor_content_filter` and `tenor_gif_limit` options from config parameters.

Task-4465463

Related: https://github.com/odoo/upgrade/pull/7137

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
