### PR TITLE
[IMP] l10n_latam_check, account: tree and search view ux improvements

### DIFF
--- a/addons/account/i18n/es_419.po
+++ b/addons/account/i18n/es_419.po
@@ -12,7 +12,7 @@
 # 
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.0\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-01-27 13:02+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
@@ -21,8 +21,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es_419\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: \n"
 
 #. module: account
 #. odoo-python
@@ -191,13 +190,13 @@ msgstr "%(partner_name)s llegó al límite de crédito de: %(credit_limit)s"
 #. odoo-python
 #: code:addons/account/models/account_move.py:0
 msgid "%(ref)s (%(currency_amount)s)"
-msgstr "%(ref)s (%(currency_amount)s)"
+msgstr ""
 
 #. module: account
 #. odoo-python
 #: code:addons/account/models/account_account_tag.py:0
 msgid "%(tag)s (%(country_code)s)"
-msgstr "%(tag)s (%(country_code)s)"
+msgstr ""
 
 #. module: account
 #. odoo-python
@@ -208,7 +207,7 @@ msgstr "%(tax_name)s (redondeo)"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_automatic_entry_wizard_form
 msgid "%<span class=\"px-3\"/>("
-msgstr "%<span class=\"px-3\"/>("
+msgstr ""
 
 #. module: account
 #. odoo-python
@@ -268,12 +267,12 @@ msgstr "(incluído)."
 #: model:ir.actions.report,print_report_name:account.account_invoices
 #: model:ir.actions.report,print_report_name:account.account_invoices_without_payment
 msgid "(object._get_report_base_filename())"
-msgstr "(object._get_report_base_filename())"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_partner_bank_form_inherit_account
 msgid ").<br/>"
-msgstr ").<br/>"
+msgstr ""
 
 #. module: account
 #. odoo-python
@@ -323,10 +322,6 @@ msgid ""
 "    --\n"
 "    <br/>"
 msgstr ""
-".\n"
-"    <br/>\n"
-"    --\n"
-"    <br/>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_partner_property_form
@@ -367,9 +362,27 @@ msgid "/ if not applicable"
 msgstr "/ si no aplica"
 
 #. module: account
+#: model:account.tax,name:account.4_ri_tax_vat_exento_compras
+#: model:account.tax,name:account.4_ri_tax_vat_exento_ventas
+msgid "0% EXEMPT"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.4_ri_tax_vat_no_corresponde_compras
+#: model:account.tax,name:account.4_ri_tax_vat_no_corresponde_ventas
+msgid "0% NA"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.4_ri_tax_vat_no_gravado_compras
+#: model:account.tax,name:account.4_ri_tax_vat_no_gravado_ventas
+msgid "0% NT"
+msgstr ""
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_template
 msgid "1.05"
-msgstr "1.05"
+msgstr ""
 
 #. module: account
 #: model:account.payment.term,name:account.account_payment_term_30_days_end_month_the_10
@@ -379,27 +392,27 @@ msgstr "10 días después del fin del siguiente mes"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_statement
 msgid "100.0"
-msgstr "100.0"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
 msgid "100.00 USD"
-msgstr "100.00 USD"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_statement
 msgid "1000.0"
-msgstr "1000.0"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "11.05"
-msgstr "11.05"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_statement
 msgid "12345"
-msgstr "12345"
+msgstr ""
 
 #. module: account
 #: model:account.payment.term,name:account.account_payment_term_15days
@@ -410,12 +423,12 @@ msgstr "15 días"
 #: model:account.tax,name:account.1_purchase_tax_template
 #: model:account.tax,name:account.1_sale_tax_template
 msgid "15%"
-msgstr "15%"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_statement
 msgid "1500.0"
-msgstr "1500.0"
+msgstr ""
 
 #. module: account
 #: model:account.payment.term,name:account.account_payment_term_30days_early_discount
@@ -425,7 +438,7 @@ msgstr "2/7 neto 30"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "20.00"
-msgstr "20.00"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
@@ -485,29 +498,34 @@ msgstr "21 días"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
 msgid "25.0 USD"
-msgstr "25.0 USD"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
 msgid "25.00 USD"
-msgstr "25.00 USD"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_template
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "27.00"
-msgstr "27.00"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "3.00"
-msgstr "3.00"
+msgstr ""
 
 #. module: account
 #: model:account.payment.term,name:account.account_payment_term_30days
 msgid "30 Days"
 msgstr "30 días"
+
+#. module: account
+#: model:account.payment.term,name:account.account_payment_term_advance
+msgid "30% Advance End of Following Month"
+msgstr ""
 
 #. module: account
 #: model:account.payment.term,name:account.account_payment_term_advance_60days
@@ -517,20 +535,20 @@ msgstr "30% ahora, el resto en 60 días"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "30.00"
-msgstr "30.00"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_template
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "31.05"
-msgstr "31.05"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_template
 msgid "4.05"
-msgstr "4.05"
+msgstr ""
 
 #. module: account
 #: model:account.payment.term,name:account.account_payment_term_45days
@@ -540,22 +558,22 @@ msgstr "45 días"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
 msgid "50 USD"
-msgstr "50 USD"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
 msgid "50.00 EUR"
-msgstr "50.00 EUR"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_statement
 msgid "534677881234"
-msgstr "534677881234"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "9.00"
-msgstr "9.00"
+msgstr ""
 
 #. module: account
 #: model:account.payment.term,name:account.account_payment_term_90days_on_the_10th
@@ -954,8 +972,6 @@ msgid ""
 "<span class=\"o_form_label oe_inline\" invisible=\"amount_type != "
 "'percentage'\">%</span>"
 msgstr ""
-"<span class=\"o_form_label oe_inline\" invisible=\"amount_type != "
-"'percentage'\">%</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_tax_form
@@ -963,8 +979,6 @@ msgid ""
 "<span class=\"o_form_label oe_inline\" invisible=\"amount_type == "
 "'fixed'\">%</span>"
 msgstr ""
-"<span class=\"o_form_label oe_inline\" invisible=\"amount_type == "
-"'fixed'\">%</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_reconcile_model_form
@@ -996,9 +1010,6 @@ msgid ""
 "                                        Balance\n"
 "                                    </span>"
 msgstr ""
-"<span class=\"o_stat_text\">\n"
-"                                        Balance\n"
-"                                    </span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_form
@@ -1079,8 +1090,6 @@ msgid ""
 "<span class=\"text-nowrap\">$ <span "
 "class=\"oe_currency_value\">11,750.00</span></span>"
 msgstr ""
-"<span class=\"text-nowrap\">$ <span "
-"class=\"oe_currency_value\">11,750.00</span></span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.bill_preview
@@ -1088,8 +1097,6 @@ msgid ""
 "<span class=\"text-nowrap\">$ <span "
 "class=\"oe_currency_value\">19,250.00</span></span>"
 msgstr ""
-"<span class=\"text-nowrap\">$ <span "
-"class=\"oe_currency_value\">19,250.00</span></span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.bill_preview
@@ -1097,18 +1104,16 @@ msgid ""
 "<span class=\"text-nowrap\">$ <span "
 "class=\"oe_currency_value\">7,500.00</span></span>"
 msgstr ""
-"<span class=\"text-nowrap\">$ <span "
-"class=\"oe_currency_value\">7,500.00</span></span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.bill_preview
 msgid "<span class=\"text-nowrap\">1,500.00</span>"
-msgstr "<span class=\"text-nowrap\">1,500.00</span>"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.bill_preview
 msgid "<span class=\"text-nowrap\">2,350.00</span>"
-msgstr "<span class=\"text-nowrap\">2,350.00</span>"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_partner_bank_form_inherit_account
@@ -1189,7 +1194,7 @@ msgstr "<span> (Reporte de débito)</span>"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
 msgid "<span> = </span>"
-msgstr "<span> = </span>"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_payment_form
@@ -1220,17 +1225,17 @@ msgstr "<span> en </span>"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.bill_preview
 msgid "<span>$ <span class=\"oe_currency_value\">19,250.00</span></span>"
-msgstr "<span>$ <span class=\"oe_currency_value\">19,250.00</span></span>"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
 msgid "<span>1 </span>"
-msgstr "<span>1 </span>"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.bill_preview
 msgid "<span>5.00</span>"
-msgstr "<span>5.00</span>"
+msgstr ""
 
 #. module: account
 #: model_terms:web_tour.tour,rainbow_man_message:account.account_tour
@@ -1253,7 +1258,7 @@ msgstr "<span>Importe</span>"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
 msgid "<span>Balance</span>"
-msgstr "<span>Balance</span>"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.bill_preview
@@ -1270,6 +1275,11 @@ msgstr "<span>Desc.%</span>"
 #: model_terms:ir.ui.view,arch_db:account.view_account_payment_form
 msgid "<span>Draft</span>"
 msgstr "<span>Borrador</span>"
+
+#. module: account
+#: model_terms:ir.ui.view,arch_db:account.account_move_send_wizard_form
+msgid "<span>Followers of the document and</span>"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
@@ -1358,7 +1368,7 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "<strong class=\"mr16\">Subtotal</strong>"
-msgstr "<strong class=\"mr16\">Subtotal</strong>"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
@@ -1398,7 +1408,7 @@ msgstr "<strong>Saldo final</strong>"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "<strong>Incoterm</strong>"
-msgstr "<strong>Incoterm</strong>"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.bill_preview
@@ -1438,7 +1448,7 @@ msgstr "<strong>Balance inicial</strong>"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.bill_preview
 msgid "<strong>Subtotal</strong>"
-msgstr "<strong>Subtotal</strong>"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_currency_form_inherit
@@ -1454,7 +1464,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_template
 msgid "<strong>Total</strong>"
-msgstr "<strong>Total</strong>"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_account_kanban
@@ -1665,6 +1675,18 @@ msgstr "No puede utilizar un número temporal para una conciliación"
 #: model:res.groups,name:account.group_warning_account
 msgid "A warning can be set on a partner (Account)"
 msgstr "Se pueden establecer avisos para los contactos (cuenta)"
+
+#. module: account
+#: model:ir.model.fields,field_description:account.field_account_setup_bank_manual_config__aba_routing
+msgid "ABA/Routing"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_art_a_pagar
+#: model:account.account,name:account.3_base_art_a_pagar
+#: model:account.account,name:account.4_base_art_a_pagar
+msgid "ART to be Paid"
+msgstr "ART a Pagar"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_validate_account_move__abnormal_amount_partner_ids
@@ -1960,7 +1982,7 @@ msgstr "Etiquetas de cuenta"
 #: model_terms:ir.ui.view,arch_db:account.view_tax_form
 #: model_terms:ir.ui.view,arch_db:account.view_tax_tree
 msgid "Account Tax"
-msgstr "Impuestos de cuenta "
+msgstr "Impuestos de cuenta"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_tax_group_form
@@ -2294,6 +2316,41 @@ msgid "Accrued total"
 msgstr "Total devengado"
 
 #. module: account
+#: model:account.account,name:account.2_base_amortizacion_acumulada_derechos_de_marca
+#: model:account.account,name:account.3_base_amortizacion_acumulada_derechos_de_marca
+#: model:account.account,name:account.4_base_amortizacion_acumulada_derechos_de_marca
+msgid "Accumulated amortization Trademark rights"
+msgstr "Amortización acumulada Derechos de marca"
+
+#. module: account
+#: model:account.account,name:account.2_base_amortizacion_acumulada_muebles_utiles
+#: model:account.account,name:account.3_base_amortizacion_acumulada_muebles_utiles
+#: model:account.account,name:account.4_base_amortizacion_acumulada_muebles_utiles
+msgid "Accumulated depreciation furniture and fixtures"
+msgstr "Amortización acumulada muebles y útiles"
+
+#. module: account
+#: model:account.account,name:account.2_base_amortizacion_acumulada_instalaciones
+#: model:account.account,name:account.3_base_amortizacion_acumulada_instalaciones
+#: model:account.account,name:account.4_base_amortizacion_acumulada_instalaciones
+msgid "Accumulated depreciation of facilities"
+msgstr "Amortización acumulada instalaciones"
+
+#. module: account
+#: model:account.account,name:account.2_base_amortizacion_acumulada_maq_y_equipos
+#: model:account.account,name:account.3_base_amortizacion_acumulada_maq_y_equipos
+#: model:account.account,name:account.4_base_amortizacion_acumulada_maq_y_equipos
+msgid "Accumulated depreciation of machinery and equipment"
+msgstr "Amortización acumulada maquinarias y equipos"
+
+#. module: account
+#: model:account.account,name:account.2_base_amortizacion_acumulada_rodados
+#: model:account.account,name:account.3_base_amortizacion_acumulada_rodados
+#: model:account.account,name:account.4_base_amortizacion_acumulada_rodados
+msgid "Accumulated depreciation on wheeled vehicles"
+msgstr "Amortización acumulada rodados"
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_automatic_entry_wizard__action
 #: model:ir.model.fields,field_description:account.field_account_report_line__action_id
 msgid "Action"
@@ -2339,6 +2396,9 @@ msgid "Activate to create sale receipt"
 msgstr "Activar para crear un recibo de venta"
 
 #. module: account
+#: model:account.group,name:account.2_account_group_activo
+#: model:account.group,name:account.3_account_group_activo
+#: model:account.group,name:account.4_account_group_activo
 #: model:ir.model.fields,field_description:account.field_account_account_tag__active
 #: model:ir.model.fields,field_description:account.field_account_fiscal_position__active
 #: model:ir.model.fields,field_description:account.field_account_fiscal_position_tax__tax_dest_active
@@ -2457,7 +2517,7 @@ msgstr "Agregar un enlace a una página web"
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.action_account_form
 msgid "Add a new account"
-msgstr "Agregar una nueva cuenta "
+msgstr "Agregar una nueva cuenta"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
@@ -2535,6 +2595,55 @@ msgstr ""
 "Asiento de ajuste {link} {percent}%% de {amount} reconocido el {new_date}"
 
 #. module: account
+#: model:account.account,name:account.2_base_ajuste_resultados
+#: model:account.account,name:account.3_base_ajuste_resultados
+#: model:account.account,name:account.4_base_ajuste_resultados
+msgid "Adjustment of prior years' results"
+msgstr "Ajuste resultados ejercicios anteriores"
+
+#. module: account
+#: model:account.account,name:account.2_base_honorarios_administracion
+#: model:account.account,name:account.3_base_honorarios_administracion
+#: model:account.account,name:account.4_base_honorarios_administracion
+msgid "Administration Fees"
+msgstr "Honorarios Administración"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_gastos_administrativos
+#: model:account.group,name:account.3_account_group_gastos_administrativos
+#: model:account.group,name:account.4_account_group_gastos_administrativos
+msgid "Administrative Expenses"
+msgstr "Gastos Administrativos"
+
+#. module: account
+#: model:account.account,name:account.2_base_servicio_de_gas_administrativos
+#: model:account.account,name:account.3_base_servicio_de_gas_administrativos
+#: model:account.account,name:account.4_base_servicio_de_gas_administrativos
+msgid "Administrative Gas Service"
+msgstr "Servicio de Gas Administrativos"
+
+#. module: account
+#: model:account.account,name:account.2_base_alquileres_administrativos
+#: model:account.account,name:account.3_base_alquileres_administrativos
+#: model:account.account,name:account.4_base_alquileres_administrativos
+msgid "Administrative Rents"
+msgstr "Alquileres Administrativos"
+
+#. module: account
+#: model:account.account,name:account.2_base_haberes_administrativos
+#: model:account.account,name:account.3_base_haberes_administrativos
+#: model:account.account,name:account.4_base_haberes_administrativos
+msgid "Administrative Salaries and SAC"
+msgstr "Sueldos y SAC Administrativos"
+
+#. module: account
+#: model:account.account,name:account.2_base_cargas_sociales_administrativos
+#: model:account.account,name:account.3_base_cargas_sociales_administrativos
+#: model:account.account,name:account.4_base_cargas_sociales_administrativos
+msgid "Administrative Social Charges"
+msgstr "Cargas Sociales Administrativos"
+
+#. module: account
 #: model:res.groups,name:account.group_account_manager
 msgid "Administrator"
 msgstr "Administrador"
@@ -2548,6 +2657,20 @@ msgstr "Opciones avanzadas"
 #: model_terms:ir.ui.view,arch_db:account.view_account_journal_form
 msgid "Advanced Settings"
 msgstr "Ajustes avanzados"
+
+#. module: account
+#: model:account.account,name:account.2_base_anticipo_proveedores
+#: model:account.account,name:account.3_base_anticipo_proveedores
+#: model:account.account,name:account.4_base_anticipo_proveedores
+msgid "Advances to Suppliers"
+msgstr "Anticipo a Proveedores"
+
+#. module: account
+#: model:account.account,name:account.2_base_publicidad
+#: model:account.account,name:account.3_base_publicidad
+#: model:account.account,name:account.4_base_publicidad
+msgid "Advertising"
+msgstr "Publicidad"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_tax__include_base_amount
@@ -2759,6 +2882,32 @@ msgstr ""
 " moneda extranjera de la línea de débito."
 
 #. module: account
+#: model:ir.model.fields,help:account.field_account_setup_bank_manual_config__aba_routing
+msgid "American Bankers Association Routing Number"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_amortizacion_instalaciones
+#: model:account.account,name:account.3_base_amortizacion_instalaciones
+#: model:account.account,name:account.4_base_amortizacion_instalaciones
+msgid "Amortization of facilities"
+msgstr "Amortización instalaciones"
+
+#. module: account
+#: model:account.account,name:account.2_base_amortizacion_rodados
+#: model:account.account,name:account.3_base_amortizacion_rodados
+#: model:account.account,name:account.4_base_amortizacion_rodados
+msgid "Amortization of rolling stock"
+msgstr "Amortización rodados"
+
+#. module: account
+#: model:account.account,name:account.2_base_amortizacion_derechos_de_marca
+#: model:account.account,name:account.3_base_amortizacion_derechos_de_marca
+#: model:account.account,name:account.4_base_amortizacion_derechos_de_marca
+msgid "Amortization of trademark rights"
+msgstr "Amortización Derechos de marca"
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_accrued_orders_wizard__amount
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__amount
 #: model:ir.model.fields,field_description:account.field_account_partial_reconcile__amount
@@ -2810,7 +2959,7 @@ msgstr "Parámetro de importe mínimo"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_payment__amount_signed
 msgid "Amount Signed"
-msgstr "Importe firmado"
+msgstr "Cantidad firmada"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__match_nature
@@ -3205,7 +3354,7 @@ msgstr "Adjuntar un archivo"
 #. module: account
 #: model:ir.model,name:account.model_ir_attachment
 msgid "Attachment"
-msgstr "Archivo adjunto"
+msgstr "Archivos adjuntos"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__message_attachment_count
@@ -3255,7 +3404,7 @@ msgstr "Mensajes de la pista de auditoría"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_report_expression__auditable
 msgid "Auditable"
-msgstr "Auditable"
+msgstr ""
 
 #. module: account
 #: model:ir.model.fields.selection,name:account.selection__res_company__fiscalyear_last_month__8
@@ -3336,6 +3485,11 @@ msgid "Automatic Entry Default Journal"
 msgstr "Diario predeterminado de asiento automático"
 
 #. module: account
+#: model:account.fiscal.position,name:account.1_account_fiscal_position_avatax_us
+msgid "Automatic Tax Mapping (AvaTax)"
+msgstr ""
+
+#. module: account
 #: model:ir.model,name:account.model_sequence_mixin
 msgid "Automatic sequence"
 msgstr "Secuencia automática"
@@ -3362,6 +3516,13 @@ msgstr "Registrar facturas en automático"
 #: model:ir.model,name:account.model_account_autopost_bills_wizard
 msgid "Autopost Bills Wizard"
 msgstr "Asistente de registro automático de facturas"
+
+#. module: account
+#: model:account.account,name:account.2_base_contrapartida_auxiliar
+#: model:account.account,name:account.3_base_contrapartida_auxiliar
+#: model:account.account,name:account.4_base_contrapartida_auxiliar
+msgid "Auxiliary Counterpart"
+msgstr "Contrapartida Auxiliar"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_report__availability_condition
@@ -3401,13 +3562,20 @@ msgstr "Precio promedio"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_base_document_layout
 msgid "BE71096123456769"
-msgstr "BE71096123456769"
+msgstr ""
 
 #. module: account
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 msgid "BILL"
 msgstr "FACTURA"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_cuentas_puentes
+#: model:account.group,name:account.3_account_group_cuentas_puentes
+#: model:account.group,name:account.4_account_group_cuentas_puentes
+msgid "BRIDGE ACCOUNTS"
+msgstr "CUENTAS PUENTES"
 
 #. module: account
 #. odoo-javascript
@@ -3424,7 +3592,7 @@ msgstr "Regresar a la factura"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "Bacon Burger"
-msgstr "Hamburguesa con tocino "
+msgstr "Hamburguesa con tocino"
 
 #. module: account
 #: model:ir.model.fields.selection,name:account.selection__res_partner__trust__bad
@@ -3434,13 +3602,195 @@ msgstr "Mal deudor"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_line__balance
 msgid "Balance"
