### PR TITLE
[FIX] mail: fix scheduled message cron infinitely failing

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -546,6 +546,12 @@ msgid "A next activity can only be planned on models that use activities."
 msgstr ""
 
 #. module: mail
+#. odoo-python
+#: code:addons/mail/models/mail_scheduled_message.py:0
+msgid "A scheduled message could not be sent"
+msgstr ""
+
+#. module: mail
 #: model:ir.model.fields,help:mail.field_res_config_settings__google_translate_api_key
 msgid ""
 "A valid Google API key is required to enable message translation. "
@@ -9391,6 +9397,14 @@ msgstr ""
 msgid ""
 "The message below could not be accepted by the address %(alias_display_name)s.\n"
 "Please try again later or contact %(company_name)s instead."
+msgstr ""
+
+#. module: mail
+#. odoo-python
+#: code:addons/mail/models/mail_scheduled_message.py:0
+msgid ""
+"The message scheduled on %(model)s(%(id)s) with the following content could "
+"not be sent:%(original_message)s"
 msgstr ""
 
 #. module: mail

--- a/addons/mail/models/mail_scheduled_message.py
+++ b/addons/mail/models/mail_scheduled_message.py
@@ -1,11 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from collections import defaultdict
 import json
+from collections import defaultdict
+from markupsafe import Markup
 
 from odoo import _, api, fields, models
 from odoo.addons.mail.tools.discuss import Store
-from odoo.exceptions import AccessError, UserError, ValidationError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools.misc import clean_context
 
 import logging
@@ -172,27 +173,43 @@ class ScheduledMessage(models.Model):
             still post permission on the related record, and to allow for the attachments to be
             transferred to the messages (see _process_attachments_for_post in mail.thread)
             if raise_exception is set to False, the method will skip the posting of a message
-            instead of raising an error. This is useful when scheduled messages are sent from
-            the _post_messages_cron
+            instead of raising an error, and send a notification to the author about the failure.
+            This is useful when scheduled messages are sent from the _post_messages_cron.
         """
         notification_parameters_whitelist = self._notification_parameters_whitelist()
         for scheduled_message in self:
             message_creator = scheduled_message.create_uid
             try:
-                scheduled_message.with_user(message_creator)._check()
-            except AccessError:
+                with self.env.cr.savepoint():
+                    scheduled_message.with_user(message_creator)._check()
+                    self.env[scheduled_message.model].browse(scheduled_message.res_id).with_user(message_creator).message_post(
+                        attachment_ids=list(scheduled_message.attachment_ids.ids),
+                        author_id=scheduled_message.author_id.id,
+                        body=scheduled_message.body,
+                        partner_ids=list(scheduled_message.partner_ids.ids),
+                        subtype_xmlid='mail.mt_note' if scheduled_message.is_note else 'mail.mt_comment',
+                        **{k: v for k, v in json.loads(scheduled_message.notification_parameters or '{}').items() if k in notification_parameters_whitelist},
+                    )
+            except Exception:
                 if raise_exception:
                     raise
-                _logger.info("Posting of scheduled message %s failed: user %s cannot post on the record", scheduled_message.id, message_creator.id)
-                continue
-            self.env[scheduled_message.model].browse(scheduled_message.res_id).with_user(message_creator).message_post(
-                attachment_ids=list(scheduled_message.attachment_ids.ids),
-                author_id=scheduled_message.author_id.id,
-                body=scheduled_message.body,
-                partner_ids=list(scheduled_message.partner_ids.ids),
-                subtype_xmlid='mail.mt_note' if scheduled_message.is_note else 'mail.mt_comment',
-                **{k: v for k, v in json.loads(scheduled_message.notification_parameters or '{}').items() if k in notification_parameters_whitelist},
-            )
+                _logger.info("Posting of scheduled message with ID %s failed", scheduled_message.id, exc_info=True)
+                # notify user about the failure (send content as user might have lost access to the record)
+                try:
+                    with self.env.cr.savepoint():
+                        self.env['mail.thread'].message_notify(
+                            partner_ids=[message_creator.partner_id.id],
+                            subject=_("A scheduled message could not be sent"),
+                            body=_("The message scheduled on %(model)s(%(id)s) with the following content could not be sent:%(original_message)s",
+                                model=scheduled_message.model,
+                                id=scheduled_message.res_id,
+                                original_message=Markup("<br>-----<br>%s<br>-----<br>") % scheduled_message.body,
+                            )
+                        )
+                except Exception:
+                    # in case even message_notify fails, make sure the failing scheduled message
+                    # will be deleted
+                    _logger.exception("The notification about the failed scheduled message could not be sent")
         self.unlink()
 
     # ------------------------------------------------------
@@ -246,7 +263,7 @@ class ScheduledMessage(models.Model):
         domain = [('scheduled_date', '<=', fields.Datetime.now())]
         messages_to_post = self.search(domain, limit=limit)
         _logger.info("Posting %s scheduled messages", len(messages_to_post))
-        messages_to_post._post_message()
+        messages_to_post._post_message(raise_exception=False)
 
         # restart cron if needed
         if self.search_count(domain, limit=1):

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -336,7 +336,7 @@ class MailThread(models.AbstractModel):
         return result
 
     def unlink(self):
-        """ Override unlink to delete messages and followers. This cannot be
+        """ Override unlink to delete (scheduled) messages and followers. This cannot be
         cascaded, because link is done through (res_model, res_id). """
         if not self:
             return True
