### PR TITLE
[FIX] stock_picking_batch: prevent traceback when sorting by zip

### DIFF
--- a/addons/stock_fleet/models/stock_picking_batch.py
+++ b/addons/stock_fleet/models/stock_picking_batch.py
@@ -68,7 +68,7 @@ class StockPickingBatch(models.Model):
 
     # Public actions
     def order_on_zip(self):
-        sorted_records = self.picking_ids.sorted('zip')
+        sorted_records = self.picking_ids.sorted(lambda p: p.zip or "")
         for idx, record in enumerate(sorted_records):
             record.batch_sequence = idx
 


### PR DESCRIPTION
Issue Before This Commit:
============================
   
   A traceback occurs when attempting to sort pickings by zip if any picking has
   a False or empty zip value.

Steps to Reproduce:
=====================
1. Install the stock_fleet module.
2. Navigate to Batch Transfer in the Stock module under the Operations tab.
3. Create a new batch and add pickings, ensuring some have a zip value while others do not.
4. Save the batch, which triggers a traceback error: TypeError: '<' not supported between instances of 'bool' and 'str'.

With This Commit:
=====================

  The issue occurred because sorting directly on the zip caused an error
  when the zip was False. this fix ensures that sorting treats zip as an empty
  string () when it is False, preventing the error.

task - [4535113](https://www.odoo.com/odoo/my-tasks/4535113)

