### PR TITLE
[FIX] mail: no crash from discuss sidebar when ongoing call

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -32,7 +32,7 @@
                 direction="compact ? 'v' : 'h'"
                 avatarClass="(p) => this.avatarClass(p)"
                 max="compact ? 1 : 4"
-                personas="sessions.map((s) => s.channel_member_id.persona)"
+                personas="sessions.map((s) => s.channel_member_id?.persona).filter(p => p)"
             >
                 <t t-set-slot="avatarExtraInfo" t-slot-scope="scope">
                     <div class="o-mail-DiscussSidebarCallParticipants-status small" t-att-class="{


### PR DESCRIPTION
When people were in a discuss call, the following crash may happen when discuss app is open:

```
Cannot read properties of undefined (reading 'persona')
```

This comes from template reading `channel_member.persona`, which can be undefined. Indeed, some flow may return channel member data without persona data, thus the persona is unknown (= undefined) in JS.

This commit fixes the issue by taking into account persona of member that could be missing in the discuss sidebar call participant component.

Task-4533395
