### PR TITLE
[FIX] web: prevent ribbon overlap on image and status bar

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -323,7 +323,7 @@
         @include media-breakpoint-up(md) {
             position: sticky;
             top: 0;
-            z-index: 1;
+            z-index: 2;
 
             &:not(.modal .o_form_statusbar) {
                 background-color: $body-bg;

--- a/addons/web/static/src/views/widgets/ribbon/ribbon.scss
+++ b/addons/web/static/src/views/widgets/ribbon/ribbon.scss
@@ -67,3 +67,7 @@
 .modal .modal-dialog .o_form_sheet:has(> .o_widget_web_ribbon) {
     position: static !important;
 }
+
+.o_form_sheet .ribbon {
+    --Ribbon-z-index: 1;
+}


### PR DESCRIPTION
Before this commit:
In the form view, the ribbon was appearing behind the image due to changes introduced in  https://github.com/odoo/odoo/pull/190381 Additionally, when scrolling down, the ribbon overlapped with the status bar.

After this commit:
The ribbon now correctly appears above the image and no longer overlaps with the status bar when scrolling in the form view.

task-4504282

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/ee2087e7-c345-4c07-84b8-5659182da0fe) | ![image](https://github.com/user-attachments/assets/61118211-5699-4e31-ae11-fc4351149ccf) |
| ![image](https://github.com/user-attachments/assets/aa412fee-de7d-4f61-85d7-629890832f79) | ![image](https://github.com/user-attachments/assets/fb11ca43-9a85-48b1-9fd9-2ceb317b7e5c) | 
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
