### PR TITLE
[FIX] im_livechat: disable composer for transient chatbot thread

### DIFF
--- a/addons/im_livechat/static/src/core/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/core/common/chat_window_patch.xml
@@ -8,7 +8,7 @@
             </t>
         </xpath>
         <xpath expr="//Composer" position="replace">
-            <t t-if="thread?.composerDisabled and store.self.notEq(thread?.livechatVisitorMember?.persona)">$0</t>
+            <t t-if="thread?.composerDisabled and !thread?.isTransient and store.self.notEq(thread?.livechatVisitorMember?.persona)">$0</t>
             <div t-if="thread?.composerDisabled" class="bg-200 py-1 text-center d-flex fst-italic fw-bold text-muted" t-ref="composerDisabledContainer">
                 <span class="flex-grow-1"/>
                 <span t-esc="thread.composerDisabledText"/>


### PR DESCRIPTION
The composer is disabled when not needed (chat bot steps not requiring user input) or when the live chat has ended. However, the composer is sometimes shown to the visitor even when the composer is disabled.

Steps to reproduce the issue:
- Go to the /contactus page
- Start the chat bot
- Composer is shown, while the bot doesn't expect any user input

In [1], we enabled the composer for operators even when the chat has ended. To do so, we check that the current user is not the visitor. However, temporary threads are missing some information such as channel members. As a result, the composer is shown to the visitor even if disabled when the thread is temporary. This PR modify this condition to handle temporary threads.

[1]: https://github.com/odoo/odoo/pull/195734