### PR TITLE
[FIX] web_editor: prevent unnecessary `feff` wrapping in links 

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1310,7 +1310,7 @@ export const formatSelection = (editor, formatName, {applyStyle, formatProps} = 
     }
 }
 export const isLinkEligibleForZwnbsp = (editable, link) => {
-    return link.isContentEditable && editable.contains(link) && !(
+    return link.parentElement.isContentEditable && link.isContentEditable && editable.contains(link) && !(
         [link, ...link.querySelectorAll('*')].some(el => el.nodeName === 'IMG' || isBlock(el)) ||
         link.matches('nav a, a.nav-link')
     );

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/link.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/link.test.js
@@ -825,6 +825,12 @@ describe('Link', () => {
                 contentBeforeEdit: '<p>a<a href="#/" class="nav-link">[]b</a>c</p>',
             });
         });
+        it('should not zwnbsp-pad link if parent is `contenteditable=false`', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: `<div contenteditable="false">a<a href="#/">[]b</a>c</div>`,
+                contentBeforeEdit: `<div contenteditable="false" data-oe-keep-contenteditable="">a<a href="#/">[]b</a>c</div>`,
+            });
+        });
         it('should not zwnbsp-pad in nav', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<nav>a<a href="#/">[]b</a>c</nav>',


### PR DESCRIPTION
**Problem**:
Wrapping links with `feff` chars allows placing the cursor
at their inner or outer edge. However, if the parent is
`contenteditable=false`, this behavior is unnecessary since
navigation outside the link is already blocked.

**Example**:
`<div contenteditable=false>/ZWS/<a contenteditable=true>`
`/ZWS/ab[]c</a></div>`
Pressing the left arrow key repeatedly places the cursor
at the start of `a`, before `feff`:
`<div contenteditable=false>/ZWS/<a contenteditable=true>`
`[]/ZWS/abc</a></div>`
This forces an extra left-arrow press to move past `a`,
which is redundant since only the link itself is editable.

**Solution**:
Wrap links with `feff` only if their parent element is
`contenteditable=true`.

**Steps to Reproduce**:
1. Add a Form snippet.
2. Focus on the "Submit" button.
3. Press the "Home" button to move the cursor to the start.
4. Press the right arrow key twice.
   - **Expected**: Cursor moves after the first visible char.
   - **Issue**: Cursor stops prematurely before the character.

opw-4505962

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
