### PR TITLE
[FIX] ressource: move @mail dependency in ressource_mail module

### DIFF
--- a/addons/resource/static/tests/resource_test_helpers.js
+++ b/addons/resource/static/tests/resource_test_helpers.js
@@ -1,6 +1,5 @@
 import { ResourceTask } from "./mock_server/mock_models/resource_task";
 import { ResourceResource } from "./mock_server/mock_models/resource_resource";
-import { mailModels } from "@mail/../tests/mail_test_helpers";
 import { defineModels } from "@web/../tests/web_test_helpers";
 
 export const resourceModels = {
@@ -9,5 +8,5 @@ export const resourceModels = {
 };
 
 export function defineResourceModels() {
-    return defineModels({ ...mailModels, ...resourceModels });
+    return defineModels(resourceModels);
 }

--- a/addons/resource_mail/static/tests/many2many_avatar_resource.test.js
+++ b/addons/resource_mail/static/tests/many2many_avatar_resource.test.js
@@ -1,4 +1,4 @@
-import { defineResourceModels } from "@resource/../tests/resource_test_helpers";
+import { defineResourceMailModels } from "./resource_mail_test_helpers";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { queryAll, queryFirst } from "@odoo/hoot-dom";
 import {
@@ -12,7 +12,7 @@ import {
 
 describe.current.tags("desktop");
 const data = {};
-defineResourceModels();
+defineResourceMailModels();
 beforeEach(async () => {
     /* 1. Create data
         3 type of resources will be tested in the widget:

--- a/addons/resource_mail/static/tests/many2one_avatar_resource.test.js
+++ b/addons/resource_mail/static/tests/many2one_avatar_resource.test.js
@@ -1,4 +1,4 @@
-import { defineResourceModels } from "@resource/../tests/resource_test_helpers";
+import { defineResourceMailModels } from "./resource_mail_test_helpers";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { queryFirst } from "@odoo/hoot-dom";
 import {
@@ -12,7 +12,7 @@ import {
 
 describe.current.tags("desktop");
 const data = {};
-defineResourceModels();
+defineResourceMailModels();
 beforeEach(async () => {
     /* 1. Create data
         3 type of records tested:

--- a/addons/resource_mail/static/tests/resource_mail_test_helpers.js
+++ b/addons/resource_mail/static/tests/resource_mail_test_helpers.js
@@ -1,0 +1,7 @@
+import { mailModels } from "@mail/../tests/mail_test_helpers";
+import { resourceModels } from "@resource/../tests/resource_test_helpers";
+import { defineModels } from "@web/../tests/web_test_helpers";
+
+export function defineResourceMailModels() {
+    return defineModels({ ...mailModels, ...resourceModels });
+}


### PR DESCRIPTION
Before this commit:
 1. Install `ressource` module
 2. In debug, open "Run unit tests" debug menu
 3. Error pop-up: 
```js
Global Error: stack trace available in the console
Missing dependencies: @mail/../tests/mail_test_helpers
```

After this commit:
 No error and units tests can proceed

Related runbot task: https://runbot.odoo.com/odoo/runbot.build.error/72187