### PR TITLE
[FIX] web_editor: properly activate the previous snippet after removal

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1,6 +1,6 @@
 odoo.define('web_editor.snippet.editor', function (require) {
 'use strict';
-
+const { isVisible } = require("@web/core/utils/ui");
 var concurrency = require('web.concurrency');
 var core = require('web.core');
 var Dialog = require('web.Dialog');
@@ -499,11 +499,11 @@ var SnippetEditor = Widget.extend({
         // unit tested.
         let parent = this.$target[0].parentElement;
         let nextSibling = this.$target[0].nextElementSibling;
-        while (nextSibling && nextSibling.matches('.o_snippet_invisible')) {
+        while (nextSibling && !isVisible(nextSibling)) {
             nextSibling = nextSibling.nextElementSibling;
         }
         let previousSibling = this.$target[0].previousElementSibling;
-        while (previousSibling && previousSibling.matches('.o_snippet_invisible')) {
+        while (previousSibling && !isVisible(previousSibling)) {
             previousSibling = previousSibling.previousElementSibling;
         }
         if ($(parent).is('.o_editable:not(body)')) {


### PR DESCRIPTION
Since [1] and later [2], the activation logic when removing a snippet relied on the `o_snippet_invisible` class to determine whether to activate the previous or next sibling. However, additional classes like `o_snippet_desktop_invisible` and `o_snippet_mobile_invisible` were introduced, making it insufficient to rely solely on `o_snippet_invisible``.

This commit ensures that the correct snippet is activated upon removal.

Steps to reproduce:

- Navigate to Web editor
- Drop text snippet 1
- Drop text snippet 2 and hide it for desktop
- Drop text snippet 3
- Remove text snippet 3
- Bug => text snippet 1 is not activated as expected

[1]: https://github.com/odoo/odoo/commit/2cdd95f140b6ec5f3b95ee19bde2f281de21f337
[2]: https://github.com/odoo/odoo/commit/2de0ad7259993f654ca8d826f5430f78090a28c5

task-4531506
