### PR TITLE
[IMP] uom,*: show ratio relative to product unit in uom widget

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -318,9 +318,11 @@ class AccountMoveLine(models.Model):
         ondelete='restrict',
         check_company=True,
     )
+    allowed_uom_ids = fields.Many2many('uom.uom', compute='_compute_allowed_uom_ids')
     product_uom_id = fields.Many2one(
         comodel_name='uom.uom',
         string='Unit',
+        domain="[('id', 'in', allowed_uom_ids)]",
         compute='_compute_product_uom_id', store=True, readonly=False, precompute=True,
         ondelete="restrict",
     )
@@ -754,6 +756,11 @@ class AccountMoveLine(models.Model):
                 comp_curr.is_zero(line.amount_residual)
                 and foreign_curr.is_zero(line.amount_residual_currency)
             )
+
+    @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids')
+    def _compute_allowed_uom_ids(self):
+        for line in self:
+            line.allowed_uom_ids = line.product_id.uom_id | line.product_id.uom_ids
 
     @api.depends('move_id.move_type', 'tax_ids', 'tax_repartition_line_id', 'debit', 'credit', 'tax_tag_ids', 'is_refund',
                  'move_id.tax_cash_basis_origin_move_id')

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1159,7 +1159,7 @@
                                                options="{'product_field': 'product_id', 'account_field': 'account_id', 'amount_field': 'price_subtotal'}"
                                                business_domain_compute="parent.move_type in ['out_invoice', 'out_refund', 'out_receipt'] and 'invoice' or parent.move_type in ['in_invoice', 'in_refund', 'in_receipt'] and 'bill' or 'general'"/>
                                         <field name="quantity" optional="show"/>
-                                        <field name="product_uom_id" groups="uom.group_uom" optional="show" width="92px" options="{'no_create': True}" widget="many2one_uom"/>
+                                        <field name="product_uom_id" groups="uom.group_uom" optional="show" width="92px" options="{'no_create': True, 'quantity_field': 'quantity'}" widget="many2one_uom"/>
                                         <!-- /l10n_in_edi.test_edi_json -->
                                         <!-- required for @api.onchange('product_id') -->
                                         <field name="product_uom_id" column_invisible="True"/>

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -211,6 +211,12 @@ class StockMove(models.Model):
         help="When activated, then the registration of consumption for that component is recorded manually exclusively.\n"
              "If not activated, and any of the components consumption is edited manually on the manufacturing order, Odoo assumes manual consumption also.")
 
+    @api.depends('product_id.bom_ids', 'product_id.bom_ids.product_uom_id')
+    def _compute_allowed_uom_ids(self):
+        super()._compute_allowed_uom_ids()
+        for move in self:
+            move.allowed_uom_ids |= move.product_id.bom_ids.product_uom_id
+
     @api.depends('production_id')
     def _compute_packaging_uom_id(self):
         super()._compute_packaging_uom_id()

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -62,7 +62,7 @@
                             <label for="product_qty" string="Quantity"/>
                             <div class="o_row">
                                 <field name="product_qty"/>
-                                <field name="product_uom_id" options="{'no_open':True,'no_create':True}" groups="uom.group_uom" widget="many2one_uom"/>
+                                <field name="product_uom_id" options="{'no_open':True, 'no_create':True, 'product_field': 'product_tmpl_id', 'quantity_field': 'product_qty'}" groups="uom.group_uom" widget="many2one_uom"/>
                             </div>
                         </group>
                         <group>
@@ -99,7 +99,7 @@
                                     <field name="attachments_count" class="text-start" string=" " column_invisible="context.get('parent_production_id')"/>
                                     <field name="product_qty"/>
                                     <field name="parent_product_tmpl_id" column_invisible="True" />
