### PR TITLE
[IMP] pos*: configure receipt layout

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/js/order_receipt.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/order_receipt.js
@@ -1,4 +1,5 @@
 import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
+import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
 patch(OrderReceipt.prototype, {
@@ -7,5 +8,22 @@ patch(OrderReceipt.prototype, {
             return false;
         }
         return super.qrCode;
+    },
+    _getAdditionalLineInfo(line) {
+        const info = super._getAdditionalLineInfo(line);
+        if (
+            line.order_id.l10n_fr_hash &&
+            line.price_type === "manual" &&
+            !this.props.basic_receipt
+        ) {
+            info.push({
+                class: "oldPrice",
+                value: _t(
+                    "Old unit price: %s / Units",
+                    this.formatCurrency(line.getTaxedlstUnitPrice())
+                ),
+            });
+        }
+        return info;
     },
 });

--- a/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
@@ -7,19 +7,4 @@
             </t>
         </xpath>
     </t>
-
-    <t t-name="l10n_fr_pos_cert.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
-        <xpath expr="//Orderline" position="inside">
-            <t t-if="line.order_id.l10n_fr_hash !== false and line.price_type === 'manual' and !props.basic_receipt">
-                <div class="pos-receipt-right-padding">
-                    Old unit price:
-                    <span class="oldPrice">
-                        <s>
-                            <t t-out="formatCurrency(line.getTaxedlstUnitPrice())" /> / Units
-                        </s>
-                    </span>
-                </div>
-            </t>
-        </xpath>
-    </t>
 </templates>

--- a/addons/l10n_gcc_pos/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/l10n_gcc_pos/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -25,6 +25,10 @@
     </t>
 
     <t t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
+        <xpath expr="//span[hasclass('label-total-qty')]" position="replace">
+            <span t-if="order.isGccCountry" class="label-total-qty" t-translation="off">Total Qty / إجمالي الكمية</span>
+            <span t-else="" class="label-total-qty">Total Qty: </span>
+        </xpath>
         <xpath expr="//span[hasclass('label-rounding')]" position="replace">
             <span t-if="order.isGccCountry" class="label-rounding" t-translation="off">Rounding / التقريب</span>
             <span t-else="" class="label-rounding">Rounding</span>

--- a/addons/l10n_in_pos/static/src/app/screens/receipt_screen/pos_receipt.js
+++ b/addons/l10n_in_pos/static/src/app/screens/receipt_screen/pos_receipt.js
@@ -1,0 +1,16 @@
+import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
+import { _t } from "@web/core/l10n/translation";
+import { patch } from "@web/core/utils/patch";
+
+patch(OrderReceipt.prototype, {
+    _getAdditionalLineInfo(line) {
+        const info = super._getAdditionalLineInfo(line);
+        if (line.l10n_in_hsn_code && this.header.company.country_id?.code === "IN") {
+            info.push({
+                class: "pos-receipt-hsn-code",
+                value: _t("HSN: ") + line.l10n_in_hsn_code,
+            });
+        }
+        return info;
+    },
+});

--- a/addons/l10n_in_pos/static/src/app/screens/receipt_screen/pos_receipt.xml
+++ b/addons/l10n_in_pos/static/src/app/screens/receipt_screen/pos_receipt.xml
@@ -18,37 +18,33 @@
     </t>
 
     <t t-name="l10n_in_pos.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
-        <xpath expr="//Orderline" position="inside">
-            <t t-if="line.l10n_in_hsn_code and header.company.country_id?.code === 'IN'">
-                <div class="pos-receipt-left-padding">
-                    <span>HSN Code: </span>
-                    <t t-out="line.l10n_in_hsn_code"/>
-                </div>
-            </t>
-        </xpath>
-        <xpath expr="//div[@class='before-footer']" position="after">
+        <xpath expr="//div[@class='pos-receipt-taxes']" position="inside">
             <t t-set="l10n_in_hsn_summary" t-value="order._prepareL10nInHsnSummary()"/>
-            <table t-if="l10n_in_hsn_summary and header.company.country_id?.code === 'IN' and l10n_in_hsn_summary.items.length > 0"
-                   class="l10n_in_hsn_summary_table pt-3 w-100">
-              <tr>
-                    <th class="text-center fw-bolder" colspan="6">HSN Summary</th>
-                </tr>
-                <tr>
-                    <th class="text-center">HSN Code</th>
-                    <th class="text-center">Rate%</th>
-                    <th class="text-center">CGST</th>
-                    <th class="text-center">SGST</th>
-                    <th class="text-center" t-if="l10n_in_hsn_summary.has_igst">IGST</th>
-                    <th class="text-center" t-if="l10n_in_hsn_summary.has_cess">CESS</th>
-                </tr>
-                <tr t-foreach="l10n_in_hsn_summary.items" t-as="item" t-key="item_index">
-                    <td class="text-center" t-out="item.l10n_in_hsn_code"/>
-                    <td class="text-center"><t t-out="item.rate"/> %</td>
-                    <td class="text-center" t-out="item.tax_amount_cgst"/>
-                    <td class="text-center" t-out="item.tax_amount_sgst"/>
-                    <td class="text-center" t-if="l10n_in_hsn_summary.has_igst" t-out="item.tax_amount_igst"/>
-                    <td class="text-center" t-if="l10n_in_hsn_summary.has_cess" t-out="item.tax_amount_cess"/>
-                </tr>
+            <table t-if="l10n_in_hsn_summary and header.company.country_id?.code === 'IN' and l10n_in_hsn_summary.items.length > 0" 
+                class="l10n_in_hsn_summary_table mt-3 tax-table" t-att-class="receiptClasses.table">
+                <thead>
+                    <tr>
+                        <th class="text-center fw-bolder" colspan="6">HSN Summary</th>
+                    </tr>
+                    <tr t-att-class="receiptClasses.thr">
+                        <th>HSN Code</th>
+                        <th>Rate%</th>
+                        <th>CGST</th>
+                        <th>SGST</th>
+                        <th t-if="l10n_in_hsn_summary.has_igst">IGST</th>
+                        <th t-if="l10n_in_hsn_summary.has_cess">CESS</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr t-foreach="l10n_in_hsn_summary.items" t-as="item" t-key="item_index" class="text-center">
+                        <td t-out="item.l10n_in_hsn_code"/>
+                        <td><t t-out="item.rate"/>%</td>
+                        <td t-out="item.tax_amount_cgst"/>
+                        <td t-out="item.tax_amount_sgst"/>
+                        <td t-if="l10n_in_hsn_summary.has_igst" t-out="item.tax_amount_igst"/>
+                        <td t-if="l10n_in_hsn_summary.has_cess" t-out="item.tax_amount_cess"/>
+                    </tr>
+                </tbody>
             </table>
         </xpath>
     </t>

--- a/addons/l10n_in_pos/static/tests/tours/test_hsn_summary.js
+++ b/addons/l10n_in_pos/static/tests/tours/test_hsn_summary.js
@@ -37,22 +37,22 @@ registry.category("web_tour.tours").add("test_l10n_in_hsn_summary_pos", {
             {
                 isActive: ["desktop"], // not rendered on mobile
                 trigger:
-                    '.receipt-screen .l10n_in_hsn_summary_table tr:nth-child(3) td:nth-child(3):contains("57.50")',
+                    '.receipt-screen .l10n_in_hsn_summary_table tbody tr:nth-child(1) td:nth-child(3):contains("57.50")',
             },
             {
                 isActive: ["desktop"], // not rendered on mobile
                 trigger:
-                    '.receipt-screen .l10n_in_hsn_summary_table tr:nth-child(3) td:nth-child(4):contains("57.50")',
+                    '.receipt-screen .l10n_in_hsn_summary_table tbody tr:nth-child(1) td:nth-child(4):contains("57.50")',
             },
             {
                 isActive: ["desktop"], // not rendered on mobile
                 trigger:
-                    '.receipt-screen .l10n_in_hsn_summary_table tr:nth-child(4) td:nth-child(3):contains("207.00")',
+                    '.receipt-screen .l10n_in_hsn_summary_table tbody tr:nth-child(2) td:nth-child(3):contains("207.00")',
             },
             {
                 isActive: ["desktop"], // not rendered on mobile
                 trigger:
-                    '.receipt-screen .l10n_in_hsn_summary_table tr:nth-child(4) td:nth-child(4):contains("207.00")',
+                    '.receipt-screen .l10n_in_hsn_summary_table tbody tr:nth-child(2) td:nth-child(4):contains("207.00")',
             },
         ].flat(),
 });

