### PR TITLE
[IMP] {pos,website}_event{_crm}: create a library of questions

### DIFF
--- a/addons/event/__manifest__.py
+++ b/addons/event/__manifest__.py
@@ -42,6 +42,7 @@ Key Features
         'views/event_tag_views.xml',
         'views/event_question_views.xml',
         'views/event_registration_answer_views.xml',
+        'data/event_question_data.xml',
     ],
     'demo': [
         'data/res_users_demo.xml',

--- a/addons/event/data/event_demo.xml
+++ b/addons/event/data/event_demo.xml
@@ -31,10 +31,10 @@
     <li>If you don't have this ticket, you will <b>not</b> be allowed entry!</li>
 </ul>
         </field>
-        <field name="question_ids" eval="[(5, 0, 0),
-            (0, 0, {'title': 'Name', 'question_type': 'name', 'is_mandatory_answer': True}),
-            (0, 0, {'title': 'Email', 'question_type': 'email', 'is_mandatory_answer': True}),
-            (0, 0, {'title': 'Phone', 'question_type': 'phone'})]"/>
+        <field name="question_ids" eval="[
+            (4, ref('event.event_question_name')),
+            (4, ref('event.event_question_email')),
+            (4, ref('event.event_question_phone'))]"/>
     </record>
     <record id="event_0_ticket_0" model="event.event.ticket">
         <field name="name">Free</field>
@@ -74,10 +74,10 @@
         <field name="stage_id" ref="event_stage_booked"/>
         <field name="kanban_state">blocked</field>
         <field name="tag_ids" eval="[(4, ref('event.event_tag_category_1_tag_4')), (4, ref('event.event_tag_category_2_tag_3'))]"/>
-        <field name="question_ids" eval="[(5, 0, 0),
-            (0, 0, {'title': 'Name', 'question_type': 'name', 'is_mandatory_answer': True}),
-            (0, 0, {'title': 'Email', 'question_type': 'email', 'is_mandatory_answer': True}),
-            (0, 0, {'title': 'Phone', 'question_type': 'phone'})]"/>
+        <field name="question_ids" eval="[
+            (4, ref('event.event_question_name')),
+            (4, ref('event.event_question_email')),
+            (4, ref('event.event_question_phone'))]"/>
     </record>
 
     <record id="message_event_1_0" model="mail.message">
@@ -131,10 +131,10 @@
         <field name="seats_max">200</field>
         <field name="stage_id" ref="event_stage_booked"/>
         <field name="tag_ids" eval="[(4, ref('event.event_tag_category_1_tag_4')), (4, ref('event.event_tag_category_2_tag_1'))]"/>
-        <field name="question_ids" eval="[(5, 0, 0),
-            (0, 0, {'title': 'Name', 'question_type': 'name', 'is_mandatory_answer': True}),
-            (0, 0, {'title': 'Email', 'question_type': 'email', 'is_mandatory_answer': True}),
-            (0, 0, {'title': 'Phone', 'question_type': 'phone'})]"/>
+        <field name="question_ids" eval="[
+            (4, ref('event.event_question_name')),
+            (4, ref('event.event_question_email')),
+            (4, ref('event.event_question_phone'))]"/>
     </record>
     <record id="event_2_ticket_1" model="event.event.ticket">
         <field name="name">Standard</field>
@@ -174,10 +174,10 @@
         <field name="address_id" ref="event.res_partner_location_1"/>
         <field name="stage_id" ref="event_stage_announced"/>
         <field name="tag_ids" eval="[(4, ref('event.event_tag_category_1_tag_3')), (4, ref('event.event_tag_category_2_tag_2'))]"/>
-        <field name="question_ids" eval="[(5, 0, 0),
-            (0, 0, {'title': 'Name', 'question_type': 'name', 'is_mandatory_answer': True}),
-            (0, 0, {'title': 'Email', 'question_type': 'email', 'is_mandatory_answer': True}),
-            (0, 0, {'title': 'Phone', 'question_type': 'phone'})]"/>
+        <field name="question_ids" eval="[
+            (4, ref('event.event_question_name')),
+            (4, ref('event.event_question_email')),
+            (4, ref('event.event_question_phone'))]"/>
     </record>
     <record id="event_3_ticket_0" model="event.event.ticket">
         <field name="name">Standard</field>
@@ -221,10 +221,10 @@
         <field name="stage_id" ref="event_stage_done"/>
         <field name="kanban_state">done</field>
         <field name="tag_ids" eval="[(4, ref('event.event_tag_category_1_tag_4')), (4, ref('event.event_tag_category_2_tag_1'))]"/>
-        <field name="question_ids" eval="[(5, 0, 0),
-            (0, 0, {'title': 'Name', 'question_type': 'name', 'is_mandatory_answer': True}),
-            (0, 0, {'title': 'Email', 'question_type': 'email', 'is_mandatory_answer': True}),
-            (0, 0, {'title': 'Phone', 'question_type': 'phone'})]"/>
+        <field name="question_ids" eval="[
+            (4, ref('event.event_question_name')),
+            (4, ref('event.event_question_email')),
+            (4, ref('event.event_question_phone'))]"/>
     </record>
     <record id="event_4_ticket_0" model="event.event.ticket">
         <field name="name">General Admission</field>
@@ -251,10 +251,10 @@
         <field name="event_type_id" ref="event_type_2"/>
         <field name="address_id" ref="event.res_partner_location_1"/>
         <field name="tag_ids" eval="[(6, 0, [ref('event.event_tag_category_1_tag_2'), ref('event.event_tag_category_2_tag_3')])]"/>
-        <field name="question_ids" eval="[(5, 0, 0),
-            (0, 0, {'title': 'Name', 'question_type': 'name', 'is_mandatory_answer': True}),
-            (0, 0, {'title': 'Email', 'question_type': 'email', 'is_mandatory_answer': True}),
-            (0, 0, {'title': 'Phone', 'question_type': 'phone'})]"/>
+        <field name="question_ids" eval="[
+            (4, ref('event.event_question_name')),
+            (4, ref('event.event_question_email')),
+            (4, ref('event.event_question_phone'))]"/>
     </record>
 
     <record id="event.event_6" model="event.event">
@@ -264,10 +264,10 @@
         <field eval="(DateTime.today()+ timedelta(days=30)).strftime('%Y-%m-%d 17:30:00')" name="date_end"/>
         <field name="event_type_id" ref="event_type_0"/>
         <field name="address_id" ref="event.res_partner_location_1"/>
-        <field name="question_ids" eval="[(5, 0, 0),
-            (0, 0, {'title': 'Name', 'question_type': 'name', 'is_mandatory_answer': True}),
-            (0, 0, {'title': 'Email', 'question_type': 'email', 'is_mandatory_answer': True}),
-            (0, 0, {'title': 'Phone', 'question_type': 'phone'})]"/>
+        <field name="question_ids" eval="[
+            (4, ref('event.event_question_name')),
+            (4, ref('event.event_question_email')),
+            (4, ref('event.event_question_phone'))]"/>
     </record>
 
     <record id="event.event_7" model="event.event">
@@ -292,10 +292,10 @@
     </div>
 </div>
         </field>
-        <field name="question_ids" eval="[(5, 0, 0),
-            (0, 0, {'title': 'Name', 'question_type': 'name', 'is_mandatory_answer': True}),
-            (0, 0, {'title': 'Email', 'question_type': 'email', 'is_mandatory_answer': True}),
-            (0, 0, {'title': 'Phone', 'question_type': 'phone'})]"/>
+        <field name="question_ids" eval="[
+            (4, ref('event.event_question_name')),
+            (4, ref('event.event_question_email')),
+            (4, ref('event.event_question_phone'))]"/>
     </record>
     <record id="event_7_ticket_1" model="event.event.ticket">
         <field name="name">Standard</field>

--- a/addons/event/data/event_question_data.xml
+++ b/addons/event/data/event_question_data.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="event_question_name" model="event.question">
+            <field name="title">Name</field>
+            <field name="question_type">name</field>
+            <field name="is_mandatory_answer">True</field>
+        </record>
+        <record id="event_question_email" model="event.question">
+            <field name="title">Email</field>
+            <field name="question_type">email</field>
+            <field name="is_mandatory_answer">True</field>
+        </record>
+        <record id="event_question_phone" model="event.question">
+            <field name="title">Phone</field>
+            <field name="question_type">phone</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/event/data/event_question_data.xml
+++ b/addons/event/data/event_question_data.xml
@@ -6,17 +6,20 @@
             <field name="question_type">name</field>
             <field name="is_mandatory_answer">True</field>
             <field name="is_default">True</field>
+            <field name="is_reusable">True</field>
         </record>
         <record id="event_question_email" model="event.question">
             <field name="title">Email</field>
             <field name="question_type">email</field>
             <field name="is_mandatory_answer">True</field>
             <field name="is_default">True</field>
