### PR TITLE
[FIX] web_editor: removing format doesn't remove font-size

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -69,7 +69,7 @@ export const PROTECTED_BLOCK_TAG = ['TR','TD','TABLE','TBODY','UL','OL','LI'];
  * override of the font-size.
  */
 export const FONT_SIZE_CLASSES = ["display-1-fs", "display-2-fs", "display-3-fs", "display-4-fs", "h1-fs",
-    "h2-fs", "h3-fs", "h4-fs", "h5-fs", "h6-fs", "base-fs", "o_small-fs", "small"];
+    "h2-fs", "h3-fs", "h4-fs", "h5-fs", "h6-fs", "base-fs", "o_small-fs", "small", "o_small_twelve-fs", "o_small_ten-fs", "o_small_eight-fs"];
 
 /**
  * Array of all the classes used by the editor to change the text style.
@@ -1322,8 +1322,11 @@ export const formatSelection = (editor, formatName, {applyStyle, formatProps} = 
 
             parentNode = currentNode.parentElement;
         }
-
-        const firstBlockOrClassHasFormat = formatSpec.isFormatted(parentNode, formatProps);
+        const isFormatted =
+            formatName === "setFontSizeClassName" && !formatProps
+                ? hasAnyFontSizeClass
+                : formatSpec.isFormatted;
+        const firstBlockOrClassHasFormat = isFormatted(parentNode, formatProps);
         if (firstBlockOrClassHasFormat && !applyStyle) {
             formatSpec.addNeutralStyle && formatSpec.addNeutralStyle(getOrCreateSpan(node, inlineAncestors));
         } else if (!firstBlockOrClassHasFormat && applyStyle) {
@@ -1332,7 +1335,7 @@ export const formatSelection = (editor, formatName, {applyStyle, formatProps} = 
                 node.after(tag);
                 tag.append(node);
 
-                if (!formatSpec.isFormatted(tag, formatProps)) {
+                if (!isFormatted(tag, formatProps)) {
                     tag.after(node);
                     tag.remove();
                     formatSpec.addStyle(getOrCreateSpan(node, inlineAncestors), formatProps);
@@ -1624,6 +1627,17 @@ export function hasClass(node, props) {
     const element = closestElement(node);
     return element.classList.contains(props.className);
 }
+
+/**
+ * Return true if the given node has any font-size class.
+ *
+ * @param {Node} node A node to check for font-size classes.
+ * @returns {boolean}
+ */
+export function hasAnyFontSizeClass(node) {
+    return FONT_SIZE_CLASSES.find((cls) => node?.classList?.contains(cls));
+}
+
 /**
  * Return true if the given node appears in a different direction than that of
  * the editable ('ltr' or 'rtl').
@@ -1651,7 +1665,8 @@ export function hasClass(node, props) {
 export function isSelectionFormat(editable, format) {
     const selectedNodes = getTraversedNodes(editable)
         .filter((n) => n.nodeType === Node.TEXT_NODE && n.nodeValue.replaceAll(ZWNBSP_CHAR, '').length);
-    const isFormatted = formatsSpecs[format].isFormatted;
+    const isFormatted =
+        format === "setFontSizeClassName" ? hasAnyFontSizeClass : formatsSpecs[format].isFormatted;
     return selectedNodes.length && selectedNodes.every(n => isFormatted(n, editable));
 }
 

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
@@ -17,6 +17,8 @@ const strikeThrough = async editor => {
 };
 const setFontSize = size => editor => editor.execCommand('setFontSize', size);
 
+const setFontSizeClassName = className => editor => editor.execCommand('setFontSizeClassName', className);
+
 const switchDirection = editor => editor.execCommand('switchDirection');
 
 describe('Format', () => {
@@ -1108,6 +1110,16 @@ describe('Format', () => {
         });
     });
 
+    describe('setFontSizeClassName', () => {
+        it('should be able to change font-size class', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: `<p>a<span class="h1-fs">[bcd]</span>e</p>`,
+                stepFunction: setFontSizeClassName("h2-fs"),
+                contentAfter: `<p>a<span class="h2-fs">[bcd]</span>e</p>`,
+            });
+        });
+    });
+
     it('should add style to a span parent of an inline', async () => {
         await testEditor(BasicEditor, {
             contentBefore: `<p>a<span style="background-color: black;">${strong(`[bc]`)}</span>d</p>`,
@@ -1207,6 +1219,23 @@ describe('Format', () => {
                 stepFunction: editor => editor.execCommand('removeFormat'),
                 contentAfter: `<div><h1>[abc</h1><h1>abc</h1><h1>abc]</h1></div>`
 
+            });
+        });
+        it('should remove font-size classes when clearing the format' , async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: `<p>123<span class="h1-fs">[abc]</span>456</p>`,
+                stepFunction: editor => editor.execCommand('removeFormat'),
+                contentAfter: `<p>123[abc]456</p>`
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: `<p>[a<span class="h1-fs">bc</span>d<span class="h2-fs">ef</span>g]</p>`,
+                stepFunction: editor => editor.execCommand('removeFormat'),
+                contentAfter: `<p>[abcdefg]</p>`
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: `<p>[a<span class="h1-fs">bc</span>d</p><p>e<span class="o_small-fs">fg</span>h]</p>`,
+                stepFunction: editor => editor.execCommand('removeFormat'),
+                contentAfter: `<p>[abcd</p><p>efgh]</p>`
             });
         });
     });

--- a/addons/website/static/tests/tours/website_text_font_size.js
+++ b/addons/website/static/tests/tours/website_text_font_size.js
@@ -94,13 +94,17 @@ function getFontSizeTestSteps(fontSizeClass) {
 
 function getAllFontSizesTestSteps() {
     const steps = [];
+    const fontSizeClassesToSkip = [
+        // This option is hidden by default because same value as base-fs.
+        "h6-fs",
+        // There is nothing related to these classes in the UI to test anymore.
+        "small",
+        "o_small_twelve-fs",
+        "o_small_ten-fs",
+        "o_small_eight-fs",
+    ];
     for (const fontSizeClass of FONT_SIZE_CLASSES) {
-        if (fontSizeClass === 'h6-fs') {
-            // That option is hidden by default because same value as base-fs
-            continue;
-        }
-        if (fontSizeClass === 'small') {
-            // There is nothing related to that class in the UI to test anymore.
+        if (fontSizeClassesToSkip.includes(fontSizeClass)) {
             continue;
         }
         steps.push(...getFontSizeTestSteps(fontSizeClass));


### PR DESCRIPTION
**Behavior before PR:**

When removing format using removeFormat button, font-size style is not getting removed from formatted text. This happens because in `removeFormat` method `editor.document.execCommand('removeFormat')` fails to remove styles applied through classes. To remove these styles, font-size classes should be removed.

**Behavior after PR is merged:**

Now font-size related classes will be removed when removing format and font-size style will be removed from formatted text.

task-4526026




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
