### PR TITLE
[FIX] fix untranslatable terms in XML templates

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.xml
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.xml
@@ -34,7 +34,7 @@
                             <th t-foreach="allPlans" t-as="plan" t-key="plan.id">
                                 <span t-out="plan.name"/> (<span t-att-class="totals[plan.id].class" t-out="totals[plan.id].formattedValue"/>)
                             </th>
-                            <th t-out="'Percentage'" class="numeric_column_width"/>
+                            <th class="numeric_column_width">Percentage</th>
                             <th t-if="valueColumnEnabled" class="numeric_column_width" t-out="props.record.fields[props.amount_field].string"/>
                             <th class="deleteColumn w-20px"/>
                         </tr>

--- a/addons/event/data/mail_template_data.xml
+++ b/addons/event/data/mail_template_data.xml
@@ -28,7 +28,8 @@
                 <tr><td valign="middle">
                     <span style="font-size: 10px;">Your registration</span><br/>
                     <span style="font-size: 20px; font-weight: bold;">
-                        <t t-out="object.name or 'Guest'"/>
+                        <t t-set="default_name">Guest</t>
+                        <t t-out="object.name or default_name"/>
                     </span>
                 </td><td valign="middle" align="right">
                     <a t-attf-href="/event/{{ object.event_id.id }}/my_tickets?badge_mode=1&amp;registration_ids={{ registration_ids }}&amp;tickets_hash={{ object.event_id._get_tickets_access_hash(registration_ids) }}"
@@ -51,7 +52,8 @@
             <table width="590" border="0" cellpadding="0" cellspacing="0" style="min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;">
                 <tr><td valign="top" style="font-size: 14px;">
                     <div>
-                        Hello <t t-out="object.name or 'Guest'"/>,<br/><br/>
+                        <t t-set="default_name">Guest</t>
+                        Hello <t t-out="object.name or default_name"/>,<br/><br/>
                         Please find attached your badge for
                         <t t-if="event_website_url">
                             <a t-att-href="event_website_url" t-attf-style="font-weight:bold;color:{{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;"
@@ -274,7 +276,8 @@
                 <tr><td valign="middle">
                     <span style="font-size: 10px;">Your registration</span><br/>
                     <span style="font-size: 20px; font-weight: bold;">
-                        <t t-out="object.name or 'Guest'"/>
+                        <t t-set="default_name">Guest</t>
+                        <t t-out="object.name or default_name"/>
                     </span>
                     <div style="margin-bottom: 5px;margin-top: 18px;">
                         <a t-if="object.event_id.address_id" t-attf-href="/event/{{ object.event_id.id }}/my_tickets?registration_ids={{ object.ids }}&amp;tickets_hash={{ object.event_id._get_tickets_access_hash(object.ids) }}&amp;responsive_html=1"
@@ -308,7 +311,8 @@
             <table width="590" border="0" cellpadding="0" cellspacing="0" style="min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;">
                 <tr><td valign="top" style="font-size: 14px;">
                     <div>
-                        Hello <t t-out="object.name or 'Guest'"/>,<br/><br/>
+                        <t t-set="default_name">Guest</t>
+                        Hello <t t-out="object.name or default_name"/>,<br/><br/>
                         We are happy to confirm your registration to the event
                         <t t-if="event_website_url">
                             <a t-att-href="event_website_url" t-attf-style="color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;font-weight:bold;"
@@ -540,7 +544,8 @@
             <table width="590" border="0" cellpadding="0" cellspacing="0" style="min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;">
                 <tr><td valign="middle">
                     <span style="font-size: 10px;">Your registration</span><br/>
-                    <span style="font-size: 20px; font-weight: bold;" t-out="object.name or 'Guest'"/>
+                    <t t-set="default_name">Guest</t>
+                    <span style="font-size: 20px; font-weight: bold;" t-out="object.name or default_name"/>
                     <div style="margin-bottom: 5px;margin-top: 18px;">
                         <a t-if="object.event_id.address_id" t-attf-href="/event/{{ object.event_id.id }}/my_tickets?registration_ids={{ object.ids }}&amp;tickets_hash={{ object.event_id._get_tickets_access_hash(object.ids) }}&amp;responsive_html=1"
                             target="_blank" style="padding: 8px 12px; font-size: 12px; color: {{object.event_id.user_id.company_id.email_primary_color or '#FFFFFF'}}; text-decoration: none !important; font-weight: 400; background-color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; border-radius:3px">
@@ -573,7 +578,8 @@
             <table width="590" border="0" cellpadding="0" cellspacing="0" style="min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;">
                 <tr><td valign="top" style="font-size: 14px;">
                     <div>
-                        Hello <t t-out="object.name or 'Guest'"/>,<br/><br/>
+                        <t t-set="default_name">Guest</t>
+                        Hello <t t-out="object.name or default_name"/>,<br/><br/>
                         We are excited to remind you that the event
                         <t t-if="event_website_url">
                             <a t-att-href="event_website_url" t-attf-style="font-weight:bold;color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;"

--- a/addons/hr_skills/views/hr_employee_cv_templates.xml
+++ b/addons/hr_skills/views/hr_employee_cv_templates.xml
@@ -79,7 +79,7 @@
                             <div class="o_main_panel_resume_title_dates">
                                 <t t-set="present">Present</t>
                                 <div class="o_main_panel_resume_year">
-                                    <span t-out="resume_line.date_start.year">2022</span> - <span t-out="resume_line.date_end.year if resume_line.date_end else 'Present'">2023</span>
+                                    <span t-out="resume_line.date_start.year">2022</span> - <span t-out="resume_line.date_end.year if resume_line.date_end else present">2023</span>
                                 </div>
                             </div>
                         </div>

--- a/addons/hr_timesheet/views/project_project_views.xml
+++ b/addons/hr_timesheet/views/project_project_views.xml
@@ -84,8 +84,8 @@
                 <xpath expr="//div[hasclass('o_project_kanban_boxes')]" position="after">
                     <t t-set="badgeColor" t-value="'border-success'"/>
                     <t t-set="badgeColor" t-value="'border-danger'" t-if="record.remaining_hours.raw_value &lt; 0"/>
-                    <t t-set="title" t-value="'Days Remaining'" t-if="record.encode_uom_in_days.raw_value"/>
-                    <t t-set="title" t-value="'Time Remaining'" t-else=""/>
+                    <t t-set="title" t-if="record.encode_uom_in_days.raw_value">Days Remaining</t>
+                    <t t-set="title" t-else="">Time Remaining</t>
                     <div t-if="record.allow_timesheets.raw_value and record.allocated_hours.raw_value &gt; 0"
                         t-attf-class="me-1 ms-1 bg-transparent badge border {{ badgeColor }}" t-att-title="title" groups="hr_timesheet.group_hr_timesheet_user">
                         <field name="remaining_hours" widget="timesheet_uom" class="p-0"/>

--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -119,8 +119,8 @@
                     <t t-set="badge" t-value="'border border-success'"/>
                     <t t-set="badge" t-value="'border border-warning'" t-if="record.progress.raw_value &gt;= 0.8 and record.progress.raw_value &lt;= 1"/>
                     <t t-set="badge" t-value="'border border-danger'" t-if="record.remaining_hours.raw_value &lt; 0"/>
-                    <t t-set="title" t-value="'Remaining days'" t-if="record.encode_uom_in_days.raw_value"/>
-                    <t t-set="title" t-value="'Time Remaining'" t-else=""/>
+                    <t t-set="title" t-if="record.encode_uom_in_days.raw_value">Remaining days</t>
+                    <t t-set="title" t-else="">Time Remaining</t>
                     <div t-attf-class="badge {{ badge }} bg-transparent flex-shrink-0" t-att-title="title">
                         <field name="remaining_hours" widget="timesheet_uom" />
                     </div>

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -165,8 +165,8 @@
                         <t t-set="badge" t-value="'border border-success'"/>
                         <t t-set="badge" t-value="'border border-warning'" t-if="record.progress.raw_value &gt;= 0.8 and record.progress.raw_value &lt;= 1"/>
                         <t t-set="badge" t-value="'border border-danger'" t-if="record.remaining_hours.raw_value &lt; 0"/>
-                        <t t-set="title" t-value="'Remaining days'" t-if="record.encode_uom_in_days.raw_value"/>
-                        <t t-set="title" t-value="'Time Remaining'" t-else=""/>
+                        <t t-set="title" t-if="record.encode_uom_in_days.raw_value">Remaining days</t>
+                        <t t-set="title" t-else="">Time Remaining</t>
                         <div t-attf-class="bg-transparent badge {{ badge }} me-0" t-att-title="title">
                             <field name="remaining_hours" widget="timesheet_uom" />
                         </div>

--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_prompt_dialog.js
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_prompt_dialog.js
@@ -1,4 +1,5 @@
 import { browser } from "@web/core/browser/browser";
+import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
 import { useAutofocus, useChildRef } from "@web/core/utils/hooks";
 import { useState, useEffect, useRef } from "@odoo/owl";
@@ -62,6 +63,11 @@ export class ChatGPTPromptDialog extends ChatGPTDialog {
             },
             () => [this.state.conversationHistory.length]
         );
