### PR TITLE
[FIX] mail: show discuss time in 24 or 12 based on browser locale

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -24,7 +24,7 @@
                         </div>
                         <t t-elif="message.isPending" t-call="mail.Message.pendingStatus"/>
                         <t t-elif="!message.is_transient">
-                            <small t-if="isActive and props.showDates" class="o-mail-Message-date o-xsmaller mt-2" t-att-title="message.datetimeShort">
+                            <small t-if="isActive and props.showDates" class="o-mail-Message-date o-xsmaller mt-2 text-center lh-1" t-att-title="message.datetimeShort">
                                 <t t-esc="message.dateSimple"/>
                             </small>
                         </t>

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -221,33 +221,32 @@ export class Message extends Record {
     }
 
     get dateSimple() {
-        return this.datetime.toLocaleString(DateTime.TIME_24_SIMPLE, {
-            locale: user.lang,
-        });
+        return this.datetime
+            .toLocaleString(DateTime.TIME_SIMPLE, {
+                locale: user.lang,
+            })
+            .replace(" ", " "); // so that AM/PM are properly wrapped
     }
 
     get dateSimpleWithDay() {
         const userLocale = { locale: user.lang };
         if (this.datetime.hasSame(DateTime.now(), "day")) {
             return _t("Today at %(time)s", {
-                time: this.datetime.toLocaleString(DateTime.TIME_24_SIMPLE, userLocale),
+                time: this.datetime.toLocaleString(DateTime.TIME_SIMPLE, userLocale),
             });
         }
         if (this.datetime.hasSame(DateTime.now().minus({ day: 1 }), "day")) {
             return _t("Yesterday at %(time)s", {
-                time: this.datetime.toLocaleString(DateTime.TIME_24_SIMPLE, userLocale),
+                time: this.datetime.toLocaleString(DateTime.TIME_SIMPLE, userLocale),
             });
         }
         if (this.datetime?.year === DateTime.now().year) {
             return this.datetime.toLocaleString(
-                { ...DateTime.DATETIME_MED, hourCycle: "h23", year: undefined },
+                { ...DateTime.DATETIME_MED, year: undefined },
                 userLocale
             );
         }
-        return this.datetime.toLocaleString(
-            { ...DateTime.DATETIME_MED, hourCycle: "h23" },
-            userLocale
-        );
+        return this.datetime.toLocaleString({ ...DateTime.DATETIME_MED }, userLocale);
     }
 
     get datetime() {
@@ -381,7 +380,7 @@ export class Message extends Record {
     }
 
     get scheduledDateSimple() {
-        return this.scheduledDatetime.toLocaleString(DateTime.TIME_24_SIMPLE, {
+        return this.scheduledDatetime.toLocaleString(DateTime.TIME_SIMPLE, {
             locale: user.lang,
         });
     }

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -835,7 +835,7 @@ test("message comment of same author within 5min. should be squashed", async () 
     await contains(".o-mail-Message", {
         contains: [
             [".o-mail-Message-content", { text: "body2" }],
-            [".o-mail-Message-sidebar .o-mail-Message-date", { text: "10:02" }],
+            [".o-mail-Message-sidebar .o-mail-Message-date", { text: "10:02 AM" }],
         ],
     });
 });


### PR DESCRIPTION
Exact time are shown in discuss since version 18.0. Format was always 24-hour, which is ok for some users but not for others.

This commit uses time format of luxon browser based on user locale, so that this is the expected format as the user is used to see in all browser apps.

Note that we don't choose DB date format, because discuss app are used by many other users and the custom format on whole DB might make some users happy but others not. In particular, the default en_US language time format in Odoo uses 24-hour when lots of english americans are used and prefer 12-hour format. Using the locale format of browser, which tend to rely on OS settings, makes (almost) everyone happy.

Also the extra AM/PM could lead to size issue on small squashed messages, this commit also fixes it.

opw-4482727

Before / After
![Screenshot 2025-01-31 at 14 16 57](https://github.com/user-attachments/assets/c065c958-51aa-4845-b84f-e09b118ecbe0) ![Screenshot 2025-01-31 at 14 17 26](https://github.com/user-attachments/assets/042f1b11-61f8-4922-b606-f0c08b6d1d43)

