### PR TITLE
[FIX] hr_maintenance: display equipment owner on mobile

### DIFF
--- a/addons/hr/models/hr_department.py
+++ b/addons/hr/models/hr_department.py
@@ -59,7 +59,7 @@ class Department(models.Model):
             department.master_department_id = int(department.parent_path.split('/')[0])
 
     def _compute_total_employee(self):
-        emp_data = self.env['hr.employee']._read_group([('department_id', 'in', self.ids)], ['department_id'], ['__count'])
+        emp_data = self.env['hr.employee'].sudo()._read_group([('department_id', 'in', self.ids)], ['department_id'], ['__count'])
         result = {department.id: count for department, count in emp_data}
         for department in self:
             department.total_employee = result.get(department.id, 0)

--- a/addons/hr_maintenance/views/maintenance_views.xml
+++ b/addons/hr_maintenance/views/maintenance_views.xml
@@ -84,7 +84,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='owner_user_id']" position="replace">
                 <field name="equipment_assign_to" widget="radio"/>
-                <field name="employee_id" string="Employee" invisible="equipment_assign_to == 'department' or not equipment_assign_to"/>
+                <field name="employee_id" string="Employee" invisible="equipment_assign_to == 'department' or not equipment_assign_to" widget="many2one_avatar_employee"/>
                 <field name="department_id" string="Department" invisible="equipment_assign_to == 'employee' or not equipment_assign_to"/>
             </xpath>
         </field>


### PR DESCRIPTION
Issue:
-----
This issue happens in mobile view only. When a user without any HR access rights
tries to assign an Employee to a piece of equipment, they don't see the list of
employees as expected. Instead, they get a "No records found!" message.

Steps to reproduce:
-----
- Install Employees & Maintenance apps
- Create a new user and set the following acces rights
    - Employees -> None
- Switch to that user
- Go to Maintenance -> Equipment and select an equipment
- Ensure the page is in mobile display mode (refresh if not already in mode)
- Select an equipment & try to assign an Employee

-> The widget displays a "No records found!" message

Other issue discovered:
-----
There is also a problem for the department field, where the user has access to
the field when in desktop mode but gets an "Access error" in mobile mode.

Cause:
-----
The equipment model stores the owner by referencing a hr.employee. Depending on
the display type, the user will get a simple dropdown list in desktop mode or a
kanban view in mobile mode.

When the kanban view is loaded in mobile mode, since the user does not have read
access to the hr.employee model, the ORM tries to load from the cache. Since it
doesn't find the content of a field (avatar_128 here) in the cache, it clears
the whole record, leading to the "No records found!" message. The hr team has a
workaround for this issue in the form of a custom many2one widget for employee
avatars.

Ticket:
opw-4309746