-msgstr "Balance"
+msgstr ""
 
 #. module: account
 #. odoo-javascript
 #: code:addons/account/static/src/components/account_type_selection/account_type_selection.js:0
 msgid "Balance Sheet"
 msgstr "Balance General "
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_ba
+#: model:account.account,name:account.3_base_saldo_favor_iibb_ba
+#: model:account.account,name:account.4_base_saldo_favor_iibb_ba
+msgid "Balance in favor IIBB Buenos Aires"
+msgstr "Saldo a favor IIBB Buenos Aires"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_caba
+#: model:account.account,name:account.3_base_saldo_favor_iibb_caba
+#: model:account.account,name:account.4_base_saldo_favor_iibb_caba
+msgid "Balance in favor IIBB CABA"
+msgstr "Saldo a favor IIBB CABA"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_ca
+#: model:account.account,name:account.3_base_saldo_favor_iibb_ca
+#: model:account.account,name:account.4_base_saldo_favor_iibb_ca
+msgid "Balance in favor IIBB Catamarca"
+msgstr "Saldo a favor IIBB Catamarca"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_ha
+#: model:account.account,name:account.3_base_saldo_favor_iibb_ha
+#: model:account.account,name:account.4_base_saldo_favor_iibb_ha
+msgid "Balance in favor IIBB Chaco"
+msgstr "Saldo a favor IIBB Chaco"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_ct
+#: model:account.account,name:account.3_base_saldo_favor_iibb_ct
+#: model:account.account,name:account.4_base_saldo_favor_iibb_ct
+msgid "Balance in favor IIBB Chubut"
+msgstr "Saldo a favor IIBB Chubut"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_rr
+#: model:account.account,name:account.3_base_saldo_favor_iibb_rr
+#: model:account.account,name:account.4_base_saldo_favor_iibb_rr
+msgid "Balance in favor IIBB Corrientes"
+msgstr "Saldo a favor IIBB Corrientes"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_co
+#: model:account.account,name:account.3_base_saldo_favor_iibb_co
+#: model:account.account,name:account.4_base_saldo_favor_iibb_co
+msgid "Balance in favor IIBB Córdoba"
+msgstr "Saldo a favor IIBB Córdoba"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_er
+#: model:account.account,name:account.3_base_saldo_favor_iibb_er
+#: model:account.account,name:account.4_base_saldo_favor_iibb_er
+msgid "Balance in favor IIBB Entre Ríos"
+msgstr "Saldo a favor IIBB Entre Ríos"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_fo
+#: model:account.account,name:account.3_base_saldo_favor_iibb_fo
+#: model:account.account,name:account.4_base_saldo_favor_iibb_fo
+msgid "Balance in favor IIBB Formosa"
+msgstr "Saldo a favor IIBB Formosa"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_ju
+#: model:account.account,name:account.3_base_saldo_favor_iibb_ju
+#: model:account.account,name:account.4_base_saldo_favor_iibb_ju
+msgid "Balance in favor IIBB Jujuy"
+msgstr "Saldo a favor IIBB Jujuy"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_lp
+#: model:account.account,name:account.3_base_saldo_favor_iibb_lp
+#: model:account.account,name:account.4_base_saldo_favor_iibb_lp
+msgid "Balance in favor IIBB La Pampa"
+msgstr "Saldo a favor IIBB La Pampa"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_lr
+#: model:account.account,name:account.3_base_saldo_favor_iibb_lr
+#: model:account.account,name:account.4_base_saldo_favor_iibb_lr
+msgid "Balance in favor IIBB La Rioja"
+msgstr "Saldo a favor IIBB La Rioja"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_za
+#: model:account.account,name:account.3_base_saldo_favor_iibb_za
+#: model:account.account,name:account.4_base_saldo_favor_iibb_za
+msgid "Balance in favor IIBB Mendoza"
+msgstr "Saldo a favor IIBB Mendoza"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_mi
+#: model:account.account,name:account.3_base_saldo_favor_iibb_mi
+#: model:account.account,name:account.4_base_saldo_favor_iibb_mi
+msgid "Balance in favor IIBB Misiones"
+msgstr "Saldo a favor IIBB Misiones"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_ne
+#: model:account.account,name:account.3_base_saldo_favor_iibb_ne
+#: model:account.account,name:account.4_base_saldo_favor_iibb_ne
+msgid "Balance in favor IIBB Neuquén"
+msgstr "Saldo a favor IIBB Neuquén"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_rn
+#: model:account.account,name:account.3_base_saldo_favor_iibb_rn
+#: model:account.account,name:account.4_base_saldo_favor_iibb_rn
+msgid "Balance in favor IIBB Río Negro"
+msgstr "Saldo a favor IIBB Río Negro"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_sa
+#: model:account.account,name:account.3_base_saldo_favor_iibb_sa
+#: model:account.account,name:account.4_base_saldo_favor_iibb_sa
+msgid "Balance in favor IIBB Salta"
+msgstr "Saldo a favor IIBB Salta"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_nn
+#: model:account.account,name:account.3_base_saldo_favor_iibb_nn
+#: model:account.account,name:account.4_base_saldo_favor_iibb_nn
+msgid "Balance in favor IIBB San Juan"
+msgstr "Saldo a favor IIBB San Juan"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_sl
+#: model:account.account,name:account.3_base_saldo_favor_iibb_sl
+#: model:account.account,name:account.4_base_saldo_favor_iibb_sl
+msgid "Balance in favor IIBB San Luis"
+msgstr "Saldo a favor IIBB San Luis"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_az
+#: model:account.account,name:account.3_base_saldo_favor_iibb_az
+#: model:account.account,name:account.4_base_saldo_favor_iibb_az
+msgid "Balance in favor IIBB Santa Cruz"
+msgstr "Saldo a favor IIBB Santa Cruz"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_sf
+#: model:account.account,name:account.3_base_saldo_favor_iibb_sf
+#: model:account.account,name:account.4_base_saldo_favor_iibb_sf
+msgid "Balance in favor IIBB Santa Fe"
+msgstr "Saldo a favor IIBB Santa Fe"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_se
+#: model:account.account,name:account.3_base_saldo_favor_iibb_se
+#: model:account.account,name:account.4_base_saldo_favor_iibb_se
+msgid "Balance in favor IIBB Santiago del Estero"
+msgstr "Saldo a favor IIBB Santiago del Estero"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_tf
+#: model:account.account,name:account.3_base_saldo_favor_iibb_tf
+#: model:account.account,name:account.4_base_saldo_favor_iibb_tf
+msgid "Balance in favor IIBB Tierra del Fuego"
+msgstr "Saldo a favor IIBB Tierra del Fuego"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_iibb_tn
+#: model:account.account,name:account.3_base_saldo_favor_iibb_tn
+#: model:account.account,name:account.4_base_saldo_favor_iibb_tn
+msgid "Balance in favor IIBB Tucumán"
+msgstr "Saldo a favor IIBB Tucumán"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_a_favor_tasa_municipal
+#: model:account.account,name:account.3_base_saldo_a_favor_tasa_municipal
+#: model:account.account,name:account.4_base_saldo_a_favor_tasa_municipal
+msgid "Balance in favor Municipal Tax"
+msgstr "Saldo a favor Tasa Municipal"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_a_favor_suss
+#: model:account.account,name:account.3_base_saldo_a_favor_suss
+#: model:account.account,name:account.4_base_saldo_a_favor_suss
+msgid "Balance in favor SUSS"
+msgstr "Saldo a favor SUSS"
 
 #. module: account
 #. odoo-python
@@ -3452,7 +3802,13 @@ msgstr "El porcentaje de balance no puede ser 0"
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 #: model:account.account,name:account.1_bank_journal_default_account_45
+#: model:account.account,name:account.2_bank_journal_default_account_342
+#: model:account.account,name:account.3_bank_journal_default_account_581
+#: model:account.account,name:account.4_bank_journal_default_account_891
 #: model:account.journal,name:account.1_bank
+#: model:account.journal,name:account.2_bank
+#: model:account.journal,name:account.3_bank
+#: model:account.journal,name:account.4_bank
 #: model:ir.model.fields,field_description:account.field_account_journal__bank_id
 #: model:ir.model.fields,field_description:account.field_account_setup_bank_manual_config__bank_id
 #: model:ir.model.fields,field_description:account.field_res_partner__bank_account_count
@@ -3603,6 +3959,9 @@ msgstr "Suspensión bancaria"
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 #: model:account.account,name:account.1_account_journal_suspense_account_id
+#: model:account.account,name:account.2_account_journal_suspense_account_id
+#: model:account.account,name:account.3_account_journal_suspense_account_id
+#: model:account.account,name:account.4_account_journal_suspense_account_id
 msgid "Bank Suspense Account"
 msgstr "Cuenta transitoria"
 
@@ -3640,6 +3999,13 @@ msgid "Bank and Cash"
 msgstr "Banco y efectivo"
 
 #. module: account
+#: model:account.account,name:account.2_base_gastos_bancarios
+#: model:account.account,name:account.3_base_gastos_bancarios
+#: model:account.account,name:account.4_base_gastos_bancarios
+msgid "Bank charges"
+msgstr "Gastos Bancarios"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_statement
 msgid "Bank of odoo"
 msgstr "Banco de Odoo"
@@ -3671,14 +4037,24 @@ msgid "Bank: Balance"
 msgstr "Banco: balance"
 
 #. module: account
+#: model:account.group,name:account.2_account_group_bancos
+#: model:account.group,name:account.3_account_group_bancos
+#: model:account.group,name:account.4_account_group_bancos
 #: model:ir.ui.menu,name:account.account_banks_menu
 msgid "Banks"
 msgstr "Bancos"
 
 #. module: account
+#: model:account.group,name:account.2_account_group_cajas_y_bancos
+#: model:account.group,name:account.3_account_group_cajas_y_bancos
+#: model:account.group,name:account.4_account_group_cajas_y_bancos
+msgid "Banks and savings"
+msgstr "Cajas y Bancos"
+
+#. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_tax_repartition_line__repartition_type__base
 msgid "Base"
-msgstr "Base"
+msgstr ""
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_tax__is_base_affected
@@ -3776,7 +4152,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_setup_bank_manual_config__bank_bic
 msgid "Bic"
-msgstr "Bic"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
@@ -3866,6 +4242,13 @@ msgid "Blocking Message"
 msgstr "Mensaje de bloqueo"
 
 #. module: account
+#: model:account.account,name:account.2_base_articulos_de_libreria
+#: model:account.account,name:account.3_base_articulos_de_libreria
+#: model:account.account,name:account.4_base_articulos_de_libreria
+msgid "Bookstore items"
+msgstr "Artículos de librería"
+
+#. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_report_column__figure_type__boolean
 #: model:ir.model.fields.selection,name:account.selection__account_report_expression__figure_type__boolean
 msgid "Boolean"
@@ -3930,7 +4313,7 @@ msgstr "Al deseleccionar el campo activo ocultará un INCOTERM que no use."
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 msgid "CABA"
-msgstr "CABA"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -3966,7 +4349,14 @@ msgstr "Importación de formatos CSV, XLS y XLSX"
 #. odoo-python
 #: code:addons/account/models/account_move.py:0
 msgid "CUST"
-msgstr "CUST"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_cadeteria_y_franqueo
+#: model:account.account,name:account.3_base_cadeteria_y_franqueo
+#: model:account.account,name:account.4_base_cadeteria_y_franqueo
+msgid "Cadastre and postage"
+msgstr "Cadeteria y franqueo"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_payment_register__can_edit_wizard
@@ -4089,7 +4479,21 @@ msgstr ""
 #. module: account
 #: model:account.account,name:account.1_capital
 msgid "Capital"
-msgstr "Capital"
+msgstr ""
+
+#. module: account
+#: model:account.group,name:account.2_account_group_capital_social
+#: model:account.group,name:account.3_account_group_capital_social
+#: model:account.group,name:account.4_account_group_capital_social
+msgid "Capital Social"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_ajustes_de_capital
+#: model:account.account,name:account.3_base_ajustes_de_capital
+#: model:account.account,name:account.4_base_ajustes_de_capital
+msgid "Capital adjustments"
+msgstr "Ajustes de capital"
 
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.action_move_in_invoice
@@ -4099,7 +4503,7 @@ msgid ""
 "your vendors."
 msgstr ""
 "Capture facturas, registre pagos y lleve el seguimiento de las "
-"conversaciones con sus proveedores. "
+"conversaciones con sus proveedores."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_report_expression__carryover_target
@@ -4110,7 +4514,13 @@ msgstr "Traspasar a"
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 #: model:account.account,name:account.1_cash_journal_default_account_46
+#: model:account.account,name:account.2_cash_journal_default_account_343
+#: model:account.account,name:account.3_cash_journal_default_account_582
+#: model:account.account,name:account.4_cash_journal_default_account_892
 #: model:account.journal,name:account.1_cash
+#: model:account.journal,name:account.2_cash
+#: model:account.journal,name:account.3_cash
+#: model:account.journal,name:account.4_cash
 #: model:ir.model.fields.selection,name:account.selection__account_journal__type__cash
 #: model_terms:ir.ui.view,arch_db:account.view_account_move_filter
 #: model_terms:ir.ui.view,arch_db:account.view_account_move_line_filter
@@ -4150,6 +4560,9 @@ msgstr "Origen de base de efectivo"
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 #: model:account.journal,name:account.1_caba
+#: model:account.journal,name:account.2_caba
+#: model:account.journal,name:account.3_caba
+#: model:account.journal,name:account.4_caba
 msgid "Cash Basis Taxes"
 msgstr "Impuestos de base de efectivo"
 
@@ -4167,6 +4580,9 @@ msgstr "Gasto por diferencia de efectivo"
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 #: model:account.account,name:account.1_cash_diff_income
+#: model:account.account,name:account.2_default_cash_difference_income_account_id
+#: model:account.account,name:account.3_default_cash_difference_income_account_id
+#: model:account.account,name:account.4_default_cash_difference_income_account_id
 msgid "Cash Difference Gain"
 msgstr "Ganancia por diferencia de efectivo"
 
@@ -4179,6 +4595,9 @@ msgstr "Ingreso por diferencia de efectivo"
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 #: model:account.account,name:account.1_cash_diff_expense
+#: model:account.account,name:account.2_default_cash_difference_expense_account_id
+#: model:account.account,name:account.3_default_cash_difference_expense_account_id
+#: model:account.account,name:account.4_default_cash_difference_expense_account_id
 msgid "Cash Difference Loss"
 msgstr "Pérdida por diferencia de efectivo"
 
@@ -4186,6 +4605,9 @@ msgstr "Pérdida por diferencia de efectivo"
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 #: model:account.account,name:account.1_cash_discount_gain
+#: model:account.account,name:account.2_account_journal_early_pay_discount_gain_account_id
+#: model:account.account,name:account.3_account_journal_early_pay_discount_gain_account_id
+#: model:account.account,name:account.4_account_journal_early_pay_discount_gain_account_id
 msgid "Cash Discount Gain"
 msgstr "Ganancia por descuento de efectivo"
 
@@ -4193,6 +4615,9 @@ msgstr "Ganancia por descuento de efectivo"
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 #: model:account.account,name:account.1_cash_discount_loss
+#: model:account.account,name:account.2_account_journal_early_pay_discount_loss_account_id
+#: model:account.account,name:account.3_account_journal_early_pay_discount_loss_account_id
+#: model:account.account,name:account.4_account_journal_early_pay_discount_loss_account_id
 msgid "Cash Discount Loss"
 msgstr "Pérdida por diferencia de efectivo"
 
@@ -4572,11 +4997,81 @@ msgstr ""
 "claves."
 
 #. module: account
+#: model:account.group,name:account.2_account_group_deudas_comerciales
+#: model:account.group,name:account.3_account_group_deudas_comerciales
+#: model:account.group,name:account.4_account_group_deudas_comerciales
+msgid "Commercial Debts"
+msgstr "Deudas Comerciales"
+
+#. module: account
+#: model:account.account,name:account.2_base_servicios_de_luz_ecomercial
+#: model:account.account,name:account.3_base_servicios_de_luz_ecomercial
+#: model:account.account,name:account.4_base_servicios_de_luz_ecomercial
+msgid "Commercial Electric Service"
+msgstr "Servicio Eléctrico Comercial"
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__commercial_partner_id
 #: model:ir.model.fields,field_description:account.field_account_move__commercial_partner_id
 #: model_terms:ir.ui.view,arch_db:account.account_move_view_activity
 msgid "Commercial Entity"
 msgstr "Entidad comercial"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_gastos_comerciales
+#: model:account.group,name:account.3_account_group_gastos_comerciales
+#: model:account.group,name:account.4_account_group_gastos_comerciales
+msgid "Commercial Expenses"
+msgstr "Gastos Comerciales"
+
+#. module: account
+#: model:account.account,name:account.2_base_honorarios_comercial
+#: model:account.account,name:account.3_base_honorarios_comercial
+#: model:account.account,name:account.4_base_honorarios_comercial
+msgid "Commercial Fees"
+msgstr "Honorarios Comercial"
+
+#. module: account
+#: model:account.account,name:account.2_base_servicio_de_gas_comercial
+#: model:account.account,name:account.3_base_servicio_de_gas_comercial
+#: model:account.account,name:account.4_base_servicio_de_gas_comercial
+msgid "Commercial Gas Service"
+msgstr "Servicio de Gas Comercial"
+
+#. module: account
+#: model:account.account,name:account.2_base_seguros_comercial
+#: model:account.account,name:account.3_base_seguros_comercial
+#: model:account.account,name:account.4_base_seguros_comercial
+msgid "Commercial Insurance"
+msgstr "Seguros Comercial"
+
+#. module: account
+#: model:account.account,name:account.2_base_alquileres_comerciales
+#: model:account.account,name:account.3_base_alquileres_comerciales
+#: model:account.account,name:account.4_base_alquileres_comerciales
+msgid "Commercial Rentals"
+msgstr "Alquileres Comercial"
+
+#. module: account
+#: model:account.account,name:account.2_base_cargas_sociales_comerciales
+#: model:account.account,name:account.3_base_cargas_sociales_comerciales
+#: model:account.account,name:account.4_base_cargas_sociales_comerciales
+msgid "Commercial Social Charges"
+msgstr "Cargas Sociales Comercial"
+
+#. module: account
+#: model:account.account,name:account.2_base_servicio_de_agua_comercial
+#: model:account.account,name:account.3_base_servicio_de_agua_comercial
+#: model:account.account,name:account.4_base_servicio_de_agua_comercial
+msgid "Commercial Water Service"
+msgstr "Servicio de Agua Comercial"
+
+#. module: account
+#: model:account.account,name:account.2_base_comisiones
+#: model:account.account,name:account.3_base_comisiones
+#: model:account.account,name:account.4_base_comisiones
+msgid "Commissions Paid"
+msgstr "Comisiones Pagadas"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_journal__invoice_reference_model
@@ -4854,6 +5349,12 @@ msgstr ""
 
 #. module: account
 #: model:account.account,name:account.1_cost_of_goods_sold
+#: model:account.account,name:account.2_base_cmv
+#: model:account.account,name:account.3_base_cmv
+#: model:account.account,name:account.4_base_cmv
+#: model:account.group,name:account.2_account_group_costo_de_mercadería_vendida
+#: model:account.group,name:account.3_account_group_costo_de_mercadería_vendida
+#: model:account.group,name:account.4_account_group_costo_de_mercadería_vendida
 #: model:ir.model.fields.selection,name:account.selection__account_move_line__display_type__cogs
 msgid "Cost of Goods Sold"
 msgstr "Costo de bienes vendidos"
@@ -4867,6 +5368,13 @@ msgstr "Costo de producción"
 #: model:ir.model.fields.selection,name:account.selection__account_account__account_type__expense_direct_cost
 msgid "Cost of Revenue"
 msgstr "Costo de ingresos"
+
+#. module: account
+#: model:account.account,name:account.2_base_recupero_de_gastos
+#: model:account.account,name:account.3_base_recupero_de_gastos
+#: model:account.account,name:account.4_base_recupero_de_gastos
+msgid "Cost recovery"
+msgstr "Recupero de gastos"
 
 #. module: account
 #. odoo-python
@@ -4980,6 +5488,9 @@ msgstr "Crear asientos automáticos"
 
 #. module: account
 #: model:account.reconcile.model,name:account.1_reconcile_bill
+#: model:account.reconcile.model,name:account.2_reconcile_bill
+#: model:account.reconcile.model,name:account.3_reconcile_bill
+#: model:account.reconcile.model,name:account.4_reconcile_bill
 msgid "Create Bill"
 msgstr "Crear factura"
 
@@ -5495,6 +6006,9 @@ msgstr "Tasa de cambio de la moneda de la empresa a la del documento."
 
 #. module: account
 #: model:account.account,name:account.1_current_assets
+#: model:account.group,name:account.2_account_group_activo_corriente
+#: model:account.group,name:account.3_account_group_activo_corriente
+#: model:account.group,name:account.4_account_group_activo_corriente
 #: model:ir.model.fields.selection,name:account.selection__account_account__account_type__asset_current
 msgid "Current Assets"
 msgstr "Activos circulantes"
@@ -5506,6 +6020,9 @@ msgstr "Balance actual"
 
 #. module: account
 #: model:account.account,name:account.1_current_liabilities
+#: model:account.group,name:account.2_account_group_pasivo_corriente
+#: model:account.group,name:account.3_account_group_pasivo_corriente
+#: model:account.group,name:account.4_account_group_pasivo_corriente
 #: model:ir.model.fields.selection,name:account.selection__account_account__account_type__liability_current
 msgid "Current Liabilities"
 msgstr "Pasivos circulantes"
@@ -5636,6 +6153,13 @@ msgid "Customer Reference"
 msgstr "Referencia del cliente"
 
 #. module: account
+#: model:account.account,name:account.2_base_anticipos_de_clientes
+#: model:account.account,name:account.3_base_anticipos_de_clientes
+#: model:account.account,name:account.4_base_anticipos_de_clientes
+msgid "Customer advances"
+msgstr "Anticipos de clientes"
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_payment__partner_id
 #: model:ir.model.fields,field_description:account.field_account_payment_register__partner_id
 #: model_terms:ir.ui.view,arch_db:account.view_account_payment_search
@@ -5712,7 +6236,7 @@ msgstr "Comprobar la inalterabilidad de datos"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_hash_integrity
 msgid "Data Inalterability Check Report -"
-msgstr "Reporte de inalterabilidad de cheque "
+msgstr "Reporte de inalterabilidad de cheque"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_hash_integrity
@@ -5985,6 +6509,13 @@ msgid "Default Terms and Conditions as a Web page"
 msgstr "Términos y condiciones predeterminados como una página web"
 
 #. module: account
+#: model:account.account,name:account.2_base_default_vat
+#: model:account.account,name:account.3_base_default_vat
+#: model:account.account,name:account.4_base_default_vat
+msgid "Default VAT Payable/Receivable Account"
+msgstr "Cuenta predeterminada de IVA por pagar/por cobrar"
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_journal__alias_defaults
 msgid "Default Values"
 msgstr "Valores predeterminados"
@@ -6030,6 +6561,13 @@ msgstr "Impuestos predeterminados que se utilizan cuando se vende el producto"
 #: model:account.account,name:account.1_deferred_revenue
 msgid "Deferred Revenue"
 msgstr "Ingresos diferidos"
+
+#. module: account
+#: model:account.account,name:account.2_base_cheques_diferidos
+#: model:account.account,name:account.3_base_cheques_diferidos
+#: model:account.account,name:account.4_base_cheques_diferidos
+msgid "Deferred checks payable"
+msgstr "Cheques diferidos a pagar"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_account__allowed_journal_ids
@@ -6111,6 +6649,26 @@ msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
 #. module: account
+#: model:account.account.tag,name:account.demo_ceo_wages_account
+msgid "Demo CEO Wages Account"
+msgstr ""
+
+#. module: account
+#: model:account.account.tag,name:account.demo_capital_account
+msgid "Demo Capital Account"
+msgstr ""
+
+#. module: account
+#: model:account.account.tag,name:account.demo_sale_of_land_account
+msgid "Demo Sale of Land Account"
+msgstr ""
+
+#. module: account
+#: model:account.account.tag,name:account.demo_stock_account
+msgid "Demo Stock Account"
+msgstr ""
+
+#. module: account
 #. odoo-python
 #: code:addons/account/wizard/account_validate_account_move.py:0
 msgid "Depending moves"
@@ -6127,6 +6685,20 @@ msgstr "Obsoleta"
 #: model:ir.model.fields.selection,name:account.selection__account_account__account_type__expense_depreciation
 msgid "Depreciation"
 msgstr "Depreciación"
+
+#. module: account
+#: model:account.account,name:account.2_base_amortizacion_muebles_utiles
+#: model:account.account,name:account.3_base_amortizacion_muebles_utiles
+#: model:account.account,name:account.4_base_amortizacion_muebles_utiles
+msgid "Depreciation of furniture and fixtures"
+msgstr "Amortización muebles y útiles"
+
+#. module: account
+#: model:account.account,name:account.2_base_amortizacion_maq_y_equipos
+#: model:account.account,name:account.3_base_amortizacion_maq_y_equipos
+#: model:account.account,name:account.4_base_amortizacion_maq_y_equipos
+msgid "Depreciation of machinery and equipment"
+msgstr "Amortización maquinarias y equipos"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_tax__description
@@ -6317,6 +6889,13 @@ msgstr "Descuento de %(amount)s si paga hoy"
 #: code:addons/account/models/account_move.py:0
 msgid "Discount of %(amount)s if paid within %(days)s days"
 msgstr "Descuento de %(amount)s si paga en %(days)s días"
+
+#. module: account
+#: model:account.account,name:account.2_base_descuentos_obtenidos
+#: model:account.account,name:account.3_base_descuentos_obtenidos
+#: model:account.account,name:account.4_base_descuentos_obtenidos
+msgid "Discounts Obtained"
+msgstr "Descuentos Obtenidos"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_analytic_applicability__display_account_prefix
@@ -6839,6 +7418,12 @@ msgid "Early payment discounts:"
 msgstr "Descuentos por pago anticipado:"
 
 #. module: account
+#: model:account.account,name:account.2_base_anticipo_ganancias
+#: model:account.account,name:account.4_base_anticipo_ganancias
+msgid "Earnings advance"
+msgstr "Anticipo ganancias"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_line_payment_tree
 #: model_terms:ir.ui.view,arch_db:account.view_move_line_tree
 msgid "Edit"
@@ -6849,6 +7434,20 @@ msgstr "Editar"
 #: model:ir.model.fields,help:account.field_account_move__tax_totals
 msgid "Edit Tax amounts if you encounter rounding issues."
 msgstr "Edite los importes de impuestos si tiene problemas de redondeo."
