### PR TITLE
[IMP] account: detach files on resetting to draft

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -111,6 +111,14 @@ msgstr ""
 
 #. module: account
 #. odoo-python
+#: code:addons/account/models/account_move.py:0
+msgid ""
+"%(attachment_name)s (detached by %(user)s on "
+"%(date)s)%(attachment_extension)s"
+msgstr ""
+
+#. module: account
+#. odoo-python
 #: code:addons/account/models/account_lock_exception.py:0
 msgid "%(exception)s for %(user)s%(end_datetime_string)s%(reason)s."
 msgstr ""

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -11,6 +11,7 @@ import logging
 from markupsafe import Markup
 import math
 import re
+import os
 from textwrap import shorten
 
 from odoo import api, fields, models, _, Command, SUPERUSER_ID, modules, tools
@@ -5244,6 +5245,37 @@ class AccountMove(models.Model):
         self.mapped('line_ids.analytic_line_ids').unlink()
         self.mapped('line_ids').remove_move_reconcile()
         self.state = 'draft'
+
+        self._detach_attachments()
+
+    def _get_fields_to_detach(self):
+        """"
+        Returns a list of field names to detach on resetting an invoice to draft. Can be overridden by other modules to
+        add more fields.
+        """
+        return ['invoice_pdf_report_file']
+
+    def _detach_attachments(self):
+        """
+        Called by button_draft to detach specific attachments for the current journal entries to allow regeneration.
+        """
+        files_to_detach = self.sudo().env['ir.attachment'].search([
+            ('res_model', '=', 'account.move'),
+            ('res_id', 'in', self.ids),
+            ('res_field', 'in', self._get_fields_to_detach()),
+        ])
+        if files_to_detach:
+            files_to_detach.res_field = False
+            today = format_date(self.env, fields.Date.context_today(self))
+            for attachment in files_to_detach:
+                attachment_name, attachment_extension = os.path.splitext(attachment.name)
+                attachment.name = _(
+                    '%(attachment_name)s (detached by %(user)s on %(date)s)%(attachment_extension)s',
+                    attachment_name=attachment_name,
+                    attachment_extension=attachment_extension,
+                    user=self.env.user.name,
+                    date=today,
+                )
 
     def _check_draftable(self):
         exchange_move_ids = set()

--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -33,6 +33,12 @@ class AccountMove(models.Model):
     # BUSINESS
     # -------------------------------------------------------------------------
 
+    def _get_fields_to_detach(self):
+        # EXTENDS account
+        fields_list = super()._get_fields_to_detach()
+        fields_list.append("ubl_cii_xml_file")
+        return fields_list
+
     def _get_invoice_legal_documents(self, filetype, allow_fallback=False):
         # EXTENDS account
         if filetype == 'ubl':

--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -114,6 +114,12 @@ class AccountMove(models.Model):
             ('19', "Payment by card"),
         ], string="Payment Means", default='04')
 
+    def _get_fields_to_detach(self):
+        # EXTENDS account
+        fields_list = super()._get_fields_to_detach()
+        fields_list.append("l10n_es_edi_facturae_xml_file")
+        return fields_list
+
     def _l10n_es_edi_facturae_get_default_enable(self):
         self.ensure_one()
         return not self.invoice_pdf_report_id \

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -188,6 +188,12 @@ class AccountMove(models.Model):
                 result = super(AccountMove, self.with_context(disable_onchange_name_predictive=True))._extend_with_attachments(l10n_it_attachments, new)
         return result or super()._extend_with_attachments(attachments, new)
 
+    def _get_fields_to_detach(self):
+        # EXTENDS account
+        fields_list = super()._get_fields_to_detach()
+        fields_list.append('l10n_it_edi_attachment_file')
+        return fields_list
+
     # -------------------------------------------------------------------------
     # Business actions
     # -------------------------------------------------------------------------

--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -88,6 +88,12 @@ class AccountMove(models.Model):
         )
         return super().button_draft()
 
+    def _get_fields_to_detach(self):
+        # EXTENDS account
+        fields_list = super()._get_fields_to_detach()
+        fields_list.append('l10n_jo_edi_xml_attachment_file')
+        return fields_list
+
     def _post(self, soft=True):
         # EXTENDS 'account'
         for invoice in self.filtered('l10n_jo_edi_is_needed'):

--- a/addons/l10n_my_edi/models/account_move.py
+++ b/addons/l10n_my_edi/models/account_move.py
@@ -178,6 +178,12 @@ class AccountMove(models.Model):
         invoices_to_reset.l10n_my_edi_file_id.unlink()
         return res
 
+    def _get_fields_to_detach(self):
+        # EXTENDS account
+        fields_list = super()._get_fields_to_detach()
+        fields_list.append('l10n_my_edi_file')
+        return fields_list
+
     def _need_cancel_request(self):
         # EXTENDS 'account'
         # For the in_progress state, we do not want to allow resetting to draft nor cancelling. We need to wait for the result first.

--- a/addons/l10n_vn_edi_viettel/models/account_move.py
+++ b/addons/l10n_vn_edi_viettel/models/account_move.py
@@ -198,6 +198,12 @@ class AccountMove(models.Model):
 
         return super().button_request_cancel()
 
+    def _get_fields_to_detach(self):
+        # EXTENDS account
+        fields_list = super()._get_fields_to_detach()
+        fields_list.extend(['l10n_vn_edi_sinvoice_file', 'l10n_vn_edi_sinvoice_xml_file','l10n_vn_edi_sinvoice_pdf_file'])
+        return fields_list
+
     def _l10n_vn_edi_fetch_invoice_file_data(self, file_format):
         """ Helper to try fetching a few time in case the files are not yet ready. """
         self.ensure_one()


### PR DESCRIPTION
Resetting a move to draft should detach the current attachments generated by the send and print and allow regenerating them after the user is done with the edits.

Task [link](https://www.odoo.com/odoo/project.task/4498564)
task-4498564

Enterprise PR: https://github.com/odoo/enterprise/pull/78429
