### PR TITLE
[FIX] point_of_sale: fix customer display auto scroll

### DIFF
--- a/addons/point_of_sale/static/src/customer_display/customer_display.xml
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.xml
@@ -13,6 +13,7 @@
                 <OrderWidget t-if="!order.finalized" lines="order.lines" t-slot-scope="scope" class="'gap-0 p-0 mx-2 pb-3 bg-view'" style="'scroll-snap-type: y mandatory;'" generalNote="order.generalNote or ''">
                     <Orderline line="scope.line" class="{
                             'o_customer_display_orderline bg-white fs-3 rounded-0': true,
+                            'selected': scope.line.isSelected
                         }"
                     />
                     <t t-set-slot="emptyCart">

--- a/addons/point_of_sale/static/tests/tours/customer_display_tour.js
+++ b/addons/point_of_sale/static/tests/tours/customer_display_tour.js
@@ -14,6 +14,8 @@ function amountIs(method, amount) {
     };
 }
 const ADD_PRODUCT =
+    '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","oldUnitPrice":"","customerNote":"","internalNote":"","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":false,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":false,"amount":"2,972.75","paymentLines":[],"change":0,"onlinePaymentData":{}}';
+const ADD_PRODUCT_SELECTED =
     '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","oldUnitPrice":"","customerNote":"","internalNote":"","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":true,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":false,"amount":"2,972.75","paymentLines":[],"change":0,"onlinePaymentData":{}}';
 const PAY_WITH_CASH =
     '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","oldUnitPrice":"","customerNote":"","internalNote":"","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":true,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":false,"amount":"2,972.75","paymentLines":[{"name":"Cash","amount":"2,972.75"}],"change":0,"onlinePaymentData":{}}';
@@ -33,6 +35,10 @@ registry.category("web_tour.tours").add("CustomerDisplayTour", {
                 },
             },
             Order.hasLine({ productName: "Letter Tray", price: "2,972.75" }),
+            {
+                content: "An order line with `isSelected: false` should not have 'selected' class",
+                trigger: ".order-container .orderline:last-child:not(.selected)",
+            },
             amountIs("Total", "2,972.75"),
             postMessage(PAY_WITH_CASH, "pay with cash"),
             amountIs("Cash", "2,972.75"),
@@ -47,5 +53,13 @@ registry.category("web_tour.tours").add("CustomerDisplayTour", {
             },
             Order.doesNotHaveLine({}),
             amountIs("Total", "0.00"),
+            {
+                trigger: "body",
+                run: () => postMessage(ADD_PRODUCT_SELECTED, "add products").run(),
+            },
+            {
+                content: "An order line with `isSelected: true` should have 'selected' class",
+                trigger: ".order-container .orderline:last-child.selected",
+            },
         ].flat(),
 });


### PR DESCRIPTION
Steps to reproduce:
- Install pos_restaurant
- In restaurant's configs, set 'Customer Display' to 'Another device'
- Open the customer display in another tab, and start adding products from the main display -> The list of products on the customer display doesn't auto scroll when the products overlow the view.

Explanation:
The last `OrderLine` is supposed to be pass a `selected` prop, so it can be targeted from JavaScript and scrolled into the view [1]. However, this prop was removed in 1bc90a18807c43206c4620d7faad2579a3a61fc9. Now we add it back.

[1]: https://github.com/odoo/odoo/blob/18.0/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.js#L28-L30

opw-4458215
