### PR TITLE
[FIX] mail: collapse call participants preserve image aspect ratio

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -63,7 +63,7 @@
 
     <t t-name="mail.DiscussSidebarCallParticipants.participant">
         <div class="o-mail-DiscussSidebarCallParticipants-participant d-flex text-reset overflow-hidden align-items-center" t-att-class="{ 'justify-content-center bg-inherit': isCompact }">
-            <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:24px;height:24px;padding:1px">
+            <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:24px;height:24px;margin:1px">
                 <img class="o-mail-DiscussSidebarCallParticipants-avatar w-100 h-100 rounded-circle o_object_fit_cover" t-att-src="session.channel_member_id.persona.avatarUrl" t-att-class="{'o-isTalking shadow': !session.isMute and session.isTalking}" alt="Participant avatar" t-att-title="session.channel_member_id.persona.name"/>
             </div>
             <span t-if="!isCompact" class="o-mail-DiscussSidebarCallParticipants-name mx-1 text-truncate fw-bold smaller user-select-none" t-att-title="session.channel_member_id.persona.name" t-att-class="{ 'o-isTalking': !session.isMute and session.isTalking }">

--- a/addons/mail/static/src/discuss/core/common/avatar_stack.xml
+++ b/addons/mail/static/src/discuss/core/common/avatar_stack.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.AvatarStack">
-        <div t-if="props.personas.length > 0" class="bg-inherit">
+        <div t-if="props.personas.length > 0" class="bg-inherit" style="margin: 1px">
             <div class="d-flex bg-inherit" t-att-class="{'flex-column': props.direction === 'v'}">
                 <span t-foreach="props.personas.slice(0, props.max)" t-as="persona" t-key="persona.localId" class="position-relative bg-inherit rounded-circle">
-                    <img t-att-src="persona.avatarUrl" t-att-title="persona.name" class="rounded-circle" t-attf-class="{{props.avatarClass(persona)}}" t-attf-style="{{getStyle(persona_index)}}"/>
+                    <img t-att-src="persona.avatarUrl" t-att-title="persona.name" class="rounded-circle o_object_fit_cover d-flex" t-attf-class="{{props.avatarClass(persona)}}" t-attf-style="{{getStyle(persona_index)}}"/>
                     <t t-slot="avatarExtraInfo" persona="persona"/>
                 </span>
                 <span t-if="props.personas.length > props.max" class="z-1 rounded-circle bg-secondary smaller d-flex justify-content-center align-items-center user-select-none" t-attf-style="{{getStyle(props.personas.length)}}">+<t t-esc="props.personas.length - props.max"/></span>


### PR DESCRIPTION
Avatar stack of call participants in discuss sidebar lacked preserving aspect ratio of image, so image may be squished.

This commit fixes the issue with `.o_object_fit_cover` used in all showings of avatars in discuss.

Before
![before](https://github.com/user-attachments/assets/25870f36-8cc4-458a-bde3-de7b8fc7d1b3)

After
![after](https://github.com/user-attachments/assets/d784644d-6fda-4dca-8890-780f37ecdbba)

