### PR TITLE
[IMP] core: log model and method in xmlrpc/jsonrpc

### DIFF
--- a/addons/web/controllers/dataset.py
+++ b/addons/web/controllers/dataset.py
@@ -5,6 +5,7 @@ from werkzeug.exceptions import NotFound
 from odoo import http
 from odoo.http import request
 from odoo.service.model import call_kw
+from odoo.service.server import thread_local
 
 from .utils import clean_action
 
@@ -26,10 +27,14 @@ class DataSet(http.Controller):
 
     @http.route(['/web/dataset/call_kw', '/web/dataset/call_kw/<path:path>'], type='jsonrpc', auth="user", readonly=_call_kw_readonly)
     def call_kw(self, model, method, args, kwargs, path=None):
+        if path != f'{model}.{method}':
+            thread_local.rpc_model_method = f'{model}.{method}'
         return call_kw(request.env[model], method, args, kwargs)
 
     @http.route(['/web/dataset/call_button', '/web/dataset/call_button/<path:path>'], type='jsonrpc', auth="user", readonly=_call_kw_readonly)
     def call_button(self, model, method, args, kwargs, path=None):
+        if path != f'{model}.{method}':
+            thread_local.rpc_model_method = f'{model}.{method}'
         action = call_kw(request.env[model], method, args, kwargs)
         if isinstance(action, dict) and action.get('type') != '':
             return clean_action(action, env=request.env)

--- a/odoo/addons/test_rpc/tests/__init__.py
+++ b/odoo/addons/test_rpc/tests/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
+from . import test_rpc_path
 from . import test_error

--- a/odoo/addons/test_rpc/tests/test_rpc_path.py
+++ b/odoo/addons/test_rpc/tests/test_rpc_path.py
@@ -1,0 +1,76 @@
+import logging
+
+from odoo.tests import Like, get_db_name, tagged
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+
+
+@tagged('-at_install', 'post_install')
+class TestRpcPath(HttpCaseWithUserDemo):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.session = cls.authenticate(cls, 'demo', 'demo')
+
+    def setUp(self):
+        super().setUp()
+        self.opener.cookies['session_id'] = self.session.sid
+
+    def test_rpc_path_call_button(self):
+        with self.assertLogs('werkzeug', logging.INFO) as capture:
+            self.make_jsonrpc_request('/web/dataset/call_button', {
+                'model': 'res.users',
+                'method': 'read',
+                'args': [self.user_demo.id],
+                'kwargs': {'fields': ['login']}
+            })
+        self.assertEqual(capture.output, [
+            Like('...POST /web/dataset/call_button#res.users.read HTTP/...'),
+        ])
+
+    def test_rpc_path_call_kw(self):
+        with self.assertLogs('werkzeug', logging.INFO) as capture:
+            self.make_jsonrpc_request('/web/dataset/call_kw', {
+                'model': 'res.users',
+                'method': 'read',
+                'args': [self.user_demo.id],
+                'kwargs': {'fields': ['login']}
+            })
+        self.assertEqual(capture.output, [
+            Like('...POST /web/dataset/call_kw#res.users.read HTTP/...'),
+        ])
+
+    def test_rpc_path_call_kw_with_path(self):
+        with self.assertLogs('werkzeug', logging.INFO) as capture:
+            self.make_jsonrpc_request('/web/dataset/call_kw/res.users.read', {
+                'model': 'res.users',
+                'method': 'read',
+                'args': [self.user_demo.id],
+                'kwargs': {'fields': ['login']}
+            })
+        self.assertEqual(capture.output, [
+            Like('...POST /web/dataset/call_kw/res.users.read HTTP/...'),
+        ])
+
+    def test_rpc_path_jsonrpc(self):
+        with self.assertLogs('werkzeug', logging.INFO) as capture:
+            self.make_jsonrpc_request('/jsonrpc', {
+                'service': 'object',
+                'method': 'execute_kw',
+                'args': [
+                    get_db_name(), self.user_demo.id, 'demo',
+                   'res.users', 'read', [self.user_demo.id, ['login']]
+                ]
+            })
+        self.assertEqual(capture.output, [
+            Like('...POST /jsonrpc#res.users.read HTTP/...'),
+        ])
+
+    def test_rpc_path_xmlrpc(self):
+        with self.assertLogs('werkzeug', logging.INFO) as capture:
+            self.xmlrpc_object.execute_kw(
+                get_db_name(), self.user_demo.id, 'demo',
+               'res.users', 'read', [self.user_demo.id, ['login']]
+            )
+        self.assertEqual(capture.output, [
+            Like('...POST /xmlrpc/2/object#res.users.read HTTP/...'),
+        ])

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -200,6 +200,7 @@ from .exceptions import UserError, AccessError, AccessDenied
 from .modules import module as module_manager
 from .modules.registry import Registry
 from .service import security, model as service_model
+from .service.server import thread_local
 from .tools import (config, consteq, file_path, get_lang, json_default,
                     parse_version, profiler, unique, exception_to_unicode)
 from .tools.func import filter_kwargs, lazy_property
@@ -2410,6 +2411,7 @@ class Application:
             del current_thread.dbname
         if hasattr(current_thread, 'uid'):
             del current_thread.uid
+        thread_local.rpc_model_method = ''
 
         if odoo.tools.config['proxy_mode'] and environ.get("HTTP_X_FORWARDED_HOST"):
             # The ProxyFix middleware has a side effect of updating the


### PR DESCRIPTION
When calling /web/dataset/call_kw or /web/dataset/call_button, the model and method name are visible on the request path. This is information is very valuable and really helpful when debugging.

The model/method are actually not taken from the path, the information is actually serialized inside the request body which isn't log. It is the webclient who crafts those requests to include `/<model>/<method>` at the end.

It means that:

1. The information could be forged, to trick sysadmins.
2. Not all clients will add `/<model>/<method>` at the end of the path.
3. For the /jsonrpc and /xmlrpc endpoints, since the endpoints are standardized, it is not possible to use the same `/<path:path>` controller trick as call_wk/call_button.

In this work we introduce another global-ish variable `request_fragment` on the current thread which is reset for every request. When set, the value is used when logging the current request, the value is added after the path, as a fake URI fragment.

The fragment part of the URI is client side only, web client will truncate it from the URI when crafting the HTTP request. And is ignored by the server may a rogue client attempts to forge a request. This makes faking a fragment server-side a good candidate to include some more information.

See-Also: e9c633cb7e80 ([IMP] web: call call_kw with full route to help debugging)
See-Also: 7dadcdac5461 ([IMP] web: log model and method on call_button)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
