### PR TITLE
[IMP] point_of_sale, pos_*: remove the ‘skipped’ status from order lines

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1320,7 +1320,6 @@ class PosOrderLine(models.Model):
 
     company_id = fields.Many2one('res.company', string='Company', related="order_id.company_id", store=True)
     name = fields.Char(string='Line No', required=True, copy=False)
-    skip_change = fields.Boolean('Skip line when sending ticket to kitchen printers.')
     notice = fields.Char(string='Discount Notice')
     product_id = fields.Many2one('product.product', string='Product', domain=[('sale_ok', '=', True)], required=True, change_default=True)
     attribute_value_ids = fields.Many2many('product.template.attribute.value', string="Selected Attributes")
@@ -1372,7 +1371,7 @@ class PosOrderLine(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return [
-            'qty', 'attribute_value_ids', 'custom_attribute_value_ids', 'price_unit', 'skip_change', 'uuid', 'price_subtotal', 'price_subtotal_incl', 'order_id', 'note', 'price_type',
+            'qty', 'attribute_value_ids', 'custom_attribute_value_ids', 'price_unit', 'uuid', 'price_subtotal', 'price_subtotal_incl', 'order_id', 'note', 'price_type',
             'product_id', 'discount', 'tax_ids', 'pack_lot_ids', 'customer_note', 'refunded_qty', 'price_extra', 'full_product_name', 'refunded_orderline_id', 'combo_parent_id', 'combo_line_ids', 'combo_item_id', 'refund_orderline_ids'
         ]
 

--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.scss
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.scss
@@ -17,23 +17,27 @@
         background-color: $o-component-active-bg;
     }
 
