### PR TITLE
[FIX] sale: sales team assigned to wrong moves

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -40,7 +40,7 @@ class AccountMove(models.Model):
             applicable_moves,
             key=lambda m: (m.invoice_user_id.id, m.company_id.id)
         ):
-            self.concat(*moves).team_id = self.env['crm.team'].with_context(
+            self.env['account.move'].concat(*moves).team_id = self.env['crm.team'].with_context(
                 allowed_company_ids=[company_id]
             )._get_default_team_id(
                 user_id=user_id,


### PR DESCRIPTION
A sales team should be assigned only to sales type moves (invoices,
credit notes, ...). Currently, it is possible that some Bills get a
sales team assigned. This is not ok as it will distort the reports
if users analyze by sales team.

It occurs when `_compute_team_id` is called on a recordset containing
sales moves and other moves.
Even if sales moves are correctly filtered a `self.concat` is used to
set the `team_id` and it will return the concatenation of `self` with
the arguments, so also the non sales moves will have the team assigned

opw-4422292