### PR TITLE
[IMP] l10n_in_ewaybill: restrict deletion of attachments

### DIFF
--- a/addons/l10n_in_ewaybill/i18n/l10n_in_ewaybill.pot
+++ b/addons/l10n_in_ewaybill/i18n/l10n_in_ewaybill.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~18.1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-22 06:18+0000\n"
-"PO-Revision-Date: 2025-01-22 06:18+0000\n"
+"POT-Creation-Date: 2025-01-30 07:09+0000\n"
+"PO-Revision-Date: 2025-01-30 07:09+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -2967,6 +2967,12 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_in_ewaybill/models/error_codes.py:0
 msgid "You can reject the e-way bill only within 72 hours from generated time"
+msgstr ""
+
+#. module: l10n_in_ewaybill
+#. odoo-python
+#: code:addons/l10n_in_ewaybill/models/ir_attachment.py:0
+msgid "You can't unlink an attachment that you received from the government"
 msgstr ""
 
 #. module: l10n_in_ewaybill

--- a/addons/l10n_in_ewaybill/models/__init__.py
+++ b/addons/l10n_in_ewaybill/models/__init__.py
@@ -2,6 +2,7 @@
 
 from . import account_move
 from . import ewaybill_type
+from . import ir_attachment
 from . import l10n_in_ewaybill
 from . import res_company
 from . import res_config_settings

--- a/addons/l10n_in_ewaybill/models/ir_attachment.py
+++ b/addons/l10n_in_ewaybill/models/ir_attachment.py
@@ -1,0 +1,20 @@
+from odoo import api, models, _
+from odoo.exceptions import UserError
+
+
+class IrAttachment(models.Model):
+    _inherit = 'ir.attachment'
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_government_document(self):
+        """
+        Prevents the deletion of attachments related to government-issued documents.
+        """
+        if any(
+            attachment.res_model == 'l10n.in.ewaybill'
+            and attachment.mimetype == 'application/json'
+            and attachment.res_field == 'attachment_file'
+            for attachment in self
+        ):
+            raise UserError(_("You can't unlink an attachment that you received from the government"))
+        return super()._unlink_except_government_document()


### PR DESCRIPTION
In this commit:
We restrict the deletion of government related attachments for Ewaybill.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
