### PR TITLE
[FIX] website_event_track: Ignore colorless tags on the proposal form

### DIFF
--- a/addons/website_event_track/static/src/js/website_event_track_proposal_form_tags.js
+++ b/addons/website_event_track/static/src/js/website_event_track_proposal_form_tags.js
@@ -30,7 +30,7 @@ publicWidget.registry.websiteEventTrackProposalFormTags = publicWidget.Widget.ex
     async willStart() {
         const choices = await rpc("/event/track_tag/search_read", {
             fields: ["id", "name", "category_id"],
-            domain: [],
+            domain: [["color", "!=", 0]],
         });
         this.choices = choices.map(({ id, category_id, name }) => {
             return {


### PR DESCRIPTION
Colorless tags are always hidden in the frontend interface, this allows
to manage them in backend without showing them.

Since there's no filter on the `websiteEventTrackProposalFormTags` widget,
those tags were still selectable from the website, resulting in the
following issues:
- Adding useless noise in the selection.
- Letting users select tags that are not intended to be selected.
- Users could also wrongly select a tag instead of the intended one.