### PR TITLE
[FIX] stock: fix traceback when creating a new stock movle line

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -147,9 +147,10 @@ class StockMoveLine(models.Model):
                 continue
             product_uom = record.product_id.uom_id
             sml_uom = record.product_uom_id
+            move_visible_quantity = record.move_id and record.move_id._visible_quantity() or 0.0
 
             move_demand = record.move_id.product_uom._compute_quantity(record.move_id.product_uom_qty, sml_uom, rounding_method='HALF-UP')
-            move_quantity = record.move_id.product_uom._compute_quantity(record.move_id._visible_quantity(), sml_uom, rounding_method='HALF-UP')
+            move_quantity = record.move_id.product_uom._compute_quantity(move_visible_quantity, sml_uom, rounding_method='HALF-UP')
             quant_qty = product_uom._compute_quantity(record.quant_id.available_quantity, sml_uom, rounding_method='HALF-UP')
 
             if float_compare(move_demand, move_quantity, precision_rounding=sml_uom.rounding) > 0:


### PR DESCRIPTION
Currently, a traceback is occurring when the user tries to create a new stock move line.

To reproduce this issue:
1) Install stock
2) Open/Create a draft/Ready deliveries stock picking record 
3) Click on the `Moves` stat button from the Picking 
4) Create a new Move line record and remove the `pick From` 
5) Add a `product` and `pick From` values

Error:- 
```
ValueError: Expected singleton: stock.move()
```

This error occurred because of the recent changes in the commit below.

https://github.com/odoo/odoo/pull/190467/commits/c8afad87a3e51ba4c0051e44d46080f3b00f61c7

When the user adds the `quant_id` value, we get the move_id as an empty record, 
leading to the above traceback from the below line. 

Because of the `ensure_one()` in the `_visible_quantity()` method.

https://github.com/odoo/odoo/blob/963af3819c27f28c07443b80e7a1fc746afd4607/addons/stock/models/stock_move_line.py#L152

We can resolve this issue by skipping the further computation when there is no move_id.

sentry-6256719588

