### PR TITLE
[FIX] mail: crash when navigating empty emoji picker

### DIFF
--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -374,11 +374,11 @@ export class EmojiPicker extends Component {
             }
             case "ArrowRight": {
                 const colRight = currentCol + 1;
-                if (colRight === this.emojiMatrix[currentRow].length) {
+                if (colRight === this.emojiMatrix[currentRow]?.length) {
                     const rowBelowRight = this.emojiMatrix[currentRow + 1];
                     newIdx = rowBelowRight?.[0];
                 } else {
-                    newIdx = this.emojiMatrix[currentRow][colRight];
+                    newIdx = this.emojiMatrix[currentRow]?.[colRight];
                 }
                 break;
             }


### PR DESCRIPTION
Before this PR, pressing the right arrow key when the emoji picker was empty led to a crash.

Steps to reproduce:
- Open the picker
- Type a search that matches no emojis ("ezaeazeza")
- Press the right arrow

This PR fixes the issue.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
