### PR TITLE
[FIX] point_of_sale: prevent parseerror when Clothes is clicked

### DIFF
--- a/addons/point_of_sale/data/scenarios/clothes_data.xml
+++ b/addons/point_of_sale/data/scenarios/clothes_data.xml
@@ -339,6 +339,7 @@
             <field
                 name="combo_item_ids"
                 eval="[
+                    Command.clear(),
                     Command.create({
                         'product_id': ref('product_blue_denim_jeans_slim'),
                         'extra_price': 0,
@@ -356,6 +357,7 @@
             <field
                 name="combo_item_ids"
                 eval="[
+                    Command.clear(),
                     Command.create({
                         'product_id': ref('casual_t_shirt'),
                         'extra_price': 0,


### PR DESCRIPTION
Currently a `Parseerror` appears when the user clicks 'Clothes' in POS.

### Error:
```
ParseError
while parsing /home/odoo/src/odoo/18.0/addons/point_of_sale/data/scenarios/clothes_data.xml:337
A combo choice can't contain duplicate products.

View error context:
'-no context-'
```

### Steps to reproduce above error :-
- Install 'Point of Sale'  (without demo data).
- Open POS and click 'Clothes', then delete 'Clothes Shop'.
- Click again 'Clothes'.
- The error appears in the log.

This commit resolves the issue by using `Command.clear()`, to clear the link before creating the combo products.

sentry-6191520798