### PR TITLE
[FIX] sale_project : Use the product name in task title at any case

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -260,8 +260,15 @@ class SaleOrderLine(models.Model):
         if self.product_id.service_type not in ['milestones', 'manual']:
             allocated_hours = self._convert_qty_company_hours(self.company_id)
         sale_line_name_parts = self.name.split('\n')
-        title = sale_line_name_parts[0] or self.product_id.name
-        description = '<br/>'.join(sale_line_name_parts[1:])
+        products_inside_template_line_with_name = self.order_id.sale_order_template_id.sale_order_template_line_ids.filtered(
+            lambda line: line.product_id and line.name).product_id
+        if self.product_id in products_inside_template_line_with_name:
+            title = self.product_id.name
+            description = '<br/>'.join(sale_line_name_parts)
+        else:
+            title = sale_line_name_parts[0]
+            description = '<br/>'.join(sale_line_name_parts[1:])
+
         return {
             'name': title if project.sale_line_id else '%s - %s' % (self.order_id.name or '', title),
             'allocated_hours': allocated_hours,


### PR DESCRIPTION
### Steps to reproduce:
	- create a new quotation with configured quotation template
	- the descriptions are added by default (thanks to the template)
	- confirm the SO
	- the task is created, but it shows the description in the title (instead of the name of the product) and the description tab is empty

### Cause:
In 'Quotation Templates' the description of each line is being stored under the name of 'name' so when using this quotation template in an SO the SO line name will be the template line name not the product name + the description and so when creating the task we use the name of the SO line which in that case will be the description.

### Fix:
We are checking if we have a quotation template or not and if we don't we use the name of the SO line to get the name and the description of the task if we have a quotation template we use the product name for the name of the task and the name of the template line as a description.

opw-4482867