### PR TITLE
[FIX] website: prevent duplicate URLs in sitemap generation

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1173,9 +1173,9 @@ class Website(models.Model):
 
         for rule in router.iter_rules():
             if 'sitemap' in rule.endpoint.routing and rule.endpoint.routing['sitemap'] is not True:
-                if rule.endpoint.func in sitemap_endpoint_done:
+                if rule.endpoint.func.__func__ in sitemap_endpoint_done:
                     continue
-                sitemap_endpoint_done.add(rule.endpoint.func)
+                sitemap_endpoint_done.add(rule.endpoint.func.__func__)
 
                 func = rule.endpoint.routing['sitemap']
                 if func is False:


### PR DESCRIPTION
Since [1], the `_enumerate_pages` method could include duplicate URLs in the sitemap due to bound method instances being treated as distinct functions. This issue became observable from 17.4, where the effect is more noticeable.

To fix this, `__func__` is used on `rule.endpoint.func`, ensuring that the same function is not processed multiple times, preventing redundant entries in the sitemap.

This fix is applied in 16.0 as the issue originates there.

Steps to reproduce (observable from 17.4):

- Install website_sale module
- Go to /sitemap.xml
- Observe that all the products and category urls are duplicated.

[1]: https://github.com/odoo/odoo/commit/1b52b00d2aa96b9360d50a0f0960f1febb5e607e

opw-4420398
task-4074719

