### PR TITLE
[FIX] marketing_card: make page titles and template name translatable

### DIFF
--- a/addons/marketing_card/i18n/marketing_card.pot
+++ b/addons/marketing_card/i18n/marketing_card.pot
@@ -126,8 +126,18 @@ msgid "Attachment Count"
 msgstr ""
 
 #. module: marketing_card
+#: model:card.template,name:marketing_card.card_template_avatar_highlight
+msgid "Avatar Highlight"
+msgstr ""
+
+#. module: marketing_card
 #: model:ir.model.fields,field_description:marketing_card.field_card_campaign__content_background
 msgid "Background"
+msgstr ""
+
+#. module: marketing_card
+#: model:card.template,name:marketing_card.card_template_blur
+msgid "Blur"
 msgstr ""
 
 #. module: marketing_card
@@ -182,6 +192,11 @@ msgid "Card Count"
 msgstr ""
 
 #. module: marketing_card
+#: model_terms:ir.ui.view,arch_db:marketing_card.card_campaign_view_form
+msgid "Card Layout"
+msgstr ""
+
+#. module: marketing_card
 #: model:ir.model.fields,field_description:marketing_card.field_mailing_mailing__card_requires_sync_count
 msgid "Card Requires Sync Count"
 msgstr ""
@@ -200,6 +215,16 @@ msgstr ""
 #. module: marketing_card
 #: model_terms:ir.ui.view,arch_db:marketing_card.mailing_mailing_view_form_inherit_marketing_card
 msgid "Cards"
+msgstr ""
+
+#. module: marketing_card
+#: model:card.template,name:marketing_card.card_template_user_image
+msgid "Center"
+msgstr ""
+
+#. module: marketing_card
+#: model:card.template,name:marketing_card.card_template_circles
+msgid "Circles"
 msgstr ""
 
 #. module: marketing_card
@@ -244,6 +269,11 @@ msgid "Created on"
 msgstr ""
 
 #. module: marketing_card
+#: model:card.template,name:marketing_card.card_template_dark
+msgid "Dark"
+msgstr ""
+
+#. module: marketing_card
 #: model:ir.model.fields,field_description:marketing_card.field_card_template__default_background
 msgid "Default Background"
 msgstr ""
@@ -267,6 +297,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:marketing_card.field_mailing_mailing__display_name
 #: model:ir.model.fields,field_description:marketing_card.field_utm_source__display_name
 msgid "Display Name"
+msgstr ""
+
+#. module: marketing_card
+#: model:card.template,name:marketing_card.card_template_drawings
+msgid "Drawings"
 msgstr ""
 
 #. module: marketing_card
@@ -312,6 +347,11 @@ msgstr ""
 #. module: marketing_card
 #: model:ir.model.fields,help:marketing_card.field_card_campaign__activity_type_icon
 msgid "Font awesome icon e.g. fa-tasks"
+msgstr ""
+
+#. module: marketing_card
+#: model:card.template,name:marketing_card.card_template_geometric
+msgid "Geometric"
 msgstr ""
 
 #. module: marketing_card
@@ -442,6 +482,21 @@ msgstr ""
 #: model:ir.model.fields,field_description:marketing_card.field_card_card__write_date
 #: model:ir.model.fields,field_description:marketing_card.field_card_template__write_date
 msgid "Last Updated on"
+msgstr ""
+
+#. module: marketing_card
+#: model:card.template,name:marketing_card.card_template_light
+msgid "Light"
+msgstr ""
+
+#. module: marketing_card
+#: model:card.template,name:marketing_card.card_template_lila
+msgid "Lila"
+msgstr ""
+
+#. module: marketing_card
+#: model:card.template,name:marketing_card.card_template_lines
+msgid "Lines"
 msgstr ""
 
 #. module: marketing_card
@@ -601,6 +656,11 @@ msgid ""
 msgstr ""
 
 #. module: marketing_card
+#: model:card.template,name:marketing_card.card_template_organic
+msgid "Organic"
+msgstr ""
+
+#. module: marketing_card
 #: model:ir.model.fields,field_description:marketing_card.field_card_campaign__target_url
 msgid "Post Link"
 msgstr ""
@@ -662,6 +722,11 @@ msgstr ""
 
 #. module: marketing_card
 #: model_terms:ir.ui.view,arch_db:marketing_card.card_campaign_view_form
+msgid "Recipient Message"
+msgstr ""
+
+#. module: marketing_card
+#: model_terms:ir.ui.view,arch_db:marketing_card.card_campaign_view_form
 msgid "Recipients"
 msgstr ""
 
@@ -714,6 +779,11 @@ msgstr ""
 #. module: marketing_card
 #: model:ir.model.fields,field_description:marketing_card.field_card_campaign__message_has_sms_error
 msgid "SMS Delivery error"
+msgstr ""
+
+#. module: marketing_card
+#: model:card.template,name:marketing_card.card_template_safari
+msgid "Safari"
 msgstr ""
 
 #. module: marketing_card
@@ -900,6 +970,11 @@ msgid "Visited"
 msgstr ""
 
 #. module: marketing_card
+#: model:card.template,name:marketing_card.card_template_waves
+msgid "Waves"
+msgstr ""
+
+#. module: marketing_card
 #: model:ir.model.fields,field_description:marketing_card.field_card_campaign__website_message_ids
 msgid "Website Messages"
 msgstr ""
@@ -912,6 +987,11 @@ msgstr ""
 #. module: marketing_card
 #: model:ir.model.fields,help:marketing_card.field_card_card__requires_sync
 msgid "Whether the image needs to be updated to match the campaign template."
+msgstr ""
+
+#. module: marketing_card
+#: model:card.template,name:marketing_card.card_template_world_map
+msgid "World Map"
 msgstr ""
 
 #. module: marketing_card

--- a/addons/marketing_card/models/card_template.py
+++ b/addons/marketing_card/models/card_template.py
@@ -12,7 +12,7 @@ class CardTemplate(models.Model):
     _name = 'card.template'
     _description = 'Marketing Card Template'
 
-    name = fields.Char(required=True)
+    name = fields.Char(required=True, translate=True)
     default_background = fields.Image()
     body = fields.Html(sanitize_tags=False, sanitize_attributes=False)
 

--- a/addons/marketing_card/views/card_campaign_views.xml
+++ b/addons/marketing_card/views/card_campaign_views.xml
@@ -82,7 +82,7 @@
                     </group>
                 </group>
                 <notebook>
-                    <page name="Card Layout">
+                    <page name="Card Layout" string="Card Layout">
                         <group>
                         <group>
                             <field name="content_background" widget="image" options="{'img_class': 'w-25 object-fit-contain'}"/>
@@ -130,7 +130,7 @@
                         </group>
                         </group>
                     </page>
-                    <page name="Recipient Message">
+                    <page name="Recipient Message" string="Recipient Message">
                         <group>
                             <group>
                                 <field name="request_title"/>


### PR DESCRIPTION
Both the page titles in the view as well as the template names were not translatable. We make them translatable here.

[opw-4421055](https://www.odoo.com/odoo/project.task/4421055)