### PR TITLE
[REF] *: use field service loadFields

### DIFF
--- a/addons/account/static/src/components/many2x_tax_tags/many2x_tax_tags.js
+++ b/addons/account/static/src/components/many2x_tax_tags/many2x_tax_tags.js
@@ -10,6 +10,7 @@ import {
     many2OneField,
 } from "@web/views/fields/many2one/many2one_field";
 import { TaxAutoComplete } from "@account/components/tax_autocomplete/tax_autocomplete";
+import { useService } from "@web/core/utils/hooks";
 
 export class Many2XTaxTagsAutocomplete extends Many2XAutocomplete {
     static components = {
@@ -20,6 +21,11 @@ export class Many2XTaxTagsAutocomplete extends Many2XAutocomplete {
         return _t("Not sure... Help me!");
     }
 
+    setup() {
+        super.setup();
+        this.fieldService = useService("field");
+    }
+
     search(name) {
         return this.orm
             .call(this.props.resModel, "search_read", [], {
@@ -27,8 +33,8 @@ export class Many2XTaxTagsAutocomplete extends Many2XAutocomplete {
                 fields: ["id", "name", "tax_scope"],
             })
             .then((records) => {
-                return this.orm
-                    .call("account.tax", "fields_get", [], { attributes: ["selection"] })
+                return this.fieldService
+                    .loadFields("account.tax", { attributes: ["selection"] })
                     .then((fields) => {
                         const selectionOptions = fields.tax_scope.selection;
 

--- a/addons/base_import/static/src/import_data_options/import_data_options.js
+++ b/addons/base_import/static/src/import_data_options/import_data_options.js
@@ -11,7 +11,7 @@ export class ImportDataOptions extends Component {
     };
 
     setup() {
-        this.orm = useService("orm");
+        this.fieldService = useService("field");
         this.state = useState({
             options: [],
         });
@@ -39,7 +39,7 @@ export class ImportDataOptions extends Component {
                 options.push(["import_skip_records", _t("Skip record")]);
             }
             if (this.props.fieldInfo.type === "selection") {
-                const fields = await this.orm.call(this.currentModel, "fields_get");
+                const fields = await this.fieldService.loadFields(this.currentModel);
                 const selection = fields[this.props.fieldInfo.name].selection.map((opt) => [
                     opt[0],
                     _t("Set to: %s", opt[1]),

--- a/addons/web/static/src/model/record.js
+++ b/addons/web/static/src/model/record.js
@@ -42,9 +42,7 @@ class _Record extends Component {
             },
         };
         const modelServices = Object.fromEntries(
-            StandaloneRelationalModel.services.map((servName) => {
-                return [servName, useService(servName)];
-            })
+            StandaloneRelationalModel.services.map((servName) => [servName, useService(servName)])
         );
         modelServices.orm = this.orm;
         this.model = useState(new StandaloneRelationalModel(this.env, modelParams, modelServices));
@@ -169,7 +167,9 @@ export class Record extends Component {
     setup() {
         const { activeFields, fieldNames, fields, resModel } = this.props;
         if (!activeFields && !fieldNames) {
-            throw Error(`Record props should have either a "activeFields" key or a "fieldNames" key`);
+            throw Error(
+                `Record props should have either a "activeFields" key or a "fieldNames" key`
+            );
         }
         if (!fields && (!fieldNames || !resModel)) {
             throw Error(
@@ -179,9 +179,9 @@ export class Record extends Component {
         if (fields) {
             this.fields = fields;
         } else {
-            const orm = useService("orm");
+            const fieldService = useService("field");
             onWillStart(async () => {
-                this.fields = await orm.call(resModel, "fields_get", [fieldNames], {});
+                this.fields = await fieldService.loadFields(resModel, { fieldNames });
             });
         }
     }


### PR DESCRIPTION
The field service caches fields_get results. Here we replace some direct calls to fields_get via the orm by calls to the method loadFields of field service.