### PR TITLE
[FIX] website_sale_loyalty: use float_compare to compare floats

### DIFF
--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -147,7 +147,7 @@ class PaymentPortal(main.PaymentPortal):
             initial_amount = order_sudo.amount_total
             order_sudo._update_programs_and_rewards()
             order_sudo.validate_taxes_on_sales_order()  # re-applies taxcloud taxes if necessary
-            if initial_amount != order_sudo.amount_total:
+            if order_sudo.currency_id.compare_amounts(initial_amount, order_sudo.amount_total):
                 raise ValidationError(
                     _("Cannot process payment: applied reward was changed or has expired.")
                 )


### PR DESCRIPTION
Versions
--------
- 16.0

Backport of https://github.com/odoo/odoo/pull/195266

Issue
-----
Use `float_compare` to compare floating point amounts on reward validation.
