### PR TITLE
[FIX] website_sale: fix alternative products not showing

### DIFF
--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/dynamic_snippet_products.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/dynamic_snippet_products.js
@@ -85,7 +85,7 @@ export class DynamicSnippetProducts extends DynamicSnippetCarousel {
      * @override
      */
     getRpcParameters() {
-        const productTemplateIdEl = document.body.querySelector("#product_details .product_category_id");
+        const productTemplateIdEl = document.body.querySelector("#product_details .product_template_id");
         return Object.assign(super.getRpcParameters(...arguments), {
             productTemplateId: productTemplateIdEl ? productTemplateIdEl.value : undefined,
         });


### PR DESCRIPTION
Steps:
- Create a product and add another product to it's alternate products
- Go to product page of first product

Issue:
- Alternate product snippet not visible

Cause:
- `getRpcParameters()` was changed in publicwidget to interaction PR

Fix:
- reverted the function

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
