### PR TITLE
[FIX] hr_skills: fix non-derministic error in skills tour

### DIFF
--- a/addons/hr_skills/static/tests/tours/skills_tour.js
+++ b/addons/hr_skills/static/tests/tours/skills_tour.js
@@ -135,7 +135,10 @@ tour.register('hr_skills_tour', {
         in_modal: true,
         run: "click",
     },
-    ...tour.stepUtils.saveForm(),
+    ...tour.stepUtils.saveForm({
+        content: "save Form",
+        extra_trigger: 'td:containsExact("Oh Mary")',
+    }),
     {
         content: "Go back to employees",
         trigger: 'a[data-menu-xmlid="hr.menu_hr_root"]',


### PR DESCRIPTION
Before this commit, `hr_skills_tour` used to randomly break in the runbot. The main issue is that it doesn't wait for the new skill to be added before trying to save the form.

This commit adds an extra trigger to make sure the skill is added before attempting to save.

Runbot Error: https://runbot.odoo.com/odoo/action-573/64575



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