-                                    <field name="product_uom_id" options="{'no_open':True,'no_create':True}" groups="uom.group_uom" widget="many2one_uom"/>
+                                    <field name="product_uom_id" options="{'no_open': True, 'no_create': True, 'quantity_field': 'product_qty'}" groups="uom.group_uom" widget="many2one_uom"/>
                                     <field name="possible_bom_product_template_attribute_value_ids" column_invisible="True"/>
                                     <field name="bom_product_template_attribute_value_ids" optional="hide" widget="many2many_tags" options="{'no_create': True}" column_invisible="parent.product_id" groups="product.group_product_variant"/>
                                     <field name="allowed_operation_ids" column_invisible="True"/>
@@ -131,7 +131,7 @@
                                     <field name="sequence" widget="handle"/>
                                     <field name="product_id" context="{'default_is_storable': True}"/>
                                     <field name="product_qty"/>
-                                    <field name="product_uom_id" groups="uom.group_uom" widget="many2one_uom"/>
+                                    <field name="product_uom_id" groups="uom.group_uom" options="{'product_field': 'product_qty'}" widget="many2one_uom"/>
                                     <field name="cost_share" optional="hide"/>
                                     <field name="allowed_operation_ids" column_invisible="True"/>
                                     <field name="operation_id" groups="mrp.group_mrp_routings" options="{'no_quick_create':True,'no_create_edit':True}"/>
@@ -268,7 +268,7 @@
                                 <label for="product_qty" string="Quantity"/>
                                 <div class="o_row">
                                     <field name="product_qty"/>
-                                    <field name="product_uom_id" options="{'no_open':True,'no_create':True}" groups="uom.group_uom" widget="many2one_uom"/>
+                                    <field name="product_uom_id" options="{'no_open':True,'no_create':True, 'quantity_field': 'product_qty'}" groups="uom.group_uom" widget="many2one_uom"/>
                                 </div>
                                 <field name="possible_bom_product_template_attribute_value_ids" invisible="1"/>
                                 <field name="bom_product_template_attribute_value_ids" widget="many2many_tags" options="{'no_create': True}" groups="product.group_product_variant"/>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -302,7 +302,7 @@
                                 </button>
                                 <label for="product_uom_id" string="" class="oe_inline"/>
                                 <field name="product_uom_id" groups="!uom.group_uom" invisible="1"/>
-                                <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom" widget="many2one_uom" readonly="state != 'draft'" class="flex-grow-0" style="width:auto!important"/>
+                                <field name="product_uom_id" options="{'no_open': True, 'no_create': True, 'quantity_field': 'product_qty'}" groups="uom.group_uom" widget="many2one_uom" readonly="state != 'draft'" class="flex-grow-0" style="width:auto!important"/>
                                 <span class='fw-bold text-nowrap'>To Produce</span>
                                 <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="forecasted_issue"/>
                                 <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="not forecasted_issue" class="text-danger"/>

--- a/addons/mrp/wizard/product_replenish.py
+++ b/addons/mrp/wizard/product_replenish.py
@@ -7,6 +7,12 @@ from odoo import api, fields, models
 class ProductReplenish(models.TransientModel):
     _inherit = 'product.replenish'
 
+    @api.depends('product_id.bom_ids', 'product_id.bom_ids.product_uom_id')
+    def _compute_allowed_uom_ids(self):
+        super()._compute_allowed_uom_ids()
+        for rec in self:
+            rec.allowed_uom_ids |= rec.product_id.bom_ids.product_uom_id
+
     @api.depends('route_id')
     def _compute_date_planned(self):
         super()._compute_date_planned()

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -88,7 +88,7 @@
                                 <field name="pack_lot_ids" widget="many2many_tags" groups="stock.group_production_lot"/>
                                 <field name="qty"/>
                                 <field name="customer_note" optional="hide"/>
-                                <field name="product_uom_id" groups="uom.group_uom" widget="many2one_uom"/>
+                                <field name="product_uom_id" groups="uom.group_uom"/>
                                 <field name="price_unit" widget="monetary"/>
                                 <field name="is_total_cost_computed" column_invisible="True"/>
                                 <field name="total_cost" invisible="not is_total_cost_computed" optional="hide" widget="monetary"/>

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -115,7 +115,7 @@ class ProductTemplate(models.Model):
         'uom.uom', 'Unit', tracking=True,
         default=_get_default_uom_id, required=True,
         help="Default unit of measure used for all stock operations.")
