### PR TITLE
[IMP] l10n_it_xml_export: Add XML export option for monthly tax report

### DIFF
--- a/addons/l10n_it_xml_export/__init__.py
+++ b/addons/l10n_it_xml_export/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/addons/l10n_it_xml_export/__manifest__.py
+++ b/addons/l10n_it_xml_export/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    'name': 'Italy - Tax Report XML Export',
+    'countries': ['it'],
+    'version': '0.1',
+    'depends': [
+        'l10n_it_edi',
+    ],
+    'description': """
+Additional module to allow the export of the Italian monthly tax report to XML format.
+    """,
+    'category': 'Accounting/Localizations',
+    'data': [
+        'security/ir.model.access.csv',
+        'data/tax_monthly_report_vat.xml',
+        'data/tax_report_export_template.xml',
+        'wizard/monthly_tax_report_xml_export_view.xml',
+    ],
+    'installable': True,
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_it_xml_export/data/tax_monthly_report_vat.xml
+++ b/addons/l10n_it_xml_export/data/tax_monthly_report_vat.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo auto_sequence="1">
+    <record id="l10n_it.tax_monthly_report_vat" model="account.report">
+        <field name="custom_handler_model_id" ref="model_l10n_it_monthly_tax_report_handler"/>
+    </record>
+</odoo>

--- a/addons/l10n_it_xml_export/data/tax_report_export_template.xml
+++ b/addons/l10n_it_xml_export/data/tax_report_export_template.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<odoo>
+    <template id="tax_report_export_template">
+<iv:Fornitura xmlns:iv="urn:www.agenziaentrate.gov.it:specificheTecniche:sco:ivp" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <iv:Intestazione>
+        <iv:CodiceFornitura t-if="supply_code"><t t-out="supply_code"/></iv:CodiceFornitura>
+        <iv:CodiceFiscaleDichiarante t-if="declarant_fiscal_code"><t t-out="declarant_fiscal_code"/></iv:CodiceFiscaleDichiarante>
+        <iv:CodiceCarica t-if="declarant_role_code"><t t-out="declarant_role_code"/></iv:CodiceCarica>
+        <iv:IdSistema t-if="id_sistema"><t t-out="id_sistema"/></iv:IdSistema>
+    </iv:Intestazione>
+    <iv:Comunicazione identificativo="00001">
+        <iv:Frontespizio>
+            <iv:CodiceFiscale t-if="taxpayer_code"><t t-out="taxpayer_code"/></iv:CodiceFiscale>
+            <iv:AnnoImposta t-if="tax_year"><t t-out="tax_year"/></iv:AnnoImposta>
+            <iv:PartitaIVA t-if="vat_number"><t t-out="vat_number"/></iv:PartitaIVA>
+            <iv:PIVAControllante t-if="parent_company_vat_number"><t t-out="parent_company_vat_number"/></iv:PIVAControllante>
+            <iv:UltimoMese t-if="last_month"><t t-out="last_month"/></iv:UltimoMese>
+            <iv:CFDichiarante t-if="declarant_fiscal_code"><t t-out="declarant_fiscal_code"/></iv:CFDichiarante>
+            <iv:CodiceCaricaDichiarante t-if="declarant_role_code"><t t-out="declarant_role_code"/></iv:CodiceCaricaDichiarante>
+            <iv:CodiceFiscaleSocieta t-if="company_code"><t t-out="company_code"/></iv:CodiceFiscaleSocieta>
+            <iv:FirmaDichiarazione>1</iv:FirmaDichiarazione>
+            <iv:CFIntermediario t-if="intermediary_code"><t t-out="intermediary_code"/></iv:CFIntermediario>
+            <iv:ImpegnoPresentazione t-if="submission_commitment"><t t-out="submission_commitment"/></iv:ImpegnoPresentazione>
+            <iv:DataImpegno t-if="commitment_date"><t t-out="commitment_date"/></iv:DataImpegno>
+            <iv:FirmaIntermediario t-if="intermediary_signature"><t t-out="intermediary_signature"/></iv:FirmaIntermediario>
+            <iv:FlagConferma>1</iv:FlagConferma>
+            <iv:IdentificativoProdSoftware>ODOO S.A.</iv:IdentificativoProdSoftware>
+        </iv:Frontespizio>
+        <iv:DatiContabili>
+            <iv:Modulo>
+                <iv:NumeroModulo>1</iv:NumeroModulo>
+                <iv:Mese t-if="month"><t t-out="month"/></iv:Mese>
+                <iv:Subfornitura t-if="subcontracting"><t t-out="subcontracting"/></iv:Subfornitura>
+                <iv:EventiEccezionali t-if="exceptional_events"><t t-out="exceptional_events"/></iv:EventiEccezionali>
+                <iv:OperazioniStraordinarie t-if="extraordinary_operations"><t t-out="extraordinary_operations"/></iv:OperazioniStraordinarie>
+                <iv:TotaleOperazioniAttive t-if="total_active_operations"><t t-out="total_active_operations"/></iv:TotaleOperazioniAttive>
+                <iv:TotaleOperazioniPassive t-if="total_passive_operations"><t t-out="total_passive_operations"/></iv:TotaleOperazioniPassive>
+                <iv:IvaEsigibile t-if="vat_payable"><t t-out="vat_payable"/></iv:IvaEsigibile>
+                <iv:IvaDetratta t-if="vat_deducted"><t t-out="vat_deducted"/></iv:IvaDetratta>
+                <iv:IvaDovuta t-if="vat_due"><t t-out="vat_due"/></iv:IvaDovuta>
+                <iv:IvaCredito t-if="vat_credit"><t t-out="vat_credit"/></iv:IvaCredito>
+                <iv:DebitoPrecedente t-if="previous_debt"><t t-out="previous_debt"/></iv:DebitoPrecedente>
+                <iv:CreditoPeriodoPrecedente t-if="previous_period_credit"><t t-out="previous_period_credit"/></iv:CreditoPeriodoPrecedente>
+                <iv:CreditoAnnoPrecedente t-if="previous_year_credit"><t t-out="previous_year_credit"/></iv:CreditoAnnoPrecedente>
+                <iv:VersamentiAutoUE t-if="eu_self_payments"><t t-out="eu_self_payments"/></iv:VersamentiAutoUE>
+                <iv:CreditiImposta t-if="tax_credits"><t t-out="tax_credits"/></iv:CreditiImposta>
+                <iv:InteressiDovuti t-if="due_interests"><t t-out="due_interests"/></iv:InteressiDovuti>
+                <iv:Metodo t-if="method"><t t-out="method"/></iv:Metodo>
+                <iv:Acconto t-if="advance_payment"><t t-out="advance_payment"/></iv:Acconto>
+                <iv:ImportoDaVersare t-if="amount_to_be_paid"><t t-out="amount_to_be_paid"/></iv:ImportoDaVersare>
+                <iv:ImportoACredito t-if="amount_in_credit"><t t-out="amount_in_credit"/></iv:ImportoACredito>
+            </iv:Modulo>
+        </iv:DatiContabili>
+    </iv:Comunicazione>
+</iv:Fornitura>
+    </template>
+</odoo>

