### PR TITLE
[FIX] website: fix the old image gallery crash after upgrading

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/000.js
+++ b/addons/website/static/src/snippets/s_image_gallery/000.js
@@ -160,6 +160,9 @@ const GallerySliderWidget = publicWidget.Widget.extend({
         this.$carousel.on('slide.bs.carousel.gallery_slider', function () {
             setTimeout(function () {
                 var $item = self.$carousel.find('.carousel-inner .carousel-item-prev, .carousel-inner .carousel-item-next');
+                if (!$item.length) {
+                    return;
+                }
                 var index = $item.index();
                 $lis.removeClass('active')
                     .filter('[data-bs-slide-to="' + index + '"]')


### PR DESCRIPTION
Steps to reproduce:

- In V17.0 drag and drop an "Image Gallery" block into the page.
- Upgrade to 18.0
- Click on the last "Image Gallery" indicator and then quickly on the first one.
- Traceback: "TypeError: Cannot read properties of null (reading 'classList') at Carousel._setActiveIndicatorElement ..."

This issue is caused by the front-end code of the image gallery, which updates the active indicator during a slide event. When the crash happens, it cannot find the active slide in the DOM.

After investigation, everything already works with Bootstrap, and the purpose of this code remains unclear. However, in the stable version, we are not taking any risks and will not modify it.

In this commit, we simply added a return; in case the active slide is not found.

opw-4519455