### PR TITLE
[FIX] point_of_sale: ensure reloading of data

### DIFF
--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -242,9 +242,12 @@ export class PosData extends Reactive {
 
     async loadInitialData() {
         let localData = await this.getCachedServerDataFromIndexedDB();
-        const sessionState = localData?.["pos.session"]?.[0]?.state;
+        const session = localData?.["pos.session"]?.[0];
 
-        if (navigator.onLine && sessionState !== "opened") {
+        if (
+            (navigator.onLine && session?.state !== "opened") ||
+            session?.id !== odoo.pos_session_id
+        ) {
             try {
                 const limitedLoading = this.isLimitedLoading();
                 const serverDate = localData?.["pos.session"]?.[0]?._data_server_date;


### PR DESCRIPTION
If the session id is outdated in the frontend, we need to ensure the reloading of data.

Now we check if the session id is up to date before loading data and if not we load the new session.


