### PR TITLE
[FIX] gamification: fix motivational description field

### DIFF
--- a/addons/gamification/models/gamification_karma_rank.py
+++ b/addons/gamification/models/gamification_karma_rank.py
@@ -13,7 +13,7 @@ class KarmaRank(models.Model):
     name = fields.Text(string='Rank Name', translate=True, required=True)
     description = fields.Html(string='Description', translate=html_translate, sanitize_attributes=False,)
     description_motivational = fields.Html(
-        string='Motivational', translate=html_translate, sanitize_attributes=False,
+        string='Motivational', translate=html_translate, sanitize_attributes=False, sanitize_overridable=True,
         help="Motivational phrase to reach this rank on your profile page")
     karma_min = fields.Integer(
         string='Required Karma', required=True, default=1)


### PR DESCRIPTION
For the same reason as [1], this commit adds the parameter "sanitize_overridable=True" to the "description_motivational" field of "gamification" model. This ensures that users with sufficient rights can properly edit the motivational description.

This issue is difficult to reproduce in 16.0, as no blocks contain `<button>` elements. However, in 18.0, some snippets—such as `accordion` or the new `image gallery`—include button elements, making the issue more apparent.

Steps to reproduce (in 18.0):

- Open website module
- Go to /slides
- Add a carousel snippet to the side panel > Save
- Traceback

[1]: https://github.com/odoo/odoo/commit/0cd42f8b55e2ab8f214653556b5bde4b54281972

opw-4272357
