### PR TITLE
[FIX] point_of_sale: not use SEPA CT on outgoing pos payments

### DIFF
--- a/addons/point_of_sale/models/account_payment.py
+++ b/addons/point_of_sale/models/account_payment.py
@@ -22,3 +22,18 @@ class AccountPayment(models.Model):
         for payment in self:
             if payment.force_outstanding_account_id:
                 payment.outstanding_account_id = payment.force_outstanding_account_id
+
+    def _get_payment_method_codes_to_exclude(self):
+        res = super()._get_payment_method_codes_to_exclude()
+
+        # Sepa Credit Transfer is an outgoing payment method. It requires a partner and bank
+        # account. In the context of PoS orders, you can make refunds that are not linked to
+        # a specific customer. We ensure that account.payment are not created using the sepa_ct
+        # account.payment.method.line. If not, closing the session would not be possible unless
+        # having an account.payment.method.line with a smaller sequence than sepa_ct.
+        account_sepa = self.env['ir.module.module'].search([('name', '=', 'account_sepa')])
+        if account_sepa.state == 'installed':
+            sepa_ct = self.env.ref('account_sepa.account_payment_method_sepa_ct', raise_if_not_found=False)
+            if sepa_ct and 'pos_payment' in self.env.context and sepa_ct.code not in res:
+                res.append(sepa_ct.code)
+        return res

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -934,7 +934,7 @@ class PosSession(models.Model):
             # revert the accounts because account.payment doesn't accept negative amount.
             outstanding_account, destination_account = destination_account, outstanding_account
 
-        account_payment = self.env['account.payment'].create({
+        account_payment = self.env['account.payment'].with_context({"pos_payment": True}).create({
             'amount': abs(amounts['amount']),
             'journal_id': payment_method.journal_id.id,
             'force_outstanding_account_id': outstanding_account.id,


### PR DESCRIPTION
Currently, when closing the session, you would encounter an issue if the a refund payment was done using bank payment method and on the journal, the SEPA Credit Transfer is positionned first in the sequence.

Steps to reproduce:
-------------------
* Install `l10n_fr`, `point_of_sale`, and `account_sepa`
* Switch to the `FR Company`
* In the **Invoicing** app, select **Configuration** > **Journals**
* Select the `Bank` journal
* Set proper IBAN account
* In **Outgoing Payments**, move `SEPA Credit Transfer` to the top
* In **Point of sale**, open pos shop
* Select any product, change the price or qty to be negative (or make a refund for an order with no customer)
* Select `Bank` payment method
* Validate
* Try closing session
> Observation: Closing session error: An error has occurred when trying to
close the sesion. You will be redirected to the back-end to manually close the session.
* In the backend, try to close the session
> Observation: To record payments with False, the recipient bank account
must be manually validated. You should go on the partner bank account in order to validate it.

Why the fix:
------------
The first payment_method_line will be used among the available payment method lines:
https://github.com/odoo/odoo/blob/ae4c01ea7c9a5709a5f5ebcaded06fd91bdabae3/addons/account/models/account_payment.py#L461-L465 https://github.com/odoo/odoo/blob/ae4c01ea7c9a5709a5f5ebcaded06fd91bdabae3/addons/account/models/account_payment.py#L470-L475

In the context of the point of sale, using SEPA CT in the context of refunds does not make too much sense. Indeed, in the pos a refund can be done on an order which is not related to a client. By definition, when using SEPA your are supposed to know the client and it bank account number.

We exclude the possibility of using SEPA CT when creating refund account payments coming from the Pos.

opw-4310781