### PR TITLE
[FIX] account: fix propagation of tax tags

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1847,7 +1847,7 @@ class AccountTax(models.Model):
                     index = (index + 1) % len(sorted_tax_reps_data)
 
         subsequent_taxes = self.env['account.tax']
-        subsequent_tags = self.env['account.account.tag']
+        subsequent_tags_per_tax = defaultdict(lambda: self.env['account.account.tag'])
         for tax_data in reversed(taxes_data):
             tax = tax_data['tax']
 
@@ -1861,7 +1861,9 @@ class AccountTax(models.Model):
                     tax_rep_data['tax_tags'] = tax_rep.tag_ids
                 if tax.include_base_amount:
                     tax_rep_data['taxes'] |= subsequent_taxes
-                    tax_rep_data['tax_tags'] |= subsequent_tags
+                    for other_tax, tags in subsequent_tags_per_tax.items():
+                        if tax != other_tax:
+                            tax_rep_data['tax_tags'] |= tags
 
                 # Add the accounting grouping_key to create the tax lines.
                 base_line_grouping_key = self._prepare_base_line_grouping_key(base_line)
@@ -1875,7 +1877,7 @@ class AccountTax(models.Model):
             if tax.is_base_affected:
                 subsequent_taxes |= tax
                 if include_caba_tags or tax.tax_exigibility == 'on_invoice':
-                    subsequent_tags |= tax[repartition_lines_field].filtered(lambda x: x.repartition_type == 'base').tag_ids
+                    subsequent_tags_per_tax[tax] |= tax[repartition_lines_field].filtered(lambda x: x.repartition_type == 'base').tag_ids
 
     @api.model
     def _add_accounting_data_in_base_lines_tax_details(self, base_lines, company, include_caba_tags=False):


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Create a tax with the following configuration:
  * Tax Type: Purchases (also reproducible with Sales)
  * Included in Price: [any]
  * Affect Base of Subsequent Taxes (include_base_amount): [checked]
  * Base Affected by Previous Taxes (is_base_affected): [checked]
  * Distribution:
      |  %   | Based On |  Account  |   Tax Grids |
      | ------ | ------------- | ------------ | -------------- |
      |      |   Base   |           | +Tag_1  +Tag_2 |
     | 100.00 |  of tax  | Account X | +Tag_3 |
     | -100.00 |  of tax  | Account Y | -Tag_4 |

(Or FR localization and "20% EU G" purchase tax can be used)
- Create a bill
- Add a line with the created tax
- Check journal items

**Issue:**
The tax tags of the base line are also added to first tax line.

**Cause:**
When a tax is "include_base_amount", the tags of its base line is propagated to the tax lines of the following taxes. However in this case, as there are several tax lines for the same tax, the system propagate the tags to the second one as if it was coming from another tax.

**Solution:**
Check if the tags are coming from another tax before adding them.


opw-4510882




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
