### PR TITLE
[FIX] hr: restrict access to 'HR Settings' & proper permissions in 'My Profile'

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -18,6 +18,7 @@ HR_READABLE_FIELDS = [
     'last_activity',
     'last_activity_time',
     'can_edit',
+    'is_hr_user',
     'is_system',
     'employee_resource_calendar_id',
     'work_contact_id',
@@ -154,6 +155,7 @@ class ResUsers(models.Model):
 
     can_edit = fields.Boolean(compute='_compute_can_edit')
     is_system = fields.Boolean(compute="_compute_is_system")
+    is_hr_user = fields.Boolean(compute='_compute_is_hr_user')
 
     @api.depends_context('uid')
     def _compute_is_system(self):
@@ -163,6 +165,11 @@ class ResUsers(models.Model):
         can_edit = self.env['ir.config_parameter'].sudo().get_param('hr.hr_employee_self_edit') or self.env.user.has_group('hr.group_hr_user')
         for user in self:
             user.can_edit = can_edit
+
+    def _compute_is_hr_user(self):
+        is_hr_user = self.env.user.has_group('hr.group_hr_user')
+        for user in self:
+            user.is_hr_user = is_hr_user
 
     @api.depends('employee_ids')
     def _compute_employee_count(self):

--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -48,8 +48,14 @@ class TestSelfAccessProfile(TestHrCommon):
         form = Form(james, view=view)
         for field in employee_related_fields:
             with self.assertRaises(AssertionError, msg="Field '%s' should be readonly in the employee profile when self editing is not allowed." % field):
-                form.__setattr__(field, 'some value')
+                form[field] = 'some value'
 
+        self.env['ir.config_parameter'].sudo().set_param('hr.hr_employee_self_edit', True)
+        hr_settings_fields = ['employee_type', 'pin', 'barcode']
+        form = Form(james, view=view)
+        for field in hr_settings_fields:
+            with self.assertRaises(AssertionError, msg="HR field '%s' should be readonly when self editing is allowed." % field):
+                form[field] = 'some value'
 
     def test_profile_view_fields(self):
         """ A simple user should see all fields in profile view, even if they are protected by groups """

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -195,12 +195,13 @@
                     </page>
                      <page name="hr_settings" string="HR Settings">
                         <group>
+                        <field name="is_hr_user" invisible="True"/>
                             <group string='Status' name="active_group">
-                                <field name="employee_type" readonly="not can_edit"/>
+                                <field name="employee_type" readonly="not is_hr_user"/>
                             </group>
                             <group string="Attendance" name="identification_group">
-                                <field name="pin" readonly="not can_edit"/>
-                                <field name="barcode" readonly="not can_edit"/>
+                                <field name="pin" readonly="not is_hr_user"/>
+                                <field name="barcode" readonly="not is_hr_user"/>
                             </group>
                         </group>
                     </page>

--- a/addons/hr_attendance/models/res_users.py
+++ b/addons/hr_attendance/models/res_users.py
@@ -29,6 +29,12 @@ class ResUsers(models.Model):
             'display_extra_hours',
         ]
 
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + [
+            'attendance_manager_id',
+        ]
+
     def _clean_attendance_officers(self):
         attendance_officers = self.env['hr.employee'].search(
             [('attendance_manager_id', 'in', self.ids)]).attendance_manager_id

--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -107,7 +107,7 @@
                 </button>
             </xpath>
             <xpath expr="//group[@name='managers']" position="inside">
-                <field name="attendance_manager_id" string="Attendance" widget="many2one_avatar_user" groups="hr_attendance.group_hr_attendance_manager"/>
+                <field name="attendance_manager_id" string="Attendance" widget="many2one_avatar_user" readonly="not can_edit" groups="hr_attendance.group_hr_attendance_manager"/>
             </xpath>
             <xpath expr="//group[@name='managers']" position="attributes">
                 <attribute name="invisible">0</attribute>

--- a/addons/hr_expense/models/hr_employee.py
+++ b/addons/hr_expense/models/hr_employee.py
@@ -82,3 +82,9 @@ class ResUsers(models.Model):
     @property
     def SELF_READABLE_FIELDS(self):
         return super().SELF_READABLE_FIELDS + ['expense_manager_id']
+
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + [
+            'expense_manager_id',
+        ]

--- a/addons/hr_holidays/models/res_users.py
+++ b/addons/hr_holidays/models/res_users.py
@@ -31,6 +31,12 @@ class ResUsers(models.Model):
             'hr_icon_display',
         ]
 
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + [
+            'leave_manager_id',
+        ]
+
     def _compute_im_status(self):
         super()._compute_im_status()
         on_leave_user_ids = self._get_on_leave_ids()


### PR DESCRIPTION
Steps:
- Go to 'My Profile'.
- Check the 'HR Settings' tab and other sections ('Resume', 'Work Information' and 'Private Information').

Issues:
- Users could edit 'HR Settings' without proper HR permissions.
- Approver fields were not editable even though self edit setting was on.

Fix:
- Restricted HR Settings edits to users with HR manager rights.
- Ensured all the fields in 'Resume', 'Work Information' and 'Private Information' are editable only with hr_employee_self_edit enabled.
- Approver related fields are now editable in 'Work Information' section.

Task-4319956

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:
