### PR TITLE
[IMP] point_of_sale: include free text attribute value on invoice

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1721,10 +1721,10 @@ class PosOrderLine(models.Model):
         is_refund_order = line.order_id.amount_total < 0.0
         is_refund_line = line.qty * line.price_unit < 0
 
-        product_name = line.product_id \
-            .with_context(lang=line.order_id.partner_id.lang or self.env.user.lang) \
-            .get_product_multiline_description_sale()
-
+        lang = line.order_id.partner_id.lang or self.env.user.lang
+        product_name = line.with_context(lang=lang).full_product_name or line.product_id.with_context(lang=lang).display_name
+        if line.product_id.description_sale:
+            product_name += '\n' + line.product_id.with_context(lang=lang).description_sale
         return {
             **self.env['account.tax']._prepare_base_line_for_taxes_computation(
                 line,

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -871,8 +871,11 @@ export class PosStore extends WithLazyGetterTrap {
                 .reduce((acc, attr) => acc + attr.price_extra, 0);
 
             values.price_extra += priceExtra;
-            values.attribute_value_ids = values.product_id.product_template_variant_value_ids.map(
-                (attr) => ["link", attr]
+            if (!values.attribute_value_ids) {
+                values.attribute_value_ids = [];
+            }
+            values.attribute_value_ids = values.attribute_value_ids.concat(
+                values.product_id.product_template_variant_value_ids.map((attr) => ["link", attr])
             );
         }
 

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -101,7 +101,7 @@ class SaleOrderLine(models.Model):
     def _load_pos_data_fields(self, config_id):
         return ['discount', 'display_name', 'price_total', 'price_unit', 'product_id', 'product_uom_qty', 'qty_delivered',
             'qty_invoiced', 'qty_to_invoice', 'display_type', 'name', 'tax_ids', 'is_downpayment', 'extra_tax_data',
-            'write_date',
+            'write_date', 'product_custom_attribute_value_ids'
         ]
 
     @api.depends('pos_order_line_ids.qty', 'pos_order_line_ids.order_id.picking_ids', 'pos_order_line_ids.order_id.picking_ids.state')

--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -112,10 +112,27 @@ patch(PosStore.prototype, {
                 customer_note: line.customer_note,
                 description: line.name,
                 order_id: this.getOrder(),
+                custom_attribute_value_ids: Object.values(
+                    line.product_custom_attribute_value_ids || {}
+                ).map((value_line) => [
+                    "create",
+                    {
+                        custom_product_template_attribute_value_id:
+                            value_line.custom_product_template_attribute_value_id,
+                        custom_value: value_line.custom_value,
+                    },
+                ]),
             };
             if (line.display_type === "line_section") {
                 continue;
             }
+            newLineValues.attribute_value_ids = line.product_custom_attribute_value_ids.map(
+                (value_line) => {
+                    if (value_line?.custom_product_template_attribute_value_id) {
+                        return ["link", value_line.custom_product_template_attribute_value_id];
+                    }
+                }
+            );
             const newLine = await this.addLineToCurrentOrder(newLineValues, {}, false);
             previousProductLine = newLine;
 


### PR DESCRIPTION
In this commit:
===
- The free text attribute value is now displayed on the invoice alongside the product name.

task-4526756
