### PR TITLE
[FIX] pos_hr: fix traceback when opening cashier dialog

### DIFF
--- a/addons/pos_hr/static/src/app/select_cashier_mixin.js
+++ b/addons/pos_hr/static/src/app/select_cashier_mixin.js
@@ -92,7 +92,7 @@ export function useCashierSelector({ exclusive, onScan } = { onScan: () => {}, e
         );
 
         if (!pinMatchEmployees.length && !pin) {
-            await ask(this.dialog, {
+            await ask(dialog, {
                 title: _t("No Cashiers"),
                 body: _t("There is no cashier available."),
             });


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
- Fixed an issue where changing the cashier with no available cashiers caused a traceback due to an undefined `this.dialog` Replaced it with the correct `dialog` reference.

## step to reproduce
- install `point of sale` 
- setup a new point_of_sale , as shown

![pos config](https://github.com/user-attachments/assets/9a700c6d-2fe9-4008-85b2-13b917f44dd4)

- start session in that pos.
- try to change the cashier

Current behavior before PR:
![pos change cashier](https://github.com/user-attachments/assets/148d7ed8-7361-4a83-99dc-89de98e3358d)


Desired behavior after PR is merged:
![expected behaviour](https://github.com/user-attachments/assets/01c74270-390e-4f51-a04e-396fbab9c8b8)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
