### PR TITLE
[FIX] website: correctly compute page of image gallery

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/gallery_slider.js
+++ b/addons/website/static/src/snippets/s_image_gallery/gallery_slider.js
@@ -124,7 +124,7 @@ export class GallerySlider extends Interaction {
     onSlidCarousel() {
         if (this.liEls) {
             const active = [...this.liEls].filter((el) => el.classList.contains("active"));
-            const index = active.length ? [...this.liEls].indexOf(active) : 0;
+            const index = active.length ? [...this.liEls].indexOf(active[0]) : 0;
             this.page = Math.floor(index / this.realNbPerPage);
         }
         this.hide();

--- a/addons/website/static/tests/interactions/snippets/gallery_slider.test.js
+++ b/addons/website/static/tests/interactions/snippets/gallery_slider.test.js
@@ -197,10 +197,10 @@ test("gallery_slider interaction on old lightbox", async () => {
     await advanceTime(SLIDE_DURATION);
     // Fix parameters that are based on sizes.
     interaction.page = 0;
-    interaction.nbPages = 6;
-    interaction.realNbPerPage = 1;
+    interaction.nbPages = 1;
+    interaction.realNbPerPage = 20;
     const imgEl = queryOne(".carousel-item.active img");
-    await click(".o_indicators_right");
+    await click("li[data-bs-slide-to]:eq(1)");
     await animationFrame();
     await onceAllImagesLoaded(getFixture());
     await advanceTime(SLIDE_DURATION);


### PR DESCRIPTION
When image gallery was converted to interactions in [1], the page calculation for old version of the snippet was wrongly adapted.

This commit solves this by looking for the active element inside the list instead of looking for an array of active elements.

Steps to reproduce:
- Install 17.0
- Drop an Image Gallery and save
- Copy the page's HTML
- Install master
- Unarchive the 'image' asset records that are archived
- Paste the page's HTML

=> The miniatures did not behave normally, and access to a second page was given even if there was no such thing.

[1]: https://github.com/odoo/odoo/commit/b9b3a605e0f4c5da3a258c980107d6162da7f44f

task-4367641
