### PR TITLE
[FIX] web: make the db name visible in dark mode

### DIFF
--- a/addons/web/static/src/webclient/user_menu/user_menu.scss
+++ b/addons/web/static/src/webclient/user_menu/user_menu.scss
@@ -4,4 +4,8 @@
     .o_user_avatar {
         height: calc(var(--o-navbar-height) - 20px);
     }
+
+    mark {
+        color: marktext;
+    }
 }


### PR DESCRIPTION
Previously after activating debug mode and then dark mode, the letters 
of database name are not visible clearly. It is happening because in new 
bootstrap version we are having a color attribute in mark tag which was 
previously not there.

After this commit the database name will be clearly visible in dark mode.

Task-4389154

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
