### PR TITLE
[FIX] l10n_cl: document_type field visibility on localizations different than CL

### DIFF
--- a/addons/l10n_cl/views/account_move_view.xml
+++ b/addons/l10n_cl/views/account_move_view.xml
@@ -17,7 +17,7 @@
         <field name="inherit_id" ref="l10n_latam_invoice_document.view_move_form"/>
         <field name="arch" type="xml">
             <field name="l10n_latam_document_number" position="attributes">
-                <attribute name="invisible">not l10n_latam_use_documents or (not l10n_latam_manual_document_number and state != "draft" and (not posted_before or country_code != "CL"))</attribute>
+                <attribute name="invisible" add="(not l10n_latam_use_documents or not posted_before or state != 'draft' or country_code != 'CL')" separator=" and "/>
                 <attribute name="readonly">posted_before and state != 'draft'</attribute>
                 <attribute name="required">l10n_latam_manual_document_number</attribute>
             </field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR intends to fix an issue we encountered when you have CL localization installed with other LATAM localizations.
The problem is that l10n_cl is modifying the visibility of the field "Document number" to appear when necessary directly on latam_invoice_document view. This make that the field visibility is being changed on other localizations as well when you have both installed.

Current behavior before PR:
The "Document Number" field below "Document Type" should is present on uruguayan electronic invoices (where it should not be).

Desired behavior after PR is merged:
The "Document Number" field is present on chilean invoices as expected and not in uruguayan electronic invoices.

Steps to reproduce the error:
- Install l10n_uy
- On the UY company, go to Customer/Invoices section, create one, select a customer and check that you have an electronic journal selected. The field "Document Number" should not be present.
- Install l10n_cl
- Go to the previously created invoice and check that the field "Document Number" now appears. 

Ticket ADHOC side: 86491
Ticket Odoo side: 4505977


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