+
+#. module: account
+#: model:account.account,name:account.2_base_servicio_de_luz_administrativos
+#: model:account.account,name:account.3_base_servicio_de_luz_administrativos
+#: model:account.account,name:account.4_base_servicio_de_luz_administrativos
+msgid "Electrical Service Administrative"
+msgstr "Servicio Eléctrico Administrativos"
+
+#. module: account
+#: model:account.account,name:account.2_base_servicio_de_luz_produccion
+#: model:account.account,name:account.3_base_servicio_de_luz_produccion
+#: model:account.account,name:account.4_base_servicio_de_luz_produccion
+msgid "Electrical Service Production"
+msgstr "Servicio Eléctrico Producción"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_journal_form
@@ -7023,11 +7622,14 @@ msgstr "Descuento por pago anticipado necesario"
 #. module: account
 #. odoo-javascript
 #: code:addons/account/static/src/components/account_type_selection/account_type_selection.js:0
+#: model:account.group,name:account.2_account_group_patrimonio_neto
+#: model:account.group,name:account.3_account_group_patrimonio_neto
+#: model:account.group,name:account.4_account_group_patrimonio_neto
 #: model:ir.model.fields.selection,name:account.selection__account_account__account_type__equity
 #: model:ir.model.fields.selection,name:account.selection__account_account__internal_group__equity
 #: model_terms:ir.ui.view,arch_db:account.view_account_search
 msgid "Equity"
-msgstr "Capital"
+msgstr "Patrimonio Neto"
 
 #. module: account
 #. odoo-python
@@ -7094,11 +7696,21 @@ msgid "Example:"
 msgstr "Ejemplo:"
 
 #. module: account
+#: model:account.group,name:account.2_account_group_bienes_de_cambio
+#: model:account.group,name:account.3_account_group_bienes_de_cambio
+#: model:account.group,name:account.4_account_group_bienes_de_cambio
+msgid "Exchange Assets"
+msgstr "Bienes de Cambio"
+
+#. module: account
 #. odoo-javascript
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 #: code:addons/account/static/src/components/account_payment_field/account_payment.xml:0
 #: model:account.journal,name:account.1_exch
+#: model:account.journal,name:account.2_exch
+#: model:account.journal,name:account.3_exch
+#: model:account.journal,name:account.4_exch
 msgid "Exchange Difference"
 msgstr "Diferencia de cambio"
 
@@ -7119,9 +7731,22 @@ msgid "Exchange difference entries:"
 msgstr "Asientos de diferencia de cambio de divisa:"
 
 #. module: account
+#: model:account.account,name:account.2_base_diferencias_de_cambio
+#: model:account.account,name:account.3_base_diferencias_de_cambio
+#: model:account.account,name:account.4_base_diferencias_de_cambio
+msgid "Exchange differences"
+msgstr "Diferencias de cambio"
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_journal_group__excluded_journal_ids
 msgid "Excluded Journals"
 msgstr "Diarios excluidos"
+
+#. module: account
+#: model_terms:account.tax,description:account.4_ri_tax_vat_exento_compras
+#: model_terms:account.tax,description:account.4_ri_tax_vat_exento_ventas
+msgid "Exempt"
+msgstr ""
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__expects_chart_of_accounts
@@ -7153,6 +7778,9 @@ msgstr "Cuenta acumulada de gastos"
 
 #. module: account
 #: model:account.account,name:account.1_expense
+#: model:account.group,name:account.2_account_group_egresos
+#: model:account.group,name:account.3_account_group_egresos
+#: model:account.group,name:account.4_account_group_egresos
 #: model:ir.model.fields.selection,name:account.selection__account_account__account_type__expense
 #: model_terms:ir.ui.view,arch_db:account.view_account_search
 msgid "Expenses"
@@ -7206,6 +7834,13 @@ msgid "Extra Edis"
 msgstr "EDI adicionales"
 
 #. module: account
+#: model:account.group,name:account.2_account_group_ingresos_extraordinarios
+#: model:account.group,name:account.3_account_group_ingresos_extraordinarios
+#: model:account.group,name:account.4_account_group_ingresos_extraordinarios
+msgid "Extraordinary Income"
+msgstr "Ingresos Extraordinarios"
+
+#. module: account
 #: model:account.incoterms,name:account.incoterm_FAS
 msgid "FREE ALONGSIDE SHIP"
 msgstr "GRATIS JUNTO CON EL ENVÍO"
@@ -7219,6 +7854,16 @@ msgstr "TRANSPORTISTA GRATIS"
 #: model:account.incoterms,name:account.incoterm_FOB
 msgid "FREE ON BOARD"
 msgstr "GRATIS A BORDO"
+
+#. module: account
+#: model:account.account,name:account.2_base_instalaciones
+#: model:account.account,name:account.3_base_instalaciones
+#: model:account.account,name:account.4_base_instalaciones
+#: model:account.group,name:account.2_account_group_instalaciones
+#: model:account.group,name:account.3_account_group_instalaciones
+#: model:account.group,name:account.4_account_group_instalaciones
+msgid "Facilities"
+msgstr "Instalaciones"
 
 #. module: account
 #. odoo-python
@@ -7320,6 +7965,20 @@ msgid "Financial Accounts Prefix"
 msgstr "Prefijo de cuentas financieras"
 
 #. module: account
+#: model:account.group,name:account.2_account_group_deudas_financieras
+#: model:account.group,name:account.3_account_group_deudas_financieras
+#: model:account.group,name:account.4_account_group_deudas_financieras
+msgid "Financial Debts"
+msgstr "Deudas Financieras"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_gastos_financieros
+#: model:account.group,name:account.3_account_group_gastos_financieros
+#: model:account.group,name:account.4_account_group_gastos_financieros
+msgid "Financial Expenses"
+msgstr "Gastos Financieros"
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_analytic_line__journal_id
 msgid "Financial Journal"
 msgstr "Diario financiero"
@@ -7338,6 +7997,13 @@ msgstr "Buscar texto en etiqueta"
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model_partner_mapping__narration_regex
 msgid "Find Text in Notes"
 msgstr "Buscar texto en notas"
+
+#. module: account
+#: model:account.account,name:account.2_base_productos_terminados
+#: model:account.account,name:account.3_base_productos_terminados
+#: model:account.account,name:account.4_base_productos_terminados
+msgid "Finished products"
+msgstr "Productos terminados"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_resequence_wizard__first_date
@@ -7433,7 +8099,7 @@ msgstr "Posiciones fiscales"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.setup_financial_year_opening_form
 msgid "Fiscal Year End"
-msgstr "Fin del año fiscal "
+msgstr "Fin del año fiscal"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_report_external_value__foreign_vat_fiscal_position_id
@@ -7477,9 +8143,19 @@ msgid "Fixed Asset"
 msgstr "Activo fijo"
 
 #. module: account
+#: model:account.group,name:account.2_account_group_activos_fijos
+#: model:account.group,name:account.3_account_group_activos_fijos
+#: model:account.group,name:account.4_account_group_activos_fijos
 #: model:ir.model.fields.selection,name:account.selection__account_account__account_type__asset_fixed
 msgid "Fixed Assets"
-msgstr "Activos fijos"
+msgstr "Activos Fijos"
+
+#. module: account
+#: model:account.account,name:account.2_base_plazo_fijo
+#: model:account.account,name:account.3_base_plazo_fijo
+#: model:account.account,name:account.4_base_plazo_fijo
+msgid "Fixed term"
+msgstr "Plazo fijo"
 
 #. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_report_column__figure_type__float
@@ -7595,6 +8271,20 @@ msgstr ""
 "Obliga a que todos los apuntes contables en esta cuenta tengan una moneda "
 "específica (por ejemplo, los diarios bancarios). Los asientos pueden usar "
 "cualquier moneda si no configura una."
+
+#. module: account
+#: model:account.account,name:account.2_base_prevision_gastos
+#: model:account.account,name:account.3_base_prevision_gastos
+#: model:account.account,name:account.4_base_prevision_gastos
+msgid "Forecast expenses"
+msgstr "Prevision gastos"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_previsiones
+#: model:account.group,name:account.3_account_group_previsiones
+#: model:account.group,name:account.4_account_group_previsiones
+msgid "Forecasts"
+msgstr "Previsiones"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__foreign_currency_id
@@ -7725,7 +8415,7 @@ msgid ""
 msgstr ""
 "Desde este reporte puede obtener un resumen de la cantidad facturada por sus"
 " proveedores. Puede utilizar la herramienta de búsqueda para personalizar "
-"sus reportes de facturas y así ajustar el análisis a sus necesidades. "
+"sus reportes de facturas y así ajustar el análisis a sus necesidades."
 
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.action_account_invoice_report_all
@@ -7750,10 +8440,31 @@ msgid "Full Reconcile"
 msgstr "Conciliación completa"
 
 #. module: account
+#: model:account.group,name:account.2_account_group_muebles_y_útiles
+#: model:account.group,name:account.3_account_group_muebles_y_útiles
+#: model:account.group,name:account.4_account_group_muebles_y_útiles
+msgid "Furniture and Fixtures"
+msgstr "Muebles y Útiles"
+
+#. module: account
+#: model:account.account,name:account.2_base_muebles_y_utiles
+#: model:account.account,name:account.3_base_muebles_y_utiles
+#: model:account.account,name:account.4_base_muebles_y_utiles
+msgid "Furniture and fixtures"
+msgstr "Muebles y útiles"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_invoice_filter
 #: model_terms:ir.ui.view,arch_db:account.view_account_payment_search
 msgid "Future Activities"
 msgstr "Actividades futuras"
+
+#. module: account
+#: model:account.account,name:account.2_base_futuras_inversiones
+#: model:account.account,name:account.3_base_futuras_inversiones
+#: model:account.account,name:account.4_base_futuras_inversiones
+msgid "Future investment reserves"
+msgstr "Reservas futuras inversiones"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.validate_account_move_view
@@ -7776,6 +8487,13 @@ msgstr "Cuenta de ganancias por diferencia de cambio"
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model_line__payment_tolerance_param
 msgid "Gap"
 msgstr "Brecha"
+
+#. module: account
+#: model:account.account,name:account.2_base_servicio_de_gas_produccion
+#: model:account.account,name:account.3_base_servicio_de_gas_produccion
+#: model:account.account,name:account.4_base_servicio_de_gas_produccion
+msgid "Gas Service Production"
+msgstr "Servicio de Gas Producción"
 
 #. module: account
 #. odoo-python
@@ -8065,14 +8783,21 @@ msgid "How total tax amount is computed in orders and invoices"
 msgstr "Cómo se calcula la cantidad total de impuestos en pedidos y facturas"
 
 #. module: account
+#: model:account.account,name:account.2_base_higiene_y_seguridad
+#: model:account.account,name:account.3_base_higiene_y_seguridad
+#: model:account.account,name:account.4_base_higiene_y_seguridad
+msgid "Hygiene and Safety"
+msgstr "Higiene y Seguridad"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_base_document_layout
 msgid "IBAN"
-msgstr "IBAN"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document_preview
 msgid "IBAN: BE76 4294 6878 9995"
-msgstr "IBAN: BE76 4294 6878 9995"
+msgstr ""
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__id
@@ -8126,33 +8851,542 @@ msgstr "IBAN: BE76 4294 6878 9995"
 #: model:ir.model.fields,field_description:account.field_account_tax_repartition_line__id
 #: model:ir.model.fields,field_description:account.field_validate_account_move__id
 msgid "ID"
-msgstr "ID"
+msgstr ""
+
+#. module: account
+#: model:account.group,name:account.2_account_group_iibb
+#: model:account.group,name:account.3_account_group_iibb
+#: model:account.group,name:account.4_account_group_iibb
+msgid "IIBB"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_ba
+#: model:account.account,name:account.3_base_impuestos_iibb_ba
+#: model:account.account,name:account.4_base_impuestos_iibb_ba
+msgid "IIBB ARBA"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_ba_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_ba_aplicada
+msgid "IIBB ARBA withholding applied"
+msgstr "Retención IIBB ARBA aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_ba_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_ba_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_ba_sufrida
+msgid "IIBB Buenos Aires withholding tax incurred"
+msgstr "Retención IIBB Buenos Aires sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_caba
+#: model:account.account,name:account.3_base_impuestos_iibb_caba
+#: model:account.account,name:account.4_base_impuestos_iibb_caba
+msgid "IIBB CABA"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_caba_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_caba_aplicada
+msgid "IIBB CABA withholding applied"
+msgstr "Retención IIBB CABA aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_caba_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_caba_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_caba_sufrida
+msgid "IIBB CABA withholding incurred"
+msgstr "Retención IIBB CABA sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_ca
+#: model:account.account,name:account.3_base_impuestos_iibb_ca
+#: model:account.account,name:account.4_base_impuestos_iibb_ca
+msgid "IIBB Catamarca"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_ha
+#: model:account.account,name:account.3_base_impuestos_iibb_ha
+#: model:account.account,name:account.4_base_impuestos_iibb_ha
+msgid "IIBB Chaco"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_ha_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_ha_aplicada
+msgid "IIBB Chaco withholding applied"
+msgstr "Retención IIBB Chaco aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_ha_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_ha_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_ha_sufrida
+msgid "IIBB Chaco withholding incurred"
+msgstr "Retención IIBB Chaco sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_ct
+#: model:account.account,name:account.3_base_impuestos_iibb_ct
+#: model:account.account,name:account.4_base_impuestos_iibb_ct
+msgid "IIBB Chubut"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_ct_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_ct_aplicada
+msgid "IIBB Chubut withholding applied"
+msgstr "Retención IIBB Chubut aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_ct_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_ct_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_ct_sufrida
+msgid "IIBB Chubut withholding incurred"
+msgstr "Retención IIBB Chubut sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_rr
+#: model:account.account,name:account.3_base_impuestos_iibb_rr
+#: model:account.account,name:account.4_base_impuestos_iibb_rr
+msgid "IIBB Corrientes"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_rr_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_rr_aplicada
+msgid "IIBB Corrientes withholding applied"
+msgstr "Retención IIBB Corrientes aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_rr_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_rr_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_rr_sufrida
+msgid "IIBB Corrientes withholding incurred"
+msgstr "Retención IIBB Corrientes sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_co
+#: model:account.account,name:account.3_base_impuestos_iibb_co
+#: model:account.account,name:account.4_base_impuestos_iibb_co
+msgid "IIBB Córdoba"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_co_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_co_aplicada
+msgid "IIBB Córdoba withholding applied"
+msgstr "Retención IIBB Córdoba aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_co_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_co_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_co_sufrida
+msgid "IIBB Córdoba withholding tax incurred"
+msgstr "Retención IIBB Córdoba sufrida"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_deudas_iibb
+#: model:account.group,name:account.3_account_group_deudas_iibb
+#: model:account.group,name:account.4_account_group_deudas_iibb
+msgid "IIBB Debts"
+msgstr "Deudas IIBB"
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_er
+#: model:account.account,name:account.3_base_impuestos_iibb_er
+#: model:account.account,name:account.4_base_impuestos_iibb_er
+msgid "IIBB Entre Ríos"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_fo
+#: model:account.account,name:account.3_base_impuestos_iibb_fo
+#: model:account.account,name:account.4_base_impuestos_iibb_fo
+msgid "IIBB Formosa"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_fo_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_fo_aplicada
+msgid "IIBB Formosa withholding applied"
+msgstr "Retención IIBB Formosa aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_fo_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_fo_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_fo_sufrida
+msgid "IIBB Formosa withholding incurred"
+msgstr "Retención IIBB Formosa sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_ju
+#: model:account.account,name:account.3_base_impuestos_iibb_ju
+#: model:account.account,name:account.4_base_impuestos_iibb_ju
+msgid "IIBB Jujuy"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_ju_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_ju_aplicada
+msgid "IIBB Jujuy withholding applied"
+msgstr "Retención IIBB Jujuy aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_ju_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_ju_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_ju_sufrida
+msgid "IIBB Jujuy withholding incurred"
+msgstr "Retención IIBB Jujuy sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_lp
+#: model:account.account,name:account.3_base_impuestos_iibb_lp
+#: model:account.account,name:account.4_base_impuestos_iibb_lp
+msgid "IIBB La Pampa"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_lr
+#: model:account.account,name:account.3_base_impuestos_iibb_lr
+#: model:account.account,name:account.4_base_impuestos_iibb_lr
+msgid "IIBB La Rioja"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_za
+#: model:account.account,name:account.3_base_impuestos_iibb_za
+#: model:account.account,name:account.4_base_impuestos_iibb_za
+msgid "IIBB Mendoza"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_za_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_za_aplicada
+msgid "IIBB Mendoza withholding applied"
+msgstr "Retención IIBB Mendoza aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_za_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_za_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_za_sufrida
+msgid "IIBB Mendoza withholding incurred"
+msgstr "Retención IIBB Mendoza sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_mi
+#: model:account.account,name:account.3_base_impuestos_iibb_mi
+#: model:account.account,name:account.4_base_impuestos_iibb_mi
+msgid "IIBB Misiones"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_mi_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_mi_aplicada
+msgid "IIBB Misiones withholding applied"
+msgstr "Retención IIBB Misiones aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_mi_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_mi_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_mi_sufrida
+msgid "IIBB Misiones withholding incurred"
+msgstr "Retención IIBB Misiones sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_ne
+#: model:account.account,name:account.3_base_impuestos_iibb_ne
+#: model:account.account,name:account.4_base_impuestos_iibb_ne
+msgid "IIBB Neuquén"
+msgstr ""
+
+#. module: account
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb
+msgid "IIBB Perceptions"
+msgstr "IIBB Percepciones"
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_rn
+#: model:account.account,name:account.3_base_impuestos_iibb_rn
+#: model:account.account,name:account.4_base_impuestos_iibb_rn
+msgid "IIBB Río Negro"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_sa
+#: model:account.account,name:account.3_base_impuestos_iibb_sa
+#: model:account.account,name:account.4_base_impuestos_iibb_sa
+msgid "IIBB Salta"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_nn
+#: model:account.account,name:account.3_base_impuestos_iibb_nn
+#: model:account.account,name:account.4_base_impuestos_iibb_nn
+msgid "IIBB San Juan"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_sl
+#: model:account.account,name:account.3_base_impuestos_iibb_sl
+#: model:account.account,name:account.4_base_impuestos_iibb_sl
+msgid "IIBB San Luis"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_az
+#: model:account.account,name:account.3_base_impuestos_iibb_az
+#: model:account.account,name:account.4_base_impuestos_iibb_az
+msgid "IIBB Santa Cruz"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_sf
+#: model:account.account,name:account.3_base_impuestos_iibb_sf
+#: model:account.account,name:account.4_base_impuestos_iibb_sf
+msgid "IIBB Santa Fe"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_se
+#: model:account.account,name:account.3_base_impuestos_iibb_se
+#: model:account.account,name:account.4_base_impuestos_iibb_se
+msgid "IIBB Santiago del Estero"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_se_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_se_aplicada
+msgid "IIBB Santiago del Estero withholding applied"
+msgstr "Retención IIBB Santiago del Estero aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_se_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_se_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_se_sufrida
+msgid "IIBB Santiago del Estero withholding incurred"
+msgstr "Retención IIBB Santiago del Estero sufrida"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_creditos_fiscales_iibb
+#: model:account.group,name:account.3_account_group_creditos_fiscales_iibb
+#: model:account.group,name:account.4_account_group_creditos_fiscales_iibb
+msgid "IIBB Tax Credits"
+msgstr "Créditos Fiscales IIBB"
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_tf
+#: model:account.account,name:account.3_base_impuestos_iibb_tf
+#: model:account.account,name:account.4_base_impuestos_iibb_tf
+msgid "IIBB Tierra del Fuego"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_iibb_tn
+#: model:account.account,name:account.3_base_impuestos_iibb_tn
+#: model:account.account,name:account.4_base_impuestos_iibb_tn
+msgid "IIBB Tucumán"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_iibb_a_pagar
+#: model:account.account,name:account.3_base_iibb_a_pagar
+#: model:account.account,name:account.4_base_iibb_a_pagar
+msgid "IIBB a pagar"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_base_plan_de_iibb_a_pagar
+#: model:account.account,name:account.3_base_plan_de_iibb_a_pagar
+#: model:account.account,name:account.4_base_plan_de_iibb_a_pagar
+msgid "IIBB plan to be paid"
+msgstr "Plan de IIBB a pagar"
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_ca_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_ca_aplicada
+msgid "IIBB withholding Catamarca applied"
+msgstr "Retención IIBB Catamarca aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_ca_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_ca_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_ca_sufrida
+msgid "IIBB withholding Catamarca incurred"
+msgstr "Retención IIBB Catamarca sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_er_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_er_aplicada
+msgid "IIBB withholding Entre Río applied"
+msgstr "Retención IIBB Entre Río aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_er_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_er_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_er_sufrida
+msgid "IIBB withholding Entre Ríos incurred"
+msgstr "Retención IIBB Entre Ríos sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_sa_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_sa_aplicada
+msgid "IIBB withholding IIBB Salta applied"
+msgstr "Retención IIBB Salta aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_sa_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_sa_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_sa_sufrida
+msgid "IIBB withholding IIBB Salta incurred"
+msgstr "Retención IIBB Salta sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_lp_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_lp_aplicada
+msgid "IIBB withholding La Pampa applied"
+msgstr "Retención IIBB La Pampa aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_lp_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_lp_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_lp_sufrida
+msgid "IIBB withholding La Pampa incurred"
+msgstr "Retención IIBB La Pampa sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_lr_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_lr_aplicada
+msgid "IIBB withholding La Rioja applied"
+msgstr "Retención IIBB La Rioja aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_lr_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_lr_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_lr_sufrida
+msgid "IIBB withholding La Rioja incurred"
+msgstr "Retención IIBB La Rioja sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_ne_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_ne_aplicada
+msgid "IIBB withholding Neuquén applied"
+msgstr "Retención IIBB Neuquén aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_ne_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_ne_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_ne_sufrida
+msgid "IIBB withholding Neuquén incurred"
+msgstr "Retención IIBB Neuquén sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_rn_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_rn_aplicada
+msgid "IIBB withholding Rio Negro applied"
+msgstr "Retención IIBB Río Negro aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_rn_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_rn_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_rn_sufrida
+msgid "IIBB withholding Rio Negro incurred"
+msgstr "Retención IIBB Río Negro sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_nn_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_nn_aplicada
+msgid "IIBB withholding San Juan applied"
+msgstr "Retención IIBB San Juan aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_nn_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_nn_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_nn_sufrida
+msgid "IIBB withholding San Juan incurred"
+msgstr "Retención IIBB San Juan sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_sl_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_sl_aplicada
+msgid "IIBB withholding San Luis applied"
+msgstr "Retención IIBB San Luis aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_sl_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_sl_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_sl_sufrida
+msgid "IIBB withholding San Luis incurred"
+msgstr "Retención IIBB San Luis sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_az_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_az_aplicada
+msgid "IIBB withholding Santa Cruz applied"
+msgstr "Retención IIBB Santa Cruz aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_az_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_az_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_az_sufrida
+msgid "IIBB withholding Santa Cruz incurred"
+msgstr "Retención IIBB Santa Cruz sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_tf_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_tf_aplicada
+msgid "IIBB withholding Tierra del Fuego applied"
+msgstr "Retención IIBB Tierra del Fuego aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_tf_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_tf_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_tf_sufrida
+msgid "IIBB withholding Tierra del Fuego incurred"
+msgstr "Retención IIBB Tierra del Fuego sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_tn_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_tn_aplicada
+msgid "IIBB withholding Tucumán applied"
+msgstr "Retención IIBB Tucumán aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_tn_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_tn_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_tn_sufrida
+msgid "IIBB withholding Tucumán incurred"
+msgstr "Retención IIBB Tucumán sufrida"
 
 #. module: account
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 msgid "INV"
-msgstr "INV"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "INV/2023/00001"
-msgstr "INV/2023/00001"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "INV/2023/0001"
-msgstr "INV/2023/0001"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
 msgid "INV0001"
-msgstr "INV0001"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
 msgid "INV001"
-msgstr "INV001"
+msgstr ""
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__activity_exception_icon
@@ -8484,7 +9718,7 @@ msgstr "En proceso"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_default_terms_and_conditions
 msgid "In order for it to be admissible,"
