### PR TITLE
[IMP] phone_validation: guess phone country

### DIFF
--- a/addons/phone_validation/models/mail_thread_phone.py
+++ b/addons/phone_validation/models/mail_thread_phone.py
@@ -219,7 +219,10 @@ class PhoneMixin(models.AbstractModel):
     def _phone_get_sanitize_triggers(self):
         """ Tool method to get all triggers for sanitize """
         res = [self._phone_get_country_field()] if self._phone_get_country_field() else []
-        return res + self._phone_get_number_fields()
+        # if partner changes, fallback country may change
+        res += [fname for fname in self._mail_get_partner_fields() if self._fields[fname].store]
+        res += self._phone_get_number_fields()
+        return res
 
     def _phone_set_blacklisted(self):
         return self.env['phone.blacklist'].sudo()._add([r.phone_sanitized for r in self])

--- a/addons/test_mail_sms/models/test_mail_sms_models.py
+++ b/addons/test_mail_sms/models/test_mail_sms_models.py
@@ -16,15 +16,17 @@ class MailTestSMS(models.Model):
     name = fields.Char()
     subject = fields.Char()
     email_from = fields.Char()
+    guest_ids = fields.Many2many('res.partner')
     phone_nbr = fields.Char()
     mobile_nbr = fields.Char()
     customer_id = fields.Many2one('res.partner', 'Customer')
+    country_id = fields.Many2one('res.country')
 
     def _phone_get_number_fields(self):
         return ['phone_nbr', 'mobile_nbr']
 
     def _mail_get_partner_fields(self, introspect_fields=False):
-        return ['customer_id']
+        return ['customer_id', 'guest_ids']
 
 
 class MailTestSMSBL(models.Model):

--- a/addons/test_mail_sms/tests/__init__.py
+++ b/addons/test_mail_sms/tests/__init__.py
@@ -3,6 +3,7 @@
 
 from . import test_mail_thread_phone
 from . import test_phone_blacklist
+from . import test_phone_format
 from . import test_sms_composer
 from . import test_sms_controller
 from . import test_sms_management

--- a/addons/test_mail_sms/tests/test_phone_format.py
+++ b/addons/test_mail_sms/tests/test_phone_format.py
@@ -1,0 +1,82 @@
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged('phone_validation')
+class TestPhoneFormat(TransactionCase):
+
+    def test_phone_format_country_guess(self):
+        # based on partner country
+        partners = self.env['res.partner'].create([
+            {'name': 'Alex Bell', 'country_id': self.env.ref('base.us').id},
+            {'name': 'Elie Grey', 'country_id': self.env.ref('base.uk').id},
+        ])
+        test_record = self.env['mail.test.sms'].create({
+            'country_id': False,
+            'name': 'Record for Context',
+            'customer_id': False,
+        })
+        base_partner_vals = [
+            {'country_id': self.env.ref('base.us').id},
+            {'country_id': self.env.ref('base.uk').id},
+        ]
+        base_record_vals = {
+            'country_id': False,
+            'customer_id': False,
+            'guest_ids': False,
+        }
+        partner_vals_all = [({}, {}), ({}, {}), ({'country_id': False}, {}), ({}, {'country_id': False}), ({}, {})]
+        record_vals_all = [
+            {'customer_id': partners[0].id}, {'guest_ids': partners}, {'guest_ids': partners},
+            {'country_id': partners[1].country_id.id, 'customer_id': partners[1].id},
+            {'country_id': partners[1].country_id.id},
+        ]
+        input_numbers = ['251 842 8701', '251 842 8701', '078 9216 4126', '078 9216 4126', '+32499000000']
+        expected_numbers = ['+12518428701', '+12518428701', '+447892164126', '+447892164126', '+32499000000']
+        test_names = ['customer country', 'first guest country', 'second guest country', 'record country', 'existing prefix']
+
+        for partner_vals, record_vals, input_number, expected_number, test_name in zip(partner_vals_all, record_vals_all, input_numbers, expected_numbers, test_names):
+            for partner, base_vals, vals in zip(partners, base_partner_vals, partner_vals):
+                partner.write(base_vals | vals)
+            test_record.write(base_record_vals | record_vals)
+            with self.subTest(test_name=test_name):
+                self.assertEqual(
+                    test_record._phone_format(
+                        number=input_number,
+                    ), expected_number)
+
+    def test_phone_format_perf(self):
+        PARTNER_COUNT = 100
+
+        countries = self.env['res.country'].create([{
+            'name': f'Test Country {n}',
+            'code': str(n),
+        } for n in range(20)])
+
+        country_partners = self.env['res.partner'].create([
+            {'name': f'{countries[_id % len(countries)].name} partner', 'country_id': countries[_id % len(countries)].id}
+            for _id in range(PARTNER_COUNT)
+        ])
+
+        nocountry_partners = self.env['res.partner'].create([
+            {'name': 'Countryless Man', 'country_id': False}
+            for _ in range(PARTNER_COUNT)
+        ])
+
+        test_records = self.env['mail.test.sms'].create([{
+            'country_id': False,
+            'name': 'Phone Format Test Record',
+            'customer_id': nocountry_p.id,
+            'guest_ids': country_p.ids,
+        } for nocountry_p, country_p in zip(nocountry_partners, country_partners)])
+
+        test_records.invalidate_recordset()
+        (country_partners + nocountry_partners).invalidate_recordset()
+        countries.invalidate_recordset()
+        # 1 query per country + 4
+        with self.assertQueryCount(24):
+            for record in test_records:
+                record._phone_format(
+                    number='078 9216 4126',
+                    raise_exception=False,
+                )

--- a/addons/test_mail_sms/tests/test_sms_performance.py
+++ b/addons/test_mail_sms/tests/test_sms_performance.py
@@ -119,7 +119,7 @@ class TestSMSMassPerformance(BaseMailPerformance, sms_common.MockSMS):
             'mass_keep_log': False,
         })
 
-        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=55):
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=56):
             composer.action_send_sms()
 
     @mute_logger('odoo.addons.sms.models.sms_sms')
@@ -135,5 +135,5 @@ class TestSMSMassPerformance(BaseMailPerformance, sms_common.MockSMS):
             'mass_keep_log': True,
         })
 
-        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=58):
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=59):
             composer.action_send_sms()


### PR DESCRIPTION
Add some logic to check the partner fields of models when formatting numbers based on a specific record.

This is useful when we would otherwise have to fallback on the current company for formatting as it's generally a much better guess.

task-4199766