### PR TITLE
[FIX] calendar_sms: calendar reminder event matching

### DIFF
--- a/addons/calendar_sms/models/calendar_alarm_manager.py
+++ b/addons/calendar_sms/models/calendar_alarm_manager.py
@@ -16,9 +16,8 @@ class AlarmManager(models.AbstractModel):
         if not events_by_alarm:
             return
 
-        event_ids = list(set(event_id for event_ids in events_by_alarm.values() for event_id in event_ids))
-        events = self.env['calendar.event'].browse(event_ids)
-        alarms = self.env['calendar.alarm'].browse(events_by_alarm.keys())
-        for event in events:
-            alarm = event.alarm_ids.filtered(lambda alarm: alarm.id in alarms.ids)
-            event._do_sms_reminder(alarm)
+        all_events_ids = list({event_id for event_ids in events_by_alarm.values() for event_id in event_ids})
+        for alarm_id, event_ids in events_by_alarm.items():
+            alarm = self.env['calendar.alarm'].browse(alarm_id).with_prefetch(list(events_by_alarm.keys()))
+            events = self.env['calendar.event'].browse(event_ids).with_prefetch(all_events_ids)
+            events._do_sms_reminder(alarm)

--- a/addons/calendar_sms/tests/test_calendar_sms.py
+++ b/addons/calendar_sms/tests/test_calendar_sms.py
@@ -1,26 +1,78 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime
+from datetime import datetime, timedelta
+from odoo import fields
+from odoo.addons.sms.tests.common import SMSCase
+from odoo.tests.common import TransactionCase
 
-from odoo.tests.common import SingleTransactionCase
 
-
-class TestCalendarSms(SingleTransactionCase):
+class TestCalendarSms(TransactionCase, SMSCase):
 
     @classmethod
     def setUpClass(cls):
         super(TestCalendarSms, cls).setUpClass()
+
+        now = fields.datetime.now()
 
         cls.partner_phone = cls.env['res.partner'].create({
             'name': 'Partner With Phone Number',
             'phone': '0477777777',
             'country_id': cls.env.ref('base.be').id,
         })
+
+        cls.partner_phone_2 = cls.env['res.partner'].create({
+            'name': 'Partner With Phone Number',
+            'phone': '0488888888',
+            'country_id': cls.env.ref('base.be').id,
+        })
         cls.partner_no_phone = cls.env['res.partner'].create({
             'name': 'Partner With No Phone Number',
             'country_id': cls.env.ref('base.be').id,
         })
+
+        cls.alarm_1h = cls.env['calendar.alarm'].create({
+            'name': 'Reminder 1 Hour',
+            'duration': 1,
+            'interval': 'hours',
+            'alarm_type': 'sms',
+        })
+        cls.alarm_24h = cls.env['calendar.alarm'].create({
+            'name': 'Reminder 24 Hours',
+            'duration': 24,
+            'interval': 'hours',
+            'alarm_type': 'sms',
+        })
+
+        cls.event_1h = cls.env['calendar.event'].create({
+            'name': 'Event in 1h',
+            'start': now + timedelta(hours=1),
+            'stop': now + timedelta(hours=2),
+            'alarm_ids': [(4, cls.alarm_1h.id), (4, cls.alarm_24h.id)],
+            'attendee_ids': [(0, 0, {'partner_id': cls.partner_phone.id})],
+
+        })
+        cls.event_24h = cls.env['calendar.event'].create({
+            'name': 'Event in 24h',
+            'start': now + timedelta(hours=24),
+            'stop': now + timedelta(hours=25),
+            'alarm_ids': [(4, cls.alarm_1h.id), (4, cls.alarm_24h.id)],
+            'attendee_ids': [(0, 0, {'partner_id': cls.partner_phone_2.id})],
+        })
+
+        cls.sms_template_1h = cls.env['sms.template'].create({
+            'name': 'Calendar Alarm SMS Template',
+            'body': 'Reminder: Your event is starting in 1 hour!',
+            'model_id': cls.env['ir.model']._get('calendar.event').id,
+        })
+        cls.alarm_1h.sms_template_id = cls.sms_template_1h.id
+
+        cls.sms_template_24h = cls.env['sms.template'].create({
+            'name': 'Calendar Alarm SMS Template',
+            'body': 'Reminder: Your event is starting in 24 hour!',
+            'model_id': cls.env['ir.model']._get('calendar.event').id,
+        })
+        cls.alarm_24h.sms_template_id = cls.sms_template_24h.id
 
     def test_attendees_with_number(self):
         """Test if only partners with sanitized number are returned."""
@@ -31,3 +83,18 @@ class TestCalendarSms(SingleTransactionCase):
             'partner_ids': [(6, 0, [self.partner_phone.id, self.partner_no_phone.id])],
         })._sms_get_default_partners()
         self.assertEqual(len(attendees), 1, "There should be only one partner retrieved")
+
+    def test_send_reminder_match_both_events(self):
+        """
+        Test that only the necessary SMS messages are sent,
+         with each SMS template correctly matching its corresponding alarm duration and the event.
+        """
+        with self.mockSMSGateway():
+            lastcall = fields.Datetime.now() - timedelta(hours=1)
+            self.env['calendar.alarm_manager'].with_context(lastcall=lastcall)._send_reminder()
+
+        self.assertEqual(len(self._sms), 2)
+        self.assertSMS(self.partner_phone, self.partner_phone.phone_sanitized, 'sent',
+                       content=self.sms_template_1h.body)
+        self.assertSMS(self.partner_phone_2, self.partner_phone_2.phone_sanitized, 'sent',
+                       content=self.sms_template_24h.body)


### PR DESCRIPTION
[FIX] calendar_sms: calendar reminder event matching

The Issue
SMS reminders are sent to customers for calendar events regardless of whether they are scheduled for 1 hour before or 24 hours before; both reminders are sent.

Steps to Reproduce

1. Create two SMS reminders with different timings: one for 1 hour before the event and another for 24 hours before.
2. Create an attendee (since the calendar event administrator will not receive the SMS). Assign the attendee a phone number and an email.
3. Configure your SMS account to receive free credits (for local: create a SaaS and use its IAP token and UUID to link the IAP service).
4. Create two calendar events:
   - One that starts in 1 hour. (event_1h)
   - One that starts in 24 hours. (event_24h)
5. Add both reminders (1-hour and 24-hour reminders that we will call reminder_1h and reminder_24h) to each event and include the attendee you created. Accept the event invitation on behalf of the attendee.
6. Run the scheduled action that triggers event reminders.

Actual Behavior
For both events, both reminders are triggered.
for event_1h, reminder_1h and reminder_24h are sent.
for event_24h, reminder_1h and reminder_24h are sent.

Expected behavior:
For event_1h, reminder_1h is sent.
For event_24h, reminder_24h is sent.

Why Does This Happen?

After the SQL query, the result is a dictionary:

{"reminder_1h": "event_1h", "reminder_24h": "event_24h"}
(In reality, these should be IDs, but they are represented as strings for clarity.)

The code in the calendar_sms module retrieves all events from the dictionary, so we have a list with [event_1h, event_24h].
It also fetches the reminders that are in the keys of the dictionary (reminder_1h, reminder_24h).
Then it iterates through the events and for each event, checks if the reminders we have exist in the event.
If it exists, it sends an SMS.
(e.g., event_24h has both reminder_1h and reminder_24h linked to it, so it will send both reminders even if one states it starts in one hour, whereas it really starts in 24h).

OPW-4473553
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