+    }
+
+    /** @returns {string} */
+    get authorName() {
+        return this.message.author === "user" ? _t("You") : _t("OdooBot");
     }
 
     onTextareaKeydown(ev) {

--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_prompt_dialog.xml
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_prompt_dialog.xml
@@ -14,7 +14,7 @@
                 </div>
                 <div class="w-100 o-min-width-0">
                     <div class="d-flex flex-wrap align-items-baseline mb-1 lh-1">
-                        <strong class="me-1 text-truncate"><t t-esc="message.author === 'user' ? 'You' : 'OdooBot'"/></strong>
+                        <strong class="me-1 text-truncate"><t t-esc="authorName"/></strong>
                     </div>
                     <div class="position-relative d-flex">
                         <div class="o-min-width-0">

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -92,7 +92,8 @@
                             </div>
                             <div t-if="state.urlTitle and state.url and state.urlTitle !== state.url" class="text-truncate" style="max-width: 200px; font-size: 12px;">
                                 <span t-attf-class="o_we_full_url text-muted o_we_webkit_box" t-attf-title="{{state.url}}">
-                                    <t t-esc="state.url || 'No URL specified'"/>
+                                    <t t-if="state.url" t-esc="state.url"/>
+                                    <t t-else="">No URL specified</t>
                                 </span>
                             </div>
                         </div>

--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.js
@@ -1,3 +1,4 @@
+import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { Component, useState } from "@odoo/owl";
 
@@ -18,6 +19,10 @@ export class ProgressBar extends Component {
         size: "",
         errorMessage: "",
     };
+
+    get errorMessage() {
+        return this.props.errorMessage || _t("File could not be saved");
+    }
 
     get progress() {
         return Math.round(this.props.progress);

--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.xml
@@ -7,7 +7,7 @@
     </small>
     <small t-if="props.uploaded or props.hasError" class="d-flex align-items-center mt-1">
         <span t-if="props.uploaded" class="text-success"><i class="fa fa-check my-1 me-1"/> File has been uploaded</span>
-        <span t-else="" class="text-danger"><i class="fa fa-times float-start my-1 me-1"/> <span class="o_we_error_text" t-esc="props.errorMessage ? props.errorMessage : 'File could not be saved'"/></span>
+        <span t-else="" class="text-danger"><i class="fa fa-times float-start my-1 me-1"/> <span class="o_we_error_text" t-esc="errorMessage"/></span>
     </small>
     <div t-else="" class="progress mt-2">
         <div class="progress-bar bg-info progress-bar-striped progress-bar-animated" role="progressbar" t-attf-style="width: {{this.progress}}%;" aria-label="Progress bar"><span t-esc="this.progress + '%'"/></div>

--- a/addons/l10n_cz/i18n/cs.po
+++ b/addons/l10n_cz/i18n/cs.po
@@ -6,10 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.2a1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 14:57+0000\n"
+"POT-Creation-Date: 2025-02-14 14:04+0000\n"
 "PO-Revision-Date: 2025-02-06 14:57+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -1354,6 +1355,12 @@ msgstr "Jihočeský kraj"
 #: model:l10n_cz.tax_office,region:l10n_cz.tax_office_171
 msgid "South Moravian"
 msgstr "Jihomoravský kraj"
+
+#. module: l10n_cz
+#: model_terms:ir.ui.view,arch_db:l10n_cz.l10n_cz_external_layout_folder
+#: model_terms:ir.ui.view,arch_db:l10n_cz.registry_vat_external_layout
+msgid "Tax ID"
+msgstr "DIČ"
 
 #. module: l10n_cz
 #: model:ir.actions.act_window,name:l10n_cz.action_l10n_cz_tax_office_tree

--- a/addons/l10n_cz/i18n/l10n_cz.pot
+++ b/addons/l10n_cz/i18n/l10n_cz.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.2a1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 14:57+0000\n"
-"PO-Revision-Date: 2025-02-06 14:57+0000\n"
+"POT-Creation-Date: 2025-02-14 14:04+0000\n"
+"PO-Revision-Date: 2025-02-14 14:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -1353,6 +1353,12 @@ msgstr ""
 #: model:l10n_cz.tax_office,region:l10n_cz.tax_office_170
 #: model:l10n_cz.tax_office,region:l10n_cz.tax_office_171
 msgid "South Moravian"
+msgstr ""
+
+#. module: l10n_cz
+#: model_terms:ir.ui.view,arch_db:l10n_cz.l10n_cz_external_layout_folder
+#: model_terms:ir.ui.view,arch_db:l10n_cz.registry_vat_external_layout
+msgid "Tax ID"
 msgstr ""
 
 #. module: l10n_cz

--- a/addons/l10n_cz/views/report_template.xml
+++ b/addons/l10n_cz/views/report_template.xml
@@ -5,7 +5,8 @@
             Company ID: <span t-field="company.company_registry"/>
         </li>
         <li t-if="company.vat and company.account_fiscal_country_id.code == 'CZ'">
-            <t t-out="company.country_id.vat_label or 'Tax ID'"/>:
+            <t t-set="default_vat_label">Tax ID</t>
+            <t t-out="company.country_id.vat_label or default_vat_label"/>:
             <span t-out="company.vat"/>
         </li>
     </template>
@@ -52,7 +53,8 @@
                 Company ID: <span t-field="company.company_registry"/>
             </div>
             <div t-if="company.vat and company.account_fiscal_country_id.code == 'CZ'">
-                <t t-out="company.country_id.vat_label or 'Tax ID'"/>:
+                <t t-set="default_vat_label">Tax ID</t>
+                <t t-out="company.country_id.vat_label or default_vat_label"/>:
                 <span t-out="company.vat"/>
             </div>
         </xpath>

--- a/addons/l10n_din5008/i18n/de.po
+++ b/addons/l10n_din5008/i18n/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.3alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-08 10:58+0000\n"
+"POT-Creation-Date: 2025-01-30 17:17+0000\n"
 "PO-Revision-Date: 2024-04-24 08:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -97,16 +97,6 @@ msgstr ""
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "<span class=\"fw-bold\">Invoicing Address:</span>"
-msgstr "<span class=\"fw-bold\">Rechnungsadresse:</span>"
-
-#. module: l10n_din5008
-#: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "<span class=\"fw-bold\">Invoicing and Shipping Address:</span>"
-msgstr "<span class=\"fw-bold\">Rechnungs- und Lieferadresse:</span>"
-
-#. module: l10n_din5008
-#: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
 msgid "<span class=\"fw-bold\">Beneficiary:</span>"
 msgstr "<span class=\"fw-bold\">Leistungsempfänger:</span>"
 
@@ -171,6 +161,11 @@ msgid "Delivery Date:"
 msgstr "Lieferdatum:"
 
 #. module: l10n_din5008
+#: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__display_name
+msgid "Display Name"
+msgstr "Anzeigename"
+
+#. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
 msgid "Draft Invoice"
 msgstr "Rechnungsentwurf"
@@ -204,6 +199,11 @@ msgstr "Kopfzeilentext, der oben in allen Berichten angezeigt wird."
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
 msgid "IBAN:"
 msgstr "IBAN:"
+
+#. module: l10n_din5008
+#: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__id
+msgid "ID"
+msgstr "ID"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_wizard_preview

--- a/addons/l10n_din5008/i18n/fr.po
+++ b/addons/l10n_din5008/i18n/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.3alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-08 10:58+0000\n"
+"POT-Creation-Date: 2025-01-30 17:17+0000\n"
 "PO-Revision-Date: 2024-04-24 08:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -67,17 +67,6 @@ msgid ""
 "                                    th {\n"
 "                                        color:"
 msgstr ""
-
-#. module: l10n_din5008
-#: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "<span class=\"fw-bold\">Invoicing Address:</span>"
-msgstr "<span class=\"fw-bold\">Adresse de facturation :</span>"
-
-#. module: l10n_din5008
-#: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "<span class=\"fw-bold\">Invoicing and Shipping Address:</span>"
-msgstr ""
-"<span class=\"fw-bold\">Adresse de facturation et d'expédition :</span>."
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
@@ -145,6 +134,11 @@ msgid "Delivery Date:"
 msgstr "Date de livraison :"
 
 #. module: l10n_din5008
+#: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__display_name
+msgid "Display Name"
+msgstr "Nom d'affichage"
+
+#. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
 msgid "Draft Invoice"
 msgstr "Facture en brouillon"
@@ -178,6 +172,11 @@ msgstr "Texte d'en-tête affiché en haut de tous les rapports."
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
 msgid "IBAN:"
 msgstr "IBAN :"
+
+#. module: l10n_din5008
+#: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__id
+msgid "ID"
+msgstr "ID"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_wizard_preview

--- a/addons/l10n_din5008/i18n/it.po
+++ b/addons/l10n_din5008/i18n/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.3alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-08 10:58+0000\n"
+"POT-Creation-Date: 2025-01-30 17:17+0000\n"
 "PO-Revision-Date: 2024-04-24 08:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -67,16 +67,6 @@ msgid ""
 "                                    th {\n"
 "                                        color:"
 msgstr ""
-
-#. module: l10n_din5008
-#: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "<span class=\"fw-bold\">Invoicing Address:</span>"
-msgstr "<span class=\"fw-bold\">Indirizzo di fatturazione:</span>"
-
-#. module: l10n_din5008
-#: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "<span class=\"fw-bold\">Invoicing and Shipping Address:</span>"
-msgstr "<span class=\"fw-bold\">Indirizzo di fatturazione e spedizione:</span>"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
@@ -144,6 +134,11 @@ msgid "Delivery Date:"
 msgstr "Data di consegna:"
 
 #. module: l10n_din5008
+#: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__display_name
+msgid "Display Name"
+msgstr "Nome visualizzato"
+
+#. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
 msgid "Draft Invoice"
 msgstr "Bozza fattura"
@@ -177,6 +172,11 @@ msgstr "Testo di intestazione visualizzato all'inizio di tutti i rapporti."
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
 msgid "IBAN:"
 msgstr "Codice IBAN:"
+
+#. module: l10n_din5008
+#: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__id
+msgid "ID"
+msgstr "ID"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_wizard_preview

--- a/addons/l10n_din5008/i18n/l10n_din5008.pot
+++ b/addons/l10n_din5008/i18n/l10n_din5008.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server saas~17.4\n"
+"Project-Id-Version: Odoo Server 18.2a1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-08 10:58+0000\n"
-"PO-Revision-Date: 2024-12-08 10:58+0000\n"
+"POT-Creation-Date: 2025-01-30 17:17+0000\n"
+"PO-Revision-Date: 2025-01-30 17:17+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -64,16 +64,6 @@ msgid ""
 "                                [name=invoice_line_table], [name=stock_move_table], .o_main_table {\n"
 "                                    th {\n"
 "                                        color:"
-msgstr ""
-
-#. module: l10n_din5008
-#: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "<span class=\"fw-bold\">Invoicing Address:</span>"
-msgstr ""
-
-#. module: l10n_din5008
-#: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "<span class=\"fw-bold\">Invoicing and Shipping Address:</span>"
 msgstr ""
 
 #. module: l10n_din5008
@@ -142,6 +132,11 @@ msgid "Delivery Date:"
 msgstr ""
 
 #. module: l10n_din5008
+#: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
 msgid "Draft Invoice"
 msgstr ""
@@ -174,6 +169,11 @@ msgstr ""
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
 msgid "IBAN:"
+msgstr ""
+
+#. module: l10n_din5008
+#: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_din5008

--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -123,7 +123,8 @@
                                 </td>
                                 <td>
                                     <ul class="list-inline">
-                                        <li t-if="company.vat"><t t-out="company.account_fiscal_country_id.vat_label or 'Tax ID'"/>:
+                                        <t t-set="default_vat_label">Tax ID</t>
+                                        <li t-if="company.vat"><t t-out="company.account_fiscal_country_id.vat_label or default_vat_label"/>:
                                             <span t-if="forced_vat" t-out="forced_vat"/>
                                             <span t-else="" t-field="company.vat"/>
                                         </li>

--- a/addons/l10n_es_pos/i18n/es.po
+++ b/addons/l10n_es_pos/i18n/es.po
@@ -4,21 +4,22 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e\n"
+"Project-Id-Version: Odoo Server 18.2a1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-29 09:17+0000\n"
+"POT-Creation-Date: 2025-01-30 17:23+0000\n"
 "PO-Revision-Date: 2023-11-29 09:17+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
 #. module: l10n_es_pos
-#: model_terms:ir.ui.view,arch_db:l10n_es_pos.res_config_settings_view_form
-msgid "Above this limit the simplified invoice won't be made"
-msgstr "Por encima de este límite no se realizará la factura simplificada."
+#: model:ir.model,name:l10n_es_pos.model_res_company
+msgid "Companies"
+msgstr "Compañías"
 
 #. module: l10n_es_pos
 #: model:ir.model.fields,field_description:l10n_es_pos.field_pos_config__is_spanish
@@ -31,27 +32,34 @@ msgid "Config Settings"
 msgstr "Opciones de configuración"
 
 #. module: l10n_es_pos
-#: model:ir.model.fields,field_description:l10n_es_pos.field_res_config_settings__pos_is_spanish
-msgid ""
-"Consider the specific spanish legislation, such as the use of simplified "
-"invoices"
-msgstr ""
-"Considere la legislación española específica, como el uso de facturas "
-"simplificadas."
-
-#. module: l10n_es_pos
 #. odoo-javascript
-#: code:addons/l10n_es_pos/static/src/overrides/components/receipt_header/receipt_header.xml:0
-#, python-format
+#: code:addons/l10n_es_pos/static/src/app/screens/receipt_screen/receipt_header/receipt_header.xml:0
 msgid "Customer:"
 msgstr "Cliente:"
 
 #. module: l10n_es_pos
+#: model:ir.model.fields,field_description:l10n_es_pos.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_es_pos.field_pos_config__display_name
+#: model:ir.model.fields,field_description:l10n_es_pos.field_pos_order__display_name
+#: model:ir.model.fields,field_description:l10n_es_pos.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_es_pos.field_res_config_settings__display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: l10n_es_pos
 #. odoo-javascript
-#: code:addons/l10n_es_pos/static/src/overrides/components/payment_screen/payment_screen.js:0
-#, python-format
+#: code:addons/l10n_es_pos/static/src/app/screens/payment_screen/payment_screen.js:0
 msgid "Error"
-msgstr ""
+msgstr "Error"
+
+#. module: l10n_es_pos
+#: model:ir.model.fields,field_description:l10n_es_pos.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_es_pos.field_pos_config__id
+#: model:ir.model.fields,field_description:l10n_es_pos.field_pos_order__id
+#: model:ir.model.fields,field_description:l10n_es_pos.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_es_pos.field_res_config_settings__id
+msgid "ID"
+msgstr "ID"
 
 #. module: l10n_es_pos
 #: model:ir.model,name:l10n_es_pos.model_account_move
@@ -66,22 +74,12 @@ msgstr ""
 
 #. module: l10n_es_pos
 #. odoo-javascript
-#: code:addons/l10n_es_pos/static/src/overrides/components/payment_screen/payment_screen.js:0
-#, python-format
+#: code:addons/l10n_es_pos/static/src/app/screens/payment_screen/payment_screen.js:0
 msgid ""
 "Order amount is too large for a simplified invoice, use an invoice instead."
 msgstr ""
 "El monto del pedido es demasiado grande para una factura simplificada; "
 "utilice una factura en su lugar."
-
-#. module: l10n_es_pos
-#: model:ir.model.fields,help:l10n_es_pos.field_pos_config__l10n_es_simplified_invoice_limit
-#: model:ir.model.fields,help:l10n_es_pos.field_res_config_settings__pos_l10n_es_simplified_invoice_limit
-msgid ""
-"Over this amount is not legally possible to create a simplified invoice"
-msgstr ""
-"Por encima de este importe no es legalmente posible crear una factura "
-"simplificada."
 
 #. module: l10n_es_pos
 #: model:ir.model,name:l10n_es_pos.model_pos_config
@@ -94,38 +92,14 @@ msgid "Point of Sale Orders"
 msgstr "Pedidos del TPV"
 
 #. module: l10n_es_pos
-#: model:ir.model,name:l10n_es_pos.model_pos_session
-msgid "Point of Sale Session"
-msgstr "Sesión TPV"
-
-#. module: l10n_es_pos
 #: model_terms:ir.ui.view,arch_db:l10n_es_pos.res_config_settings_view_form
 msgid "Simplified Invoice"
 msgstr "Factura Simplificada"
 
 #. module: l10n_es_pos
-#: model_terms:ir.ui.view,arch_db:l10n_es_pos.res_config_settings_view_form
-msgid "Simplified Invoice Limit"
-msgstr "Factura Simplificada Límite"
-
-#. module: l10n_es_pos
-#: model:ir.model.fields,field_description:l10n_es_pos.field_pos_config__l10n_es_simplified_invoice_limit
-#: model:ir.model.fields,field_description:l10n_es_pos.field_res_config_settings__pos_l10n_es_simplified_invoice_limit
-msgid "Simplified Invoice limit amount"
-msgstr "Factura Simplificada Monto del Límite"
-
-#. module: l10n_es_pos
-#. odoo-python
-#: code:addons/l10n_es_pos/models/pos_config.py:0
-#, python-format
-msgid "Simplified Invoices"
-msgstr ""
-
-#. module: l10n_es_pos
 #. odoo-javascript
-#: code:addons/l10n_es_pos/static/src/overrides/components/receipt_header/receipt_header.xml:0
+#: code:addons/l10n_es_pos/static/src/app/screens/receipt_screen/receipt_header/receipt_header.xml:0
 #: model:ir.model.fields,field_description:l10n_es_pos.field_pos_order__is_l10n_es_simplified_invoice
-#, python-format
 msgid "Simplified invoice"
 msgstr "Factura simplificada"
 
@@ -138,3 +112,9 @@ msgstr "Número de factura simplificada"
 #: model:ir.model.fields,field_description:l10n_es_pos.field_pos_config__simplified_partner_id
 msgid "Simplified invoice partner"
 msgstr "Socio de factura simplificada"
+
+#. module: l10n_es_pos
+#. odoo-javascript
+#: code:addons/l10n_es_pos/static/src/app/screens/receipt_screen/receipt_header/receipt_header.xml:0
+msgid "Tax ID"
+msgstr "Identificación fiscal"

--- a/addons/l10n_es_pos/i18n/l10n_es_pos.pot
+++ b/addons/l10n_es_pos/i18n/l10n_es_pos.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e\n"
+"Project-Id-Version: Odoo Server 18.2a1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-29 09:15+0000\n"
-"PO-Revision-Date: 2023-11-29 09:15+0000\n"
+"POT-Creation-Date: 2025-01-30 17:23+0000\n"
+"PO-Revision-Date: 2025-01-30 17:23+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,8 +16,8 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_es_pos
-#: model_terms:ir.ui.view,arch_db:l10n_es_pos.res_config_settings_view_form
-msgid "Above this limit the simplified invoice won't be made"
+#: model:ir.model,name:l10n_es_pos.model_res_company
+msgid "Companies"
 msgstr ""
 
 #. module: l10n_es_pos
@@ -31,24 +31,33 @@ msgid "Config Settings"
 msgstr ""
 
 #. module: l10n_es_pos
-#: model:ir.model.fields,field_description:l10n_es_pos.field_res_config_settings__pos_is_spanish
-msgid ""
-"Consider the specific spanish legislation, such as the use of simplified "
-"invoices"
-msgstr ""
-
-#. module: l10n_es_pos
 #. odoo-javascript
-#: code:addons/l10n_es_pos/static/src/overrides/components/receipt_header/receipt_header.xml:0
-#, python-format
+#: code:addons/l10n_es_pos/static/src/app/screens/receipt_screen/receipt_header/receipt_header.xml:0
 msgid "Customer:"
 msgstr ""
 
 #. module: l10n_es_pos
+#: model:ir.model.fields,field_description:l10n_es_pos.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_es_pos.field_pos_config__display_name
+#: model:ir.model.fields,field_description:l10n_es_pos.field_pos_order__display_name
+#: model:ir.model.fields,field_description:l10n_es_pos.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_es_pos.field_res_config_settings__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_es_pos
 #. odoo-javascript
-#: code:addons/l10n_es_pos/static/src/overrides/components/payment_screen/payment_screen.js:0
-#, python-format
+#: code:addons/l10n_es_pos/static/src/app/screens/payment_screen/payment_screen.js:0
 msgid "Error"
+msgstr ""
+
+#. module: l10n_es_pos
+#: model:ir.model.fields,field_description:l10n_es_pos.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_es_pos.field_pos_config__id
+#: model:ir.model.fields,field_description:l10n_es_pos.field_pos_order__id
+#: model:ir.model.fields,field_description:l10n_es_pos.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_es_pos.field_res_config_settings__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_es_pos
@@ -64,17 +73,9 @@ msgstr ""
 
 #. module: l10n_es_pos
 #. odoo-javascript
-#: code:addons/l10n_es_pos/static/src/overrides/components/payment_screen/payment_screen.js:0
-#, python-format
+#: code:addons/l10n_es_pos/static/src/app/screens/payment_screen/payment_screen.js:0
 msgid ""
 "Order amount is too large for a simplified invoice, use an invoice instead."
-msgstr ""
-
-#. module: l10n_es_pos
-#: model:ir.model.fields,help:l10n_es_pos.field_pos_config__l10n_es_simplified_invoice_limit
-#: model:ir.model.fields,help:l10n_es_pos.field_res_config_settings__pos_l10n_es_simplified_invoice_limit
-msgid ""
-"Over this amount is not legally possible to create a simplified invoice"
 msgstr ""
 
 #. module: l10n_es_pos
@@ -88,38 +89,14 @@ msgid "Point of Sale Orders"
 msgstr ""
 
 #. module: l10n_es_pos
-#: model:ir.model,name:l10n_es_pos.model_pos_session
-msgid "Point of Sale Session"
-msgstr ""
-
-#. module: l10n_es_pos
 #: model_terms:ir.ui.view,arch_db:l10n_es_pos.res_config_settings_view_form
 msgid "Simplified Invoice"
 msgstr ""
 
 #. module: l10n_es_pos
-#: model_terms:ir.ui.view,arch_db:l10n_es_pos.res_config_settings_view_form
-msgid "Simplified Invoice Limit"
-msgstr ""
-
-#. module: l10n_es_pos
-#: model:ir.model.fields,field_description:l10n_es_pos.field_pos_config__l10n_es_simplified_invoice_limit
-#: model:ir.model.fields,field_description:l10n_es_pos.field_res_config_settings__pos_l10n_es_simplified_invoice_limit
-msgid "Simplified Invoice limit amount"
-msgstr ""
-
-#. module: l10n_es_pos
-#. odoo-python
-#: code:addons/l10n_es_pos/models/pos_config.py:0
-#, python-format
-msgid "Simplified Invoices"
-msgstr ""
-
-#. module: l10n_es_pos
 #. odoo-javascript
-#: code:addons/l10n_es_pos/static/src/overrides/components/receipt_header/receipt_header.xml:0
+#: code:addons/l10n_es_pos/static/src/app/screens/receipt_screen/receipt_header/receipt_header.xml:0
 #: model:ir.model.fields,field_description:l10n_es_pos.field_pos_order__is_l10n_es_simplified_invoice
-#, python-format
 msgid "Simplified invoice"
 msgstr ""
 
@@ -131,4 +108,10 @@ msgstr ""
 #. module: l10n_es_pos
 #: model:ir.model.fields,field_description:l10n_es_pos.field_pos_config__simplified_partner_id
 msgid "Simplified invoice partner"
+msgstr ""
+
+#. module: l10n_es_pos
+#. odoo-javascript
+#: code:addons/l10n_es_pos/static/src/app/screens/receipt_screen/receipt_header/receipt_header.xml:0
+msgid "Tax ID"
 msgstr ""

--- a/addons/l10n_es_pos/static/src/app/screens/receipt_screen/receipt_header/receipt_header.xml
+++ b/addons/l10n_es_pos/static/src/app/screens/receipt_screen/receipt_header/receipt_header.xml
@@ -18,7 +18,8 @@
             <t t-set="partner" t-value="order.partner_id"/>
             <t t-if="order.config.is_spanish and partner and partner.id !== order.config.simplified_partner_id.id">
                 <div>Customer: <t t-esc="partner.name" /></div>
-                <div t-if="partner.vat"><t t-esc="order.company.country_id?.vat_label || 'Tax ID'"/>: <t t-esc="partner.vat" /></div>
+                <t t-set="default_vat_label">Tax ID</t>
+                <div t-if="partner.vat"><t t-esc="order.company.country_id?.vat_label || default_vat_label"/>: <t t-esc="partner.vat" /></div>
                 <div t-if="partner.address" t-esc="partner.address"/>
             </t>
         </xpath>

--- a/addons/l10n_hu_edi/i18n/hu.po
+++ b/addons/l10n_hu_edi/i18n/hu.po
@@ -4,9 +4,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e\n"
+"Project-Id-Version: Odoo Server 18.2a1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-03 08:13+0000\n"
+"POT-Creation-Date: 2025-01-30 17:28+0000\n"
 "PO-Revision-Date: 2024-05-03 12:35+0000\n"
 "Last-Translator: Tóth Csaba <csaba.toth@odootech.hu>\n"
 "Language-Team: Hungarian\n"
@@ -30,26 +30,28 @@ msgstr ""
 "\n"
 "            - Éles: A számlákat a NAV éles rendszerébe küldi.\n"
 "            - Teszt: A számlákat a NAV teszt rendszerébe küldi.\n"
-"            - Demó: A NAV kapcsolat modellezése (nem igényel hitelesítő adatokat).\n"
+"            - Demó: A NAV kapcsolat modellezése (nem igényel hitelesítő "
+"adatokat).\n"
 "        "
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields,help:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_invoice_chain_index
 #: model:ir.model.fields,help:l10n_hu_edi.field_account_move__l10n_hu_invoice_chain_index
-#: model:ir.model.fields,help:l10n_hu_edi.field_account_payment__l10n_hu_invoice_chain_index
 msgid ""
 "\n"
 "            Index in the chain of modification invoices:\n"
 "                -1 for a base invoice;\n"
 "                1, 2, 3, ... for modification invoices;\n"
-"                0 for rejected/cancelled invoices or if it has not yet been set.\n"
+"                0 for rejected/cancelled invoices or if it has not yet been "
+"set.\n"
 "            "
 msgstr ""
 "\n"
 "            Index a módosító számlák láncolatában:\n"
 "                -1 egy alap számla esetében;\n"
 "                1, 2, 3, ... a módosító számlák esetében;\n"
-"                0 az elutasított/megszakított számlák esetében, vagy ha még nem került megadásra.\n"
+"                0 az elutasított/megszakított számlák esetében, vagy ha még "
+"nem került megadásra.\n"
 "            "
 
 #. module: l10n_hu_edi
@@ -64,8 +66,8 @@ msgstr "<strong>Vevő:</strong>"
 
 #. module: l10n_hu_edi
 #: model_terms:ir.ui.view,arch_db:l10n_hu_edi.report_invoice_document
-msgid "<strong>Payment Mode:</strong>"
-msgstr "<strong>Fizetési mód:</strong>"
+msgid "<strong>Payment Mode</strong>"
+msgstr "<strong>Fizetési mód</strong>"
 
 #. module: l10n_hu_edi
 #: model_terms:ir.ui.view,arch_db:l10n_hu_edi.report_invoice_document
@@ -90,7 +92,6 @@ msgstr "AAM - Alanyi adómentes"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_tax.py:0
-#, python-format
 msgid "AAM Tax exempt"
 msgstr "AAM Alanyi adómentes"
 
@@ -119,7 +120,6 @@ msgstr "ATK - Áfa törvény hatályán kívüli"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_tax.py:0
-#, python-format
 msgid "ATK Outside the scope of VAT - VAT tv.2-3.§"
 msgstr "ATK ÁFA törvény hatályán kívüli - ÁFA tv.2-3.§"
 
@@ -141,7 +141,6 @@ msgstr "Bizonylat küldés"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
 "All advance invoices must be paid and sent to NAV before the final invoice "
 "is issued."
@@ -187,7 +186,6 @@ msgstr "CSK - Csomagolási katalógus kód"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "Cancellation request failed."
 msgstr "A törlési kérelem sikertelen."
 
@@ -204,14 +202,12 @@ msgstr "Elküldött törlési kérelem"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "Cancellation request submitted, waiting for response."
 msgstr "Törlési kérelem beküldve, várakozás a válaszra."
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
 "Cancellation request timed out. Please wait at least 6 minutes, then update "
 "the status."
@@ -227,13 +223,12 @@ msgstr "Törölt"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
 "Cannot reset to draft or cancel invoice %s because an electronic document "
 "was already sent to NAV!"
 msgstr ""
-"Nem lehet visszaállítani a %s számlát tervezetté vagy visszavonttá, mert már"
-" elektronikus dokumentumot küldött a NAV-nak!"
+"Nem lehet visszaállítani a %s számlát tervezetté vagy visszavonttá, mert már "
+"elektronikus dokumentumot küldött a NAV-nak!"
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields.selection,name:l10n_hu_edi.selection__uom_uom__l10n_hu_edi_code__carton
@@ -285,7 +280,6 @@ msgstr "Figyelmeztetésekkel megerősítve"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/l10n_hu_edi_connection.py:0
-#, python-format
 msgid "Connection to NAV servers timed out."
 msgstr "Csatlakozás a NAV szerveréhez időtúllépés miatt meghiúsult."
 
@@ -297,7 +291,6 @@ msgstr "Névjegy"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
 "Could not acquire lock on invoices - is another user performing operations "
 "on them?"
@@ -308,8 +301,6 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "Could not authenticate with NAV. Check your credentials and try again."
 msgstr ""
 "Nem sikerült a NAV-nál hitelesíteni. Ellenőrizze a hitelesítő adatokat, és "
@@ -318,30 +309,32 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
-"Could not match NAV transaction_code %s, index %s to an invoice in Odoo"
+"Could not match NAV transaction_code %(code)s, index %(index)s to an invoice "
+"in Odoo"
 msgstr ""
-"Nem sikerült megfeleltetni a NAV transaction_code %s, sorszám %s adatot egy "
-"számlának az Odoo-ban"
+"Nem sikerült megfeleltetni a NAV transaction_code %(code)s, sorszám "
+"%(index)s adatot egy számlának az Odoo-ban"
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/l10n_hu_edi_connection.py:0
-#, python-format
 msgid "Could not parse time of previous transaction"
 msgstr "Nem sikerült értelmezni az előző tranzakció idejét"
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/__init__.py:0
-#, python-format
 msgid ""
-"Could not set NAV tax types on taxes because some taxes from l10n_hu are missing.\n"
-"You should set the type manually or reload the CoA before sending invoices to NAV."
+"Could not set NAV tax types on taxes because some taxes from l10n_hu are "
+"missing.\n"
+"You should set the type manually or reload the CoA before sending invoices "
+"to NAV."
 msgstr ""
-"Nem sikerült beállítani a NAV adótípusait az adókra, mert néhány adó hiányzik a l10n_hu-ból.\n"
-"A típusokat kézzel kell beállítani, vagy újra kell tölteni a CoA-t, mielőtt a számlákat elküldi a NAV-nak."
+"Nem sikerült beállítani a NAV adótípusait az adókra, mert néhány adó "
+"hiányzik a l10n_hu-ból.\n"
+"A típusokat kézzel kell beállítani, vagy újra kell tölteni a CoA-t, mielőtt "
+"a számlákat elküldi a NAV-nak."
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_l10n_hu_edi_cancellation__create_uid
@@ -391,8 +384,18 @@ msgid "Demo"
 msgstr "Demó"
 
 #. module: l10n_hu_edi
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_chart_template__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move_reversal__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move_send__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_tax__display_name
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_l10n_hu_edi_cancellation__display_name
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_l10n_hu_edi_tax_audit_export__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_product_template__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_res_partner__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_uom_uom__display_name
 msgid "Display Name"
 msgstr "Megjelenített név"
 
@@ -406,7 +409,6 @@ msgstr "EAM - Termékexport 3.országba - ÁFA tv.98-109.§"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_tax.py:0
-#, python-format
 msgid "EAM Product export to 3rd country - VAT tv.98-109.§"
 msgstr "EAM Termékexport 3.országba - ÁFA tv.98-109.§"
 
@@ -443,7 +445,6 @@ msgstr "EUE - 2.EU-s országban teljesített eladás - nem EUFAD37 és nem EUFAD
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_tax.py:0
-#, python-format
 msgid "EUE Sales made in a 2nd EU country"
 msgstr "EUE 2.EU-s országban teljesített eladás"
 
@@ -457,23 +458,20 @@ msgstr "EUFAD37 - ÁFA tv. 37.§ (1) Fordított ÁFA másik EU-s országban"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_tax.py:0
-#, python-format
 msgid "EUFAD37 § 37 (1) Reverse VAT in another EU country"
 msgstr "EUFAD37 ÁFA tv. 37.§ (1) Fordított ÁFA másik EU-s országban"
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields.selection,name:l10n_hu_edi.selection__account_tax__l10n_hu_tax_type__eufade
 msgid ""
-"EUFADE - Reverse charge transaction carried out in another Member State, not"
-" subject to Section 37 of the VAT Act"
+"EUFADE - Reverse charge transaction carried out in another Member State, not "
+"subject to Section 37 of the VAT Act"
 msgstr "EUFADE - Fordított ÁFA másik EU-s országban nem ÁFA tv. 37.§ (1)"
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_tax.py:0
-#, python-format
-msgid ""
-"EUFADE Reverse charge of VAT in another EU country not VAT tv. § 37 (1)"
+msgid "EUFADE Reverse charge of VAT in another EU country not VAT tv. § 37 (1)"
 msgstr "EUFADE Fordított ÁFA másik EU-s országban nem ÁFA tv. 37.§ (1)"
 
 #. module: l10n_hu_edi
@@ -486,14 +484,12 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/l10n_hu_edi_connection.py:0
-#, python-format
 msgid "Error during decryption of ExchangeToken."
 msgstr "Hiba az ExchangeToken dekódolása során."
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/res_company.py:0
-#, python-format
 msgid "Error listing transactions while attempting transaction recovery."
 msgstr ""
 "A tranzakciók listázási hibája a tranzakció helyreállításának megkísérlése "
@@ -502,7 +498,6 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/res_company.py:0
-#, python-format
 msgid "Error querying transaction while attempting transaction recovery."
 msgstr ""
 "A tranzakció lekérdezésének hibája a tranzakció helyreállításának "
@@ -544,7 +539,6 @@ msgstr "HO - Szolgáltatás 3.országba"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_tax.py:0
-#, python-format
 msgid "HO Service to 3rd country"
 msgstr "HO Szolgáltatás 3.országba"
 
@@ -571,8 +565,18 @@ msgid "Hungary"
 msgstr "Magyarország"
 
 #. module: l10n_hu_edi
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_chart_template__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move_reversal__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move_send__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_tax__id
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_l10n_hu_edi_cancellation__id
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_l10n_hu_edi_tax_audit_export__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_product_template__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_res_config_settings__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_res_partner__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_uom_uom__id
 msgid "ID"
 msgstr "Azonosító"
 
@@ -581,8 +585,7 @@ msgstr "Azonosító"
 #: model:ir.model.fields,help:l10n_hu_edi.field_res_partner__l10n_hu_group_vat
 #: model:ir.model.fields,help:l10n_hu_edi.field_res_users__l10n_hu_group_vat
 msgid ""
-"If this company belongs to a VAT group, indicate the group's VAT number "
-"here."
+"If this company belongs to a VAT group, indicate the group's VAT number here."
 msgstr ""
 "Ha ez a vállalat áfacsoporthoz tartozik, itt kell feltüntetni a csoport "
 "adószámát."
@@ -610,18 +613,18 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/res_company.py:0
-#, python-format
 msgid ""
-"Incorrect NAV Credentials! Check that your company VAT number is set correctly. \n"
+"Incorrect NAV Credentials! Check that your company VAT number is set "
+"correctly. \n"
 "Error details: %s"
 msgstr ""
-"Helytelen NAV hitelesítő adatok! Ellenőrizze, hogy a cég adószáma helyesen van-e beállítva. \n"
+"Helytelen NAV hitelesítő adatok! Ellenőrizze, hogy a cég adószáma helyesen "
+"van-e beállítva. \n"
 "Hiba részletei: %s"
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_edi_batch_upload_index
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_edi_batch_upload_index
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_edi_batch_upload_index
 msgid "Index of invoice within a batch upload"
 msgstr "A számla indexe egy kötegelt feltöltésen belül"
 
@@ -633,22 +636,18 @@ msgstr "Alanyi adómentes"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/l10n_hu_edi_connection.py:0
-#, python-format
 msgid "Invalid NAV response!"
 msgstr "Érvénytelen NAV válasz!"
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_invoice_chain_index
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_invoice_chain_index
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_invoice_chain_index
 msgid "Invoice Chain Index"
 msgstr "Számlalánc index"
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/l10n_hu_edi_connection.py:0
-#: code:addons/l10n_hu_edi/models/l10n_hu_edi_connection.py:0
-#, python-format
 msgid "Invoice Upload failed: NAV did not return a Transaction ID."
 msgstr ""
 "A számla feltöltése sikertelen: NAV nem adott vissza tranzakcióazonosítót."
@@ -656,28 +655,24 @@ msgstr ""
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_edi_attachment
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_edi_attachment
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_edi_attachment
 msgid "Invoice XML file"
 msgstr "Számla XML fájl"
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_edi_attachment_filename
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_edi_attachment_filename
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_edi_attachment_filename
 msgid "Invoice XML filename"
 msgstr "Számla XML fájlnév"
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "Invoice submission failed."
 msgstr "A számla beküldése sikertelen."
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
 "Invoice submission timed out. Please wait at least 6 minutes, then update "
 "the status."
@@ -688,7 +683,6 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "Invoice submitted, waiting for response."
 msgstr "A számla beküldésre került, várakozás a válaszra."
 
@@ -700,30 +694,23 @@ msgstr "Törlendő számla"
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_edi_send_time
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_edi_send_time
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_edi_send_time
 msgid "Invoice upload time"
 msgstr "Számla beküldés ideje"
 
 #. module: l10n_hu_edi
 #. odoo-python
-#: code:addons/l10n_hu_edi/wizard/account_move_send.py:0
-#, python-format
+#: code:addons/l10n_hu_edi/models/account_move_send.py:0
 msgid ""
 "Invoices issued in Hungary must, with few exceptions, be reported to the "
-"NAV's Online-Invoice system!"
+"NAV's Online-Invoice system."
 msgstr ""
 "Magyarországon a kiállított számlákat, néhány kivételtől eltekintve, "
-"kötelező jelenteni az adóhatóság online számla rendszerébe!"
+"kötelező jelenteni az adóhatóság online számla rendszerébe."
 
 #. module: l10n_hu_edi
 #: model:ir.model,name:l10n_hu_edi.model_account_move
 msgid "Journal Entry"
 msgstr "Könyvelési tétel"
-
-#. module: l10n_hu_edi
-#: model:ir.model,name:l10n_hu_edi.model_account_move_line
-msgid "Journal Item"
-msgstr "Napló tétel"
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields.selection,name:l10n_hu_edi.selection__account_tax__l10n_hu_tax_type__kbaet
@@ -733,7 +720,6 @@ msgstr "KBAET - EU-ba eladás - ÁFA tv.89.§"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_tax.py:0
-#, python-format
 msgid "KBAET sale to EU - VAT tv.§ 89."
 msgstr "KBAET EU-n belüli eladás - ÁFA tv.89.§."
 
@@ -745,7 +731,6 @@ msgstr "KBAUK - Új közlekedési eszköz EU-n belülre - ÁFA tv.89.§(2)"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_tax.py:0
-#, python-format
 msgid "KBAUK New means of transport within the EU - VAT tv.§ 89.§(2)"
 msgstr "KBAUK Új közlekedési eszköz EU-n belülre - ÁFA tv.89.§(2)"
 
@@ -773,11 +758,6 @@ msgstr "Kilométer"
 #: model:ir.model.fields.selection,name:l10n_hu_edi.selection__uom_uom__l10n_hu_edi_code__kwh
 msgid "Kilowatt hour"
 msgstr "Kilowatt óra"
-
-#. module: l10n_hu_edi
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move_send__l10n_hu_edi_enable_nav_30
-msgid "L10N Hu Edi Enable Nav 30"
-msgstr "L10N Hu Edi Nav 30 engedélyezése"
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_res_config_settings__l10n_hu_edi_is_active
@@ -835,14 +815,12 @@ msgstr "Perc"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/res_company.py:0
-#, python-format
 msgid "Missing NAV credentials for company %s"
 msgstr "Hiányzó NAV hitelesítő adatok a %s vállalathoz"
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/l10n_hu_edi_connection.py:0
-#, python-format
 msgid "Missing token in response from NAV."
 msgstr "Hiányzó token a NAV válaszában."
 
@@ -854,7 +832,6 @@ msgstr "Üzemmód"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/l10n_hu_edi_connection.py:0
-#, python-format
 msgid "Mode should be Production or Test!"
 msgstr "Az üzemmód legyen Éles vagy Teszt!"
 
@@ -865,19 +842,18 @@ msgstr "Hónap"
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields.selection,name:l10n_hu_edi.selection__account_tax__l10n_hu_tax_type__nam
-msgid ""
-"NAM - tax-exempt on other grounds related to international transactions"
+msgid "NAM - tax-exempt on other grounds related to international transactions"
 msgstr "NAM - egyéb export ügylet ÁFA tv 110-118.§"
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_tax.py:0
-#, python-format
 msgid "NAM other export transaction VAT law § 110-118"
 msgstr "NAM egyéb export ügylet ÁFA tv 110-118.§"
 
 #. module: l10n_hu_edi
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move_send__l10n_hu_edi_checkbox_nav_30
+#. odoo-python
+#: code:addons/l10n_hu_edi/models/account_move_send.py:0
 #: model_terms:ir.ui.view,arch_db:l10n_hu_edi.view_move_form_inherit_l10n_hu_edi
 msgid "NAV 3.0"
 msgstr ""
@@ -885,7 +861,6 @@ msgstr ""
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_edi_state
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_edi_state
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_edi_state
 msgid "NAV 3.0 status"
 msgstr "NAV 3.0 állapot"
 
@@ -902,7 +877,6 @@ msgstr "NAV Hitelesítési Azonosítók"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/res_company.py:0
-#, python-format
 msgid ""
 "NAV Credentials: Please set the hungarian vat number on the company first!"
 msgstr ""
@@ -957,16 +931,8 @@ msgstr "NAV ÁFA adótípus"
 #. module: l10n_hu_edi
 #: model:ir.model.fields,help:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_payment_mode
 #: model:ir.model.fields,help:l10n_hu_edi.field_account_move__l10n_hu_payment_mode
-#: model:ir.model.fields,help:l10n_hu_edi.field_account_payment__l10n_hu_payment_mode
 msgid "NAV expected payment mode of the invoice."
 msgstr ""
-
-#. module: l10n_hu_edi
-#. odoo-python
-#: code:addons/l10n_hu_edi/models/l10n_hu_edi_connection.py:0
-#, python-format
-msgid "NAV replied with non-OK funcCode: %s"
-msgstr "A NAV nem OK funcCode-dal válaszolt: %s"
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields.selection,name:l10n_hu_edi.selection__account_tax__l10n_hu_tax_type__nonrefundable_vat
@@ -990,7 +956,6 @@ msgstr "Számlaszámig"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/wizard/l10n_hu_edi_tax_audit_export.py:0
-#, python-format
 msgid "No invoice to export!"
 msgstr "Nincs exportálandó számla!"
 
@@ -1002,7 +967,6 @@ msgstr "Normál ÁFA (százalékos)"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "Open Accounting Settings"
 msgstr "Nyissa meg a Számlázási beállításokat"
 
@@ -1030,7 +994,6 @@ msgstr "Jelszó"
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_payment_mode
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_payment_mode
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_payment_mode
 msgid "Payment mode"
 msgstr "Fizetési mód"
 
@@ -1042,7 +1005,6 @@ msgstr "Darab"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
 "Please create a sales tax with type ATK (outside the scope of the VAT Act)."
 msgstr ""
@@ -1052,19 +1014,16 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
 "Please enter the Hungarian VAT (and/or Group VAT) number in 12345678-1-12 "
 "format!"
 msgstr ""
-"Kérjük, adja meg a magyar ÁFA (és/vagy csoportos ÁFA) számot a 12345678-1-12"
-" formátumban!"
+"Kérjük, adja meg a magyar ÁFA (és/vagy csoportos ÁFA) számot a 12345678-1-12 "
+"formátumban!"
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "Please set NAV credentials in the Accounting Settings!"
 msgstr ""
 "Kérjük, állítsa be a NAV hitelesítő adatait a Könyvelési beállításoknál!"
@@ -1072,7 +1031,12 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
+msgid "Please set a valid recipient bank account number!"
+msgstr ""
+
+#. module: l10n_hu_edi
+#. odoo-python
+#: code:addons/l10n_hu_edi/models/account_move.py:0
 msgid "Please set any VAT taxes to be 'Affected by previous taxes'!"
 msgstr ""
 "Kérjük, állítsa be az ÁFA adókat úgy, hogy a 'Korábbi adók által érintett' "
@@ -1081,10 +1045,9 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
-"Please set any non-VAT (excise) taxes to be 'Included in Price' and 'Affects"
-" subsequent taxes'!"
+"Please set any non-VAT (excise) taxes to be 'Included in Price' and 'Affects "
+"subsequent taxes'!"
 msgstr ""
 "Kérjük, hogy a nem-áfás (jövedéki) adókat állítsa be úgy, hogy 'Az ár "
 "tartalmazza' és 'Hatással van a későbbi adókra'!"
@@ -1092,7 +1055,6 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "Please set company Country, Zip, City and Street!"
 msgstr ""
 "Kérjük, adja meg vállalatának országát, irányítószámát, városát és utcáját!"
@@ -1100,28 +1062,24 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "Please set company VAT number!"
 msgstr "Kérjük, adja meg a vállalata adószámát!"
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "Please set exactly one VAT tax on each invoice line!"
 msgstr "Kérjük, hogy minden számlasoron pontosan egy áfa adót adjon meg!"
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "Please set invoice date to today!"
 msgstr "Kérjük, állítsa a számla dátumát a mai napra!"
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "Please set partner Country, Zip, City and Street!"
 msgstr ""
 "Kérjük, állítsa be a partner országát, irányítószámát, városát és utcáját!"
@@ -1129,14 +1087,12 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "Please set partner Tax ID on company partners!"
 msgstr "Kérjük, adja meg a névjegy adószámát a céges partnerekre!"
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "Please use HUF as company currency!"
 msgstr "Kérjük, hogy a vállalat pénznemeként HUF-ot használjon!"
 
@@ -1183,8 +1139,8 @@ msgid ""
 "REFUNDABLE_VAT - VAT incurred under sections 11 or 14, without an agreement "
 "from the beneficiary to reimburse VAT"
 msgstr ""
-"REFUNDABLE_VAT - a 11. vagy 14. szakasz alapján felmerült ÁFA, anélkül, hogy"
-" a kedvezményezett az ÁFA visszatérítésére vonatkozó megállapodással "
+"REFUNDABLE_VAT - a 11. vagy 14. szakasz alapján felmerült ÁFA, anélkül, hogy "
+"a kedvezményezett az ÁFA visszatérítésére vonatkozó megállapodással "
 "rendelkezne"
 
 #. module: l10n_hu_edi
@@ -1247,7 +1203,6 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_tax.py:0
-#, python-format
 msgid "TAM Exempt property"
 msgstr "TAM Tárgyi adómentes"
 
@@ -1267,6 +1222,11 @@ msgid "Tax"
 msgstr "Adó"
 
 #. module: l10n_hu_edi
+#: model_terms:ir.ui.view,arch_db:l10n_hu_edi.report_invoice_document
+msgid "Tax ID"
+msgstr "Adószám"
+
+#. module: l10n_hu_edi
 #: model:ir.actions.act_window,name:l10n_hu_edi.action_l10n_hu_edi_tax_audit_export_form
 #: model:ir.model,name:l10n_hu_edi.model_l10n_hu_edi_tax_audit_export
 #: model:ir.ui.menu,name:l10n_hu_edi.menu_hu_tax_audit_export
@@ -1276,7 +1236,6 @@ msgstr "Adóhatósági Ellenőrzési Adatszolgáltatás"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "Technical Annulment"
 msgstr "Technikai érvénytelenítés"
 
@@ -1288,11 +1247,15 @@ msgstr "Technikai érvénytelenítés varázsló"
 #. module: l10n_hu_edi
 #: model_terms:ir.ui.view,arch_db:l10n_hu_edi.l10n_hu_edi_cancellation_form
 msgid ""
-"Technical Annulment should only be used when an error in the software caused an incorrect data report.<br/>\n"
-"                    To cancel an invoice / credit note in a normal business flow, please create a credit note / debit note."
+"Technical Annulment should only be used when an error in the software caused "
+"an incorrect data report.<br/>\n"
+"                    To cancel an invoice / credit note in a normal business "
+"flow, please create a credit note / debit note."
 msgstr ""
-"A technikai érvénytelenítés csak akkor alkalmazható, ha a szoftver hibájából kifolyólag hibás adatszolgáltatás történt.<br/>\n"
-"                    A számla / jóváírás normál ügymenetben történő visszavonásához hozzon létre jóváíró / bővítő számlát."
+"A technikai érvénytelenítés csak akkor alkalmazható, ha a szoftver hibájából "
+"kifolyólag hibás adatszolgáltatás történt.<br/>\n"
+"                    A számla / jóváírás normál ügymenetben történő "
+"visszavonásához hozzon létre jóváíró / bővítő számlát."
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields.selection,name:l10n_hu_edi.selection__res_company__l10n_hu_edi_server_mode__test
@@ -1302,18 +1265,16 @@ msgstr "Teszt"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
 "The annulment request has been approved by the user on the OnlineSzámla "
 "portal."
 msgstr ""
-"A technikai érvénytelenítési kérelmet a felhasználó az OnlineSzámla portálon"
-" jóváhagyta."
+"A technikai érvénytelenítési kérelmet a felhasználó az OnlineSzámla portálon "
+"jóváhagyta."
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
 "The annulment request is pending, please confirm it on the OnlineSzámla "
 "portal."
@@ -1324,7 +1285,6 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
 "The annulment request was received by the NAV, but has not been confirmed "
 "yet."
@@ -1335,24 +1295,21 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "The annulment request was rejected by NAV."
 msgstr "A technikai érvénytelenítési kérelmet a NAV elutasította."
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
 "The annulment request was rejected by the user on the OnlineSzámla portal."
 msgstr ""
-"A technikai érvénytelenítési kérelmet a felhasználó az OnlineSzámla portálon"
-" elutasította."
+"A technikai érvénytelenítési kérelmet a felhasználó az OnlineSzámla portálon "
+"elutasította."
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
 "The annulment was sent to the NAV, but there was an error querying its "
 "status."
@@ -1363,14 +1320,12 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "The cancellation request could not be performed."
 msgstr "A törlési kérelmet nem lehetett teljesíteni."
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
 "The following invoices appear to be earlier in the chain, but have not yet "
 "been sent. Please send them first."
@@ -1381,10 +1336,9 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
-"The invoice was accepted by the NAV, but warnings were reported. To reverse,"
-" create a credit note / debit note."
+"The invoice was accepted by the NAV, but warnings were reported. To reverse, "
+"create a credit note / debit note."
 msgstr ""
 "A számlát a NAV elfogadta, de figyelmeztetést jelzett. Visszafordításhoz "
 "hozzon létre jóváíró / módostó számlát."
@@ -1392,21 +1346,18 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "The invoice was received by the NAV, but has not been confirmed yet."
 msgstr "A számlát a NAV befogadta, de még nem igazolta vissza."
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "The invoice was rejected by the NAV."
 msgstr "A számlát a NAV elutasította."
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid ""
 "The invoice was sent to the NAV, but there was an error querying its status."
 msgstr ""
@@ -1416,7 +1367,6 @@ msgstr ""
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "The invoice was successfully accepted by the NAV."
 msgstr "A számlát a NAV sikeresen elfogadta."
 
@@ -1453,21 +1403,18 @@ msgstr "Tonna"
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_edi_transaction_code
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_edi_transaction_code
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_edi_transaction_code
 msgid "Transaction Code"
 msgstr "Tranzakciós kód"
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_edi_message_html
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_edi_message_html
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_edi_message_html
 msgid "Transaction messages"
 msgstr "Tranzakciós üzenetek"
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_edi_messages
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_edi_messages
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_edi_messages
 msgid "Transaction messages (JSON)"
 msgstr "Tranzakciós üzenetek (JSON)"
 
@@ -1499,43 +1446,30 @@ msgstr "VTSZ - Vámtarifaszám"
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#: code:addons/l10n_hu_edi/models/account_move.py:0
-#: code:addons/l10n_hu_edi/models/account_move.py:0
-#: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "View Company/ies"
 msgstr "Vállalat(ok) megtekintése"
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "View advance invoice(s)"
 msgstr "Előlegszámla(k) megtekintése"
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#: code:addons/l10n_hu_edi/models/account_move.py:0
-#: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "View invoice(s)"
 msgstr "Számla(k) megtekintése"
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#: code:addons/l10n_hu_edi/models/account_move.py:0
-#: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "View partner(s)"
 msgstr "Partner(ek) megtekintése"
 
 #. module: l10n_hu_edi
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
-#: code:addons/l10n_hu_edi/models/account_move.py:0
-#, python-format
 msgid "View tax(es)"
 msgstr "Adó(k) megtekintése"
 

--- a/addons/l10n_hu_edi/i18n/l10n_hu_edi.pot
+++ b/addons/l10n_hu_edi/i18n/l10n_hu_edi.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.4alpha1+e\n"
+"Project-Id-Version: Odoo Server 18.2a1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-07 13:56+0000\n"
-"PO-Revision-Date: 2024-06-07 13:56+0000\n"
+"POT-Creation-Date: 2025-01-30 17:28+0000\n"
+"PO-Revision-Date: 2025-01-30 17:28+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -29,7 +29,6 @@ msgstr ""
 #. module: l10n_hu_edi
 #: model:ir.model.fields,help:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_invoice_chain_index
 #: model:ir.model.fields,help:l10n_hu_edi.field_account_move__l10n_hu_invoice_chain_index
-#: model:ir.model.fields,help:l10n_hu_edi.field_account_payment__l10n_hu_invoice_chain_index
 msgid ""
 "\n"
 "            Index in the chain of modification invoices:\n"
@@ -51,7 +50,7 @@ msgstr ""
 
 #. module: l10n_hu_edi
 #: model_terms:ir.ui.view,arch_db:l10n_hu_edi.report_invoice_document
-msgid "<strong>Payment Mode:</strong>"
+msgid "<strong>Payment Mode</strong>"
 msgstr ""
 
 #. module: l10n_hu_edi
@@ -348,8 +347,18 @@ msgid "Demo"
 msgstr ""
 
 #. module: l10n_hu_edi
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_chart_template__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move_reversal__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move_send__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_tax__display_name
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_l10n_hu_edi_cancellation__display_name
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_l10n_hu_edi_tax_audit_export__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_product_template__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_res_partner__display_name
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_uom_uom__display_name
 msgid "Display Name"
 msgstr ""
 
@@ -514,8 +523,18 @@ msgid "Hungary"
 msgstr ""
 
 #. module: l10n_hu_edi
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_chart_template__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move_reversal__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move_send__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_tax__id
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_l10n_hu_edi_cancellation__id
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_l10n_hu_edi_tax_audit_export__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_product_template__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_res_config_settings__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_res_partner__id
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_uom_uom__id
 msgid "ID"
 msgstr ""
 
@@ -555,7 +574,6 @@ msgstr ""
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_edi_batch_upload_index
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_edi_batch_upload_index
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_edi_batch_upload_index
 msgid "Index of invoice within a batch upload"
 msgstr ""
 
@@ -573,7 +591,6 @@ msgstr ""
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_invoice_chain_index
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_invoice_chain_index
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_invoice_chain_index
 msgid "Invoice Chain Index"
 msgstr ""
 
@@ -586,14 +603,12 @@ msgstr ""
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_edi_attachment
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_edi_attachment
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_edi_attachment
 msgid "Invoice XML file"
 msgstr ""
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_edi_attachment_filename
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_edi_attachment_filename
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_edi_attachment_filename
 msgid "Invoice XML filename"
 msgstr ""
 
@@ -625,26 +640,20 @@ msgstr ""
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_edi_send_time
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_edi_send_time
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_edi_send_time
 msgid "Invoice upload time"
 msgstr ""
 
 #. module: l10n_hu_edi
 #. odoo-python
-#: code:addons/l10n_hu_edi/wizard/account_move_send.py:0
+#: code:addons/l10n_hu_edi/models/account_move_send.py:0
 msgid ""
 "Invoices issued in Hungary must, with few exceptions, be reported to the "
-"NAV's Online-Invoice system!"
+"NAV's Online-Invoice system."
 msgstr ""
 
 #. module: l10n_hu_edi
 #: model:ir.model,name:l10n_hu_edi.model_account_move
 msgid "Journal Entry"
-msgstr ""
-
-#. module: l10n_hu_edi
-#: model:ir.model,name:l10n_hu_edi.model_account_move_line
-msgid "Journal Item"
 msgstr ""
 
 #. module: l10n_hu_edi
@@ -692,11 +701,6 @@ msgstr ""
 #. module: l10n_hu_edi
 #: model:ir.model.fields.selection,name:l10n_hu_edi.selection__uom_uom__l10n_hu_edi_code__kwh
 msgid "Kilowatt hour"
-msgstr ""
-
-#. module: l10n_hu_edi
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move_send__l10n_hu_edi_enable_nav_30
-msgid "L10N Hu Edi Enable Nav 30"
 msgstr ""
 
 #. module: l10n_hu_edi
@@ -793,7 +797,8 @@ msgid "NAM other export transaction VAT law § 110-118"
 msgstr ""
 
 #. module: l10n_hu_edi
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move_send__l10n_hu_edi_checkbox_nav_30
+#. odoo-python
+#: code:addons/l10n_hu_edi/models/account_move_send.py:0
 #: model_terms:ir.ui.view,arch_db:l10n_hu_edi.view_move_form_inherit_l10n_hu_edi
 msgid "NAV 3.0"
 msgstr ""
@@ -801,7 +806,6 @@ msgstr ""
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_edi_state
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_edi_state
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_edi_state
 msgid "NAV 3.0 status"
 msgstr ""
 
@@ -870,14 +874,7 @@ msgstr ""
 #. module: l10n_hu_edi
 #: model:ir.model.fields,help:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_payment_mode
 #: model:ir.model.fields,help:l10n_hu_edi.field_account_move__l10n_hu_payment_mode
-#: model:ir.model.fields,help:l10n_hu_edi.field_account_payment__l10n_hu_payment_mode
 msgid "NAV expected payment mode of the invoice."
-msgstr ""
-
-#. module: l10n_hu_edi
-#. odoo-python
-#: code:addons/l10n_hu_edi/models/l10n_hu_edi_connection.py:0
-msgid "NAV replied with non-OK funcCode: %s"
 msgstr ""
 
 #. module: l10n_hu_edi
@@ -938,7 +935,6 @@ msgstr ""
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_payment_mode
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_payment_mode
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_payment_mode
 msgid "Payment mode"
 msgstr ""
 
@@ -966,6 +962,12 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
 msgid "Please set NAV credentials in the Accounting Settings!"
+msgstr ""
+
+#. module: l10n_hu_edi
+#. odoo-python
+#: code:addons/l10n_hu_edi/models/account_move.py:0
+msgid "Please set a valid recipient bank account number!"
 msgstr ""
 
 #. module: l10n_hu_edi
@@ -1143,6 +1145,11 @@ msgid "Tax"
 msgstr ""
 
 #. module: l10n_hu_edi
+#: model_terms:ir.ui.view,arch_db:l10n_hu_edi.report_invoice_document
+msgid "Tax ID"
+msgstr ""
+
+#. module: l10n_hu_edi
 #: model:ir.actions.act_window,name:l10n_hu_edi.action_l10n_hu_edi_tax_audit_export_form
 #: model:ir.model,name:l10n_hu_edi.model_l10n_hu_edi_tax_audit_export
 #: model:ir.ui.menu,name:l10n_hu_edi.menu_hu_tax_audit_export
@@ -1297,21 +1304,18 @@ msgstr ""
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_edi_transaction_code
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_edi_transaction_code
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_edi_transaction_code
 msgid "Transaction Code"
 msgstr ""
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_edi_message_html
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_edi_message_html
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_edi_message_html
 msgid "Transaction messages"
 msgstr ""
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_bank_statement_line__l10n_hu_edi_messages
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move__l10n_hu_edi_messages
-#: model:ir.model.fields,field_description:l10n_hu_edi.field_account_payment__l10n_hu_edi_messages
 msgid "Transaction messages (JSON)"
 msgstr ""
 
@@ -1354,8 +1358,6 @@ msgstr ""
 
 #. module: l10n_hu_edi
 #. odoo-python
-#: code:addons/l10n_hu_edi/models/account_move.py:0
-#: code:addons/l10n_hu_edi/models/account_move.py:0
 #: code:addons/l10n_hu_edi/models/account_move.py:0
 msgid "View invoice(s)"
 msgstr ""

--- a/addons/l10n_hu_edi/views/report_invoice.xml
+++ b/addons/l10n_hu_edi/views/report_invoice.xml
@@ -19,8 +19,9 @@
                     <ul class="list-unstyled">
                         <li><t t-out="o.company_id.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/></li>
                         <li>
+                            <t t-set="default_vat_label">Tax ID</t>
                             <t t-if="not o.fiscal_position_id.foreign_vat and o.company_id.partner_id.l10n_hu_group_vat">Group Tax ID</t>
-                            <t t-else="else" t-out="o.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>:
+                            <t t-else="else" t-out="o.company_id.account_fiscal_country_id.vat_label or default_vat_label"/>:
                             <span t-if="o.fiscal_position_id.foreign_vat" t-out="o.fiscal_position_id.foreign_vat"/>
                             <span t-else="else" t-out="o.company_id.vat"/>
                         </li>

--- a/addons/l10n_sk/i18n/l10n_sk.pot
+++ b/addons/l10n_sk/i18n/l10n_sk.pot
@@ -1,0 +1,120 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_sk
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.2a1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-30 17:30+0000\n"
+"PO-Revision-Date: 2025-01-30 17:30+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_sk
+#: model_terms:ir.ui.view,arch_db:l10n_sk.report_invoice_document
+msgid "<strong>Taxable Supply</strong>"
+msgstr ""
+
+#. module: l10n_sk
+#: model_terms:ir.ui.view,arch_db:l10n_sk.report_invoice_document
+msgid "<strong>Trade registry: </strong>"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model,name:l10n_sk.model_account_chart_template
+msgid "Account Chart Template"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model,name:l10n_sk.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model,name:l10n_sk.model_base_document_layout
+msgid "Company Document Layout"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model.fields,field_description:l10n_sk.field_base_document_layout__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model.fields,field_description:l10n_sk.field_account_chart_template__display_name
+#: model:ir.model.fields,field_description:l10n_sk.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_sk.field_base_document_layout__display_name
+#: model:ir.model.fields,field_description:l10n_sk.field_res_company__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model.fields,field_description:l10n_sk.field_base_document_layout__account_fiscal_country_id
+msgid "Fiscal Country"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model.fields,field_description:l10n_sk.field_account_chart_template__id
+#: model:ir.model.fields,field_description:l10n_sk.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_sk.field_base_document_layout__id
+#: model:ir.model.fields,field_description:l10n_sk.field_res_company__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_sk
+#: model_terms:ir.ui.view,arch_db:l10n_sk.l10n_sk_external_layout_folder
+#: model_terms:ir.ui.view,arch_db:l10n_sk.report_invoice_document
+#: model_terms:ir.ui.view,arch_db:l10n_sk.vat_registry_tax_id_external_layout
+msgid "ID:"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model.fields,field_description:l10n_sk.field_base_document_layout__income_tax_id
+#: model:ir.model.fields,field_description:l10n_sk.field_res_company__income_tax_id
+msgid "Income Tax ID"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model,name:l10n_sk.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_sk
+#: model_terms:ir.ui.view,arch_db:l10n_sk.l10n_sk_external_layout_folder
+#: model_terms:ir.ui.view,arch_db:l10n_sk.vat_registry_tax_id_external_layout
+msgid "Tax ID"
+msgstr ""
+
+#. module: l10n_sk
+#: model_terms:ir.ui.view,arch_db:l10n_sk.l10n_sk_external_layout_folder
+#: model_terms:ir.ui.view,arch_db:l10n_sk.vat_registry_tax_id_external_layout
+msgid "Tax ID:"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model.fields,field_description:l10n_sk.field_account_bank_statement_line__taxable_supply_date
+#: model:ir.model.fields,field_description:l10n_sk.field_account_move__taxable_supply_date
+msgid "Taxable Supply Date"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model.fields,help:l10n_sk.field_base_document_layout__account_fiscal_country_id
+msgid "The country to use the tax reports from for this company"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model.fields,help:l10n_sk.field_base_document_layout__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model.fields,field_description:l10n_sk.field_res_company__trade_registry
+msgid "Trade Registry"
+msgstr ""

--- a/addons/l10n_sk/i18n/sk.po
+++ b/addons/l10n_sk/i18n/sk.po
@@ -1,0 +1,120 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_sk
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.2a1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-30 17:30+0000\n"
+"PO-Revision-Date: 2025-01-30 17:30+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_sk
+#: model_terms:ir.ui.view,arch_db:l10n_sk.report_invoice_document
+msgid "<strong>Taxable Supply</strong>"
+msgstr ""
+
+#. module: l10n_sk
+#: model_terms:ir.ui.view,arch_db:l10n_sk.report_invoice_document
+msgid "<strong>Trade registry: </strong>"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model,name:l10n_sk.model_account_chart_template
+msgid "Account Chart Template"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model,name:l10n_sk.model_res_company
+msgid "Companies"
+msgstr "Spoločnosti"
+
+#. module: l10n_sk
+#: model:ir.model,name:l10n_sk.model_base_document_layout
+msgid "Company Document Layout"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model.fields,field_description:l10n_sk.field_base_document_layout__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model.fields,field_description:l10n_sk.field_account_chart_template__display_name
+#: model:ir.model.fields,field_description:l10n_sk.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_sk.field_base_document_layout__display_name
+#: model:ir.model.fields,field_description:l10n_sk.field_res_company__display_name
+msgid "Display Name"
+msgstr "Zobrazovaný názov"
+
+#. module: l10n_sk
+#: model:ir.model.fields,field_description:l10n_sk.field_base_document_layout__account_fiscal_country_id
+msgid "Fiscal Country"
+msgstr "Fiškálna krajina"
+
+#. module: l10n_sk
+#: model:ir.model.fields,field_description:l10n_sk.field_account_chart_template__id
+#: model:ir.model.fields,field_description:l10n_sk.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_sk.field_base_document_layout__id
+#: model:ir.model.fields,field_description:l10n_sk.field_res_company__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_sk
+#: model_terms:ir.ui.view,arch_db:l10n_sk.l10n_sk_external_layout_folder
+#: model_terms:ir.ui.view,arch_db:l10n_sk.report_invoice_document
+#: model_terms:ir.ui.view,arch_db:l10n_sk.vat_registry_tax_id_external_layout
+msgid "ID:"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model.fields,field_description:l10n_sk.field_base_document_layout__income_tax_id
+#: model:ir.model.fields,field_description:l10n_sk.field_res_company__income_tax_id
+msgid "Income Tax ID"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model,name:l10n_sk.model_account_move
+msgid "Journal Entry"
+msgstr "Vstup účtovnej knihy"
+
+#. module: l10n_sk
+#: model_terms:ir.ui.view,arch_db:l10n_sk.l10n_sk_external_layout_folder
+#: model_terms:ir.ui.view,arch_db:l10n_sk.vat_registry_tax_id_external_layout
+msgid "Tax ID"
+msgstr "DIČ"
+
+#. module: l10n_sk
+#: model_terms:ir.ui.view,arch_db:l10n_sk.l10n_sk_external_layout_folder
+#: model_terms:ir.ui.view,arch_db:l10n_sk.vat_registry_tax_id_external_layout
+msgid "Tax ID:"
+msgstr "DIČ:"
+
+#. module: l10n_sk
+#: model:ir.model.fields,field_description:l10n_sk.field_account_bank_statement_line__taxable_supply_date
+#: model:ir.model.fields,field_description:l10n_sk.field_account_move__taxable_supply_date
+msgid "Taxable Supply Date"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model.fields,help:l10n_sk.field_base_document_layout__account_fiscal_country_id
+msgid "The country to use the tax reports from for this company"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model.fields,help:l10n_sk.field_base_document_layout__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_sk
+#: model:ir.model.fields,field_description:l10n_sk.field_res_company__trade_registry
+msgid "Trade Registry"
+msgstr ""

--- a/addons/l10n_sk/views/report_template.xml
+++ b/addons/l10n_sk/views/report_template.xml
@@ -8,7 +8,8 @@
             Tax ID: <span t-field="company.income_tax_id"/>
         </li>
         <li t-if="company.vat and company.account_fiscal_country_id.code == 'SK'">
-            <t t-out="company.country_id.vat_label or 'Tax ID'"/>:
+            <t t-set="default_vat_label">Tax ID</t>
+            <t t-out="company.country_id.vat_label or default_vat_label"/>:
             <span t-out="company.vat"/>
         </li>
     </template>
@@ -58,7 +59,8 @@
                 Tax ID: <span t-field="company.income_tax_id"/>
             </div>
             <div t-if="company.vat and company.account_fiscal_country_id.code == 'SK'">
-                <t t-out="company.country_id.vat_label or 'Tax ID'"/>:
+                <t t-set="default_vat_label">Tax ID</t>
+                <t t-out="company.country_id.vat_label or default_vat_label"/>:
                 <span t-out="company.vat"/>
             </div>
         </xpath>

--- a/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.js
+++ b/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.js
@@ -2,6 +2,7 @@ import { ControlPanel } from "@web/search/control_panel/control_panel";
 import { BomOverviewDisplayFilter } from "../bom_overview_display_filter/mrp_bom_overview_display_filter";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { _t } from "@web/core/l10n/translation";
 import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
 import { Component } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
@@ -78,6 +79,10 @@ export class BomOverviewControlPanel extends Component {
             },
         };
         return this.action.doAction(action);
+    }
+
+    get foldButtonText() {
+        return this.props.allFolded ? _t("Unfold") : _t("Fold");
     }
 
     get precision() {

--- a/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.xml
+++ b/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.xml
@@ -12,7 +12,7 @@
                         <t t-if="props.showVariants">
                             <button t-on-click="() => this.props.print(true)" type="button" class="btn btn-secondary text-nowrap">Print All Variants</button>
                         </t>
-                        <button t-on-click="clickTogglefold" type="button" class="btn btn-secondary"><t t-esc="props.allFolded ? 'Unfold' : 'Fold'"/></button>
+                        <button t-on-click="clickTogglefold" type="button" class="btn btn-secondary" t-esc="foldButtonText"/>
                     </div>
                 </div>
             </t>

--- a/addons/payment/views/payment_form_templates.xml
+++ b/addons/payment/views/payment_form_templates.xml
@@ -189,13 +189,13 @@
                                 <t t-if="is_unpublished" t-call="payment.form_icon">
                                     <t t-set="icon_name" t-value="'eye-slash'"/>
                                     <t t-set="color_name" t-value="'danger'"/>
-                                    <t t-set="title" t-value="'Unpublished'"/>
+                                    <t t-set="title">Unpublished</t>
                                 </t>
                                 <!-- === "Test mode" icon === -->
                                 <t t-if="is_test" t-call="payment.form_icon">
                                     <t t-set="icon_name" t-value="'exclamation-triangle'"/>
                                     <t t-set="color_name" t-value="'warning'"/>
-                                    <t t-set="title" t-value="'Test mode'"/>
+                                    <t t-set="title">Test mode</t>
                                 </t>
                             </div>
                         </div>
@@ -291,13 +291,13 @@
                             <t t-if="is_unpublished" t-call="payment.form_icon">
                                 <t t-set="icon_name" t-value="'eye-slash'"/>
                                 <t t-set="color_name" t-value="'danger'"/>
-                                <t t-set="title" t-value="'Unpublished'"/>
+                                <t t-set="title">Unpublished</t>
                             </t>
                             <!-- === "Test mode" icon === -->
                             <t t-if="is_test" t-call="payment.form_icon">
                                 <t t-set="icon_name" t-value="'exclamation-triangle'"/>
                                 <t t-set="color_name" t-value="'warning'"/>
-                                <t t-set="title" t-value="'Test mode'"/>
+                                <t t-set="title">Test mode</t>
                             </t>
                         </div>
                     </div>

--- a/addons/payment/views/portal_templates.xml
+++ b/addons/payment/views/portal_templates.xml
@@ -18,7 +18,7 @@
             - partner_is_different: Whether the partner logged in is the one making the payment.
         -->
         <t t-call="portal.frontend_layout">
-            <t t-set="page_title" t-value="'Payment'"/>
+            <t t-set="page_title">Payment</t>
             <t t-set="additional_title"><t t-esc="page_title"/></t>
             <div class="wrap">
                 <div class="container">
@@ -90,7 +90,7 @@
     <!-- Display of /my/payment_methods -->
     <template id="payment.payment_methods" name="Payment Methods">
         <t t-call="portal.frontend_layout">
-            <t t-set="page_title" t-value="'Payment Methods'"/>
+            <t t-set="page_title">Payment Methods</t>
             <t t-set="additional_title"><t t-esc="page_title"/></t>
             <div class="wrap">
                 <div class="container">
@@ -110,7 +110,7 @@
     <!-- Display of /payment/status -->
     <template id="payment.payment_status" name="Payment Status">
         <t t-call="portal.frontend_layout">
-            <t t-set="page_title" t-value="'Payment Status'"/>
+            <t t-set="page_title">Payment Status</t>
             <t t-set="additional_title"><t t-esc="page_title"/></t>
             <div class="wrap">
                 <div class="container">
@@ -166,7 +166,7 @@
             - tx: The transaction to display.
         -->
         <t t-call="portal.frontend_layout">
-            <t t-set="page_title" t-value="'Payment Confirmation'"/>
+            <t t-set="page_title">Payment Confirmation</t>
             <t t-set="additional_title"><t t-esc="page_title"/></t>
             <t t-set="show_pm" t-value="tx.payment_method_code != 'unknown'"/>
             <div class="wrap">

--- a/addons/payment_demo/views/payment_demo_templates.xml
+++ b/addons/payment_demo/views/payment_demo_templates.xml
@@ -173,8 +173,9 @@
                                 class="form-select"
                                 disabled="true"
                         >
+                            <t t-set="default_country">Belgium</t>
                             <option t-att-value="customer.country_id.code or 'BE'"
-                                    t-out="customer.country_id.name or 'Belgium'"
+                                    t-out="customer.country_id.name or default_country"
                             />
                         </select>
                     </div>

--- a/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.js
@@ -39,6 +39,11 @@ export class NumberPopup extends Component {
             buffer: this.props.startingValue,
         });
     }