-msgstr "Para que sea admisible, "
+msgstr "Para que sea admisible,"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
@@ -8555,6 +9789,52 @@ msgid "Income Account"
 msgstr "Cuenta de ingresos"
 
 #. module: account
+#: model:account.group,name:account.2_account_group_imp_a_las_ganancias
+#: model:account.group,name:account.3_account_group_imp_a_las_ganancias
+#: model:account.group,name:account.4_account_group_imp_a_las_ganancias
+msgid "Income Tax"
+msgstr "Imp a las Ganancias"
+
+#. module: account
+#: model:account.account,name:account.2_base_anticipos_imp_a_las_ganancias_a_pagar
+#: model:account.account,name:account.4_base_anticipos_imp_a_las_ganancias_a_pagar
+msgid "Income Tax Advances Payable"
+msgstr "Anticipos Imp a las Ganancias a Pagar"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_deudas_imp_ganancias
+#: model:account.group,name:account.3_account_group_deudas_imp_ganancias
+#: model:account.group,name:account.4_account_group_deudas_imp_ganancias
+msgid "Income Tax Debts"
+msgstr "Deudas Imp. Ganancias"
+
+#. module: account
+#: model:account.account,name:account.2_base_impuestos_a_las_ganancias
+#: model:account.account,name:account.4_base_impuestos_a_las_ganancias
+msgid "Income Taxes"
+msgstr "Impuestos a las ganancias"
+
+#. module: account
+#: model:account.account,name:account.2_base_resultado_del_ejercicio
+#: model:account.account,name:account.3_base_resultado_del_ejercicio
+#: model:account.account,name:account.4_base_resultado_del_ejercicio
+msgid "Income for the year"
+msgstr "Resultado del ejercicio"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_ingresos_por_resultados_financieros
+#: model:account.group,name:account.3_account_group_ingresos_por_resultados_financieros
+#: model:account.group,name:account.4_account_group_ingresos_por_resultados_financieros
+msgid "Income from financial results"
+msgstr "Ingresos por resultados financieros"
+
+#. module: account
+#: model:account.account,name:account.2_base_impuesto_ganancias_a_pagar
+#: model:account.account,name:account.4_base_impuesto_ganancias_a_pagar
+msgid "Income tax payable"
+msgstr "Impuesto a las ganancias a pagar"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_journal_form
 msgid "Incoming Payments"
 msgstr "Pagos entrantes"
@@ -8573,7 +9853,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__invoice_incoterm_id
 #: model:ir.model.fields,field_description:account.field_account_move__invoice_incoterm_id
 msgid "Incoterm"
-msgstr "Incoterm"
+msgstr ""
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__incoterm_location
@@ -8594,7 +9874,7 @@ msgstr "Código estándar del Incoterm"
 #: model_terms:ir.ui.view,arch_db:account.account_incoterms_view_search
 #: model_terms:ir.ui.view,arch_db:account.view_incoterms_tree
 msgid "Incoterms"
-msgstr "Incoterms"
+msgstr ""
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_incoterms__name
@@ -8614,7 +9894,7 @@ msgid ""
 "buyer and seller."
 msgstr ""
 "Los Incoterms se usan para dividir los costos de transacción y determinar "
-"las obligaciones del comprador y vendedor. "
+"las obligaciones del comprador y vendedor."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_move_line__tax_line_id
@@ -8649,6 +9929,27 @@ msgid "Installments Switch Html"
 msgstr "HTML del botón de cuotas"
 
 #. module: account
+#: model:account.account,name:account.2_base_seguros_administracion
+#: model:account.account,name:account.3_base_seguros_administracion
+#: model:account.account,name:account.4_base_seguros_administracion
+msgid "Insurance Administration"
+msgstr "Seguros Administración"
+
+#. module: account
+#: model:account.account,name:account.2_base_seguros_produccion
+#: model:account.account,name:account.3_base_seguros_produccion
+#: model:account.account,name:account.4_base_seguros_produccion
+msgid "Insurance Production"
+msgstr "Seguros Producción"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_activos_intangibles
+#: model:account.group,name:account.3_account_group_activos_intangibles
+#: model:account.group,name:account.4_account_group_activos_intangibles
+msgid "Intangible Assets"
+msgstr "Activos Intangibles"
+
+#. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_report_column__figure_type__integer
 #: model:ir.model.fields.selection,name:account.selection__account_report_expression__figure_type__integer
 msgid "Integer"
@@ -8663,6 +9964,34 @@ msgstr "Redondeo de enteros"
 #: model:ir.model.fields,field_description:account.field_res_company__transfer_account_id
 msgid "Inter-Banks Transfer Account"
 msgstr "Cuenta de transferencias interbancarias"
+
+#. module: account
+#: model:account.account,name:account.2_base_resultado_intereses_ganados
+#: model:account.account,name:account.3_base_resultado_intereses_ganados
+#: model:account.account,name:account.4_base_resultado_intereses_ganados
+msgid "Interest earned"
+msgstr "Intereses ganados"
+
+#. module: account
+#: model:account.account,name:account.2_base_resultado_intereses_y_recargos
+#: model:account.account,name:account.3_base_resultado_intereses_y_recargos
+#: model:account.account,name:account.4_base_resultado_intereses_y_recargos
+msgid "Interest on loans"
+msgstr "Intereses por préstamos"
+
+#. module: account
+#: model:account.account,name:account.2_base_intereses_por_venta_de_valores
+#: model:account.account,name:account.3_base_intereses_por_venta_de_valores
+#: model:account.account,name:account.4_base_intereses_por_venta_de_valores
+msgid "Interest on sale of securities"
+msgstr "Intereses por venta de valores"
+
+#. module: account
+#: model:account.account,name:account.2_base_intereses_a_pagar
+#: model:account.account,name:account.3_base_intereses_a_pagar
+#: model:account.account,name:account.4_base_intereses_a_pagar
+msgid "Interest payable"
+msgstr "Intereses a pagar"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_res_config_settings__transfer_account_id
@@ -8698,6 +10027,13 @@ msgid "Internal Reference"
 msgstr "Referencia interna"
 
 #. module: account
+#: model:account.tax.group,name:account.2_tax_impuestos_internos
+#: model:account.tax.group,name:account.3_tax_impuestos_internos
+#: model:account.tax.group,name:account.4_tax_impuestos_internos
+msgid "Internal Taxes"
+msgstr "Impuestos internos"
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__transfer_account_id
 msgid "Internal Transfer"
 msgstr "Transferencia interna"
@@ -8706,6 +10042,9 @@ msgstr "Transferencia interna"
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 #: model:account.reconcile.model,name:account.1_internal_transfer_reco
+#: model:account.reconcile.model,name:account.2_internal_transfer_reco
+#: model:account.reconcile.model,name:account.3_internal_transfer_reco
+#: model:account.reconcile.model,name:account.4_internal_transfer_reco
 #: model:ir.actions.act_window,name:account.action_account_payments_transfer
 msgid "Internal Transfers"
 msgstr "Transferencias internas"
@@ -8774,9 +10113,16 @@ msgstr ""
 " usados en las transacciones internacionales."
 
 #. module: account
+#: model:account.account,name:account.2_base_servicio_de_internet
+#: model:account.account,name:account.3_base_servicio_de_internet
+#: model:account.account,name:account.4_base_servicio_de_internet
+msgid "Internet Service"
+msgstr "Servicio de Internet"
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__module_account_intrastat
 msgid "Intrastat"
-msgstr "Intrastat"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_bank_statement_search
@@ -8822,6 +10168,13 @@ msgstr "Invertir etiquetas"
 #: model:account.account.tag,name:account.account_tag_investing
 msgid "Investing & Extraordinary Activities"
 msgstr "Actividades de inversión y extraordinarias"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_inversiones
+#: model:account.group,name:account.3_account_group_inversiones
+#: model:account.group,name:account.4_account_group_inversiones
+msgid "Investments"
+msgstr "Inversiones"
 
 #. module: account
 #. odoo-python
@@ -9172,6 +10525,9 @@ msgstr "Facturas cuyos apuntes contables se conciliaron con estos pagos."
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 #: model:account.reconcile.model,name:account.1_reconcile_partial_underpaid
+#: model:account.reconcile.model,name:account.2_reconcile_partial_underpaid
+#: model:account.reconcile.model,name:account.3_reconcile_partial_underpaid
+#: model:account.reconcile.model,name:account.4_reconcile_partial_underpaid
 msgid "Invoices/Bills Partial Match if Underpaid"
 msgstr "Coincidencia parcial si hay pagos parciales en facturas"
 
@@ -9179,6 +10535,9 @@ msgstr "Coincidencia parcial si hay pagos parciales en facturas"
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 #: model:account.reconcile.model,name:account.1_reconcile_perfect_match
+#: model:account.reconcile.model,name:account.2_reconcile_perfect_match
+#: model:account.reconcile.model,name:account.3_reconcile_perfect_match
+#: model:account.reconcile.model,name:account.4_reconcile_perfect_match
 msgid "Invoices/Bills Perfect Match"
 msgstr "Coincidencia perfecta de facturas"
 
@@ -9932,6 +11291,13 @@ msgid "Legal mentions that have to be printed on the invoices."
 msgstr "Menciones legales que se tienen que imprimir en las facturas."
 
 #. module: account
+#: model:account.account,name:account.2_base_reserva_legal
+#: model:account.account,name:account.3_base_reserva_legal
+#: model:account.account,name:account.4_base_reserva_legal
+msgid "Legal reserve"
+msgstr "Reserva legal"
+
+#. module: account
 #. odoo-python
 #: code:addons/account/models/account_move.py:0
 msgid "Less Payment"
@@ -9977,6 +11343,20 @@ msgid "Liability"
 msgstr "Pasivo"
 
 #. module: account
+#: model:account.account,name:account.2_base_embargos_a_depositar
+#: model:account.account,name:account.3_base_embargos_a_depositar
+#: model:account.account,name:account.4_base_embargos_a_depositar
+msgid "Liens to be deposited"
+msgstr "Embargos a depositar"
+
+#. module: account
+#: model:account.account,name:account.2_base_seguro_de_vida_a_pagar
+#: model:account.account,name:account.3_base_seguro_de_vida_a_pagar
+#: model:account.account,name:account.4_base_seguro_de_vida_a_pagar
+msgid "Life Insurance to be Paid"
+msgstr "Seguro de Vida a Pagar"
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__line_ids
 msgid "Line"
 msgstr "Línea"
@@ -9999,6 +11379,11 @@ msgid "Line \"%s\" defines itself as its parent."
 msgstr "La línea \"%s\" se define a sí misma como su línea principal. "
 
 #. module: account
+#: model:account.reconcile.model,name:account.1_reconcile_from_label
+msgid "Line with Bank Fees"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_report__line_ids
 msgid "Lines"
 msgstr "Líneas"
@@ -10018,6 +11403,9 @@ msgstr "Liquidez"
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 #: model:account.account,name:account.1_transfer_account_id
+#: model:account.account,name:account.2_transfer_account_id
+#: model:account.account,name:account.3_transfer_account_id
+#: model:account.account,name:account.4_transfer_account_id
 msgid "Liquidity Transfer"
 msgstr "Transferencia de liquidez"
 
@@ -10025,6 +11413,13 @@ msgstr "Transferencia de liquidez"
 #: model:ir.model.fields,field_description:account.field_account_report__load_more_limit
 msgid "Load More Limit"
 msgstr "Cargar más límite"
+
+#. module: account
+#: model:account.account,name:account.2_base_prestamo_banco_x
+#: model:account.account,name:account.3_base_prestamo_banco_x
+#: model:account.account,name:account.4_base_prestamo_banco_x
+msgid "Loan Bank xxxxx"
+msgstr "Prestamo Banco xxxxx"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
@@ -10056,7 +11451,21 @@ msgstr "Bloquear campos de crédito"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.bill_preview
 msgid "Logo"
-msgstr "Logo"
+msgstr ""
+
+#. module: account
+#: model:account.group,name:account.2_account_group_deudas_comerciales_a_largo_plazo
+#: model:account.group,name:account.3_account_group_deudas_comerciales_a_largo_plazo
+#: model:account.group,name:account.4_account_group_deudas_comerciales_a_largo_plazo
+msgid "Long-Term Commercial Debts"
+msgstr "Deudas Comerciales a Largo Plazo"
+
+#. module: account
+#: model:account.account,name:account.2_base_proveedores_largo_plazo
+#: model:account.account,name:account.3_base_proveedores_largo_plazo
+#: model:account.account,name:account.4_base_proveedores_largo_plazo
+msgid "Long-term debt Suppliers"
+msgstr "Deudas Proveedores a largo plazo"
 
 #. module: account
 #: model:onboarding.onboarding.step,done_text:account.onboarding_onboarding_step_base_document_layout
@@ -10086,6 +11495,20 @@ msgstr "Cuenta de pérdida por diferencia de cambio"
 #: code:addons/account/models/chart_template.py:0
 msgid "MISC"
 msgstr "VARIOS"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_maquinarias_y_equipos
+#: model:account.group,name:account.3_account_group_maquinarias_y_equipos
+#: model:account.group,name:account.4_account_group_maquinarias_y_equipos
+msgid "Machinery and Equipment"
+msgstr "Maquinarias y Equipos"
+
+#. module: account
+#: model:account.account,name:account.2_base_maq_y_equipos
+#: model:account.account,name:account.3_base_maq_y_equipos
+#: model:account.account,name:account.4_base_maq_y_equipos
+msgid "Machinery and equipment"
+msgstr "Maquinarias y equipos"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__made_sequence_gap
@@ -10118,7 +11541,7 @@ msgstr "Archivo adjunto principal"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Main Currency"
-msgstr "Moneda principal "
+msgstr "Moneda principal"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_report__commercial_partner_id
@@ -10134,6 +11557,20 @@ msgstr "Moneda principal de la empresa."
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Main currency of your company"
 msgstr "Moneda principal de su empresa"
+
+#. module: account
+#: model:account.account,name:account.2_base_mantenimiento_y_reparaciones_produccion
+#: model:account.account,name:account.3_base_mantenimiento_y_reparaciones_produccion
+#: model:account.account,name:account.4_base_mantenimiento_y_reparaciones_produccion
+msgid "Maintenance and Repairs Production"
+msgstr "Mantenimiento y Reparaciones Producción"
+
+#. module: account
+#: model:account.account,name:account.2_base_mantenimiento_y_limpieza
+#: model:account.account,name:account.3_base_mantenimiento_y_limpieza
+#: model:account.account,name:account.4_base_mantenimiento_y_limpieza
+msgid "Maintenance and cleaning"
+msgstr "Mantenimiento y limpieza"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_accrued_orders_wizard
@@ -10225,7 +11662,7 @@ msgstr "Mapeo de los códigos de cuenta por empresa"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_statement
 msgid "Marc Demo"
-msgstr "Marc Demo"
+msgstr ""
 
 #. module: account
 #: model:ir.model.fields.selection,name:account.selection__res_company__fiscalyear_last_month__3
@@ -10365,14 +11802,14 @@ msgstr "Mayo"
 #: model:ir.model.fields,field_description:account.field_account_payment_register__communication
 #: model_terms:ir.ui.view,arch_db:account.view_account_payment_form
 msgid "Memo"
-msgstr "Memo"
+msgstr ""
 
 #. module: account
 #. odoo-javascript
 #: code:addons/account/static/src/components/account_payment_field/account_payment.xml:0
 #: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
 msgid "Memo:"
-msgstr "Memo:"
+msgstr ""
 
 #. module: account
 #: model:ir.model,name:account.model_ir_ui_menu
@@ -10464,11 +11901,35 @@ msgid "Miscellaneous"
 msgstr "Varios"
 
 #. module: account
+#: model:account.account,name:account.2_base_gastos_varios_administrativos
+#: model:account.account,name:account.3_base_gastos_varios_administrativos
+#: model:account.account,name:account.4_base_gastos_varios_administrativos
+msgid "Miscellaneous Administrative Expenses"
+msgstr "Gastos varios Administrativos"
+
+#. module: account
+#: model:account.account,name:account.2_base_gastos_varios_comerciales
+#: model:account.account,name:account.3_base_gastos_varios_comerciales
+#: model:account.account,name:account.4_base_gastos_varios_comerciales
+msgid "Miscellaneous Commercial"
+msgstr "Gastos Varios Comercial"
+
+#. module: account
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 #: model:account.journal,name:account.1_general
+#: model:account.journal,name:account.2_general
+#: model:account.journal,name:account.3_general
+#: model:account.journal,name:account.4_general
 msgid "Miscellaneous Operations"
 msgstr "Operaciones varias"
+
+#. module: account
+#: model:account.account,name:account.2_base_gastos_varios_produccion
+#: model:account.account,name:account.3_base_gastos_varios_produccion
+#: model:account.account,name:account.4_base_gastos_varios_produccion
+msgid "Miscellaneous Production"
+msgstr "Gastos Varios Producción"
 
 #. module: account
 #. odoo-python
@@ -10500,6 +11961,13 @@ msgstr "Faltan las divisas extranjeras en los parciales con ID: %s"
 #: model:ir.model.constraint,message:account.constraint_account_move_line_check_accountable_required_fields
 msgid "Missing required account on accountable line."
 msgstr "Falta la cuenta requerida en la línea contable."
+
+#. module: account
+#: model:account.account,name:account.2_base_movilidad_y_viaticos
+#: model:account.account,name:account.3_base_movilidad_y_viaticos
+#: model:account.account,name:account.4_base_movilidad_y_viaticos
+msgid "Mobility and per diems"
+msgstr "Movilidad y viáticos"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model_line__model_id
@@ -10605,6 +12073,55 @@ msgid ""
 msgstr ""
 "Multiplicador que depende del tipo de documento, se usa para convertir un "
 "precio en un balance"
+
+#. module: account
+#: model:account.account,name:account.2_base_tasa_municipal
+#: model:account.account,name:account.3_base_tasa_municipal
+#: model:account.account,name:account.4_base_tasa_municipal
+msgid "Municipal Tax"
+msgstr "Tasa Municipal"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_creditos_fiscales_municipales
+#: model:account.group,name:account.3_account_group_creditos_fiscales_municipales
+#: model:account.group,name:account.4_account_group_creditos_fiscales_municipales
+msgid "Municipal Tax Credits"
+msgstr "Créditos Fiscales Municipales"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_deudas_tasas_municipales
+#: model:account.group,name:account.3_account_group_deudas_tasas_municipales
+#: model:account.group,name:account.4_account_group_deudas_tasas_municipales
+msgid "Municipal Tax Debts"
+msgstr "Deudas Tasas Municipales"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_tasas_municipales
+#: model:account.group,name:account.3_account_group_tasas_municipales
+#: model:account.group,name:account.4_account_group_tasas_municipales
+msgid "Municipal Taxes"
+msgstr "Tasas Municipales"
+
+#. module: account
+#: model:account.tax.group,name:account.2_tax_group_percepcion_municipal
+#: model:account.tax.group,name:account.3_tax_group_percepcion_municipal
+#: model:account.tax.group,name:account.4_tax_group_percepcion_municipal
+msgid "Municipal Taxes Perceptions"
+msgstr "Percepción de los impuestos municipales"
+
+#. module: account
+#: model:account.account,name:account.2_base_tasa_municipal_a_pagar
+#: model:account.account,name:account.3_base_tasa_municipal_a_pagar
+#: model:account.account,name:account.4_base_tasa_municipal_a_pagar
+msgid "Municipal tax payable"
+msgstr "Tasa Municipal a pagar"
+
+#. module: account
+#: model:account.account,name:account.2_base_fondo_comun_de_inversion
+#: model:account.account,name:account.3_base_fondo_comun_de_inversion
+#: model:account.account,name:account.4_base_fondo_comun_de_inversion
+msgid "Mutual fund"
+msgstr "Fondo común de inversión"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__my_activity_date_deadline
@@ -10798,7 +12315,7 @@ msgstr "Siguiente fecha de pago"
 #. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_move__auto_post__no
 msgid "No"
-msgstr "No"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_payment_search
@@ -10885,6 +12402,13 @@ msgid "Non Trade Receivable"
 msgstr "Cuentas por cobrar no comerciales"
 
 #. module: account
+#: model:account.group,name:account.2_account_group_pasivo_no_corriente
+#: model:account.group,name:account.3_account_group_pasivo_no_corriente
+#: model:account.group,name:account.4_account_group_pasivo_no_corriente
+msgid "Non-Current Liabilities"
+msgstr "Pasivo no Corriente"
+
+#. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_account__account_type__asset_non_current
 msgid "Non-current Assets"
 msgstr "Activos no circulantes"
@@ -10897,8 +12421,18 @@ msgstr "Pasivos no circulantes"
 
 #. module: account
 #: model:account.account,name:account.1_non_current_assets
+#: model:account.group,name:account.2_account_group_activo_no_corriente
+#: model:account.group,name:account.3_account_group_activo_no_corriente
+#: model:account.group,name:account.4_account_group_activo_no_corriente
 msgid "Non-current assets"
 msgstr "Activos no circulantes"
+
+#. module: account
+#: model:account.account,name:account.2_base_aportes_no_reembolsables
+#: model:account.account,name:account.3_base_aportes_no_reembolsables
+#: model:account.account,name:account.4_base_aportes_no_reembolsables
+msgid "Non-reimbursable contributions (subsidies)"
+msgstr "Aportes no reeombolsables (subsidios)"
 
 #. module: account
 #. odoo-python
@@ -11127,7 +12661,7 @@ msgstr "Octubre"
 #. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_journal__invoice_reference_model__odoo
 msgid "Odoo"
-msgstr "Odoo"
+msgstr ""
 
 #. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_report_expression__engine__domain
@@ -11167,6 +12701,11 @@ msgstr "Fuera de balance"
 #: model:ir.model.fields.selection,name:account.selection__account_account__account_type__off_balance
 msgid "Off-Balance Sheet"
 msgstr "Fuera de balance"
+
+#. module: account
+#: model:account.account.tag,name:account.demo_office_furniture_account
+msgid "Office Furniture"
+msgstr ""
 
 #. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_reconcile_model__matching_order__old_first
@@ -11369,6 +12908,13 @@ msgid "Operating Activities"
 msgstr "Actividades operativas"
 
 #. module: account
+#: model:account.group,name:account.2_account_group_gastos_operativos
+#: model:account.group,name:account.3_account_group_gastos_operativos
+#: model:account.group,name:account.4_account_group_gastos_operativos
+msgid "Operating Expenses"
+msgstr "Gastos Operativos"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_reconcile_model_form
 msgid "Operation Templates"
 msgstr "Plantillas de operaciones"
@@ -11388,6 +12934,13 @@ msgstr "Operación incompatible"
 #: model:ir.model.fields.selection,name:account.selection__account_report__filter_hierarchy__optional
 msgid "Optional"
 msgstr "Opcional"
+
+#. module: account
+#: model:account.account,name:account.2_base_reservas_facultativas
+#: model:account.account,name:account.3_base_reservas_facultativas
+#: model:account.account,name:account.4_base_reservas_facultativas
+msgid "Optional reserves"
+msgstr "Reservas facultativas"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_account__tag_ids
@@ -11476,6 +13029,44 @@ msgid "Other Info"
 msgstr "Otra información"
 
 #. module: account
