### PR TITLE
[FIX] mail: empty push notification when tracking record changes

### DIFF
--- a/addons/mail/static/src/core/web/message_patch.js
+++ b/addons/mail/static/src/core/web/message_patch.js
@@ -1,20 +1,8 @@
+import { formatTrackingOrNone } from "@mail/utils/common/format";
 import { Message } from "@mail/core/common/message";
 import { markEventHandled } from "@web/core/utils/misc";
 
-import {
-    deserializeDate,
-    deserializeDateTime,
-    formatDate,
-    formatDateTime,
-} from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
-import {
-    formatChar,
-    formatFloat,
-    formatInteger,
-    formatMonetary,
-    formatText,
-} from "@web/views/fields/formatters";
 import { useService } from "@web/core/utils/hooks";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { patch } from "@web/core/utils/patch";
@@ -68,53 +56,8 @@ patch(Message.prototype, {
     /**
      * @returns {string}
      */
-    formatTracking(trackingType, trackingValue) {
-        switch (trackingType) {
-            case "boolean":
-                return trackingValue.value ? _t("Yes") : _t("No");
-            /**
-             * many2one formatter exists but is expecting id/display_name or data
-             * object but only the target record name is known in this context.
-             *
-             * Selection formatter exists but requires knowing all
-             * possibilities and they are not given in this context.
-             */
-            case "char":
-            case "many2one":
-            case "selection":
-                return formatChar(trackingValue.value);
-            case "date": {
-                const value = trackingValue.value
-                    ? deserializeDate(trackingValue.value)
-                    : trackingValue.value;
-                return formatDate(value);
-            }
-            case "datetime": {
-                const value = trackingValue.value
-                    ? deserializeDateTime(trackingValue.value)
-                    : trackingValue.value;
-                return formatDateTime(value);
-            }
-            case "float":
-                return formatFloat(trackingValue.value, { digits: trackingValue.floatPrecision });
-            case "integer":
-                return formatInteger(trackingValue.value);
-            case "text":
-                return formatText(trackingValue.value);
-            case "monetary":
-                return formatMonetary(trackingValue.value, {
-                    currencyId: trackingValue.currencyId,
-                });
-            default:
-                return trackingValue.value;
-        }
-    },
 
-    /**
-     * @returns {string}
-     */
     formatTrackingOrNone(trackingType, trackingValue) {
-        const formattedValue = this.formatTracking(trackingType, trackingValue);
-        return formattedValue || _t("None");
+        return formatTrackingOrNone(trackingType, trackingValue);
     },
 });


### PR DESCRIPTION
**Current behavior before PR:**

Push notifications were empty when a user tracked record changes (e.g., stage changes in a task). This happened because `trackingValues` were not included in the notification message.

**Desired behavior after PR is merged:**

`trackingValues` are now correctly added to the notification message, ensuring that push notifications display the relevant record change details.

Task-[4510508](https://www.odoo.com/odoo/project/1519/tasks/4510508)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
