### PR TITLE
[FIX] core: adapt python form view to new object 'companies'

### DIFF
--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -4715,7 +4715,13 @@ class ViewModifiers(ViewCase):
         _test_modifiers("""<field name="a" invisible="a == context['b']"/>""",
             {"a"},
         )
-        _test_modifiers("""<field name="a" invisible="company_id == allowed_company_ids[0]"/>""",
+        _test_modifiers("""<field name="a" invisible="company_id == allowed_company_ids[0]"/>""",  # deprecated
+            {"company_id"},
+        )
+        _test_modifiers("""<field name="a" invisible="company_id == companies.active_id"/>""",
+            {"company_id"},
+        )
+        _test_modifiers("""<field name="a" invisible="companies.has(company_id, 'country_code', 'BE')"/>""",
             {"company_id"},
         )
         _test_modifiers("""<field name="a" invisible="company_id == (field_1 or False)"/>""",

--- a/odoo/tests/form.py
+++ b/odoo/tests/form.py
@@ -402,6 +402,7 @@ class Form:
             'active_ids': self._record.ids,
             'active_model': self._record._name,
             'current_date': date.today().strftime("%Y-%m-%d"),
+            'companies': Companies(self._env),
             **self._env.context,
         }
         if values is None:
@@ -1034,3 +1035,54 @@ class Dotter:
     def __getattr__(self, key):
         val = self.__values[key]
         return Dotter(val) if isinstance(val, dict) else val
+
+
+class Companies:
+    """ Simple object that simulates the corresponding "companies" object in
+    client-side Python expressions.  It provides access to the currently active
+    companies, and is also used to test some company "properties".
+    """
+    def __init__(self, env):
+        self.__env = env
+
+    @property
+    def active_id(self) -> int:
+        """ The ID of the main company selected.
+        (the one highlighted in the company switcher dropdown and displayed in the navbar of the webclient)
+        """
+        return self.__env.company.id
+
+    @property
+    def active_ids(self) -> list[int]:
+        """ The list of company IDs the user is connected to (selected in the company switcher dropdown). """
+        # actually equal to context['allowed_company_ids']
+        return self.__env.companies.ids
+
+    @property
+    def allowed_ids(self) -> list[int]:
+        """ The list of company IDs the user is allowed to connect to. """
+        return self.__env.user._get_company_ids()
+
+    @property
+    def multi_company(self) -> bool:
+        """ A boolean indicating whether the user has access to multiple companies. """
+        return len(self.__env.companies) > 1
+
+    def has(self, ids: int|list[int], field_name: str, value) -> bool:
+        """ Return a boolean indicating whether there is a company with id in
+        `ids` for which `field_name` matches the given `value`.
+        """
+        ids = [ids] if isinstance(ids, int) else ids
+        user_companies = self.__env['res.company'].sudo().browse(self.allowed_ids)
+        all_companies = user_companies | user_companies.parent_ids
+        company_info = {
+            company.id: company._get_session_info(user_companies)
+            for company in user_companies
+        } | {
+            company.id: company._get_session_info(all_companies)
+            for company in all_companies - user_companies
+        }
+        return any(
+            company_info[id_].get(field_name) == value
+            for id_ in ids if id_ in company_info
+        )


### PR DESCRIPTION
See https://github.com/odoo/odoo/pull/190218 for the definition of the new object.

The `companies` object contains:
- multi_company: A boolean indicating whether the user has access to multiple companies.
- allowed_ids : The list of company IDs the user is allowed to connect to.
- active_ids: The list of company IDs the user is connected to (selected in the company switcher dropdown).
- active_id: The ID of the main company selected (the one highlighted in the company switcher dropdown and displayed in the navbar of the webclient).
- has(id|ids, 'property', value) : returns a boolean indicating whether there's a company with id in `ids` for which `field` matches the given `value`.

Example:

- A DB has 50 intalled companies;
- Michel has the right to connect to 4 companies (A, B, C, D) => user.allowedCompanies/companies.allowed_ids
- Michel in his interface he sees 4 companies (A, B, C, E, D) (he sees E (even if he can't connect) because it is the parent company of D) => user.allowedCompaniesWithAncestors
- Michel selects, in the dropdown, two companies D and A, with D as the main company => user.activeCompanies/companies.active_ids (contains the list [D,A]) and user.activeCompany/companies.active_id (contains D)

(NB: I write also the 'user' object but it's not defied in this pr)