--- a/addons/l10n_it_xml_export/data/validation/comunicazioneIvp_2018_v1.xsd
+++ b/addons/l10n_it_xml_export/data/validation/comunicazioneIvp_2018_v1.xsd
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2017 sp2 (x64) (http://www.altova.com) by rsiino (Sogei S.p.A.) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cm="urn:www.agenziaentrate.gov.it:specificheTecniche:common" xmlns:sc="urn:www.agenziaentrate.gov.it:specificheTecniche:sco:common" xmlns:iv="urn:www.agenziaentrate.gov.it:specificheTecniche:sco:ivp" xmlns:ns1="www.agenziaentrate.gov.it:specificheTecniche:telent:v1" targetNamespace="urn:www.agenziaentrate.gov.it:specificheTecniche:sco:ivp" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0">
+	<xs:annotation>
+		<xs:documentation xml:lang="it"><![CDATA[
+		Versione 1.0 - 13/02/16]]></xs:documentation>
+	</xs:annotation>
+	<xs:import namespace="urn:www.agenziaentrate.gov.it:specificheTecniche:common" schemaLocation="fornitura_v3.xsd"/>
+	<xs:element name="Comunicazione" type="iv:Comunicazione_IVP_Type"/>
+	<xs:complexType name="Comunicazione_IVP_Type">
+		<xs:complexContent>
+			<xs:extension base="cm:Documento_Type">
+				<xs:sequence>
+					<xs:element name="Frontespizio" type="iv:Frontespizio_IVP_Type"/>
+					<xs:element name="DatiContabili" type="iv:DatiContabili_IVP_Type"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="Frontespizio_IVP_Type">
+		<xs:sequence>
+			<xs:element name="CodiceFiscale" type="cm:DatoCF_Type"/>
+			<xs:element name="AnnoImposta" type="cm:DatoDA_Type"/>
+			<xs:element name="PartitaIVA" type="cm:DatoPI_Type"/>
+			<xs:element name="PIVAControllante" type="cm:DatoPI_Type" minOccurs="0"/>
+			<xs:element name="UltimoMese" minOccurs="0">
+				<xs:simpleType>
+					<xs:restriction base="cm:DatoNP_Type">
+						<xs:enumeration value="1"/>
+						<xs:enumeration value="2"/>
+						<xs:enumeration value="3"/>
+						<xs:enumeration value="4"/>
+						<xs:enumeration value="5"/>
+						<xs:enumeration value="6"/>
+						<xs:enumeration value="7"/>
+						<xs:enumeration value="8"/>
+						<xs:enumeration value="9"/>
+						<xs:enumeration value="10"/>
+						<xs:enumeration value="11"/>
+						<xs:enumeration value="12"/>
+						<xs:enumeration value="13"/>
+						<xs:enumeration value="99"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="LiquidazioneGruppo" type="cm:DatoCB_Type" minOccurs="0"/>
+			<xs:element name="CFDichiarante" type="cm:DatoCF_Type" minOccurs="0"/>
+			<xs:element name="CodiceCaricaDichiarante" minOccurs="0">
+				<xs:simpleType>
+					<xs:restriction base="cm:DatoNP_Type">
+						<xs:enumeration value="1"/>
+						<xs:enumeration value="2"/>
+						<xs:enumeration value="3"/>
+						<xs:enumeration value="4"/>
+						<xs:enumeration value="5"/>
+						<xs:enumeration value="6"/>
+						<xs:enumeration value="7"/>
+						<xs:enumeration value="8"/>
+						<xs:enumeration value="9"/>
+						<xs:enumeration value="11"/>
+						<xs:enumeration value="12"/>
+						<xs:enumeration value="13"/>
+						<xs:enumeration value="14"/>
+						<xs:enumeration value="15"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="CodiceFiscaleSocieta" type="cm:DatoCN_Type" minOccurs="0"/>
+			<xs:element name="FirmaDichiarazione" type="cm:DatoCB_Type"/>
+			<xs:element name="CFIntermediario" type="cm:DatoCF_Type" minOccurs="0"/>
+			<xs:element name="ImpegnoPresentazione" minOccurs="0">
+				<xs:simpleType>
+					<xs:restriction base="cm:DatoN1_Type">
+						<xs:enumeration value="1"/>
+						<xs:enumeration value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="DataImpegno" type="cm:DatoDT_Type" minOccurs="0"/>
+			<xs:element name="FirmaIntermediario" type="cm:DatoCB_Type" minOccurs="0"/>
+			<xs:element name="FlagConferma" type="cm:DatoCB_Type" minOccurs="0"/>
+			<xs:element name="IdentificativoProdSoftware" type="cm:DatoAN_Type" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DatiContabili_IVP_Type">
+		<xs:sequence>
+			<xs:element name="Modulo" maxOccurs="5">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="NumeroModulo">
+							<xs:simpleType>
+								<xs:restriction base="cm:DatoN1_Type">
+									<xs:enumeration value="1"/>
+									<xs:enumeration value="2"/>
+									<xs:enumeration value="3"/>
+									<xs:enumeration value="4"/>
+									<xs:enumeration value="5"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="Mese" minOccurs="0">
+							<xs:simpleType>
+								<xs:restriction base="cm:DatoNP_Type">
+									<xs:enumeration value="1"/>
+									<xs:enumeration value="2"/>
+									<xs:enumeration value="3"/>
+									<xs:enumeration value="4"/>
+									<xs:enumeration value="5"/>
+									<xs:enumeration value="6"/>
+									<xs:enumeration value="7"/>
+									<xs:enumeration value="8"/>
+									<xs:enumeration value="9"/>
+									<xs:enumeration value="10"/>
+									<xs:enumeration value="11"/>
+									<xs:enumeration value="12"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="Trimestre" minOccurs="0">
+							<xs:simpleType>
+								<xs:restriction base="cm:DatoN1_Type">
+									<xs:enumeration value="1"/>
+									<xs:enumeration value="2"/>
+									<xs:enumeration value="3"/>
+									<xs:enumeration value="4"/>
+									<xs:enumeration value="5"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="Subfornitura" type="cm:DatoCB_Type" minOccurs="0"/>
+						<xs:element name="EventiEccezionali" type="iv:Eventi_Ecc_Type" minOccurs="0"/>
+						<xs:element name="OperazioniStraordinarie" type="cm:DatoCB_Type" minOccurs="0"/>
+						<xs:element name="TotaleOperazioniAttive" type="iv:DatoVN_Type" minOccurs="0"/>
+						<xs:element name="TotaleOperazioniPassive" type="iv:DatoVN_Type" minOccurs="0"/>
+						<xs:element name="IvaEsigibile" type="iv:DatoVN_Type" minOccurs="0"/>
+						<xs:element name="IvaDetratta" type="iv:DatoVN_Type" minOccurs="0"/>
+						<xs:element name="IvaDovuta" type="cm:DatoVP_Type" minOccurs="0"/>
+						<xs:element name="IvaCredito" type="cm:DatoVP_Type" minOccurs="0"/>
+						<xs:element name="DebitoPrecedente" type="cm:DatoVP_Type" minOccurs="0"/>
+						<xs:element name="CreditoPeriodoPrecedente" type="cm:DatoVP_Type" minOccurs="0"/>
+						<xs:element name="CreditoAnnoPrecedente" type="iv:DatoVN_Type" minOccurs="0"/>
+						<xs:element name="VersamentiAutoUE" type="cm:DatoVP_Type" minOccurs="0"/>
+						<xs:element name="CreditiImposta" type="cm:DatoVP_Type" minOccurs="0"/>
+						<xs:element name="InteressiDovuti" type="cm:DatoVP_Type" minOccurs="0"/>
+						<xs:element name="Metodo" minOccurs="0">
+							<xs:simpleType>
+								<xs:restriction base="cm:DatoN1_Type">
+									<xs:enumeration value="1"/>
+									<xs:enumeration value="2"/>
+									<xs:enumeration value="3"/>
+									<xs:enumeration value="4"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="Acconto" type="cm:DatoVP_Type" minOccurs="0"/>
+						<xs:element name="ImportoDaVersare" type="cm:DatoVP_Type" minOccurs="0"/>
+						<xs:element name="ImportoACredito" type="cm:DatoVP_Type" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="Eventi_Ecc_Type">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="9"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoVN_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica numeri positivi con 2 cifre decimali. La lunghezza massima prevista è di 16 caratteri, il separatore decimale previsto è la virgola.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="16"/>
+			<xs:pattern value="[\-]{0,1}[0-9]+,[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/addons/l10n_it_xml_export/data/validation/fornituraIvp_2018_v1.xsd
+++ b/addons/l10n_it_xml_export/data/validation/fornituraIvp_2018_v1.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2017 sp2 (x64) (http://www.altova.com) by rsiino 
+       (Sogei S.p.A.) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cm="urn:www.agenziaentrate.gov.it:specificheTecniche:common" xmlns:sc="urn:www.agenziaentrate.gov.it:specificheTecniche:sco:common" xmlns:iv="urn:www.agenziaentrate.gov.it:specificheTecniche:sco:ivp" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="urn:www.agenziaentrate.gov.it:specificheTecniche:sco:ivp" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0">
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema.xsd"/>
+	<xs:annotation>
+		<xs:documentation xml:lang="it"><![CDATA[
+             Versione 1.0 - 13/02/16
+             ]]></xs:documentation>
+	</xs:annotation>
+	<xs:include schemaLocation="intestazioneIvp_2018_v1.xsd"/>
+	<xs:include schemaLocation="comunicazioneIvp_2018_v1.xsd"/>
+	<xs:element name="Fornitura">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Intestazione" type="iv:Intestazione_IVP_Type"/>
+				<xs:element name="Comunicazione" type="iv:Comunicazione_IVP_Type"/>
+				<xs:element ref="ds:Signature" minOccurs="0"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/addons/l10n_it_xml_export/data/validation/fornitura_v3.xsd
+++ b/addons/l10n_it_xml_export/data/validation/fornitura_v3.xsd
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="urn:www.agenziaentrate.gov.it:specificheTecniche:common" targetNamespace="urn:www.agenziaentrate.gov.it:specificheTecniche:common" elementFormDefault="qualified" attributeFormDefault="unqualified" version="3.0">
+	<xs:annotation>
+		<xs:documentation xml:lang="it"><![CDATA[
+		Versione 3.0 - 10/12/13
+		- modificato import typesDati_v3.xsd
+		- modificato targetNamespace
+
+		Versione 2.1 - 10/07/13
+		- rimossi gli elementi complessi Fornitura e Intestazione
+
+		Versione 2.0 - 15/02/12
+		- modificato il tipo Intestazione_Type: introdotto il tipo complesso Dati_Intestazione_Type
+		- modificato il tipo Codice_Fornitura_Type
+		- modificato l'elemento TipoFornitore: associato il type DatoNP_Type
+		- modificato targetNamespace
+		]]></xs:documentation>
+	</xs:annotation>
+	<xs:include schemaLocation="typesDati_v3.xsd"/>
+	<xs:element name="Documento" type="Documento_Type" abstract="true"/>
+	<xs:complexType name="Documento_Type">
+		<xs:annotation>
+			<xs:documentation xml:lang="it">Documento trasmesso</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="identificativo" type="Identificativo_Type" use="required"/>
+	</xs:complexType>
+	<xs:simpleType name="Identificativo_Type">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{4}[1-9]|[0-9]{3}[1-9][0-9]|[0-9]{2}[1-9][0-9]{2}|[0-9][1-9][0-9]{3}|[1-9][0-9]{4}
+"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/addons/l10n_it_xml_export/data/validation/intestazioneIvp_2018_v1.xsd
+++ b/addons/l10n_it_xml_export/data/validation/intestazioneIvp_2018_v1.xsd
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2017 sp2 (x64) (http://www.altova.com) by rsiino (Sogei S.p.A.) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cm="urn:www.agenziaentrate.gov.it:specificheTecniche:common" xmlns:sc="urn:www.agenziaentrate.gov.it:specificheTecniche:sco:common" xmlns:iv="urn:www.agenziaentrate.gov.it:specificheTecniche:sco:ivp" xmlns:ns1="www.agenziaentrate.gov.it:specificheTecniche:telent:v1" targetNamespace="urn:www.agenziaentrate.gov.it:specificheTecniche:sco:ivp" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0">
+	<xs:annotation>
+		<xs:documentation xml:lang="it"><![CDATA[
+		Versione 1.0 - 13/02/16
+		]]></xs:documentation>
+	</xs:annotation>
+	<xs:import namespace="urn:www.agenziaentrate.gov.it:specificheTecniche:common" schemaLocation="fornitura_v3.xsd"/>
+	<xs:element name="Intestazione"/>
+	<xs:complexType name="Intestazione_IVP_Type">
+		<xs:sequence>
+			<xs:element name="CodiceFornitura">
+				<xs:simpleType>
+					<xs:restriction base="cm:DatoAN_Type">
+						<xs:enumeration value="IVP18"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="CodiceFiscaleDichiarante" type="cm:DatoCF_Type" minOccurs="0"/>
+			<xs:element name="CodiceCarica" minOccurs="0">
+				<xs:simpleType>
+					<xs:restriction base="cm:DatoNP_Type">
+						<xs:enumeration value="1"/>
+						<xs:enumeration value="2"/>
+						<xs:enumeration value="3"/>
+						<xs:enumeration value="4"/>
+						<xs:enumeration value="5"/>
+						<xs:enumeration value="6"/>
+						<xs:enumeration value="7"/>
+						<xs:enumeration value="8"/>
+						<xs:enumeration value="9"/>
+						<xs:enumeration value="11"/>
+						<xs:enumeration value="12"/>
+						<xs:enumeration value="13"/>
+						<xs:enumeration value="14"/>
+						<xs:enumeration value="15"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="IdSistema" type="cm:DatoCF_Type" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/addons/l10n_it_xml_export/data/validation/typesDati_v3.xsd
+++ b/addons/l10n_it_xml_export/data/validation/typesDati_v3.xsd
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="urn:www.agenziaentrate.gov.it:specificheTecniche:common" targetNamespace="urn:www.agenziaentrate.gov.it:specificheTecniche:common" elementFormDefault="qualified" attributeFormDefault="unqualified" version="3.0">
+	<xs:annotation>
+		<xs:documentation xml:lang="it"><![CDATA[
+		Versione 3.0 - 10/12/13
+		- modificato targetNamespace
+		Versione 2.0.1 - 14/06/12
+		- modificati i tipi semplici DatoAN_Type, DatoEM_Type
+		Versione 2.0 - 15/02/12
+		- modificato targetNamespace
+		- introdotti i tipi semplici DatoGA_Type, DatoTL_Type, DatoCP_Type
+		]]></xs:documentation>
+	</xs:annotation>
+	<xs:include schemaLocation="typesProvincie_v3.xsd"/>
+	<xs:simpleType name="DatoAN_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice costituito da caratteri alfanumerici maiuscoli e dai caratteri: punto, virgola, apice, trattino, spazio, barra semplice, °, ^, ampersand, parentesi aperta e chiusa, doppie virgolette, barra rovesciata, la barra dritta, il più, le maiuscole accentate e la Ü. Tali caratteri non sono ammesi come primo carattere tranne: i numeri da 0 a 9, i caratteri maiuscoli da A a Z, il meno e le dopppie virgolette.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="([0-9A-Z\-]|&quot;){1}([ 0-9A-Z&amp;]|'|\-|\.|,|/|°|\^|\(|\)|À|È|É|Ì|Ò|Ù|Ü|&quot;|\\|\||\+)*"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoNU_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica numeri naturali positivi e negativi con al massimo 16 cifre.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="16"/>
+			<xs:pattern value="(\-[1-9]|[1-9])[0-9]*"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoPC_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che esprime una percentuale e dunque consente valori positivi non superiori a 100, con al massimo 2 cifre decimali. Il separatore decimale previsto è la virgola.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="16"/>
+			<xs:pattern value="[0-9]?[0-9](,\d{1,3})?|100(,0{1,3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoQU_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica numeri positivi con al massimo 5 cifre decimali. La lunghezza massima prevista è di 16 caratteri, il separatore decimale previsto è la virgola.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="16"/>
+			<xs:pattern value="[0-9]+(,[0-9]{1,5})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoVP_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica numeri positivi con 2 cifre decimali. La lunghezza massima prevista è di 16 caratteri, il separatore decimale previsto è la virgola.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="16"/>
+			<xs:pattern value="[0-9]+,[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoN1_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica i numeri naturali da 1 a 9.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="1"/>
+			<xs:pattern value="[1-9]"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoNP_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica numeri naturali positivi con al massimo 16 cifre.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[1-9]{1}[0-9]*"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoPI_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica la partita IVA rispettandone i vincoli di struttura. </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:length value="11"/>
+			<xs:pattern value="[0-7][0-9]{10}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoCN_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica un codice fiscale numerico rispettandone i vincoli di struttura.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:length value="11"/>
+			<xs:pattern value="[0-9]{11}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoCF_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica un codice fiscale provvisorio o alfanumerico rispettandone i vincoli di struttura.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{11}|[A-Z]{6}[0-9LMNPQRSTUV]{2}[A-Z]{1}[0-9LMNPQRSTUV]{2}[A-Z]{1}[0-9LMNPQRSTUV]{3}[A-Z]{1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoCB_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che consente esclusivamente i valori 0 e 1.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:byte">
+			<xs:pattern value="[01]"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoCB12_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che consente esclusivamente 12 caratteri con i valori 0 e 1.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:byte">
+			<xs:pattern value="[10]{12}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoDT_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica una data nel formato ggmmaaaa. La data indicata non deve essere successiva alla data corrente.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:length value="8"/>
+			<xs:pattern value="(((0[1-9]|[12][0-9]|3[01])(0[13578]|10|12)(\d{4}))|(([0][1-9]|[12][0-9]|30)(0[469]|11)(\d{4}))|((0[1-9]|1[0-9]|2[0-8])(02)(\d{4}))|((29)(02)([02468][048]00))|((29)(02)([13579][26]00))|((29)(02)([0-9][0-9][0][48]))|((29)(02)([0-9][0-9][2468][048]))|((29)(02)([0-9][0-9][13579][26])))"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoDA_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica un anno nel formato aaaa. Sono ammessi anni dal 1800 al 2099.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:length value="4"/>
+			<xs:pattern value="(18|19|20)[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoDN_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica una data nel formato ggmmaaaa.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:length value="8"/>
+			<xs:pattern value="(((0[1-9]|[12][0-9]|3[01])(0[13578]|10|12)(\d{4}))|(([0][1-9]|[12][0-9]|30)(0[469]|11)(\d{4}))|((0[1-9]|1[0-9]|2[0-8])(02)(\d{4}))|((29)(02)([02468][048]00))|((29)(02)([13579][26]00))|((29)(02)([0-9][0-9][0][48]))|((29)(02)([0-9][0-9][2468][048]))|((29)(02)([0-9][0-9][13579][26])))"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoD6_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica una data nel formato mmaaaa.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:length value="6"/>
+			<xs:pattern value="((0[0-9])|(1[0-2]))((19|20)[0-9][0-9])"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoEM_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica un elemento di tipo email</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[a-zA-Z0-9._%\-'&quot;?^~=]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,4}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoGA_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica il numero di giorni in un anno e va da 1 a 365</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="3"/>
+			<xs:pattern value="[1-9]|([1-9][0-9])|([12][0-9][0-9])|(3[0-5][0-9])|(36[0-5])"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoTL_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica un elemento di tipo telefono</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]*"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatoCP_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice che identifica un elemento di tipo cap</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{5}"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/addons/l10n_it_xml_export/data/validation/typesProvincie_v3.xsd
+++ b/addons/l10n_it_xml_export/data/validation/typesProvincie_v3.xsd
@@ -1,0 +1,285 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2012 (http://www.altova.com) by rdobrowolny (Sogei S.p.A.) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="urn:www.agenziaentrate.gov.it:specificheTecniche:common" targetNamespace="urn:www.agenziaentrate.gov.it:specificheTecniche:common" elementFormDefault="qualified" attributeFormDefault="unqualified" version="3.0">
+	<xs:annotation>
+		<xs:documentation xml:lang="it"><![CDATA[
+		Versione 3.0 - 10/12/13
+		- modificato targetNamespace
+		Versione 2.0 - 15/02/12
+		- modificato targetNamespace
+		]]></xs:documentation>
+	</xs:annotation>
+	<xs:simpleType name="PR_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice costituito dalle sigle delle provincie italiane in vigore.</xs:documentation>
+		</xs:annotation>
+		<xs:union memberTypes="ProvincieItaliane"/>
+	</xs:simpleType>
+	<xs:simpleType name="PN_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice costituito dalle sigle delle provincie italiane in vigore,  dalle sigle delle provincie croate di Fiume, Pola e Zara e dalla sigla “EE” che indica un paese estero.</xs:documentation>
+		</xs:annotation>
+		<xs:union memberTypes="ProvincieItaliane ProvincieCroate Estero"/>
+	</xs:simpleType>
+	<xs:simpleType name="PE_Type">
+		<xs:annotation>
+			<xs:documentation>Tipo semplice costituito dalle sigle delle provincie italiane in vigore e dalla sigla “EE” che indica un paese estero.</xs:documentation>
+		</xs:annotation>
+		<xs:union memberTypes="ProvincieItaliane Estero"/>
+	</xs:simpleType>
+	<xs:simpleType name="ProvincieItaliane">
+		<xs:annotation>
+			<xs:documentation>
+			Elenco delle provincie italiane in vigore, valori ammessi:
+
+				Agrigento				AG
+				Alessandria				AL
+				Ancona					AN
+				Aosta   				AO
+				Ascoli Piceno			AP
+				L'Aquila				AQ
+				Arezzo					AR
+				Asti					AT
+				Avellino				AV
+				Bari					BA
+				Bergamo					BG
+				Biella					BI
+				Belluno					BL
+				Benevento				BN
+				Bologna					BO
+				Brindisi				BR
+				Brescia					BS
+				Barletta-Andria-Trani	BT
+				Bolzano					BZ
+				Cagliari				CA
+				Campobasso				CB
+				Caserta					CE
+				Chieti					CH
+				Carbonia-Iglessias		CI
+				Caltanissetta			CL
+				Cuneo					CN
+				Como					CO
+				Cremona					CR
+				Cosenza					CS
+				Catania					CT
+				Catanzaro				CZ
+				Enna					EN
+				Forlì-Cesena			FC
+				Ferrara					FE
+				Foggia					FG
+				Firenze					FI
+				Fermo					FM
+				Frosinone				FR
+				Genova					GE
+				Gorizia					GO
+				Grosseto				GR
+				Imperia					IM
+				Isernia					IS
+				Crotone					KR
+				Lecco					LC
+				Lecce					LE
+				Livorno					LI
+				Lodi					LO
+				Latina					LT
+				Lucca					LU
+				Monza e Brianza			MB
+				Macerata				MC
+				Messina					ME
+				Milano					MI
+				Mantova					MN
+				Modena					MO
+				Massa e Carrara			MS
+				Matera					MT
+				Napoli					NA
+				Novara					NO
+				Nuoro					NU
+				Ogliastra				OG
+				Oristano				OR
+				Olbia-Tempio			OT
+				Palermo					PA
+				Piacenza				PC
+				Padova					PD
+				Pescara					PE
+				Perugia					PG
+				Pisa					PI
+				Pordenone				PN
+				Prato					PO
+				Parma					PR
+				Pistoia					PT
+				Pesaro e Urbino			PU
+				Pavia					PV
+				Potenza					PZ
+				Ravenna					RA
+				Reggio Calabria			RC
+				Reggio Emilia			RE
+				Ragusa					RG
+				Rieti					RI
+				Roma					RM
+				Rimini					RN
+				Rovigo					RO
+				Salerno					SA
+				iena					SI
+				Sondrio					SO
+				La Spezia				SP
+				Siracusa				SR
+				Sassari					SS
+				Savona					SV
+				Taranto					TA
+				Teramo					TE
+				Trento 					TN
+				Torino					TO
+				Trapani					TP
+				Terni					TR
+				Trieste					TS
+				Treviso					TV
+				Udine					UD
+				Varese					VA
+				Verbano-Cusio-Ossola	VB
+				Vercelli				VC
+				Venezia					VE
+				Vicenza					VI
+				Verona					VR
+				Medio Campidano			VS
+				Viterbo					VT
+				Vibo Valentia			VV
+
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AG"/>
+			<xs:enumeration value="AL"/>
+			<xs:enumeration value="AN"/>
+			<xs:enumeration value="AO"/>
+			<xs:enumeration value="AP"/>
+			<xs:enumeration value="AQ"/>
+			<xs:enumeration value="AR"/>
+			<xs:enumeration value="AT"/>
+			<xs:enumeration value="AV"/>
+			<xs:enumeration value="BA"/>
+			<xs:enumeration value="BG"/>
+			<xs:enumeration value="BI"/>
+			<xs:enumeration value="BL"/>
+			<xs:enumeration value="BN"/>
+			<xs:enumeration value="BO"/>
+			<xs:enumeration value="BR"/>
+			<xs:enumeration value="BS"/>
+			<xs:enumeration value="BT"/>
+			<xs:enumeration value="BZ"/>
+			<xs:enumeration value="CA"/>
+			<xs:enumeration value="CB"/>
+			<xs:enumeration value="CE"/>
+			<xs:enumeration value="CH"/>
+			<xs:enumeration value="CI"/>
+			<xs:enumeration value="CL"/>
+			<xs:enumeration value="CN"/>
+			<xs:enumeration value="CO"/>
+			<xs:enumeration value="CR"/>
+			<xs:enumeration value="CS"/>
+			<xs:enumeration value="CT"/>
+			<xs:enumeration value="CZ"/>
+			<xs:enumeration value="EN"/>
+			<xs:enumeration value="FC"/>
+			<xs:enumeration value="FE"/>
+			<xs:enumeration value="FG"/>
+			<xs:enumeration value="FI"/>
+			<xs:enumeration value="FM"/>
+			<xs:enumeration value="FR"/>
+			<xs:enumeration value="GE"/>
+			<xs:enumeration value="GO"/>
+			<xs:enumeration value="GR"/>
+			<xs:enumeration value="IM"/>
+			<xs:enumeration value="IS"/>
+			<xs:enumeration value="KR"/>
+			<xs:enumeration value="LC"/>
+			<xs:enumeration value="LE"/>
+			<xs:enumeration value="LI"/>
+			<xs:enumeration value="LO"/>
+			<xs:enumeration value="LT"/>
+			<xs:enumeration value="LU"/>
+			<xs:enumeration value="MB"/>
+			<xs:enumeration value="MC"/>
+			<xs:enumeration value="ME"/>
+			<xs:enumeration value="MI"/>
+			<xs:enumeration value="MN"/>
+			<xs:enumeration value="MO"/>
+			<xs:enumeration value="MS"/>
+			<xs:enumeration value="MT"/>
+			<xs:enumeration value="NA"/>
+			<xs:enumeration value="NO"/>
+			<xs:enumeration value="NU"/>
+			<xs:enumeration value="OG"/>
+			<xs:enumeration value="OR"/>
+			<xs:enumeration value="OT"/>
+			<xs:enumeration value="PA"/>
+			<xs:enumeration value="PC"/>
+			<xs:enumeration value="PD"/>
+			<xs:enumeration value="PE"/>
+			<xs:enumeration value="PG"/>
+			<xs:enumeration value="PI"/>
+			<xs:enumeration value="PN"/>
+			<xs:enumeration value="PO"/>
+			<xs:enumeration value="PR"/>
+			<xs:enumeration value="PT"/>
+			<xs:enumeration value="PU"/>
+			<xs:enumeration value="PV"/>
+			<xs:enumeration value="PZ"/>
+			<xs:enumeration value="RA"/>
+			<xs:enumeration value="RC"/>
+			<xs:enumeration value="RE"/>
+			<xs:enumeration value="RG"/>
+			<xs:enumeration value="RI"/>
+			<xs:enumeration value="RM"/>
+			<xs:enumeration value="RN"/>
+			<xs:enumeration value="RO"/>
+			<xs:enumeration value="SA"/>
+			<xs:enumeration value="SI"/>
+			<xs:enumeration value="SO"/>
+			<xs:enumeration value="SP"/>
+			<xs:enumeration value="SR"/>
+			<xs:enumeration value="SS"/>
+			<xs:enumeration value="SV"/>
+			<xs:enumeration value="TA"/>
+			<xs:enumeration value="TE"/>
+			<xs:enumeration value="TN"/>
+			<xs:enumeration value="TO"/>
+			<xs:enumeration value="TP"/>
+			<xs:enumeration value="TR"/>
+			<xs:enumeration value="TS"/>
+			<xs:enumeration value="TV"/>
+			<xs:enumeration value="UD"/>
+			<xs:enumeration value="VA"/>
+			<xs:enumeration value="VB"/>
+			<xs:enumeration value="VC"/>
+			<xs:enumeration value="VE"/>
+			<xs:enumeration value="VI"/>
+			<xs:enumeration value="VR"/>
+			<xs:enumeration value="VS"/>
+			<xs:enumeration value="VT"/>
+			<xs:enumeration value="VV"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ProvincieCroate">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="FU">
+				<xs:annotation>
+					<xs:documentation>Fiume</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PL">
+				<xs:annotation>
+					<xs:documentation>Pola</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZA">
+				<xs:annotation>
+					<xs:documentation>Zara</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Estero">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="EE"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/addons/l10n_it_xml_export/data/validation/xmldsig-core-schema.xsd
+++ b/addons/l10n_it_xml_export/data/validation/xmldsig-core-schema.xsd
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE schema
+  PUBLIC "-//W3C//DTD XMLSchema 200102//EN" "http://www.w3.org/2001/XMLSchema.dtd"
+ [
+   <!ATTLIST schema
+     xmlns:ds CDATA #FIXED "http://www.w3.org/2000/09/xmldsig#">
+   <!ENTITY dsig 'http://www.w3.org/2000/09/xmldsig#'>
+   <!ENTITY % p ''>
+   <!ENTITY % s ''>
+  ]>
+
+<!-- Schema for XML Signatures
+    http://www.w3.org/2000/09/xmldsig#
+    $Revision: 1.1 $ on $Date: 2002/02/08 20:32:26 $ by $Author: reagle $
+
+    Copyright 2001 The Internet Society and W3C (Massachusetts Institute
+    of Technology, Institut National de Recherche en Informatique et en
+    Automatique, Keio University). All Rights Reserved.
+    http://www.w3.org/Consortium/Legal/
+
+    This document is governed by the W3C Software License [1] as described
+    in the FAQ [2].
+
+    [1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
+    [2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
+-->
+
+
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+        targetNamespace="http://www.w3.org/2000/09/xmldsig#"
+        version="0.1" elementFormDefault="qualified">
+
+<!-- Basic Types Defined for Signatures -->
+
+<simpleType name="CryptoBinary">
+  <restriction base="base64Binary">
+  </restriction>
+</simpleType>
+
+<!-- Start Signature -->
+
+<element name="Signature" type="ds:SignatureType"/>
+<complexType name="SignatureType">
+  <sequence>
+    <element ref="ds:SignedInfo"/>
+    <element ref="ds:SignatureValue"/>
+    <element ref="ds:KeyInfo" minOccurs="0"/>
+    <element ref="ds:Object" minOccurs="0" maxOccurs="unbounded"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+  <element name="SignatureValue" type="ds:SignatureValueType"/>
+  <complexType name="SignatureValueType">
+    <simpleContent>
+      <extension base="base64Binary">
+        <attribute name="Id" type="ID" use="optional"/>
+      </extension>
+    </simpleContent>
+  </complexType>
+
+<!-- Start SignedInfo -->
+
+<element name="SignedInfo" type="ds:SignedInfoType"/>
+<complexType name="SignedInfoType">
+  <sequence>
+    <element ref="ds:CanonicalizationMethod"/>
+    <element ref="ds:SignatureMethod"/>
+    <element ref="ds:Reference" maxOccurs="unbounded"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+  <element name="CanonicalizationMethod" type="ds:CanonicalizationMethodType"/>
+  <complexType name="CanonicalizationMethodType" mixed="true">
+    <sequence>
+      <any namespace="##any" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- (0,unbounded) elements from (1,1) namespace -->
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/>
+  </complexType>
+
+  <element name="SignatureMethod" type="ds:SignatureMethodType"/>
+  <complexType name="SignatureMethodType" mixed="true">
+    <sequence>
+      <element name="HMACOutputLength" minOccurs="0" type="ds:HMACOutputLengthType"/>
+      <any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- (0,unbounded) elements from (1,1) external namespace -->
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/>
+  </complexType>
+
+<!-- Start Reference -->
+
+<element name="Reference" type="ds:ReferenceType"/>
+<complexType name="ReferenceType">
+  <sequence>
+    <element ref="ds:Transforms" minOccurs="0"/>
+    <element ref="ds:DigestMethod"/>
+    <element ref="ds:DigestValue"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+  <attribute name="URI" type="anyURI" use="optional"/>
+  <attribute name="Type" type="anyURI" use="optional"/>
+</complexType>
+
+  <element name="Transforms" type="ds:TransformsType"/>
+  <complexType name="TransformsType">
+    <sequence>
+      <element ref="ds:Transform" maxOccurs="unbounded"/>
+    </sequence>
+  </complexType>
+
+  <element name="Transform" type="ds:TransformType"/>
+  <complexType name="TransformType" mixed="true">
+    <choice minOccurs="0" maxOccurs="unbounded">
+      <any namespace="##other" processContents="lax"/>
+      <!-- (1,1) elements from (0,unbounded) namespaces -->
+      <element name="XPath" type="string"/>
+    </choice>
+    <attribute name="Algorithm" type="anyURI" use="required"/>
+  </complexType>
+
+<!-- End Reference -->
+
+<element name="DigestMethod" type="ds:DigestMethodType"/>
+<complexType name="DigestMethodType" mixed="true">
+  <sequence>
+    <any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+  </sequence>
+  <attribute name="Algorithm" type="anyURI" use="required"/>
+</complexType>
+
+<element name="DigestValue" type="ds:DigestValueType"/>
+<simpleType name="DigestValueType">
+  <restriction base="base64Binary"/>
+</simpleType>
+
+<!-- End SignedInfo -->
+
+<!-- Start KeyInfo -->
+
+<element name="KeyInfo" type="ds:KeyInfoType"/>
+<complexType name="KeyInfoType" mixed="true">
+  <choice maxOccurs="unbounded">
+    <element ref="ds:KeyName"/>
+    <element ref="ds:KeyValue"/>
+    <element ref="ds:RetrievalMethod"/>
+    <element ref="ds:X509Data"/>
+    <element ref="ds:PGPData"/>
+    <element ref="ds:SPKIData"/>
+    <element ref="ds:MgmtData"/>
+    <any processContents="lax" namespace="##other"/>
+    <!-- (1,1) elements from (0,unbounded) namespaces -->
+  </choice>
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+  <element name="KeyName" type="string"/>
+  <element name="MgmtData" type="string"/>
+
+  <element name="KeyValue" type="ds:KeyValueType"/>
+  <complexType name="KeyValueType" mixed="true">
+   <choice>
+     <element ref="ds:DSAKeyValue"/>
+     <element ref="ds:RSAKeyValue"/>
+     <any namespace="##other" processContents="lax"/>
+   </choice>
+  </complexType>
+
+  <element name="RetrievalMethod" type="ds:RetrievalMethodType"/>
+  <complexType name="RetrievalMethodType">
+    <sequence>
+      <element ref="ds:Transforms" minOccurs="0"/>
+    </sequence>
+    <attribute name="URI" type="anyURI"/>
+    <attribute name="Type" type="anyURI" use="optional"/>
+  </complexType>
+
+<!-- Start X509Data -->
+
+<element name="X509Data" type="ds:X509DataType"/>
+<complexType name="X509DataType">
+  <sequence maxOccurs="unbounded">
+    <choice>
+      <element name="X509IssuerSerial" type="ds:X509IssuerSerialType"/>
+      <element name="X509SKI" type="base64Binary"/>
+      <element name="X509SubjectName" type="string"/>
+      <element name="X509Certificate" type="base64Binary"/>
+      <element name="X509CRL" type="base64Binary"/>
+      <any namespace="##other" processContents="lax"/>
+    </choice>
+  </sequence>
+</complexType>
+
+<complexType name="X509IssuerSerialType">
+  <sequence>
+    <element name="X509IssuerName" type="string"/>
+    <element name="X509SerialNumber" type="integer"/>
+  </sequence>
+</complexType>
+
+<!-- End X509Data -->
+
+<!-- Begin PGPData -->
+
+<element name="PGPData" type="ds:PGPDataType"/>
+<complexType name="PGPDataType">
+  <choice>
+    <sequence>
+      <element name="PGPKeyID" type="base64Binary"/>
+      <element name="PGPKeyPacket" type="base64Binary" minOccurs="0"/>
+      <any namespace="##other" processContents="lax" minOccurs="0"
+       maxOccurs="unbounded"/>
+    </sequence>
+    <sequence>
+      <element name="PGPKeyPacket" type="base64Binary"/>
+      <any namespace="##other" processContents="lax" minOccurs="0"
+       maxOccurs="unbounded"/>
+    </sequence>
+  </choice>
+</complexType>
+
+<!-- End PGPData -->
+
+<!-- Begin SPKIData -->
+
+<element name="SPKIData" type="ds:SPKIDataType"/>
+<complexType name="SPKIDataType">
+  <sequence maxOccurs="unbounded">
+    <element name="SPKISexp" type="base64Binary"/>
+    <any namespace="##other" processContents="lax" minOccurs="0"/>
+  </sequence>
+</complexType>
+
+<!-- End SPKIData -->
+
+<!-- End KeyInfo -->
+
+<!-- Start Object (Manifest, SignatureProperty) -->
+
+<element name="Object" type="ds:ObjectType"/>
+<complexType name="ObjectType" mixed="true">
+  <sequence minOccurs="0" maxOccurs="unbounded">
+    <any namespace="##any" processContents="lax"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+  <attribute name="MimeType" type="string" use="optional"/> <!-- add a grep facet -->
+  <attribute name="Encoding" type="anyURI" use="optional"/>
+</complexType>
+
+<element name="Manifest" type="ds:ManifestType"/>
+<complexType name="ManifestType">
+  <sequence>
+    <element ref="ds:Reference" maxOccurs="unbounded"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+<element name="SignatureProperties" type="ds:SignaturePropertiesType"/>
+<complexType name="SignaturePropertiesType">
+  <sequence>
+    <element ref="ds:SignatureProperty" maxOccurs="unbounded"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+   <element name="SignatureProperty" type="ds:SignaturePropertyType"/>
+   <complexType name="SignaturePropertyType" mixed="true">
+     <choice maxOccurs="unbounded">
+       <any namespace="##other" processContents="lax"/>
+       <!-- (1,1) elements from (1,unbounded) namespaces -->
+     </choice>
+     <attribute name="Target" type="anyURI" use="required"/>
+     <attribute name="Id" type="ID" use="optional"/>
+   </complexType>
+
+<!-- End Object (Manifest, SignatureProperty) -->
+
+<!-- Start Algorithm Parameters -->
+
+<simpleType name="HMACOutputLengthType">
+  <restriction base="integer"/>
+</simpleType>
+
+<!-- Start KeyValue Element-types -->
+
+<element name="DSAKeyValue" type="ds:DSAKeyValueType"/>
+<complexType name="DSAKeyValueType">
+  <sequence>
+    <sequence minOccurs="0">
+      <element name="P" type="ds:CryptoBinary"/>
+      <element name="Q" type="ds:CryptoBinary"/>
+    </sequence>
+    <element name="G" type="ds:CryptoBinary" minOccurs="0"/>
+    <element name="Y" type="ds:CryptoBinary"/>
+    <element name="J" type="ds:CryptoBinary" minOccurs="0"/>
+    <sequence minOccurs="0">
+      <element name="Seed" type="ds:CryptoBinary"/>
+      <element name="PgenCounter" type="ds:CryptoBinary"/>
+    </sequence>
+  </sequence>
+</complexType>
+
+<element name="RSAKeyValue" type="ds:RSAKeyValueType"/>
+<complexType name="RSAKeyValueType">
+  <sequence>
+    <element name="Modulus" type="ds:CryptoBinary"/>
+    <element name="Exponent" type="ds:CryptoBinary"/>
+  </sequence>
+</complexType>
+
+<!-- End KeyValue Element-types -->
+
+<!-- End Signature -->
+
+</schema>

--- a/addons/l10n_it_xml_export/i18n/it.po
+++ b/addons/l10n_it_xml_export/i18n/it.po
@@ -1,0 +1,356 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_it_xml_export
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-02-13 08:01+0000\n"
+"PO-Revision-Date: 2025-02-13 08:01+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__method__1
+msgid "1 - Historical Method"
+msgstr "1 - Metodo storico"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__1
+msgid "1 - Legal representative"
+msgstr "1 - Rappresentante legale"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__11
+msgid "11 - Legal guardian"
+msgstr "11 - Tutore legale"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__12
+msgid "12 - Sole proprietor liquidator"
+msgstr "12 - Liquidatore della ditta individuale"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__13
+msgid "13 - Property manager"
+msgstr "13 - Manager di proprietà"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__14
+msgid "14 - Public representative"
+msgstr "14 - Rappresentante pubblico"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__15
+msgid "15 - Public liquidator"
+msgstr "15 - Liquidatore pubblico"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__2
+msgid "2 - Administrator of underaged"
+msgstr "2 - Amministratore di minorenni"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__method__2
+msgid "2 - Forecasting Method"
+msgstr "2 - Metodo di previsione"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__method__3
+msgid "3 - Analytical Method"
+msgstr "3 - Metodo analitico"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__3
+msgid "3 - Controller of sequestered goods"
+msgstr "3 - Controllore dei beni sequestrati"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__4
+msgid "4 - Fiscal representative"
+msgstr "4 - Rappresentante fiscale"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__5
+msgid "5 - General legatee"
+msgstr "5 - Legato generale"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__6
+msgid "6 - Liquidator"
+msgstr "6 - Liquidatore"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__7
+msgid "7 - Extraordinary operator"
+msgstr "7 - Operatore straordinario"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__8
+msgid "8 - Bankruptcy curator"
+msgstr "8 - Curatore fallimentare"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__9
+msgid "9 - Commissioned liquidator"
+msgstr "9 - Liquidatore incaricato"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__extraordinary_operations
+msgid "Check this if the company has undergone extraordinary operations."
+msgstr "Verificate se l'azienda ha subito operazioni straordinarie."
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__subcontracting
+msgid "Check this if the company operates in sub-contracting."
+msgstr "Verificare se l'azienda opera in subappalto."
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__exceptional_events
+msgid "Check this if the declaration is affected by exceptional events."
+msgstr "Selezionare questa opzione se la dichiarazione è influenzata da eventi eccezionali."
+
+#. module: l10n_it_xml_export
+#: model_terms:ir.ui.view,arch_db:l10n_it_xml_export.monthly_tax_report_xml_export_wizard_view
+msgid "Close"
+msgstr "Chiudere"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_fiscal_code
+msgid "Codice Fiscale of the declarant."
+msgstr "Codice fiscale del dichiarante."
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__taxpayer_code
+msgid ""
+"Codice Fiscale of the taxpayer. Defaults to the company's Codice Fiscale but"
+" can be changed."
+msgstr ""
+"Codice fiscale del contribuente. Per impostazione predefinita, il codice "
+"fiscale dell'azienda può essere modificato."
+
+#. module: l10n_it_xml_export
+#: model:ir.model,name:l10n_it_xml_export.model_res_company
+msgid "Companies"
+msgstr "Aziende"
+
+#. module: l10n_it_xml_export
+#: model_terms:ir.ui.view,arch_db:l10n_it_xml_export.monthly_tax_report_xml_export_wizard_view
+msgid "Confirm"
+msgstr "Confermare"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__create_uid
+msgid "Created by"
+msgstr "Creato da"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__create_date
+msgid "Created on"
+msgstr "Creato il"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__commitment_date
+msgid "Date of Commitment"
+msgstr "Data Impegno"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_fiscal_code
+msgid "Declarant Fiscal Code"
+msgstr "Codice Fiscale Dichiarante"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code
+msgid "Declarant Role Code"
+msgstr "Codice Carica Dichiarante"
+
+#. module: l10n_it_xml_export
+#. odoo-python
+#: code:addons/l10n_it_xml_export/wizard/monthly_tax_report_xml_export.py:0
+#, python-format
+msgid "Declarant tax code must be 16 characters long."
+msgstr "Il codice fiscale del dichiarante deve essere di 16 caratteri."
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__display_name
+msgid "Display Name"
+msgstr "Nome visualizzato"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__exceptional_events
+msgid "Exceptional Events"
+msgstr "Eventi Eccezionali"
+
+#. module: l10n_it_xml_export
+#. odoo-python
+#: code:addons/l10n_it_xml_export/wizard/monthly_tax_report_xml_export.py:0
+#, python-format
+msgid "Exceptional Events can only take a value from 1 to 9."
+msgstr "Gli Eventi eccezionali possono assumere un valore compreso tra 1 e 9."
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__extraordinary_operations
+msgid "Extraordinary Operations"
+msgstr "Operazioni Straordinarie"
+
+#. module: l10n_it_xml_export
+#: model_terms:ir.ui.view,arch_db:l10n_it_xml_export.monthly_tax_report_xml_export_wizard_view
+msgid "Generate Monthly Tax Report XML"
+msgstr "Generazione del rapporto fiscale mensile XML"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__id
+msgid "ID"
+msgstr "ID"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__submission_commitment
+msgid ""
+"If an intermediary is involved, this field precises whether the declaration "
+"was done by the taxpayer or that intermediary."
+msgstr ""
+"Se è coinvolto un intermediario, questo campo specifica se la dichiarazione "
+"è stata fatta dal contribuente o da tale intermediario."
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__method
+msgid ""
+"Indicates which advance payment calculation method was used. The value of "
+"the advance payment can be found in the VP13 line of the report."
+msgstr ""
+"Indica il metodo di calcolo dell'anticipo utilizzato. Il valore dell'anticipo "
+"è riportato nella riga VP13 del rapporto."
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__intermediary_code
+msgid "Intermediary Code"
+msgstr "Codice intermediario"
+
+#. module: l10n_it_xml_export
+#: model:ir.model,name:l10n_it_xml_export.model_l10n_it_monthly_tax_report_handler
+msgid "Italian Monthly Tax Report Custom Handler"
+msgstr "Gestore personalizzato del rapporto fiscale mensile italiano"
+
+#. module: l10n_it_xml_export
+#: model:ir.model,name:l10n_it_xml_export.model_l10n_it_xml_export_monthly_tax_report_xml_export_wizard
+msgid "Italian Monthly Tax Report XML Export Wizard"
+msgstr "Procedura di esportazione guidata XML del rapporto fiscale mensile italiano"
+
+#. module: l10n_it_xml_export
+#: model:ir.model,name:l10n_it_xml_export.model_account_move
+msgid "Journal Entry"
+msgstr "Registrazione contabile"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__write_uid
+msgid "Last Updated by"
+msgstr "Ultimo aggiornamento da"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__write_date
+msgid "Last Updated on"
+msgstr "Ultimo aggiornamento il"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__method
+msgid "Method"
+msgstr "Metodo"
+
+#. module: l10n_it_xml_export
+#: model_terms:ir.ui.view,arch_db:l10n_it_xml_export.tax_report_export_template
+msgid "Odoo"
+msgstr "Odoo"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__parent_vat_number
+msgid "Parent VAT Number"
+msgstr "Partita IVA Controllante"
+
+#. module: l10n_it_xml_export
+#. odoo-python
+#: code:addons/l10n_it_xml_export/wizard/monthly_tax_report_xml_export.py:0
+#, python-format
+msgid "Parent VAT number must be 11 characters long."
+msgstr "Il numero di partita IVA del genitore deve essere di 11 caratteri."
+
+#. module: l10n_it_xml_export
+#. odoo-python
+#: code:addons/l10n_it_xml_export/models/account_move.py:0
+#, python-format
+msgid "Post a tax report entry"
+msgstr "Pubblicare una voce di rapporto fiscale"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__submission_commitment__2
+msgid "Prepared by the sender"
+msgstr "Preparato dal mittente"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__submission_commitment__1
+msgid "Prepared by the taxpayer"
+msgstr "Preparato dal contribuente"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code
+msgid "Role code of the declarant"
+msgstr "Codice ruolo del dichiarante"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__subcontracting
+msgid "Subcontracting"
+msgstr "Subfornitura"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__submission_commitment
+msgid "Submission Commitment"
+msgstr "Impegno Presentazione"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__id_sistema
+msgid "System ID"
+msgstr "ID Sistema"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__taxpayer_code
+msgid "Taxpayer Fiscal Code"
+msgstr "Codice Fiscale"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__id_sistema
+msgid "Unique identifier of the system that generated the file."
+msgstr "Identificatore univoco del sistema che ha generato il file."
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__parent_vat_number
+msgid "VAT number of the parent company."
+msgstr "Numero di partita IVA della società madre."
+
+#. module: l10n_it_xml_export
+#. odoo-python
+#: code:addons/l10n_it_xml_export/models/tax_report.py:0
+#: code:addons/l10n_it_xml_export/models/tax_report.py:0
+#, python-format
+msgid "XML"
+msgstr "XML"
+
+#. module: l10n_it_xml_export
+#. odoo-python
+#: code:addons/l10n_it_xml_export/models/tax_report.py:0
+#, python-format
+msgid "XML Export Options"
+msgstr "Opzioni di esportazione XML"
+
+#. module: l10n_it_xml_export
+#: model_terms:ir.ui.view,arch_db:l10n_it_xml_export.monthly_tax_report_xml_export_wizard_view
+msgid "e.g. 1234567890123456"
+msgstr "Ad esempio, 1234567890123456"
+
+#. module: l10n_it_xml_export
+#: model_terms:ir.ui.view,arch_db:l10n_it_xml_export.monthly_tax_report_xml_export_wizard_view
+msgid "e.g. ABCDEF12G34H567I"
+msgstr "ad esempio ABCDEF12G34H567I"

--- a/addons/l10n_it_xml_export/i18n/l10n_it_xml_export.pot
+++ b/addons/l10n_it_xml_export/i18n/l10n_it_xml_export.pot
@@ -1,0 +1,350 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_it_xml_export
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-02-13 08:00+0000\n"
+"PO-Revision-Date: 2025-02-13 08:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__method__1
+msgid "1 - Historical Method"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__1
+msgid "1 - Legal representative"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__11
+msgid "11 - Legal guardian"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__12
+msgid "12 - Sole proprietor liquidator"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__13
+msgid "13 - Property manager"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__14
+msgid "14 - Public representative"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__15
+msgid "15 - Public liquidator"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__2
+msgid "2 - Administrator of underaged"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__method__2
+msgid "2 - Forecasting Method"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__method__3
+msgid "3 - Analytical Method"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__3
+msgid "3 - Controller of sequestered goods"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__4
+msgid "4 - Fiscal representative"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__5
+msgid "5 - General legatee"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__6
+msgid "6 - Liquidator"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__7
+msgid "7 - Extraordinary operator"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__8
+msgid "8 - Bankruptcy curator"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code__9
+msgid "9 - Commissioned liquidator"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__extraordinary_operations
+msgid "Check this if the company has undergone extraordinary operations."
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__subcontracting
+msgid "Check this if the company operates in sub-contracting."
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__exceptional_events
+msgid "Check this if the declaration is affected by exceptional events."
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model_terms:ir.ui.view,arch_db:l10n_it_xml_export.monthly_tax_report_xml_export_wizard_view
+msgid "Close"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_fiscal_code
+msgid "Codice Fiscale of the declarant."
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__taxpayer_code
+msgid ""
+"Codice Fiscale of the taxpayer. Defaults to the company's Codice Fiscale but"
+" can be changed."
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model,name:l10n_it_xml_export.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model_terms:ir.ui.view,arch_db:l10n_it_xml_export.monthly_tax_report_xml_export_wizard_view
+msgid "Confirm"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__commitment_date
+msgid "Date of Commitment"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_fiscal_code
+msgid "Declarant Fiscal Code"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code
+msgid "Declarant Role Code"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#. odoo-python
+#: code:addons/l10n_it_xml_export/wizard/monthly_tax_report_xml_export.py:0
+#, python-format
+msgid "Declarant tax code must be 16 characters long."
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__exceptional_events
+msgid "Exceptional Events"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#. odoo-python
+#: code:addons/l10n_it_xml_export/wizard/monthly_tax_report_xml_export.py:0
+#, python-format
+msgid "Exceptional Events can only take a value from 1 to 9."
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__extraordinary_operations
+msgid "Extraordinary Operations"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model_terms:ir.ui.view,arch_db:l10n_it_xml_export.monthly_tax_report_xml_export_wizard_view
+msgid "Generate Monthly Tax Report XML"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__submission_commitment
+msgid ""
+"If an intermediary is involved, this field precises whether the declaration "
+"was done by the taxpayer or that intermediary."
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__method
+msgid ""
+"Indicates which advance payment calculation method was used. The value of "
+"the advance payment can be found in the VP13 line of the report."
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__intermediary_code
+msgid "Intermediary Code"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model,name:l10n_it_xml_export.model_l10n_it_monthly_tax_report_handler
+msgid "Italian Monthly Tax Report Custom Handler"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model,name:l10n_it_xml_export.model_l10n_it_xml_export_monthly_tax_report_xml_export_wizard
+msgid "Italian Monthly Tax Report XML Export Wizard"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model,name:l10n_it_xml_export.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__method
+msgid "Method"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model_terms:ir.ui.view,arch_db:l10n_it_xml_export.tax_report_export_template
+msgid "Odoo"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__parent_vat_number
+msgid "Parent VAT Number"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#. odoo-python
+#: code:addons/l10n_it_xml_export/wizard/monthly_tax_report_xml_export.py:0
+#, python-format
+msgid "Parent VAT number must be 11 characters long."
+msgstr ""
+
+#. module: l10n_it_xml_export
+#. odoo-python
+#: code:addons/l10n_it_xml_export/models/account_move.py:0
+#, python-format
+msgid "Post a tax report entry"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__submission_commitment__2
+msgid "Prepared by the sender"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields.selection,name:l10n_it_xml_export.selection__l10n_it_xml_export_monthly_tax_report_xml_export_wizard__submission_commitment__1
+msgid "Prepared by the taxpayer"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__declarant_role_code
+msgid "Role code of the declarant"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__subcontracting
+msgid "Subcontracting"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__submission_commitment
+msgid "Submission Commitment"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__id_sistema
+msgid "System ID"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,field_description:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__taxpayer_code
+msgid "Taxpayer Fiscal Code"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__id_sistema
+msgid "Unique identifier of the system that generated the file."
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model:ir.model.fields,help:l10n_it_xml_export.field_l10n_it_xml_export_monthly_tax_report_xml_export_wizard__parent_vat_number
+msgid "VAT number of the parent company."
+msgstr ""
+
+#. module: l10n_it_xml_export
+#. odoo-python
+#: code:addons/l10n_it_xml_export/models/tax_report.py:0
+#: code:addons/l10n_it_xml_export/models/tax_report.py:0
+#, python-format
+msgid "XML"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#. odoo-python
+#: code:addons/l10n_it_xml_export/models/tax_report.py:0
+#, python-format
+msgid "XML Export Options"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model_terms:ir.ui.view,arch_db:l10n_it_xml_export.monthly_tax_report_xml_export_wizard_view
+msgid "e.g. 1234567890123456"
+msgstr ""
+
+#. module: l10n_it_xml_export
+#: model_terms:ir.ui.view,arch_db:l10n_it_xml_export.monthly_tax_report_xml_export_wizard_view
+msgid "e.g. ABCDEF12G34H567I"
+msgstr ""

--- a/addons/l10n_it_xml_export/models/__init__.py
+++ b/addons/l10n_it_xml_export/models/__init__.py
@@ -1,0 +1,3 @@
+from . import account_move
+from . import res_company
+from . import tax_report

--- a/addons/l10n_it_xml_export/models/account_move.py
+++ b/addons/l10n_it_xml_export/models/account_move.py
@@ -1,0 +1,33 @@
+from odoo import models, _
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def action_post(self):
+        """This action will be called by the POST button on a tax report account move.
+           As posting this move will generate the XML report, it won't call `action_post`
+           immediately, but will open the wizard that configures this XML file.
+           Validating the wizard will resume the `action_post` and take these options in
+           consideration when generating the XML report.
+        """
+        closing_move = self.filtered(lambda move: move.tax_closing_end_date and move.move_type == 'entry' and move.tax_country_code == 'IT')[:1]
+        if closing_move and "l10n_it_xml_export_monthly_tax_report_options" not in self.env.context:
+            view_id = self.env.ref('l10n_it_xml_export.monthly_tax_report_xml_export_wizard_view').id
+
+            return {
+                'name': _('Post a tax report entry'),
+                'view_mode': 'form',
+                'views': [[view_id, 'form']],
+                'res_model': 'l10n_it_xml_export.monthly.tax.report.xml.export.wizard',
+                'type': 'ir.actions.act_window',
+                'target': 'new',
+                'context': {
+                    **self.env.context,
+                    'l10n_it_xml_export_monthly_tax_report_options': {
+                        'date': {'date_to': closing_move.tax_closing_end_date}
+                    },
+                },
+            }
+
+        return super().action_post()

--- a/addons/l10n_it_xml_export/models/res_company.py
+++ b/addons/l10n_it_xml_export/models/res_company.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    def _get_countries_allowing_tax_representative(self):
+        rslt = super()._get_countries_allowing_tax_representative()
+        rslt.add('IT')
+        return rslt

--- a/addons/l10n_it_xml_export/models/tax_report.py
+++ b/addons/l10n_it_xml_export/models/tax_report.py
@@ -1,0 +1,127 @@
+from dateutil.relativedelta import relativedelta
+from lxml import etree
+from markupsafe import Markup
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+from odoo.tools import file_open, xml_utils
+
+class ItalianReportCustomHandler(models.AbstractModel):
+    _name = 'l10n_it.monthly.tax.report.handler'
+    _inherit = 'account.tax.report.handler'
+    _description = 'Italian Monthly Tax Report Custom Handler'
+
+    def _custom_options_initializer(self, report, options, previous_options=None):
+        super()._custom_options_initializer(report, options, previous_options=previous_options)
+
+        options.setdefault("buttons", []).append({
+            "name": _("XML"),
+            "sequence": 30,
+            "action": "print_tax_report_to_xml",
+            "file_export_type": _("XML"),
+            "branch_allowed": True,
+        })
+
+    def print_tax_report_to_xml(self, options):
+        view_id = self.env.ref('l10n_it_xml_export.monthly_tax_report_xml_export_wizard_view').id
+        return {
+            'name': _('XML Export Options'),
+            'view_mode': 'form',
+            'views': [[view_id, 'form']],
+            'res_model': 'l10n_it_xml_export.monthly.tax.report.xml.export.wizard',
+            'type': 'ir.actions.act_window',
+            'target': 'new',
+            'context': dict(self._context, l10n_it_xml_export_monthly_tax_report_options=options),
+        }
+
+    def export_tax_report_to_xml(self, options):
+        xml_content = self.env["ir.qweb"]._render("l10n_it_xml_export.tax_report_export_template", self._get_xml_export_data(options))
+        xml_content = Markup("""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>""") + xml_content
+        xml_content = xml_content.encode()
+
+        with file_open("l10n_it_xml_export/data/validation/fornituraIvp_2018_v1.xsd", 'rb') as xsd:
+            xsd_schema = etree.XMLSchema(etree.parse(xsd))
+            try:
+                xsd_schema.assertValid(etree.fromstring(xml_content))
+            except etree.DocumentInvalid as xml_errors:
+                self.env['bus.bus']._sendone(
+                    self.env.user.partner_id,
+                    'simple_notification',
+                    {
+                        'type': 'warning',
+                        'title': _('XML Validation Error'),
+                        'message': _(
+                            "Some values will not pass the authority's validation, please check them before submitting your file: %s",
+                            [error.path.split(":")[-1] for error in xml_errors.error_log]
+                        ),
+                        'sticky': True,
+                    },
+                )
+
+        return {
+            "file_name": self.env["account.report"].browse(options["report_id"]).get_default_report_filename(options, 'xml'),
+            "file_content": xml_content,
+            "file_type": "xml",
+        }
+
+    def _get_xml_export_data(self, options):
+        options_date_to = fields.Date.from_string(options["date"]["date_to"])
+        report = self.env["account.report"].browse(options["report_id"])
+        company = report._get_sender_company_for_export(options)
+        report_lines = report._get_lines(options)
+        colname_to_idx = {col['expression_label']: idx for idx, col in enumerate(options.get('columns', []))}
+        report_line2amount = {
+            line['columns'][colname_to_idx['balance']]['report_line_id']: (
+                "{:.2f}".format(
+                    float(line['columns'][colname_to_idx['balance']]['no_format'])
+                ).replace(".", ",")
+                if line['columns'][colname_to_idx['balance']]['no_format'] else
+                False
+            )
+            for line in report_lines
+        }
+        report_lines_data = {}
+        for report_line in self.env['account.report.line'].browse(report_line2amount.keys()):
+            report_lines_data[report_line.code] = report_line2amount[report_line.id]
+
+        # VP6a and VP6b values must be absolute values.
+        for code in ["VP6a", "VP6b"]:
+            if report_lines_data[code] and report_lines_data[code][0] == "-":
+                report_lines_data[code] = report_lines_data[code][1:]
+
+        return {
+            "supply_code": "IVP18",
+            "declarant_fiscal_code": options["declarant_fiscal_code"],
+            "declarant_role_code": options["declarant_role_code"],
+            "id_sistema": options["id_sistema"],
+            "taxpayer_code": company.l10n_it_codice_fiscale,
+            "tax_year": options_date_to.year,
+            "vat_number": "".join([char for char in report.get_vat_for_export(options) if char.isdigit()]),
+            "parent_company_vat_number": options["parent_company_vat_number"],
+            "last_month": (options_date_to - relativedelta(months=1)).month,
+            "company_code": options["company_code"],
+            "intermediary_code": options["intermediary_code"],
+            "submission_commitment": options["intermediary_code"] and int(options["submission_commitment"]),
+            "commitment_date": options["intermediary_code"] and fields.Date.from_string(options["commitment_date"]).strftime("%d%m%Y"),
+            "intermediary_signature": options["intermediary_code"] and 1,
+            "month": options_date_to.month,
+            "subcontracting": options["subcontracting"] and 1,
+            "exceptional_events": options["exceptional_events"] and 1,
+            "extraordinary_operations": options["extraordinary_operations"] and 1,
+            "total_active_operations": report_lines_data["VP2"],
+            "total_passive_operations": report_lines_data["VP3"],
+            "vat_payable": report_lines_data["VP4"],
+            "vat_deducted": report_lines_data["VP5"],
+            "vat_due": report_lines_data["VP6a"],
+            "vat_credit": report_lines_data["VP6b"],
+            "previous_debt": report_lines_data["VP7"],
+            "previous_period_credit": report_lines_data["VP8"],
+            "previous_year_credit": report_lines_data["VP9"],
+            "eu_self_payments": report_lines_data["VP10"],
+            "tax_credits": report_lines_data["VP11"],
+            "due_interests": report_lines_data["VP12"],
+            "method": int(options["method"]),
+            "advance_payment": report_lines_data["VP13"],
+            "amount_to_be_paid": report_lines_data["VP14a"],
+            "amount_in_credit": report_lines_data["VP14b"],
+        }

--- a/addons/l10n_it_xml_export/security/ir.model.access.csv
+++ b/addons/l10n_it_xml_export/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_l10n_it_xml_export_monthly_tax_report_xml_export_wizard,access.l10n_it_xml_export.monthly.tax.report.xml.export.wizard,model_l10n_it_xml_export_monthly_tax_report_xml_export_wizard,account.group_account_user,1,1,1,0

--- a/addons/l10n_it_xml_export/wizard/__init__.py
+++ b/addons/l10n_it_xml_export/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import monthly_tax_report_xml_export

--- a/addons/l10n_it_xml_export/wizard/monthly_tax_report_xml_export.py
+++ b/addons/l10n_it_xml_export/wizard/monthly_tax_report_xml_export.py
@@ -1,0 +1,144 @@
+import json
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import models, fields
+
+
+class L10nItMonthlyTaxReportXmlExportWizard(models.TransientModel):
+    _name = "l10n_it_xml_export.monthly.tax.report.xml.export.wizard"
+    _description = "Italian Monthly Tax Report XML Export Wizard"
+
+    declarant_fiscal_code = fields.Char(
+        string="Declarant Fiscal Code",
+        help="Codice Fiscale of the declarant.",
+        default=lambda self: (self.env.company.account_representative_id or self.env.company).l10n_it_codice_fiscale,
+    )
+    declarant_role_code = fields.Selection(
+        string="Declarant Role Code",
+        help="Role code of the declarant",
+        default="1",
+        selection=[
+            ("1", "1 - Legal representative"),
+            ("2", "2 - Administrator of underaged"),
+            ("3", "3 - Controller of sequestered goods"),
+            ("4", "4 - Fiscal representative"),
+            ("5", "5 - General legatee"),
+            ("6", "6 - Liquidator"),
+            ("7", "7 - Extraordinary operator"),
+            ("8", "8 - Bankruptcy curator"),
+            ("9", "9 - Commissioned liquidator"),
+            ("11", "11 - Legal guardian"),
+            ("12", "12 - Sole proprietor liquidator"),
+            ("13", "13 - Property manager"),
+            ("14", "14 - Public representative"),
+            ("15", "15 - Public liquidator"),
+        ],
+    )
+    id_sistema = fields.Char(
+        string="System ID",
+        help="Unique identifier of the system that generated the file."
+    )
+    taxpayer_code = fields.Char(
+        string="Taxpayer Fiscal Code",
+        help="Codice Fiscale of the taxpayer. Defaults to the company's Codice Fiscale but can be changed.",
+        default=lambda self: self.env.company.l10n_it_codice_fiscale,
+    )
+    parent_company_id = fields.Many2one(
+        comodel_name="res.company",
+        default=lambda x: x._get_default_parent_company_data()["parent_id"],
+    )
+    parent_company_vat_number = fields.Char(
+        string="Parent VAT Number",
+        help="VAT number of the parent company.",
+        default=lambda x: x._get_default_parent_company_data()["vat_number"],
+    )
+    company_code = fields.Char(
+        string="Company Code",
+        help="Codice Fiscale of the company.",
+        default=lambda self: "".join([char for char in self.env.company.vat if char.isdigit()]) if self.env.company.vat else False,
+    )
+    intermediary_code = fields.Char(
+        string="Intermediary Code",
+        default=lambda self: self.env.company.account_representative_id.l10n_it_codice_fiscale if self.env.company.account_representative_id else False,
+    )
+    submission_commitment = fields.Selection(
+        string="Prepared by",
+        help="If a representative is involved, this field precises whether the declaration was done by the taxpayer or the representative.",
+        default="1",
+        selection=[
+            ("1", "the Taxpayer"),
+            ("2", "the Representative"),
+        ],
+    )
+    commitment_date = fields.Date(
+        string="Date of Commitment",
+        default=fields.Date.context_today,
+    )
+    subcontracting = fields.Boolean(string="Subcontracting", help="Check this if the company operates in sub-contracting.")
+    exceptional_events = fields.Boolean(string="Exceptional Events", help="Check this if the declaration is affected by exceptional events.")
+    extraordinary_operations = fields.Boolean(string="Extraordinary Operations", help="Check this if the company has undergone extraordinary operations.")
+    show_method = fields.Boolean(
+        string="Show Method",
+        help="Check this if you want to show the method field.",
+        compute="_compute_show_method",
+    )
+    method = fields.Selection(
+        string="Method",
+        help="Indicates which advance payment calculation method was used. The value of the advance payment can be found in the VP13 line of the report.",
+        selection=[
+            ("1", "1 - Historical Method"),
+            ("2", "2 - Forecasting Method"),
+            ("3", "3 - Analytical Method"),
+        ],
+    )
+
+    def _get_default_parent_company_data(self):
+        parent_id = self.env.company.parent_id or (hasattr(self.env.company, "company.account_tax_unit_ids") and self.env.company.account_tax_unit_ids[0].main_company_id)
+        return {
+            "parent_id": parent_id,
+            "vat_number": "".join([char for char in parent_id.vat if char.isdigit()]) if parent_id else False,
+        }
+
+    def _compute_show_method(self):
+        self.show_method = False
+
+        submissions_periodicity = hasattr(self.env.company, "account_tax_periodicity") and self.env.company.account_tax_periodicity
+        date_to = fields.Date.from_string(self.env.context['l10n_it_xml_export_monthly_tax_report_options']['date']['date_to'])
+        for wizard in self:
+            if submissions_periodicity == "trimester" and (date_to.month - 1) // 3 == 3:
+                wizard.show_method = True
+            if date_to.month == 12:
+                wizard.show_method = True
+
+    def action_generate_export(self):
+        self.ensure_one()
+        options = self.env.context.get("l10n_it_xml_export_monthly_tax_report_options", {})
+        if not options:
+            _dummy, options = self.env['account.move'].browse(self.env.context['active_id'])._get_report_options_from_tax_closing_entry()
+        options.update(self._get_wizard_field_dict())
+        return {
+            'type': 'ir_actions_account_report_download',
+            'data': {
+                'model': self.env.context.get('model'),
+                'options': json.dumps(options),
+                'file_generator': 'export_tax_report_to_xml',
+            }
+        }
+
+    def _get_wizard_field_dict(self):
+        return {
+            "declarant_fiscal_code": self.declarant_fiscal_code,
+            "declarant_role_code": self.declarant_role_code,
+            "id_sistema": self.id_sistema,
+            "taxpayer_code": self.taxpayer_code,
+            "parent_company_vat_number": self.parent_company_vat_number,
+            "company_code": self.company_code,
+            "intermediary_code": self.intermediary_code,
+            "submission_commitment": self.submission_commitment,
+            "commitment_date": fields.Date.to_string(self.commitment_date),  # Date fields are not json serializable.
+            "subcontracting": self.subcontracting,
+            "exceptional_events": self.exceptional_events,
+            "extraordinary_operations": self.extraordinary_operations,
+            "method": self.method,
+        }

--- a/addons/l10n_it_xml_export/wizard/monthly_tax_report_xml_export_view.xml
+++ b/addons/l10n_it_xml_export/wizard/monthly_tax_report_xml_export_view.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="monthly_tax_report_xml_export_wizard_view" model="ir.ui.view">
+            <field name="name">l10n_it_xml_export.monthly_tax_report_xml_export_wizard_view</field>
+            <field name="model">l10n_it_xml_export.monthly.tax.report.xml.export.wizard</field>
+            <field name="arch" type="xml">
+                <form string="Generate Monthly Tax Report XML">
+                    <group>
+                        <group>
+                            <field name="taxpayer_code" placeholder="e.g. ABCDEF12G34H567I"/>
+                            <field name="parent_company_id" invisible="1"/>
+                            <field name="parent_company_vat_number" placeholder="e.g. 12345678901" invisible="not parent_company_id"/>
+                            <field name="declarant_fiscal_code" placeholder="e.g. 12345678901 or ABCDEF12G34H567I"/>
+                            <field name="declarant_role_code" required="declarant_fiscal_code"/>
+                            <field name="intermediary_code" invisible="1"/>
+                            <field name="commitment_date" invisible="not intermediary_code" required="intermediary_code"/>
+                            <field name="submission_commitment" invisible="not intermediary_code" required="intermediary_code" widget="radio" options="{'horizontal': True}"/>
+                        </group>
+                        <group>
+                            <field name="subcontracting"/>
+                            <field name="exceptional_events"/>
+                            <field name="extraordinary_operations"/>
+                            <field name="id_sistema"/>
+                            <field name="show_method" invisible="1"/>
+                            <field name="method" invisible="not show_method"/>
+                        </group>
+                    </group>
+                    <footer>
+                        <button name="action_generate_export" string="Confirm" type="object"
+                                class="btn-primary" data-hotkey="q"/>
+                        <button string="Close" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Description of the issue this commit addresses:

The Italian localization currently doesn't allow users to export the periodic
tax report to xml format. This feature is missing.

---

Desired behavior after the commit is merged:

The Italian monthly tax report has a button that allows the user to export the
report to an xml format.

---

Enterprise PR: https://github.com/odoo/enterprise/pull/80009
task-4507942

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
