### PR TITLE
[IMP] account: add vat to base document layout view

### DIFF
--- a/addons/account/views/base_document_layout_views.xml
+++ b/addons/account/views/base_document_layout_views.xml
@@ -9,8 +9,9 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='paperformat_id']" position="after">
                     <field name="from_invoice" invisible="1"/>
+                    <field name="vat"/>
+                    <field name="account_number" string="Bank Account Number" required="qr_code" placeholder="BE71096123456769"/>
                     <field name="qr_code" string="QR Code" invisible="not from_invoice"/>
-                    <field name="account_number" string="IBAN" invisible="not qr_code" required="qr_code" placeholder="BE71096123456769"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
[IMP] account: add vat to base document layout view

When users try to "send and print" their very first invoice without
having set their company first, the wizard will tell them to go fill
some of that information first. That behaviour can be annoying (the
back and forth before being able to "send and print").

We improve that behaviour by leveraging the fact that before the users
can "send and print" their first invoice, there is already the base
document layout wizard that asked them to fill up some information. We
simply add the company information that we need to be filled there
(`vat` and `account_number`). That way if the users correctly filled
what is suggested they avoid the back and forth.

In practice, we want to change this on the base document layout:
- Add the vat field
- Remove the invisible from account_number if qr_code is not selected

task-4486167

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
