### PR TITLE
[FIX] web: action service: soft_reload: reload correct record

### DIFF
--- a/addons/web/static/tests/webclient/actions/client_action.test.js
+++ b/addons/web/static/tests/webclient/actions/client_action.test.js
@@ -156,6 +156,28 @@ test("soft_reload will refresh data", async () => {
     expect.verifySteps(["web_search_read"]);
 });
 
+test("soft_reload a form view", async () => {
+    onRpc("web_read", ({ args }) => {
+        expect.step(`read ${args[0][0]}`);
+    });
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction({
+        name: "Partners",
+        res_model: "partner",
+        views: [
+            [false, "list"],
+            [false, "form"],
+        ],
+        type: "ir.actions.act_window",
+    });
+    await contains(".o_data_row .o_data_cell").click();
+    await contains(".o_form_view .o_pager_next").click();
+    expect.verifySteps(["read 1", "read 2"]);
+
+    await getService("action").doAction("soft_reload");
+    expect.verifySteps(["read 2"]);
+});
+
 test("soft_reload when there is no controller", async () => {
     await mountWithCleanup(WebClient);
     await getService("action").doAction("soft_reload");


### PR DESCRIPTION
From a list or kanban view with several records, open a record in form view. Then use the pager to navigate to another record. From this point, execute the `soft_reload` client action (e.g. call a python method from a view button, which returns that client action). This client action is supposed to reload the current controller (the form view in this case), without reloading the whole webclient.

Before this commit, the form was indeed reloaded, but the reloaded record was the one we opened first, not the one we reached after navigating with the pager. With this commit, the correct record is reloaded.

Issue spotted for task-3935688

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
