### PR TITLE
[FIX] account_check_printing: allow printing with non-reconcilable account

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -152,7 +152,7 @@ class AccountPayment(models.Model):
     def print_checks(self):
         """ Check that the recordset is valid, set the payments state to sent and call print_checks() """
         # Since this method can be called via a client_action_multi, we need to make sure the received records are what we expect
-        valid_payments = self.filtered(lambda r: r.payment_method_line_id.code == 'check_printing' and r.state != 'paid')
+        valid_payments = self.filtered(lambda r: r.payment_method_line_id.code == 'check_printing' and not r.is_sent)
 
         if len(valid_payments) == 0:
             raise UserError(_("Payments to print as a checks must have 'Check' selected as payment method and "

--- a/addons/account_check_printing/views/account_payment_views.xml
+++ b/addons/account_check_printing/views/account_payment_views.xml
@@ -6,7 +6,7 @@
             <field name="inherit_id" ref="account.view_account_payment_form" />
             <field name="arch" type="xml">
                 <xpath expr="//button[@name='action_post']" position="before">
-                    <button name="print_checks" class="oe_highlight" invisible="payment_method_code != 'check_printing' or state != 'in_process' or is_sent" string="Print Check" type="object" data-hotkey="g" />
+                    <button name="print_checks" class="oe_highlight" invisible="payment_method_code != 'check_printing' or is_sent" string="Print Check" type="object" data-hotkey="g" />
                     <button name="unmark_as_sent" invisible="payment_method_code != 'check_printing' or not is_sent" string="Unmark Sent" type="object" data-hotkey="l" />
                     <button name="action_void_check" invisible="payment_method_code != 'check_printing' or state != 'in_process' or not is_sent" string="Void Check" type="object" data-hotkey="o" />
                 </xpath>


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Go to "Accounting / Configuration / Accounting / Journals"
- Open "Bank" Journal
- Go to "Outgoing Payments" tab
- Set a check layout
- For "Checks" line, set "101401 Bank" (i.e. an account that doesn't allow reconciliation) as outstanding payments account
- Create a vendor bill and confirm it
- Pay the bill with "Checks" as payment method
=> The bill is directly marked as "PAID" and not "IN PAYMENT" because the "Bank" account doesn't allow reconciliation
- Go the the check payment

**Issue:**
It is not possible to print it.
The same configuration allows to print the check in previous versions.

**Cause:**
As the check payment is using an account that doesn't allow reconciliation, the payment is set in "Paid" state directly, but the printing is disabled for checks in that state.

**Solution:**
As it should be harmless to allow to print the check even if it is already paid, we will allow to print it to keep a consistent behavior with previous versions.
Only printing the check will be allowed.
Voiding or rejecting will still be impossible.

opw-4498446




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
