### PR TITLE
[IMP] project: sub-tasks list on task kanban card improvements

### DIFF
--- a/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_create/subtask_kanban_create.js
+++ b/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_create/subtask_kanban_create.js
@@ -12,10 +12,11 @@ export class SubtaskCreate extends Component {
         onBlur: { type: Function },
     };
     setup() {
-        this.placeholder = _t("Add Sub-tasks");
+        this.placeholder = _t("Write a task name");
         this.state = useState({
             inputSize: 1,
             name: this.props.name,
+            isFieldInvalid: false,
         });
         this.input = useRef("subtaskCreateInput");
         useAutofocus({ refName: "subtaskCreateInput" });
@@ -37,14 +38,11 @@ export class SubtaskCreate extends Component {
     _onInput(ev) {
         const value = ev.target.value;
         this.state.name = value;
+        this.state.isFieldInvalid = false;
     }
 
     _onClick() {
         this.input.el.focus();
-    }
-
-    async _onBlur() {
-        this.props.onBlur();
     }
 
     /**
@@ -53,13 +51,17 @@ export class SubtaskCreate extends Component {
      */
     _onNameChanged(ev) {
         const value = ev.target.value.trim();
-        this.props.onSubtaskCreateNameChanged(value);
-        ev.target.blur();
+        if (value !== "") {
+            this.props.onSubtaskCreateNameChanged(value);
+            ev.target.blur();
+        }
     }
 
     _onSaveClick() {
-        if (this.input.el.value !== "") {
-            this.props.onSubtaskCreateNameChanged(this.input.el.value);
+        if (this.input.el.value.trim() === "") {
+            this.props.onSubtaskCreateNameChanged(this.input.el.value.trim());
+            this.state.isFieldInvalid = true;
+            this.state.name = "";
         }
     }
 }

--- a/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_create/subtask_kanban_create.xml
+++ b/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_create/subtask_kanban_create.xml
@@ -2,13 +2,13 @@
 <templates>
     <div t-name="project.SubtaskCreate" class="subtask_create_input d-flex" owl="1">
         <input type="text" title="Rename" 
-            class='border-0 border-bottom py-1'
+            class='o_input border-0 border-bottom py-1'
+            t-att-class="{'o_field_invalid border-danger': state.isFieldInvalid}"
             t-ref='subtaskCreateInput'
             t-att-value="state.name"
             t-att-placeholder="placeholder"
             t-on-input="_onInput"
             t-on-click="_onClick"
-            t-on-blur="_onBlur"
             t-on-change="_onNameChanged"
             t-att-disabled="props.isReadonly"/>
         <button t-on-click="_onSaveClick" class="ms-auto fw-bold btn btn-link py-0 px-2">

--- a/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.xml
+++ b/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.xml
@@ -23,7 +23,8 @@
                         type="'project_task_state_selection'"
                         fieldInfo="fieldInfo.state"/>
                 </div>
-                <div class="subtask_create" t-on-click.stop="(ev) => this.onSubTaskCreated(ev)">
+                <div class="subtask_create" t-on-click.stop="(ev) => this.onSubTaskCreated(ev)"
+                    t-on-keydown="(ev) => ev.code === 'Escape' ? this._onBlur(ev) : ()=>{}">
                     <t t-if="subtaskCreate.open">
                         <SubtaskCreate
                             name="subtaskCreate.name"
@@ -32,7 +33,7 @@
                             onBlur.bind="_onBlur" />
                     </t>
                     <t t-else="">
-                        <i class="fa fa-plus my-2"/> New
+                        <i class="fa fa-plus my-2"/> Add Sub-task
                     </t>
                 </div>
             </div>

--- a/addons/project/static/tests/project_task_subtask.test.js
+++ b/addons/project/static/tests/project_task_subtask.test.js
@@ -286,3 +286,30 @@ test("project.task (form): check focus on new subtask's name", async () => {
         message: "Upon clicking on 'Add a line', the new subtask's name should be focused.",
     });
 });
+
+test("project.task (kanban): check subtask creation when input is empty", async () => {
+    await mountView({
+        resModel: "project.task",
+        type: "kanban",
+    });
+    await click(".subtask_list_button");
+    await animationFrame();
+    await click(".subtask_create");
+    await animationFrame();
+    await click(".subtask_create_input input");
+    await edit("");
+    await click(".subtask_create_input button");
+    await animationFrame();
+    expect(".subtask_create_input input").toHaveClass("o_field_invalid", {
+        message: "input field should be displayed as invalid",
+    });
+    expect(".o_notification_content").toHaveInnerHTML("<ul><li>Display Name</li></ul>", {
+        message: "The content of the notification should contain 'Display Name'.",
+    });
+    expect(".o_notification_title").toHaveText("Invalid fields:", {
+        message: "The notification title should be 'Invalid fields'.",
+    });
+    expect(".o_notification_bar").toHaveClass("bg-danger", {
+        message: "The notification bar should have type 'danger'.",
+    });
+});


### PR DESCRIPTION
Before this commit:
New sub-tasks created from the Kanban card sub-task list appeared at the top of the list.
Pressing the Esc key did not exit the edit mode.
Done/canceled sub-tasks were not displayed until the view was refreshed. Missing task names were not highlighted and no error notification appeared.

After this commit
New sub-tasks created from the Kanban card sub-task list will appear at the bottom of the list.
Pressing the Esc key will exit the edit mode.
Done/canceled sub-tasks stay visible until the page is reloaded. If the task name is missing, it is highlighted in red and an error notification is shown.
The 'New' button is now labeled 'Add Sub-task'.
The placeholder text is now 'Write a task name'.

Task - 4461334