### PR TITLE
[FIX] website_sale: use correct limit when filtering newest products

### DIFF
--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import Counter
+from functools import partial
 
 from odoo import _, api, fields, models
 from odoo.osv import expression
@@ -15,7 +16,7 @@ class WebsiteSnippetFilter(models.Model):
             " cross selling",
     )
 
-    def _prepare_values(self, **kwargs):
+    def _prepare_values(self, limit=None, **kwargs):
         website = self.env['website'].get_current_website()
         if self.model_name == 'product.product' and not website.has_ecommerce_access():
             return []
@@ -25,10 +26,26 @@ class WebsiteSnippetFilter(models.Model):
             hide_variants = True
             search_domain.remove('hide_variants')
             kwargs['search_domain'] = search_domain
-        return super(
+        update_limit_cache = False
+        product_limit = limit or self.limit
+        if hide_variants and self.filter_id.model_id == 'product.product':
+            # When hiding variants, temporarily update cache to increase `self.limit`
+            # so we hopefully end up with the correct amount of product templates
+            update_limit_cache = partial(
+                self.env.cache.set,
+                record=self,
+                field=self._fields['limit'],
+            )
+            limit = product_limit ** 2  # heuristic, may still be inadequate in some cases
+            stored_limit = self.limit
+            update_limit_cache(value=limit)
+        res = super(
             WebsiteSnippetFilter,
-            self.with_context(hide_variants=hide_variants),
-        )._prepare_values(**kwargs)
+            self.with_context(hide_variants=hide_variants, product_limit=product_limit),
+        )._prepare_values(limit=limit, **kwargs)
+        if update_limit_cache:
+            update_limit_cache(value=stored_limit)
+        return res
 
     @api.model
     def _get_website_currency(self):
@@ -73,7 +90,8 @@ class WebsiteSnippetFilter(models.Model):
     def _filter_records_to_values(self, records, is_sample=False):
         hide_variants = self.env.context.get('hide_variants') and not isinstance(records, list)
         if hide_variants:
-            records = records.product_tmpl_id
+            product_limit = self.env.context.get('product_limit') or self.limit
+            records = records.product_tmpl_id[:product_limit]
         res_products = super()._filter_records_to_values(records, is_sample)
         if self.model_name == 'product.product':
             for res_product in res_products:

--- a/addons/website_sale/tests/test_website_sale_product_filters.py
+++ b/addons/website_sale/tests/test_website_sale_product_filters.py
@@ -77,6 +77,25 @@ class TestWebsiteSaleProductFilters(WebsiteSaleCommon, TestSaleProductAttributeV
             'website_published': True,
         })
 
+        # More generic products to get the number of product templates to 17
+        generics = cls.env['product.template'].create([{
+            'name': f"Generic product {i}",
+            'company_id': False,
+            'website_published': True,
+        } for i in range(1, 13)])
+
+        cls.product_tmpls = (
+            cls.computer_case + cls.monitor + cls.computer + cls.windows_pc + cls.mac + generics
+        )
+
+        if 'loyalty.program' in cls.env:
+            programs = cls.env['loyalty.program'].sudo().search([])
+            programs.active = False
+            programs.coupon_ids.unlink()
+            programs.unlink()
+
+        cls.env['product.template'].search([('id', 'not in', cls.product_tmpls.ids)]).active = False
+
     def test_latest_sold_filter(self):
         """Check the latest sold filter after selling 1 computer and 3 different cases.
 
@@ -262,4 +281,38 @@ class TestWebsiteSaleProductFilters(WebsiteSaleCommon, TestSaleProductAttributeV
                 [p['product_id'] for p in no_variants],
                 [self.computer.product_variant_id.id, self.windows_pc.product_variant_id.id],
                 "Alternative products filter should return 2 results when hiding variants",
+            )
+
+    def test_newest_products_filter(self):
+        """Check the newest products filter.
+
+        When showing variants, the filter should return 16 variants with repeating templates.
+        When hiding variants, the filter should return 16 templates, all unique.
+
+        This filter is unique in that it's defined in `data/data.xml`, and hence can't be called
+        via the `_get_products` method.
+        """
+        # Ensure we're working with a known set of products
+        self.assertEqual(len(self.env['product.template'].search([])), 17)
+
+        dyn_filter = self.env.ref('website_sale.dynamic_filter_newest_products')
+        with MockRequest(self.env, website=self.website):
+            with_variants = dyn_filter._prepare_values(search_domain=[])
+            self.assertEqual(
+                len(with_variants),
+                16,
+                "When displaying newest variants, 16 records should be shown",
+            )
+            self.assertLess(
+                len({p['product_template_id'] for p in with_variants}),
+                16,
+                "When displaying newest variants, some product templates should be repeating",
+            )
+
+            no_variants = dyn_filter._prepare_values(search_domain=['hide_variants'])
+            self.assertEqual(len(no_variants), 16)
+            self.assertEqual(
+                len({p['product_template_id'] for p in no_variants}),
+                16,
+                "When displaying newest product templates, 16 unique templates should be shown",
             )


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Create a new product with a lot of variants;
2. publish it to the website;
3. edit the website home page to add a product carousel;
4. set it to display newest products & hide variants.

Issue
-----
Fewer than 16 products are displayed in the carousel.

Cause
-----
Unlike the other product filters handled in https://github.com/odoo/odoo/pull/189040, the "Newest Products" filter is defined in `data/data.xml`, and stored as a record.

This means it doesn't use the `_get_products` method to perform the search, instead using the `_prepare_values` method from the `website` module.

For obvious reasons, the method defined in `website` doesn't take the `hide_variants` parameter into account to get the correct amount of search results: https://github.com/odoo/odoo/blob/0f64298c871ffea088a4fe6255d19852c8348159/addons/website/models/website_snippet_filter.py#L102-L108
Instead it passes 16 `product.product` records to the `_filter_records_to_values` override in `website_sale`, where duplicate templates are filtered out, resulting in fewer than 16 product templates: https://github.com/odoo/odoo/blob/0f64298c871ffea088a4fe6255d19852c8348159/addons/website_sale/models/website_snippet_filter.py#L73-L76

Solution
--------
When calling `super()._prepare_values` for stored `product.product` filters, temporarily square the usual limit for the search, and filter reduce to size later.

This may still be inadequate when working with products with dozens of variants, but should cover most normal use cases without requiring drastic changes to filter templates or search domain in stable.

On master, we could add a new filter specifically for `product.template`.

opw-4302856