### PR TITLE
[18.0][FIX] purchase: fix inherit_id on view_partner_property_form

### DIFF
--- a/addons/purchase/views/res_partner_views.xml
+++ b/addons/purchase/views/res_partner_views.xml
@@ -18,6 +18,14 @@
                     </div>
                     <field name="property_purchase_currency_id" options="{'no_create': True, 'no_open': True}" groups='base.group_multi_currency'/>
                 </group>
+            </field>
+    </record>
+
+    <record id="view_partner_account_form" model="ir.ui.view">
+            <field name="name">res.partner.purchase.property.form.inherit</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="account.view_partner_property_form"/>
+            <field name="arch" type="xml">
                 <field name="property_supplier_payment_term_id" position="before">
                     <field name="buyer_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
                 </field>


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

When installing a module updating the base partner form view, the consolidation of this view is failing, reporting it cannot locate the `property_supplier_payment_term_id` element in parent view. Indeed this field is coming from `account.view_partner_property_form` view, not `base.view_partner_property_form`.

### Current behavior before PR:

```python
Element '<field name="property_supplier_payment_term_id">' cannot be located in parent view

View error context:
{'file': '/odoo/external-src/sale-workflow/sale_wishlist/views/partner.xml',
 'line': 12,
 'name': 'res.partner.purchase.property.form.inherit',
 'view': ir.ui.view(6911,),
 'view.model': 'res.partner',
 'view.parent': ir.ui.view(5099,),
 'xmlid': 'res_partner_view_form'}
```

List of views making usage of `property_supplier_payment_term_id` element:
```
odoodb=# SELECT module, name, model, res_id, noupdate FROM ir_model_data WHERE model='ir.ui.view' AND res_id IN (SELECT id FROM ir_ui_view WHERE arch_db->>'en_US' ILIKE '%property_supplier_payment_term_id%' AND model='res.partner' AND active=true);
  module  |                  name                  |   model    | res_id | noupdate 
----------+----------------------------------------+------------+--------+----------
 sale     | res_partner_view_form_property_inherit | ir.ui.view |   7121 | f
 purchase | view_partner_property_form             | ir.ui.view |   6911 | f
(2 rows)

```

### Desired behavior after PR is merged:

Make the consolidation of view partner form working as expected, as it is done in `sale` module by using the right parent view to inherit the `property_supplier_payment_term_id` field.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
