### PR TITLE
[FIX] web: fix unit test error_checker

### DIFF
--- a/addons/web/static/lib/hoot/core/runner.js
+++ b/addons/web/static/lib/hoot/core/runner.js
@@ -92,7 +92,7 @@ import { EXCLUDE_PREFIX, createUrlFromId, setParams, urlParams } from "./url";
 
 const {
     clearTimeout,
-    console: { groupEnd: $groupEnd, log: $log, table: $table },
+    console: { error: $error, groupEnd: $groupEnd, log: $log, table: $table },
     EventTarget,
     Map,
     Math: { floor: $floor },
@@ -1092,7 +1092,7 @@ export class Runner {
 
         const { passed, failed, assertions } = this.reporting;
         if (failed > 0) {
-            const errorMessage = ["test failed (see above for details)"];
+            const errorMessage = ["Some tests failed: see above for details"];
             if (this.config.headless) {
                 const link = createUrlFromId(this.state.failedIds, "test");
                 errorMessage.push(`Failed tests link: ${link.toString()}`);
@@ -1101,7 +1101,9 @@ export class Runner {
             logger.logGlobal(
                 `failed ${failed} tests (${passed} passed, total time: ${this.totalTime})`
             );
-            logger.logGlobalError(errorMessage.join("\n"));
+            // Do not use logger to not apply the [HOOT] prefix and allow the CI
+            // to stop the test run browser.
+            $error(errorMessage.join("\n"));
         } else {
             // Use console.dir for this log to appear on runbot sub-builds page
             logger.logGlobal(

--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -12,7 +12,7 @@ RE_ONLY = re.compile(r'QUnit\.(only|debug)\(')
 
 
 def unit_test_error_checker(message):
-    return '[HOOT]' not in message or message == '[HOOT] test failed (see above for details)'
+    return '[HOOT]' not in message
 
 
 def qunit_error_checker(message):


### PR DESCRIPTION
Before this commit, the error_checker asserting that a JS unit test run failed performed a strict equality with an outdated string on error logs.

Now, the message has been changed, flagged explicitly as something that shouldn't be changed and the presence of that message is checked accross the entire message for robustness.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
