### PR TITLE
[FIX] website_blog: fix very long list of blogs in navbar

### DIFF
--- a/addons/website_blog/static/src/scss/website_blog.scss
+++ b/addons/website_blog/static/src/scss/website_blog.scss
@@ -52,6 +52,19 @@ $o-wblog-loader-size: 50px;
         }
     }
 
+    > nav > .container {
+        > ul.navbar-nav {
+            flex-wrap: wrap;
+            flex-shrink: 2;
+        }
+        // If the navbar contains at least 10 items (random choice), the search
+        // input is placed at the top to avoid being centered in a multi-line
+        // navbar, which wouldn’t look good.
+        &:has(> ul.navbar-nav .nav-item:nth-child(10)) .o_searchbar_form {
+            align-self: start;
+        }
+    }
+
     .css_website_mail {
         .o_has_error {
             border-color: red;


### PR DESCRIPTION
Steps to reproduce:

- Go to the "/blog" page.
- Click on "Configuration > Blogs" in the main navbar.
- Create at least 15 new blogs with "Astronomy" as the name.
- Go back to the "/blog" page.
- Bug: The navbar overflows the page to the right, causing a horizontal
scrollbar to appear.

After this commit, the navbar no longer overflows, and the list items
are displayed on multiple lines.

[opw-4507558](https://www.odoo.com/web#id=4507558&cids=1&menu_id=4720&action=333&active_id=1695&model=project.task&view_type=form)