### PR TITLE
[FIX] website_hr_recruitment: handle removed description field

### DIFF
--- a/addons/website_hr_recruitment/data/config_data.xml
+++ b/addons/website_hr_recruitment/data/config_data.xml
@@ -33,6 +33,7 @@
                 'department_id',
                 'linkedin_profile',
                 'applicant_properties',
+                'applicant_notes',
             ]"/>
         </function>
     </data>

--- a/addons/website_hr_recruitment/static/src/js/website_hr_recruitment_editor.js
+++ b/addons/website_hr_recruitment/static/src/js/website_hr_recruitment_editor.js
@@ -26,7 +26,7 @@ FormEditorRegistry.add('apply_job', {
         string: _t('LinkedIn Profile'),
     }, {
         type: 'text',
-        name: 'description',
+        name: 'applicant_notes',
         string: _t('Short Introduction'),
     }, {
         type: 'binary',


### PR DESCRIPTION
Issue:
1. Open the website editor.
2. Drop the "Contact & Forms" snippet.
3. Select the first form.
4. Click on any input field.
5. In snippet options (Form), change the action from "Send an e-mail" to "Apply for a job".
6. Save the form.

Upon saving, it logs the error due to the inability to whitelist the `description` field.

Root Cause:
The `description` field was removed in commit [[1](https://github.com/odoo/odoo/commit/e0f281433eec3f34d6f720656ead51e417679cd1)] instead replaced by the `applicant_notes`, causing error log when attempting to save the form.

Fix:
This commit resolves the issue by handling the removal of the `description` from `formbuilder_whitelist` while adapting the
`applicant_notes` field.
- To ensure functionality, the field in the website form for job applicants relevant information in the `applicant_notes`field.

task-4364668

[1] : https://github.com/odoo/odoo/commit/e0f281433eec3f34d6f720656ead51e417679cd1
