### PR TITLE
[FIX] purchase_stock: merge multi lingual POL created by the same RR 2

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -357,7 +357,7 @@ class PurchaseOrderLine(models.Model):
             name = product_lang.display_name
             if product_lang.description_purchase:
                 name += '\n' + product_lang.description_purchase
-            lines = lines.filtered(lambda l: l.name == name + '\n' + description_picking)
+            lines = lines.filtered(lambda l: (l.name == name + '\n' + description_picking) or (product_lang.name == values.get('product_description_variants') and l.name == name))
             if lines:
                 return lines[0]
 


### PR DESCRIPTION
### Steps to reproduce:

- In the settings: - Add a second language say FR + Change the language - Enable Multi-step routes
- Create a second warehouse: WH2 ressuplied from WH1
- Create a storable product with a different FR name and a set FR vendor and the buy route enabled
- Click on the "Reordering Rules" smart button of the product form
- Create a reordering rule for WH2/Stock using the ressuplied from WH1
- Add a quantity to reorder > "Order Once"
- Open the associated purchase order in a second window.
- Repeat the operation of adding a quantity to reorder
#### > "Order Once" ** A new POL is created instead of being merged to the first one**

### Cause of the issue:

Using a multilingual setup such as above will end up with a `product_description_variants` equal to the product name in the appropriavte language. Since this description is the same as the prodcut name is is not added to the name the POL name at creation: https://github.com/odoo/odoo/blob/a848c3854c94b5c2b752edddbcf49337acf9d6ea/addons/purchase_stock/models/purchase_order_line.py#L314-L318 However, the `_find_candidate` pol method defined in order to find pol to updates rather than a new pol creation:
https://github.com/odoo/odoo/blob/a848c3854c94b5c2b752edddbcf49337acf9d6ea/addons/purchase_stock/models/stock_rule.py#L131-L139 compares the name of candidate lines is actually expecting that this description is always added to the name: https://github.com/odoo/odoo/blob/a848c3854c94b5c2b752edddbcf49337acf9d6ea/addons/purchase_stock/models/purchase_order_line.py#L341-L342 https://github.com/odoo/odoo/blob/a848c3854c94b5c2b752edddbcf49337acf9d6ea/addons/purchase_stock/models/purchase_order_line.py#L360-L364

opw-4397376
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
