### PR TITLE
[FIX] mrp: prevent an error when start date is not available

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -870,7 +870,7 @@ class MrpProduction(models.Model):
 
         date_start_map = dict()
         if 'date_start' in vals:
-            date_start = fields.Datetime.to_datetime(vals['date_start'])
+            date_start = fields.Datetime.to_datetime(vals['date_start'] or fields.Date.today())
             date_start_map = {
                 prod: date_start - datetime.timedelta(days=prod.bom_id.produce_delay)
                 if prod.bom_id else date_start


### PR DESCRIPTION
The issue occurs when the system tries to convert different types of date or date objects into proper python datetime.datetime object but 'date_start' is False in vals at [1]. It might be write when `_plan_workorders` is executed and mrp workorder has not 'leave_id' [2].

The issue occurs when the system attempts to convert various date or date-related objects into a valid Python datetime.datetime object. However, at [1], 'date_start' in 'vals' is False [1]. This may be write when the '_plan_workorders' method is executed and the mrp workorder does not have a 'leave_id' [2].

Link [1]: https://github.com/odoo/odoo/blob/a848c3854c94b5c2b752edddbcf49337acf9d6ea/addons/mrp/models/mrp_production.py#L875

Link [2]: https://github.com/odoo/odoo/blob/a848c3854c94b5c2b752edddbcf49337acf9d6ea/addons/mrp/models/mrp_production.py#L1533-L1536

To resolve this, provide a default date as today if start date is not available

Sentry-6255515427



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
