### PR TITLE
[FIX] point_of_sale: traceback while add product and close session

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.js
@@ -36,15 +36,22 @@ export class OpeningControlPopup extends Component {
         return this.pos.models["pos.order"].filter((o) => o.lines.length > 0 && o.state === "draft")
             .length;
     }
-    confirm() {
+    async confirm() {
         this.pos.session.state = "opened";
-        this.pos.data.call(
+        await this.pos.data.call(
             "pos.session",
             "set_opening_control",
             [this.pos.session.id, parseFloat(this.state.openingCash), this.state.notes],
             {},
             true
         );
+        const order = this.pos.getOrder();
+        if (order) {
+            if (order.session_id !== this.pos.session) {
+                order.session_id = this.pos.session;
+                this.pos.getNextOrderRefs(order);
+            }
+        }
         this.props.close();
     }
     async openDetailsPopup() {


### PR DESCRIPTION
Steps:
===
1. open pos system.
2. add product and close session.
3. open register again and repeat the step 2

Issue:
===
- blank screen with traceback in the console.

Fix:
===
- changed the session and reference of the draft order of the previous session.

Task: 4518123
