### PR TITLE
[FIX] mail: fix mail_template_dynamic_placeholder_tour

### DIFF
--- a/addons/mail/static/tests/tours/mail_template_dynamic_placeholder_tour.js
+++ b/addons/mail/static/tests/tours/mail_template_dynamic_placeholder_tour.js
@@ -1,5 +1,6 @@
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
+import { delay } from "@odoo/hoot-dom";
 
 registry.category("web_tour.tours").add("mail_template_dynamic_placeholder_tour", {
     url: "/odoo",
@@ -33,6 +34,9 @@ registry.category("web_tour.tours").add("mail_template_dynamic_placeholder_tour"
         {
             content: "Wait for the autocomplete RPC",
             trigger: 'div[name="model_id"] .ui-autocomplete:contains("Contact")',
+            run: async() => {
+                await delay(300);
+            }
         },
         {
             content: "Click on contact",


### PR DESCRIPTION
mail_template_dynamic_placeholder_tour is failing, as the
delay between two steps is too small and dom is rendering
right after clicking the dropdown. this pr fixes the issue.

[failing runbot builds](https://runbot.odoo.com/odoo/action-573/111986)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