+            <field name="is_reusable">True</field>
         </record>
         <record id="event_question_phone" model="event.question">
             <field name="title">Phone</field>
             <field name="question_type">phone</field>
             <field name="is_default">True</field>
+            <field name="is_reusable">True</field>
         </record>
     </data>
 </odoo>

--- a/addons/event/data/event_question_data.xml
+++ b/addons/event/data/event_question_data.xml
@@ -5,15 +5,18 @@
             <field name="title">Name</field>
             <field name="question_type">name</field>
             <field name="is_mandatory_answer">True</field>
+            <field name="is_default">True</field>
         </record>
         <record id="event_question_email" model="event.question">
             <field name="title">Email</field>
             <field name="question_type">email</field>
             <field name="is_mandatory_answer">True</field>
+            <field name="is_default">True</field>
         </record>
         <record id="event_question_phone" model="event.question">
             <field name="title">Phone</field>
             <field name="question_type">phone</field>
+            <field name="is_default">True</field>
         </record>
     </data>
 </odoo>

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -194,13 +194,12 @@ class EventEvent(models.Model):
         compute='_compute_ticket_instructions', store=True, readonly=False,
         help="This information will be printed on your tickets.")
     # questions
-    question_ids = fields.One2many(
-        'event.question', 'event_id', 'Questions', copy=True,
-        compute='_compute_question_ids', readonly=False, store=True, precompute=True)
-    general_question_ids = fields.One2many('event.question', 'event_id', 'General Questions',
-                                           domain=[('once_per_order', '=', True)])
-    specific_question_ids = fields.One2many('event.question', 'event_id', 'Specific Questions',
-                                            domain=[('once_per_order', '=', False)])
+    question_ids = fields.Many2many('event.question', 'event_event_event_question_rel',
+        string='Questions', compute='_compute_question_ids', readonly=False, store=True, precompute=True)
+    general_question_ids = fields.Many2many('event.question', 'event_event_event_question_rel',
+        string='General Questions', domain=[('once_per_order', '=', True)])
+    specific_question_ids = fields.Many2many('event.question', 'event_event_event_question_rel',
+        string='Specific Questions', domain=[('once_per_order', '=', False)])
 
     def _compute_use_barcode(self):
         use_barcode = self.env['ir.config_parameter'].sudo().get_param('event.use_event_barcode') == 'True'
@@ -220,18 +219,18 @@ class EventEvent(models.Model):
 
         When synchronizing questions:
 
-          * lines with no registered answers are removed;
+          * lines with no registered answers for the event are removed;
           * type lines are added;
         """
-        if self._origin.question_ids:
-            # lines to keep: those with already given answers
-            questions_tokeep_ids = self.env['event.registration.answer'].search(
-                [('question_id', 'in', self._origin.question_ids.ids)]
-            ).question_id.ids
-        else:
-            questions_tokeep_ids = []
         for event in self:
-            if not event.event_type_id and not event.question_ids:
+            questions_tokeep_ids = []
+            if self._origin.question_ids:
+                # Keep questions with attendee answers for the event.
+                questions_tokeep_ids.extend(
+                    (event.registration_ids.registration_answer_ids.question_id & self._origin.question_ids).ids
+                )
+
+            if not event.event_type_id and not questions_tokeep_ids:
                 event.question_ids = self._default_question_ids()
                 continue
 
@@ -242,11 +241,7 @@ class EventEvent(models.Model):
             else:
                 command = [(5, 0)]
             event.question_ids = command
-
-            # copy questions so changes in the event don't affect the event type
-            event.question_ids += event.event_type_id.question_ids.copy({
-                'event_type_id': False,
-            })
+            event.question_ids = [Command.link(question_id.id) for question_id in event.event_type_id.question_ids]
 
     @api.depends('event_slot_count', 'is_multi_slots', 'seats_max', 'registration_ids.state', 'registration_ids.active')
     def _compute_seats(self):

--- a/addons/event/models/event_question.py
+++ b/addons/event/models/event_question.py
@@ -19,19 +19,24 @@ class EventQuestion(models.Model):
         ('phone', 'Phone'),
         ('company_name', 'Company'),
     ], default='simple_choice', string="Question Type", required=True)
-    event_type_id = fields.Many2one('event.type', 'Event Type', ondelete='cascade', index='btree_not_null')
-    event_id = fields.Many2one('event.event', 'Event', ondelete='cascade', index='btree_not_null')
+    event_type_ids = fields.Many2many('event.type', string='Event Types', copy=False)
+    event_ids = fields.Many2many('event.event', string='Events', copy=False)
+    event_count = fields.Integer('# Events', compute='_compute_event_count')
     answer_ids = fields.One2many('event.question.answer', 'question_id', "Answers", copy=True)
     sequence = fields.Integer(default=10)
     once_per_order = fields.Boolean('Ask once per order',
-                                    help="If True, this question will be asked only once and its value will be propagated to every attendees."
-                                         "If not it will be asked for every attendee of a reservation.")
+                                    help="Check this for order-level questions (e.g., 'Company Name') where the answer is the same for everyone.")
     is_mandatory_answer = fields.Boolean('Mandatory Answer')
 
-    @api.constrains('event_type_id', 'event_id')
-    def _constrains_event(self):
-        if any(question.event_type_id and question.event_id for question in self):
-            raise UserError(_("Question cannot be linked to both an Event and an Event Type."))
+    @api.depends('event_ids')
+    def _compute_event_count(self):
+        event_count_per_question = dict(self.env['event.event']._read_group(
+            domain=[('question_ids', 'in', self.ids)],
+            groupby=['question_ids'],
+            aggregates=['__count']
+        ))
+        for question in self:
+            question.event_count = event_count_per_question.get(question, 0)
 
     def write(self, vals):
         """ We add a check to prevent changing the question_type of a question that already has answers.
@@ -50,16 +55,32 @@ class EventQuestion(models.Model):
         if self.env['event.registration.answer'].search_count([('question_id', 'in', self.ids)]):
             raise UserError(_('You cannot delete a question that has already been answered by attendees.'))
 
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_default_question(self):
+        if set(self.ids) & set(self.env['event.type']._default_question_ids()):
+            raise UserError(_('You cannot delete a default question.'))
+
     def action_view_question_answers(self):
         """ Allow analyzing the attendees answers to event questions in a convenient way:
-        - A graph view showing counts of each suggestions for simple_choice questions
+        - A graph view showing counts of each suggestion for simple_choice questions
           (Along with secondary pivot and list views)
         - A list view showing textual answers values for text_box questions. """
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id("event.action_event_registration_report")
-        action['domain'] = [('question_id', '=', self.id)]
+        action['context'] = {'search_default_question_id': self.id}
+        if event_id := self.env.context.get('search_default_event_id'):
+            action['context'].update(search_default_event_id=event_id)
+        # Fetch attendee answers for which the event is still linked to the question.
+        action['domain'] = [('event_id.question_ids', 'in', self.ids)]
+
         if self.question_type == 'simple_choice':
             action['views'] = [(False, 'graph'), (False, 'pivot'), (False, 'list')]
         elif self.question_type == 'text_box':
             action['views'] = [(False, 'list')]
+        return action
+
+    def action_event_view(self):
+        self.ensure_one()
+        action = self.env["ir.actions.actions"]._for_xml_id("event.action_event_view")
+        action['domain'] = [('question_ids', 'in', self.ids)]
         return action

--- a/addons/event/models/event_question.py
+++ b/addons/event/models/event_question.py
@@ -22,6 +22,7 @@ class EventQuestion(models.Model):
     event_type_ids = fields.Many2many('event.type', string='Event Types', copy=False)
     event_ids = fields.Many2many('event.event', string='Events', copy=False)
     event_count = fields.Integer('# Events', compute='_compute_event_count')
+    is_default = fields.Boolean('Default question', help="Include by default in new events.")
     answer_ids = fields.One2many('event.question.answer', 'question_id', "Answers", copy=True)
     sequence = fields.Integer(default=10)
     once_per_order = fields.Boolean('Ask once per order',

--- a/addons/event/models/event_question.py
+++ b/addons/event/models/event_question.py
@@ -19,6 +19,7 @@ class EventQuestion(models.Model):
         ('phone', 'Phone'),
         ('company_name', 'Company'),
     ], default='simple_choice', string="Question Type", required=True)
+    active = fields.Boolean('Active', default=True)
     event_type_ids = fields.Many2many('event.type', string='Event Types', copy=False)
     event_ids = fields.Many2many('event.event', string='Events', copy=False)
     event_count = fields.Integer('# Events', compute='_compute_event_count')
@@ -66,7 +67,7 @@ class EventQuestion(models.Model):
     @api.ondelete(at_uninstall=False)
     def _unlink_except_answered_question(self):
         if self.env['event.registration.answer'].search_count([('question_id', 'in', self.ids)]):
-            raise UserError(_('You cannot delete a question that has already been answered by attendees.'))
+            raise UserError(_('You cannot delete a question that has already been answered by attendees. You can archive it instead.'))
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_default_question(self):

