### PR TITLE
[FIX] mail: ease click on call participant collapse button

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -24,8 +24,8 @@
             'rounded-3': props.compact === undefined,
             'opacity-75': props.thread.notEq(rtc.state.channel) and compact,
         }">
-            <button class="btn btn-link p-0 align-self-start" t-if="!compact">
-                <i class="oi o-xxsmaller text-muted me-1" t-att-class="{'oi-chevron-right': !state.expanded, 'oi-chevron-down': state.expanded}" t-att-title="title" t-on-click="() => state.expanded = !state.expanded"/>
+            <button class="btn btn-link p-1 m-n1 align-self-start" t-if="!compact" t-on-click="() => state.expanded = !state.expanded">
+                <i class="oi o-xxsmaller text-muted me-1" t-att-class="{'oi-chevron-right': !state.expanded, 'oi-chevron-down': state.expanded}" t-att-title="title"/>
             </button>
             <AvatarStack
                 t-if="!state.expanded"


### PR DESCRIPTION
The click was on the icon rather than button, and since icon is very small this is quite hard to click.

This commit moves click handler to button, and also increase the click area of button without affecting it's position.

<img width="292" alt="Screenshot 2025-01-30 at 11 57 29" src="https://github.com/user-attachments/assets/c8c5a8cd-f463-4440-a9ec-66b42a878aaa" />

Before / After (click area)
<img width="293" alt="Screenshot 2025-01-30 at 11 58 12" src="https://github.com/user-attachments/assets/4e9acb87-e9f8-406d-aa57-48039daa5db7" /> <img width="290" alt="Screenshot 2025-01-30 at 11 58 57 (2)" src="https://github.com/user-attachments/assets/9b00e5f4-eb02-435b-93ca-b503412727ec" />