+#: model:account.tax.group,name:account.2_tax_group_otras_percepciones
+#: model:account.tax.group,name:account.3_tax_group_otras_percepciones
+#: model:account.tax.group,name:account.4_tax_group_otras_percepciones
+msgid "Other Perceptions"
+msgstr "Otras percepciones"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_otros_impuestos
+#: model:account.group,name:account.3_account_group_otros_impuestos
+#: model:account.group,name:account.4_account_group_otros_impuestos
+#: model:account.tax.group,name:account.2_tax_group_otros_impuestos
+#: model:account.tax.group,name:account.3_tax_group_otros_impuestos
+#: model:account.tax.group,name:account.4_tax_group_otros_impuestos
+msgid "Other Taxes"
+msgstr "Otros Impuestos"
+
+#. module: account
+#: model:account.account,name:account.2_base_acreedores_varios
+#: model:account.account,name:account.3_base_acreedores_varios
+#: model:account.account,name:account.4_base_acreedores_varios
+msgid "Other accounts payable"
+msgstr "Acreedores varios"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_otros_creditos
+#: model:account.group,name:account.3_account_group_otros_creditos
+#: model:account.group,name:account.4_account_group_otros_creditos
+msgid "Other credits"
+msgstr "Otros créditos"
+
+#. module: account
+#: model:account.account,name:account.2_base_otras_deudas_documentadas
+#: model:account.account,name:account.3_base_otras_deudas_documentadas
+#: model:account.account,name:account.4_base_otras_deudas_documentadas
+msgid "Other documented debts"
+msgstr "Otras deudas documentadas"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.portal_my_home_invoice
 msgid "Our Invoices"
 msgstr "Nuestras facturas"
@@ -11489,7 +13080,7 @@ msgid ""
 msgstr ""
 "Nuestras facturas se pueden pagar en un plazo de 21 días laborales, a menos "
 "que otro plazo de pago se indique en la factura o en la orden. En caso de "
-"impago en la fecha de vencimiento,  "
+"impago en la fecha de vencimiento,"
 
 #. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_payment_method__payment_type__outbound
@@ -11515,6 +13106,12 @@ msgstr "Cuenta pendiente"
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 #: model:account.account,name:account.1_account_journal_payment_credit_account_id
+#: model:account.account,name:account.2_account_journal_payment_credit_account_id
+#: model:account.account,name:account.2_base_outstanding_payments
+#: model:account.account,name:account.3_account_journal_payment_credit_account_id
+#: model:account.account,name:account.3_base_outstanding_payments
+#: model:account.account,name:account.4_account_journal_payment_credit_account_id
+#: model:account.account,name:account.4_base_outstanding_payments
 msgid "Outstanding Payments"
 msgstr "Pagos pendientes"
 
@@ -11527,6 +13124,12 @@ msgstr "Cuentas de pagos pendientes"
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 #: model:account.account,name:account.1_account_journal_payment_debit_account_id
+#: model:account.account,name:account.2_account_journal_payment_debit_account_id
+#: model:account.account,name:account.2_base_outstanding_receipts
+#: model:account.account,name:account.3_account_journal_payment_debit_account_id
+#: model:account.account,name:account.3_base_outstanding_receipts
+#: model:account.account,name:account.4_account_journal_payment_debit_account_id
+#: model:account.account,name:account.4_base_outstanding_receipts
 msgid "Outstanding Receipts"
 msgstr "Recibos pendientes"
 
@@ -11546,6 +13149,20 @@ msgstr "Créditos pendientes"
 #: code:addons/account/models/account_move.py:0
 msgid "Outstanding debits"
 msgstr "Débitos pendientes"
+
+#. module: account
+#: model:account.account,name:account.2_base_giro_en_descubierto
+#: model:account.account,name:account.3_base_giro_en_descubierto
+#: model:account.account,name:account.4_base_giro_en_descubierto
+msgid "Overdraft Bank xxxxx"
+msgstr "Giro en descubierto Banco xxxxx"
+
+#. module: account
+#: model:account.account,name:account.2_base_intereses_por_descubierto
+#: model:account.account,name:account.3_base_intereses_por_descubierto
+#: model:account.account,name:account.4_base_intereses_por_descubierto
+msgid "Overdraft interest"
+msgstr "Intereses por descubierto"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.portal_invoice_page
@@ -11590,16 +13207,328 @@ msgid "P&L Accounts"
 msgstr "Cuentas del estado de resultados"
 
 #. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_ba_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_ba_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_ba_sufrida
+msgid "P. IIBB BA"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_ba_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_ba_aplicada
+msgid "P. IIBB BA 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_ca_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_ca_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_ca_sufrida
+msgid "P. IIBB C"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_ca_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_ca_aplicada
+msgid "P. IIBB C 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_caba_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_caba_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_caba_sufrida
+msgid "P. IIBB CABA"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_caba_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_caba_aplicada
+msgid "P. IIBB CABA 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_co_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_co_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_co_sufrida
+msgid "P. IIBB CBA"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_co_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_co_aplicada
+msgid "P. IIBB CBA 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_ha_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_ha_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_ha_sufrida
+msgid "P. IIBB CHO"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_ha_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_ha_aplicada
+msgid "P. IIBB CHO 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_ct_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_ct_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_ct_sufrida
+msgid "P. IIBB CHT"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_ct_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_ct_aplicada
+msgid "P. IIBB CHT 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_rr_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_rr_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_rr_sufrida
+msgid "P. IIBB CTS"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_rr_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_rr_aplicada
+msgid "P. IIBB CTS 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_er_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_er_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_er_sufrida
+msgid "P. IIBB ER"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_er_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_er_aplicada
+msgid "P. IIBB ER 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_fo_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_fo_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_fo_sufrida
+msgid "P. IIBB F"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_fo_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_fo_aplicada
+msgid "P. IIBB F 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_ju_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_ju_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_ju_sufrida
+msgid "P. IIBB J"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_ju_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_ju_aplicada
+msgid "P. IIBB J 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_lp_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_lp_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_lp_sufrida
+msgid "P. IIBB LP"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_lp_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_lp_aplicada
+msgid "P. IIBB LP 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_lr_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_lr_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_lr_sufrida
+msgid "P. IIBB LR"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_lr_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_lr_aplicada
+msgid "P. IIBB LR 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_mi_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_mi_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_mi_sufrida
+msgid "P. IIBB MS"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_mi_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_mi_aplicada
+msgid "P. IIBB MS 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_za_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_za_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_za_sufrida
+msgid "P. IIBB MZA"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_za_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_za_aplicada
+msgid "P. IIBB MZA 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_ne_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_ne_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_ne_sufrida
+msgid "P. IIBB N"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_ne_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_ne_aplicada
+msgid "P. IIBB N 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_rn_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_rn_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_rn_sufrida
+msgid "P. IIBB RN"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_rn_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_rn_aplicada
+msgid "P. IIBB RN 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_sa_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_sa_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_sa_sufrida
+msgid "P. IIBB S"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_sa_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_sa_aplicada
+msgid "P. IIBB S 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_az_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_az_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_az_sufrida
+msgid "P. IIBB SC"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_az_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_az_aplicada
+msgid "P. IIBB SC 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_se_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_se_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_se_sufrida
+msgid "P. IIBB SE"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_se_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_se_aplicada
+msgid "P. IIBB SE 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_sf_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_sf_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_sf_sufrida
+msgid "P. IIBB SF"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_sf_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_sf_aplicada
+msgid "P. IIBB SF 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_nn_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_nn_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_nn_sufrida
+msgid "P. IIBB SJ"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_nn_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_nn_aplicada
+msgid "P. IIBB SJ 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_sl_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_sl_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_sl_sufrida
+msgid "P. IIBB SL"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_sl_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_sl_aplicada
+msgid "P. IIBB SL 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_tn_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_tn_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_tn_sufrida
+msgid "P. IIBB T"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_tn_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_tn_aplicada
+msgid "P. IIBB T 0%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_tf_sufrida
+#: model:account.tax,name:account.3_ri_tax_percepcion_iibb_tf_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_tf_sufrida
+msgid "P. IIBB TAIS"
+msgstr ""
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iibb_tf_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iibb_tf_aplicada
+msgid "P. IIBB TAIS 0%"
+msgstr ""
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
 msgid "PAY001"
-msgstr "PAY001"
+msgstr ""
 
 #. module: account
 #. odoo-python
 #: code:addons/account/models/account_move.py:0
 #: model:ir.actions.report,name:account.account_invoices
 msgid "PDF"
-msgstr "PDF"
+msgstr ""
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__invoice_pdf_report_id
@@ -11636,7 +13565,7 @@ msgstr "Elegible para PEPPOL"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "PROFORMA"
-msgstr "PROFORMA"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -11836,6 +13765,20 @@ msgstr "Cuentas bancarias faltantes de los contactos"
 msgid "Partners that are used in hashed entries cannot be merged."
 msgstr ""
 "No es posible fusionar los contactos que se usan en asientos con hash."
+
+#. module: account
+#: model:account.group,name:account.2_account_group_pasivo
+#: model:account.group,name:account.3_account_group_pasivo
+#: model:account.group,name:account.4_account_group_pasivo
+msgid "Passive"
+msgstr "Pasivo"
+
+#. module: account
+#: model:account.account,name:account.2_base_patentes_comercial
+#: model:account.account,name:account.3_base_patentes_comercial
+#: model:account.account,name:account.4_base_patentes_comercial
+msgid "Patents Commercial"
+msgstr "Patentes Comercial"
 
 #. module: account
 #. odoo-python
@@ -12077,12 +14020,12 @@ msgstr "Términos de pago: 10 días después del fin del siguiente mes"
 #. module: account
 #: model_terms:account.payment.term,note:account.account_payment_term_15days
 msgid "Payment terms: 15 Days"
-msgstr "Términos de pago: 15 días "
+msgstr "Términos de pago: 15 días"
 
 #. module: account
 #: model_terms:account.payment.term,note:account.account_payment_term_21days
 msgid "Payment terms: 21 Days"
-msgstr "Términos de pago: 21 días "
+msgstr "Términos de pago: 21 días"
 
 #. module: account
 #: model_terms:account.payment.term,note:account.account_payment_term_30days
@@ -12096,6 +14039,11 @@ msgid "Payment terms: 30 Days, 2% Early Payment Discount under 7 days"
 msgstr ""
 "Términos de pago: 30 días, 2% de descuento por pago anticipado antes de 7 "
 "días"
+
+#. module: account
+#: model_terms:account.payment.term,note:account.account_payment_term_advance
+msgid "Payment terms: 30% Advance End of Following Month"
+msgstr ""
 
 #. module: account
 #: model_terms:account.payment.term,note:account.account_payment_term_advance_60days
@@ -12168,6 +14116,332 @@ msgstr ""
 "especificada se saltarán."
 
 #. module: account
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_ba
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_ba
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_ba
+msgid "Perc IIBB ARBA"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_ba_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_ba_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_ba_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_ba_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_ba_sufrida
+msgid "Perc IIBB Buenos Aires"
+msgstr ""
+
+#. module: account
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_caba
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_caba
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_caba
+msgid "Perc IIBB CABA"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_ca_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_ca_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_ca_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_ca_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_ca_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_ca
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_ca
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_ca
+msgid "Perc IIBB Catamarca"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_ha_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_ha_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_ha_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_ha_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_ha_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_ha
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_ha
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_ha
+msgid "Perc IIBB Chaco"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_ct_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_ct_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_ct_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_ct_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_ct_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_ct
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_ct
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_ct
+msgid "Perc IIBB Chubut"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_caba_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_caba_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_caba_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_caba_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_caba_sufrida
+msgid "Perc IIBB Ciudad Autónoma de Buenos Aires"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_rr_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_rr_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_rr_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_rr_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_rr_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_rr
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_rr
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_rr
+msgid "Perc IIBB Corrientes"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_co_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_co_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_co_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_co_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_co_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_co
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_co
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_co
+msgid "Perc IIBB Córdoba"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_er_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_er_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_er_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_er_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_er_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_er
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_er
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_er
+msgid "Perc IIBB Entre Ríos"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_fo_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_fo_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_fo_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_fo_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_fo_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_fo
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_fo
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_fo
+msgid "Perc IIBB Formosa"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_ju_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_ju_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_ju_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_ju_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_ju_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_ju
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_ju
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_ju
+msgid "Perc IIBB Jujuy"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_lp_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_lp_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_lp_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_lp_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_lp_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_lp
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_lp
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_lp
+msgid "Perc IIBB La Pampa"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_lr_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_lr_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_lr_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_lr_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_lr_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_lr
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_lr
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_lr
+msgid "Perc IIBB La Rioja"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_za_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_za_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_za_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_za_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_za_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_za
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_za
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_za
+msgid "Perc IIBB Mendoza"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_mi_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_mi_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_mi_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_mi_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_mi_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_mi
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_mi
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_mi
+msgid "Perc IIBB Misiones"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_ne_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_ne_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_ne_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_ne_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_ne_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_ne
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_ne
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_ne
+msgid "Perc IIBB Neuquén"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_rn_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_rn_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_rn_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_rn_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_rn_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_rn
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_rn
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_rn
+msgid "Perc IIBB Río Negro"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_sa_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_sa_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_sa_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_sa_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_sa_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_sa
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_sa
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_sa
+msgid "Perc IIBB Salta"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_nn_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_nn_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_nn_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_nn_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_nn_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_nn
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_nn
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_nn
+msgid "Perc IIBB San Juan"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_sl_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_sl_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_sl_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_sl_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_sl_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_sl
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_sl
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_sl
+msgid "Perc IIBB San Luis"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_az_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_az_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_az_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_az_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_az_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_az
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_az
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_az
+msgid "Perc IIBB Santa Cruz"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_sf_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_sf_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_sf_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_sf_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_sf_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_sf
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_sf
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_sf
+msgid "Perc IIBB Santa Fe"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_se_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_se_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_se_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_se_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_se_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_se
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_se
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_se
+msgid "Perc IIBB Santiago del Estero"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_tf_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_tf_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_tf_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_tf_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_tf_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_tf
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_tf
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_tf
+msgid "Perc IIBB Tierra del Fuego"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_tn_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iibb_tn_sufrida
+#: model:account.tax,invoice_label:account.3_ri_tax_percepcion_iibb_tn_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_tn_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iibb_tn_sufrida
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iibb_tn
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iibb_tn
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iibb_tn
+msgid "Perc IIBB Tucumán"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_ganancias_aplicada
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_ganancias_sufrida
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_ganancias_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_ganancias_sufrida
+#: model:account.tax,name:account.2_ri_tax_percepcion_ganancias_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_ganancias_sufrida
+msgid "Perc Profits"
+msgstr "Perc Ganancias"
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_ganancias_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_ganancias_aplicada
+msgid "Perc Profits 0%"
+msgstr "Perc Gananc"
+
+#. module: account
+#: model:account.tax,invoice_label:account.2_ri_tax_percepcion_iva_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iva_aplicada
+#: model:account.tax,invoice_label:account.4_ri_tax_percepcion_iva_sufrida
+#: model:account.tax,name:account.4_ri_tax_percepcion_iva_sufrida
+msgid "Perc VAT"
+msgstr "Perc IVA"
+
+#. module: account
+#: model:account.tax,name:account.2_ri_tax_percepcion_iva_aplicada
+#: model:account.tax,name:account.4_ri_tax_percepcion_iva_aplicada
+msgid "Perc VAT 0%"
+msgstr "Perc IVA"
+
+#. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_payment_term_line__value__percent
 msgid "Percent"
 msgstr "Porcentaje"
@@ -12214,6 +14488,584 @@ msgstr ""
 "Los porcentajes en las líneas de términos de pago deben estar entre 0 y 100."
 
 #. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_ba_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_ba_aplicada
+msgid "Perception IIBB ARBA applied"
+msgstr "Percepción IIBB ARBA aplicada"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_ba_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_ba_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_ba_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_ba_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_ba_sufrida
+msgid "Perception IIBB Buenos Aires"
+msgstr "Percepción IIBB Buenos Aires"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_ba_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_ba_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_ba_sufrida
+msgid "Perception IIBB Buenos Aires incurred"
+msgstr "Percepción IIBB Buenos Aires sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_ca_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_ca_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_ca_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_ca_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_ca_sufrida
+msgid "Perception IIBB Catamarca"
+msgstr "Percepción IIBB Catamarca"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_ca_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_ca_aplicada
+msgid "Perception IIBB Catamarca applied"
+msgstr "Percepción IIBB Catamarca aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_ca_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_ca_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_ca_sufrida
+msgid "Perception IIBB Catamarca incurred"
+msgstr "Percepción IIBB Catamarca sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_ha_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_ha_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_ha_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_ha_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_ha_sufrida
+msgid "Perception IIBB Chaco"
+msgstr "Percepción IIBB Chaco"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_ha_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_ha_aplicada
+msgid "Perception IIBB Chaco applied"
+msgstr "Percepción IIBB Chaco aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_ha_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_ha_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_ha_sufrida
+msgid "Perception IIBB Chaco incurred"
+msgstr "Percepción IIBB Chaco sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_ct_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_ct_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_ct_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_ct_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_ct_sufrida
+msgid "Perception IIBB Chubut"
+msgstr "Percepción IIBB Chubut"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_ct_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_ct_aplicada
+msgid "Perception IIBB Chubut applied"
+msgstr "Percepción IIBB Chubut aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_ct_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_ct_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_ct_sufrida
+msgid "Perception IIBB Chubut incurred"
+msgstr "Percepción IIBB Chubut sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_caba_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_caba_aplicada
+msgid "Perception IIBB Ciudad Autónoma de Buenos Aires"
+msgstr "Percepción IIBB Ciudad Autónoma de Buenos Aires"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_rr_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_rr_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_rr_sufrida
+msgid "Perception IIBB Corrientes"
+msgstr "Percepción IIBB Corrientes"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_rr_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_rr_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_rr_sufrida
+msgid "Perception IIBB Corrientes incurred"
+msgstr "Percepción IIBB Corrientes sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_co_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_co_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_co_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_co_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_co_sufrida
+msgid "Perception IIBB Córdoba"
+msgstr "Percepción IIBB Córdoba"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_co_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_co_aplicada
+msgid "Perception IIBB Córdoba applied"
+msgstr "Percepción IIBB Córdoba aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_co_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_co_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_co_sufrida
+msgid "Perception IIBB Córdoba incurred"
+msgstr "Percepción IIBB Córdoba sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_er_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_er_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_er_sufrida
+msgid "Perception IIBB Entre Ríos"
+msgstr "Percepción IIBB Entre Ríos"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_er_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_er_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_er_sufrida
+msgid "Perception IIBB Entre Ríos incurred"
+msgstr "Percepción IIBB Entre Ríos sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_fo_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_fo_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_fo_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_fo_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_fo_sufrida
+msgid "Perception IIBB Formosa"
+msgstr "Percepción IIBB Formosa"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_fo_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_fo_aplicada
+msgid "Perception IIBB Formosa applied"
+msgstr "Percepción IIBB Formosa aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_fo_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_fo_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_fo_sufrida
+msgid "Perception IIBB Formosa incurred"
+msgstr "Percepción IIBB Formosa sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_ju_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_ju_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_ju_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_ju_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_ju_sufrida
+msgid "Perception IIBB Jujuy"
+msgstr "Percepción IIBB Jujuy"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_ju_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_ju_aplicada
+msgid "Perception IIBB Jujuy applied"
+msgstr "Percepción IIBB Jujuy aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_ju_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_ju_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_ju_sufrida
+msgid "Perception IIBB Jujuy incurred"
+msgstr "Percepción IIBB Jujuy sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_lp_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_lp_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_lp_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_lp_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_lp_sufrida
+msgid "Perception IIBB La Pampa"
+msgstr "Percepción IIBB La Pampa"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_lr_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_lr_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_lr_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_lr_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_lr_sufrida
+msgid "Perception IIBB La Rioja"
+msgstr "Percepción IIBB La Rioja"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_lr_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_lr_aplicada
+msgid "Perception IIBB La Rioja applied"
+msgstr "Percepción IIBB La Rioja aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_lr_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_lr_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_lr_sufrida
+msgid "Perception IIBB La Rioja incurred"
+msgstr "Percepción IIBB La Rioja sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_za_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_za_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_za_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_za_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_za_sufrida
+msgid "Perception IIBB Mendoza"
+msgstr "Percepción IIBB Mendoza"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_za_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_za_aplicada
+msgid "Perception IIBB Mendoza applied"
+msgstr "Percepción IIBB Mendoza aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_za_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_za_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_za_sufrida
+msgid "Perception IIBB Mendoza incurred"
+msgstr "Percepción IIBB Mendoza sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_mi_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_mi_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_mi_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_mi_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_mi_sufrida
+msgid "Perception IIBB Misiones"
+msgstr "Percepción IIBB Misiones"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_mi_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_mi_aplicada
+msgid "Perception IIBB Misiones applied"
+msgstr "Percepción IIBB Misiones aplicada"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_ne_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_ne_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_ne_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_ne_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_ne_sufrida
+msgid "Perception IIBB Neuquén"
+msgstr "Percepción IIBB Neuquén"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_ne_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_ne_aplicada
+msgid "Perception IIBB Neuquén applied"
+msgstr "Percepción IIBB Neuquén aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_ne_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_ne_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_ne_sufrida
+msgid "Perception IIBB Neuquén incurred"
+msgstr "Percepción IIBB Neuquén sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_rn_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_rn_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_rn_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_rn_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_rn_sufrida
+msgid "Perception IIBB Río Negro"
+msgstr "Percepción IIBB Río Negro"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_rn_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_rn_aplicada
+msgid "Perception IIBB Río Negro applied"
+msgstr "Percepción IIBB Río Negro aplicada"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_sa_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_sa_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_sa_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_sa_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_sa_sufrida
+msgid "Perception IIBB Salta"
+msgstr "Percepción IIBB Salta"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_sa_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_sa_aplicada
+msgid "Perception IIBB Salta applied"
+msgstr "Percepción IIBB Salta aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_sa_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_sa_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_sa_sufrida
+msgid "Perception IIBB Salta incurred"
+msgstr "Percepción IIBB Salta sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_nn_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_nn_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_nn_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_nn_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_nn_sufrida
+msgid "Perception IIBB San Juan"
+msgstr "Percepción IIBB SJ"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_nn_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_nn_aplicada
+msgid "Perception IIBB San Juan applied"
+msgstr "Percepción IIBB San Juan aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_nn_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_nn_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_nn_sufrida
+msgid "Perception IIBB San Juan incurred"
+msgstr "Percepción IIBB San Juan sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_sl_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_sl_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_sl_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_sl_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_sl_sufrida
+msgid "Perception IIBB San Luis"
+msgstr "Percepción IIBB SL"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_sl_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_sl_aplicada
+msgid "Perception IIBB San Luis applied"
+msgstr "Percepción IIBB San Luis aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_sl_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_sl_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_sl_sufrida
+msgid "Perception IIBB San Luis incurred"
+msgstr "Percepción IIBB San Luis sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_az_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_az_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_az_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_az_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_az_sufrida
+msgid "Perception IIBB Santa Cruz"
+msgstr "Percepción IIBB Santa Cruz"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_az_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_az_aplicada
+msgid "Perception IIBB Santa Cruz applied"
+msgstr "Percepción IIBB Santa Cruz aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_az_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_az_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_az_sufrida
+msgid "Perception IIBB Santa Cruz incurred"
+msgstr "Percepción IIBB Santa Cruz sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_sf_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_sf_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_sf_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_sf_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_sf_sufrida
+msgid "Perception IIBB Santa Fe"
+msgstr "Percepción IIBB SF"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_sf_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_sf_aplicada
+msgid "Perception IIBB Santa Fe applied"
+msgstr "Percepción IIBB Santa Fe aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_sf_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_sf_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_sf_sufrida
+msgid "Perception IIBB Santa Fe incurred"
+msgstr "Percepción IIBB Santa Fe sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_se_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_se_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_se_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_se_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_se_sufrida
+msgid "Perception IIBB Santiago del Estero"
+msgstr "Percepción IIBB Santiago del Estero"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_se_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_se_aplicada
+msgid "Perception IIBB Santiago del Estero applied"
+msgstr "Percepción IIBB Santiago del Estero aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_se_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_se_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_se_sufrida
+msgid "Perception IIBB Santiago del Estero incurred"
+msgstr "Percepción IIBB Santiago del Estero sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_tf_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_tf_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_tf_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_tf_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_tf_sufrida
+msgid "Perception IIBB Tierra del Fuego"
+msgstr "Percepción IIBB Tierra del Fuego"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_tf_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_tf_aplicada
+msgid "Perception IIBB Tierra del Fuego applied"
+msgstr "Percepción IIBB Tierra del Fuego aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_tf_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_tf_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_tf_sufrida
+msgid "Perception IIBB Tierra del Fuego incurred"
+msgstr "Percepción IIBB Tierra del Fuego sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_tn_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_tn_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_tn_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_tn_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_tn_sufrida
+msgid "Perception IIBB Tucumán"
+msgstr "Percepción IIBB Tucumán"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_tn_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_tn_aplicada
+msgid "Perception IIBB Tucumán applied"
+msgstr "Percepción IIBB Tucumán aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_tn_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_tn_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_tn_sufrida
+msgid "Perception IIBB Tucumán incurred"
+msgstr "Percepción IIBB Tucumán sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iva_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iva_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iva_sufrida
+msgid "Perception VAT"
+msgstr "Percepción IVA"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iva_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iva_aplicada
+msgid "Perception VAT applied"
+msgstr "Percepción IVA aplicada"
+
+#. module: account
+#: model:account.account,name:account.4_ri_percepcion_iva_sufrida
+msgid "Perception VAT incurred"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_ganancias_aplicada
+#: model:account.account,name:account.4_ri_percepcion_ganancias_aplicada
+msgid "Perception applied earnings"
+msgstr "Percepción ganancias aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_caba_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_caba_aplicada
+msgid "Perception of IIBB CABA applied"
+msgstr "Percepción IIBB CABA aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_caba_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_caba_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_caba_sufrida
+msgid "Perception of IIBB CABA incurred"
+msgstr "Percepción IIBB CABA sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_caba_sufrida
+#: model_terms:account.tax,description:account.3_ri_tax_percepcion_iibb_caba_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_caba_sufrida
+msgid "Perception of IIBB Ciudad Autónoma de Buenos Aires"
+msgstr "Percepción IIBB Ciudad Autónoma de Buenos Aires"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_rr_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_rr_aplicada
+msgid "Perception of IIBB Corrientes"
+msgstr "Percepción IIBB Corrientes"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_rr_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_rr_aplicada
+msgid "Perception of IIBB Corrientes applied"
+msgstr "Percepción IIBB Corrientes aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_er_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_er_aplicada
+msgid "Perception of IIBB Entre Río applied"
+msgstr "Percepción IIBB Entre Río aplicada"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_iibb_er_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_iibb_er_aplicada
+msgid "Perception of IIBB Entre Ríos"
+msgstr "Percepción IIBB Entre Ríos"
+
+#. module: account
+#: model:account.account,name:account.2_ri_percepcion_iibb_lp_aplicada
+#: model:account.account,name:account.4_ri_percepcion_iibb_lp_aplicada
+msgid "Perception of IIBB La Pampa applied"
+msgstr "Percepción IIBB La Pampa aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_lp_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_lp_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_lp_sufrida
+msgid "Perception of IIBB La Pampa incurred"
+msgstr "Percepción IIBB La Pampa sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_mi_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_mi_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_mi_sufrida
+msgid "Perception of IIBB Misiones incurred"
+msgstr "Percepción IIBB Misiones sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_iibb_rn_sufrida
+#: model:account.account,name:account.3_base_percepcion_iibb_rn_sufrida
+#: model:account.account,name:account.4_base_percepcion_iibb_rn_sufrida
+msgid "Perception of IIBB Río Negro incurred"
+msgstr "Percepción IIBB Río Negro sufrida"
+
+#. module: account
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_ganancias_aplicada
+#: model_terms:account.tax,description:account.2_ri_tax_percepcion_ganancias_sufrida
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_ganancias_aplicada
+#: model_terms:account.tax,description:account.4_ri_tax_percepcion_ganancias_sufrida
+msgid "Perception of Profits"
+msgstr "Percepción Ganancias"
+
+#. module: account
+#: model:account.account,name:account.2_base_percepcion_ganancias_sufrida
+#: model:account.account,name:account.4_base_percepcion_ganancias_sufrida
+msgid "Perceptions of Earnings incurred"
+msgstr "Percepciones de Ganancias Sufridas"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_invoice_filter
 msgid "Period"
 msgstr "Periodo"