@@ -347,6 +347,7 @@ class MailThread(models.AbstractModel):
         self.env['mail.followers'].sudo().search(
             [('res_model', '=', self._name), ('res_id', 'in', self.ids)]
         ).unlink()
+        self.env['mail.scheduled.message'].sudo().search([('model', '=', self._name), ('res_id', 'in', self.ids)]).unlink()
         return res
 
     def copy_data(self, default=None):

--- a/addons/test_mail/tests/test_mail_scheduled_message.py
+++ b/addons/test_mail/tests/test_mail_scheduled_message.py
@@ -125,6 +125,9 @@ class TestScheduledMessageBusiness(TestScheduledMessage, CronMixinCase):
             scheduled_message.write({'res_id': 2})
         with self.assertRaises(UserError):
             scheduled_message.write({'model': 'mail.test.track'})
+        # unlink the test record should also unlink the test message
+        self.test_record.sudo().unlink()
+        self.assertFalse(scheduled_message.exists())
 
     @users('employee')
     def test_scheduled_message_posting(self):

--- a/addons/test_mail/tests/test_mail_scheduled_message.py
+++ b/addons/test_mail/tests/test_mail_scheduled_message.py
@@ -2,10 +2,13 @@
 
 from odoo.addons.base.tests.test_ir_cron import CronMixinCase
 from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.test_mail.models.mail_test_lead import MailTestTLead
 from odoo.addons.test_mail.tests.common import TestRecipients
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.fields import Datetime as FieldDatetime
 from odoo.tests import tagged, users
+from odoo.tools import mute_logger
+from unittest.mock import patch
 
 
 @tagged('mail_scheduled_message')
@@ -132,6 +135,7 @@ class TestScheduledMessageBusiness(TestScheduledMessage, CronMixinCase):
     @users('employee')
     def test_scheduled_message_posting(self):
         schedule_cron_id = self.env.ref('mail.ir_cron_post_scheduled_message').id
+        test_lead = self.env["mail.test.lead"].create({})
         with self.mock_mail_gateway(), \
             self.mock_mail_app(), \
             self.capture_triggers(schedule_cron_id) as capt:
@@ -139,6 +143,7 @@ class TestScheduledMessageBusiness(TestScheduledMessage, CronMixinCase):
                 self.test_record,
                 scheduled_date='2022-12-24 14:00:00',
                 partner_ids=self.test_record.customer_id,
+                body="success",
             ).id
             # cron should be triggered at scheduled date
             self.assertEqual(capt.records['call_at'], FieldDatetime.to_datetime('2022-12-24 14:00:00'))
