### PR TITLE
[FIX] web: don't aggregate grouped by fields

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -687,11 +687,14 @@ export class RelationalModel extends Model {
     }
 
     async _webReadGroup(config, orderBy) {
-        const aggregates = Object.values(config.fields).filter(
-            (field) => field.aggregator && field.name in config.activeFields
-        ).map(
-            (field) => `${field.name}:${field.aggregator}`
-        )
+        const aggregates = Object.values(config.fields)
+            .filter(
+                (field) =>
+                    field.aggregator &&
+                    field.name in config.activeFields &&
+                    field.name !== config.groupBy[0]
+            )
+            .map((field) => `${field.name}:${field.aggregator}`);
         return this.orm.webReadGroup(
             config.resModel,
             config.domain,


### PR DESCRIPTION
This commit fixes an issue where if the user applies a group by on an aggregatable field (an integer like color_index for example), this field is also registered as an aggregator in the webReadGroup call and this leads to nonsensical results by the orm. After this commit, the group by field is automatically excluded from aggregators so the issue cannot happen.

task-4491839
