### PR TITLE
[FIX] base, *: allow access to restricted attachments with token

### DIFF
--- a/addons/point_of_sale/models/product_product.py
+++ b/addons/point_of_sale/models/product_product.py
@@ -26,6 +26,6 @@ class ProductProduct(models.Model):
                 ))
 
     def _can_return_content(self, field_name=None, access_token=None):
-        if self.available_in_pos and field_name == "image_128":
+        if field_name == "image_128" and self.sudo().available_in_pos:
             return True
         return super()._can_return_content(field_name, access_token)

--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -82,7 +82,7 @@ class ProductTemplate(models.Model):
         return res
 
     def _can_return_content(self, field_name=None, access_token=None):
-        if self.sudo().self_order_available and field_name == "image_512":
+        if field_name == "image_512" and self.sudo().self_order_available:
             return True
         return super()._can_return_content(field_name, access_token)
 
@@ -119,6 +119,6 @@ class ProductProduct(models.Model):
                 })
 
     def _can_return_content(self, field_name=None, access_token=None):
-        if self.sudo().self_order_available and field_name == "image_512":
+        if field_name == "image_512" and self.sudo().self_order_available:
             return True
         return super()._can_return_content(field_name, access_token)

--- a/addons/web/tests/test_image.py
+++ b/addons/web/tests/test_image.py
@@ -10,7 +10,7 @@ from PIL import Image
 from werkzeug.urls import url_unquote_plus
 
 from odoo.tools.misc import limited_field_access_token
-from odoo.tests.common import HttpCase, tagged
+from odoo.tests.common import HttpCase, new_test_user, tagged
 
 
 @tagged('-at_install', 'post_install')
@@ -234,3 +234,107 @@ class TestImage(HttpCase):
             # a different model generates a different token
             model_res = get_datetime_from_record_field(self.env["res.partner"].browse(3), "raw")
             self.assertNotIn(model_res, [base_result, record_res, field_res])
+
+    def test_06_web_image_attachment_access(self):
+        """Tests all the combination of user/ways to access an attachment through `/web/content`
+        or `/web/image` routes"""
+        new_test_user(self.env, "portal_user", groups="base.group_portal")
+        new_test_user(self.env, "internal_user")
+        # record of arbitrary model with restrictive ACL even for internal users
+        restricted_record = self.env["res.users.settings"].create({"user_id": self.env.user.id})
+        # record of arbitrary model with permissive ACL for internal users
+        accessible_record = self.env["res.partner"].create({"name": "test partner"})
+        attachments = self.env["ir.attachment"].create(
+            [
+                {
+                    "datas": b"R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=",
+                    "description": "restricted attachment",
+                    "name": "test.gif",
+                    "res_id": restricted_record.id,
+                    "res_model": restricted_record._name,
+                },
+                {
+                    "datas": b"R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=",
+                    "description": "restricted attachment",
+                    "name": "test.gif",
+                    "res_id": accessible_record.id,
+                    "res_model": accessible_record._name,
+                },
+                {
+                    "datas": b"R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=",
+                    "description": "standalone attachment",
+                    "name": "test.gif",
+                },
+                {
+                    "datas": b"R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=",
+                    "description": "public attachment",
+                    "name": "test.gif",
+                    "public": True,
+                },
+            ]
+        )
+        attachments.generate_access_token()
+        internal_restricted, internal_accessible, standalone, public = attachments
+        tests = [
+            # (attachment, user, token, expected result (True if accessible))
+            (internal_restricted, "public_user", None, False),
+            (internal_restricted, "public_user", "token", True),
+            (internal_restricted, "public_user", "limited token", True),
+            (internal_restricted, "portal_user", None, False),
+            (internal_restricted, "portal_user", "token", True),
+            (internal_restricted, "portal_user", "limited token", True),
+            (internal_restricted, "internal_user", None, False),
+            (internal_restricted, "internal_user", "token", True),
+            (internal_restricted, "internal_user", "limited token", True),
+            (internal_accessible, "public_user", None, False),
+            (internal_accessible, "public_user", "token", True),
+            (internal_accessible, "public_user", "limited token", True),
+            (internal_accessible, "portal_user", None, False),
+            (internal_accessible, "portal_user", "token", True),
+            (internal_accessible, "portal_user", "limited token", True),
+            (internal_accessible, "internal_user", None, True),
+            (internal_accessible, "internal_user", "token", True),
+            (internal_accessible, "internal_user", "limited token", True),
+            (standalone, "public_user", None, False),
+            (standalone, "public_user", "token", True),
+            (standalone, "public_user", "limited token", True),
+            (standalone, "portal_user", None, False),
+            (standalone, "portal_user", "token", True),
+            (standalone, "portal_user", "limited token", True),
+            (standalone, "internal_user", None, False),
+            (standalone, "internal_user", "token", True),
+            (standalone, "internal_user", "limited token", True),
+            (public, "public_user", None, True),
+            (public, "public_user", "token", True),
+            (public, "public_user", "limited token", True),
+            (public, "portal_user", None, True),
+            (public, "portal_user", "token", True),
+            (public, "portal_user", "limited token", True),
+            (public, "internal_user", None, True),
+            (public, "internal_user", "token", True),
+            (public, "internal_user", "limited token", True),
+        ]
+        for attachment, user, token, result in tests:
+            login = None if user == "public_user" else user
+            self.authenticate(login, login)
+            access_token_param = ""
+            if token:
+                access_token = (
+                    attachment.access_token
+                    if token == "token"
+                    else limited_field_access_token(attachment, "raw")
+                )
+                access_token_param = f"?access_token={access_token}"
+            res = self.url_open(f"/web/image/{attachment.id}{access_token_param}")
+            if result:
+                self.assertEqual(
+                    res.headers["Content-Disposition"],
+                    "inline; filename=test.gif",
+                    f"{user} should have access to {attachment.description} with {token or 'no token'}",
+                )
+            else:
+                self.assertEqual(
+                    res.headers["Content-Disposition"],
+                    "inline; filename=placeholder.png",
+                    f"{user} should not have access to {attachment.description} with {token or 'no token'}",
+                )

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -126,13 +126,12 @@ class TestStandardPerformance(UtilPerf):
         url = '/web/image/res.users/2/image_256'
         select_tables_perf = {
             'orm_signaling_registry': 1,
-            'res_company': 2,
             'res_users': 2,
             'res_partner': 1,
             'ir_attachment': 2,
         }
