### PR TITLE
[FIX] website_sale: sales team not updated on partner change

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -465,11 +465,11 @@ class SaleOrder(models.Model):
                     or (self.env.user.has_group('sales_team.group_sale_salesman') and self.env.user)
                 )
 
-    @api.depends('partner_id', 'user_id')
+    @api.depends('user_id')
     def _compute_team_id(self):
         cached_teams = {}
         for order in self:
-            default_team_id = self.env.context.get('default_team_id', False) or order.team_id.id
+            default_team_id = order._default_team_id()
             user_id = order.user_id.id
             company_id = order.company_id.id
             key = (default_team_id, user_id, company_id)
@@ -481,6 +481,9 @@ class SaleOrder(models.Model):
                     domain=self.env['crm.team']._check_company_domain(company_id),
                 )
             order.team_id = cached_teams[key]
+
+    def _default_team_id(self):
+        return self.env.context.get('default_team_id', False) or self.team_id.id
 
     @api.depends('order_line.price_subtotal', 'currency_id', 'company_id')
     def _compute_amounts(self):

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -144,12 +144,8 @@ class SaleOrder(models.Model):
                     or order.partner_id.user_id.id
                 )
 
-    def _compute_team_id(self):
-        website_orders = self.filtered('website_id')
-        super(SaleOrder, self - website_orders)._compute_team_id()
-        for order in website_orders:
-            if not order.team_id and (team := order.website_id.salesteam_id):
-                order.team_id = team.id
+    def _default_team_id(self):
+        return super()._default_team_id() or self.website_id.salesteam_id.id
 
     #=== CRUD METHODS ===#
 


### PR DESCRIPTION
Recent commit 27bf2e55810b200563ed6b93b1e22dfda65cf4ea modified the salesperson assignation on ecommerce orders, to avoid assigning any salesperson until the order confirmation.

Nevertheless, this commit also disabled the salesteam recomputation on salesman change for ecommerce orders.

In some cases (subscription orders), the salesperson might be manually changed on the order and we still want the right salesteam to be assigned on the order, even if it came from the ecommerce.

This commit adds a hook to allow subscription orders to keep the salesteam recomputation on salesman change for ecommerce orders.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
