### PR TITLE
[FIX] web: throw if dynamicContent is missing a selector

### DIFF
--- a/addons/web/static/src/public/colibri.js
+++ b/addons/web/static/src/public/colibri.js
@@ -217,6 +217,9 @@ export class Colibri {
 
     processContent(content) {
         for (const sel in content) {
+            if (sel.startsWith("t-")) {
+                throw new Error(`Selector missing for key ${sel} in dynamicContent (interaction '${this.interaction.constructor.name}').`);
+            }
             let nodes;
             if (this.dynamicNodes.has(sel)) {
                 nodes = this.dynamicNodes.get(sel);

--- a/addons/web/static/src/public/interaction_service.js
+++ b/addons/web/static/src/public/interaction_service.js
@@ -144,7 +144,6 @@ class InteractionService {
         this.activeInteractions.add(el, I);
         if (I.prototype instanceof Interaction) {
             try {
-                // console.log(`[colibri] starting ${I.name}`);
                 const interaction = new Colibri(this, I, el);
                 this.interactions.push(interaction);
                 proms.push(interaction.start());
@@ -160,7 +159,6 @@ class InteractionService {
         const interactions = [];
         for (const interaction of this.interactions.slice().reverse()) {
             if (el === interaction.el || el.contains(interaction.el)) {
-                // console.log(`[colibri] stopping ${interaction.interaction.constructor.name}`);
                 interaction.destroy();
                 this.activeInteractions.delete(interaction.el, interaction.interaction.constructor);
             } else {

--- a/addons/web/static/tests/public/interaction.test.js
+++ b/addons/web/static/tests/public/interaction.test.js
@@ -589,6 +589,16 @@ describe("handling crashes", () => {
             .rejects
             .toThrow("The selector should be defined as a static property on the class Test, not on the instance");
     });
+
+    test("crash if first-level key on dynamicContent is a directive, not a selector", async () => {
+        class Test extends Interaction {
+            static selector = ".test";
+            dynamicContent = { "t-on-click": () => {} };
+        }
+        await expect(startInteraction(Test, TemplateTest))
+            .rejects
+            .toThrow("Selector missing for key t-on-click in dynamicContent (interaction 'Test')");
+    });
 });
 
 describe("using qualifiers", () => {


### PR DESCRIPTION
`dynamicContent` in Interactions (see [1]) expects selectors as keys, but had no safety mechanism to make sure there is a selector before the directive (t-...).

[1]: https://github.com/odoo/odoo/commit/12f04ee10f0ec38a3a750155ef7359631dcf4669