### PR TITLE
[IMP] event: add group by properties filter in attendees list

### DIFF
--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -201,7 +201,7 @@
                 <field name="event_user_id" string="Responsible" invisible="1"/>
                 <field name="event_organizer_id" string="Organizer" invisible="1"/>
                 <filter string="Ongoing Events" name="filter_is_ongoing" domain="[('event_id.is_ongoing', '=', True)]"/>
-                <filter string="Taken" name="taken" domain="[('state', 'in', ['open', 'done'])]"/>
+                <filter string="Attending" name="attending" domain="[('state', 'in', ['open', 'done'])]"/>
                 <separator/>
                 <filter string="Unconfirmed" name="unconfirmed" domain="[('state', '=', 'draft')]"/>
                 <filter string="Registered" name="confirmed" domain="[('state', '=', 'open')]"/>
@@ -236,6 +236,7 @@
                             context="{'group_by': 'utm_medium_id'}"/>
                     <filter string="Source" name="group_by_utm_source_id" domain="[]"
                             context="{'group_by': 'utm_source_id'}"/>
+                    <filter string="Properties" name="group_by_registration_properties" context="{'group_by': 'registration_properties'}"/>
                </group>
             </search>
         </field>
@@ -265,7 +266,7 @@
         <field name="context">{
             'default_event_id': active_id,
             'name_with_seats_availability': True,
-            'search_default_taken': True,
+            'search_default_attending': True,
         }</field>
         <field name="search_view_id" ref="event_registration_view_search_event_specific"/>
         <field name="help" type="html">
@@ -321,7 +322,7 @@
         <field name="view_mode">graph,pivot,kanban,list,form</field>
         <field name="context">{
                 'search_default_filter_last_month_creation': 1,
-                'search_default_taken': 1,
+                'search_default_attending': 1,
                 'search_default_status': 2,
                 'search_default_group_by_create_date_day': 3,
                 'search_default_group_event': 1,


### PR DESCRIPTION
Specifications :
- We have `registration_properties` field but it was not used in group by search, add filter group by 'Properties'.
- Rename the default filter from 'Taken' to 'Attending' for more clarity

Task-3989993
