### PR TITLE
[FIX] stock: account for context in product.template quantities calculation

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -758,6 +758,7 @@ class ProductTemplate(models.Model):
         'product_variant_ids.incoming_qty',
         'product_variant_ids.outgoing_qty',
     )
+    @api.depends_context('warehouse_id')
     def _compute_quantities(self):
         res = self._compute_quantities_dict()
         for template in self:

--- a/addons/stock/tests/test_product.py
+++ b/addons/stock/tests/test_product.py
@@ -376,3 +376,17 @@ class TestVirtualAvailable(TestStockCommon):
         self.picking_out.button_validate()
         with self.assertRaises(UserError):
             self.product_3.write({'is_storable': False})
+
+    def test_product_template_multiwarehouse_quantities(self):
+        warehouse_one, warehouse_two = self.env['stock.warehouse'].search([], limit=2)
+
+        self.env['stock.quant'].search([('product_id', '=', self.product_3.id)]).unlink()
+        self.env['stock.quant']._update_available_quantity(self.product_3, warehouse_one.lot_stock_id, 200)
+        self.env['stock.quant']._update_available_quantity(self.product_3, warehouse_two.lot_stock_id, 50)
+
+        product_template = self.product_3.product_tmpl_id
+        main_qty = product_template.with_context(warehouse_id=warehouse_one.id).qty_available
+        other_qty = product_template.with_context(warehouse_id=warehouse_two.id).qty_available
+
+        self.assertEqual(main_qty, 200)
+        self.assertEqual(other_qty, 50)


### PR DESCRIPTION
Currently, the available and forecasted product quantities are not always calculated correctly across multiple warehouses.

### Steps to reproduce

1. Install the `stock` and `point_of_sale` modules.
2. Ensure that a product exists in multiple warehouses, with different quantities in each warehouse.
3. Make sure the product is available in the POS.
4. Start the POS.
5. Find the product and click the "i" button in the top-right corner to view more details.

Expected Behavior: The system should display the correct available and forecasted quantities for each warehouse. Actual Behavior: All warehouses incorrectly show the same available and forecasted quantities.

### Cause

The system retrieves product quantities by reading the `qty_available` and `virtual_available` fields on the product template record, applying a `warehouse_id` context key for each warehouse (see [here](https://github.com/odoo/odoo/blob/afac1319a2bf230ec0702a7822fca405638fc38b/addons/point_of_sale/models/product_template.py#L215-L221)). However, these fields are computed and do not depend on the context, meaning only the quantities for the first warehouse are computed correctly. For all other warehouses, the values are retrieved from the cache, resulting in all warehouses displaying the same quantities.

opw-4421070