### PR TITLE
[IMP] point_of_sale: align amounts in the payment screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.xml
@@ -9,13 +9,13 @@
             <div class="payment-status-container d-flex flex-column-reverse flex-lg-row justify-content-between fs-2">
                 <div t-if="this.props.order.hasRemainingAmount()" class="payment-status-remaining d-flex justify-content-between flex-grow-1">
                     <span class="label pe-2">Remaining</span>
-                    <span class="amount align-self-end" t-att-class="{ 'highlight text-danger fw-bolder': props.order.getDue() > 0 }">
+                    <span class="amount align-self-end me-5 pe-5" t-att-class="{ 'highlight text-danger fw-bolder': props.order.getDue() > 0 }">
                         <t t-esc="remainingText" />
                     </span>
                 </div>
                 <div t-else="" class="payment-status-change d-flex justify-content-between flex-grow-1">
                     <span class="label pe-2">Change</span>
-                    <span class="amount align-self-end" t-att-class="{ 'highlight text-success fw-bolder': props.order.getChange() > 0 }">
+                    <span class="amount align-self-end me-5 pe-5" t-att-class="{ 'highlight text-success fw-bolder': props.order.getChange() > 0 }">
                         <t t-esc="changeText" />
                     </span>
                 </div>


### PR DESCRIPTION
In this commit:
==========
- Improved the alignment of the remaining amount, change amount, and payment line amount.
- Ensured all amounts were consistently aligned on the same line for better readability.

task-4517934