-    uom_ids = fields.Many2many('uom.uom', string='Packagings', help="Additional packagings for this product which can be used for sales")
+    uom_ids = fields.Many2many('uom.uom', string='Packagings', help="Additional packagings for this product which can be used for sales", domain="[('id', '!=', uom_id)]")
     uom_name = fields.Char(string='Unit Name', related='uom_id.name', readonly=True)
     company_id = fields.Many2one(
         'res.company', 'Company', index=True)

--- a/addons/product/models/product_uom.py
+++ b/addons/product/models/product_uom.py
@@ -12,7 +12,7 @@ class ProductUom(models.Model):
 
     uom_id = fields.Many2one('uom.uom', 'Unit', required=True, ondelete='cascade')
     product_id = fields.Many2one('product.product', 'Product', required=True, ondelete='cascade')
-    barcode = fields.Char(index='btree_not_null', required=True)
+    barcode = fields.Char(index='btree_not_null', required=True, copy=False)
     company_id = fields.Many2one('res.company', 'Company', default=lambda self: self.env.company)
 
     _barcode_uniq = models.Constraint('unique(barcode)', 'A barcode can only be assigned to one packaging.')

--- a/addons/product/models/uom_uom.py
+++ b/addons/product/models/uom_uom.py
@@ -1,22 +1,13 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models, fields, _
+from odoo import models, fields, _
 
 
 class UomUom(models.Model):
     _inherit = 'uom.uom'
 
     product_uom_ids = fields.One2many('product.uom', 'uom_id', string='Barcodes', domain=lambda self: ['|', ('product_id', '=', self.env.context.get('product_id')), ('product_id', 'in', self.env.context.get('product_ids', []))])
-    packaging_barcodes_count = fields.Integer('Packaging Barcodes', compute='_compute_packaging_barcodes_count')
-
-    @api.depends('product_uom_ids')
-    def _compute_packaging_barcodes_count(self):
-        uom_to_barcode_count = dict(self.env['product.uom']._read_group(
-            [('uom_id', 'in', self.ids)], ['uom_id'], ['barcode:count'],
-        ))
-        for uom in self:
-            uom.packaging_barcodes_count = uom_to_barcode_count.get(uom, 0)
 
     def action_open_packaging_barcodes(self):
         self.ensure_one()

--- a/addons/product/report/product_reports.xml
+++ b/addons/product/report/product_reports.xml
@@ -66,7 +66,7 @@
             <field name="report_type">qweb-pdf</field>
             <field name="report_name">product.report_packagingbarcode</field>
             <field name="report_file">product.report_packagingbarcode</field>
-            <field name="print_report_name">'Products packaging - %s' % (object.name)</field>
+            <field name="print_report_name">'Products packaging - %s' % (object.uom_id.name)</field>
             <field name="binding_model_id" ref="product.model_product_uom"/>
             <field name="binding_type">report</field>
         </record>

--- a/addons/product/views/uom_views.xml
+++ b/addons/product/views/uom_views.xml
@@ -4,10 +4,10 @@
         <field name="name">product.uom.list</field>
         <field name="model">product.uom</field>
         <field name="arch" type="xml">
-            <list string="Packaging Barcodes">
-                <field name="barcode"/>
+            <list string="Packaging Barcodes" editable="bottom">
                 <field name="product_id"/>
-                <field name="uom_id" widget="many2one_uom"/>
+                <field name="barcode"/>
+                <field name="uom_id" readonly="context.get('default_uom_id')" optional="hide"/>
             </list>
         </field>
     </record>
@@ -18,17 +18,15 @@
         <field name="inherit_id" ref="uom.product_uom_form_view"/>
         <field name="arch" type="xml">
             <xpath expr="//sheet" position="inside">
