### PR TITLE
[FIX] l10n_fr_account: exclude custom bics from getting xmlid

### DIFF
--- a/addons/l10n_fr_account/migrations/2.2/pre-migrate-add-bank-xmlid.py
+++ b/addons/l10n_fr_account/migrations/2.2/pre-migrate-add-bank-xmlid.py
@@ -10,7 +10,7 @@ def migrate(cr, version):
                AND d.name = 'fr'
                AND d.res_id = bank.country
              WHERE bank.active
-               AND bank.bic IS NOT NULL
+               AND bank.bic ~ '^[A-Z0-9]+$'
         )
         INSERT INTO ir_model_data(
                         model,
@@ -21,7 +21,7 @@ def migrate(cr, version):
                     )
              SELECT 'res.bank',
                     'l10n_fr_account',
-                    CONCAT('bank_fr_', REPLACE(banks.bic, ' ', '')),
+                    CONCAT('bank_fr_', banks.bic),
                     banks.id,
                     True
                FROM banks


### PR DESCRIPTION
The upgrade script is supposed to create xmlids for french banks that were already created from csv, if it matches custom records that have unusual bic, it is better to skip the whole record. Standard BIC format is a capital alphanumeric only. Replacing the spaces or unsupported characters in the xmlid will result in custom records looking like they come from standard module.

alternate fix for https://github.com/odoo/odoo/pull/191970



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