--- a/addons/event/models/event_registration_answer.py
+++ b/addons/event/models/event_registration_answer.py
@@ -12,7 +12,7 @@ class EventRegistrationAnswer(models.Model):
 
     question_id = fields.Many2one(
         'event.question', ondelete='restrict', required=True,
-        domain="[('event_id', '=', event_id)]")
+        domain="[('event_ids', 'in', event_id)]")
     registration_id = fields.Many2one('event.registration', required=True, index=True, ondelete='cascade')
     partner_id = fields.Many2one('res.partner', related='registration_id.partner_id')
     event_id = fields.Many2one('event.event', related='registration_id.event_id')

--- a/addons/event/models/event_type.py
+++ b/addons/event/models/event_type.py
@@ -28,11 +28,7 @@ class EventType(models.Model):
                  })]
 
     def _default_question_ids(self):
-        """ Get ids of default questions from ir.model.data. """
-        return self.env['ir.model.data'].sudo().search([
-            ('module', '=', 'event'),
-            ('name', 'in', ['event_question_name', 'event_question_email', 'event_question_phone'])
-        ]).mapped('res_id')
+        return self.env['event.question'].search([('is_default', '=', True), ('active', '=', True)]).ids
 
     name = fields.Char('Event Template', required=True, translate=True)
     note = fields.Html(string='Note')

--- a/addons/event/models/event_type.py
+++ b/addons/event/models/event_type.py
@@ -1,4 +1,4 @@
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.addons.base.models.res_partner import _tz_get
 
 
@@ -28,11 +28,11 @@ class EventType(models.Model):
                  })]
 
     def _default_question_ids(self):
-        return [
-            (0, 0, {'title': _('Name'), 'question_type': 'name', 'is_mandatory_answer': True}),
-            (0, 0, {'title': _('Email'), 'question_type': 'email', 'is_mandatory_answer': True}),
-            (0, 0, {'title': _('Phone'), 'question_type': 'phone'}),
-        ]
+        """ Get ids of default questions from ir.model.data. """
+        return self.env['ir.model.data'].sudo().search([
+            ('module', '=', 'event'),
+            ('name', 'in', ['event_question_name', 'event_question_email', 'event_question_phone'])
+        ]).mapped('res_id')
 
     name = fields.Char('Event Template', required=True, translate=True)
     note = fields.Html(string='Note')
@@ -55,8 +55,8 @@ class EventType(models.Model):
     # ticket reports
     ticket_instructions = fields.Html('Ticket Instructions', translate=True,
         help="This information will be printed on your tickets.")