-        self._check_url_hot_query(url, 8, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(url, cache=False), 8)
+        self._check_url_hot_query(url, 6, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(url, cache=False), 6)
 
     @mute_logger('odoo.http')
     def test_20_perf_sql_img_controller_bis(self):

--- a/odoo/addons/base/models/ir_binary.py
+++ b/odoo/addons/base/models/ir_binary.py
@@ -49,12 +49,9 @@ class IrBinary(models.AbstractModel):
             raise MissingError(f"No record found for xmlid={xmlid}, res_model={res_model}, id={res_id}")  # pylint: disable=missing-gettext
         if access_token and verify_limited_field_access_token(record, field, access_token):
             return record.sudo()
-        try:
-            record.check_access("read")
-        except AccessError:
-            if record._can_return_content(field, access_token):
-                return record.sudo()
-            raise
+        if record._can_return_content(field, access_token):
+            return record.sudo()
+        record.check_access("read")
         return record
 
     def _record_to_stream(self, record, field_name):


### PR DESCRIPTION
\* = web, point_of_sale, pos_self_order

A restricted attachment is an attachment linked to a record the current user cannot access, or linked to no record at all. The `check_access` methods allows access to such attachments, but the `check` and `_search` override methods forbid it.

By verifying `check_access` first (and if it passes never checking `access_token`), users might end up being blocked later in the flow even though they had a valid token.

Ideally `check_access` should be properly implemented for attachment, but it is out of the scope of this fix.

The fix is rather simple, call `_can_return_content` (which for attachment checks `access_token` and calls `check`) before `check_access`. The order is rather arbitrary. `_can_return_content` used to be slower and therefore called only when necessary, but it is no longer slow so it can be called first.

The opportunity is taken to clean the `pos` overrides:
- better check field name first before fetching the record
- use sudo when checking if access is allowed (otherwise it would raise for non-accessible records rather than returning False)

Follow-up of https://github.com/odoo/odoo/pull/186003 (which broke the access) and https://github.com/odoo/odoo/pull/193407 (which fixed performance and allowed to inverse the call order of the checks).
