### PR TITLE
[FIX] web: fix export for inherited properties

### DIFF
--- a/addons/test_import_export/models/models_import.py
+++ b/addons/test_import_export/models/models_import.py
@@ -126,3 +126,11 @@ class Property(models.Model):
 
     properties = fields.Properties(definition='record_definition_id.properties_definition')
     record_definition_id = fields.Many2one('import.properties.definition')
+
+
+class PropertyInherits(models.Model):
+    _name = _description = 'import.properties.inherits'
+    _inherits = {'import.properties': 'parent_id'}
+
+    parent_id = fields.Many2one('import.properties', required=True, ondelete="cascade")
+

--- a/addons/test_import_export/security/ir.model.access.csv
+++ b/addons/test_import_export/security/ir.model.access.csv
@@ -49,3 +49,4 @@ access_import_preview,import_preview,model_import_preview,base.group_user,1,1,1,
 access_import_complex,access_import_complex,model_import_complex,base.group_user,1,0,0,0
 access_import_properties_definition,access_import_properties_definition,model_import_properties_definition,base.group_user,1,0,0,0
 access_import_properties,access_import_properties,model_import_properties,base.group_user,1,0,0,0
+access_import_properties_inherits,access_import_properties_inherits,model_import_properties_inherits,base.group_user,1,0,0,0

--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -317,7 +317,8 @@ class Export(http.Controller):
             # Depends of the records selected to avoid showing useless Properties
             if domain:
                 self_subquery = Model.with_context(active_test=False)._search(domain)
-                domain_definition.append(('id', 'in', self_subquery.subselect(definition_record)))
+                field_to_get = Model._field_to_sql(Model._table, definition_record, self_subquery)
+                domain_definition.append(('id', 'in', self_subquery.subselect(field_to_get)))
 
             definition_records = target_model.search_fetch(
                 domain_definition, [definition_record_field, 'display_name'],


### PR DESCRIPTION
Try to export one selected product.product generate a traceback due to the `_get_property_fields` that doesn't manage inherited properties.


opw-4438752