@@ -12232,6 +15084,19 @@ msgstr "Riesgo de phishing: alto"
 #: model_terms:ir.ui.view,arch_db:account.view_partner_bank_search_inherit
 msgid "Phishing risk: Medium"
 msgstr "Riesgo de phishing: medio"
+
+#. module: account
+#: model:account.account,name:account.2_base_planes_a_pagar_afip
+#: model:account.account,name:account.4_base_planes_a_pagar_afip
+msgid "Plan Earnings to be paid"
+msgstr "Plan Ganancias a pagar"
+
+#. module: account
+#: model:account.account,name:account.2_base_plan_tasa_municipal_a_pagar
+#: model:account.account,name:account.3_base_plan_tasa_municipal_a_pagar
+#: model:account.account,name:account.4_base_plan_tasa_municipal_a_pagar
+msgid "Plan Municipal Tax to be paid"
+msgstr "Plan Tasa Municipal a pagar"
 
 #. module: account
 #. odoo-python
@@ -12280,7 +15145,7 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.bill_preview
 msgid "Please use the following communication for your payment:"
-msgstr "Utilice la siguiente referencia al realizar su pago: "
+msgstr "Utilice la siguiente referencia al realizar su pago:"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_tax_group__pos_receipt_label
@@ -12477,13 +15342,17 @@ msgstr "Precios"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_move_send_wizard_form
-#: model_terms:ir.ui.view,arch_db:account.view_move_form
 msgid "Print"
 msgstr "Imprimir"
 
 #. module: account
 #. odoo-python
 #: code:addons/account/models/account_move.py:0
+#: model_terms:ir.ui.view,arch_db:account.account_move_send_batch_wizard_form
+#: model_terms:ir.ui.view,arch_db:account.account_move_send_wizard_form
+#: model_terms:ir.ui.view,arch_db:account.view_move_form
+#: model_terms:ir.ui.view,arch_db:account.view_out_credit_note_tree
+#: model_terms:ir.ui.view,arch_db:account.view_out_invoice_tree
 msgid "Print & Send"
 msgstr "Imprimir y enviar"
 
@@ -12496,6 +15365,20 @@ msgstr "Imprimir en una nueva página"
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Print checks to pay your vendors"
 msgstr "Imprima cheques para pagar a sus proveedores"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_cuentas_particulares
+#: model:account.group,name:account.3_account_group_cuentas_particulares
+#: model:account.group,name:account.4_account_group_cuentas_particulares
+msgid "Private Accounts"
+msgstr "Cuentas Particulares"
+
+#. module: account
+#: model:account.account,name:account.2_base_cta_particular_socio_x
+#: model:account.account,name:account.3_base_cta_particular_socio_x
+#: model:account.account,name:account.4_base_cta_particular_socio_x
+msgid "Private account partner x"
+msgstr "Cta particular socio x"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement__problem_description
@@ -12527,7 +15410,7 @@ msgstr "Categorías de productos"
 #: model:ir.model.fields,field_description:account.field_account_move_line__product_category_id
 #: model_terms:ir.ui.view,arch_db:account.view_account_invoice_report_search
 msgid "Product Category"
-msgstr "Categoría de producto"
+msgstr "Categoría del producto"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_report__quantity
@@ -12550,6 +15433,20 @@ msgid "Product Variant"
 msgstr "Variante del producto"
 
 #. module: account
+#: model:account.group,name:account.2_account_group_gastos_de_producción
+#: model:account.group,name:account.3_account_group_gastos_de_producción
+#: model:account.group,name:account.4_account_group_gastos_de_producción
+msgid "Production Expenses"
+msgstr "Gastos de Producción"
+
+#. module: account
+#: model:account.account,name:account.2_base_honorarios_produccion
+#: model:account.account,name:account.3_base_honorarios_produccion
+#: model:account.account,name:account.4_base_honorarios_produccion
+msgid "Production Fees"
+msgstr "Honorarios Producción"
+
+#. module: account
 #: model:ir.actions.act_window,name:account.product_product_action_purchasable
 #: model:ir.actions.act_window,name:account.product_product_action_sellable
 #: model:ir.model.fields.selection,name:account.selection__account_account_tag__applicability__products
@@ -12558,6 +15455,13 @@ msgstr "Variante del producto"
 #: model_terms:ir.ui.view,arch_db:account.product_template_view_tree
 msgid "Products"
 msgstr "Productos"
+
+#. module: account
+#: model:account.account,name:account.2_base_productos_en_proceso
+#: model:account.account,name:account.3_base_productos_en_proceso
+#: model:account.account,name:account.4_base_productos_en_proceso
+msgid "Products in process"
+msgstr "Productos en proceso"
 
 #. module: account
 #: model:account.account,name:account.1_to_receive_rec
@@ -12577,6 +15481,33 @@ msgid "Profit Account"
 msgstr "Cuenta de ganancias"
 
 #. module: account
+#: model:account.tax.group,name:account.2_tax_group_percepcion_ganancias
+#: model:account.tax.group,name:account.3_tax_group_percepcion_ganancias
+#: model:account.tax.group,name:account.4_tax_group_percepcion_ganancias
+msgid "Profit Perceptions"
+msgstr "Percepción de los beneficios"
+
+#. module: account
+#: model:account.account,name:account.2_base_saldo_favor_ganancias
+#: model:account.account,name:account.4_base_saldo_favor_ganancias
+msgid "Profit balance"
+msgstr "Saldo a favor Ganancias"
+
+#. module: account
+#: model:account.account,name:account.2_base_resultado_venta_bienes_de_uso
+#: model:account.account,name:account.3_base_resultado_venta_bienes_de_uso
+#: model:account.account,name:account.4_base_resultado_venta_bienes_de_uso
+msgid "Profit/(loss) on sale of property, plant and equipment"
+msgstr "Resultado venta bienes de uso"
+
+#. module: account
+#: model:account.account,name:account.2_base_prevision_sac_a_pagar
+#: model:account.account,name:account.3_base_prevision_sac_a_pagar
+#: model:account.account,name:account.4_base_prevision_sac_a_pagar
+msgid "Projected SAC Payable"
+msgstr "Previsión SAC a Pagar"
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_res_partner__property_inbound_payment_method_line_id
 #: model:ir.model.fields,field_description:account.field_res_users__property_inbound_payment_method_line_id
 msgid "Property Inbound Payment Method Line"
@@ -12587,6 +15518,19 @@ msgstr "Línea de método de pago de entrada de la propiedad"
 #: model:ir.model.fields,field_description:account.field_res_users__property_outbound_payment_method_line_id
 msgid "Property Outbound Payment Method Line"
 msgstr "Línea de método de pago de salida de la propiedad"
+
+#. module: account
+#: model:account.account,name:account.2_base_prevision_para_despidos
+#: model:account.account,name:account.3_base_prevision_para_despidos
+#: model:account.account,name:account.4_base_prevision_para_despidos
+msgid "Provision for Layoffs"
+msgstr "Previsión para Despidos"
+
+#. module: account
+#: model:account.account,name:account.2_base_provision_imp_a_las_ganancias
+#: model:account.account,name:account.4_base_provision_imp_a_las_ganancias
+msgid "Provision for income tax"
+msgstr "Provisión Imp a las Ganancias"
 
 #. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_journal__type__purchase
@@ -12640,6 +15584,13 @@ msgid "Purchase of Equipments"
 msgstr "Compra de equipo"
 
 #. module: account
+#: model:account.account,name:account.2_base_compra_mercaderia
+#: model:account.account,name:account.3_base_compra_mercaderia
+#: model:account.account,name:account.4_base_compra_mercaderia
+msgid "Purchase of merchandise"
+msgstr "Compra de mercadería"
+
+#. module: account
 #: model:ir.actions.act_window,name:account.action_account_moves_journal_purchase
 #: model:ir.model.fields.selection,name:account.selection__account_tax__type_tax_use__purchase
 #: model_terms:ir.ui.view,arch_db:account.view_account_journal_search
@@ -12647,6 +15598,21 @@ msgstr "Compra de equipo"
 #: model_terms:ir.ui.view,arch_db:account.view_account_move_line_filter
 msgid "Purchases"
 msgstr "Compras"
+
+#. module: account
+#: model:account.fiscal.position,name:account.4_fiscal_position_template_free_zone
+msgid "Purchases / Sales Free Trade Zone"
+msgstr ""
+
+#. module: account
+#: model:account.fiscal.position,name:account.4_fiscal_position_template_exempt_operations
+msgid "Purchases / Sales abroad"
+msgstr ""
+
+#. module: account
+#: model:account.fiscal.position,name:account.4_fiscal_position_template_iva_no_corresponde
+msgid "Purchases VAT in the correspondent"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -12703,14 +15669,35 @@ msgid "Quick encoding"
 msgstr "Codificación rápida"
 
 #. module: account
+#: model:account.account,name:account.2_base_r_e_c_p_a_m
+#: model:account.account,name:account.3_base_r_e_c_p_a_m
+#: model:account.account,name:account.4_base_r_e_c_p_a_m
+msgid "R.E.C.P.A.M."
+msgstr ""
+
+#. module: account
 #: model:account.account,name:account.1_expense_rd
 msgid "RD Expenses"
 msgstr "Gastos de I+D"
 
 #. module: account
+#: model:account.account,name:account.2_base_materia_prima
+#: model:account.account,name:account.3_base_materia_prima
+#: model:account.account,name:account.4_base_materia_prima
+msgid "Raw Materials"
+msgstr "Materia Prima"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_resequence_view
 msgid "Re-Sequence"
 msgstr "Resecuenciación"
+
+#. module: account
+#: model:account.account,name:account.2_base_impuesto_inmobiliario_produccion
+#: model:account.account,name:account.3_base_impuesto_inmobiliario_produccion
+#: model:account.account,name:account.4_base_impuesto_inmobiliario_produccion
+msgid "Real Estate Tax Production"
+msgstr "Impuesto Inmobiliario Producción"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_lock_exception__reason
@@ -12782,6 +15769,7 @@ msgstr "Cuenta bancaria receptora"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_send_wizard__mail_partner_ids
+#: model_terms:ir.ui.view,arch_db:account.account_move_send_wizard_form
 msgid "Recipients"
 msgstr "Destinatarios"
 
@@ -12869,7 +15857,7 @@ msgstr "Impuesto reducido:"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_analytic_line__ref
 msgid "Ref."
-msgstr "Ref."
+msgstr ""
 
 #. module: account
 #. odoo-python
@@ -12945,6 +15933,26 @@ msgid "Rejected"
 msgstr "Rechazado"
 
 #. module: account
+#: model:account.account,name:account.2_base_cheques_rechazados
+#: model:account.account,name:account.3_base_cheques_rechazados
+#: model:account.account,name:account.4_base_cheques_rechazados
+msgid "Rejected Checks"
+msgstr "Cheques Rechazados"
+
+#. module: account
+#: model:account.account,name:account.2_base_cheques_de_terceros_rechazados
+#: model:account.account,name:account.2_cash_journal_default_account_345
+#: model:account.account,name:account.3_base_cheques_de_terceros_rechazados
+#: model:account.account,name:account.3_cash_journal_default_account_584
+#: model:account.account,name:account.4_base_cheques_de_terceros_rechazados
+#: model:account.account,name:account.4_cash_journal_default_account_894
+#: model:account.journal,name:account.2_rejected_third_party_check
+#: model:account.journal,name:account.3_rejected_third_party_check
+#: model:account.journal,name:account.4_rejected_third_party_check
+msgid "Rejected Third Party Checks"
+msgstr "Cheques de Terceros Rechazados"
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_setup_bank_manual_config__related_moves
 #: model:ir.model.fields,field_description:account.field_res_partner_bank__related_moves
 msgid "Related Moves"
@@ -12972,7 +15980,7 @@ msgid ""
 " This action is irreversible."
 msgstr ""
 "Volver a cargar datos contables (impuestos, cuentas,...) si hay "
-"inconsistencias. Esta acción es irreversible. "
+"inconsistencias. Esta acción es irreversible."
 
 #. module: account
 #: model:ir.model,name:account.model_account_resequence_wizard
@@ -12986,9 +15994,30 @@ msgid "Removed"
 msgstr "Eliminado"
 
 #. module: account
+#: model:account.group,name:account.2_account_group_remueraciones_y_cargas_sociales
+#: model:account.group,name:account.3_account_group_remueraciones_y_cargas_sociales
+#: model:account.group,name:account.4_account_group_remueraciones_y_cargas_sociales
+msgid "Remunerations and Social Charges"
+msgstr "Remuneraciones y Cargas Sociales"
+
+#. module: account
 #: model:account.account,name:account.1_expense_rent
 msgid "Rent"
 msgstr "Renta"
+
+#. module: account
+#: model:account.account,name:account.2_base_alquileres_a_pagar
+#: model:account.account,name:account.3_base_alquileres_a_pagar
+#: model:account.account,name:account.4_base_alquileres_a_pagar
+msgid "Rent to be paid"
+msgstr "Alquileres a pagar"
+
+#. module: account
+#: model:account.account,name:account.2_base_alquileres_produccion
+#: model:account.account,name:account.3_base_alquileres_produccion
+#: model:account.account,name:account.4_base_alquileres_produccion
+msgid "Rentals Production"
+msgstr "Alquileres Producción"
 
 #. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_resequence_wizard__ordering__date
@@ -13014,7 +16043,7 @@ msgstr "Acción de reporte"
 #: model_terms:ir.ui.view,arch_db:account.view_account_move_line_filter
 #: model_terms:ir.ui.view,arch_db:account.view_account_move_line_payment_filter
 msgid "Report Dates"
-msgstr "Fechas de reporte "
+msgstr "Fechas de reporte"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_report_expression__report_line_id
@@ -13057,9 +16086,23 @@ msgid "Res Partner Bank"
 msgstr "Banco del contacto"
 
 #. module: account
+#: model:account.account,name:account.2_base_mercaderia_reventa
+#: model:account.account,name:account.3_base_mercaderia_reventa
+#: model:account.account,name:account.4_base_mercaderia_reventa
+msgid "Resale merchandise"
+msgstr "Mercaderia de reventa"
+
+#. module: account
 #: model:ir.actions.act_window,name:account.action_account_resequence
 msgid "Resequence"
 msgstr "Resecuenciación"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_reservas
+#: model:account.group,name:account.3_account_group_reservas
+#: model:account.group,name:account.4_account_group_reservas
+msgid "Reservations"
+msgstr "Reservas"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_payment_form
@@ -13076,7 +16119,7 @@ msgstr "Restablecer a borrador"
 #: model_terms:ir.ui.view,arch_db:account.view_move_line_payment_tree
 #: model_terms:ir.ui.view,arch_db:account.view_move_line_tree
 msgid "Residual"
-msgstr "Residual"
+msgstr ""
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__amount_residual
@@ -13130,6 +16173,27 @@ msgid "Restricted"
 msgstr "Restringido"
 
 #. module: account
+#: model:account.group,name:account.2_account_group_resultados
+#: model:account.group,name:account.3_account_group_resultados
+#: model:account.group,name:account.4_account_group_resultados
+msgid "Results"
+msgstr "Resultados"
+
+#. module: account
+#: model:account.account,name:account.2_base_resultado_acumulados
+#: model:account.account,name:account.3_base_resultado_acumulados
+#: model:account.account,name:account.4_base_resultado_acumulados
+msgid "Results of prior years"
+msgstr "Resultados de ejercicios anteriores"
+
+#. module: account
+#: model:account.account,name:account.2_base_ret_percepcion_tasa_municipal
+#: model:account.account,name:account.3_base_ret_percepcion_tasa_municipal
+#: model:account.account,name:account.4_base_ret_percepcion_tasa_municipal
+msgid "Ret/Perception Municipal Tax"
+msgstr "Ret/Percepción Tasa Municipal"
+
+#. module: account
 #. odoo-python
 #: code:addons/account/wizard/accrued_orders.py:0
 #: model:ir.model.fields,field_description:account.field_digest_digest__kpi_account_total_revenue
@@ -13147,6 +16211,13 @@ msgstr "Cuenta acumulada de ingresos"
 #: model:ir.model.fields,field_description:account.field_account_invoice_report__account_id
 msgid "Revenue/Expense Account"
 msgstr "Cuenta de ingresos/gastos"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_ingresos
+#: model:account.group,name:account.3_account_group_ingresos
+#: model:account.group,name:account.4_account_group_ingresos
+msgid "Revenues"
+msgstr "Ingresos"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_accrued_orders_wizard__reversal_date
@@ -13310,6 +16381,13 @@ msgid "Rounding Strategy"
 msgstr "Estrategia de redondeo"
 
 #. module: account
+#: model:account.account,name:account.2_base_ajuste_por_redondeo
+#: model:account.account,name:account.3_base_ajuste_por_redondeo
+#: model:account.account,name:account.4_base_ajuste_por_redondeo
+msgid "Rounding adjustment"
+msgstr "Ajuste por redondeo"
+
+#. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_reconcile_model__rule_type__invoice_matching
 msgid "Rule to match invoices/bills"
 msgstr "Regla para emparejar facturas"
@@ -13340,6 +16418,19 @@ msgid "SEPA Direct Debit (SDD)"
 msgstr "Domiciliación bancaria SEPA (SDD)"
 
 #. module: account
+#: model:account.account,name:account.2_ri_retencion_sicore_a_pagar
+#: model:account.account,name:account.4_ri_retencion_sicore_a_pagar
+msgid "SICORE to be paid"
+msgstr "SICORE a pagar"
+
+#. module: account
+#: model:account.account,name:account.2_base_sircreb
+#: model:account.account,name:account.3_base_sircreb
+#: model:account.account,name:account.4_base_sircreb
+msgid "SIRCREB"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__message_has_sms_error
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__message_has_sms_error
 #: model:ir.model.fields,field_description:account.field_account_journal__message_has_sms_error
@@ -13356,12 +16447,47 @@ msgstr "Error en el envío del SMS"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "SO123"
-msgstr "SO123"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_default_terms_and_conditions
 msgid "STANDARD TERMS AND CONDITIONS OF SALE"
 msgstr "TÉRMINOS Y CONDICIONES ESTÁNDAR DE VENTA"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_creditos_fiscales_suss
+#: model:account.group,name:account.3_account_group_creditos_fiscales_suss
+#: model:account.group,name:account.4_account_group_creditos_fiscales_suss
+msgid "SUSS Tax Credits"
+msgstr "Créditos Fiscales SUSS"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_suss_sufrida
+#: model:account.account,name:account.3_base_retencion_suss_sufrida
+#: model:account.account,name:account.4_base_retencion_suss_sufrida
+msgid "SUSS Withholding incurred"
+msgstr "Retención SUSS Sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_base_haberes_comerciales
+#: model:account.account,name:account.3_base_haberes_comerciales
+#: model:account.account,name:account.4_base_haberes_comerciales
+msgid "Salaries and SAC Commercial"
+msgstr "Sueldos y SAC Comercial"
+
+#. module: account
+#: model:account.account,name:account.2_base_haberes_produccion
+#: model:account.account,name:account.3_base_haberes_produccion
+#: model:account.account,name:account.4_base_haberes_produccion
+msgid "Salaries and SAC Production"
+msgstr "Sueldos y SAC Producción"
+
+#. module: account
+#: model:account.account,name:account.2_base_sueldos_a_pagar
+#: model:account.account,name:account.3_base_sueldos_a_pagar
+#: model:account.account,name:account.4_base_sueldos_a_pagar
+msgid "Salaries to be paid"
+msgstr "Sueldos a pagar"
 
 #. module: account
 #: model:account.account,name:account.1_expense_salary
@@ -13383,6 +16509,20 @@ msgstr "Venta"
 #: model:res.groups,name:account.group_sale_receipts
 msgid "Sale Receipt"
 msgstr "Recibo de venta"
