### PR TITLE
[FIX] tests: retore test-file behaviour

### DIFF
--- a/odoo/addons/base/tests/test_tests_tags.py
+++ b/odoo/addons/base/tests/test_tests_tags.py
@@ -352,3 +352,16 @@ class TestSelectorSelection(TransactionCase):
         tags = TagsSelector('standard')
         position = TagsSelector('post_install')
         self.assertTrue(tags.check(post_install_obj) and position.check(post_install_obj))
+
+        # module part
+        tags = TagsSelector('/base')
+        self.assertTrue(tags.check(no_tags_obj), 'Test should match is module path')
+        tags = TagsSelector('/base/tests/test_tests_tags.py')
+        self.assertTrue(tags.check(no_tags_obj), 'Test should match is module path with file')
+
+        tags = TagsSelector('/account/tests/test_tests_tags.py')
+        self.assertFalse(tags.check(no_tags_obj), 'Test should not match another module path with file')
+
+        # absolute path case (used by test-file)
+        tags = TagsSelector(__file__)
+        self.assertTrue(tags.check(no_tags_obj), 'Test should its absolute file path')

--- a/odoo/tests/tag_selector.py
+++ b/odoo/tests/tag_selector.py
@@ -61,7 +61,7 @@ class TagsSelector(object):
             (tag, module, klass, method, file_path) = test_filter
             if tag and tag not in test_tags:
                 return False
-            elif file_path and not test_module_path.endswith(file_path):
+            elif file_path and not file_path.endswith(test_module_path):
                 return False
             elif not file_path and module and module != test_module:
                 return False


### PR DESCRIPTION
Following #191388, the test-file behavior was broken. The commit introducing the issue fixes a case that was working before but was never specified (actually, it was a bug)

This commit reverts the previous fix to restore the test-tags behavior We could consider manage both cases, but it's not clear if it's worth it The / part of a tag was always meant to be a module (/base) and was extended to allow a more precise selection (/base/tests/test_ui.py) but it was never meant to be a filename or partial filepath (/test_ui.py)