--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -24,6 +24,8 @@
         'wizard/pos_daily_sales_reports.xml',
         'wizard/pos_confirmation_wizard.xml',
         'wizard/pos_make_invoice.xml',
+        'wizard/pos_receipt_layout_preview.xml',
+        'wizard/pos_receipt_layout.xml',
         'views/pos_assets_index.xml',
         'views/point_of_sale_report.xml',
         'views/point_of_sale_view.xml',
@@ -82,6 +84,7 @@
             'point_of_sale/static/src/backend/pos_payment_provider_cards/*',
             'point_of_sale/static/src/app/hooks/hooks.js',
             'point_of_sale/static/src/backend/many2many_placeholder_list_view/*',
+            'point_of_sale/static/src/backend/receipt_preview_iframe/*',
         ],
         "web.assets_web_dark": [
             'point_of_sale/static/src/scss/pos_dashboard.dark.scss',
@@ -241,6 +244,16 @@
             'barcodes/static/tests/legacy/helpers.js',
             'point_of_sale/static/tests/generic_helpers/**/*',
             'point_of_sale/static/tests/pos/tours/**/*',
+        ],
+        'point_of_sale.receipt_assets_lazy': [
+            ('include', 'web.assets_backend_lazy'),
+            'point_of_sale/static/src/app/screens/receipt_screen/receipt/**/*',
+            'point_of_sale/static/src/utils.js',
+        ],
+        'point_of_sale.receipt_assets': [
+            ('include', 'web.assets_frontend'),
+            'web/static/fonts/fonts.scss',
+            'point_of_sale/static/src/css/pos_receipts.css',
         ],
     },
     'author': 'Odoo S.A.',

--- a/addons/point_of_sale/security/ir.model.access.csv
+++ b/addons/point_of_sale/security/ir.model.access.csv
@@ -53,3 +53,4 @@ access_pos_make_invoice,pos.make.invoice.user,model_pos_make_invoice,point_of_sa
 access_pos_make_invoice_manager,pos.make.invoice.manager,model_pos_make_invoice,point_of_sale.group_pos_manager,1,1,1,1
 access_pos_confirmation_wizard,pos.confirmation.wizard.user,model_pos_confirmation_wizard,point_of_sale.group_pos_user,1,1,1,1
 access_pos_confirmation_wizard_manager,pos.confirmation.wizard.manager,model_pos_confirmation_wizard,point_of_sale.group_pos_manager,1,1,1,1
+access_pos_receipt_layout,pos.receipt.layout.user,model_pos_receipt_layout,point_of_sale.group_pos_user,1,1,1,0

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
@@ -1,17 +1,18 @@
-import { Component } from "@odoo/owl";
-import { Orderline } from "@point_of_sale/app/components/orderline/orderline";
-import { ReceiptHeader } from "@point_of_sale/app/screens/receipt_screen/receipt/receipt_header/receipt_header";
-import { OrderDisplay } from "@point_of_sale/app/components/order_display/order_display";
-import { qrCodeSrc } from "@point_of_sale/utils";
-import { _t } from "@web/core/l10n/translation";
+import { Component, markup } from "@odoo/owl";
 import { formatCurrency } from "@web/core/currency";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { TagsList } from "@web/core/tags_list/tags_list";