-                <div invisible="not packaging_barcodes_count" class="oe_button_box" name="button_box">
+                <div class="oe_button_box" name="button_box">
                     <button
                         class="oe_stat_button"
                         icon="fa-barcode"
                         type="object"
+                        context="{'default_uom_id': id}"
                         name="action_open_packaging_barcodes">
                         <div class="o_field_widget o_stat_info">
-                            <span class="o_stat_value d-flex gap-1">
-                                <field name="packaging_barcodes_count" class="oe_inline"/>
-                            </span>
-                            <span class="o_stat_text">Barcodes</span>
+                            <span class="o_stat_text">Packaging Barcodes</span>
                         </div>
                     </button>
                 </div>

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -370,11 +370,6 @@ class PurchaseOrderLine(models.Model):
                 product_ctx = {'seller_id': seller.id, 'lang': get_lang(line.env, line.partner_id.lang).code}
                 line.name = line._get_product_purchase_description(line.product_id.with_context(product_ctx))
 
-    @api.depends('product_id')
-    def _compute_product_uom_id(self):
-        for line in self:
-            line.product_uom_id = line.product_id.seller_ids.filtered(lambda s: s.partner_id == line.partner_id).product_uom_id or line.product_id.uom_id if line.product_id else False
-
     @api.depends('product_uom_id', 'product_qty', 'product_id.uom_id')
     def _compute_product_uom_qty(self):
         for line in self:
@@ -550,7 +545,7 @@ class PurchaseOrderLine(models.Model):
         product_taxes = product_id.supplier_taxes_id.filtered(lambda x: x.company_id in company_id.parent_ids)
         taxes = po.fiscal_position_id.map_tax(product_taxes)
 
-        price_unit = seller.price if seller else product_id.standard_price
+        price_unit = (seller.product_uom_id._compute_price(seller.price, product_uom) if product_uom else seller.price) if seller else product_id.standard_price
         price_unit = self.env['account.tax']._fix_tax_included_price_company(
             price_unit, product_taxes, taxes, company_id)
         if price_unit and seller and po.currency_id and seller.currency_id != po.currency_id:
