### PR TITLE
[FIX] website_sale: show expected product image in cart overview

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1974,15 +1974,17 @@
                             always shown for unsellable lines, we use the raw image data as src
                             (which doesn't require access, unlike the image URL).
                         -->
-                        <t t-call="website_sale.cart_line_product_link">
-                            <img
-                                t-if="line._is_not_sellable_line() and line.product_id.image_128"
-                                t-att-src="image_data_uri(line.product_id.image_128)"
-                                class="o_image_64_max img rounded"
-                                t-att-alt="line.name_short"
-                            />
+                        <img
+                            t-if="line._is_not_sellable_line() and line.product_id.image_128"
+                            t-att-src="image_data_uri(line.product_id.image_128)"
+                            class="o_image_64_max img rounded"
+                            t-att-alt="line.name_short"
+                        />
+                        <t
+                            t-elif="line.product_id.image_128"
+                            t-call="website_sale.cart_line_product_link"
+                        >
                             <div
-                                t-elif="line.product_id.image_128"
                                 t-field="line.product_id.image_128"
                                 t-options="{
                                     'widget': 'image',


### PR DESCRIPTION
Currently, product image for unsellable lines are not shown due to the
link encapsulation. It'll now show the image again.

opw-4338036
