### PR TITLE
[FIX] web: report min-width for less background image cropping


### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report.scss
+++ b/addons/web/static/src/webclient/actions/reports/report.scss
@@ -102,9 +102,9 @@ li.oe-nested {
 }
 
 .o_report_layout_background {
-    background-size: contains;
     background-position: center 300px;
     background-repeat: no-repeat;
+    min-height: 600px;
 }
 
 .o_company_logo {


### PR DESCRIPTION
Scenario:

- set the report background to demo logo (621x196 pixels)
- print a report with short content (eg. quotation without lines)

Result: the logo is cropped at the bottom

Why:

Before 18.0, the background image was stretched over all the
report, so needed to be ok esthetically if stretched.

From 18.0 with https://github.com/odoo/odoo/commit/87258f05c7398173d3df6ec39869f52031502ede, the image is
only intended to be shown one time on the first page without stretching
over the whole document.

There is two issues:

- the "background-size" value "contains" is a typo of "contain"

- if we fixed the typo we would break case where the image has a portait
  aspect ratio, the image would be zoomed to fit vertically (possibly
  over several page, which is itself an issue that the commit was
  trying to fix), but since we have the value "background-position: auto
   300px" the contain is computed over the whole element area, and we
  will have 300px cropped of the bottom of the image

Fix:

This is not simple to fix, we could have used something like:

background-size: auto calc(min(100% - 300px, 800px));

but both min and calc do not seem supported by wkhtmltopdf.

So it seems that the only way to make this work better would be:

- have a min-width, so people can know that if they can use an image of
  eg. 300px (for a min-width of 600px) of height without bottom cropped

- we could fix the background-size: contain, but then we would possibly
  bring more issue for vertical image (that will be zoomed up or down
  all of a sudden) that are not solvable because of background-position.

This fix just set the min-height to 600px.

opw-4364722