### PR TITLE
[FIX] point_of_sale: prevent error when loading product suppliers

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -148,6 +148,7 @@ class ProductProduct(models.Model):
             for s in list(group):
                 if not((s.date_start and s.date_start > date.today()) or (s.date_end and s.date_end < date.today()) or (s.min_qty > quantity)):
                     supplier_list.append({
+                        'id': s.id,
                         'name': s.partner_id.name,
                         'delay': s.delay,
                         'price': s.price

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
@@ -77,7 +77,7 @@
                     <div class="section-supplier mt-3 mb-4 pb-4 border-bottom text-start" t-if="productInfo.suppliers.length > 0">
                         <h3 class="section-title">Replenishment</h3>
                         <div class="section-supplier-body">
-                            <t t-foreach="productInfo.suppliers" t-as="supplier" t-key="supplier.name">
+                            <t t-foreach="productInfo.suppliers" t-as="supplier" t-key="supplier.id">
                                 <div class="d-flex flex-column flex-md-row gap-2">
                                     <div>
                                         <span t-esc="supplier.name" class="table-name"/>:


### PR DESCRIPTION
Previously, opening the product info popup would fail if a product had multiple sellers with the same name but different prices and delays.

opw-4472861

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
