### PR TITLE
[FIX] mail: keep composer when livechat has ended for operator

### DIFF
--- a/addons/im_livechat/static/src/core/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/core/common/chat_window_patch.xml
@@ -8,6 +8,7 @@
             </t>
         </xpath>
         <xpath expr="//Composer" position="replace">
+            <t t-if="thread?.composerDisabled and store.self.notEq(thread?.livechatVisitorMember?.persona)">$0</t>
             <div t-if="thread?.composerDisabled" class="bg-200 py-1 text-center d-flex fst-italic fw-bold text-muted" t-ref="composerDisabledContainer">
                 <span class="flex-grow-1"/>
                 <span t-esc="thread.composerDisabledText"/>

--- a/addons/im_livechat/static/tests/channel_join_leave.test.js
+++ b/addons/im_livechat/static/tests/channel_join_leave.test.js
@@ -135,6 +135,7 @@ test("visitor leaving ends the livechat conversation", async () => {
     // simulate visitor leaving
     await withGuest(guestId, () => rpc("/im_livechat/visitor_leave_session", { channel_id }));
     await contains("span", { text: "This livechat conversation has ended" });
+    await contains(".o-mail-Composer-input"); // so that can still `/lead` or last resort send message to visitor
     await click("button[title*='Close Chat Window']");
     await contains(".o-mail-ChatWindow", { count: 0 });
 });

--- a/addons/im_livechat/static/tests/embed/feedback_panel.test.js
+++ b/addons/im_livechat/static/tests/embed/feedback_panel.test.js
@@ -77,6 +77,7 @@ test("Last operator leaving ends the livechat", async () => {
         ])
     );
     await contains("span", { text: "This livechat conversation has ended" });
+    await contains(".o-mail-Composer-input", { count: 0 });
     await click("[title*='Close Chat Window']");
     await contains("p", { text: "Did we correctly answer your question?" }); // shows immediately feedback
 });


### PR DESCRIPTION
When a livechat has ended, it replaces the composer by "This livechat conversation has ended" for both visitor and operators.

This is good for visitor to make it very clear the conversation has ended, and they cannot post message again to the operator unless they initiate another livechat session.

Operators however sometimes need to do extra things after the conversation has ended, such as `/lead`. Because of the removal of composer, this was no longer possible.

This commit fixes the issue by keep showing the composer for livechat operators even when the conversation has ended.

Part of Task-4528331

Before / After
<img width="383" alt="Screenshot 2025-01-30 at 11 25 49" src="https://github.com/user-attachments/assets/67ca2f71-180a-4545-9f41-2b3927884a66" /> <img width="384" alt="Screenshot 2025-01-30 at 11 25 37" src="https://github.com/user-attachments/assets/c3e93086-b3fc-4604-9dce-0931178eaeb7" />
