### PR TITLE
[IMP] mail: hide quick actions in inactive WhatsApp channels

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -244,6 +244,10 @@ export class Composer extends Component {
         return "";
     }
 
+    get showQuickAction() {
+        return true;
+    }
+
     onClickCancelOrSaveEditText(ev) {
         const composer = toRaw(this.props.composer);
         if (composer.message && ev.target.dataset?.type === EDIT_CLICK_TYPE.CANCEL) {

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -153,7 +153,7 @@
 </t>
 
 <t t-name="mail.Composer.quickActionButton">
-    <button class="btn border-0 rounded-circle" t-att-class="{ 'o-large': ui.isSmall and env.inChatWindow, 'o-small': !ui.isSmall or !env.inChatWindow }" t-attf-class="{{ action.btnClass }}" t-att-title="action.name" t-on-click="(ev) => action.onClick?.(ev)" t-att-data-hotkey="action.hotkey" t-att-disabled="action.disabledCondition or areAllActionsDisabled" t-att-name="action.id" t-ref="{{ action.id }}" tabindex="0"><i class="fa-fw fa-lg" t-att-class="action.icon"/></button>
+    <button class="btn border-0 rounded-circle" t-if="showQuickAction" t-att-class="{ 'o-large': ui.isSmall and env.inChatWindow, 'o-small': !ui.isSmall or !env.inChatWindow }" t-attf-class="{{ action.btnClass }}" t-att-title="action.name" t-on-click="(ev) => action.onClick?.(ev)" t-att-data-hotkey="action.hotkey" t-att-disabled="action.disabledCondition or areAllActionsDisabled" t-att-name="action.id" t-ref="{{ action.id }}" tabindex="0"><i class="fa-fw fa-lg" t-att-class="action.icon"/></button>
 </t>
 
 <t t-name="mail.Composer.moreActions">


### PR DESCRIPTION
PURPOSE

The purpose of this commit is to stop displaying unnecessary quick actions in deactivated WhatsApp channels.

SPECIFICATION

The `showAction` getter function is introduced in the composer. This function is overridden in WhatsApp to prevent actions like the emoji picker, GIF picker, etc. from being displayed. As a result, the WhatsApp Revive Conversation action button remains visible to users for deactivated WhatsApp channels.

TASK-3525549