### PR TITLE
[FIX] web: correctly detect empty fields

### DIFF
--- a/addons/web/static/src/legacy/js/views/kanban/kanban_record.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_record.js
@@ -119,10 +119,10 @@ var KanbanRecord = Widget.extend(WidgetAdapterMixin, {
      * @param {string} htmlContent
      * @returns {boolean} true if no content found or if containing only formatting tags
      */
-    isHtmlEmpty: function (htmlContent) {
-        let div = document.createElement('div');
-        div.innerHTML = htmlContent || "";
-        return div.innerText.trim() === "";
+    isHtmlEmpty: function (htmlContent = "") {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(htmlContent, "text/html");
+        return doc.body.innerText.trim() === "";
     },
     /**
      * Re-renders the record with a new state

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -26,7 +26,9 @@ const { COLORS } = ColorList;
 const formatters = registry.category("formatters");
 
 // These classes determine whether a click on a record should open it.
-export const CANCEL_GLOBAL_CLICK = ["a", ".dropdown", ".oe_kanban_action", "[data-bs-toggle]"].join(",");
+export const CANCEL_GLOBAL_CLICK = ["a", ".dropdown", ".oe_kanban_action", "[data-bs-toggle]"].join(
+    ","
+);
 const ALLOW_GLOBAL_CLICK = [".oe_kanban_global_click", ".oe_kanban_global_click_edit"].join(",");
 
 /**
@@ -150,8 +152,9 @@ function isBinSize(value) {
  * @returns {boolean} true if no content found or if containing only formatting tags
  */
 function isHtmlEmpty(innerHTML = "") {
-    const div = Object.assign(document.createElement("div"), { innerHTML });
-    return div.innerText.trim() === "";
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(innerHTML, "text/html");
+    return doc.body.innerText.trim() === "";
 }
 
 export class KanbanRecord extends Component {

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -67,6 +67,12 @@ function parseActiveIds(ids) {
     return activeIds;
 }
 
+const parser = new DOMParser();
+function isHelpEmpty(help) {
+    const doc = parser.parseFromString(help, "text/html");
+    return doc.body.innerText.trim() === "";
+}
+
 // -----------------------------------------------------------------------------
 // Errors
 // -----------------------------------------------------------------------------
@@ -208,9 +214,7 @@ function makeActionManager(env) {
                 ? evaluateExpr(domain, Object.assign({}, env.services.user.context, action.context))
                 : domain;
         if (action.help) {
-            const htmlHelp = document.createElement("div");
-            htmlHelp.innerHTML = action.help;
-            if (!htmlHelp.innerText.trim()) {
+            if (isHelpEmpty(action.help)) {
                 delete action.help;
             }
         }


### PR DESCRIPTION
At two different places, we try to determine if the value of an html field is empty. To do so, we create a node on the fly and set its innerHTML to that value. Then, we check if the element has a non-empty innerText. However, this doesn't work as expected if the given value is a text instead of a markuped html. This commit fixes the issue.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
