### PR TITLE
[FIX] im_livechat: clear answers when changing step type from question to other

### DIFF
--- a/addons/im_livechat/models/chatbot_script.py
+++ b/addons/im_livechat/models/chatbot_script.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models, fields
+from odoo import api, Command, models, fields
 from odoo.http import request
 from odoo.tools import email_normalize, get_lang, html2plaintext, is_html_empty, plaintext2html
 from odoo.exceptions import ValidationError
@@ -34,6 +34,12 @@ class ChatbotScript(models.Model):
         for step in self.script_step_ids:
             if step.step_type == "question_selection" and not step.answer_ids:
                 raise ValidationError(self.env._("Step of type 'Question' must have answers."))
+
+    @api.onchange("script_step_ids")
+    def _onchange_script_step_ids(self):
+        for step in self.script_step_ids:
+            if step.step_type != "question_selection" and step.answer_ids:
+                step.answer_ids = [Command.clear()]
 
     def _compute_livechat_channel_count(self):
         channels_data = self.env['im_livechat.channel.rule']._read_group(

--- a/addons/im_livechat/static/tests/tours/chatbot_step_type_clear_only.js
+++ b/addons/im_livechat/static/tests/tours/chatbot_step_type_clear_only.js
@@ -1,0 +1,38 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("change_chatbot_step_type", {
+    steps: () => [
+        {
+            content: "Open an existing script",
+            trigger: ".o_field_cell[data-tooltip='Clear Answer Test Bot']",
+            run: "click",
+        },
+        {
+            content: "Open first step",
+            trigger: '.o_row_draggable .o_field_cell:contains("Question")',
+            run: "click",
+        },
+        {
+            content: "Change step type to 'text'",
+            trigger: 'div[name="step_type"] select',
+            run: function (el) {
+                el.anchor.value = '"text"';
+                el.anchor.dispatchEvent(new Event("change", { bubbles: true }));
+            },
+        },
+        {
+            content: "Verify answers cleared",
+            trigger: ".btn-primary:contains('Save')",
+            run: "click",
+        },
+        {
+            trigger: ".o_form_button_save",
+            run: "click",
+        },
+        {
+            trigger: ".o_form_view",
+        },
+    ],
+});


### PR DESCRIPTION
**Current behavior before PR**:

When the step type was changed from "question selection" to another type and the step was saved,
answers were not cleared.

**Desired behavior after PR is merged**:

Now, when the step type is changed from "question selection" to any other type and the step is saved, 
the answers are cleared.

**task**-[4510555](https://odoo.com/odoo/all-tasks/4510555)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr