### PR TITLE
[FIX] website_sale: hide Contact Us button if sale is possible

### DIFF
--- a/addons/website_sale/static/src/js/sale_variant_mixin.js
+++ b/addons/website_sale/static/src/js/sale_variant_mixin.js
@@ -503,7 +503,7 @@ var VariantMixin = {
             $product.trigger('view_item_event', combination['product_tracking_info']);
         }
         const addToCart = $parent.find('#add_to_cart_wrap');
-        const contactUsButton = $parent.find('#contact_us_wrapper');
+        const contactUsButton = $parent.parents('#product_details').find('#contact_us_wrapper');
         const productPrice = $parent.find('.product_price');
         const quantity = $parent.find('.css_quantity');
         const product_unavailable = $parent.find('#product_unavailable');

--- a/addons/website_sale/static/tests/tours/website_sale_zero_priced_product.js
+++ b/addons/website_sale/static/tests/tours/website_sale_zero_priced_product.js
@@ -1,0 +1,44 @@
+import { registry } from '@web/core/registry';
+
+registry.category('web_tour.tours').add('website_sale_contact_us_button', {
+    checkDelay: 50,
+    steps: () => [
+        {
+            content: "Check that the red color attribute is selected",
+            trigger: '.js_attribute_value:has([checked]):contains(red)',
+        },
+        {
+            content: "Zero-priced product should be unavailable",
+            trigger: '#product_unavailable',
+        },
+        {
+            content: "Price should be hidden",
+            trigger: '.product_price:not(:visible)',
+        },
+        {
+            content: '"Add to Cart" button should be hidden',
+            trigger: '#add_to_cart_wrap:not(:visible)',
+        },
+        {
+            content: '"Contact Us" button should be visible',
+            trigger: '#contact_us_wrapper',
+        },
+        {
+            content: "Select attribute with price extra value",
+            trigger: '.js_attribute_value:contains(blue):contains(20.00) input',
+            run: 'click',
+        },
+        {
+            content: "Product price should be updated",
+            trigger: '.product_price .oe_currency_value:contains(20.00)',
+        },
+        {
+            content: '"Add to Cart" button should now be visibile',
+            trigger: '#add_to_cart_wrap',
+        },
+        {
+            content: '"Contact Us" button should now be hidden',
+            trigger: '#contact_us_wrapper:not(:visible)',
+        },
+    ],
+});

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -26,6 +26,7 @@ from . import test_website_sale_pricelist
 from . import test_website_sale_product_attribute_value_config
 from . import test_website_sale_product_configurator
 from . import test_website_sale_product_filters
+from . import test_website_sale_product_page
 from . import test_website_sale_product_template
 from . import test_website_sale_reorder_from_portal
 from . import test_website_sale_show_compare_list_price

--- a/addons/website_sale/tests/test_website_sale_product_page.py
+++ b/addons/website_sale/tests/test_website_sale_product_page.py
@@ -1,0 +1,30 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import HttpCase, tagged
+
+from odoo.addons.product.tests.common import ProductVariantsCommon
+from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleProductPage(HttpCase, ProductVariantsCommon, WebsiteSaleCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.product_template_sofa.website_published = True
+
+    def test_toggle_contact_us_button_visibility(self):
+        """Check that the "Contact Us" button:
+          - is shown for zero-priced products
+          - is hidden for other products
+          - is not displayed at the same time as the "Add to Cart" button
+        """
+        self.website.prevent_zero_price_sale = True
+
+        self.product_template_sofa.list_price = 0
+        red_sofa, blue_sofa = self.product_template_sofa.product_variant_ids[:2]
+        blue_sofa.product_template_attribute_value_ids.price_extra = 20
+
+        self.start_tour(red_sofa.website_url, 'website_sale_contact_us_button')


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Enable Prevent Sale of Zero Priced Product;
2. have a product with attributes;
3. set its list price to 0;
4. add a price extra to one of its attributes;
5. go to its eCommerce page;
6. select the price extra attribute.

Issue
-----
Both the "Add to cart" and "Contact Us" buttons are shown.

Cause
-----
- Commit 8f4c8ada7e9fe refactored the `website_sale.product` template, moving the "Contact Us" button outside of the `div.js_product` element.
- This element gets passed as `$parent` to the `_onChangeCombination` method, which ought to handle these changes.
- Because the `#contact_us_wrapper` is no longer in `$parent`, it fails to find it and change its classes accordingly.

Solution
--------
Instead of querying for the `#contact_us_wrapper` element directly in `$parent`, look for the `#product_details` element first, then query it.

opw-4423323