### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: amount in text

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -1,4 +1,7 @@
-from odoo import models, _
+import math
+from num2words import num2words
+
+from odoo import _, api, models
 from odoo.exceptions import UserError
 
 
@@ -46,7 +49,21 @@ class AccountEdiXmlUblTr(models.AbstractModel):
         # Nilvera will reject any <BuyerReference> tag, so remove it
         if vals['vals'].get('buyer_reference'):
             del vals['vals']['buyer_reference']
+
+        vals['vals']['note_vals'].append({'note': self._l10n_tr_get_amount_integer_partn_text_note(invoice.amount_residual_signed, self.env.ref('base.TRY')), 'note_attrs': {}})
+        if vals['invoice'].currency_id.name != 'TRY':
+            vals['vals']['note_vals'].append({'note': self._l10n_tr_get_amount_integer_partn_text_note(invoice.amount_residual, vals['invoice'].currency_id), 'note_attrs': {}})
         return vals
+
+    @api.model
+    def _l10n_tr_get_amount_integer_partn_text_note(self, amount, currency):
+        sign = math.copysign(1.0, amount)
+        amount_integer_part, amount_decimal_part = divmod(abs(amount), 1)
+        amount_decimal_part = int(amount_decimal_part * 100)
+
+        text_i = num2words(amount_integer_part * sign, lang="tr") or 'Sifir'
+        text_d = num2words(amount_decimal_part * sign, lang="tr") or 'Sifir'
+        return f'YALNIZ : {text_i} {currency.name} {text_d} {currency.currency_subunit_label}'.upper()
 
     def _get_country_vals(self, country):
         # EXTENDS account.edi.xml.ubl_21


### PR DESCRIPTION
This commit will add the amount residual in text in the note of the xml we sent to nilvera.
If the invoice is in another currency than Turkish Lira, we have to add two notes one for the amount in turkish lira and one in the other currency

task-4518269




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
