### PR TITLE
[IMP] hr_holidays: allocation import of accrual plans

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -289,6 +289,7 @@
                 <field name="date_from" string="Validity Start" optional="hide"/>
                 <field name="date_to" string="Validity Stop" optional="hide" readonly="state in ['refuse', 'validate', 'validate1']"/>
                 <field name="allocation_type" readonly="state not in ['confirm']"/>
+                <field name="accrual_plan_id"/>
                 <field name="notes" string="Reason" optional="hide"/>
                 <field name="message_needaction" column_invisible="True"/>
                 <field name="active_employee" column_invisible="True"/>


### PR DESCRIPTION
Problem
----------
It is impossible to import batch of data with allocation_type set to 'accrual'

Objective
----------
- DO NOT make it possible by removing the readonly attribute on the allocation_type field
- Allow the user to set directly an accrual plan and the allocation_type will be set automatically accordingly

Solution
----------
On creation of allocation :
-> if the accrual plan exists, it will update the value of allocation_type to "accrual" 
-> if the accrual plan is empty (==False) it will not update the allocation_type => "regular"

task-4521658
