### PR TITLE
[FIX] mrp{,_subcontracting{,_purchase}}: handle mo date start write

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -868,19 +868,7 @@ class MrpProduction(models.Model):
                 if production.state == 'draft' and picking_type != production.picking_type_id:
                     production.name = picking_type.sequence_id.next_by_id()
 
-        date_start_map = dict()
-        if 'date_start' in vals:
-            date_start = fields.Datetime.to_datetime(vals['date_start'])
-            date_start_map = {
-                prod: date_start - datetime.timedelta(days=prod.bom_id.produce_delay)
-                if prod.bom_id else date_start
-                for prod in self
-            }
-            res = True
-            for production in self:
-                res &= super(MrpProduction, production).write({**vals, 'date_start': date_start_map[production]})
-        else:
-            res = super().write(vals)
+        res = super().write(vals)
 
         for production in self:
             if 'date_start' in vals and not self.env.context.get('force_date', False):

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4504,6 +4504,29 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(grandparent_production._get_children(), (parent_production | parent_production_2))
         self.assertEqual(parent_production_2._get_children(), child_production_2)
 
+    def test_mo_modify_date_with_manuf_lead_time(self):
+        """ A direct write on MrpProduction.date_start should result in that exact date value being
+        written to the MO.
+        """
+        finished_product = self.env['product.product'].create({'name': 'finished product'})
+        finished_bom_id = self.env['mrp.bom'].create({
+            'produce_delay': 17,
+            'product_id': finished_product.id,
+            'product_tmpl_id': finished_product.product_tmpl_id.id,
+            'product_uom_id': self.uom_unit.id,
+            'product_qty': 1.0,
+            'bom_line_ids': [(0, 0, {'product_id': self.product.id, 'product_qty': 1})],
+        })
+        mo = self.env['mrp.production'].create({'bom_id': finished_bom_id.id})
+        mo.action_confirm()
+        original_start_date = mo.date_start
+        with Form(mo) as production_form:
+            production_form.date_start = fields.Date.today() - timedelta(days=10)
+        self.assertEqual(mo.date_start.date(), original_start_date.date() - timedelta(days=10))
+        with Form(mo) as production_form:
+            production_form.date_start = original_start_date
+        self.assertEqual(mo.date_start, original_start_date)
+
 @tagged('post_install', '-at_install')
 class TestMrpSynchronization(HttpCase):
 

--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -141,7 +141,7 @@ class StockMove(models.Model):
             for move in self:
                 if move.state in ('done', 'cancel') or not move.is_subcontract:
                     continue
-                move.move_orig_ids.production_id.filtered(lambda p: p.state not in ('done', 'cancel')).write({
+                move.move_orig_ids.production_id.with_context(from_subcontract=True).filtered(lambda p: p.state not in ('done', 'cancel')).write({
                     'date_start': move.date,
                     'date_finished': move.date,
                 })

--- a/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
+++ b/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
@@ -946,7 +946,8 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
     @freeze_time('2000-05-01')
     def test_mrp_subcontract_modify_date(self):
         """ Ensure consistent results when modifying date fields of a weakly-linked reception and
-        manufacturing order.
+        manufacturing order. Additionally, modifying `date_start` directly on an MO has a
+        well-defined result.
         """
         self.bom_finished2.produce_delay = 35
         po = self.env['purchase.order'].create({
@@ -967,5 +968,11 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
         self.assertEqual(mo.date_start, datetime(year=2000, month=6, day=1) - timedelta(days=self.bom_finished2.produce_delay))
         with Form(po.picking_ids[0]) as receipt_form:
             receipt_form.scheduled_date = '2000-05-01'
-        new_mo_start_date = mo.date_start
-        self.assertEqual(original_mo_start_date, new_mo_start_date, f'{original_mo_start_date} != {new_mo_start_date}')
+        self.assertEqual(mo.date_start, original_mo_start_date)
+
+        with Form(mo) as production_form:
+            production_form.date_start = '2000-03-20'
+        self.assertEqual(mo.date_start.date(), Date.to_date('2000-03-20'))
+        with Form(mo) as production_form:
+            production_form.date_start = original_mo_start_date
+        self.assertEqual(mo.date_start, original_mo_start_date)


### PR DESCRIPTION
**Current behavior:**
After commit https://github.com/odoo/odoo/commit/7c808beaf36853b4d9171ef0981d1ec9c4b73a44 all writes on `date_start` would silently
alter the written date value (totally unintuiative for a user &
undesired behavior regardless).

**Expected behavior:**
Only when handling indirect writes on `date_start` from a
linked-via-subcontract purchase order should we modify
`date_start` to account for the manufacture delay.

opw-4489485