### PR TITLE
[IMP] mail: quick reaction opens full picker on char keypress

### DIFF
--- a/addons/mail/static/src/core/common/quick_reaction_menu.js
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.js
@@ -1,4 +1,4 @@
-import { Component, onMounted, onPatched, useRef, useState } from "@odoo/owl";
+import { Component, onMounted, onPatched, useExternalListener, useRef, useState } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { loadEmoji, loader, useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
@@ -47,13 +47,24 @@ export class QuickReactionMenu extends Component {
             }
         });
         onPatched(() => void this.state.emojiLoaded);
+        useExternalListener(window, "keydown", async (ev) => {
+            if (
+                !this.dropdown.isOpen ||
+                this.picker.isOpen ||
+                !this.toggle.el?.contains(ev.target) ||
+                ["Shift", "Control", "Meta", "Alt"].includes(ev.key)
+            ) {
+                return;
+            }
+            this.togglePicker(ev.key);
+        });
     }
 
-    togglePicker() {
+    togglePicker(initialSearchTerm) {
         if (this.picker.isOpen) {
             this.picker.close();
         } else {
-            this.picker.open(this.toggle);
+            this.picker.open(this.toggle, { initialSearchTerm });
         }
     }
 

--- a/addons/mail/static/src/core/common/quick_reaction_menu.xml
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.xml
@@ -10,7 +10,7 @@
                     <button t-foreach="mostFrequentEmojis" t-as="emoji" t-key="emoji" class="o-mail-QuickReactionMenu-emoji o-mail-QuickReactionMenu-popEffect o-navigable d-flex justify-content-center align-items-center rounded-circle btn lh-1 p-1" t-att-class="{ 'bg-secondary': reactedBySelf(emoji) }" t-att-title="getEmojiShortcode(emoji)" t-on-click="() => this.toggleReaction(emoji)">
                         <span class="fs-2" t-esc="emoji"/>
                     </button>
-                    <button class="o-mail-QuickReactionMenu-emojiPicker o-mail-QuickReactionMenu-popEffect o-mail-QuickReactionMenu-popEffect--smaller o-navigable text-muted d-flex justify-content-center align-items-center btn btn-secondary rounded-circle" title="Toggle Emoji Picker" t-on-click="togglePicker">
+                    <button class="o-mail-QuickReactionMenu-emojiPicker o-mail-QuickReactionMenu-popEffect o-mail-QuickReactionMenu-popEffect--smaller o-navigable text-muted d-flex justify-content-center align-items-center btn btn-secondary rounded-circle" title="Toggle Emoji Picker" t-on-click="() => this.togglePicker()">
                         <i class="oi oi-close"/>
                     </button>
                 </div>

--- a/addons/mail/static/tests/quick_reaction_menu/quick_reaction_menu.test.js
+++ b/addons/mail/static/tests/quick_reaction_menu/quick_reaction_menu.test.js
@@ -9,7 +9,7 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { QuickReactionMenu } from "@mail/core/common/quick_reaction_menu";
 import { describe, test } from "@odoo/hoot";
-import { press } from "@odoo/hoot-dom";
+import { animationFrame, press } from "@odoo/hoot-dom";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -101,4 +101,25 @@ test("navigate quick reaction menu using arrow keys", async () => {
         await press("ArrowLeft");
     }
     await contains(".o-mail-QuickReactionMenu-emojiPicker:focus");
+});
+
+test("can quick search emoji from quick reaction", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await insertText(".o-mail-Composer-input", "Hello world!");
+    await press("Enter");
+    await click("[title='Add a Reaction']");
+    await contains(".o-mail-QuickReactionMenu");
+    await press("b");
+    await contains(".o-EmojiPicker");
+    await contains(".o-EmojiPicker-search input:value('b')");
+    for (const ch of [..."roccoli"]) {
+        await press(ch);
+    }
+    await contains(".o-EmojiPicker-search input:value('broccoli')");
+    await animationFrame();
+    await press("Enter");
+    await contains(".o-mail-MessageReaction", { text: "🥦1" });
 });

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -92,7 +92,7 @@ export const PICKER_PROPS = [
 ];
 
 export class EmojiPicker extends Component {
-    static props = [...PICKER_PROPS, "class?"];
+    static props = [...PICKER_PROPS, "class?", "initialSearchTerm?"];
     static template = "web.EmojiPicker";
 
     categories = null;
@@ -110,7 +110,7 @@ export class EmojiPicker extends Component {
         this.state = useState({
             activeEmojiIndex: 0,
             categoryId: null,
-            searchTerm: "",
+            searchTerm: this.props.initialSearchTerm ?? "",
             /** @type {Emoji|undefined} */
             hoveredEmoji: undefined,
         });
@@ -580,7 +580,7 @@ export function usePicker(PickerComponent, ref, props, options = {}) {
             }
             return def;
         }
-        return popover.open(ref.el, props);
+        return popover.open(ref.el, { ...props, ...openProps });
     }
 
     function close() {


### PR DESCRIPTION
"Add reaction" message action shows the quick reaction menu, which shows a nice listing of the most frequently used emoji.

Sometimes the desired emoji is not there, and it's clunky to click on "+" and then search.

This commit intercepts keydown that are not used for naviation in the quick reaction menu, so that it automatically opens the full emoji picker. That way, we can quickly search for the desired emoji for the message reaction

![Jan-30-2025 15-35-36](https://github.com/user-attachments/assets/ab92868e-5e89-4b65-ad98-0c5ee1a1c1eb)
