### PR TITLE
[FIX] mail: improve regex finding unfollow nodes

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -19,7 +19,7 @@ from odoo.addons.base.models.ir_mail_server import MailDeliveryException
 from odoo.modules.registry import Registry
 
 _logger = logging.getLogger(__name__)
-_UNFOLLOW_REGEX = re.compile(r'<span\s.*(t-if="\w.*")?\s.*id="mail_unfollow".*?<\/span>', re.DOTALL)
+_UNFOLLOW_REGEX = re.compile(r'<span\s*(t-if="show_unfollow")?\s*id="mail_unfollow".*?<\/span>', re.DOTALL)
 
 
 class MailMail(models.Model):

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1774,18 +1774,22 @@ class MailCommon(common.TransactionCase, MailCase):
         if not layout_arch_db:
             layout_arch_db = """
 <body>
+    <t t-set="show_header" t-value="email_notification_force_header or (
+        email_notification_allow_header and has_button_access)"/>
+    <t t-set="show_footer" t-value="email_notification_force_footer or (
+        email_notification_allow_footer and show_header and author_user and author_user._is_internal())"/>
     <p>English Layout for <t t-esc="model_description"/></p>
     <img t-att-src="'/logo.png?company=%s' % (company.id or 0)" t-att-alt="'%s' % company.name"/>
-    <a t-if="has_button_access" t-att-href="button_access['url']">
-        <t t-esc="button_access['title']"/>
-    </a>
-    <t t-if="actions">
-        <t t-foreach="actions" t-as="action">
+    <div t-if="show_header">HEADER
+        <a t-if="has_button_access" t-att-href="button_access['url']">
+            <t t-esc="button_access['title']"/>
+        </a>
+        <t t-if="actions" t-foreach="actions" t-as="action">
             <a t-att-href="action['url']">
                 <t t-esc="action['title']"/>
             </a>
         </t>
-    </t>
+    </div>
     <t t-out="message.body"/>
     <ul t-if="tracking_values">
         <li t-foreach="tracking_values" t-as="tracking">
@@ -1793,7 +1797,12 @@ class MailCommon(common.TransactionCase, MailCase):
         </li>
     </ul>
     <div t-if="signature" t-out="signature"/>
-    <p>Sent by <t t-esc="company.name"/></p>
+    <div t-if="show_footer">
+        <p>Sent by <t t-esc="company.name"/></p>
+        <span t-if="show_unfollow" id="mail_unfollow">
+            | <a href="/mail/unfollow" style="text-decoration:none; color:#555555;">Unfollow</a>
+        </span>
+    </div>
 </body>"""
         view = cls.env['ir.ui.view'].create({
             'arch_db': layout_arch_db,


### PR DESCRIPTION
Notification layout contain a somehow-fake node holding a generic
unfollow link. It is dynamically replaced at sending time to make
it recipient-specific.

In a lot of cases we don't need that unfollow URL and the node should
be removed. This is done using a regex to avoid parshing HTML. Current
regex can be improved, notably to avoid backtracking. When having
bodies with lot of span, timing become quite bad.

Our use cases are simple, either old <span id="mail_unfollow">..</span>
either new <span t-if="show_unfollow" id="mail_unfollow">..</span>
layouts. Regex can be therefore be simplified.

Note that we support "two" kind of nodes mainly to maintain support
of custom / copied / frozen notification layouts.

Followup of https://github.com/odoo/odoo/pull/189741

Task-4529263