+
+    get confirmButtonLabel() {
+        return this.props.confirmButtonLabel || _t("Ok");
+    }
+
     confirm() {
         this.props.getPayload(this.state.buffer);
         this.props.close();

--- a/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.xml
@@ -14,10 +14,10 @@
             <t t-set-slot="footer">
                 <div class="d-flex flex-grow-1 justify-content-center">
                     <button t-att-disabled="!props.isValid(state.buffer)" class="btn btn-primary btn-lg lh-lg o-default-button me-2" tabindex="1" t-on-click="confirm">
-                        <t t-esc="props.confirmButtonLabel || 'Ok'" />
+                        <t t-esc="confirmButtonLabel"/>
                     </button>
                     <button class="btn btn-secondary btn-lg lh-lg o-default-button" tabindex="1" t-on-click="cancel">
-                        <t t-esc="'Discard'" />
+                        Discard
                     </button>
                 </div>
             </t>

--- a/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.js
@@ -3,6 +3,7 @@ import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { Component, onMounted, onWillUnmount, useState } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
 
 export class ScaleScreen extends Component {
     static template = "point_of_sale.ScaleScreen";
@@ -52,6 +53,10 @@ export class ScaleScreen extends Component {
             Math.ceil(Math.log(1.0 / this.props.uomRounding) / Math.log(10))
         );
         return weightRound - parseFloat(this.state.tare);
+    }
+
+    get productName() {
+        return this.props.product?.display_name || _t("Unnamed Product");
     }
 
     get productWeightString() {

--- a/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.ScaleScreen">
-        <Dialog size="'md'" title="props.product?.display_name || 'Unnamed Product'">
+        <Dialog size="'md'" title="productName">
             <t t-set-slot="header">
                 <t t-if="this.env.isSmall">
                     <button class="btn oi oi-arrow-left" data-bs-dismiss="modal" aria-label="Close" t-on-click="props.close" />
                 </t>
                 <h4 class="modal-title text-break text-center w-100" t-att-class="{ 'me-auto': this.env.isSmall }">
-                    <t t-esc="props.productName || 'Unnamed Product'"/>
+                    <t t-set="defaultProductName">Unnamed Product</t>
+                    <t t-esc="props.productName || defaultProductName"/>
                 </h4>
                 <t t-if="!this.env.isSmall">
                     <button type="button" class="btn-close" aria-label="Close" tabindex="-1" t-on-click="props.close"></button>


### PR DESCRIPTION
In XML templates, only text nodes and a few static attributes (title, placeholder, etc.) are translated. This commit redefines some strings that couldn't be translated before in a different way, so that they become translatable.