-    question_ids = fields.One2many(
-        'event.question', 'event_type_id', default=_default_question_ids,
+    question_ids = fields.Many2many(
+        'event.question', default=_default_question_ids,
         string='Questions', copy=True)
 
     @api.depends('has_seats_limitation')

--- a/addons/event/tests/common.py
+++ b/addons/event/tests/common.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from freezegun import freeze_time
 from unittest.mock import patch
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.tests import common
 
@@ -121,7 +121,7 @@ class EventCase(common.TransactionCase):
         cls.event_question_1 = cls.env['event.question'].create({
             'title': 'Question1',
             'question_type': 'simple_choice',
-            'event_type_id': cls.event_type_questions.id,
+            'event_type_ids': [Command.set(cls.event_type_questions.ids)],
             'once_per_order': False,
             'answer_ids': [
                 (0, 0, {'name': 'Q1-Answer1'}),
@@ -131,7 +131,7 @@ class EventCase(common.TransactionCase):
         cls.event_question_2 = cls.env['event.question'].create({
             'title': 'Question2',
             'question_type': 'simple_choice',
-            'event_type_id': cls.event_type_questions.id,
+            'event_type_ids': [Command.set(cls.event_type_questions.ids)],
             'once_per_order': True,
             'answer_ids': [
                 (0, 0, {'name': 'Q2-Answer1'}),
@@ -141,7 +141,7 @@ class EventCase(common.TransactionCase):
         cls.event_question_3 = cls.env['event.question'].create({
             'title': 'Question3',
             'question_type': 'text_box',
-            'event_type_id': cls.event_type_questions.id,
+            'event_type_ids': [Command.set(cls.event_type_questions.ids)],
             'once_per_order': True,
         })
 

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -123,38 +123,15 @@
                                     <field name="question_type" string="Type" />
                                     <field name="answer_ids" widget="many2many_tags"
                                         invisible="question_type != 'simple_choice'" />
-                                    <button name="action_view_question_answers" type="object" class="p-0" icon="fa-bar-chart pe-1" string="Stats"
-                                            title="Answer Breakdown" invisible="question_type not in ['simple_choice', 'text_box']"/>
+                                    <button name="action_view_question_answers"
+                                        type="object"
+                                        class="p-0"
+                                        icon="fa-bar-chart pe-1"
+                                        string="Stats"
+                                        title="Answer Breakdown"
+                                        context="{'search_default_event_id': parent.id}"
+                                        invisible="question_type not in ['simple_choice', 'text_box']"/>
                                 </list>
-                                <!-- Need to repeat the whole tree form here to be able to create answers properly
-                                    Without this, the sub-fields of answer_ids are unknown to the web framework.
-                                    We need this because we create questions and answers when the event type changes. -->
-                                <form string="Question">
-                                    <sheet>
-                                        <h1 class="d-flex"><field name="title" placeholder='e.g. "Do you have any diet restrictions?"' class="flex-grow-1"/></h1>
-                                        <group>
-                                            <group>
-                                                <field name="is_mandatory_answer"/>
-                                                <field name="question_type" widget="radio"/>
-                                            </group>
-                                            <group>
-                                                <field name="once_per_order"/>
-                                            </group>
-                                        </group>
-                                        <notebook invisible="question_type != 'simple_choice'">
-                                            <page string="Answers" name="answers">
-                                                <field name="answer_ids">
-                                                    <list editable="bottom">
-                                                        <!-- 'display_name' is necessary for the many2many_tags to work on the event view -->
-                                                        <field name="display_name" column_invisible="True" />
-                                                        <field name="sequence" widget="handle" />
-                                                        <field name="name"/>
-                                                    </list>
-                                                </field>
-                                            </page>
-                                        </notebook>
-                                    </sheet>
-                                </form>
                             </field>
                         </page>
                         <page string="Notes &amp; Documents" name="event_notes">
@@ -320,6 +297,7 @@
                 <field name="stage_id"/>
                 <field name="activity_user_id" string="Activities of"/>
                 <field name="activity_type_id" string="Activity type"/>
+                <field name="question_ids"/>
                 <filter string="My Events" name="myevents" help="My Events" domain="[('user_id', '=', uid)]"/>
                 <separator/>
                 <filter string="Upcoming/Running" name="upcoming"

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -114,7 +114,7 @@
                             </field>
                         </page>
                          <page string="Questions" name="questions">
-                            <field name="question_ids" string="Question" nolabel="1">
+                            <field name="question_ids" string="Question" nolabel="1" domain="[('is_reusable', '=', True)]" context="{'list_view_ref': 'event.event_question_view_list_add'}">
                                 <list>
                                     <field name="sequence" widget="handle" />
                                     <field name="title"/>
@@ -124,6 +124,7 @@
                                     <field name="answer_ids" widget="many2many_tags"
                                         invisible="question_type != 'simple_choice'" />
                                     <field name="is_default" optional="hide"/>
+                                    <field name="is_reusable" optional="hide"/>
                                     <button name="action_view_question_answers"
                                         type="object"
                                         class="p-0"

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -123,6 +123,7 @@
                                     <field name="question_type" string="Type" />
                                     <field name="answer_ids" widget="many2many_tags"
                                         invisible="question_type != 'simple_choice'" />
+                                    <field name="is_default" optional="hide"/>
                                     <button name="action_view_question_answers"
                                         type="object"
                                         class="p-0"

--- a/addons/event/views/event_menu_views.xml
+++ b/addons/event/views/event_menu_views.xml
@@ -45,5 +45,9 @@
         id="menu_event_category"
         sequence="3"
         parent="menu_event_configuration"/>
+    <menuitem name="Event Questions"
+        id="event_question_menu"
+        sequence="4"
+        parent="menu_event_configuration"/>
 
 </data></odoo>

--- a/addons/event/views/event_question_views.xml
+++ b/addons/event/views/event_question_views.xml
@@ -26,6 +26,7 @@
                 <filter name="filter_is_not_reusable" string="Not Reusable" domain="[('is_reusable', '=', False)]"/>
                 <separator/>
                 <filter name="filter_is_default" string="Default Questions" domain="[('is_default', '=', True)]"/>
+                <filter name="filter_archive" string="Archived" domain="[('active', '=', False)]"/>
                 <group>
                     <filter string="Event" name="group_by_event" context="{'group_by': 'event_ids'}"/>
                 </group>

--- a/addons/event/views/event_question_views.xml
+++ b/addons/event/views/event_question_views.xml
@@ -1,11 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <record id="event_question_view_search" model="ir.ui.view">
+        <field name="name">event.question.view.search</field>
+        <field name="model">event.question</field>
+        <field name="arch" type="xml">
+            <search string="Search Event Question">
+                <field name="title"/>
+                <field name="question_type"/>
+                <field name="answer_ids"/>
+                <filter string="Mandatory"
+                        name="filter_is_mandatory_answer"
+                        domain="[('is_mandatory_answer', '=', True)]"/>
+                <filter string="Not mandatory"
+                        name="filter_is_not mandatory_answer"
+                        domain="[('is_mandatory_answer', '=', False)]"/>
+                <separator/>
+                <filter string="Once per order"
+                        name="filter_once_per_order"
+                        domain="[('once_per_order', '=', True)]"/>
+                <filter string="For each attendee"
+                        name="filter_for_each_attendee"
+                        domain="[('once_per_order', '=', False)]"/>
+                <group>
+                    <filter string="Event" name="group_by_event" context="{'group_by': 'event_ids'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
     <record id="event_question_view_form" model="ir.ui.view">
         <field name="name">event.question.view.form</field>
         <field name="model">event.question</field>
         <field name="arch" type="xml">
             <form string="Question">
                 <sheet>
+                    <div class="alert alert-warning" role="alert"
+                        invisible="event_count == 0">
+                        This question is used by
+                        <button class="oe_link p-0 align-baseline" type="object" name="action_event_view">
+                            <field name="event_count"/>
+                            events
+                        </button>.
+                    </div>
                     <h1 class="d-flex"><field name="title" placeholder='e.g. "Do you have any diet restrictions?"' class="flex-grow-1"/></h1>
                     <group>
                         <group>
@@ -31,5 +67,36 @@
                 </sheet>
             </form>
         </field>
+    </record>
+
+    <record id="event_question_view_list" model="ir.ui.view">
+        <field name="name">event.question.view.list</field>
+        <field name="model">event.question</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="title"/>
+                <field name="is_mandatory_answer" string="Mandatory"/>
+                <field name="once_per_order" string="Once per Order"/>
+                <field name="question_type" string="Type"/>
+                <field name="answer_ids" widget="many2many_tags"
+                    invisible="question_type != 'simple_choice'"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="event_question_action" model="ir.actions.act_window">
+        <field name="name">Event Question</field>
+        <field name="res_model">event.question</field>
+        <field name="view_mode">list,form</field>
+        <field name="search_view_id" ref="event.event_question_view_search"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No questions yet! Please create one.
+            </p>
+        </field>
+    </record>
+
+    <record id="event_question_menu" model="ir.ui.menu">
+        <field name="action" ref="event.event_question_action"/>
     </record>
 </odoo>

--- a/addons/event/views/event_question_views.xml
+++ b/addons/event/views/event_question_views.xml
@@ -22,6 +22,9 @@
                         name="filter_for_each_attendee"
                         domain="[('once_per_order', '=', False)]"/>
                 <separator/>
+                <filter name="filter_is_reusable" string="Reusable" domain="[('is_reusable', '=', True)]"/>
+                <filter name="filter_is_not_reusable" string="Not Reusable" domain="[('is_reusable', '=', False)]"/>
+                <separator/>
                 <filter name="filter_is_default" string="Default Questions" domain="[('is_default', '=', True)]"/>
                 <group>
                     <filter string="Event" name="group_by_event" context="{'group_by': 'event_ids'}"/>
@@ -53,6 +56,8 @@
                         <group>
                             <field name="once_per_order"/>
                             <field name="is_default"/>
+                            <field name="event_type_ids" invisible="1"/>
+                            <field name="is_reusable" readonly="is_default"/>
                         </group>
                     </group>
                     <notebook invisible="question_type != 'simple_choice'">
@@ -75,6 +80,7 @@
     <record id="event_question_view_list" model="ir.ui.view">
         <field name="name">event.question.view.list</field>
         <field name="model">event.question</field>
+        <field name="priority" eval="10"/>
         <field name="arch" type="xml">
             <list>
                 <field name="title"/>
@@ -84,7 +90,19 @@
                 <field name="answer_ids" widget="many2many_tags"
                     invisible="question_type != 'simple_choice'"/>
                 <field name="is_default"/>
+                <field name="is_reusable" optional="hide"/>
             </list>
+        </field>
+    </record>
+
+    <record id="event_question_view_list_add" model="ir.ui.view">
+        <field name="name">event.question.view.list.add</field>
+        <field name="model">event.question</field>
+        <field name="inherit_id" ref="event.event_question_view_list"/>
+        <field name="mode">primary</field>
+        <field name="priority" eval="20"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='is_reusable']" position="replace"/>
         </field>
     </record>
 

--- a/addons/event/views/event_question_views.xml
+++ b/addons/event/views/event_question_views.xml
@@ -21,6 +21,8 @@
                 <filter string="For each attendee"
                         name="filter_for_each_attendee"
                         domain="[('once_per_order', '=', False)]"/>
+                <separator/>
+                <filter name="filter_is_default" string="Default Questions" domain="[('is_default', '=', True)]"/>
                 <group>
                     <filter string="Event" name="group_by_event" context="{'group_by': 'event_ids'}"/>
                 </group>
@@ -50,6 +52,7 @@
                         </group>
                         <group>
                             <field name="once_per_order"/>
+                            <field name="is_default"/>
                         </group>
                     </group>
                     <notebook invisible="question_type != 'simple_choice'">
@@ -80,6 +83,7 @@
                 <field name="question_type" string="Type"/>
                 <field name="answer_ids" widget="many2many_tags"
                     invisible="question_type != 'simple_choice'"/>
+                <field name="is_default"/>
             </list>
         </field>
     </record>

--- a/addons/event/views/event_question_views.xml
+++ b/addons/event/views/event_question_views.xml
@@ -40,6 +40,19 @@
         <field name="arch" type="xml">
             <form string="Question">
                 <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="action_view_question_answers"
+                                type="object"
+                                class="oe_stat_button"
+                                icon="fa-line-chart"
+                                invisible="question_type not in ['simple_choice', 'text_box']">
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">
+                                    Attendee answers
+                                </span>
+                            </div>
+                        </button>
+                    </div>
                     <div class="alert alert-warning" role="alert"
                         invisible="event_count == 0">
                         This question is used by
@@ -92,6 +105,13 @@
                     invisible="question_type != 'simple_choice'"/>
                 <field name="is_default"/>
                 <field name="is_reusable" optional="hide"/>
+                <button name="action_view_question_answers"
+                        type="object"
+                        class="p-0"
+                        icon="fa-bar-chart pe-1"
+                        string="Stats"
+                        title="Answer Breakdown"
+                        invisible="question_type not in ['simple_choice', 'text_box']"/>
             </list>
         </field>
     </record>
@@ -104,6 +124,7 @@
         <field name="priority" eval="20"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='is_reusable']" position="replace"/>
+            <xpath expr="//button[@name='action_view_question_answers']" position="replace"/>
         </field>
     </record>
 

--- a/addons/event/views/event_registration_answer_views.xml
+++ b/addons/event/views/event_registration_answer_views.xml
@@ -8,6 +8,7 @@
                 <field name="value_text_box" />
                 <field name="value_answer_id" />
                 <field name="question_id" />
+                <field name="event_id"/>
             </search>
         </field>
     </record>

--- a/addons/event/views/event_registration_answer_views.xml
+++ b/addons/event/views/event_registration_answer_views.xml
@@ -23,6 +23,7 @@
                 <field name="question_id" optional="show" />
                 <field name="value_text_box" />
                 <field name="value_answer_id" string="Selected answer" />
+                <field name="event_id" optional="hide"/>
             </list>
         </field>
     </record>
@@ -31,8 +32,9 @@
         <field name="name">event.registration.answer.view.graph</field>
         <field name="model">event.registration.answer</field>
         <field name="arch" type="xml">
-            <graph string="Answer Breakdown" sample="1">
-                <field name="value_answer_id" />
+            <graph string="Answer Breakdown" sample="1" type="bar">
+                <field name="value_answer_id" type="col"/>
+                <field name="event_id" type="row"/>
             </graph>
         </field>
     </record>

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -93,7 +93,7 @@
                             <field name="registration_answer_ids" widget="one2many">
                                 <list editable="bottom">
                                     <field name="event_id" column_invisible="True" />
-                                    <field name="question_id" domain="[('event_id', '=', event_id)]" options="{'no_create': True}" />
+                                    <field name="question_id" domain="[('event_ids', 'in', event_id)]" options="{'no_create': True}"/>
                                     <field name="question_type" string="Type" />
                                     <field name="value_answer_id"
                                         invisible="question_type != 'simple_choice'"
@@ -105,7 +105,7 @@
                                     <field name="question_type"/>
                                     <templates>
                                         <t t-name="card" class="justify-content-between">
-                                            <field class="fw-bold fs-5" name="question_id" domain="[('event_id', '=', event_id)]"/>
+                                            <field class="fw-bold fs-5" name="question_id" domain="[('event_ids', 'in', event_id)]"/>
                                             <field name="value_answer_id"
                                                 invisible="question_type != 'simple_choice'"
                                                 domain="[('question_id', '=', question_id)]" options="{'no_create': True}"/>

--- a/addons/event/views/event_type_views.xml
+++ b/addons/event/views/event_type_views.xml
@@ -56,7 +56,7 @@
                                     <field name="is_mandatory_answer" string="Mandatory"/>
                                     <field name="once_per_order" string="Once per Order"/>
                                     <field name="question_type" />
-                                    <field name="answer_ids" widget="many2many_tags"/>
+                                    <field name="answer_ids" widget="many2many_tags" invisible="question_type != 'simple_choice'"/>
                                 </list>
                             </field>
                         </page>

--- a/addons/event/views/event_type_views.xml
+++ b/addons/event/views/event_type_views.xml
@@ -50,7 +50,7 @@
                            </field>
                        </page>
                         <page string="Questions" name="page_questions">
-                            <field name="question_ids" class="w-100">
+                            <field name="question_ids" class="w-100" domain="[('is_reusable', '=', True)]" context="{'list_view_ref': 'event.event_question_view_list_add'}">
                                 <list sample="1">
                                     <field name="title"/>
                                     <field name="is_mandatory_answer" string="Mandatory"/>
@@ -58,6 +58,7 @@
                                     <field name="question_type" />
                                     <field name="answer_ids" widget="many2many_tags" invisible="question_type != 'simple_choice'"/>
                                     <field name="is_default" optional="hide"/>
+                                    <field name="is_reusable" optional="hide"/>
                                 </list>
                             </field>
                         </page>

--- a/addons/event/views/event_type_views.xml
+++ b/addons/event/views/event_type_views.xml
@@ -57,6 +57,7 @@
                                     <field name="once_per_order" string="Once per Order"/>
                                     <field name="question_type" />
                                     <field name="answer_ids" widget="many2many_tags" invisible="question_type != 'simple_choice'"/>
+                                    <field name="is_default" optional="hide"/>
                                 </list>
                             </field>
                         </page>

--- a/addons/event_crm/__manifest__.py
+++ b/addons/event_crm/__manifest__.py
@@ -18,10 +18,16 @@
         'views/event_registration_views.xml',
         'views/event_lead_rule_views.xml',
         'views/event_event_views.xml',
+        'views/event_question_views.xml',
     ],
     'demo': [
         'data/event_crm_demo.xml',
     ],
+    'assets': {
+        'web.assets_tests': [
+            'event_crm/static/tests/tours/*.js',
+        ],
+    },
     'installable': True,
     'auto_install': True,
     'author': 'Odoo S.A.',

--- a/addons/event_crm/models/__init__.py
+++ b/addons/event_crm/models/__init__.py
@@ -5,4 +5,5 @@ from . import crm_lead
 from . import event_event
 from . import event_lead_request
 from . import event_lead_rule
+from . import event_question_answer
 from . import event_registration

--- a/addons/event_crm/models/event_question_answer.py
+++ b/addons/event_crm/models/event_question_answer.py
@@ -1,0 +1,20 @@
+from odoo import models
+
+
+class EventQuestionAnswer(models.Model):
+    _inherit = 'event.question.answer'
+
+    def action_add_rule_button(self):
+        self.ensure_one()
+        action = self.env['ir.actions.actions']._for_xml_id('event_crm.event_lead_rule_answer_action')
+        action['context'] = {
+            'default_name': self.name,
+            'default_lead_user_id': self.env.user.id,
+            'default_event_registration_filter': [
+                '&',
+                ('registration_answer_ids.question_id', 'in', self.question_id.ids),
+                ('registration_answer_choice_ids.value_answer_id', 'in', self.ids)
+            ]
+        }
+        action['target'] = 'new'
+        return action

--- a/addons/event_crm/static/tests/tours/event_question_answers_rule_creation_tour.js
+++ b/addons/event_crm/static/tests/tours/event_question_answers_rule_creation_tour.js
@@ -1,0 +1,43 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_utils";
+
+registry.category("web_tour.tours").add("event_question_answers_rule_creation_tour", {
+    url: "/odoo",
+    steps: () => [
+        ...stepUtils.goToAppSteps("event.event_main_menu"),
+        {
+            content: "Click on the Configuration menu.",
+            trigger: 'button[data-menu-xmlid="event.menu_event_configuration"]',
+            run: "click",
+        },
+        {
+            content: "Go to the list of questions.",
+            trigger: 'a[data-menu-xmlid="event.event_question_menu"]',
+            run: "click",
+        },
+        {
+            content: "Go to the form of a specific question.",
+            trigger: 'td[name="title"]:contains("Question Test")',
+            run: "click",
+        },
+        {
+            content: "Click on the 'Add rule' button.",
+            trigger: 'tr:contains("Answer Test") button[name="action_add_rule_button"]',
+            run: "click",
+        },
+        {
+            content: "Edit the name of the rule.",
+            trigger: "[name=name] input",
+            run: "edit event_question_answer_rule",
+        },
+        {
+            content: "Save the rule creation form with pre-filled data, except for the name.",
+            trigger: '.modal:contains("Event lead rule") .o_form_button_save',
+            run: "click",
+        },
+        {
+            content: "Wait until the modal is closed",
+            trigger: "body:not(.modal-open)",
+        },
+    ],
+});

--- a/addons/event_crm/tests/__init__.py
+++ b/addons/event_crm/tests/__init__.py
@@ -2,4 +2,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_event_crm_flow
+from . import test_event_crm_http
 from . import test_crm_lead_merge

--- a/addons/event_crm/tests/test_event_crm_http.py
+++ b/addons/event_crm/tests/test_event_crm_http.py
@@ -1,0 +1,39 @@
+from odoo.addons.event_crm.tests.common import TestEventCrmCommon
+from odoo.fields import Command
+from odoo.tests import HttpCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestEventCrmHttp(TestEventCrmCommon, HttpCase):
+
+    def test_event_question_answers_lead_creation(self):
+        """ Test that a rule has been created for a question.answer by clicking on the "Add rules" button
+        next to it and that a lead is generated when this is selected by a new registration. """
+        question = self.env["event.question"].create({
+            "title": "Question test",
+            "event_ids": [Command.link(self.event_0.id)],
+        })
+        answer = self.env["event.question.answer"].create({
+            "name": "Answer test",
+            "question_id": question.id,
+        })
+        self.start_tour("/odoo", "event_question_answers_rule_creation_tour", login="admin")
+        # Check that a rule has been created for the answer.
+        self.assertEqual(
+            len(self.env["event.lead.rule"].search([("name", "=", "event_question_answer_rule")])),
+            1
+        )
+
+        self.env["event.registration"].create({
+            "event_id": self.event_0.id,
+            "email": "event_question_answer_email@odoo.com",
+            "registration_answer_ids": [Command.create({
+                "question_id": question.id,
+                "value_answer_id": answer.id,
+            })],
+        })
+        # Check that the rule generate a lead when the answer is selected by a new registration.
+        self.assertEqual(
+            len(self.env["crm.lead"].search([("email_normalized", "=", "event_question_answer_email@odoo.com")])),
+            1
+        )

--- a/addons/event_crm/views/event_lead_rule_views.xml
+++ b/addons/event_crm/views/event_lead_rule_views.xml
@@ -91,6 +91,12 @@
         </field>
     </record>
 
+    <record id="event_lead_rule_answer_action" model="ir.actions.act_window">
+        <field name="name">Event lead Rule</field>
+        <field name="res_model">event.lead.rule</field>
+        <field name="view_mode">form</field>
+    </record>
+
     <menuitem name="Lead Generation"
         id="event_lead_rule_menu"
         action="event_lead_rule_action"

--- a/addons/event_crm/views/event_question_views.xml
+++ b/addons/event_crm/views/event_question_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="event_question_view_form" model="ir.ui.view">
+        <field name="name">event.question.view.form</field>
+        <field name="model">event.question</field>
+        <field name="inherit_id" ref="event.event_question_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='answer_ids']/list/field[last()]" position="after">
+                <button type="object"
+                        name="action_add_rule_button"
+                        string="Add a rule"
+                        class="ms-auto"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/pos_event/models/event_question.py
+++ b/addons/pos_event/models/event_question.py
@@ -9,8 +9,8 @@ class EventQuestion(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config):
-        return ['title', 'question_type', 'event_type_id', 'event_id', 'sequence', 'once_per_order', 'is_mandatory_answer', 'answer_ids']
+        return ['title', 'question_type', 'event_type_ids', 'event_ids', 'sequence', 'once_per_order', 'is_mandatory_answer', 'answer_ids']
 
     @api.model
     def _load_pos_data_domain(self, data, config):
-        return [('event_id', 'in', [event['id'] for event in data['event.event']])]
+        return [('event_ids', 'in', [event['id'] for event in data['event.event']])]

--- a/addons/test_event_full/tests/common.py
+++ b/addons/test_event_full/tests/common.py
@@ -3,6 +3,7 @@
 
 from datetime import datetime, timedelta, time
 
+from odoo import Command
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo, HttpCaseWithUserPortal
 from odoo.addons.base.tests.test_ir_cron import CronMixinCase
 from odoo.addons.event.tests.common import EventCase
@@ -480,7 +481,7 @@ class TestWEventCommon(HttpCaseWithUserDemo, HttpCaseWithUserPortal, MockVisitor
         self.event_question_1 = self.env['event.question'].create({
             'title': 'Which field are you working in',
             'question_type': 'simple_choice',
-            'event_id': self.event.id,
+            'event_ids': [Command.set(self.event.ids)],
             'once_per_order': False,
             'answer_ids': [
                 (0, 0, {'name': 'Consumers'}),
@@ -491,7 +492,7 @@ class TestWEventCommon(HttpCaseWithUserDemo, HttpCaseWithUserPortal, MockVisitor
         self.event_question_2 = self.env['event.question'].create({
             'title': 'How did you hear about us ?',
             'question_type': 'text_box',
-            'event_id': self.event.id,
+            'event_ids': [Command.set(self.event.ids)],
             'once_per_order': True,
         })
 

--- a/addons/website_event/data/event_question_demo.xml
+++ b/addons/website_event/data/event_question_demo.xml
@@ -6,6 +6,7 @@
         <field name="question_type">simple_choice</field>
         <field name="once_per_order" eval="False"/>
         <field name="event_type_ids" eval="[(5, 0, 0), (4, ref('event.event_type_2'))]"/>
+        <field name="is_reusable">False</field>
     </record>
     <record id="event_question_about_0_answer_0" model="event.question.answer">
         <field name="name">Social Media</field>
@@ -29,6 +30,7 @@
         <field name="question_type">simple_choice</field>
         <field name="once_per_order" eval="True"/>
         <field name="event_ids" eval="[(5, 0, 0), (4, ref('event.event_0'))]"/>
+        <field name="is_reusable">False</field>
     </record>
         <record id="event_question_about_1_answer_0" model="event.question.answer">
         <field name="name">Our website</field>
@@ -52,6 +54,7 @@
         <field name="question_type">simple_choice</field>
         <field name="once_per_order" eval="True"/>
         <field name="event_ids" eval="[(5, 0, 0), (4, ref('event.event_1')), (4, ref('event.event_5'))]"/>
+        <field name="is_reusable">True</field>
     </record>
     <record id="event_question_about_2_answer_0" model="event.question.answer">
         <field name="name">Social Media</field>
@@ -75,6 +78,7 @@
         <field name="question_type">text_box</field>
         <field name="once_per_order" eval="True"/>
         <field name="event_ids" eval="[(5, 0, 0), (4, ref('event.event_7'))]"/>
+        <field name="is_reusable">False</field>
     </record>
 
     <!-- EVENT QUESTION : Meal Type -->
@@ -83,6 +87,7 @@
         <field name="question_type">simple_choice</field>
         <field name="once_per_order" eval="False"/>
         <field name="event_ids" eval="[(5, 0, 0), (4, ref('event.event_0'))]"/>
+        <field name="is_reusable">False</field>
     </record>
     <record id="event_question_meal_type_answer_0" model="event.question.answer">
         <field name="name">Mixed</field>
@@ -106,6 +111,7 @@
         <field name="question_type">text_box</field>
         <field name="once_per_order" eval="False"/>
         <field name="event_ids" eval="[(5, 0, 0), (4, ref('event.event_0'))]"/>
+        <field name="is_reusable">False</field>
     </record>
 
     <!-- EVENT QUESTION : Which field are you working in? -->
@@ -114,6 +120,7 @@
         <field name="question_type">simple_choice</field>
         <field name="once_per_order" eval="False"/>
         <field name="event_ids" eval="[(5, 0, 0), (4, ref('event.event_7'))]"/>
+        <field name="is_reusable">False</field>
     </record>
         <record id="event_question_working_field_answer_0" model="event.question.answer">
         <field name="name">Consumers</field>
@@ -137,6 +144,7 @@
         <field name="question_type">text_box</field>
         <field name="once_per_order" eval="False"/>
         <field name="event_ids" eval="[(5, 0, 0), (4, ref('event.event_5'))]"/>
+        <field name="is_reusable">False</field>
     </record>
 
 </data></odoo>

--- a/addons/website_event/data/event_question_demo.xml
+++ b/addons/website_event/data/event_question_demo.xml
@@ -1,156 +1,142 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo><data>
-    <!-- EVENT TYPE SPECIFIC -->
-    <record id="event_type_data_sports_question_0" model="event.question">
+    <!-- EVENT QUESTION : How did you learn about this event? (simple choice 0) -->
+    <record id="event_question_about_0" model="event.question">
         <field name="title">How did you learn about this event?</field>
-        <field name="once_per_order" eval="False"/>
-        <field name="event_type_id" ref="event.event_type_2"/>
-    </record>
-    <record id="event_type_data_sports_question_0_answer_0" model="event.question.answer">
-        <field name="name">Social Media</field>
-        <field name="sequence">1</field>
-        <field name="question_id" ref="website_event.event_type_data_sports_question_0"/>
-    </record>
-    <record id="event_type_data_sports_question_0_answer_1" model="event.question.answer">
-        <field name="name">Blog Post</field>
-        <field name="sequence">2</field>
-        <field name="question_id" ref="website_event.event_type_data_sports_question_0"/>
-    </record>
-    <record id="event_type_data_sports_question_0_answer_2" model="event.question.answer">
-        <field name="name">Radio Ad</field>
-        <field name="sequence">3</field>
-        <field name="question_id" ref="website_event.event_type_data_sports_question_0"/>
-    </record>
-
-    <!-- EVENT SPECIFIC -->
-    <record id="event_0_question_0" model="event.question">
-        <field name="title">Meal Type</field>
         <field name="question_type">simple_choice</field>
         <field name="once_per_order" eval="False"/>
-        <field name="event_id" ref="event.event_0"/>
+        <field name="event_type_ids" eval="[(5, 0, 0), (4, ref('event.event_type_2'))]"/>
     </record>
-    <record id="event_0_question_0_answer_0" model="event.question.answer">
-        <field name="name">Mixed</field>
+    <record id="event_question_about_0_answer_0" model="event.question.answer">
+        <field name="name">Social Media</field>
         <field name="sequence">1</field>
-        <field name="question_id" ref="website_event.event_0_question_0"/>
+        <field name="question_id" ref="website_event.event_question_about_0"/>
     </record>
-    <record id="event_0_question_0_answer_1" model="event.question.answer">
-        <field name="name">Vegetarian</field>
+    <record id="event_question_about_0_answer_1" model="event.question.answer">
+        <field name="name">Blog Post</field>
         <field name="sequence">2</field>
-        <field name="question_id" ref="website_event.event_0_question_0"/>
+        <field name="question_id" ref="website_event.event_question_about_0"/>
     </record>
-    <record id="event_0_question_0_answer_2" model="event.question.answer">
-        <field name="name">Pastafarian</field>
+    <record id="event_question_about_0_answer_2" model="event.question.answer">
+        <field name="name">Radio Ad</field>
         <field name="sequence">3</field>
-        <field name="question_id" ref="website_event.event_0_question_0"/>
+        <field name="question_id" ref="website_event.event_question_about_0"/>
     </record>
-    <record id="event_0_question_1" model="event.question">
-        <field name="title">Allergies</field>
-        <field name="question_type">text_box</field>
-        <field name="once_per_order" eval="False"/>
-        <field name="event_id" ref="event.event_0"/>
-    </record>
-    <record id="event_0_question_2" model="event.question">
+
+    <!-- EVENT QUESTION : How did you learn about this event? (simple choice 1) -->
+    <record id="event_question_about_1" model="event.question">
         <field name="title">How did you learn about this event?</field>
         <field name="question_type">simple_choice</field>
         <field name="once_per_order" eval="True"/>
-        <field name="event_id" ref="event.event_0"/>
+        <field name="event_ids" eval="[(5, 0, 0), (4, ref('event.event_0'))]"/>
     </record>
-    <record id="event_0_question_2_answer_0" model="event.question.answer">
+        <record id="event_question_about_1_answer_0" model="event.question.answer">
         <field name="name">Our website</field>
         <field name="sequence">1</field>
-        <field name="question_id" ref="website_event.event_0_question_2"/>
+        <field name="question_id" ref="website_event.event_question_about_1"/>
     </record>
-    <record id="event_0_question_2_answer_1" model="event.question.answer">
+    <record id="event_question_about_1_answer_1" model="event.question.answer">
         <field name="name">Commercials</field>
         <field name="sequence">2</field>
-        <field name="question_id" ref="website_event.event_0_question_2"/>
+        <field name="question_id" ref="website_event.event_question_about_1"/>
     </record>
-    <record id="event_0_question_2_answer_2" model="event.question.answer">
+    <record id="event_question_about_1_answer_2" model="event.question.answer">
         <field name="name">A friend</field>
         <field name="sequence">3</field>
-        <field name="question_id" ref="website_event.event_0_question_2"/>
+        <field name="question_id" ref="website_event.event_question_about_1"/>
     </record>
 
-    <!-- Questions of: "Great Reno Ballon Race" -->
-    <record id="event_1_question_0" model="event.question">
+    <!-- EVENT QUESTION : How did you learn about this event? (simple choice 0 + once_per_order) -->
+    <record id="event_question_about_2" model="event.question">
         <field name="title">How did you learn about this event?</field>
         <field name="question_type">simple_choice</field>
         <field name="once_per_order" eval="True"/>
-        <field name="event_id" ref="event.event_1"/>
+        <field name="event_ids" eval="[(5, 0, 0), (4, ref('event.event_1')), (4, ref('event.event_5'))]"/>
     </record>
-    <record id="event_1_question_0_answer_0" model="event.question.answer">
+    <record id="event_question_about_2_answer_0" model="event.question.answer">
         <field name="name">Social Media</field>
         <field name="sequence">1</field>
-        <field name="question_id" ref="website_event.event_1_question_0"/>
+        <field name="question_id" ref="website_event.event_question_about_2"/>
     </record>
-    <record id="event_1_question_0_answer_1" model="event.question.answer">
+    <record id="event_question_about_2_answer_1" model="event.question.answer">
         <field name="name">Blog Post</field>
         <field name="sequence">2</field>
-        <field name="question_id" ref="website_event.event_1_question_0"/>
+        <field name="question_id" ref="website_event.event_question_about_2"/>
     </record>
-    <record id="event_1_question_0_answer_2" model="event.question.answer">
+    <record id="event_question_about_2_answer_2" model="event.question.answer">
         <field name="name">Radio Ad</field>
         <field name="sequence">3</field>
-        <field name="question_id" ref="website_event.event_1_question_0"/>
+        <field name="question_id" ref="website_event.event_question_about_2"/>
     </record>
 
-    <!-- Questions of: "Hockey Tournament" -->
-    <record id="event_5_question_0" model="event.question">
-        <field name="title">How did you learn about this event?</field>
-        <field name="question_type">simple_choice</field>
-        <field name="once_per_order" eval="True"/>
-        <field name="event_id" ref="event.event_5"/>
-    </record>
-    <record id="event_5_question_0_answer_0" model="event.question.answer">
-        <field name="name">Social Media</field>
-        <field name="sequence">1</field>
-        <field name="question_id" ref="website_event.event_5_question_0"/>
-    </record>
-    <record id="event_5_question_0_answer_1" model="event.question.answer">
-        <field name="name">Blog Post</field>
-        <field name="sequence">2</field>
-        <field name="question_id" ref="website_event.event_5_question_0"/>
-    </record>
-    <record id="event_5_question_0_answer_2" model="event.question.answer">
-        <field name="name">Radio Ad</field>
-        <field name="sequence">3</field>
-        <field name="question_id" ref="website_event.event_5_question_0"/>
-    </record>
-    <record id="event_5_question_1" model="event.question">
-        <field name="title">What's your Hockey level?</field>
-        <field name="question_type">text_box</field>
-        <field name="once_per_order" eval="False"/>
-        <field name="event_id" ref="event.event_5"/>
-    </record>
-
-    <!-- Questions of: "OpenWood: Furniture Collection Online Reveal" -->
-    <record id="event_7_question_0" model="event.question">
-        <field name="title">Which field are you working in</field>
-        <field name="question_type">simple_choice</field>
-        <field name="once_per_order" eval="False"/>
-        <field name="event_id" ref="event.event_7"/>
-    </record>
-    <record id="event_7_question_0_answer_0" model="event.question.answer">
-        <field name="name">Consumers</field>
-        <field name="sequence">1</field>
-        <field name="question_id" ref="website_event.event_7_question_0"/>
-    </record>
-    <record id="event_7_question_0_answer_1" model="event.question.answer">
-        <field name="name">Sales</field>
-        <field name="sequence">2</field>
-        <field name="question_id" ref="website_event.event_7_question_0"/>
-    </record>
-    <record id="event_7_question_0_answer_2" model="event.question.answer">
-        <field name="name">Research</field>
-        <field name="sequence">3</field>
-        <field name="question_id" ref="website_event.event_7_question_0"/>
-    </record>
-    <record id="event_7_question_1" model="event.question">
+    <!-- EVENT QUESTION : How did you hear about us? -->
+    <record id="event_question_about_us" model="event.question">
         <field name="title">How did you hear about us?</field>
         <field name="question_type">text_box</field>
         <field name="once_per_order" eval="True"/>
-        <field name="event_id" ref="event.event_7"/>
+        <field name="event_ids" eval="[(5, 0, 0), (4, ref('event.event_7'))]"/>
+    </record>
+
+    <!-- EVENT QUESTION : Meal Type -->
+    <record id="event_question_meal_type" model="event.question">
+        <field name="title">Meal Type</field>
+        <field name="question_type">simple_choice</field>
+        <field name="once_per_order" eval="False"/>
+        <field name="event_ids" eval="[(5, 0, 0), (4, ref('event.event_0'))]"/>
+    </record>
+    <record id="event_question_meal_type_answer_0" model="event.question.answer">
+        <field name="name">Mixed</field>
+        <field name="sequence">1</field>
+        <field name="question_id" ref="website_event.event_question_meal_type"/>
+    </record>
+    <record id="event_question_meal_type_answer_1" model="event.question.answer">
+        <field name="name">Vegetarian</field>
+        <field name="sequence">2</field>
+        <field name="question_id" ref="website_event.event_question_meal_type"/>
+    </record>
+    <record id="event_question_meal_type_answer_2" model="event.question.answer">
+        <field name="name">Pastafarian</field>
+        <field name="sequence">3</field>
+        <field name="question_id" ref="website_event.event_question_meal_type"/>
+    </record>
+
+    <!-- EVENT QUESTION : Allergies -->
+    <record id="event_question_allergies" model="event.question">
+        <field name="title">Allergies</field>
+        <field name="question_type">text_box</field>
+        <field name="once_per_order" eval="False"/>
+        <field name="event_ids" eval="[(5, 0, 0), (4, ref('event.event_0'))]"/>
+    </record>
+
+    <!-- EVENT QUESTION : Which field are you working in? -->
+    <record id="event_question_working_field" model="event.question">
+        <field name="title">Which field are you working in?</field>
+        <field name="question_type">simple_choice</field>
+        <field name="once_per_order" eval="False"/>
+        <field name="event_ids" eval="[(5, 0, 0), (4, ref('event.event_7'))]"/>
+    </record>
+        <record id="event_question_working_field_answer_0" model="event.question.answer">
+        <field name="name">Consumers</field>
+        <field name="sequence">1</field>
+        <field name="question_id" ref="website_event.event_question_working_field"/>
+    </record>
+    <record id="event_question_working_field_answer_1" model="event.question.answer">
+        <field name="name">Sales</field>
+        <field name="sequence">2</field>
+        <field name="question_id" ref="website_event.event_question_working_field"/>
+    </record>
+    <record id="event_question_working_field_answer_2" model="event.question.answer">
+        <field name="name">Research</field>
+        <field name="sequence">3</field>
+        <field name="question_id" ref="website_event.event_question_working_field"/>
+    </record>
+
+    <!-- EVENT QUESTION : What's your Hockey level? -->
+    <record id="event_question_hockey_level" model="event.question">
+        <field name="title">What's your Hockey level?</field>
+        <field name="question_type">text_box</field>
+        <field name="once_per_order" eval="False"/>
+        <field name="event_ids" eval="[(5, 0, 0), (4, ref('event.event_5'))]"/>
     </record>
 
 </data></odoo>

--- a/addons/website_event/data/event_question_demo.xml
+++ b/addons/website_event/data/event_question_demo.xml
@@ -86,8 +86,8 @@
         <field name="title">Meal Type</field>
         <field name="question_type">simple_choice</field>
         <field name="once_per_order" eval="False"/>
-        <field name="event_ids" eval="[(5, 0, 0), (4, ref('event.event_0'))]"/>
-        <field name="is_reusable">False</field>
+        <field name="event_ids" eval="[(5, 0, 0), (4, ref('event.event_0')), (4, ref('event.event_7'))]"/>
+        <field name="is_reusable">True</field>
     </record>
     <record id="event_question_meal_type_answer_0" model="event.question.answer">
         <field name="name">Mixed</field>

--- a/addons/website_event/data/event_registration_answer_demo.xml
+++ b/addons/website_event/data/event_registration_answer_demo.xml
@@ -2,58 +2,58 @@
 <odoo><data>
 
     <record id="event_registration_0_0_registration_answer_0" model="event.registration.answer">
-        <field name="value_answer_id" ref="website_event.event_0_question_0_answer_0" />
-        <field name="question_id" ref="website_event.event_0_question_0" />
+        <field name="value_answer_id" ref="website_event.event_question_meal_type_answer_0"/>
+        <field name="question_id" ref="website_event.event_question_meal_type"/>
         <field name="registration_id" ref="event.event_registration_0_0" />
     </record>
     <record id="event_registration_0_0_registration_answer_1" model="event.registration.answer">
         <field name="value_text_box">Fish Nuts</field>
-        <field name="question_id" ref="website_event.event_0_question_1" />
+        <field name="question_id" ref="website_event.event_question_allergies"/>
         <field name="registration_id" ref="event.event_registration_0_0" />
     </record>
     <record id="event_registration_0_0_registration_answer_2" model="event.registration.answer">
-        <field name="value_answer_id" ref="website_event.event_0_question_2_answer_0" />
-        <field name="question_id" ref="website_event.event_0_question_2" />
+        <field name="value_answer_id" ref="website_event.event_question_about_1_answer_0"/>
+        <field name="question_id" ref="website_event.event_question_about_1"/>
         <field name="registration_id" ref="event.event_registration_0_0" />
     </record>
     <record id="event_registration_0_1_registration_answer_0" model="event.registration.answer">
-        <field name="value_answer_id" ref="website_event.event_0_question_0_answer_1" />
-        <field name="question_id" ref="website_event.event_0_question_0" />
+        <field name="value_answer_id" ref="website_event.event_question_meal_type_answer_1"/>
+        <field name="question_id" ref="website_event.event_question_meal_type"/>
         <field name="registration_id" ref="event.event_registration_0_1" />
     </record>
     <record id="event_registration_0_1_registration_answer_1" model="event.registration.answer">
-        <field name="value_answer_id" ref="website_event.event_0_question_2_answer_0" />
-        <field name="question_id" ref="website_event.event_0_question_2" />
+        <field name="value_answer_id" ref="website_event.event_question_about_1_answer_0"/>
+        <field name="question_id" ref="website_event.event_question_about_1"/>
         <field name="registration_id" ref="event.event_registration_0_1" />
     </record>
     <record id="event_registration_0_2_registration_answer_0" model="event.registration.answer">
-        <field name="value_answer_id" ref="website_event.event_0_question_0_answer_2" />
-        <field name="question_id" ref="website_event.event_0_question_0" />
+        <field name="value_answer_id" ref="website_event.event_question_meal_type_answer_2"/>
+        <field name="question_id" ref="website_event.event_question_meal_type"/>
         <field name="registration_id" ref="event.event_registration_0_2" />
     </record>
     <record id="event_registration_0_2_registration_answer_1" model="event.registration.answer">
-        <field name="value_answer_id" ref="website_event.event_0_question_2_answer_2" />
-        <field name="question_id" ref="website_event.event_0_question_2" />
+        <field name="value_answer_id" ref="website_event.event_question_about_1_answer_2"/>
+        <field name="question_id" ref="website_event.event_question_about_1"/>
         <field name="registration_id" ref="event.event_registration_0_2" />
     </record>
     <record id="event_registration_7_0_registration_answer_0" model="event.registration.answer">
-        <field name="value_answer_id" ref="website_event.event_7_question_0_answer_0" />
-        <field name="question_id" ref="website_event.event_7_question_0" />
+        <field name="value_answer_id" ref="website_event.event_question_working_field_answer_0"/>
+        <field name="question_id" ref="website_event.event_question_working_field"/>
         <field name="registration_id" ref="event.event_registration_7_0" />
     </record>
     <record id="event_registration_7_1_registration_answer_0" model="event.registration.answer">
-        <field name="value_answer_id" ref="website_event.event_7_question_0_answer_1" />
-        <field name="question_id" ref="website_event.event_7_question_0" />
+        <field name="value_answer_id" ref="website_event.event_question_working_field_answer_1"/>
+        <field name="question_id" ref="website_event.event_question_working_field"/>
         <field name="registration_id" ref="event.event_registration_7_1" />
     </record>
     <record id="event_registration_7_2_registration_answer_0" model="event.registration.answer">
-        <field name="value_answer_id" ref="website_event.event_7_question_0_answer_2" />
-        <field name="question_id" ref="website_event.event_7_question_0" />
+        <field name="value_answer_id" ref="website_event.event_question_working_field_answer_2"/>
+        <field name="question_id" ref="website_event.event_question_working_field"/>
         <field name="registration_id" ref="event.event_registration_7_2" />
     </record>
     <record id="event_registration_7_3_registration_answer_0" model="event.registration.answer">
-        <field name="value_answer_id" ref="website_event.event_7_question_0_answer_0" />
-        <field name="question_id" ref="website_event.event_7_question_0" />
-        <field name="registration_id" ref="event.event_registration_7_3" />
+        <field name="value_answer_id" ref="website_event.event_question_working_field_answer_0"/>
+        <field name="question_id" ref="website_event.event_question_working_field"/>
+        <field name="registration_id" ref="event.event_registration_7_3"/>
     </record>
 </data></odoo>

--- a/addons/website_event/data/event_registration_answer_demo.xml
+++ b/addons/website_event/data/event_registration_answer_demo.xml
@@ -56,4 +56,9 @@
         <field name="question_id" ref="website_event.event_question_working_field"/>
         <field name="registration_id" ref="event.event_registration_7_3"/>
     </record>
+    <record id="event_registration_7_3_registration_answer_1" model="event.registration.answer">
+        <field name="value_answer_id" ref="website_event.event_question_meal_type_answer_1"/>
+        <field name="question_id" ref="website_event.event_question_meal_type"/>
+        <field name="registration_id" ref="event.event_registration_7_3"/>
+    </record>
 </data></odoo>

--- a/addons/website_event/security/event_security.xml
+++ b/addons/website_event/security/event_security.xml
@@ -48,7 +48,7 @@
     <record id="ir_rule_event_question_published" model="ir.rule">
         <field name="name">Event Question: not event groups: event published read</field>
         <field name="model_id" ref="event.model_event_question"/>
-        <field name="domain_force">[('event_id.is_published', '=', True)]</field>
+        <field name="domain_force">[('event_ids', 'any', [('is_published', '=', True)])]</field>
         <field name="groups" eval="[(4, ref('base.group_public')), (4, ref('base.group_portal')), (4, ref('base.group_user'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>
@@ -70,7 +70,7 @@
     <record id="ir_rule_event_question_answer_published" model="ir.rule">
         <field name="name">Event Question Answer: not event groups: event published read</field>
         <field name="model_id" ref="event.model_event_question_answer"/>
-        <field name="domain_force">[('question_id.event_id.is_published', '=', True)]</field>
+        <field name="domain_force">[('question_id.event_ids', 'any', [('is_published', '=', True)])]</field>
         <field name="groups" eval="[(4, ref('base.group_public')), (4, ref('base.group_portal')), (4, ref('base.group_user'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>

--- a/addons/website_event/tests/test_event_internals.py
+++ b/addons/website_event/tests/test_event_internals.py
@@ -3,7 +3,7 @@
 
 from datetime import datetime, timedelta
 
-from odoo.fields import Datetime as FieldsDatetime
+from odoo.fields import Command, Datetime as FieldsDatetime
 from odoo.tests.common import users
 from odoo.addons.website.tests.test_website_visitor import MockVisitor
 from odoo.addons.http_routing.tests.common import MockRequest
@@ -47,11 +47,11 @@ class TestEventData(EventCase, MockVisitor):
         [second_phone_question, company_name_question] = self.env['event.question'].create([{
             'title': 'Second Phone',
             'question_type': 'phone',
-            'event_id': event.id,
+            'event_ids': [Command.set(event.ids)],
         }, {
             'title': 'Company Name',
             'question_type': 'company_name',
-            'event_id': event.id,
+            'event_ids': [Command.set(event.ids)],
         }])
 
         form_details = {


### PR DESCRIPTION
This commit allow users to create questions and share them between events and event types. Therefore, no need to create identical questions for each events and event type. So the conversion of the one2many relationship between event.event and event.question in many2many is the main change of this PR.

This feature imply other changes. Thus, 5 other commits has been done.
- commit 1: Users can create default questions, and can avoid to populate new event and new event templates with unwanted questions.
- commit 2: Users can chose if a question can still be selected in the event and event template forms. 
- commit 3: Users can not delete questions, because it can lead to irreversible changes as lost of attendee answers. Therefore, they can archive questions if they does not want to use them anymore.
- commit 4: A reporting has been added to the questions and events list. Users can analyse the attendee answers to a question by event in a single report.
- commit 5: Users can add rules on answers of 'simple choice' questions. So, if a visitor select an answer with a rule on it, a lead will be generated.  

A migration is needed to create the is_default and is_reusable columns and to store default questions in existing databases as they must be usable by multiple events and event templates.

Ugrade PR: odoo/upgrade#7153

task-4247015