### PR TITLE
[FIX] website_sale: don't show discount when not available for sale

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -550,11 +550,11 @@ class ProductTemplate(models.Model):
         monetary_options = {'display_currency': mapping['detail']['display_currency']}
         if combination_info['prevent_zero_price_sale']:
             website = self.env['website'].get_current_website()
-            price = website.prevent_zero_price_sale_text
-        else:
-            price = self.env['ir.qweb.field.monetary'].value_to_html(
-                combination_info['price'], monetary_options
-            )
+            return website.prevent_zero_price_sale_text, None
+
+        price = self.env['ir.qweb.field.monetary'].value_to_html(
+            combination_info['price'], monetary_options
+        )
         if combination_info['has_discounted_price']:
             list_price = self.env['ir.qweb.field.monetary'].value_to_html(
                 combination_info['list_price'], monetary_options


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Go to Settings / Website;
2. enable the following options:
    - Comparison Price;
    - Pricelists: Advanced price rules;
    - Prevent Sale of Zero Priced Product;
3. create a pricelist setting all prices to 0;
4. make pricelist selectable;
5. set pricelist's Discount Policy to Show public price & discount to customer;
6. go to `/shop`;
7. query the search bar.

Issue
-----
A strikethrough price is added, despite the item not being available for sale.

Cause
-----
The `_search_render_results_prices` method still checks for `has_discounted_price` and `compare_list_price` after it already knows the product isn't available for sale.

Solution
--------
If `prevent_zero_price_sale` is given for the product, do an early return, disregarding the `has_discounted_price` and `compare_list_price` options.

opw-4263554