+
+#. module: account
+#: model:account.account,name:account.2_base_venta_de_mercaderia
+#: model:account.account,name:account.3_base_venta_de_mercaderia
+#: model:account.account,name:account.4_base_venta_de_mercaderia
+msgid "Sale of merchandise"
+msgstr "Venta de mercadería"
+
+#. module: account
+#: model:account.account,name:account.2_base_venta_de_servicios
+#: model:account.account,name:account.3_base_venta_de_servicios
+#: model:account.account,name:account.4_base_venta_de_servicios
+msgid "Sale of services"
+msgstr "Venta de servicios"
 
 #. module: account
 #: model:ir.actions.act_window,name:account.action_account_moves_journal_sales
@@ -13434,6 +16574,30 @@ msgstr "Impuesto de venta"
 #: model:ir.model.fields,field_description:account.field_product_template__taxes_id
 msgid "Sales Taxes"
 msgstr "Impuesto de ventas"
+
+#. module: account
+#: model:account.account,name:account.2_base_deudores_por_ventas
+#: model:account.account,name:account.3_base_deudores_por_ventas
+#: model:account.account,name:account.4_base_deudores_por_ventas
+#: model:account.group,name:account.2_account_group_creditos_por_ventas
+#: model:account.group,name:account.3_account_group_creditos_por_ventas
+#: model:account.group,name:account.4_account_group_creditos_por_ventas
+msgid "Sales receivables"
+msgstr "Créditos por ventas"
+
+#. module: account
+#: model:account.account,name:account.2_base_deudores_por_ventas_pos
+#: model:account.account,name:account.3_base_deudores_por_ventas_pos
+#: model:account.account,name:account.4_base_deudores_por_ventas_pos
+msgid "Sales receivables (PoS)"
+msgstr "Créditos por ventas (PoS)"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_ingresos_por_ventas
+#: model:account.group,name:account.3_account_group_ingresos_por_ventas
+#: model:account.group,name:account.4_account_group_ingresos_por_ventas
+msgid "Sales revenue"
+msgstr "Ingresos por ventas"
 
 #. module: account
 #. odoo-python
@@ -13490,6 +16654,13 @@ msgid "Save this page and come back here to set up the feature."
 msgstr "Guarde esta página y luego regrese para configurar la función."
 
 #. module: account
+#: model:account.group,name:account.2_account_group_caja
+#: model:account.group,name:account.3_account_group_caja
+#: model:account.group,name:account.4_account_group_caja
+msgid "Savings"
+msgstr "Caja"
+
+#. module: account
 #. odoo-javascript
 #: code:addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml:0
 msgid "Scan barcode"
@@ -13505,7 +16676,14 @@ msgstr "Escanéeme con su aplicación bancaria."
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document_preview
 msgid "Scan this QR Code with<br/>your banking application"
-msgstr "Escanee este código de barras con <br/>su aplicación bancaria "
+msgstr "Escanee este código de barras con <br/>su aplicación bancaria"
+
+#. module: account
+#: model:account.account,name:account.2_base_sellados_y_certificaciones
+#: model:account.account,name:account.3_base_sellados_y_certificaciones
+#: model:account.account,name:account.4_base_sellados_y_certificaciones
+msgid "Seals and Certifications"
+msgstr "Sellados y Certificaciones"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_journal_search
@@ -13525,7 +16703,7 @@ msgstr "Buscar posiciones fiscales"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_tax_group_view_search
 msgid "Search Group"
-msgstr "Buscar grupo "
+msgstr "Buscar grupo"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_invoice_filter
@@ -13746,11 +16924,6 @@ msgstr "Vender y comprar productos en diferentes unidades de medida"
 
 #. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_payment__payment_type__outbound
-#: model_terms:ir.ui.view,arch_db:account.account_move_send_batch_wizard_form
-#: model_terms:ir.ui.view,arch_db:account.account_move_send_wizard_form
-#: model_terms:ir.ui.view,arch_db:account.view_move_form
-#: model_terms:ir.ui.view,arch_db:account.view_out_credit_note_tree
-#: model_terms:ir.ui.view,arch_db:account.view_out_invoice_tree
 msgid "Send"
 msgstr "Enviar"
 
@@ -13835,7 +17008,6 @@ msgstr "Métodos de envío"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_setup_bank_manual_config__allow_out_payment
-#: model:ir.model.fields,help:account.field_res_partner_bank__allow_out_payment
 msgid ""
 "Sending fake invoices with a fraudulent account number is a common phishing "
 "practice. To protect yourself, always verify new bank account numbers, "
@@ -14194,6 +17366,20 @@ msgid "Snailmail"
 msgstr "Correo postal"
 
 #. module: account
+#: model:account.account,name:account.2_base_cargas_sociales_produccion
+#: model:account.account,name:account.3_base_cargas_sociales_produccion
+#: model:account.account,name:account.4_base_cargas_sociales_produccion
+msgid "Social Charges Production"
+msgstr "Cargas Sociales Producción"
+
+#. module: account
+#: model:account.account,name:account.2_base_suss_a_pagar
+#: model:account.account,name:account.3_base_suss_a_pagar
+#: model:account.account,name:account.4_base_suss_a_pagar
+msgid "Social Laws to be paid"
+msgstr "Leyes Sociales a pagar"
+
+#. module: account
 #. odoo-python
 #: code:addons/account/models/company.py:0
 msgid "Some documents are being sent by another process already."
@@ -14420,6 +17606,13 @@ msgid "Status with secured indicator for Journal Entries"
 msgstr "Estado con indicador de protección para los asientos contables"
 
 #. module: account
+#: model:account.account,name:account.2_base_reserva_estatuitaria
+#: model:account.account,name:account.3_base_reserva_estatuitaria
+#: model:account.account,name:account.4_base_reserva_estatuitaria
+msgid "Statutory reserve"
+msgstr "Reserva estatuitaria"
+
+#. module: account
 #: model:onboarding.onboarding.step,done_text:account.onboarding_onboarding_step_sales_tax
 msgid "Step Completed!"
 msgstr "¡Listo!"
@@ -14492,9 +17685,16 @@ msgid "Subject..."
 msgstr "Asunto..."
 
 #. module: account
+#: model:account.account,name:account.2_base_capital
+#: model:account.account,name:account.3_base_capital
+#: model:account.account,name:account.4_base_capital
+msgid "Subscribed capital"
+msgstr "Capital suscripto"
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_line__price_subtotal
 msgid "Subtotal"
-msgstr "Subtotal"
+msgstr ""
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__suitable_journal_ids
@@ -14508,12 +17708,26 @@ msgid "Summary Data"
 msgstr "Datos resumidos"
 
 #. module: account
+#: model:account.account,name:account.2_base_otros_creditos
+#: model:account.account,name:account.3_base_otros_creditos
+#: model:account.account,name:account.4_base_otros_creditos
+msgid "Sundry Accounts Receivable"
+msgstr "Deudores Varios"
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_setup_bank_manual_config__partner_supplier_rank
 #: model:ir.model.fields,field_description:account.field_res_partner__supplier_rank
 #: model:ir.model.fields,field_description:account.field_res_partner_bank__partner_supplier_rank
 #: model:ir.model.fields,field_description:account.field_res_users__supplier_rank
 msgid "Supplier Rank"
 msgstr "Rango de proveedor"
+
+#. module: account
+#: model:account.account,name:account.2_base_proveedores
+#: model:account.account,name:account.3_base_proveedores
+#: model:account.account,name:account.4_base_proveedores
+msgid "Suppliers"
+msgstr "Proveedores"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_journal__suspense_account_id
@@ -14524,6 +17738,13 @@ msgstr "Cuenta transitoria"
 #: model:ir.actions.server,name:account.action_move_switch_move_type
 msgid "Switch into invoice/credit note"
 msgstr "Cambiar a factura/nota de crédito"
+
+#. module: account
+#: model:account.account,name:account.2_base_sistema_y_software
+#: model:account.account,name:account.3_base_sistema_y_software
+#: model:account.account,name:account.4_base_sistema_y_software
+msgid "System and Software"
+msgstr "Sistema y Software"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_account_tag__name
@@ -14638,6 +17859,20 @@ msgstr "País del impuesto"
 #: model:ir.model.fields,field_description:account.field_account_move__tax_country_code
 msgid "Tax Country Code"
 msgstr "Código del país del impuesto"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_creditos_fiscales_ganancias
+#: model:account.group,name:account.3_account_group_creditos_fiscales_ganancias
+#: model:account.group,name:account.4_account_group_creditos_fiscales_ganancias
+msgid "Tax Credits Earnings"
+msgstr "Créditos Fiscales Ganancias"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_deudas_fiscales
+#: model:account.group,name:account.3_account_group_deudas_fiscales
+#: model:account.group,name:account.4_account_group_deudas_fiscales
+msgid "Tax Debts"
+msgstr "Deudas Fiscales"
 
 #. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_tax__price_include_override__tax_excluded
@@ -14806,6 +18041,13 @@ msgid "Tax calculation rounding method"
 msgstr "Método de redondeo del cálculo de impuestos"
 
 #. module: account
+#: model:account.group,name:account.2_account_group_creditos_fiscales
+#: model:account.group,name:account.3_account_group_creditos_fiscales
+#: model:account.group,name:account.4_account_group_creditos_fiscales
+msgid "Tax credits"
+msgstr "Créditos fiscales"
+
+#. module: account
 #: model:ir.model.fields,help:account.field_account_tax_group__tax_payable_account_id
 msgid ""
 "Tax current account used as a counterpart to the Tax Closing Entry when in "
@@ -14832,10 +18074,24 @@ msgstr ""
 "movimiento, en su caso"
 
 #. module: account
+#: model:account.account,name:account.2_base_intereses_fiscales
+#: model:account.account,name:account.3_base_intereses_fiscales
+#: model:account.account,name:account.4_base_intereses_fiscales
+msgid "Tax interest"
+msgstr "Intereses fiscales"
+
+#. module: account
 #. odoo-python
 #: code:addons/account/models/account_tax.py:0
 msgid "Tax names must be unique!"
 msgstr "El nombre de los impuestos debe ser único."
+
+#. module: account
+#: model:account.account,name:account.2_base_imp_debitos_computables
+#: model:account.account,name:account.3_base_imp_debitos_computables
+#: model:account.account,name:account.4_base_imp_debitos_computables
+msgid "Tax on Computable Debits"
+msgstr "Impuesto a los Débitos Computables"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_fiscal_position_tax__tax_src_id
@@ -14855,6 +18111,9 @@ msgstr "Impuestos usados"
 #. module: account
 #. odoo-python
 #: code:addons/account/models/account_account.py:0
+#: model:account.group,name:account.2_account_group_impuestos
+#: model:account.group,name:account.3_account_group_impuestos
+#: model:account.group,name:account.4_account_group_impuestos
 #: model:ir.actions.act_window,name:account.action_tax_form
 #: model:ir.model.fields,field_description:account.field_account_move_line__tax_ids
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model_line__tax_ids
@@ -14902,13 +18161,20 @@ msgid "Taxes in company currency"
 msgstr "Impuestos en la moneda de la empresa"
 
 #. module: account
+#: model:account.account,name:account.2_base_impuestos_debitos_y_creditos
+#: model:account.account,name:account.3_base_impuestos_debitos_y_creditos
+#: model:account.account,name:account.4_base_impuestos_debitos_y_creditos
+msgid "Taxes on bank debits and credits"
+msgstr "Impuestos a los débitos y créditos bancarios"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid ""
 "Taxes, fiscal positions, chart of accounts & legal statements for your "
 "country"
 msgstr ""
 "Impuestos, posiciones fiscales, planes de cuentas y declaraciones legales de"
-" su país.  "
+" su país."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_res_company__account_enabled_tax_country_ids
@@ -15621,7 +18887,7 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/account/static/src/js/tours/account.js:0
 msgid "The invoice having been sent, the button has changed priority."
-msgstr "Se envió la factura, cambió la prioridad del botón."
+msgstr "Habiéndose enviado la factura, la prioridad del botón ha cambiado."
 
 #. module: account
 #. odoo-python
@@ -16286,6 +19552,19 @@ msgstr ""
 "Asegúrese de que el archivo original sea válido."
 
 #. module: account
+#: model:account.account,name:account.2_base_cheques_de_terceros
+#: model:account.account,name:account.2_cash_journal_default_account_344
+#: model:account.account,name:account.3_base_cheques_de_terceros
+#: model:account.account,name:account.3_cash_journal_default_account_583
+#: model:account.account,name:account.4_base_cheques_de_terceros
+#: model:account.account,name:account.4_cash_journal_default_account_893
+#: model:account.journal,name:account.2_third_party_check
+#: model:account.journal,name:account.3_third_party_check
+#: model:account.journal,name:account.4_third_party_check
+msgid "Third Party Checks"
+msgstr "Cheques de Terceros"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "Thirty one dollar and Five cents"
 msgstr "Treinta y un dólares con cinco centavos"
@@ -16315,6 +19594,18 @@ msgstr "Esta semana"
 #: model:ir.model.fields.selection,name:account.selection__account_report__default_opening_date_filter__this_year
 msgid "This Year"
 msgstr "Este año"
+
+#. module: account
+#: model:ir.model.fields,help:account.field_res_partner_bank__allow_out_payment
+msgid "This account can be used for outgoing payments"
+msgstr ""
+"Con frecuencia se reciben correos que contienen facturas falsas con números "
+"de cuenta fraudulentos, a esta práctica se le llama phishing. Es importante "
+"verificar los nuevos números de cuenta y la mejor manera de hacerlo es "
+"llamar al proveedor, lo cual es esencial porque si se encuentra en esta "
+"situación, quiere decir que el correo del proveedor está en peligro. Una vez"
+" que haya comprobado que la información es correcta, puede activar la "
+"función de enviar dinero."
 
 #. module: account
 #. odoo-python
@@ -16701,7 +19992,6 @@ msgstr "Consejo: deje de buscar los documentos que necesita"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_automatic_entry_wizard__destination_account_id
-#: model_terms:ir.ui.view,arch_db:account.account_move_send_wizard_form
 msgid "To"
 msgstr "A"
 
@@ -16809,7 +20099,7 @@ msgstr "Actividades de hoy"
 #: model_terms:ir.ui.view,arch_db:account.view_invoice_tree
 #: model_terms:ir.ui.view,arch_db:account.view_move_tree
 msgid "Total"
-msgstr "Total"
+msgstr ""
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__quick_edit_total_amount
@@ -16972,6 +20262,20 @@ msgid "Trade %s"
 msgstr "%s comercial"
 
 #. module: account
+#: model:account.group,name:account.2_account_group_derechos_de_marcas
+#: model:account.group,name:account.3_account_group_derechos_de_marcas
+#: model:account.group,name:account.4_account_group_derechos_de_marcas
+msgid "Trademark Rights"
+msgstr "Derechos de Marcas"
+
+#. module: account
+#: model:account.account,name:account.2_base_derechos_de_marca
+#: model:account.account,name:account.3_base_derechos_de_marca
+#: model:account.account,name:account.4_base_derechos_de_marca
+msgid "Trademark rights"
+msgstr "Derechos de marca"
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__transaction_details
 msgid "Transaction Details"
 msgstr "Detalles de la transacción"
@@ -17113,6 +20417,13 @@ msgstr ""
 "las transacciones de nuevo antes de continuar."
 
 #. module: account
+#: model:account.account,name:account.2_base_aportes_no_capitalizados
+#: model:account.account,name:account.3_base_aportes_no_capitalizados
+#: model:account.account,name:account.4_base_aportes_no_capitalizados
+msgid "Uncapitalized contributions"
+msgstr "Aportes no capitalizados"
+
+#. module: account
 #. odoo-python
 #: code:addons/account/models/account_journal.py:0
 msgid "Undefined Yet"
@@ -17139,6 +20450,13 @@ msgstr "Asientos sin codificar"
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
 msgid "Unhashed entries"
 msgstr "Asientos sin codificar"
+
+#. module: account
+#: model:account.account,name:account.2_base_aportes_sindicales_a_pagar
+#: model:account.account,name:account.3_base_aportes_sindicales_a_pagar
+#: model:account.account,name:account.4_base_aportes_sindicales_a_pagar
+msgid "Union to be paid"
+msgstr "Sindicato a pagar"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_report_line__code
@@ -17542,9 +20860,183 @@ msgstr ""
 "contabilidad Storno"
 
 #. module: account
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_0_compras
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_0_ventas
+#: model:account.tax,name:account.4_ri_tax_vat_0_compras
+#: model:account.tax,name:account.4_ri_tax_vat_0_ventas
+#: model:account.tax.group,name:account.2_tax_group_iva_0
+#: model:account.tax.group,name:account.3_tax_group_iva_0
+#: model:account.tax.group,name:account.4_tax_group_iva_0
+msgid "VAT 0%"
+msgstr "IVA 0%"
+
+#. module: account
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_10_compras
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_10_ventas
+#: model:account.tax,name:account.4_ri_tax_vat_10_compras
+#: model:account.tax,name:account.4_ri_tax_vat_10_ventas
+#: model:account.tax.group,name:account.2_tax_group_iva_105
+#: model:account.tax.group,name:account.3_tax_group_iva_105
+#: model:account.tax.group,name:account.4_tax_group_iva_105
+msgid "VAT 10.5%"
+msgstr "IVA 10,5%"
+
+#. module: account
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_25_compras
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_25_ventas
+#: model:account.tax,name:account.4_ri_tax_vat_25_compras
+#: model:account.tax,name:account.4_ri_tax_vat_25_ventas
+#: model:account.tax.group,name:account.2_tax_group_iva_025
+#: model:account.tax.group,name:account.3_tax_group_iva_025
+#: model:account.tax.group,name:account.4_tax_group_iva_025
+msgid "VAT 2.5%"
+msgstr "IVA 2,5%"
+
+#. module: account
+#: model:account.tax,name:account.4_ri_tax_ganancias_iva_adicional
+msgid "VAT 20%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_21_compras
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_21_ventas
+#: model:account.tax,name:account.4_ri_tax_vat_21_compras
+#: model:account.tax,name:account.4_ri_tax_vat_21_ventas
+#: model:account.tax.group,name:account.2_tax_group_iva_21
+#: model:account.tax.group,name:account.3_tax_group_iva_21
+#: model:account.tax.group,name:account.4_tax_group_iva_21
+msgid "VAT 21%"
+msgstr "IVA 21%"
+
+#. module: account
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_27_compras
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_27_ventas
+#: model:account.tax,name:account.4_ri_tax_vat_27_compras
+#: model:account.tax,name:account.4_ri_tax_vat_27_ventas
+#: model:account.tax.group,name:account.2_tax_group_iva_27
+#: model:account.tax.group,name:account.3_tax_group_iva_27
+#: model:account.tax.group,name:account.4_tax_group_iva_27
+msgid "VAT 27%"
+msgstr "IVA 27%"
+
+#. module: account
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_5_compras
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_5_ventas
+#: model:account.tax,name:account.4_ri_tax_vat_5_compras
+#: model:account.tax,name:account.4_ri_tax_vat_5_ventas
+#: model:account.tax.group,name:account.2_tax_group_iva_5
+#: model:account.tax.group,name:account.3_tax_group_iva_5
+#: model:account.tax.group,name:account.4_tax_group_iva_5
+msgid "VAT 5%"
+msgstr "IVA 5%"
+
+#. module: account
+#: model:account.tax,invoice_label:account.4_ri_tax_ganancias_iva_adicional
+#: model_terms:account.tax,description:account.4_ri_tax_ganancias_iva_adicional
+msgid "VAT Additional 20%"
+msgstr ""
+
+#. module: account
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_exento_compras
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_exento_ventas
+#: model:account.tax.group,name:account.2_tax_group_iva_exento
+#: model:account.tax.group,name:account.3_tax_group_iva_exento
+#: model:account.tax.group,name:account.4_tax_group_iva_exento
+msgid "VAT Exempt"
+msgstr "IVA Exento"
+
+#. module: account
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_no_corresponde_compras
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_no_corresponde_ventas
+#: model:account.tax.group,name:account.2_tax_group_iva_no_corresponde
+#: model:account.tax.group,name:account.3_tax_group_iva_no_corresponde
+#: model:account.tax.group,name:account.4_tax_group_iva_no_corresponde
+#: model_terms:account.tax,description:account.4_ri_tax_vat_no_corresponde_compras
+#: model_terms:account.tax,description:account.4_ri_tax_vat_no_corresponde_ventas
+msgid "VAT Not Applicable"
+msgstr "IVA No Corresponde"
+
+#. module: account
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_no_gravado_compras
+#: model:account.tax,invoice_label:account.4_ri_tax_vat_no_gravado_ventas
+#: model_terms:account.tax,description:account.4_ri_tax_vat_no_gravado_compras
+#: model_terms:account.tax,description:account.4_ri_tax_vat_no_gravado_ventas
+msgid "VAT Not Taxed"
+msgstr ""
+
+#. module: account
+#: model:account.tax.group,name:account.2_tax_group_percepcion_iva
+#: model:account.tax.group,name:account.3_tax_group_percepcion_iva
+#: model:account.tax.group,name:account.4_tax_group_percepcion_iva
+msgid "VAT Perception"
+msgstr "Percepción del IVA"
+
+#. module: account
+#: model:account.group,name:account.2_account_group_creditos_fiscales_iva
+#: model:account.group,name:account.3_account_group_creditos_fiscales_iva
+#: model:account.group,name:account.4_account_group_creditos_fiscales_iva
+msgid "VAT Tax Credits"
+msgstr "Créditos Fiscales IVA"
+
+#. module: account
+#: model:account.account,name:account.4_ri_iva_saldo_tecnico_favor
+msgid "VAT Technical balance"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.4_ri_iva_saldo_libre_disponibilidad
+msgid "VAT Unrestricted balance"
+msgstr ""
+
+#. module: account
+#: model:account.tax.group,name:account.2_tax_group_iva_no_gravado
+#: model:account.tax.group,name:account.3_tax_group_iva_no_gravado
+#: model:account.tax.group,name:account.4_tax_group_iva_no_gravado
+msgid "VAT Untaxed"
+msgstr "IVA No Gravado"
+
+#. module: account
+#: model:account.account,name:account.4_ri_iva_saldo_a_pagar
+msgid "VAT balance payable"
+msgstr ""
+
+#. module: account
+#: model:account.group,name:account.2_account_group_deudas_iva
+#: model:account.group,name:account.3_account_group_deudas_iva
+#: model:account.group,name:account.4_account_group_deudas_iva
+msgid "VAT debts"
+msgstr "Deudas IVA"
+
+#. module: account
+#: model:account.account,name:account.4_base_plan_iva_a_pagar
+msgid "VAT plan to be paid"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_fiscal_position__vat_required
 msgid "VAT required"
 msgstr "Requiere número de identificación tributaria"
+
+#. module: account
+#: model:account.account,name:account.4_ri_iva_credito_fiscal
+msgid "VAT tax credit"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.4_ri_iva_debito_fiscal
+msgid "VAT tax debit"
+msgstr ""
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iva_aplicada
+#: model:account.account,name:account.4_ri_retencion_iva_aplicada
+msgid "VAT withholding applied"
+msgstr "Retención IVA aplicada"
+
+#. module: account
+#: model:account.account,name:account.4_ri_retencion_iva_sufrida
+msgid "VAT withholding incurred"
+msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_lock_exception_form
@@ -17554,7 +21046,7 @@ msgstr "Válido para"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_payment_form
 msgid "Validate"
-msgstr "Validar "
+msgstr "Validar"
 
 #. module: account
 #: model:ir.model,name:account.model_validate_account_move
@@ -17621,6 +21113,16 @@ msgid "Variants"
 msgstr "Variantes"
 
 #. module: account
+#: model:account.account,name:account.2_base_rodados
+#: model:account.account,name:account.3_base_rodados
+#: model:account.account,name:account.4_base_rodados
+#: model:account.group,name:account.2_account_group_rodados
+#: model:account.group,name:account.3_account_group_rodados
+#: model:account.group,name:account.4_account_group_rodados
+msgid "Vehicules"
+msgstr "Rodados"
+
+#. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_payment__partner_type__supplier
 #: model:ir.model.fields.selection,name:account.selection__account_payment_register__partner_type__supplier
 #: model_terms:ir.ui.view,arch_db:account.product_view_search_catalog
