### PR TITLE
[FIX] pos_restaurant: transfer preparation change

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -13,7 +13,9 @@ export const changesToOrder = (
         : Object.values(order.last_order_preparation_change.lines);
 
     for (const lineChange of linesChanges) {
-        if (lineChange["quantity"] > 0 && !cancelled) {
+        if (lineChange["quantity"] === 0) {
+            continue;
+        } else if (lineChange["quantity"] > 0 && !cancelled) {
             toAdd.push(lineChange);
         } else {
             lineChange["quantity"] = Math.abs(lineChange["quantity"]); // we need always positive values.

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -459,6 +459,153 @@ registry.category("web_tour.tours").add("ComboSortedPreparationReceiptTour", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("TableTransferPreparationChange1", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            //Transfer sent product on table with same product sent
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Product Test"),
+            ProductScreen.clickOrderButton(),
+            Dialog.confirm(),
+            ProductScreen.orderlinesHaveNoChange("Product Test"),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("4"),
+            ProductScreen.clickDisplayedProduct("Product Test"),
+            ProductScreen.clickOrderButton(),
+            Dialog.confirm(),
+            ProductScreen.orderlinesHaveNoChange("Product Test"),
+            ProductScreen.clickControlButton("Transfer"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.orderlinesHaveNoChange("Product Test"),
+            ProductScreen.orderLineHas("Product Test", "2"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("TableTransferPreparationChange2", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            //Transfer sent product on table with same product not sent
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Product Test"),
+            ProductScreen.orderlineIsToOrder("Product Test"),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("4"),
+            ProductScreen.clickDisplayedProduct("Product Test"),
+            ProductScreen.clickOrderButton(),
+            Dialog.confirm(),
+            ProductScreen.orderlinesHaveNoChange("Product Test"),
+            ProductScreen.clickControlButton("Transfer"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.orderlineIsToOrder("Product Test"),
+            ProductScreen.orderLineHas("Product Test", "2"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            Chrome.clickPlanButton(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("TableTransferPreparationChange3", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            //Transfer sent product on table without the same product
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Product Test"),
+            ProductScreen.clickOrderButton(),
+            Dialog.confirm(),
+            ProductScreen.clickControlButton("Transfer"),
+            FloorScreen.clickTable("4"),
+            ProductScreen.orderlinesHaveNoChange("Product Test"),
+            ProductScreen.orderLineHas("Product Test", "1"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            Chrome.clickPlanButton(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("TableTransferPreparationChange4", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            //Transfer not sent product on table with same product not sent
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Product Test"),
+            ProductScreen.orderlineIsToOrder("Product Test"),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("4"),
+            ProductScreen.clickDisplayedProduct("Product Test"),
+            ProductScreen.orderlineIsToOrder("Product Test"),
+            ProductScreen.clickControlButton("Transfer"),
+            FloorScreen.hasTable("5"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.orderLineHas("Product Test", "2"),
+            ProductScreen.orderlineIsToOrder("Product Test"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("4"),
+            ProductScreen.orderIsEmpty(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("TableTransferPreparationChange5", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+
+            //Transfer not sent product on table with same product sent
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Product Test"),
+            ProductScreen.orderLineHas("Product Test", "1"),
+            ProductScreen.clickOrderButton(),
+            Dialog.confirm(),
+            ProductScreen.orderlinesHaveNoChange("Product Test"),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("4"),
+            ProductScreen.clickDisplayedProduct("Product Test"),
+            ProductScreen.orderLineHas("Product Test", "1"),
+            ProductScreen.orderlineIsToOrder("Product Test"),
+            ProductScreen.clickControlButton("Transfer"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.orderlineIsToOrder("Product Test"),
+            ProductScreen.orderLineHas("Product Test", "2"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            Chrome.clickPlanButton(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("TableTransferPreparationChange6", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            //Transfer not sent product on table without the same product
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Product Test"),
+            ProductScreen.clickControlButton("Transfer"),
+            FloorScreen.clickTable("4"),
+            ProductScreen.orderlineIsToOrder("Product Test"),
+            ProductScreen.orderLineHas("Product Test", "1"),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("MultiPreparationPrinter", {
     checkDelay: 50,
     steps: () =>

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -400,6 +400,42 @@ class TestFrontend(TestFrontendCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PreparationPrinterContent', login="pos_user")
 
+    def test_transfer_table_last_preparation_change(self):
+        """This test will check if the last preparation change is correctly transferred to the new table with 6 possible cases:
+            - Transfer sent product on table with same product sent
+            - Transfer sent product on table with same product not sent
+            - Transfer sent product on table without the same product
+            - Transfer not sent product on table with same product not sent
+            - Transfer not sent product on table with same product sent
+            - Transfer not sent product on table without the same product"""
+        self.env['pos.printer'].create({
+            'name': 'Printer',
+            'printer_type': 'epson_epos',
+            'epson_printer_ip': '0.0.0.0',
+            'product_categories_ids': [Command.set(self.env['pos.category'].search([]).ids)],
+        })
+
+        self.main_pos_config.write({
+            'is_order_printer' : True,
+            'printer_ids': [Command.set(self.env['pos.printer'].search([]).ids)],
+        })
+
+        self.product_test = self.env['product.product'].create({
+            'name': 'Product Test',
+            'available_in_pos': True,
+            'list_price': 10,
+            'pos_categ_ids': [(6, 0, [self.env['pos.category'].search([], limit=1).id])],
+            'taxes_id': False,
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'TableTransferPreparationChange1', login="pos_user")
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'TableTransferPreparationChange2', login="pos_user")
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'TableTransferPreparationChange3', login="pos_user")
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'TableTransferPreparationChange4', login="pos_user")
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'TableTransferPreparationChange5', login="pos_user")
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'TableTransferPreparationChange6', login="pos_user")
+
     def test_combo_preparation_receipt(self):
         setup_product_combo_items(self)
         pos_printer = self.env['pos.printer'].create({


### PR DESCRIPTION
When trasnsfering/merging order with some preparation changes, the preparation changes are not correctly transferred to the new order.

Steps to reproduce:
-------------------
* Setup a restaurant with a kitchen printer
* Open PoS restaurant
* Open table 1 add any product and send it to kitchen
* Open table 2 add the same product and send it to kitchen
* Merge table 1 and table 2
> Observation: The preparation change are printed again

Why the fix:
------------
The issue is that the preparation change were not transferred to the new order. This was causing the preparation change to be printed again. I identified 6 use cases to test :
- Transfer sent product on table with same product sent
- Transfer sent product on table with same product not sent
- Transfer sent product on table without the same product
- Transfer not sent product on table with same product not sent
- Transfer not sent product on table with same product sent
- Transfer not sent product on table without the same product

https://github.com/odoo/odoo/blob/948c36a7d8706126dce3f43e9f074d16c10d3395/addons/point_of_sale/static/src/app/models/utils/order_change.js#L16-L18
We need to make sure to ignore changes that have exactly 0 quantity

https://github.com/odoo-dev/odoo/blob/948c36a7d8706126dce3f43e9f074d16c10d3395/addons/pos_restaurant/static/src/overrides/models/pos_store.js#L335

Here we need to make sure that the order are synchronised. This is not really needed for real use, but in the tour it was not working because it was going too fast
opw-4462713