### PR TITLE
[IMP] mail: removed padding around participant card

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -44,6 +44,7 @@ export class Call extends Component {
         this.grid = useRef("grid");
         this.notification = useService("notification");
         this.rtc = useService("discuss.rtc");
+        this.ui = useService("ui");
         this.state = useState({
             isFullscreen: false,
             sidebar: false,
@@ -191,9 +192,7 @@ export class Call extends Component {
     }
 
     get isControllerFloating() {
-        return (
-            this.state.isFullscreen || (this.props.thread.activeRtcSession && !this.props.compact)
-        );
+        return this.state.isFullscreen || (this.props.thread.activeRtcSession && !this.ui.isSmall);
     }
 
     onMouseleaveMain(ev) {

--- a/addons/mail/static/src/discuss/call/common/call.scss
+++ b/addons/mail/static/src/discuss/call/common/call.scss
@@ -7,6 +7,11 @@
     min-height: 50%;
     background: var(--o-discuss-Call-bgColor, #{$dark});
 
+    &.o-compact {
+        height: auto;
+        min-height: auto;
+    }
+
     &.o-minimized {
         height: 20%; // ensures that the view returns to the right height when resized
         min-height: #{"max(20%, 130px)"};
@@ -42,6 +47,11 @@
     min-width: var(--width);
     min-height: var(--height);
     aspect-ratio: 16/9;
+    
+    &.o-active {
+        width: 100%;
+        height: auto;
+    }
 }
 
 .o-discuss-Call-sidebarToggler {

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.Call">
         <PttAdBanner/>
-        <div class="o-discuss-Call user-select-none d-flex position-relative" t-att-class="{
+        <div class="o-discuss-Call user-select-none d-flex position-relative shadow-sm" t-att-class="{
             'o-fullscreen fixed-top vw-100 vh-100': state.isFullscreen,
             'o-compact': props.compact,
             'o-minimized': minimized,
@@ -12,6 +12,7 @@
             <div class="o-discuss-Call-main d-flex flex-grow-1 flex-column align-items-center justify-content-center position-relative overflow-auto" t-on-mouseleave="onMouseleaveMain">
                 <div
                     class="o-discuss-Call-mainCards d-flex align-items-center overflow-hidden h-100 w-100 flex-wrap justify-content-center"
+                    t-att-class="{'mt-1': minimized}"
                     t-attf-style="--height:{{state.tileHeight}}px; --width:{{state.tileWidth}}px;"
                     t-on-click="() => this.showOverlay()"
                     t-on-mousemove="onMousemoveMain"
@@ -21,6 +22,7 @@
                         cardData="cardData"
                         className="'o-discuss-Call-mainCardStyle'"
                         minimized="minimized"
+                        compact="props.compact"
                         thread="props.thread"
                     />
                     <span t-if="env.inChatWindow and visibleMainCards.length > 6" class="fa fa-ellipsis-h ps-1 pe-1"/>
@@ -28,6 +30,7 @@
                         cardData="cardData"
                         className="'o-discuss-Call-mainCardStyle'"
                         minimized="minimized"
+                        compact="props.compact"
                         thread="props.thread"
                     />
                 </div>

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -21,7 +21,7 @@ import { rpc } from "@web/core/network/rpc";
 const HIDDEN_CONNECTION_STATES = new Set([undefined, "connected", "completed"]);
 
 export class CallParticipantCard extends Component {
-    static props = ["className", "cardData", "thread", "minimized?", "inset?"];
+    static props = ["className", "cardData", "thread", "minimized?", "inset?", "compact?"];
     static components = { CallParticipantVideo };
     static template = "discuss.CallParticipantCard";
 
@@ -127,6 +127,10 @@ export class CallParticipantCard extends Component {
             this.rtcSession.raisingHand &&
                 (!screenStream || screenStream !== this.props.cardData.videoStream)
         );
+    }
+
+    get isActiveRtcSession() {
+        return this.rtcSession && this.rtcSession.eq(this.rtcSession.channel.activeRtcSession);
     }
 
     async onClick(ev) {

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.scss
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.scss
@@ -3,7 +3,8 @@
     aspect-ratio: 16/9;
 
     &.o-isTalking {
-        box-shadow: inset 0 0 0 map-get($spacers, 1) var(--discuss-talkingColor, $o-discuss-talkingColor);
+        outline: 4px solid var(--discuss-talkingColor, $o-discuss-talkingColor);
+        outline-offset: -4px;
 
         &.o-inset {
             box-shadow: inset 0 0 0 map-get($spacers, 1)/2 var(--discuss-talkingColor, $o-discuss-talkingColor);

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -2,12 +2,14 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallParticipantCard">
-        <div class="o-discuss-CallParticipantCard position-relative cursor-pointer d-flex flex-column align-items-center justify-content-center mh-100 mw-100 p-1 rounded-1"
+        <div class="o-discuss-CallParticipantCard position-relative cursor-pointer d-flex flex-column align-items-center justify-content-center mh-100 mw-100"
             t-att-class="{
                 'o-isTalking': !props.minimized and isTalking,
                 'o-isInvitation opacity-50': !rtcSession,
                 'o-inset': props.inset,
-                'o-small': props.inset and (ui.isSmall or props.minimized)
+                'o-small': props.inset and (ui.isSmall or props.minimized),
+                'o-active': isActiveRtcSession and !props.inset and props.compact,
+                'p-1 rounded-1': !isActiveRtcSession,
             }"
             t-att-title="name"
             t-att-aria-label="name"

--- a/addons/mail/static/src/discuss/call/common/call_participant_video.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_video.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="discuss.CallParticipantVideo">
-        <video class="w-100 h-100 rounded-1 cursor-pointer"
-            t-att-class="{ 'o-inset': props.inset }"
+        <video class="w-100 h-100 cursor-pointer"
+            t-att-class="{ 'o-inset rounded-1': props.inset }"
             t-att-type="props.type"
             playsinline="true"
             autoplay="true"


### PR DESCRIPTION
This commit removes the padding around the participant card when it is not minimized (screen share and video).
This is commit also makes the call controls floating in the chat window, in order to save more space.

| Before  | After |
| ------------- | ------------- |
| ![Pasted image 20250130144215](https://github.com/user-attachments/assets/14d728b3-9838-42ec-994c-4d71c0dc5444) | ![image](https://github.com/user-attachments/assets/d68bf3bc-5217-40dd-9562-0433732dd53f)  |

task-4448832
