### PR TITLE
[FIX] mail: increase max-height of message edit

### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -156,7 +156,7 @@
 
 .o-mail-Composer-input {
     font-family: "text-emoji", $font-family-base;
-    max-height: Min(100px, 60vh);
+    max-height: Min(400px, 60vh);
     resize: none;
 
     .o-mail-Composer.o-chatWindow & {


### PR DESCRIPTION
Edit of message was limited to 100px of height, which is too narrow especially when editing a message in chatter.

This 100px made sense when chat windows were small, but now there's no point to restrict as much.

This commit increases to up to 4 times the height, so 400px, giving much more room to edit long messages.

Before
<img width="2557" alt="Screenshot 2025-01-30 at 16 17 23" src="https://github.com/user-attachments/assets/eee3e2a9-e8db-4c3a-a7b0-02999d9f4c0b" />

After
<img width="2558" alt="Screenshot 2025-01-30 at 16 17 00" src="https://github.com/user-attachments/assets/52a32b90-f8ce-4c51-9842-62a0d61307ef" />
