### PR TITLE
[FIX] im_livechat, *: ensure 'question selection' step has answers

### DIFF
--- a/addons/crm_livechat/tests/chatbot_common.py
+++ b/addons/crm_livechat/tests/chatbot_common.py
@@ -44,7 +44,7 @@ class CrmChatbotCase(ChatbotCase):
             cls.step_create_lead_email,
             cls.step_create_lead_phone,
             cls.step_create_lead,
-        ] = cls.env['chatbot.script.step'].sudo().create([{
+        ] = cls.env['chatbot.script.step'].with_context(install_mode=True).sudo().create([{
             'step_type': 'question_email',
             'message': 'Could you provide us your email please.',
             'sequence': 20,

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -43,6 +43,14 @@ class ChatbotScriptStep(models.Model):
     # forward-operator specifics
     is_forward_operator_child = fields.Boolean(compute='_compute_is_forward_operator_child')
 
+    @api.constrains('step_type', 'answer_ids')
+    def _check_question_selection(self):
+        if self.env.context.get('install_mode'):
+            return
+        for step in self:
+            if step.step_type == 'question_selection' and not step.answer_ids:
+                raise ValidationError(_('Step of type "Question" must have answers.'))
+
     @api.depends('sequence')
     def _compute_triggering_answer_ids(self):
         for step in self.filtered('triggering_answer_ids'):

--- a/addons/im_livechat/tests/chatbot_common.py
+++ b/addons/im_livechat/tests/chatbot_common.py
@@ -14,7 +14,7 @@ class ChatbotCase(common.HttpCase):
             'title': 'Testing Bot',
         })
 
-        ChatbotScriptStep = cls.env['chatbot.script.step'].sudo()
+        ChatbotScriptStep = cls.env['chatbot.script.step'].with_context(install_mode=True).sudo()
 
         [
             cls.step_hello,

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -127,7 +127,7 @@ class TestLivechatChatbotUI(TestImLivechatCommon, TestWebsiteLivechatCommon, Cha
             {"title": "Redirection Bot"}
         )
         question_step, _ = tuple(
-            self.env["chatbot.script.step"].create([
+            self.env["chatbot.script.step"].with_context(install_mode=True).create([
                 {
                     "chatbot_script_id": chatbot_redirect_script.id,
                     "message": "Hello, were do you want to go?",
@@ -169,7 +169,7 @@ class TestLivechatChatbotUI(TestImLivechatCommon, TestWebsiteLivechatCommon, Cha
             {"title": "Trigger question selection bot"}
         )
         question_1, question_2 = tuple(
-            self.env["chatbot.script.step"].create([
+            self.env["chatbot.script.step"].with_context(install_mode=True).create([
                 {
                     "chatbot_script_id": chatbot_trigger_selection.id,
                     "message": "Hello, here is a first question?",
@@ -224,7 +224,7 @@ class TestLivechatChatbotUI(TestImLivechatCommon, TestWebsiteLivechatCommon, Cha
 
     def test_question_selection_overlapping_answers(self):
         chatbot_script = self.env["chatbot.script"].create({"title": "Question selection bot"})
-        question_1 = self.env["chatbot.script.step"].create(
+        question_1 = self.env["chatbot.script.step"].with_context(install_mode=True).create(
             [
                 {
                     "chatbot_script_id": chatbot_script.id,


### PR DESCRIPTION
*= crm_livechat, website_livechat

**Current behavior before PR:**

It was possible to save a step with step_type set to "question selection" without any answers. However, this would cause an error when the bot was tested or executed.

**Desired behavior after PR is merged:**

A constraint has been added to ensure that a "question selection" step cannot be saved without at least one answer.

task-id:4522835

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
