### PR TITLE
[IMP]  point_of_sale: allow editing of preset settings during an active session

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -516,7 +516,7 @@ class PosConfig(models.Model):
         return new_vals
 
     def _get_forbidden_change_fields(self):
-        return ['module_pos_restaurant', 'payment_method_ids', 'use_presets', 'default_preset_id']
+        return ['module_pos_restaurant', 'payment_method_ids']
 
     def unlink(self):
         # Delete the pos.config records first then delete the sequences linked to them

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -49,19 +49,18 @@
                                 </div>
                             </setting>
                             <setting string="Take out / Delivery / Members" help="Define presets to manage taxes &amp; prices for eat in, take out, members..." >
-                                <field name="pos_use_presets" readonly="pos_has_active_session"/>
+                                <field name="pos_use_presets"/>
                                 <div class="content-group" invisible="not pos_use_presets">
                                     <div class="row">
                                         <label for="pos_default_preset_id" class="col-lg-3" string="Default"/>
                                         <field name="pos_default_preset_id"
                                             options="{'no_create': True}"
                                             required="pos_use_presets"
-                                            readonly="pos_has_active_session"
                                             domain="[('identification', '=', 'none')]" />
                                     </div>
                                     <div class="row">
                                         <label for="pos_available_preset_ids" class="col-lg-3" string="Others"/>
-                                        <field name="pos_available_preset_ids" widget="many2many_tags" options="{'no_quick_create': True, 'color_field': 'color'}" readonly="pos_has_active_session" />
+                                        <field name="pos_available_preset_ids" widget="many2many_tags" options="{'no_quick_create': True, 'color_field': 'color'}"/>
                                     </div>
                                 </div>
                             </setting>


### PR DESCRIPTION
This commit enables editing of preset settings while a session is active that was previously not allowed.

task-4526151
