### PR TITLE
[IMP] core: log xmlrpc/jsonrpc model and method

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -2041,6 +2041,8 @@ class Application:
             del current_thread.dbname
         if hasattr(current_thread, 'uid'):
             del current_thread.uid
+        if hasattr(current_thread, 'rpc_path'):
+            del current_thread.rpc_path
 
         if odoo.tools.config['proxy_mode'] and environ.get("HTTP_X_FORWARDED_HOST"):
             # The ProxyFix middleware has a side effect of updating the

--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -24,17 +24,19 @@ MAX_TRIES_ON_CONCURRENCY_FAILURE = 5
 
 
 def dispatch(method, params):
-    db, uid, passwd = params[0], int(params[1]), params[2]
+    db, uid, passwd, model, model_method, *args = params
+    uid = int(uid)
     security.check(db, uid, passwd)
 
     threading.current_thread().dbname = db
     threading.current_thread().uid = uid
+    threading.current_thread().rpc_path = f'/{model}/{model_method}'
     registry = odoo.registry(db).check_signaling()
     with registry.manage_changes():
         if method == 'execute':
-            res = execute(db, uid, *params[3:])
+            res = execute(db, uid, model, model_method, *args)
         elif method == 'execute_kw':
-            res = execute_kw(db, uid, *params[3:])
+            res = execute_kw(db, uid, model, model_method, *args)
         else:
             raise NameError("Method not available %s" % method)
     return res

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -159,6 +159,14 @@ class RequestHandler(werkzeug.serving.WSGIRequestHandler):
             self.rfile = BytesIO()
             self.wfile = BytesIO()
 
+    @property
+    def path(self):
+        return self._opath + getattr(threading.current_thread(), 'rpc_path', '')
+
+    @path.setter
+    def path(self, path):
+        self._opath = path
+
 class ThreadedWSGIServerReloadable(LoggingBaseWSGIServerMixIn, werkzeug.serving.ThreadedWSGIServer):
     """ werkzeug Threaded WSGI Server patched to allow reusing a listen socket
     given by the environment, this is used by autoreload to keep the listen


### PR DESCRIPTION
decided to log *after* the method was executed, so the log line appears the closest to werkzeug's one

success log:
```
2025-01-30 11:32:17,819 23543 INFO odoo-dispatch-rpc-log odoo.service.model: called test_http.galaxy render 
2025-01-30 11:32:17,819 23543 INFO odoo-dispatch-rpc-log werkzeug: 127.0.0.1 - - [30/Jan/2025 11:32:17] "POST /jsonrpc HTTP/1.0" 200 - 4 0.001 0.020
```
success log with `--log-handle odoo.service.model:DEBUG`
```

2025-01-30 11:37:16,538 24288 DEBUG odoo-dispatch-rpc-log odoo.service.model: called test_http.galaxy render with args (1,) kwargs {}
2025-01-30 11:37:16,538 24288 INFO odoo-dispatch-rpc-log werkzeug: 127.0.0.1 - - [30/Jan/2025 11:37:16] "POST /jsonrpc HTTP/1.0" 200 - 22 0.008 0.629
```


error log:
```
2025-01-30 11:33:20,382 23707 INFO odoo-dispatch-rpc-log odoo.service.model: called test_http.galaxy render
2025-01-30 11:33:20,384 23707 ERROR odoo-dispatch-rpc-log odoo.http: Exception during request handling. 
Traceback (most recent call last):
  File "/home/julien/Odoo/community/odoo/http.py", line 2066, in __call__
    response = request._serve_db()
  File "/home/julien/Odoo/community/odoo/http.py", line 1653, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/julien/Odoo/community/odoo/service/model.py", line 137, in retrying
    result = func()
  File "/home/julien/Odoo/community/odoo/http.py", line 1681, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/julien/Odoo/community/odoo/http.py", line 1885, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/julien/Odoo/community/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/home/julien/Odoo/community/odoo/http.py", line 734, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/julien/Odoo/community/odoo/addons/base/controllers/rpc.py", line 163, in jsonrpc
    return dispatch_rpc(service, method, args)
  File "/home/julien/Odoo/community/odoo/http.py", line 369, in dispatch_rpc
    return dispatch(method, params)
  File "/home/julien/Odoo/community/odoo/service/model.py", line 35, in dispatch
    res = execute(db, uid, *params[3:])
  File "/home/julien/Odoo/community/odoo/service/model.py", line 69, in execute
    res = execute_cr(cr, uid, obj, method, *args, **kw)
  File "/home/julien/Odoo/community/odoo/service/model.py", line 51, in execute_cr
    0/0
ZeroDivisionError: division by zero
2025-01-30 11:33:20,384 23707 INFO odoo-dispatch-rpc-log werkzeug: 127.0.0.1 - - [30/Jan/2025 11:33:20] "POST /jsonrpc HTTP/1.0" 200 - 16 0.004 0.610
```