### PR TITLE
[FIX] web: properly rethrow errors in Interaction waitFor

### DIFF
--- a/addons/web/static/src/public/interaction.js
+++ b/addons/web/static/src/public/interaction.js
@@ -170,17 +170,26 @@ export class Interaction {
      * code has acted.
      */
     waitFor(promise) {
-        const prom = new Promise((resolve) => {
-            promise.then((result) => {
-                if (!this.isDestroyed) {
-                    resolve(result);
-                    prom.then(() => {
-                        if (this.isReady) {
+        const prom = new Promise((resolve, reject) => {
+            promise
+                .then((result) => {
+                    if (!this.isDestroyed) {
+                        resolve(result);
+                        prom.then(() => {
+                            if (this.isReady) {
+                                this.updateContent();
+                            }
+                        });
+                    }
+                })
+                .catch((e) => {
+                    reject(e);
+                    prom.catch(() => {
+                        if (this.isReady && !this.isDestroyed) {
                             this.updateContent();
                         }
                     });
-                }
-            });
+                });
         });
         return prom;
     }


### PR DESCRIPTION
The waitFor helper wrap an inner promise in a new promise that is only resolved if the interaction has not been destroyed in the meantime.

The problem is that if some code tries to do a try/catch around the waitFor, like this:

try {
  await this.waitFor(...);
} catch (e) {
 ...
}
Then the error from the inner promise would not be propagated to the outer promise, so the catch operation does not actually work.

This commit fixes the issue by rejecting the outer promise if the inner promise fails.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
