### PR TITLE
[FIX] html_editor: prevent using self-closing elements in editor

### DIFF
--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -2,7 +2,7 @@ import { MAIN_PLUGINS } from "./plugin_sets";
 import { removeClass } from "./utils/dom";
 import { isEmpty } from "./utils/dom_info";
 import { resourceSequenceSymbol, withSequence } from "./utils/resource";
-import { initElementForEdition } from "./utils/sanitize";
+import { fixInvalidHTML, initElementForEdition } from "./utils/sanitize";
 
 /**
  * @typedef { import("./plugin_sets").SharedMethods } SharedMethods
@@ -94,7 +94,7 @@ export class Editor {
         this.editable = editable;
         this.document = editable.ownerDocument;
         if (this.config.content) {
-            editable.innerHTML = this.config.content;
+            editable.innerHTML = fixInvalidHTML(this.config.content);
             if (isEmpty(editable)) {
                 editable.innerHTML = "<p><br></p>";
             }


### PR DESCRIPTION
**Problem**:
When content comes from the config containing self-closing tags,
the browser misinterprets them as they are not valid HTML,
leading to a broken template when displayed.

**Solution**:
Convert self-closing tags to explicitly opened and closed tags
when content is added to the editor.

**Steps to Reproduce**:
1. Open Email Templates > "Sales: Order Confirmation".
2. Inspect and observe that self-closing tags are not rendered correctly.

opw-4531812

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
