### PR TITLE
[IMP] web_editor: enhance sub-options design within the editor

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.variables.scss
+++ b/addons/web_editor/static/src/scss/web_editor.variables.scss
@@ -24,7 +24,7 @@ $o-we-color-success: #40ad67 !default;
 $o-we-color-info: #6999a8 !default;
 
 $o-we-bg: $o-we-bg-light !default;
-$o-we-color: $o-we-fg-light !default;
+$o-we-color: $o-we-fg-lighter !default;
 $o-we-font-size: 13px !default;
 $o-we-font-family: $o-font-family-sans-serif !default;
 $o-we-accent: #01bad2 !default;
@@ -122,7 +122,7 @@ $o-we-sidebar-top-height: 46px !default;
 $o-we-sidebar-tabs-size-ratio: 1 !default;
 $o-we-sidebar-tabs-height: 3rem;
 $o-we-sidebar-tabs-bg: $o-we-bg-darker !default;
-$o-we-sidebar-tabs-color: $o-we-sidebar-color !default;
+$o-we-sidebar-tabs-color: $o-we-fg-light !default;
 $o-we-sidebar-tabs-disabled-color: $o-we-fg-darker !default;
 $o-we-sidebar-tabs-active-border-width: 2px !default;
 $o-we-sidebar-tabs-active-border-color: $o-we-accent !default;

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -279,7 +279,10 @@
     }
     @for $level from 1 through 3 {
         .o_we_sublevel_#{$level} {
+            --o-we-checkbox-color: #{$o-we-fg-light};
+
             @extend %o_we_sublevel;
+            color: $o-we-fg-light;
 
             @if $level > 1 {
                 > we-title {
@@ -882,6 +885,12 @@
                     flex-direction: column;
                 }
             }
+
+            &:hover, &.active {
+                &::after {
+                    color: $o-we-fg-lighter;
+                }
+            }
         }
         %we-icon-button {
             position: relative;
@@ -1076,6 +1085,7 @@
             border: none;
             background: none;
             cursor: default;
+            color: var(--o-we-checkbox-color, $o-we-color);
 
             > we-title {
                 cursor: pointer;
@@ -1107,9 +1117,6 @@
             &.active we-checkbox {
                 background-color: $o-we-sidebar-content-field-toggle-active-bg;
                 justify-content: flex-end;
-            }
-            &.active, &:hover {
-                color: $o-we-sidebar-content-field-clickable-color;
             }
         }
 


### PR DESCRIPTION
This PR aims to enhance the sub-options within the editor, fixing an issue about sub-options being overemphasized.

task-4492278

----------

Prior to this PR, both options and sub-options were using the same color, making it a bit hard for the user to distinguish whether he was applying changes on an (sub)option or not.

There were also different issue like options that could be triggered by clicking on their label but without providing any visual feedback, nested sub-options in collapse not showing the user the all the options he unfolded in order to reach the one he's applying changes with.

This PR introduces different improvement to solve these issues by :

#### 1) Setting options to white, while sub-options will remain gray;

| Options and sub-options color - Master | This PR |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/db183e3f-dbdf-4bb2-9afb-6159fb156376) | ![image](https://github.com/user-attachments/assets/1d6fac00-01a2-4032-a425-a2b5d0b00278) | 


#### 2) Settings the unfold icon to white when hovering 
| Visual feedback when hovering a foldable icon - Master| This PR |
|--------|--------|
| <img width="109" alt="image" src="https://github.com/user-attachments/assets/0d2ee7ec-31e3-4295-a111-49df4bc46f8e" /> | <img width="109" alt="image" src="https://github.com/user-attachments/assets/d6dd51b6-1b95-4b78-8101-5b8c9bd83ef8" /> | 

#### 3) Setting a white color to the fold icon when unfolding nested options collapse, highlighting the path user is currently in.
| Options hierarchy visual feedback | This PR |
|--------|--------|
| <img width="290" alt="image" src="https://github.com/user-attachments/assets/67ee66db-8d5e-4ce5-bd95-ed919dd0b7d7" /> | <img width="289" alt="image" src="https://github.com/user-attachments/assets/a463fae7-64ac-433a-ae9e-0ae9bce548aa" /> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
