### PR TITLE
[FIX] stock {purchase,sale}_mrp: handle inter_company kit delivery/reception

### DIFF
--- a/addons/purchase_mrp/models/purchase.py
+++ b/addons/purchase_mrp/models/purchase.py
@@ -64,8 +64,11 @@ class PurchaseOrderLine(models.Model):
                 moves = line.move_ids.filtered(lambda m: m.state == 'done' and not m.scrapped)
                 order_qty = line.product_uom._compute_quantity(line.product_uom_qty, kit_bom.product_uom_id)
                 filters = {
-                    'incoming_moves': lambda m: m.location_id.usage == 'supplier' and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
-                    'outgoing_moves': lambda m: m.location_id.usage != 'supplier' and m.to_refund
+                    'incoming_moves': lambda m:
+                        m._is_incoming() and
+                        (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
+                    'outgoing_moves': lambda m:
+                        m._is_outgoing() and m.to_refund,
                 }
                 line.qty_received = moves._compute_kit_quantities(line.product_id, order_qty, kit_bom, filters)
                 kit_lines += line

--- a/addons/sale_mrp/models/sale_order_line.py
+++ b/addons/sale_mrp/models/sale_order_line.py
@@ -66,8 +66,12 @@ class SaleOrderLine(models.Model):
                         continue
                     moves = order_line.move_ids.filtered(lambda m: m.state == 'done' and not m.scrapped)
                     filters = {
-                        'incoming_moves': lambda m: m.location_dest_id.usage == 'customer' and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
-                        'outgoing_moves': lambda m: m.location_dest_id.usage != 'customer' and m.to_refund
+                        # in/out perspective w/ respect to moves is flipped for sale order document
+                        'incoming_moves': lambda m:
+                            m._is_outgoing() and
+                            (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
+                        'outgoing_moves': lambda m:
+                            m._is_incoming() and m.to_refund,
                     }
                     order_qty = order_line.product_uom._compute_quantity(order_line.product_uom_qty, relevant_bom.product_uom_id)
                     qty_delivered = moves._compute_kit_quantities(order_line.product_id, order_qty, relevant_bom, filters)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2387,3 +2387,15 @@ Please change the quantity done or the rounding precision of your unit of measur
             ),
             'readOnly': False,
         }
+
+    def _is_incoming(self):
+        self.ensure_one()
+        return self.location_id.usage in ('customer', 'supplier') or (
+            self.location_id.usage == 'transit' and not self.location_id.company_id
+        )
+
+    def _is_outgoing(self):
+        self.ensure_one()
+        return self.location_dest_id.usage in ('customer', 'supplier') or (
+            self.location_dest_id.usage == 'transit' and not self.location_dest_id.company_id
+        )


### PR DESCRIPTION
Currently there are two bugs:
1) Selling a kit product to another internal company
(inter_company) and validating the delivery will not update the
`qty_delivered` field on the corresponding `SaleOrderLine`
* Currently the filters to capture moves which informs the
delivered quantity of the line do not account for moves with
`location_dest_id` pointing to the inter-company transit
location (which should count towards the delivered value)

2) Receiving a kit product via inter_company which has a
`comp:final` ratio >1 will result in an inaccurate update on the
`qty_received` field on the corresponding `PurchaseOrderLine`
* The BoM of the sold kit-product belongs to the selling
company, and in the purchase_mrp override of
`_compute_qty_received` they fail to get marked as kit lines
because the `bom_line_id` is hidden due to a company-precise
domain constraint

**Steps to reproduce:**
*Having `sale_purchase_stock_inter_company_rules` and enabled
synchronization of sale & purchase orders for both companies*
1. Create a kit product

2. Deliver it to another internal company

3. After validating the delivery, check the the sale order line
and observe that the delivered qty is 0

**Cause of the issue:**
When computing `qty_delivered`, we have the following filters to
capture in/out move qty:
https://github.com/odoo/odoo/blob/ef1be75601e7ce346d8e6b9367505cbf39b05101/addons/sale_mrp/models/sale_order_line.py#L69-L70
which don't account for moves to inter-company transit.

When computing `qty_received`, we aggregate purchase lines:
https://github.com/odoo/odoo/blob/b13e46f06c1d3166fd64fc72cacd8af1f3673ae6/addons/purchase_mrp/models/purchase.py#L56
however using the line's `company_id` means the BoM belonging to
the delivering company isn't revealed. Then the `qty_received`
is computed as though the line was an ordinary product, leading
to the mismatch between product and qty.

**Fix:**
Modify the existing incoming/outgoing move filters in the qty
received and delivered compute methods to account for
inter-company moves.

opw-4267210