### PR TITLE
[FIX] analytic: do no re-create plan

### DIFF
--- a/addons/analytic/data/analytic_data.xml
+++ b/addons/analytic/data/analytic_data.xml
@@ -11,7 +11,7 @@
             The other plans will generate dynamic columns, so changing this param would require renaming the columns also.
         -->
         <function model="ir.config_parameter" name="set_param" eval="('analytic.project_plan', '1')"/>
-        <record id="analytic_plan_projects" model="account.analytic.plan">
+        <record id="analytic_plan_projects" model="account.analytic.plan" forcecreate="0">
             <field name="name">Projects</field>
             <field name="default_applicability">optional</field>
         </record>


### PR DESCRIPTION
If Projects plan is removed we cannot let it be recreated in a module upgrade. If we allow so the new plan will create an unnecessary column in `account_analytic_line`. This would repeat each time the user upgrades the module in case the plan is removed before the upgrade. In principle this is not an issue, unless account_budget is also installed. In such case the new column for `budget_line` won't be created and that would cause errors.

Steps to reproduce
1. Install `account_budget`
2. Create a new Plan
3. Set the config parameter to the id of the new plan
4. Remove Projects plan
5. Upgrade analytic module
6. Try to create a new analytic account.

There is an error in the frontend
```
OwlError: The following error occurred in onWillStart: ""budget.line"."x_plan3_id" field is undefined."
```

The problem is that since the new plan was created via an upgrade the post init hook of `account_budget` didn't run. Therefore the new column in `budget_line` was not created.

Notes:
* In step 4 above the column `x_plan2_id` in analytic line is left unused. This is not a problem per-se besides extra data dangling in the DB.
* We may argue that we should ensure that the column plan is created in a register_hook in `account_budget` but conceptually the relevant setting is the config parameter, recreating a plan that has no reason to exist could cause more issues down the line.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
