### PR TITLE
[FIX] mrp: correctly plan necessary workorders

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -522,10 +522,9 @@ class MrpWorkorder(models.Model):
         # Plan workorder after its predecessors
         start_date = max(self.production_id.date_planned_start, datetime.now())
         for workorder in self.blocked_by_workorder_ids:
-            if workorder.state in ['done', 'cancel']:
-                continue
             workorder._plan_workorder(replan)
-            start_date = max(start_date, workorder.date_planned_finished)
+            if workorder.date_planned_finished and workorder.date_planned_finished > start_date:
+                start_date = workorder.date_planned_finished
         # Plan only suitable workorders
         if self.state not in ['pending', 'waiting', 'ready']:
             return

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -3289,6 +3289,38 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(mo_backorder.workorder_ids[1].date_planned_start, datetime(2023, 3, 1, 12, 0))
         self.assertEqual(mo_backorder.workorder_ids[2].date_planned_start, datetime(2023, 3, 1, 12, 45))
 
+    @freeze_time('2023-03-01 12:00')
+    def test_all_workorders_planned(self):
+        """
+            Test, when writing to a confirmed MO, that all workorders that are expected to be planned are planned.
+        """
+        self.env.user.groups_id += self.env.ref('mrp.group_mrp_routings')
+
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = self.product_8
+        with mo_form.workorder_ids.new() as workorder:
+            workorder.name = "OP1"
+            workorder.workcenter_id = self.workcenter_2
+        with mo_form.workorder_ids.new() as workorder:
+            workorder.name = "OP2"
+            workorder.workcenter_id = self.workcenter_2
+        mo = mo_form.save()
+        mo.action_confirm()
+
+        mo.workorder_ids[1].button_start()
+        mo.workorder_ids[1].button_finish()
+
+        self.assertTrue(mo.workorder_ids[1].date_planned_start)
+
+        with Form(mo) as mo_form:
+            with mo_form.workorder_ids.new() as workorder:
+                workorder.name = "OP3"
+                workorder.workcenter_id = self.workcenter_2
+            mo = mo_form.save()
+
+        self.assertTrue(mo.workorder_ids[0].date_planned_start)
+        self.assertTrue(mo.workorder_ids[2].date_planned_start)
+
     def test_compute_product_id(self):
         """
             Tests the creation of a production order automatically sets the product when the bom is provided,


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/112800 added a fix to ignore planning done or cancelled workorders. However it introduced an issue where any unfinished workorders before the ignored workorder will also be ignored and cause a traceback in certain workflows.

Steps to reproduce
-----
1. Create a manufacturing order, and add 2 workorders
2. Start and finish the 2nd workorder
3. Attempt to add a 3rd workorder
4. Traceback occurs
```
    'date_planned_start': min([workorder.leave_id.date_from for workorder in workorders]),
TypeError: '<' not supported between instances of 'datetime.datetime' and 'bool'
```

Cause
-----
This early continue added in https://github.com/odoo/odoo/pull/112800 is too eager: https://github.com/odoo/odoo/blob/f19b61b640c6623aad3269d8f0e515b5480e6880/addons/mrp/models/mrp_workorder.py#L525-L526
Although the specified workorder should be ignored, it could potentially have children (`workorder.blocked_by_workorder_ids`) that need to be planned.

Solution
-----
Remove the early continue and keep running `_plan_workorder` on the done/cancelled workorder. All of its children `workorder.blocked_by_workorder_ids` will be correctly planned in the recursive call, and the done/cancelled workorder will still be correctly ignored afterwards in this existing early return:
https://github.com/odoo/odoo/blob/f19b61b640c6623aad3269d8f0e515b5480e6880/addons/mrp/models/mrp_workorder.py#L529-L531
Also backport the fix from https://github.com/odoo/odoo/pull/123802 to handle the null `date_planned_finished` from the ignored workorder.

opw-4497704