-    &::before {
+    &.has-change::before {
         content: "";
         position: absolute;
-        top: 50%;
+        top: -1px;
+        bottom: -1px;
         width: 6px;
-        height: 66%;
-        transform: translateY(-50%);
-        border-top-right-radius: $border-radius-lg;
-        border-bottom-right-radius: $border-radius-lg;
+        background-color: $o-brand-primary;
     }
 
-    &.skip-change::before {
-        background-color: $o-warning;
+    &.has-change:first-child::before, &.has-change:not(.has-change + .has-change)::before {
+        /* First has-change*/
+        top: 0;
+        border-top-left-radius: 3px;
+        border-top-right-radius: 3px;
     }
 
-    &.has-change::before {
-        background-color: $o-success;
+    &.has-change:not(:has(+ .has-change))::before, &.has-change:has(+ .orderline-combo)::before{
+        /* Last has-change*/
+        bottom: 0;
+        border-bottom-left-radius: 3px;
+        border-bottom-right-radius: 3px;
     }
 
     .info-list {
@@ -43,8 +47,10 @@
 
 
 .orderline-combo {
-    &.skip-change::before, &.has-change::before {
+    &.has-change::before {
         left: -3px;
-        border-radius: $border-radius-lg;
+    }
+    &.has-change:not(:has(+ .has-change))::before{
+        border-radius: 3px;
     }
 }

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -277,27 +277,25 @@ export class PosOrder extends Base {
     updateLastOrderChange() {
         const orderlineIdx = [];
         this.lines.forEach((line) => {
-            if (!line.skip_change) {
-                orderlineIdx.push(line.preparationKey);
+            orderlineIdx.push(line.preparationKey);
 
-                if (this.last_order_preparation_change.lines[line.preparationKey]) {
-                    this.last_order_preparation_change.lines[line.preparationKey]["quantity"] =
-                        line.getQuantity();
-                } else {
-                    this.last_order_preparation_change.lines[line.preparationKey] = {
-                        attribute_value_names: line.attribute_value_ids.map((a) => a.name),
-                        uuid: line.uuid,
-                        isCombo: line.combo_item_id?.id,
-                        product_id: line.getProduct().id,
-                        name: line.getFullProductName(),
-                        basic_name: line.getProduct().name,
-                        display_name: line.getProduct().display_name,
-                        note: line.getNote(),
-                        quantity: line.getQuantity(),
-                    };
-                }
-                line.setHasChange(false);
+            if (this.last_order_preparation_change.lines[line.preparationKey]) {
+                this.last_order_preparation_change.lines[line.preparationKey]["quantity"] =
+                    line.getQuantity();
+            } else {
+                this.last_order_preparation_change.lines[line.preparationKey] = {
+                    attribute_value_names: line.attribute_value_ids.map((a) => a.name),
+                    uuid: line.uuid,
+                    isCombo: line.combo_item_id?.id,
+                    product_id: line.getProduct().id,
+                    name: line.getFullProductName(),
+                    basic_name: line.getProduct().name,
+                    display_name: line.getProduct().display_name,
+                    note: line.getNote(),
+                    quantity: line.getQuantity(),
+                };
             }
+            line.setHasChange(false);
         });
         // Checks whether an orderline has been deleted from the order since it
         // was last sent to the preparation tools or updated. If so we delete older changes.
@@ -312,14 +310,6 @@ export class PosOrder extends Base {
         this.last_order_preparation_change.general_customer_note = this.general_customer_note;
         this.last_order_preparation_change.internal_note = this.internal_note;
         this.last_order_preparation_change.sittingMode = this.preset_id?.id || 0;
-    }
-
-    hasSkippedChanges() {
-        return Boolean(
-            this.lines.find(
-                (orderline) => orderline.skip_change && !orderline.uiState.hideSkipChangeClass
-            )
-        );
     }
 
     isEmpty() {

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -19,7 +19,6 @@ export class PosOrderline extends Base {
             return;
         }
         this.uuid = vals.uuid ? vals.uuid : uuidv4();
-        this.skip_change = vals.skip_change || false;
         this.setFullProductName();
 
         // Data that are not saved in the backend
@@ -323,7 +322,6 @@ export class PosOrderline extends Base {
 
         // only orderlines of the same product can be merged
         return (
-            !this.skip_change &&
             orderline.getNote() === this.getNote() &&
             this.getProduct().id === orderline.getProduct().id &&
             this.isPosGroupable() &&

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1514,8 +1514,8 @@ export class PosStore extends WithLazyGetterTrap {
         }
         return true;
     }
-    getOrderChanges(skipped = false, order = this.getOrder()) {
-        return getOrderChanges(order, skipped, this.config.preparationCategories);
+    getOrderChanges(order = this.getOrder()) {
+        return getOrderChanges(order, this.config.preparationCategories);
     }
     // Now the printer should work in PoS without restaurant
     async sendOrderInPreparation(order, opts = {}) {
@@ -1524,7 +1524,6 @@ export class PosStore extends WithLazyGetterTrap {
                 let reprint = false;
                 let orderChange = changesToOrder(
                     order,
-                    false,
                     this.config.preparationCategories,
                     opts.cancelled
                 );

--- a/addons/pos_restaurant/static/src/app/components/order_tabs/order_tabs.xml
+++ b/addons/pos_restaurant/static/src/app/components/order_tabs/order_tabs.xml
@@ -2,18 +2,18 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_restaurant.OrderTabs" t-inherit="point_of_sale.OrderTabs" t-inherit-mode="extension">
        <xpath expr="//div[hasclass('floating-order-container')]" position="before">
-            <t t-set="changes" t-value="this.pos.getOrderChanges(false, order)" />
+            <t t-set="changes" t-value="this.pos.getOrderChanges(order)" />
         </xpath>
         <xpath expr="//div[hasclass('floating-order-container')]" position="inside">
-            <div t-if="(changes.nbrOfChanges or changes.nbrOfSkipped) and this.pos.config.module_pos_restaurant"
+            <div t-if="changes.nbrOfChanges and this.pos.config.module_pos_restaurant"
                 class="position-absolute rounded-circle d-flex align-items-center justify-content-center"
                 style="top: -7px; right: -6px; width: 1.5rem; height: 1.5rem"
-                t-attf-class="{{ changes.nbrOfChanges ? 'text-bg-danger bg-danger' : 'text-bg-info bg-info'}}">
-                <span t-esc="changes.nbrOfChanges || changes.nbrOfSkipped" />
+                t-att-class="{'text-bg-danger bg-danger': changes.nbrOfChanges}">
+                <span t-esc="changes.nbrOfChanges" />
             </div>
         </xpath>
         <xpath expr="//div[hasclass('floating-order-container')]" position="attributes">
-            <attribute name="t-att-class">{'me-2': (changes.nbrOfChanges || changes.nbrOfSkipped) and this.pos.config.module_pos_restaurant}</attribute>
+            <attribute name="t-att-class">{'me-2': changes.nbrOfChanges and this.pos.config.module_pos_restaurant}</attribute>
         </xpath>
     </t>
 </templates>

--- a/addons/pos_restaurant/static/src/app/models/pos_order_line.js
+++ b/addons/pos_restaurant/static/src/app/models/pos_order_line.js
@@ -12,32 +12,6 @@ patch(PosOrderline.prototype, {
         orderline.note = this.note;
         return orderline;
     },
-    toggleSkipChange() {
-        if (this.course_id) {
-            return;
-        }
-
-        if (this.uiState.hasChange || this.skip_change) {
-            this.setDirty();
-            this.skip_change = !this.skip_change;
-            // update with the combo parent if applicable
-            if (this.combo_parent_id) {
-                const parent = this.combo_parent_id;
-                parent.skip_change = this.skip_change;
-                this.updateChildrenSkipChange(parent);
-            }
-            if (this.combo_line_ids) {
-                this.updateChildrenSkipChange(this);
-            }
-        }
-    },
-    updateChildrenSkipChange(parentOrderline) {
-        for (const comboLine of parentOrderline.combo_line_ids) {
-            if (comboLine.uiState.hasChange || comboLine.skip_change) {
-                comboLine.skip_change = this.skip_change;
-            }
-        }
-    },
     serialize(options = {}) {
         const data = super.serialize(...arguments);
         if (options.orm && data.course_id) {
@@ -45,14 +19,10 @@ patch(PosOrderline.prototype, {
         }
         return data;
     },
-    showSkipChange() {
-        return this.skip_change && !this.uiState.hideSkipChangeClass && !this.course_id;
-    },
     getDisplayClasses() {
         return {
             ...super.getDisplayClasses(),
             "has-change": this.uiState.hasChange && this.config.module_pos_restaurant,
-            "skip-change": this.showSkipChange() && this.config.module_pos_restaurant,
         };
     },
     canBeMergedWith(orderline) {

--- a/addons/pos_restaurant/static/src/app/models/restaurant_table.js
+++ b/addons/pos_restaurant/static/src/app/models/restaurant_table.js
@@ -12,7 +12,6 @@ export class RestaurantTable extends Base {
             initialPosition: {},
             orderCount: 0,
             changeCount: 0,
-            skipCount: 0,
         };
     }
     isParent(t) {

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
@@ -1086,18 +1086,16 @@ export class FloorScreen extends Component {
         // This information in uiState came by websocket
         // If the table is not synced, we need to count the unsynced orders
         let changeCount = 0;
-        let skipCount = 0;
         const tableOrders = this.pos.models["pos.order"].filter(
             (o) => o.table_id?.id === table.id && !o.finalized
         );
 
         for (const order of tableOrders) {
-            const changes = getOrderChanges(order, false, this.pos.config.preparationCategories);
+            const changes = getOrderChanges(order, this.pos.config.preparationCategories);
             changeCount += changes.nbrOfChanges;
-            skipCount += changes.nbrOfSkipped;
         }
 
-        return { changes: changeCount, skip: skipCount };
+        return { changes: changeCount };
     }
     setColor(hasSelectedTable, color) {
         if (hasSelectedTable) {

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.xml
@@ -164,11 +164,10 @@
                                     </div>
                                     <t t-set="data" t-value="getChangeCount(table)"/>
                                     <div
-                                        t-if="data.changes > 0 || data.skip > 0"
-                                        t-esc="data.changes > 0 ? data.changes : data.skip"
+                                        t-if="data.changes > 0"
+                                        t-esc="data.changes"
                                         t-att-class="{
-                                            'text-bg-danger': data.changes,
-                                            'text-bg-info'  : !data.changes and data.skip,
+                                            'text-bg-danger': data.changes
                                         }"
                                         class="order-count d-flex align-items-center justify-content-center position-absolute top-0 end-0 rounded-3 smaller fw-bolder z-2 badge"
                                     />

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.xml
@@ -10,10 +10,5 @@
                 </button>
             </div>
         </xpath>
-        <xpath expr="//Orderline" position="attributes">
-            <attribute name="t-on-dblclick">
-                () => line.toggleSkipChange()
-            </attribute>
-        </xpath>
     </t>
 </templates>

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -357,15 +357,12 @@ patch(PosStore.prototype, {
             );
             const qtyChange = tableOrders.reduce(
                 (acc, order) => {
-                    const quantityChange = this.getOrderChanges(false, order);
-                    const quantitySkipped = this.getOrderChanges(true, order);
+                    const quantityChange = this.getOrderChanges(order);
                     acc.changed += quantityChange.count;
-                    acc.skipped += quantitySkipped.count;
                     return acc;
                 },
-                { changed: 0, skipped: 0 }
+                { changed: 0 }
             );
-
             table.uiState.orderCount = tableOrders.length;
             table.uiState.changeCount = qtyChange.changed;
         }

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -77,8 +77,11 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
             inLeftSide(Order.hasLine({ productName: "Coca-Cola", run: "dblclick" })),
             ProductScreen.clickDisplayedProduct("Water", true),
             ProductScreen.orderlineIsToOrder("Water"),
-            ProductScreen.orderlineIsToSkip("Coca-Cola"),
-            checkOrderChanges([{ name: "Water", quantity: 1 }]),
+            ProductScreen.orderlineIsToOrder("Coca-Cola"),
+            checkOrderChanges([
+                { name: "Water", quantity: 1 },
+                { name: "Coca-Cola", quantity: 1 },
+            ]),
             ProductScreen.clickOrderButton(),
             {
                 ...Dialog.confirm(),
@@ -106,7 +109,7 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
             ReceiptScreen.clickNextOrder(),
 
             // order on another table with a product variant
-            FloorScreen.orderCountSyncedInTableIs("105", "1"),
+            FloorScreen.orderCountSyncedInTableIs("105", "0"),
             FloorScreen.clickTable("104"),
             ProductScreen.clickDisplayedProduct("Desk Organizer", false),
             {
@@ -132,7 +135,7 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
 
             // After clicking next order, floor screen is shown.
             // It should have 1 as number of draft synced order.
-            FloorScreen.orderCountSyncedInTableIs("105", "1"),
+            FloorScreen.orderCountSyncedInTableIs("105", "0"),
             FloorScreen.clickTable("105"),
             ProductScreen.totalAmountIs("4.40"),
 
@@ -142,7 +145,7 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
             ProductScreen.clickDisplayedProduct("Coca-Cola", true),
             ProductScreen.clickDisplayedProduct("Minute Maid", true),
             Chrome.clickPlanButton(),
-            FloorScreen.orderCountSyncedInTableIs("105", "1"),
+            FloorScreen.orderCountSyncedInTableIs("105", "0"),
 
             // Delete the first order then go back to floor
             Chrome.clickOrders(),

--- a/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
@@ -82,6 +82,13 @@ export function selectedFloorIs(name) {
     ];
 }
 export function orderCountSyncedInTableIs(table, count) {
+    if (count === 0 || count === "0") {
+        return [
+            {
+                trigger: `.floor-map .table:has(.label:contains("${table}")):not(:has(.order-count))`,
+            },
+        ];
+    }
     return [
         {
             trigger: `.floor-map .table:has(.label:contains("${table}")):has(.order-count:contains("${count}"))`,

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -21,12 +21,6 @@ export function orderlineIsToOrder(name) {
         withClass: ".orderline.has-change",
     });
 }
-export function orderlineIsToSkip(name) {
-    return Order.hasLine({
-        withClass: ".orderline.skip-change",
-        productName: name,
-    });
-}
 export function guestNumberIs(num) {
     return [
         ...ProductScreen.clickControlButtonMore(),


### PR DESCRIPTION
pos_* = post_restaurant

The “skipped” status was introduced to ensure that the kitchen prepares order lines only when requested by the waiter. This commit removes that status, as it will be replaced by the courses feature, which manages it more effectively, aligning with standard POS software practices.

task-4513945