@@ -146,11 +151,61 @@ class TestScheduledMessageBusiness(TestScheduledMessage, CronMixinCase):
             self.assertFalse(self.test_record.message_ids)
             self.assertFalse(self._new_mails)
 
-            with self.mock_datetime_and_now('2022-12-24 14:00:00'):
-                self.env['mail.scheduled.message'].sudo()._post_messages_cron()
-            # message should be posted and mail should be sent
-            self.assertEqual(len(self.test_record.message_ids), 1)
+            # add a scheduled message that will fail to check that it won't block the cron
+            failing_schedueld_message_id = self.schedule_message(
+                test_lead,
+                scheduled_date='2022-12-24 14:00:00',
+                partner_ids=self.test_record.customer_id,
+                body="fail",
+            ).id
+
+            def _message_post_after_hook(self, message, values):
+                raise Exception("Boum!")
+
+            with self.mock_datetime_and_now('2022-12-24 14:00:00'),\
+                patch.object(MailTestTLead, '_message_post_after_hook', _message_post_after_hook),\
+                mute_logger('odoo.addons.mail.models.mail_scheduled_message'):
+                self.env['mail.scheduled.message'].with_user(self.user_root)._post_messages_cron()
+            new_messages = self._new_msgs.exists()
+            self.assertEqual(len(new_messages), 2)
+            # failed scheduled message shouldn't be posted
+            self.assertFalse(new_messages.filtered(lambda m: m.model == test_lead._name))
+            # but user should be notified about the failed posting
+            self.assertMailNotifications(
+                new_messages.filtered(lambda m: not m.model),
+                [{
+                    'content': f"<p>The message scheduled on {test_lead._name}({test_lead.id}) with"
+                    " the following content could not be sent:<br>-----<br></p><p>fail</p><br>-----<br>",
+                    'message_type': 'user_notification',
+                    'subtype': 'mail.mt_note',
+                    'message_values': {
+                        'author_id': self.partner_root,
+                        'model': False,
+                        'res_id': False,
+                        'subject': "A scheduled message could not be sent",
+                    },
+                    'notif': [
+                        {'partner': self.partner_employee, 'type': 'inbox'}
+                    ]
+                }])
+            # other message should be posted and mail should be sent
+            self.assertMailNotifications(
+                new_messages.filtered(lambda m: m.model == self.test_record._name),
+                [{
+                    'content': "<p>success</p>",
+                    'message_type': 'notification',
+                    'message_values': {
+                        'author_id': self.partner_employee,
+                        'model': self.test_record._name,
+                        'res_id': self.test_record.id,
+                        'subject': self.test_record._message_compute_subject(),
+                    },
+                    'notif': [
+                        {'partner': self.test_record.customer_id, 'type': 'email'}
+                    ]
+                }]
+            )
             self.assertEqual(len(self._new_mails), 1)
             self.assertEqual(self._new_mails[0].state, 'sent')
-            # scheduled message shouldn't exist anymore
-            self.assertFalse(self.env['mail.scheduled.message'].search([['id', '=', scheduled_message_id]]))
+            # scheduled messages shouldn't exist anymore
+            self.assertFalse(self.env['mail.scheduled.message'].search([['id', 'in', [scheduled_message_id, failing_schedueld_message_id]]]))


### PR DESCRIPTION
Purpose:
--------
Currently, when posting a scheduled message failed due to an error,
the cron interrupts and will attempt to resend the message on each of its
subsequent runs and fail again, preventing any scheduled message to be
posted.

This commit changes the cron behavior to catch any exceptions raised during
message posting, notify the author of the message about the failure, and
delete the failed scheduled message. This prevents infinite retry attempts.

The notification to the author of the scheduled message contains the content
of the scheduled message. The rationale is that the posting might fail
because the user does not have access to the record it will be posted on
anymore, and won't be able to see the scheduled message again.

The scheduled messages will now be unlinked when unlinking the record on
which they are scheduled.

Task-4531402