@@ -570,9 +565,9 @@ class PurchaseOrderLine(models.Model):
 
         return {
             'name': name,
-            'product_qty': uom_po_qty,
+            'product_qty': product_qty if product_uom else uom_po_qty,
             'product_id': product_id.id,
-            'product_uom_id': seller.product_uom_id.id or product_uom.id,
+            'product_uom_id': product_uom.id or seller.product_uom_id.id,
             'price_unit': price_unit,
             'date_planned': date_planned,
             'tax_ids': [(6, 0, taxes.ids)],

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -253,7 +253,7 @@
                                     <field name="product_uom_id" groups="uom.group_uom"
                                         readonly="state in ('purchase', 'done', 'cancel') or is_downpayment"
                                         required="not display_type and not is_downpayment"
-                                        options="{'no_open': True}"
+                                        options="{'no_open': True, 'quantity_field': 'product_qty'}"
                                         widget="many2one_uom"
                                         force_save="1" optional="show"/>
                                     <field name="price_unit" readonly="qty_invoiced != 0"/>

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -84,7 +84,7 @@ class TestStockValuation(TransactionCase):
         kgm_price = 100
         ap_price = kgm_price * ap.factor / kgm.factor
 
-        self.product1.uom_id = ap
+        self.product1.uom_id = kgm
 
         # Set vendor
         vendor = self.env['res.partner'].create(dict(name='The Replenisher'))
@@ -117,7 +117,7 @@ class TestStockValuation(TransactionCase):
             last_po_id = self.env[model_name].browse(int(purchase_order_id))
 
         order_line = last_po_id.order_line.search([('product_id', '=', self.product1.id)])
-        self.assertEqual(order_line.product_qty,
+        self.assertEqual(order_line.product_uom_qty,
             ap._compute_quantity(replenishment_uom_qty, kgm, rounding_method='HALF-UP'),
             'Quantities does not match')
 
@@ -130,7 +130,7 @@ class TestStockValuation(TransactionCase):
         picking.button_validate()
 
         self.assertEqual(move.stock_valuation_layer_ids.unit_cost,
-            last_po_id.currency_id.round(ap_price),
+            order_line.product_uom_id._compute_price(last_po_id.currency_id.round(ap_price), move.product_uom),
             "Wrong Unit price")
 
     def test_change_unit_cost_average_1(self):

--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -39,6 +39,7 @@
         'report/report_stock_rule.xml',
         'report/stock_lot_customer.xml',
         'report/package_templates.xml',
+        'report/packaging_barcode.xml',
         'report/picking_templates.xml',
         'report/product_templates.xml',
         'report/report_return_slip.xml',

--- a/addons/stock/report/packaging_barcode.xml
+++ b/addons/stock/report/packaging_barcode.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <data>
-        <template id="label_product_packaging_view">
+        <template id="label_packaging_barcode_view">
             <t t-foreach="docs" t-as="packaging">
                 <t t-translation="off">
 ^XA
 ^FO100,50
-^A0N,44,33^FD<t t-esc="packaging.name"/>^FS
+^A0N,44,33^FD<t t-esc="packaging.uom_id.name"/>^FS
 ^FO100,100
 ^A0N,44,33^FD<t t-esc="packaging.product_id.display_name"/>^FS
 ^FO100,150
-^A0N,44,33^FDQty: <t t-esc="packaging.qty"/> <t t-esc="packaging.product_uom_id.name" groups="uom.group_uom"/>^FS
+^A0N,44,33^FDQty: <t t-esc="packaging.uom_id.relative_factor"/> <t t-esc="packaging.uom_id.name" groups="uom.group_uom"/>^FS
 <t t-if="packaging.barcode">
 ^FO100,200^BY3
 ^BCN,100,Y,N,N

--- a/addons/stock/report/stock_report_views.xml
+++ b/addons/stock/report/stock_report_views.xml
@@ -127,6 +127,15 @@
             <field name="binding_model_id" ref="model_stock_quant_package"/>
             <field name="binding_type">report</field>
         </record>
+        <record id="label_packaging_barcode" model="ir.actions.report">
+            <field name="name">Packaging Barcodes (ZPL)</field>
+            <field name="model">product.uom</field>
+            <field name="report_type">qweb-text</field>
+            <field name="report_name">stock.label_packaging_barcode_view</field>
+            <field name="report_file">stock.label_packaging_barcode_view</field>
+            <field name="binding_model_id" ref="product.model_product_uom"/>
+            <field name="binding_type">report</field>
+        </record>
         <record id="label_picking_type" model="ir.actions.report">
             <field name="name">Operation type (ZPL)</field>
             <field name="model">stock.picking.type</field>

--- a/addons/stock/wizard/product_replenish_views.xml
+++ b/addons/stock/wizard/product_replenish_views.xml
@@ -28,7 +28,7 @@
                             <field name="product_uom_id"
                                 groups="uom.group_uom"
                                 widget="many2one_uom"
-                                options="{'no_open': 1, 'no_create': 1}"/>
+                                options="{'no_open': 1, 'no_create': 1, 'quantity_field': 'quantity'}"/>
                         </div>
                         <field name="date_planned"/>
                         <field name="warehouse_id"

--- a/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js
+++ b/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js
@@ -10,25 +10,79 @@ import {
     many2OneField,
 } from "@web/views/fields/many2one/many2one_field";
 import { UomAutoComplete } from "@uom/components/uom_autocomplete/uom_autocomplete";
+import { roundPrecision } from "@web/core/utils/numbers";
+import { onWillUpdateProps } from "@odoo/owl";
 
 export class Many2XUomTagsAutocomplete extends Many2XAutocomplete {
     static components = {
         ...Many2XAutocomplete.components,
         AutoComplete: UomAutoComplete,
     };
+    static props = {
+        ...Many2XAutocomplete.props,
+        productModel: { type: String, optional: true },
+        productId: { type: Number, optional: true },
+        productQuantity: { type: Number, optional: true },
+    };
+
+    async setup() {
+        super.setup();
+        onWillUpdateProps(async (nextProps) => {
+            if (nextProps.productModel !== this.props.productModel || 
+                nextProps.productId !== this.props.productId ||
+                nextProps.productQuantity !== this.props.productQuantity
+            ) {
+                await this.updateReferenceUnit(nextProps);
+                await this.render();
+            }
+        });
+        await this.updateReferenceUnit();
+    }
+
+    async render() {
+        await super.render();
+    }
+
+    async updateReferenceUnit(props = this.props) {
+        if (props.productModel && props.productId) {
+            const product = await this.orm.searchRead(props.productModel, [["id", "=", props.productId]], ["uom_id"]);
+            this.referenceUnit = (await this.orm.searchRead("uom.uom", [["id", "=", product[0].uom_id[0]]], ["name", "factor", "parent_path", "rounding"]))[0];
+        }
+    }
 
     async search(name) {
-        const records = await this.orm.searchRead(
+        let records = await this.orm.searchRead(
             this.props.resModel,
-            [...this.props.getDomain(), ["name", "ilike", name]], 
-            ["id", "name", "relative_factor", "relative_uom_id"],
+            [...this.props.getDomain(), ["name", "ilike", name]],
+            ["id", "name", "relative_factor", "factor", "relative_uom_id", "parent_path"],
         );
-        return records.map((record) => {
+        const hasCommonReference = (uom1, uom2) => {
+            const uom1Path = uom1.parent_path.split("/");
+            const uom2Path = uom2.parent_path.split("/");
+            const commonPath = [];
+            for (let i = 0; i < Math.min(uom1Path.length, uom2Path.length); i++) {
+                if (uom1Path[i] === uom2Path[i]) {
+                    commonPath.push(uom1Path[i]);
+                } else {
+                    break;
+                }
+            }
+            return commonPath.length > 0;
+        };
+        records = records.map((record) => {
+            let relativeInfo = this.referenceUnit && this.referenceUnit.id !== record.id ? `${roundPrecision((this.props.productQuantity || 1) * record.factor / this.referenceUnit.factor, this.referenceUnit.rounding)} ${this.referenceUnit.name}` : "";
+            if (this.referenceUnit && record.id !== this.referenceUnit.id && hasCommonReference(record, this.referenceUnit)) {
+                relativeInfo = `${roundPrecision((this.props.productQuantity || 1) * record.relative_factor, this.referenceUnit.rounding)} ${record.relative_uom_id[1]}`;
+            }
             return {
                 ...record,
-                relative_info: record.relative_uom_id ? `${record.relative_factor} ${record.relative_uom_id[1]}` : undefined,
+                relative_info: relativeInfo,
             };
         });
+        if (this.referenceUnit) {
+            records.sort((a, b) => hasCommonReference(a, this.referenceUnit) ? -1 : hasCommonReference(b, this.referenceUnit) ? 1 : 0);
+        }
+        return records;
     }
 
     mapRecordToOption(result) {
@@ -42,29 +96,93 @@ export class Many2XUomTagsAutocomplete extends Many2XAutocomplete {
 }
 
 export class Many2ManyUomTagsField extends Many2ManyTagsFieldColorEditable {
+    static template = "uom.Many2ManyUomTagsField";
     static components = {
         ...Many2ManyTagsFieldColorEditable.components,
         Many2XAutocomplete: Many2XUomTagsAutocomplete,
     };
+    static props = {
+        ...Many2ManyTagsFieldColorEditable.props,
+        productField: { type: String, optional: true },
+        quantityField: { type: String, optional: true },
+    }
+    static defaultProps = {
+        ...Many2OneField.defaultProps,
+        productField: "product_id",
+        quantityField: "product_uom_qty",
+    }
 }
 
 export class Many2OneUomField extends Many2OneField {
+    static template = "uom.Many2OneUomField";
     static components = {
         ...Many2OneField.components,
         Many2XAutocomplete: Many2XUomTagsAutocomplete,
     };
+    static props = {
+        ...Many2OneField.props,
+        productField: { type: String, optional: true },
+        quantityField: { type: String, optional: true },
+    }
+    static defaultProps = {
+        ...Many2OneField.defaultProps,
+        productField: "product_id",
+        quantityField: "product_uom_qty",
+    }
 }   
 
 export const many2ManyUomTagsField = {
     ...many2ManyTagsFieldColorEditable,
     component: Many2ManyUomTagsField,
     additionalClasses: ['o_field_many2many_tags'],
+    supportedOptions: [
+        ...(many2ManyTagsFieldColorEditable.supportedOptions || []),
+        {
+            label: _t("Product Field Name"),
+            name: "product_field",
+            type: "field",
+            availableTypes: ["integer"]
+        },
+        {
+            label: _t("Quantity Field Name"),
+            name: "quantity_field",
+            type: "field",
+            availableTypes: ["integer"]
+        }
+    ],
+    extractProps({ options }) {
+        const props = many2ManyTagsFieldColorEditable.extractProps(...arguments);
+        props.productField = options.product_field;
+        props.quantityField = options.quantity_field;
+        return props;
+    },
 };
 
 export const many2OneUomField = {
     ...many2OneField,
     component: Many2OneUomField,
     additionalClasses: ['o_field_many2one'],
+    supportedOptions: [
+        ...(many2OneField.supportedOptions || []),
+        {
+            label: _t("Product Field Name"),
+            name: "product_field",
+            type: "field",
+            availableTypes: ["integer"]
+        },
+        {
+            label: _t("Quantity Field Name"),
+            name: "quantity_field",
+            type: "field",
+            availableTypes: ["integer"]
+        }
+    ],
+    extractProps({ options }) {
+        const props = many2OneField.extractProps(...arguments);
+        props.productField = options.product_field;
+        props.quantityField = options.quantity_field;
+        return props;
+    },
 };
 
 registry.category("fields").add("many2many_uom_tags", many2ManyUomTagsField);

--- a/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.xml
+++ b/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="uom.Many2ManyUomTagsField" t-inherit="web.Many2ManyTagsField">
+        <xpath expr="//Many2XAutocomplete" position="attributes">
+            <attribute name="productModel">["product.template", "product.product"].includes(this.props.record.resModel) ? this.props.record.resModel : "product.product"</attribute>
+            <attribute name="productId">["product.template", "product.product"].includes(this.props.record.resModel) ? (this.props.record.resId || 0) : this.props.record.data[this.props.productField][0] || 0</attribute>
+            <attribute name="productQuantity">this.props.record.data[this.props.quantityField]</attribute>
+        </xpath>
+    </t>
+    <t t-name="uom.Many2OneUomField" t-inherit="web.Many2OneField">
+        <xpath expr="//Many2XAutocomplete" position="attributes">
+            <attribute name="productModel">["product.template", "product.product"].includes(this.props.record.resModel) ? this.props.record.resModel : "product.product"</attribute>
+            <attribute name="productId">["product.template", "product.product"].includes(this.props.record.resModel) ? (this.props.record.resId || 0) : this.props.record.data[this.props.productField][0] || 0</attribute>
+            <attribute name="productQuantity">this.props.record.data[this.props.quantityField]</attribute>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
This commit changes the behavior of the widget created in 31d251f, so that it shows the ratio of the unit relative to the base unit of the current open or related product. The widget now uses `product_id` field to retrieve the related product to the current record, but the commit adds a new option to the widget `product_field` to pass the product field name in case it's different than `product_id`.

Task-4471379


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
