### PR TITLE
[FIX] http: remove cache headers in static files for wkhtmltopdf

### DIFF
--- a/odoo/addons/test_http/tests/test_static.py
+++ b/odoo/addons/test_http/tests/test_static.py
@@ -372,6 +372,29 @@ class TestHttpStatic(TestHttpStaticCommon):
             self.assertEqual(res.headers['Content-Type'], 'application/octet-stream')  # Shouldn't be text/html
             self.assertEqual(res.headers['Content-Security-Policy'], "default-src 'none'")
 
+    def test_static23_remove_cache_control_wkhmtltopdf(self):
+        session = self.authenticate(None, None)
+        for debug in ('', 'assets'):
+            session.debug = debug
+            odoo.http.root.session_store.save(self.session)
+            with self.subTest(debug=debug):
+                res = self.db_url_open('/test_http/static/src/img/gizeh.png', headers={
+                    'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) '
+                                  'AppleWebKit/534.34 (KHTML, like Gecko) '
+                                  'wkhtmltopdf Safari/534.34',
+                })
+                res.raise_for_status()
+                self.assertEqual(res.status_code, 200)
+                try:
+                    self.assertIn('Cache-Control', res.headers)
+                    cc = self.parse_http_cache_control(res.headers['Cache-Control'])
+                    self.assertTrue(cc.max_age, "max-age must be set and positive")
+                    self.assertFalse(cc.no_cache, "no-cache must not be set")
+                    self.assertFalse(cc.no_store, "no-store must not be set")
+                except AssertionError as exc:
+                    e = "wkhtmltopdf only works if it is allowed to cache everything"
+                    raise AssertionError(e) from exc
+                self.assertEqual(res.content, self.gizeh_data)
 
 @tagged('post_install', '-at_install')
 class TestHttpStaticLogo(TestHttpStaticCommon):

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1598,8 +1598,12 @@ class Request:
         try:
             directory = root.statics[module]
             filepath = werkzeug.security.safe_join(directory, path)
+            debug = (
+                'assets' in self.session.debug and
+                ' wkhtmltopdf ' not in self.httprequest.user_agent.string
+            )
             res = Stream.from_path(filepath, public=True).get_response(
-                max_age=0 if 'assets' in self.session.debug else STATIC_CACHE,
+                max_age=0 if debug else STATIC_CACHE,
                 content_security_policy=None,
             )
             root.set_csp(res)


### PR DESCRIPTION
Steps to reproduce
==================

- Activate the assets debug mode
- Print a report => The footer is missing

Cause of the issue
==================

The sames fonts are used in the header and footer.

A first request is made


```http
GET /web/static/fonts/lato/Lato-Reg-webfont.woff HTTP/1.1
Accept: */*
Cookie: REDACTED
Connection: Keep-Alive
Accept-Encoding: gzip
Accept-Language: en-US,*
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) wkhtmltopdf Safari/534.34

HTTP/1.0 200 OK
Server: Werkzeug/2.0.2 Python/3.11.11
Etag: "1710849406-32964-706485214"
Expires: Tue, 28 Jan 2025 13:18:36 GMT
Content-Disposition: inline; filename=Lato-Bla-webfont.woff
Content-Type: application/font-woff
Date: Tue, 28 Jan 2025 13:18:36 GMT
Last-Modified: Tue, 19 Mar 2024 11:56:46 GMT
Content-Length: 32964
Cache-Control: no-cache, max-age=0
Accept-Ranges: bytes
```

The second request from the footer is

```http
GET /web/static/fonts/lato/Lato-Reg-webfont.woff HTTP/1.1
Cache-Control: no-cache
Pragma: no-cache
If-Modified-Since: Tue, 19 Mar 2024 11:56:46 GMT
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) wkhtmltopdf Safari/534.34
Cookie: REDACTED
Connection: Keep-Alive
Accept-Encoding: gzip
If-None-Match: "1710849406-32964-706485214"
Accept: */*
Accept-Language: en-US,*

HTTP/1.0 304 NOT MODIFIED
Server: Werkzeug/2.0.2 Python/3.11.11
Date: Tue, 28 Jan 2025 13:18:36 GMT
Accept-Ranges: bytes
Content-Disposition: inline; filename=Lato-Bla-webfont.woff
Cache-Control: no-cache, max-age=0
Expires: Tue, 28 Jan 2025 13:18:36 GMT
Etag: "1710849406-32964-706485214"
```
When running wkhtmltopdf manually, we obtain the following output:

```
Warning: Received createRequest signal on a disposed ResourceObject's NetworkAccessManager.
This might be an indication of an iframe taking too long to load.
```

This indicates that wkhtmltopdf is not handling the cache headers
correctly and fails to recognize the fact that it should reuse the
previously received version of the file.

Solution
========

In production, odoo should run behind a reverse proxy that handles
static files, and the debug assets mode should not be used.

Nevertheless, since wkhtmltopdf misinterprets cache headers, we simply
remove them in case

opw-4413445