### PR TITLE
[IMP] point_of_sale: partner exact match search

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -206,7 +206,7 @@ export class ProductProduct extends Base {
     }
 
     get searchString() {
-        const fields = ["display_name", "description_sale", "description"];
+        const fields = ["display_name"];
         return fields
             .map((field) => this[field] || "")
             .filter(Boolean)
@@ -215,7 +215,9 @@ export class ProductProduct extends Base {
 
     exactMatch(searchWord) {
         const fields = ["barcode", "default_code"];
-        return fields.some((field) => this[field] && this[field].includes(searchWord));
+        return fields.some(
+            (field) => this[field] && this[field].toLowerCase().includes(searchWord)
+        );
     }
 
     _isArchivedCombination(attributeValueIds) {

--- a/addons/point_of_sale/static/src/app/models/res_partner.js
+++ b/addons/point_of_sale/static/src/app/models/res_partner.js
@@ -28,7 +28,7 @@ export class ResPartner extends Base {
 
     exactMatch(searchWord) {
         const fields = ["barcode"];
-        return fields.some((field) => this[field] && this[field] === searchWord);
+        return fields.some((field) => this[field] && this[field].toLowerCase() === searchWord);
     }
 }
 registry.category("pos_available_models").add(ResPartner.pythonModel, ResPartner);

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -1,6 +1,5 @@
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import { fuzzyLookup } from "@web/core/utils/search";
 import { Dialog } from "@web/core/dialog/dialog";
 import { PartnerLine } from "@point_of_sale/app/screens/partner_list/partner_line/partner_line";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
@@ -75,7 +74,7 @@ export class PartnerList extends Component {
         this.pos.closeTempScreen();
     }
     getPartners() {
-        const searchWord = unaccent((this.state.query || "").trim(), false);
+        const searchWord = unaccent((this.state.query || "").trim(), false).toLowerCase();
         const partners = this.pos.models["res.partner"].getAll();
         const exactMatches = partners.filter((partner) => partner.exactMatch(searchWord));
 
@@ -84,7 +83,9 @@ export class PartnerList extends Component {
         }
 
         const availablePartners = searchWord
-            ? fuzzyLookup(searchWord, partners, (partner) => unaccent(partner.searchString, false))
+            ? partners.filter((p) =>
+                  unaccent(p.searchString, false).toLowerCase().includes(searchWord)
+              )
             : partners
                   .slice(0, 1000)
                   .toSorted((a, b) =>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -17,7 +17,6 @@ import { Orderline } from "@point_of_sale/app/generic_components/orderline/order
 import { OrderWidget } from "@point_of_sale/app/generic_components/order_widget/order_widget";
 import { OrderSummary } from "@point_of_sale/app/screens/product_screen/order_summary/order_summary";
 import { ProductInfoPopup } from "./product_info_popup/product_info_popup";
-import { fuzzyLookup } from "@web/core/utils/search";
 import { ProductCard } from "@point_of_sale/app/generic_components/product_card/product_card";
 import {
     ControlButtons,
@@ -375,17 +374,18 @@ export class ProductScreen extends Component {
     }
 
     getProductsBySearchWord(searchWord) {
-        const exactMatches = this.products.filter((product) => product.exactMatch(searchWord));
+        const words = searchWord.toLowerCase();
+        const exactMatches = this.products.filter((product) => product.exactMatch(words));
 
-        if (exactMatches.length > 0 && searchWord.length > 2) {
+        if (exactMatches.length > 0 && words.length > 2) {
             return exactMatches;
         }
 
-        const fuzzyMatches = fuzzyLookup(unaccent(searchWord, false), this.products, (product) =>
-            unaccent(product.searchString, false)
+        const matches = this.products.filter((p) =>
+            unaccent(p.searchString, false).toLowerCase().includes(words)
         );
 
-        return Array.from(new Set([...exactMatches, ...fuzzyMatches]));
+        return Array.from(new Set([...exactMatches, ...matches]));
     }
 
     addMainProductsToDisplay(products) {

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -470,8 +470,8 @@ registry.category("web_tour.tours").add("ProductSearchTour", {
             ProductScreen.productIsDisplayed("Test Product 1").map(negateStep),
             ProductScreen.productIsDisplayed("Test Product 2").map(negateStep),
             ProductScreen.searchProduct("Test Produt"), // typo to test the fuzzy search
-            ProductScreen.productIsDisplayed("Test Product 1"),
-            ProductScreen.productIsDisplayed("Test Product 2"),
+            ProductScreen.productIsDisplayed("Test Product 1").map(negateStep),
+            ProductScreen.productIsDisplayed("Test Product 2").map(negateStep),
             ProductScreen.searchProduct("1234567890123"),
             ProductScreen.productIsDisplayed("Test Product 2").map(negateStep),
             ProductScreen.productIsDisplayed("Test Product 1"),


### PR DESCRIPTION
Before this commit, we was using fuzzy search which was creating a score for each partner and then sorting the partners based on that score. This was causing error in search result.

Now we use exact match search which will search for the exact match of the search string in the partner name, phone, mobile, email, street, city, state, country, zip, vat, and barcode.

taskId: 4517586