+import { ReceiptHeader } from "@point_of_sale/app/screens/receipt_screen/receipt/receipt_header/receipt_header";
+import { qrCodeSrc, imageDataUri } from "@point_of_sale/utils";
+
+const { DateTime } = luxon;
 
 export class OrderReceipt extends Component {
     static template = "point_of_sale.OrderReceipt";
     static components = {
-        Orderline,
-        OrderDisplay,
         ReceiptHeader,
+        TagsList,
     };
     static props = {
         order: Object,
@@ -20,6 +21,14 @@ export class OrderReceipt extends Component {
     static defaultProps = {
         basic_receipt: false,
     };
+
+    get previewMode() {
+        return this.props.previewMode || false;
+    }
+
+    get layout() {
+        return this.order.config.receipt_layout;
+    }
 
     get header() {
         return {
@@ -30,20 +39,49 @@ export class OrderReceipt extends Component {
     }
 
     get order() {
-        return this.props.order;
+        return this.previewMode ? this._getPreviewOrderData() : this.props.order;
     }
 
     get qrCode() {
         const baseUrl = this.order.config._base_url;
         return (
+            !this.previewMode &&
             this.order.company.point_of_sale_use_ticket_qr_code &&
             this.order.finalized &&
             qrCodeSrc(`${baseUrl}/pos/ticket?order_uuid=${this.order.uuid}`)
         );
     }
 
+    get footerMarkup() {
+        return markup(this.order.config.receipt_footer);
+    }
+
     get paymentLines() {
         return this.order.payment_ids.filter((p) => !p.is_change);
+    }
+
+    get orderLines() {
+        return this.order.lines.filter((line) => !line.combo_parent_id);
+    }
+
+    get orderQuantity() {
+        return this.orderLines.reduce((acc, line) => acc + line.qty, 0);
+    }
+
+    get internalNotes() {
+        return JSON.parse(this.order.internal_note || "[]");
+    }
+
+    get bgImageUrl() {
+        const { receipt_bg_layout, receipt_bg_image, receipt_logo } = this.order.config;
+
+        if (receipt_bg_layout == "blank") {
+            return false;
+        }
+        if (receipt_bg_layout == "config_logo") {
+            return receipt_logo ? imageDataUri(receipt_logo) : false;
+        }
+        return receipt_bg_image ? imageDataUri(receipt_bg_image) : false;
     }
 
     formatCurrency(amount) {
@@ -67,4 +105,214 @@ export class OrderReceipt extends Component {
         }
         return _t("Tax ID: %(vatId)s", { vatId: this.order.company.vat });
     }
+
+    get receiptClasses() {
+        return {
+            table: `table border-dark mb-0 text-start ${
+                this.layout === "boxes" ? "table-bordered" : "table-borderless"
+            }`,
+            thr: {
+                "border-top border-bottom border-dark": this.layout === "lined",
+                "d-none": this.isDefaultLayout,
+            },
+        };
+    }
+
+    get isDefaultLayout() {
+        return this.layout == "default";
+    }
+
+    // meant to override these when ever needed to add/hide any columns
+    get layoutColumnKeys() {
+        return {
+            lined: ["name", "qty", "priceUnit", "price"],
+            boxes: ["index", "name", "price"],
+            default: ["qty", "name", "price"],
+        };
+    }
+    get headerColumnsData() {
+        return {
+            index: { class: "index", value: _t("No.") },
+            name: { class: "name", value: _t("Item") },
+            qty: { class: "qty", value: _t("Qty") },
+            priceUnit: { class: "price-per-unit", value: _t("Price") },
+            price: { class: "product-price price", value: _t("Total") },
+            priceTaxLabel: { class: "product-tax-label", value: _t("Tax Label") },
+        };
+    }
+
+    get layoutKey() {
+        const columnLeys = this.props.basic_receipt
+            ? this.layoutColumnKeys[this.layout].filter((key) => !key.includes("price"))
+            : this.layoutColumnKeys[this.layout];
+
+        if (this.doesAnyOrderlineHaveTaxLabel()) {
+            columnLeys.push("priceTaxLabel");
+        }
+        return columnLeys;
+    }
+
+    get headerInfo() {
+        return this.layoutKey.map((key) => this.headerColumnsData[key]);
+    }
+
+    lineData(line, lineIndex) {
+        return {
+            index: { class: "index", value: lineIndex + 1 },
+            name: {
+                class: "product-name",
+                value: line.orderDisplayProductName.name,
+                other: this._getAdditionalLineInfo(line),
+            },
+            qty: { class: "qty", value: line.qty },
+            priceUnit: {
+                class: "price-per-unit",
+                value: this.formatCurrency(line.unitDisplayPrice),
+            },
+            price: { class: "product-price price", value: line.getPriceString() },
+            priceTaxLabel: { class: "product-tax-label text-end", value: line.taxGroupLabels },
+        };
+    }
+
+    getLineInfo(line, lineIndex) {
+        const lineData = this.lineData(line, lineIndex);
+        return this.layoutKey.map((key) => lineData[key]);
+    }
+
+    // to add extra info below product name (i.e. customer note, lot number, etc.)
+    _getAdditionalLineInfo(line) {
+        const info = [];
+        if (line.orderDisplayProductName.attributeString) {
+            info.push({
+                class: "attribute-line fst-italic ms-2",
+                value: line.orderDisplayProductName.attributeString,
+            });
+        }
+        if (
+            !this.props.basic_receipt &&
+            this.isDefaultLayout &&
+            line.price !== 0 &&
+            line.qty != 1 &&
+            line.price_type !== "original"
+        ) {
+            info.push({
+                class: "price-per-unit",
+                value: `${this.formatCurrency(line.unitDisplayPrice)} / ${
+                    line.product_id.uom_id?.name || ""
+                }`,
+            });
+        }
+        if (this.layout === "boxes") {
+            info.push({
+                class: "qty",
+                value:
+                    line.qty +
+                    (this.props.basic_receipt
+                        ? " " + line.product_id.uom_id.name
+                        : " x " + this.formatCurrency(line.unitDisplayPrice)),
+            });
+        }
+        const discount = line.getDiscountStr();
+        if (!this.props.basic_receipt && discount) {
+            info.push({
+                class: "discount",
+                value: _t(
+                    "%s with a %s% discount",
+                    this.formatCurrency(line.allPrices.priceWithTaxBeforeDiscount),
+                    discount
+                ),
+                iclass: "fa-tag",
+            });
+        }
+        if (line.customer_note) {
+            info.push({
+                class: "customer-note",
+                value: line.customer_note,
+                iclass: "fa-sticky-note",
+            });
+        }
+        line.packLotLines?.forEach((lotLine) => {
+            info.push({ class: "lot-number", value: lotLine });
+        });
+        if (line.combo_line_ids?.length) {
+            let combo_info = _t("Combo Choice:");
+            line.combo_line_ids.forEach(
+                (cl) =>
+                    (combo_info += `<div class="fw-bold fst-italic">- ${cl.getFullProductName()}</div>`)
+            );
+            info.push({
+                class: "combo-options fw-bolder",
+                value: markup(combo_info),
+            });
+        }
+        return info;
+    }
+
+    _getPreviewOrderData() {
+        const _getPreviewOrderLine = (product, index) => {
+            const qty = (product.id % 8) + 1;
+            return {
+                orderDisplayProductName: { name: product.name },
+                qty: qty,
+                unitDisplayPrice: product.list_price,
+                getPriceString: () => this.formatCurrency(qty * product.list_price),
+                getDiscountStr: () => false,
+                product_id: { uom_id: { name: product.uom_id[1] } },
+            };
+        };
+
+        const orderLines = this.props.product_data.map(_getPreviewOrderLine);
+        const orderTotal = orderLines.reduce(
+            (acc, line) => acc + line.unitDisplayPrice * line.qty,
+            0
+        );
+        const taxTotals = {
+            has_tax_groups: true,
+            same_tax_base: true,
+            order_total: orderTotal,
+            order_sign: 1,
+            subtotals: [
+                {
+                    name: _t("Untaxed Amount"),
+                    base_amount_currency: orderTotal * 0.95,
+                    tax_groups: [
+                        {
+                            id: 1,
+                            group_label: false,
+                            group_name: _t("Tax 5%"),
+                            base_amount_currency: orderTotal * 0.95,
+                            tax_amount_currency: orderTotal * 0.05,
+                        },
+                    ],
+                },
+            ],
+        };
+        const paymentLines = [
+            {
+                id: 1,
+                is_change: false,
+                getAmount: () => orderTotal,
+                payment_method_id: {
+                    name: _t("Cash"),
+                },
+            },
+        ];
+        return {
+            getTotalDiscount: () => false,
+            config: this.props.config_data,
+            company: this.props.company_data,
+            currency: { id: this.props.config_data.currency_id },
+            lines: orderLines,
+            taxTotals: taxTotals,
+            payment_ids: paymentLines,
+            pos_reference: "2504-003-0001",
+            formatDateOrTime: () => DateTime.now().toLocaleString(DateTime.DATETIME_SHORT),
+            getCashierName: () => _t("Mitchell Admin"),
+            session: {},
+            tracking_number: "021",
+            date_order: DateTime.now(),
+        };
+    }
 }
+
+registry.category("lazy_components").add("OrderReceipt", OrderReceipt);

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -1,79 +1,145 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.OrderReceipt">
-        <div class="pos-receipt p-2">
+        <div class="pos-receipt table-responsive position-relative z-1" t-attf-class="pos-receipt-#{this.layout}-layout #{previewMode ? 'pos-receipt-preview' : ''}"
+            t-attf-style="font-family: #{order.config.receipt_font};">
+            <img t-if="bgImageUrl" t-att-src="bgImageUrl" class="pos-receipt-background-image" />
             <t t-set="showTaxGroupLabels" t-value="doesAnyOrderlineHaveTaxLabel()"/>
-            <ReceiptHeader order="order" />
-            <div class="pt-3"/>
-            <OrderDisplay order="order" t-slot-scope="scope" mode="'receipt'">
-                <t t-set="line" t-value="scope.line"/>
-                <Orderline line="line" showTaxGroup="showTaxGroupLabels" mode="'receipt'" basic_receipt="props.basic_receipt">
-                    <li t-if="line.customerNote" class="customer-note w-100 p-2 my-1 rounded text-break">
-                        <i class="fa fa-sticky-note me-1" role="img" aria-label="Customer Note" title="Customer Note"/>
-                        <t t-esc="line.customerNote" />
-                    </li>
-                </Orderline>
-            </OrderDisplay>
-            <t t-if="!props.basic_receipt">
-                <t t-set="taxTotals" t-value="order.taxTotals"/>
-                <div t-if="taxTotals and taxTotals.has_tax_groups" class="pos-receipt-taxes pt-3">
-                    <t t-foreach="taxTotals.subtotals" t-as="subtotal" t-key="subtotal.name">
-                        <div class="d-flex">
-                            <span class="text-nowrap mw-100">Subtotal</span>
-                            <span t-out="formatCurrency(subtotal.base_amount_currency)" class="ms-auto font-monospace"/>
-                        </div>
-
-                        <div t-foreach="subtotal.tax_groups" t-as="tax_group" t-key="tax_group.id" class="d-flex">
-                            <span>
-                                <span t-esc="tax_group.group_name"/>
-                                <t t-if="showTaxGroupLabels">
-                                    (<span t-if="tax_group.group_label" t-out="tax_group.group_label"/>)
+            <ReceiptHeader order="order" previewMode="previewMode"/>
+            <!-- Orderlines -->
+            <table t-att-class="receiptClasses.table" >
+                <thead>
+                    <tr t-att-class="receiptClasses.thr">
+                        <th t-foreach="headerInfo" t-as="headerName" t-key="headerName_index" t-out="headerName.value" t-att-class="headerName.class" class="fw-bolder"/>
+                    </tr>
+                </thead>
+                <tbody class="order-container">
+                    <t t-foreach="orderLines" t-as="line" t-key="line.id">
+                        <tr class="orderline">
+                            <td t-foreach="getLineInfo(line, line_index)" t-as="lineInfo" t-key="lineInfo_index">
+                                <div t-att-class="lineInfo.class" t-out="lineInfo.value"/>
+                                <t t-if="lineInfo.other" >
+                                    <ul class="info-list d-flex flex-column p-0 m-0">
+                                        <li t-foreach="lineInfo.other" t-as="info" t-key="info_index" t-att-class="info.class" class="list-unstyled">
+                                            <i t-if="info.iclass" t-attf-class="fa #{info.iclass} me-1"/>
+                                            <t t-out="info.value" />
+                                        </li>
+                                    </ul>
                                 </t>
-                                <t id="tax_base" t-if="!taxTotals.same_tax_base">
-                                    on
-                                    <span t-esc="formatCurrency(tax_group.base_amount_currency)"/>
-                                </t>
-                            </span>
-                            <span t-out="formatCurrency(tax_group.tax_amount_currency)" class="ms-auto font-monospace"/>
+                            </td>
+                        </tr>
+                    </t>
+                </tbody>
+            </table>
+            <div t-if="order.general_customer_note or internalNotes.length" class="receipt-order-notes p-1 ps-2">
+                <div t-if="order.general_customer_note" class="flex-wrap w-100">
+                    <t t-foreach="order.general_customer_note.trim().split('\n')" t-as="subNote" t-key="subNote_index">
+                        <div class="d-inline text-break">
+                            <t t-out="subNote"/><br/>
                         </div>
                     </t>
                 </div>
+                <div t-if="internalNotes.length" class="internal-note-container d-flex flex-wrap gap-2 mt-1">
+                    <TagsList tags="internalNotes" />
+                </div>
+            </div>
+
+            <t t-if="!props.basic_receipt">
+                <t t-set="taxTotals" t-value="order.taxTotals"/>
 
                 <!-- Total -->
-                <div class="pos-receipt-amount receipt-total fw-bolder">
-                    <span class="label-total">Total</span>
-                    <span t-out="formatCurrency(taxTotals.order_sign * taxTotals.order_total)" class="pos-receipt-right-align font-monospace"/>
+                <div class="pos-receipt-total-container">
+                    <div t-if="!isDefaultLayout" class="pos-receipt-amount total-qty">
+                        <span class="label-total-qty pe-1">Total Qty: </span>
+                        <span t-out="orderQuantity"/>
+                    </div>
+                    <div class="pos-receipt-amount pos-receipt-amount-container">
+                        <div class="receipt-total">
+                            <span class="label-total">Total</span>
+                            <span t-out="formatCurrency(taxTotals.order_sign * taxTotals.order_total)" class="pos-receipt-right-align font-monospace"/>
+                        </div>
+                        <t t-if="order.showRounding">
+                            <div class="receipt-rounding">
+                                <span class="label-rounding">Rounding</span>
+                                <span t-out='formatCurrency(taxTotals.order_sign * taxTotals.order_rounding)' class="pos-receipt-right-align font-monospace"/>
+                            </div>
+                            <div class="receipt-to-pay">
+                                <span>To Pay</span>
+                                <span t-out='formatCurrency(taxTotals.order_sign * (taxTotals.order_total + taxTotals.order_rounding))' class="pos-receipt-right-align font-monospace"/>
+                            </div>
+                        </t>
+                    </div>
                 </div>
-                <t t-if="order.showRounding">
-                    <div class="pos-receipt-amount receipt-rounding">
-                        <span class="label-rounding">Rounding</span>
-                        <span t-out='formatCurrency(taxTotals.order_sign * taxTotals.order_rounding)' class="pos-receipt-right-align font-monospace"/>
-                    </div>
-                    <div class="pos-receipt-amount receipt-to-pay">
-                        To Pay
-                        <span t-out='formatCurrency(taxTotals.order_sign * (taxTotals.order_total + taxTotals.order_rounding))' class="pos-receipt-right-align font-monospace"/>
-                    </div>
-                </t>
 
                 <!-- Payment Lines -->
-                <div class="paymentlines text-start pt-1" t-foreach="paymentLines" t-as="line" t-key="line_index">
-                    <t t-esc="line.payment_method_id.name" />
-                    <span t-out="formatCurrency(line.getAmount())" class="pos-receipt-right-align font-monospace"/>
-                </div>
+                <div t-if="paymentLines.length" class="pos-receipt-payment-container">
+                    <div t-if="!isDefaultLayout" class="pos-receipt-total-qty" />
+                    <div class="pos-receipt-amount" >
+                        <div class="paymentlines text-start" t-foreach="paymentLines" t-as="line" t-key="line_index">
+                            <span t-out="line.payment_method_id.name" />
+                            <span t-out="formatCurrency(line.getAmount())" class="pos-receipt-right-align font-monospace"/>
+                        </div>
 
-                <div t-if="order.showChange" class="pos-receipt-amount receipt-change">
-                    <span class="label-change">Change</span>
-                    <span t-out="formatCurrency(order.orderChange)" class="pos-receipt-right-align font-monospace"/>
-                </div>
+                        <div t-if="order.showChange" class="receipt-change">
+                            <span class="label-change">Change</span>
+                            <span t-out="formatCurrency(order.orderChange)" class="pos-receipt-right-align font-monospace"/>
+                        </div>
 
-                <!-- Extra Payment Info -->
-                <t t-set="totalDiscount" t-value="order.getTotalDiscount()" />
-                <t t-if="totalDiscount">
-                    <div class="text-start">
-                        <span class="label-discount">Discounts</span>
-                        <span t-out="formatCurrency(totalDiscount)" class="pos-receipt-right-align font-monospace"/>
+                        <!-- Extra Payment Info -->
+                        <t t-set="totalDiscount" t-value="order.getTotalDiscount()" />
+                        <div t-if="totalDiscount">
+                            <span class="label-discount">Discounts</span>
+                            <span t-out="formatCurrency(totalDiscount)" class="pos-receipt-right-align font-monospace"/>
+                        </div>
                     </div>
-                </t>
+                </div>
+
+                <!-- Tax Details -->
+                <div t-if="taxTotals and taxTotals.has_tax_groups" class="pos-receipt-taxes">
+                    <t t-foreach="taxTotals.subtotals" t-as="subtotal" t-key="subtotal.name">
+                        <t t-if="isDefaultLayout">
+                            <div class="d-flex">
+                                <span class="text-nowrap mw-100">Subtotal</span>
+                                <span t-out="formatCurrency(subtotal.base_amount_currency)" class="ms-auto font-monospace"/>
+                            </div>
+
+                            <div t-foreach="subtotal.tax_groups" t-as="tax_group" t-key="tax_group.id" class="d-flex">
+                                <span>
+                                    <span t-out="tax_group.group_name"/>
+                                    <t t-if="showTaxGroupLabels">
+                                        (<span t-if="tax_group.group_label" t-out="tax_group.group_label"/>)
+                                    </t>
+                                    <t t-if="!taxTotals.same_tax_base">
+                                        on
+                                        <span t-out="formatCurrency(tax_group.base_amount_currency)"/>
+                                    </t>
+                                </span>
+                                <span t-out="formatCurrency(tax_group.tax_amount_currency)" class="ms-auto"/>
+                            </div>
+                        </t>
+                        <table t-else="" class="mt-3 tax-table" t-att-class="receiptClasses.table">
+                            <thead>
+                                <tr t-att-class="receiptClasses.thr">
+                                    <th>Tax</th>
+                                    <th>Amount</th>
+                                    <th>Base</th>
+                                    <th>Total</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr t-foreach="subtotal.tax_groups" t-as="tax_group" t-key="tax_group.id">
+                                    <td>
+                                        <span t-if="showTaxGroupLabels and tax_group.group_label" t-out="tax_group.group_label" class="me-2"/>
+                                        <span t-out="tax_group.group_name"/>
+                                    </td>
+                                    <td t-out="formatCurrency(tax_group.tax_amount_currency)" />
+                                    <td t-out="formatCurrency(tax_group.base_amount_currency)" />
+                                    <td t-out="formatCurrency(tax_group.tax_amount_currency + tax_group.base_amount_currency)" />
+                                </tr>
+                            </tbody>
+                        </table>
+                    </t>
+                </div>
 
                 <div t-if="qrCode" class="gap-2 d-flex flex-row pt-3" style="font-size: 75%;">
                     <div t-if="['qr_code', 'qr_code_and_url'].includes(header.company.point_of_sale_ticket_portal_url_display_mode)" class="pt-1">
@@ -97,14 +163,14 @@
 
             <!-- Footer -->
             <div t-if="order.config.receipt_footer" class="pos-receipt-center-align pt-3 text-center" style="white-space:pre-line">
-                <t t-esc="order.config.receipt_footer" />
+                <t t-out="footerMarkup" />
             </div>
 
             <div class="after-footer">
                 <t t-foreach="paymentLines" t-as="line" t-key="line_index">
                     <t t-if="line.ticket">
                         <div class="pos-payment-terminal-receipt pt-3">
-                            <pre t-esc="line.ticket" />
+                            <pre t-out="line.ticket" />
                         </div>
                     </t>
                 </t>
@@ -113,7 +179,7 @@
             <t t-if="order.shipping_date">
                 <div class="pos-receipt-order-data d-flex gap-2 pt-3">
                     Expected delivery:
-                    <div><t t-esc="order.formatDateOrTime('shipping_date', 'date')" /></div>
+                    <div><t t-out="order.formatDateOrTime('shipping_date', 'date')" /></div>
                 </div>
             </t>
 

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js
@@ -1,9 +1,11 @@
-import { Component } from "@odoo/owl";
+import { Component, markup } from "@odoo/owl";
+import { imageDataUri } from "@point_of_sale/utils";
 
 export class ReceiptHeader extends Component {
     static template = "point_of_sale.ReceiptHeader";
     static props = {
         order: Object,
+        previewMode: { type: Boolean, optional: true },
     };
 
     get order() {
@@ -15,5 +17,17 @@ export class ReceiptHeader extends Component {
             .split("\n")
             .filter((line) => line.trim() !== "")
             .join(", ");
+    }
+
+    get receiptLogoSrc() {
+        if (this.order.config.receipt_logo) {
+            return imageDataUri(this.order.config.receipt_logo);
+        }
+        // If in preview mode, show a placeholder image if no logo is selected
+        return this.props.previewMode ? "/web/static/img/placeholder.png" : false;
+    }
+
+    get headerMarkup() {
+        return markup(this.order.config.receipt_header);
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.ReceiptHeader">
-        <img t-attf-src="/web/image?model=res.company&amp;id={{order.company.id}}&amp;field=logo" alt="Logo" class="pos-receipt-logo"/>
+        <img t-if="receiptLogoSrc" t-att-src="receiptLogoSrc" alt="Logo" class="pos-receipt-logo"/>
         <div class="text-center pt-3" style="font-size: 75%;">
             <span>
                 <t t-if="order.config._IS_VAT"> VAT </t>
@@ -12,7 +12,7 @@
         </div>
         <div class="d-flex flex-column align-items-center">
             <div class="pos-receipt-contact">
-                <div t-if="order.config.receipt_header" style="white-space:pre-line" t-esc="order.config.receipt_header" />
+                <div t-if="order.config.receipt_header" style="white-space:pre-line" class="pos-receipt-header pt-2" t-out="headerMarkup" />
                 <div t-if="order?.getCashierName() and (!order.preset_id or order.preset_id.identification === 'name')" class="cashier">
                     <div>Served by: <t t-esc="order.getCashierName()" /></div>
                 </div>

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -88,7 +88,7 @@ export class ReceiptScreen extends Component {
             {
                 order: this.pos.getOrder(),
             },
-            { addClass: "pos-receipt-print p-3" }
+            { addClass: "pos-receipt-print" }
         );
     async _sendReceiptToCustomer({ action, destination }) {
         const order = this.currentOrder;

--- a/addons/point_of_sale/static/src/backend/receipt_preview_iframe/receipt_preview_iframe.js
+++ b/addons/point_of_sale/static/src/backend/receipt_preview_iframe/receipt_preview_iframe.js
@@ -1,0 +1,93 @@
+import { App, Component, useEffect, useRef, xml } from "@odoo/owl";
+import { LazyComponent } from "@web/core/assets";
+import { registry } from "@web/core/registry";
+import { getTemplate } from "@web/core/templates";
+import { _t } from "@web/core/l10n/translation";
+
+/**
+ * This component renders a preview of the receipt in the configuration wizard.
+ * On the first render, it injects the HTML content into the iframe and ensures all required assets are properly loaded.
+ * On subsequent updates, it re-mounts the receipt component with the latest props whenever they change.
+ */
+export class ReceiptPreview extends Component {
+    static template = xml`
+        <div class="o_receipt_preview_iframe_wrapper">
+            <iframe t-ref="iframeRef" sandbox="allow-scripts allow-same-origin" style="width: 360px; height: 650px"/>
+        </div>
+    `;
+
+    setup() {
+        this.iframeRef = useRef("iframeRef");
+        this.isLoading = false;
+        useEffect(
+            (value) => {
+                if (!this.wrapwrapEl) {
+                    this._loadHtmlIntoIframe(value);
+                } else if (!this.props.record.data["write_date"]) {
+                    this._mountReceiptComponent(value);
+                }
+            },
+            () => [this.props.record.data[this.props.name]]
+        );
+    }
+
+    get wrapwrapEl() {
+        return this.iframeRef.el.contentDocument.getElementById("wrapwrap");
+    }
+
+    _loadHtmlIntoIframe(value) {
+        const iframeDoc = this.iframeRef.el.contentDocument;
+
+        // Initialize iframe with HTML content only once
+        iframeDoc.open();
+        iframeDoc.write(value);
+        iframeDoc.close();
+
+        // Load the receipt component once the iframe finishes loading html
+        this.iframeRef.el.addEventListener("load", () => {
+            this._mountReceiptComponent(value, true);
+        });
+    }
+
+    _mountReceiptComponent(value, isFirstMount = false) {
+        if (!this.wrapwrapEl || this.isLoading) {
+            return;
+        }
+        this.isLoading = true;
+
+        // Extract component props from the raw HTML content.
+        const el = new DOMParser()
+            .parseFromString(value, "text/html")
+            .querySelector("receipt-component");
+        const props = JSON.parse(el?.getAttribute("props") || "{}");
+
+        // Mount the LazyComponent, which will lazily load the OrderReceipt component.
+        // Using LazyComponent prevents loading all OrderReceipt component assets in the `assets_backend` bundle upfront.
+        const app = new App(LazyComponent, {
+            getTemplate,
+            props: {
+                bundle: "point_of_sale.receipt_assets_lazy",
+                Component: "OrderReceipt",
+                props: props,
+            },
+            translateFn: _t,
+        });
+        this.wrapwrapEl.innerHTML = "";
+        app.mount(this.wrapwrapEl);
+        app.root.mounted.push(() => {
+            this.isLoading = false;
+            if (isFirstMount) {
+                // Hide the loader once the component has been mounted
+                document.querySelector(".receipt_preview_spinner")?.classList.add("d-none");
+            }
+        });
+    }
+}
+
+export const receiptPreview = {
+    component: ReceiptPreview,
+    displayName: "POS Receipt Preview",
+    supportedTypes: ["text", "html"],
+};
+
+registry.category("fields").add("receipt_preview_iframe", receiptPreview);

--- a/addons/point_of_sale/static/src/css/pos_receipts.css
+++ b/addons/point_of_sale/static/src/css/pos_receipts.css
@@ -1,7 +1,33 @@
 .pos-receipt-print {
     width: 512px;
-    font-size: 22px;
+    font-size: 24px;
     color: #000000;
+    overflow: hidden;
+}
+
+.pos-receipt{
+    --dark-rgb: #111827;
+}
+
+.pos-receipt-preview {
+    padding: 8px;
+}
+
+#wrapwrap {
+    display: inline-block;
+    border: 2px solid #dee2e6;
+    border-radius: 0.25rem;
+    text-align: left;
+    overflow-y: auto;
+}
+
+.pos-receipt-background-image {
+    position: absolute;
+    width: 85%;
+    top: 50%;
+    left: 50%;
+    transform: translateY(-50%) translateX(-50%);
+    opacity: 0.25;
 }
 
 .pos-receipt .pos-receipt-right-align {
@@ -38,7 +64,21 @@
 }
 
 .pos-receipt .pos-receipt-amount {
+    width: 60%;
     text-align: start;
+}
+
+.pos-receipt-total-container, .pos-receipt-payment-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.pos-receipt .total-qty {
+    text-align: start;
+    width: 40%;
+    display: flex;
+    font-weight: bolder;
 }
 
 .pos-receipt .pos-receipt-title {
@@ -53,7 +93,7 @@
 }
 
 .pos-receipt .attribute-line {
-    font-size: 85%;
+    font-size: 90%;
 }
 
 .pos-payment-terminal-receipt {
@@ -80,15 +120,121 @@
     flex-direction: column;
 }
 
-.pos-receipt .orderlines {
-    /*rtl:ignore*/
-    direction: ltr;
+.pos-receipt-amount > span:first-child, .pos-receipt-amount > div > span:first-child {
+    font-weight: bolder;
 }
 
-.pos-receipt-print .qty {
-    min-width: 3.5rem;
+.pos-receipt .price {
+    text-align: end;
 }
 
-.pos-receipt-print .info-list {
-    margin-left: 1.5rem !important;
+.tax-table tr > * {
+    text-align: center;
+    padding: 2px 4px !important;
+}
+
+.tax-table th {
+    font-weight: bold;
+}
+
+.pos-receipt .paymentlines {
+    display: flex;
+    justify-content: space-between;
+    align-items: end;
+}
+
+.pos-receipt .receipt-total{
+    font-size: 125% !important;
+    font-weight: bolder;
+}
+
+.pos-receipt-payment-container,
+.pos-receipt-amount-container,
+.pos-receipt-taxes{
+    font-size: 90%;
+}
+
+.pos-receipt .info-list{
+    font-size: 75%;
+}
+
+/* Layout releted styles */
+.pos-receipt-default-layout {
+    .pos-receipt-amount {
+        width: 100%;
+    }
+    .orderline td {
+        padding: 4px;
+    }
+}
+
+.pos-receipt-boxes-layout {
+    .pos-receipt-amount {
+        border: 1px solid var(--dark-rgb);
+        padding: 0.5rem 0.35rem;
+        border-top: none;
+    }
+    .pos-receipt-amount-container {
+        border-bottom: none;
+        border-right: none;
+    }
+    .total-qty {
+        padding: 0.5rem 0.35rem;
+        border: none;
+    }
+    .product-name {
+        font-weight: bolder;
+    }
+    td, th {
+        padding: 4px;
+    }
+    .orderline {
+        border-top: 1px solid var(--dark-rgb);
+        border-bottom: 1px solid var(--dark-rgb);
+    }
+    .pos-receipt-total-container {
+        border: 1px solid var(--dark-rgb);
+        border-top: none;
+    }
+    .receipt-order-notes {
+        border: 1px solid var(--dark-rgb);
+        border-top: none;
+    }
+}
+
+.pos-receipt-lined-layout {
+    .pos-receipt-amount {
+        padding: 4px 0;
+    }
+    td {
+        padding: 8px 2px;
+    }
+    th {
+        padding: 4px 2px;
+    }
+    .pos-receipt-total-container {
+        border-top: 1px solid var(--dark-rgb);
+        padding-top: 4px;
+    }
+    .tax-table tr *{
+        text-align: end;
+    }
+    .tax-table tr *:first-child {
+        text-align: start;
+    }
+    .tax-table tr {
+        padding: 0 4px;
+    }
+    .receipt-total {
+        background-color: var(--dark-rgb);
+        color: #ffffff;
+        padding: 2px 8px;
+        border-radius: 6px;
+    }
+    .pos-receipt-payment-container > * {
+        padding: 2px 8px;
+    }
+    .price-per-unit, .price {
+        text-align: end;
+    }
 }

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -174,3 +174,14 @@ export function isValidEmail(email) {
 }
 
 export const LONG_PRESS_DURATION = session.test_mode ? 100 : 1000;
+
+const FILETYPE_BASE64_MAGICWORD = {
+    "/": "jpg",
+    R: "gif",
+    i: "png",
+    P: "svg+xml",
+    U: "webp",
+};
+export function imageDataUri(base64_source) {
+    return `data:image/${FILETYPE_BASE64_MAGICWORD[base64_source[0]]};base64,${base64_source}`;
+}

--- a/addons/point_of_sale/static/tests/pos/tours/receipt_configuration_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/receipt_configuration_tour.js
@@ -1,0 +1,59 @@
+import { waitFor } from "@odoo/hoot-dom";
+import { registry } from "@web/core/registry";
+
+async function checkReceiptLayout(layout) {
+    await waitFor("body .receipt_preview_spinner.d-none", { timeout: 10000 });
+
+    const iframe = document.querySelector("iframe");
+    const receipt = iframe.contentDocument.querySelector(".pos-receipt");
+
+    if (!iframe || !receipt) {
+        new Error("Preview receipt is missing in the receipt configurator.");
+    }
+
+    if (!receipt.classList.contains(`pos-receipt-${layout}-layout`)) {
+        new Error(`Preview receipt does not use the '${layout}' layout.`);
+    }
+}
+
+registry.category("web_tour.tours").add("ReceiptLayoutConfigurationTour", {
+    steps: () =>
+        [
+            {
+                content: "Click to open the receipt configurator",
+                trigger: "button[name=action_view_pos_receipt_layout]",
+                run: "click",
+            },
+            {
+                content: "Check receipt configurator is open",
+                trigger: ".modal-header .modal-title:contains('Configure receipt')",
+            },
+            {
+                content: "Check the preview receipt uses the default 'default' layout",
+                trigger: "div[name=receipt_preview] .o_receipt_preview_iframe_wrapper iframe",
+                timeout: 15000,
+                run: async () => await checkReceiptLayout("default"),
+            },
+            {
+                content: "Select the 'Boxes' layout option",
+                trigger: "div[name=receipt_layout] span:contains('Boxes')",
+                run: "click",
+            },
+            {
+                content: "Verify the preview updates to use the 'Boxes' layout",
+                trigger: "div[name=receipt_preview] .o_receipt_preview_iframe_wrapper iframe",
+                timeout: 15000,
+                run: async () => await checkReceiptLayout("Boxes"),
+            },
+            {
+                content: "Click to save your layout configuration",
+                trigger: ".modal-footer button[name=receipt_layout_save]",
+                run: "click",
+            },
+            {
+                content: "Return to the home menu",
+                trigger: ".o_main_navbar a[title='Home menu']",
+                run: "click",
+            },
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
@@ -240,3 +240,20 @@ registry.category("web_tour.tours").add("point_of_sale.test_printed_receipt_tour
             }, "Basic receipt doesn't have price"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("ReceiptLayoutTour", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Desk Pad", "1", "5"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+
+            ReceiptScreen.receiptIsThere(),
+            ReceiptScreen.hasLayout("boxes"),
+            ReceiptScreen.containsReceiptHeader("Because boring receipts are so outdated"),
+            ReceiptScreen.noReceiptLogo(),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
@@ -239,3 +239,30 @@ export function discardOrderWarningDialog() {
         Dialog.discard(),
     ];
 }
+
+export function hasLayout(layoutName) {
+    return [
+        {
+            content: `receipt should use the ${layoutName} layout format`,
+            trigger: `.receipt-screen .pos-receipt.pos-receipt-${layoutName}-layout`,
+        },
+    ];
+}
+
+export function containsReceiptHeader(headerText) {
+    return [
+        {
+            content: "receipt should have header text",
+            trigger: `.receipt-screen .pos-receipt .pos-receipt-header:has(h2:contains(${headerText}))`,
+        },
+    ];
+}
+
+export function noReceiptLogo() {
+    return [
+        {
+            content: "receipt should not display a logo",
+            trigger: ".receipt-screen .pos-receipt:not(:contains('.pos-receipt-logo'))",
+        },
+    ];
+}

--- a/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
@@ -226,7 +226,7 @@ export function containsOrderLine(name, quantity, price_unit, line_price) {
     return [
         {
             content: `Order line with name: ${name}, quantity: ${quantity}, price per unit: ${price_unit}, and line price: ${line_price} exists`,
-            trigger: `.pos-receipt .orderline:has(.product-name:contains('${name}') .qty:contains('${quantity}')):has(.product-price:contains('${line_price}')):has(.price-per-unit:contains('${price_unit}'))`,
+            trigger: `.pos-receipt .orderline:has(.product-name:contains('${name}')):has(.qty:contains('${quantity}')):has(.product-price:contains('${line_price}')):has(.price-per-unit:contains('${price_unit}'))`,
         },
     ];
 }

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1190,6 +1190,34 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour("point_of_sale.test_printed_receipt_tour")
 
+    def test_receipt_layout(self):
+        self.main_pos_config.write({
+            'receipt_layout': 'boxes',
+            'receipt_header': '<h2>Because boring receipts are so outdated</h2>',
+            'receipt_logo': False,
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour("ReceiptLayoutTour")
+
+    def test_receipt_layout_configuration(self):
+        """ Test the Receipt Layout Configuration Wizard.
+
+            This test ensures that the receipt configurator wizard loads correctly. A failure here often
+            means the wizard is not opening properly, possibly due to missing data in `_getPreviewOrderData`,
+            which is responsible for generating the receipt preview.
+
+            To fix issues, ensure that `_getPreviewOrderData` returns all required fields to render the preview.
+        """
+        pos_config_id = self.main_pos_config
+        self.pos_admin.group_ids += self.env.ref('base.group_system')
+
+        def _default_pos_config_patch(*_args, **_kwargs):
+            return pos_config_id
+
+        with patch.object(self.env.registry.models['res.config.settings'], "_default_pos_config", _default_pos_config_patch):
+            self.start_tour("/odoo/settings#point_of_sale", 'ReceiptLayoutConfigurationTour', login="pos_admin")
+            self.assertEqual(self.main_pos_config.receipt_layout, 'boxes')
+
     def test_limited_product_pricelist_loading(self):
         self.env['ir.config_parameter'].sudo().set_param('point_of_sale.limited_product_count', '1')
 

--- a/addons/point_of_sale/tests/test_res_config_settings.py
+++ b/addons/point_of_sale/tests/test_res_config_settings.py
@@ -40,45 +40,25 @@ class TestConfigureShops(TestPoSCommon):
 
         pos_config1 = self.env['pos.config'].create({'name': 'Shop 1', 'module_pos_restaurant': False})
         pos_config2 = self.env['pos.config'].create({'name': 'Shop 2', 'module_pos_restaurant': False})
-        self.assertEqual(pos_config1.receipt_header, False)
-        self.assertEqual(pos_config2.receipt_header, False)
+        self.assertFalse(pos_config1.basic_receipt)
+        self.assertFalse(pos_config2.basic_receipt)
 
         # Modify Shop 1.
         with Form(self.env['res.config.settings']) as form:
             form.pos_config_id = pos_config1
-            form.pos_is_header_or_footer = True
-            form.pos_receipt_header = 'xxxxx'
+            form.pos_basic_receipt = True
             form.account_tax_return_journal_id = self.account_tax_return_journal
 
-        self.assertEqual(pos_config1.receipt_header, 'xxxxx')
-        self.assertEqual(pos_config2.receipt_header, False)
+        self.assertTrue(pos_config1.basic_receipt)
+        self.assertFalse(pos_config2.basic_receipt)
 
         # Modify Shop 2.
         with Form(self.env['res.config.settings']) as form:
             form.pos_config_id = pos_config2
-            form.pos_is_header_or_footer = True
-            form.pos_receipt_header = 'yyyyy'
+            form.pos_basic_receipt = True
 
-        self.assertEqual(pos_config1.receipt_header, 'xxxxx')
-        self.assertEqual(pos_config2.receipt_header, 'yyyyy')
-
-    def test_is_header_or_footer_to_false(self):
-        self._remove_on_payment_taxes()
-
-        pos_config = self.env['pos.config'].create({
-            'name': 'Shop',
-            'is_header_or_footer': True,
-            'module_pos_restaurant': False,
-            'receipt_header': 'header val',
-            'receipt_footer': 'footer val',
-        })
-
-        with Form(self.env['res.config.settings']) as form:
-            form.pos_config_id = pos_config
-            form.pos_is_header_or_footer = False
-
-        self.assertEqual(pos_config.receipt_header, False)
-        self.assertEqual(pos_config.receipt_footer, False)
+        self.assertTrue(pos_config1.basic_receipt)
+        self.assertTrue(pos_config2.basic_receipt)
 
     def test_properly_set_pos_config_x2many_fields(self):
         """Simulate what is done from the res.config.settings view when editing x2 many fields."""

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -20,7 +20,7 @@
 
                 <app data-string="Point of sale" string="Point of Sale" name="point_of_sale" groups="point_of_sale.group_pos_manager">
                     <div style="z-index:1000;" class="position-fixed w-100 bg-white">
-                        <setting type="header" string="Point of Sale">
+                        <setting type="header" string="Point of Sale">  
                             <field name="pos_config_id" options="{'no_open': True, 'no_create': True}" title="Settings on this page will apply to this point of sale."/>
                             <button name="action_pos_config_create_new" type="object" string="+ New Shop" class="btn btn-link"/>
                         </setting>
@@ -295,18 +295,8 @@
                             </block>
 
                             <block title="Bills &amp; Receipts" id="pos_bills_and_receipts_section">
-                                <setting help="Add a custom message to header and footer" documentation="/applications/sales/point_of_sale/receipts_invoices.html">
-                                    <field name="pos_is_header_or_footer"/>
-                                    <div class="content-group mt16" invisible="not pos_is_header_or_footer">
-                                        <div>
-                                            <label string="Header" for="pos_receipt_header" class="col-lg-2 o_light_label"/>
-                                            <field name="pos_receipt_header" placeholder="e.g. Company Address, Website"/>
-                                        </div>
-                                        <div>
-                                            <label string="Footer" for="pos_receipt_footer" class="col-lg-2 o_light_label"/>
-                                            <field name="pos_receipt_footer" placeholder="e.g. Return Policy, Thanks for shopping with us!"/>
-                                        </div>
-                                    </div>
+                                <setting string="Receipt Layout">
+                                    <button name="action_view_pos_receipt_layout" string="Configure Receipt" type="object" class="oe_link" icon="oi-arrow-right"/>
                                 </setting>
                                 <setting id="auto_printing" help="Print receipts automatically once the payment is registered" documentation="/applications/sales/point_of_sale/receipts_invoices.html">
                                     <field name="pos_iface_print_auto"/>

--- a/addons/point_of_sale/wizard/__init__.py
+++ b/addons/point_of_sale/wizard/__init__.py
@@ -7,3 +7,4 @@ from . import pos_close_session_wizard
 from . import pos_daily_sales_reports
 from . import pos_confirmation_wizard
 from . import pos_make_invoice
+from . import pos_receipt_layout

--- a/addons/point_of_sale/wizard/pos_receipt_layout.py
+++ b/addons/point_of_sale/wizard/pos_receipt_layout.py
@@ -1,0 +1,68 @@
+import json
+
+from odoo import api, fields, models, _
+
+
+class PosReceiptLayout(models.TransientModel):
+    _name = 'pos.receipt.layout'
+    _description = 'POS Receipt Layout'
+
+    pos_config_id = fields.Many2one('pos.config', string='Point of Sale', required=True)
+    receipt_layout = fields.Selection(related='pos_config_id.receipt_layout', readonly=False, required=True)
+    receipt_logo = fields.Binary(related='pos_config_id.receipt_logo', readonly=False)
+    receipt_bg_layout = fields.Selection(related='pos_config_id.receipt_bg_layout', readonly=False)
+    receipt_bg_image = fields.Binary(related='pos_config_id.receipt_bg_image', readonly=False)
+    receipt_header = fields.Html(related='pos_config_id.receipt_header', readonly=False)
+    receipt_footer = fields.Html(related='pos_config_id.receipt_footer', readonly=False)
+    receipt_font = fields.Selection(related='pos_config_id.receipt_font', readonly=False)
+    receipt_preview = fields.Html(compute='_compute_receipt_preview', sanitize=False)
+    basic_receipt_preview = fields.Boolean(string='Basic Receipt Preview')
+
+    @api.depends('receipt_layout', 'receipt_logo', 'receipt_bg_layout', 'receipt_bg_image', 'receipt_header', 'receipt_footer', 'receipt_font', 'basic_receipt_preview')
+    def _compute_receipt_preview(self):
+        for wizard in self:
+            preview_props = wizard._get_preivew_data()
+            wizard.receipt_preview = wizard.env['ir.ui.view']._render_template(
+                'point_of_sale.pos_receipt_layout_preview',
+                {
+                    'title': 'POS Receipt Preview',
+                    'props': json.dumps(preview_props)
+                }
+            )
+
+    def _get_preivew_data(self):
+        company_data = self.pos_config_id.company_id.read(['id', 'phone', 'email', 'website', 'street', 'city', 'state_id', 'zip'])[0]
+
+        config_data = {
+            'id': self.pos_config_id.id,
+            'receipt_layout': self.receipt_layout,
+            'receipt_logo': self.receipt_logo and self.receipt_logo.decode('utf-8'),
+            'receipt_bg_layout': self.receipt_bg_layout,
+            'receipt_bg_image': self.receipt_bg_image and self.receipt_bg_image.decode('utf-8'),
+            'receipt_header': self.receipt_header,
+            'receipt_footer': self.receipt_footer,
+            'receipt_font': self.receipt_font,
+            'currency_id': self.pos_config_id.currency_id.id,
+        }
+        return {
+            'company_data': company_data,
+            'config_data': config_data,
+            'previewMode': True,
+            'basic_receipt': self.basic_receipt_preview,
+            'product_data': self._get_preview_products(),
+        }
+
+    def _get_preview_products(self):
+        excluded_product_ids = self.env['pos.config']._get_special_products().product_tmpl_id.ids
+        unit_uom = self.env.ref('uom.product_uom_unit')
+        domain = [('id', 'not in', excluded_product_ids), ('list_price', 'not in', [0.0])]
+        if self.pos_config_id.iface_available_categ_ids:
+            domain += [('pos_categ_ids', 'in', self.pos_config_id.iface_available_categ_ids.ids)]
+        return self.env['product.template'].search_read(domain, ['name', 'list_price', 'uom_id'], limit=4) or [
+            {'id': 5, 'name': _('Margarita Pizza'), 'list_price': 11.35, 'uom_id': [unit_uom.id, unit_uom.name]},
+            {'id': 2, 'name': _('Apple Pie'), 'list_price': 13.0, 'uom_id': [unit_uom.id, unit_uom.name]},
+            {'id': 3, 'name': _('Chees Burger'), 'list_price': 12.2, 'uom_id': [unit_uom.id, unit_uom.name]},
+        ]
+
+    def receipt_layout_save(self):
+        return {'type': 'ir.actions.act_window_close'}

--- a/addons/point_of_sale/wizard/pos_receipt_layout.xml
+++ b/addons/point_of_sale/wizard/pos_receipt_layout.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_pos_receipt_layout" model="ir.ui.view">
+            <field name="name">Receipt Layout</field>
+            <field name="model">pos.receipt.layout</field>
+            <field name="arch" type="xml">
+                <form class="o_document_layout">
+                    <group>
+                        <group class="o_document_layout_company">
+                            <field name="pos_config_id" invisible="1"/>
+                            <field name="receipt_layout" widget="selection_badge" options="{'size': 'sm'}"/>
+                            <field name="receipt_logo" string="Logo" widget="image" options="{'size': [0, 50]}"/>
+                            <field name="receipt_bg_layout" required="1"/>
+                            <field name="receipt_bg_image" options="{'accepted_file_extensions': 'image/*'}" string="Background Image" invisible="receipt_bg_layout != 'custom'" required="receipt_bg_layout == 'custom'">Upload your file</field>
+                            <field name="receipt_font" string="Text" required="1"/>
+                            <field name="receipt_header" string="Header" placeholder="e.g. Shop Name, Location" />
+                            <field name="receipt_footer" string="Footer" placeholder="Thanks, visit again ..." />
+                            <separator string="Preview Options"/>
+                            <field name="basic_receipt_preview" />
+                        </group>
+                        <div class="o_preview position-relative">
+                            <field name="receipt_preview" widget="receipt_preview_iframe" class="w-100 h-100 d-flex justify-content-center mb-0" />
+                            <div class="receipt_preview_spinner spinner-border position-absolute top-50 start-50" style="width: 40px; height: 40px;" />
+                        </div>
+                    </group>
+                    <footer>
+                        <button string="Continue" class="btn-primary" type="object" name="receipt_layout_save" data-hotkey="q"/>
+                        <button special="cancel" data-hotkey="x" string="Discard" />
+                    </footer>
+                </form>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/point_of_sale/wizard/pos_receipt_layout_preview.xml
+++ b/addons/point_of_sale/wizard/pos_receipt_layout_preview.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="pos_receipt_layout_preview">
+        <t t-call="web.layout">
+            <t t-set="head">
+                <t t-call-assets="point_of_sale.receipt_assets" />
+            </t>
+            <t t-set="body_classname" t-value="'overflow-hidden'"/>
+            <div id="wrapwrap" class="h-100">
+                <receipt-component t-att-props="props"/>
+            </div>
+        </t>
+    </template>
+</odoo>

--- a/addons/pos_event/static/src/app/screens/receipt_screen/receipt/order_receipt.js
+++ b/addons/pos_event/static/src/app/screens/receipt_screen/receipt/order_receipt.js
@@ -1,0 +1,16 @@
+import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
+import { patch } from "@web/core/utils/patch";
+
+patch(OrderReceipt.prototype, {
+    _getAdditionalLineInfo(line) {
+        const info = super._getAdditionalLineInfo(line);
+        if (line.event_ticket_id) {
+            info.push({
+                class: "event-name",
+                value: line.event_ticket_id.event_id.name,
+                iclass: "fa-ticket",
+            });
+        }
+        return info;
+    },
+});

--- a/addons/pos_loyalty/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
+++ b/addons/pos_loyalty/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
@@ -2,6 +2,9 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="pos_coupon.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
+        <xpath expr="//tbody[hasclass('order-container')]//tr" position="attributes">
+            <attribute name="t-att-class">{"fst-italic": line.is_reward_line}</attribute>
+        </xpath>
         <xpath expr="//div[hasclass('pos-receipt')]//div[hasclass('before-footer')]" position="inside">
             <t t-if="order.new_coupon_info and order.new_coupon_info.length !== 0">
                 <div class="pos-coupon-rewards pt-3">

--- a/addons/pos_loyalty/static/src/css/Loyalty.scss
+++ b/addons/pos_loyalty/static/src/css/Loyalty.scss
@@ -1,3 +1,11 @@
 .pos-coupon-rewards .coupon-container {
     font-size: 75%;
 }
+
+.pos-receipt .loyalty,.pos-receipt .loyalty-customer {
+    font-size: 90%;
+}
+
+.pos-receipt .loyalty > div > *:first-child {
+    font-weight: bolder;
+}

--- a/addons/pos_restaurant/static/src/app/components/orderline/orderline.xml
+++ b/addons/pos_restaurant/static/src/app/components/orderline/orderline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_sale.Orderline" t-inherit="point_of_sale.Orderline" t-inherit-mode="extension">
+    <t t-name="pos_restaurant.Orderline" t-inherit="point_of_sale.Orderline" t-inherit-mode="extension">
         <xpath expr="//t[@t-esc='line.getQuantityStr().unitPart']" position="replace">
             <t t-esc="line.uiState.splitQty or line.getQuantityStr().unitPart"/>
         </xpath>

--- a/addons/pos_restaurant/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
+++ b/addons/pos_restaurant/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
@@ -3,7 +3,7 @@
 
     <t t-name="pos_restaurant.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
         <xpath expr="//ReceiptHeader" position="after">
-            <div t-if="!order.finalized" class="fs-2 mb-1">Pro forma receipt</div>
+            <div t-if="!order.finalized" class="fs-2 mb-1 text-center">Pro forma receipt</div>
         </xpath>
         <xpath expr="//div[hasclass('before-footer')]" position="after">
             <t t-if="order.config.set_tip_after_payment">

--- a/addons/pos_restaurant/static/src/scss/restaurant.scss
+++ b/addons/pos_restaurant/static/src/scss/restaurant.scss
@@ -29,6 +29,7 @@
 
 .pos-receipt .tip-form > div {
     margin-top: 1rem;
+    font-size: 90%;
 }
 
 .tip-cell {

--- a/addons/pos_sale/static/src/app/components/screens/receipt_screen/receipt/order_receipt.js
+++ b/addons/pos_sale/static/src/app/components/screens/receipt_screen/receipt/order_receipt.js
@@ -1,0 +1,16 @@
+import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
+import { patch } from "@web/core/utils/patch";
+
+patch(OrderReceipt.prototype, {
+    _getAdditionalLineInfo(line) {
+        const info = super._getAdditionalLineInfo(line);
+        if (line.sale_order_origin_id?.name) {
+            info.push({
+                class: "sale-order-name",
+                value: line.sale_order_origin_id?.name,
+                iclass: "fa-shopping-basket",
+            });
+        }
+        return info;
+    },
+});


### PR DESCRIPTION
Now users can configure their receipt format for each POS configuration. 
Configuration options are accessible through the `pos_receipt_layout` wizard.

The following options are editable with this wizard:
- **Receipt Layout:** Users can choose the overall look of the receipt. Available options are: "Default", "Boxed", "Lined"
- **Receipt Logo:** A logo is displayed at the top of the receipt.
- **Receipt Font:** Allows changing the overall font of the receipt.
- **Background Image:** Enables custom backgrounds for the receipt.
- **Header and Footer:** Personalize the receipt with custom header & footer content


Task - 4411861

Related- odoo/upgrade#7140