@@ -17663,6 +21165,9 @@ msgstr "Factura de proveedor creada"
 #: code:addons/account/models/account_analytic_account.py:0
 #: code:addons/account/models/chart_template.py:0
 #: model:account.journal,name:account.1_purchase
+#: model:account.journal,name:account.2_purchase
+#: model:account.journal,name:account.3_purchase
+#: model:account.journal,name:account.4_purchase
 #: model:ir.model.fields.selection,name:account.selection__account_reconcile_model__counterpart_type__purchase
 #: model:ir.model.fields.selection,name:account.selection__res_company__quick_edit_mode__in_invoices
 #: model_terms:ir.ui.view,arch_db:account.account_analytic_account_view_form_inherit
@@ -17704,7 +21209,7 @@ msgstr "Pagos de proveedor"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
 msgid "Vendor:"
-msgstr "Proveedor: "
+msgstr "Proveedor:"
 
 #. module: account
 #: model:ir.actions.act_window,name:account.res_partner_action_supplier
@@ -17714,6 +21219,13 @@ msgstr "Proveedor: "
 #: model_terms:ir.ui.view,arch_db:account.view_partner_bank_search_inherit
 msgid "Vendors"
 msgstr "Proveedores"
+
+#. module: account
+#: model:account.journal,name:account.2_sale
+#: model:account.journal,name:account.3_sale
+#: model:account.journal,name:account.4_sale
+msgid "Ventas Preimpreso"
+msgstr ""
 
 #. module: account
 #. odoo-javascript
@@ -17775,6 +21287,20 @@ msgstr "Advertencias"
 #: model:ir.model.fields,field_description:account.field_res_config_settings__group_warning_account
 msgid "Warnings in Invoices"
 msgstr "Advertencias en facturas"
+
+#. module: account
+#: model:account.account,name:account.2_base_servicio_de_agua_administrativos
+#: model:account.account,name:account.3_base_servicio_de_agua_administrativos
+#: model:account.account,name:account.4_base_servicio_de_agua_administrativos
+msgid "Water Service Administrative"
+msgstr "Servicio de Agua Administrativos"
+
+#. module: account
+#: model:account.account,name:account.2_base_servicio_de_agua_produccion
+#: model:account.account,name:account.3_base_servicio_de_agua_produccion
+#: model:account.account,name:account.4_base_servicio_de_agua_produccion
+msgid "Water Service Production"
+msgstr "Servicio de Agua Producción"
 
 #. module: account
 #. odoo-python
@@ -17912,6 +21438,37 @@ msgstr "Con residual"
 #: model_terms:ir.ui.view,arch_db:account.view_account_reconcile_model_search
 msgid "With tax"
 msgstr "Impuestos incluidos"
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_sf_aplicada
+#: model:account.account,name:account.4_ri_retencion_iibb_sf_aplicada
+msgid "Withholding IIBB Santa Fe applied"
+msgstr "Retención IIBB Santa Fe aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_iibb_sf_sufrida
+#: model:account.account,name:account.3_base_retencion_iibb_sf_sufrida
+#: model:account.account,name:account.4_base_retencion_iibb_sf_sufrida
+msgid "Withholding IIBB Santa Fe incurred"
+msgstr "Retención IIBB Santa Fe sufrida"
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_ganancias_aplicada
+#: model:account.account,name:account.4_ri_retencion_ganancias_aplicada
+msgid "Withholding applied to earnings"
+msgstr "Retención ganancias aplicada"
+
+#. module: account
+#: model:account.account,name:account.2_ri_retencion_iibb_a_pagar
+#: model:account.account,name:account.4_ri_retencion_iibb_a_pagar
+msgid "Withholding/Perception IIBB to be paid"
+msgstr "Retención/Percepción IIBB a pagar"
+
+#. module: account
+#: model:account.account,name:account.2_base_retencion_ganancias_sufrida
+#: model:account.account,name:account.4_base_retencion_ganancias_sufrida
+msgid "Withholdings of Profits incurred"
+msgstr "Retenciones de Ganancias Sufridas"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_merge_wizard_line__wizard_id
@@ -18966,6 +22523,7 @@ msgstr "Por ejemplo, GEBABEBB"
 #. module: account
 #. odoo-python
 #: code:addons/account/models/account_analytic_distribution_model.py:0
+#: code:addons/account/models/account_analytic_plan.py:0
 msgid "e.g. %(prefix)s"
 msgstr "Por ejemplo, %(prefix)s"
 

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -8,7 +8,7 @@
             <field name="name">account.payment.list</field>
             <field name="model">account.payment</field>
             <field name="arch" type="xml">
-                <list edit="false" sample="1" decoration-info="state == 'draft'" decoration-muted="state == 'cancel'">
+                <list edit="false" sample="1" decoration-info="state == 'draft'" decoration-muted="state == 'canceled'">
                     <header>
                         <button name="action_post" type="object" string="Confirm"/>
                     </header>

--- a/addons/l10n_latam_check/i18n/es_419.po
+++ b/addons/l10n_latam_check/i18n/es_419.po
@@ -6,16 +6,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-07 13:16+0000\n"
-"PO-Revision-Date: 2024-10-07 13:16+0000\n"
+"POT-Creation-Date: 2025-02-10 15:08+0000\n"
+"PO-Revision-Date: 2025-02-10 15:08+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-"X-Generator: Poedit 3.0.1\n"
 
 #. module: l10n_latam_check
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.l10n_latam_check_view_form
@@ -43,7 +41,9 @@ msgstr "<span>Asiento conciliado</span>"
 msgid ""
 "A payment with any Third Party Check or Own Check payment methods needs an "
 "outstanding account"
-msgstr "Un pago con cualquiera de los métodos de pago Cheque de terceros o Cheque propio requiere una cuenta pendiente"
+msgstr ""
+"Un pago con cualquiera de los métodos de pago Cheque de terceros o Cheque "
+"propio requiere una cuenta pendiente"
 
 #. module: l10n_latam_check
 #. odoo-python
@@ -54,7 +54,7 @@ msgstr "Se ha creado un segundo pago: "
 #. module: l10n_latam_check
 #: model:ir.model,name:l10n_latam_check.model_account_chart_template
 msgid "Account Chart Template"
-msgstr "Plantilla de Plan de Cuentas"
+msgstr "Plantilla de plan de cuentas"
 
 #. module: l10n_latam_check
 #: model:ir.model,name:l10n_latam_check.model_l10n_latam_check
@@ -136,8 +136,8 @@ msgstr "Cheque"
 #. module: l10n_latam_check
 #. odoo-python
 #: code:addons/l10n_latam_check/models/account_payment.py:0
-msgid "Check %s - "
-msgstr "Cheque %s - "
+msgid "Check %(check_number)s - %(suffix)s"
+msgstr ""
 
 #. module: l10n_latam_check
 #. odoo-python
@@ -152,6 +152,7 @@ msgid "Check Transfer"
 msgstr "Transferir Cheque"
 
 #. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_move_line__l10n_latam_check_ids
 #: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment__l10n_latam_new_check_ids
 #: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_register__l10n_latam_move_check_ids
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_form_inherited
@@ -180,11 +181,6 @@ msgstr "Transferencia Masiva de Cheques"
 #: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment__l10n_latam_move_check_ids
 msgid "Checks Operations"
 msgstr "Cheques"
-
-#. module: l10n_latam_check
-#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_third_party_checks_search
-msgid "Checks on hand"
-msgstr "Cheque en mano"
 
 #. module: l10n_latam_check
 #: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_check__payment_method_code
@@ -288,6 +284,7 @@ msgstr "Actividades futuras"
 
 #. module: l10n_latam_check
 #: model:ir.model.fields.selection,name:l10n_latam_check.selection__l10n_latam_check__issue_state__handed
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_search
 msgid "Handed"
 msgstr "Entregado"
 
@@ -345,18 +342,15 @@ msgstr "CUIT del Emisor"
 #. odoo-python
 #: code:addons/l10n_latam_check/models/account_payment.py:0
 msgid ""
-"It seems you're trying to move a check with a date (%s) prior to last "
-"operation done with the check (%s). This may be wrong, please double check "
-"it. By continue, the last operation on the check will remain being %s"
+"It seems you're trying to move a check with a date (%(date)s) prior to last "
+"operation done with the check (%(last_operation)s). This may be wrong, "
+"please double check it. By continue, the last operation on the check will "
+"remain being %(last_operation)s"
 msgstr ""
-"Parece que quieres mover un cheque con fecha (%s) previo a la última "
-"operación realizada con el cheque (%s). Esto puede ser incorrecto, por "
-"favor chequear. De continuar, la última operación en el cheque continuará "
-"siendo %s"
 
 #. module: l10n_latam_check
 #: model:ir.model,name:l10n_latam_check.model_account_journal
-#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_check__journal_id
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_check__original_journal_id
 #: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_payment_mass_transfer__journal_id
 msgid "Journal"
 msgstr "Diario"
@@ -365,6 +359,11 @@ msgstr "Diario"
 #: model:ir.model,name:l10n_latam_check.model_account_move
 msgid "Journal Entry"
 msgstr "Asiento contable"
+
+#. module: l10n_latam_check
+#: model:ir.model,name:l10n_latam_check.model_account_move_line
+msgid "Journal Item"
+msgstr "Apunte contable"
 
 #. module: l10n_latam_check
 #: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment__l10n_latam_check_warning_msg
@@ -391,25 +390,14 @@ msgid "Late Activities"
 msgstr "Actividades tardías"
 
 #. module: l10n_latam_check
-#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_check__outstanding_line_id
-msgid "Liquidity Line"
-msgstr "Línea de Liquidez"
-
-#. module: l10n_latam_check
 #: model:ir.model.fields,help:l10n_latam_check.field_l10n_latam_check__payment_method_line_id
 msgid ""
 "Manual: Pay or Get paid by any method outside of Odoo.\n"
-"Payment Providers: Each payment provider has its own Payment Method. "
-"Request a transaction on/to a card thanks to a payment token saved by the "
-"partner when buying or subscribing online.\n"
+"Payment Providers: Each payment provider has its own Payment Method. Request a transaction on/to a card thanks to a payment token saved by the partner when buying or subscribing online.\n"
 "Check: Pay bills by check and print it from Odoo.\n"
-"Batch Deposit: Collect several customer checks at once generating and "
-"submitting a batch deposit to your bank. Module account_batch_payment is "
-"necessary.\n"
-"SEPA Credit Transfer: Pay in the SEPA zone by submitting a SEPA Credit "
-"Transfer file to your bank. Module account_sepa is necessary.\n"
-"SEPA Direct Debit: Get paid in the SEPA zone thanks to a mandate your "
-"partner will have granted to you. Module account_sepa is necessary.\n"
+"Batch Deposit: Collect several customer checks at once generating and submitting a batch deposit to your bank. Module account_batch_payment is necessary.\n"
+"SEPA Credit Transfer: Pay in the SEPA zone by submitting a SEPA Credit Transfer file to your bank. Module account_sepa is necessary.\n"
+"SEPA Direct Debit: Get paid in the SEPA zone thanks to a mandate your partner will have granted to you. Module account_sepa is necessary.\n"
 msgstr ""
 
 #. module: l10n_latam_check
@@ -424,7 +412,7 @@ msgstr ""
 #. module: l10n_latam_check
 #: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_payment_mass_transfer__communication
 msgid "Memo"
-msgstr "Memo"
+msgstr ""
 
 #. module: l10n_latam_check
 #: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_check__message_has_error
@@ -493,9 +481,9 @@ msgid "Number of messages with delivery error"
 msgstr "Número de mensajes con error de envío"
 
 #. module: l10n_latam_check
-#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_search
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_third_party_checks_search
 msgid "On hand"
-msgstr "En Mano"
+msgstr ""
 
 #. module: l10n_latam_check
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_form_inherited
@@ -520,6 +508,11 @@ msgstr ""
 "pagos/cheques: %s"
 
 #. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_check__outstanding_line_id
+msgid "Outstanding Line"
+msgstr "Línea de Liquidez"
+
+#. module: l10n_latam_check
 #. odoo-python
 #: code:addons/l10n_latam_check/models/account_chart_template.py:0
 msgid "Outstanding Payments"
@@ -542,6 +535,11 @@ msgstr "Cheques Propios"
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_search
 msgid "Partner"
 msgstr ""
+
+#. module: l10n_latam_check
+#: model:ir.model,name:l10n_latam_check.model_account_payment_register
+msgid "Pay"
+msgstr "Pagar"
 
 #. module: l10n_latam_check
 #: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_check__payment_id
@@ -589,11 +587,6 @@ msgid "Payments"
 msgstr "Pagos"
 
 #. module: l10n_latam_check
-#: model:ir.model,name:l10n_latam_check.model_account_payment_register
-msgid "Register Payment"
-msgstr "Registrar pago"
-
-#. module: l10n_latam_check
 #. odoo-python
 #: code:addons/l10n_latam_check/models/account_chart_template.py:0
 msgid "Rejected Third Party Checks"
@@ -605,6 +598,11 @@ msgid "Responsible User"
 msgstr "Usuario responsable"
 
 #. module: l10n_latam_check
+#: model:account.payment.method,name:l10n_latam_check.account_payment_method_return_third_party_checks
+msgid "Return Third Party Checks"
+msgstr ""
+
+#. module: l10n_latam_check
 #: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_check__message_has_sms_error
 msgid "SMS Delivery error"
 msgstr "Error de entrega del SMS"
@@ -612,8 +610,8 @@ msgstr "Error de entrega del SMS"
 #. module: l10n_latam_check
 #. odoo-python
 #: code:addons/l10n_latam_check/models/account_payment.py:0
-msgid "Selecteds checks \"%s\" are not posted"
-msgstr "Los cheques seleccionados \"%s\" no están publicados"
+msgid "Selected checks \"%s\" are not posted"
+msgstr ""
 
 #. module: l10n_latam_check
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_search
@@ -705,6 +703,12 @@ msgid "Third Party Checks"
 msgstr "Cheques de Terceros"
 
 #. module: l10n_latam_check
+#. odoo-python
+#: code:addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py:0
+msgid "This payment has been created from: "
+msgstr ""
+
+#. module: l10n_latam_check
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_search
 msgid "Today Activities"
 msgstr "Actividades de hoy"
@@ -739,12 +743,10 @@ msgstr "Historial de comunicaciones del sitio web"
 #. odoo-python
 #: code:addons/l10n_latam_check/models/account_payment.py:0
 msgid ""
-"You can't cancel or re-open a payment with checks if some check has been "
-"debited or been voided. Checks:\n"
+"You can't cancel or re-open a payment with checks if some check has been debited or been voided. Checks:\n"
 "%s"
 msgstr ""
-"No puede cancelar o reabrir un pago con cheques si algún cheque ha sido "
-"debitado o anulado. Cheques:\n"
+"No puede cancelar o reabrir un pago con cheques si algún cheque ha sido debitado o anulado. Cheques:\n"
 "%s"
 
 #. module: l10n_latam_check

--- a/addons/l10n_latam_check/i18n/l10n_latam_check.pot
+++ b/addons/l10n_latam_check/i18n/l10n_latam_check.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-07 13:16+0000\n"
-"PO-Revision-Date: 2024-10-07 13:16+0000\n"
+"POT-Creation-Date: 2025-02-10 15:09+0000\n"
+"PO-Revision-Date: 2025-02-10 15:09+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -133,7 +133,7 @@ msgstr ""
 #. module: l10n_latam_check
 #. odoo-python
 #: code:addons/l10n_latam_check/models/account_payment.py:0
-msgid "Check %s - "
+msgid "Check %(check_number)s - %(suffix)s"
 msgstr ""
 
 #. module: l10n_latam_check
@@ -149,6 +149,7 @@ msgid "Check Transfer"
 msgstr ""
 
 #. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_move_line__l10n_latam_check_ids
 #: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment__l10n_latam_new_check_ids
 #: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_register__l10n_latam_move_check_ids
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_form_inherited
@@ -176,11 +177,6 @@ msgstr ""
 #. module: l10n_latam_check
 #: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment__l10n_latam_move_check_ids
 msgid "Checks Operations"
-msgstr ""
-
-#. module: l10n_latam_check
-#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_third_party_checks_search
-msgid "Checks on hand"
 msgstr ""
 
 #. module: l10n_latam_check
@@ -285,6 +281,7 @@ msgstr ""
 
 #. module: l10n_latam_check
 #: model:ir.model.fields.selection,name:l10n_latam_check.selection__l10n_latam_check__issue_state__handed
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_search
 msgid "Handed"
 msgstr ""
 
@@ -341,14 +338,15 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_latam_check/models/account_payment.py:0
 msgid ""
-"It seems you're trying to move a check with a date (%s) prior to last "
-"operation done with the check (%s). This may be wrong, please double check "
-"it. By continue, the last operation on the check will remain being %s"
+"It seems you're trying to move a check with a date (%(date)s) prior to last "
+"operation done with the check (%(last_operation)s). This may be wrong, "
+"please double check it. By continue, the last operation on the check will "
+"remain being %(last_operation)s"
 msgstr ""
 
 #. module: l10n_latam_check
 #: model:ir.model,name:l10n_latam_check.model_account_journal
-#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_check__journal_id
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_check__original_journal_id
 #: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_payment_mass_transfer__journal_id
 msgid "Journal"
 msgstr ""
@@ -356,6 +354,11 @@ msgstr ""
 #. module: l10n_latam_check
 #: model:ir.model,name:l10n_latam_check.model_account_move
 msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_latam_check
+#: model:ir.model,name:l10n_latam_check.model_account_move_line
+msgid "Journal Item"
 msgstr ""
 
 #. module: l10n_latam_check
@@ -380,11 +383,6 @@ msgstr ""
 #. module: l10n_latam_check
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_search
 msgid "Late Activities"
-msgstr ""
-
-#. module: l10n_latam_check
-#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_check__outstanding_line_id
-msgid "Liquidity Line"
 msgstr ""
 
 #. module: l10n_latam_check
@@ -477,13 +475,12 @@ msgid "Number of messages with delivery error"
 msgstr ""
 
 #. module: l10n_latam_check
-#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_search
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_third_party_checks_search
 msgid "On hand"
 msgstr ""
 
 #. module: l10n_latam_check
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_form_inherited
-#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_register_form
 msgid "Open"
 msgstr ""
 
@@ -499,6 +496,11 @@ msgid ""
 "Other checks were found with same number, issuer and bank. Please double "
 "check you are not encoding the same check more than once. List of other "
 "payments/checks: %s"
+msgstr ""
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_check__outstanding_line_id
+msgid "Outstanding Line"
 msgstr ""
 
 #. module: l10n_latam_check
@@ -523,6 +525,11 @@ msgstr ""
 #. module: l10n_latam_check
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_search
 msgid "Partner"
+msgstr ""
+
+#. module: l10n_latam_check
+#: model:ir.model,name:l10n_latam_check.model_account_payment_register
+msgid "Pay"
 msgstr ""
 
 #. module: l10n_latam_check
@@ -571,11 +578,6 @@ msgid "Payments"
 msgstr ""
 
 #. module: l10n_latam_check
-#: model:ir.model,name:l10n_latam_check.model_account_payment_register
-msgid "Register Payment"
-msgstr ""
-
-#. module: l10n_latam_check
 #. odoo-python
 #: code:addons/l10n_latam_check/models/account_chart_template.py:0
 msgid "Rejected Third Party Checks"
@@ -587,6 +589,11 @@ msgid "Responsible User"
 msgstr ""
 
 #. module: l10n_latam_check
+#: model:account.payment.method,name:l10n_latam_check.account_payment_method_return_third_party_checks
+msgid "Return Third Party Checks"
+msgstr ""
+
+#. module: l10n_latam_check
 #: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_check__message_has_sms_error
 msgid "SMS Delivery error"
 msgstr ""
@@ -594,7 +601,7 @@ msgstr ""
 #. module: l10n_latam_check
 #. odoo-python
 #: code:addons/l10n_latam_check/models/account_payment.py:0
-msgid "Selecteds checks \"%s\" are not posted"
+msgid "Selected checks \"%s\" are not posted"
 msgstr ""
 
 #. module: l10n_latam_check
@@ -675,6 +682,12 @@ msgid "Third Party Checks"
 msgstr ""
 
 #. module: l10n_latam_check
+#. odoo-python
+#: code:addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py:0
+msgid "This payment has been created from: "
+msgstr ""
+
+#. module: l10n_latam_check
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_search
 msgid "Today Activities"
 msgstr ""
@@ -722,6 +735,5 @@ msgstr ""
 
 #. module: l10n_latam_check
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_form_inherited
-#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_register_form
 msgid "open"
 msgstr ""

--- a/addons/l10n_latam_check/views/l10n_latam_check_view.xml
+++ b/addons/l10n_latam_check/views/l10n_latam_check_view.xml
@@ -14,7 +14,7 @@
                 <separator/>
                 <filter string="Payment Date" name="payment_date" date="payment_date"/>
                 <separator/>
-                <filter string="On hand" name="checks_on_hand" domain="[('issue_state', '=', 'handed')]"/>
+                <filter string="Handed" name="checks_on_hand" domain="[('issue_state', '=', 'handed')]"/>
                 <filter string="Voided" name="checks_voided" domain="[('issue_state', '=', 'voided')]"/>
                 <filter string="Debited" name="checks_debited" domain="[('issue_state', '=', 'debited')]"/>
                 <separator/>
@@ -40,7 +40,7 @@
             <filter name="checks_on_hand" position="replace"/>
             <filter name="checks_voided" position="replace"/>
             <filter name="checks_debited" position="replace">
-                <filter string="Checks on hand" name="checks_on_hand"
+                <filter string="On hand" name="checks_on_hand"
                     domain="[('current_journal_id.inbound_payment_method_line_ids.payment_method_id.code', '=', 'in_third_party_checks')]"/>
             </filter>
             <field name="original_journal_id" position="before">
@@ -150,7 +150,7 @@
         <field name="model">l10n_latam.check</field>
         <field name="priority">100</field>
         <field name="arch" type="xml">
-            <list edit="false" create="false" delete="false" duplicate="false" sample="1" decoration-info="issue_state == 'handed'" decoration-muted="issue_state == 'voided'">
+            <list edit="false" create="false" delete="false" duplicate="false" sample="1" decoration-info="issue_state == 'handed'" decoration-muted="issue_state in ('voided','debited')">
                     <header>
                     </header>
                     <field name="payment_date" optional="show"/>
@@ -161,7 +161,7 @@
                     <field name="partner_id" string="Customer"/>
                     <field name="amount"  optional="show"/>
                     <field name="currency_id" string="Payment Currency" optional="hide"/>
-                    <field name="issue_state" widget="badge" decoration-info="issue_state == 'handed'"  decoration-muted="issue_state == 'voided'" decoration-success="issue_state == 'debited'"/>
+                    <field name="issue_state" widget="badge" decoration-info="issue_state == 'handed'"  decoration-muted="issue_state in ('voided','debited')"/>
             </list>
         </field>
     </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR aims to add better visibility to own checks. Made voided and debited checks appear gray on tree view in order to make handed checks more eye-catching. 
I also refactor the labels on search views for own and third party checks to make them consistent with "Issue state" field.
Lastly, I refactored account.payment tree view to make decoration-muted work well when "state" is "Canceled".

Current behavior before PR:
- l10n_latam_check 
Debited checks records appear black on tree view, and "Issue state" tag on green. 
Voided checks records appear gray on tree view as well as "Issue state" tag.
![image](https://github.com/user-attachments/assets/2c8aa165-e544-448e-a1b5-7fb257c717c6)
- account
"Canceled" payments records appear black on tree view.

Desired behavior after PR is merged:
- l10n_latam_check 
Voided or debited checks records will appear with gray color on tree view, as well as "Issue state" tag. 
Handed checks records will appear blue on tree view, as well as "Issue state" tag. 
![image](https://github.com/user-attachments/assets/7da1eb9b-9d5d-462b-a744-04072bea0a1b)
- account
"Canceled" payments records appear gray on tree view.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
