### PR TITLE
[FIX] web: Prevent users from using json field in the field_selector

### DIFF
--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
@@ -40,7 +40,7 @@ class Page {
 
     get title() {
         const prefix = this.previousPage?.previousPage ? "... > " : "";
-        const title = this.previousPage?.selectedField.string || "";
+        const title = this.previousPage?.selectedField?.string || "";
         return `${prefix}${title}`;
     }
 
@@ -102,7 +102,7 @@ export class ModelFieldSelectorPopover extends Component {
         update: Function,
     };
     static defaultProps = {
-        filter: (fieldDef) => fieldDef.searchable,
+        filter: (value) => value.searchable && value.type != "json",
         isDebugMode: false,
         followRelations: true,
     };

--- a/addons/web/static/tests/core/model_field_selector_tests.js
+++ b/addons/web/static/tests/core/model_field_selector_tests.js
@@ -100,6 +100,11 @@ QUnit.module("Components", (hooks) => {
                             relation: "product",
                             searchable: true,
                         },
+                        json_field: {
+                            string: "Json field",
+                            type: "json",
+                            searchable: true,
+                        },
                     },
                     records: [
                         { id: 1, foo: "yop", bar: true, product_id: 37 },


### PR DESCRIPTION
Steps:
    - Install `purchase` or any other model with analytic_mixin
    - Install `analytic`
    - Install `web_studio`
    - Enable analytic in configuration
    - Add a new approval on 'button_confirm' in `purchase.order`
    - Set a domain with analytic_distribution e.g
    -   - e.g. ("order_line.analytic_distribution", "=", "Administrative")
    - Click on Refresh button
    - The refresh button preview shows x records
    - Create a new purchase.order
    - Add analytic on optional column
    - Add a new product with analytic_distribution Administrative
    - Try to use `button_confirm`
    - Approval is not working while the refresh shows record is available

The json fields, in particular the `analytic_distribution` fields, are not designed to be searched via a `filtered_domain` (which is what studio approval uses to check whether or not a button can be used by the current user), this is currently a technical limitation.

To avoid any future problems, this commit prevents users from using a json field to search on them, since this is not supported.

opw-4416646