### PR TITLE
[FIX] l10n_es_edi_tbai: allow billing user to send edi cancels

### DIFF
--- a/addons/account_edi/tests/common.py
+++ b/addons/account_edi/tests/common.py
@@ -168,7 +168,7 @@ class AccountEdiTestCommon(AccountTestInvoicingCommon):
         if formats_to_return != None:
             documents_to_return = documents_to_return.filtered(lambda x: x.edi_format_id.code in formats_to_return)
 
-        attachments = documents_to_return.attachment_id
+        attachments = documents_to_return.sudo().attachment_id
         data_str_list = []
         for attachment in attachments.with_context(bin_size=False):
             data_str_list.append(base64.decodebytes(attachment.datas))

--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -607,7 +607,7 @@ class AccountEdiFormat(models.Model):
         return results
 
     def _has_oss_taxes(self, invoice):
-        oss_tax_groups = self.env['ir.model.data'].search([
+        oss_tax_groups = self.env['ir.model.data'].sudo().search([
             ('module', '=', 'l10n_eu_oss'),
             ('model', '=', 'account.tax.group')])
         lines = invoice.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_section', 'line_note'))

--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -478,7 +478,9 @@ class AccountEdiFormat(models.Model):
 
     def _l10n_es_tbai_sign_invoice(self, invoice, xml_root):
         company = invoice.company_id
-        cert_private, cert_public = company.l10n_es_edi_certificate_id._get_key_pair()
+        cert_private, cert_public = (
+            company.l10n_es_edi_certificate_id.sudo()._get_key_pair()
+        )
         public_key = cert_public.public_key()
 
         # Identifiers

--- a/addons/l10n_es_edi_tbai/tests/common.py
+++ b/addons/l10n_es_edi_tbai/tests/common.py
@@ -57,20 +57,20 @@ class TestEsEdiTbaiCommon(AccountEdiTestCommon):
             cert_name = 'araba_1234.p12'
             cert_password = '1234'
         elif agency == 'bizkaia':
-            cert_name = 'bizkaia_111111.p12'
-            cert_password = '111111'
+            cert_name = 'Bizkaia-IZDesa2021.p12'
+            cert_password = 'IZDesa2021'
         elif agency == 'gipuzkoa':
             cert_name = 'gipuzkoa_IZDesa2021.p12'
             cert_password = 'IZDesa2021'
         else:
             raise ValueError("Unknown tax agency: " + agency)
 
-        cls.certificate = cls.env['l10n_es_edi.certificate'].create({
+        cls.certificate = cls.env['l10n_es_edi.certificate'].sudo().create({
             'content': base64.encodebytes(
                 misc.file_open("l10n_es_edi_tbai/demo/certificates/" + cert_name, 'rb').read()),
             'password': cert_password,
         })
-        cls.company_data['company'].write({
+        cls.company_data['company'].sudo().write({
             'l10n_es_tbai_tax_agency': agency,
             'l10n_es_edi_certificate_id': cls.certificate.id,
         })

--- a/addons/l10n_es_edi_tbai/tests/test_edi_web_services.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_web_services.py
@@ -16,6 +16,9 @@ class TestEdiTbaiWebServices(TestEsEdiTbaiCommon):
     def setUpClass(cls, chart_template_ref='l10n_es.account_chart_template_full', edi_format_ref='l10n_es_edi_tbai.edi_es_tbai'):
         super().setUpClass(chart_template_ref=chart_template_ref, edi_format_ref=edi_format_ref)
 
+        # Operations tested here should be available to a billing user
+        cls.env.user.groups_id = cls.env.ref("account.group_account_invoice")
+
         # Invoice name are tracked by the web-services so this constant tries to get a new unique invoice name at each
         # execution.
         cls.today = datetime.now()
@@ -59,3 +62,30 @@ class TestEdiTbaiWebServices(TestEsEdiTbaiCommon):
         generated_files = self._process_documents_web_services(self.moves, {'es_tbai'})
         self.assertTrue(generated_files)
         self.assertRecordValues(self.out_invoice, [{'edi_state': 'sent'}])
+
+    def test_edi_cancellation(self):
+        self._set_tax_agency("gipuzkoa")
+        # Post the invoices
+        self.moves.action_process_edi_web_services(with_commit=False)
+        generated_files = self._process_documents_web_services(self.moves, {"es_tbai"})
+        self.assertTrue(generated_files)
+        self.assertRecordValues(
+            self.moves,
+            [
+                {"edi_state": "sent", "state": "posted"},
+                {"edi_state": False, "state": "posted"},
+            ],
+        )
+        # Cancel the invoices
+        self.moves.invalidate_recordset(["l10n_es_tbai_post_xml"])
+        self.moves.button_cancel_posted_moves()
+        self.moves.action_process_edi_web_services(with_commit=False)
+        generated_files = self._process_documents_web_services(self.moves, {"es_tbai"})
+        # self.assertTrue(generated_files)
+        self.assertRecordValues(
+            self.moves,
+            [
+                {"edi_state": "cancelled", "state": "cancel"},
+                {"edi_state": False, "state": "cancel"},
+            ],
+        )


### PR DESCRIPTION
Before this patch, if a billing user (without any administration settings level) tried to cancel a posted invoice and clicked on the "Process now" button, they got an exception.

In particular, it happened because those users shouldn't have access to stuff such as the certificate, its password or the contents of the sent EDI attachment.

However, they should be able to post the documents using whatever configuration the sysadmin saved. Thus, I use some `sudo()` calls and add a test to assert it won't break anymore.

**How to test functionally:**
1. Configure a Spanish company.
2. Install `l10n_es_edi_tbai` and configure it.
3. Switch to a user that only has "Invoicing / Billing" permissions.
4. Post an invoice.
5. Send it to tbai.
6. Request EDI cancellation.
7. Send it to tbai.
8. It should work now.

@moduon MT-8894 OPW-4535149


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
