### PR TITLE
[IMP] point_of_sale: add raise to notify user about errors

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -147,6 +147,7 @@ class PosOrder(models.Model):
                 raise
             except Exception as e:
                 _logger.error('Could not fully process the POS Order: %s', tools.ustr(e), exc_info=True)
+                raise
             pos_order._create_order_picking()
             pos_order._compute_total_cost_in_real_time()
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Prior to this change, if there was an error related to the order not being fully processed when paying the order and updating the data in the back end, the user was not aware of this error and this caused inconsistencies in orders appearing as paid in the PoS but in the back end appeared in Draft status

Current behavior before PR:

No error is displayed when entering the exception where the log error Could not fully process the POS Order is logged

Desired behavior after PR is merged:

A notification should be displayed to warn the user about the error


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
