### PR TITLE
[FIX] hr_holidays: fix leave duration for flex calendars

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -423,6 +423,12 @@ class HolidaysRequest(models.Model):
             if not leave.date_from or not leave.date_to or not calendar:
                 result[leave.id] = (0, 0)
                 continue
+            if calendar.flexible_hours:
+                days = (leave.date_to - leave.date_from).days + (1 if not leave.request_unit_half else 0.5)
+                hours = min(leave.request_hour_to - leave.request_hour_from, calendar.hours_per_day) if leave.request_unit_hours \
+                    else ceil(days * calendar.hours_per_day)
+                result[leave.id] = (days, hours)
+                continue
             hours, days = (0, 0)
             if leave.employee_id:
                 if leave.employee_id.is_flexible and leave.leave_type_request_unit in ['day','half_day']:

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -388,6 +388,111 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         leave2.action_validate()
         self.assertEqual(leave2.number_of_hours, 4)
 
+    def test_number_of_hours_display_flexible_calendar(self):
+        # Test that the field number_of_hours_dispay do change for flexible calendars
+        calendar = self.env['resource.calendar'].create({
+            'name': 'Full Time 24h/8day',
+            'hours_per_day': 24,
+            'attendance_ids': [
+                (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 0, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 12, 'hour_to': 24, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 0, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 12, 'hour_to': 24, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 0, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 12, 'hour_to': 24, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 0, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Thursday Afternoon', 'dayofweek': '3', 'hour_from': 12, 'hour_to': 24, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 0, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 12, 'hour_to': 24, 'day_period': 'afternoon'})
+            ],
+        })
+        employee = self.employee_emp
+        employee.resource_calendar_id = calendar
+        self.env.user.company_id.resource_calendar_id = calendar
+        leave_type = self.env['hr.leave.type'].create({
+            'name': 'Paid Time Off',
+            'request_unit': 'hour',
+            'leave_validation_type': 'both',
+        })
+        self.env['hr.leave.allocation'].create({
+            'name': '20 days allocation',
+            'holiday_status_id': leave_type.id,
+            'number_of_days': 20,
+            'employee_id': employee.id,
+            'state': 'confirm',
+            'date_from': time.strftime('2018-1-1'),
+            'date_to': time.strftime('%Y-1-1'),
+        })
+
+        leave0 = self.env['hr.leave'].create({
+            'name': 'Holiday 1 day',
+            'employee_id': employee.id,
+            'holiday_status_id': leave_type.id,
+            'request_date_from': fields.Date.from_string('2019-12-9'),
+            'request_date_to': fields.Date.from_string('2019-12-9'),
+        })
+
+        self.assertAlmostEqual(leave0.number_of_hours, 24, 2)
+
+        calendar.write({
+            'flexible_hours': True,
+            'hours_per_day': 8.0
+        })
+
+        leave1 = self.env['hr.leave'].create({
+            'name': 'Holiday 1 week',
+            'employee_id': employee.id,
+            'holiday_status_id': leave_type.id,
+            'request_date_from': fields.Date.from_string('2019-12-16'),
+            'request_date_to': fields.Date.from_string('2019-12-20'),
+        })
+
+        self.assertEqual(leave1.number_of_hours, 5 * 8)
+
+        leave2 = self.env['hr.leave'].create({
+            'name': 'Holiday 1 Day',
+            'employee_id': employee.id,
+            'holiday_status_id': leave_type.id,
+            'request_date_from': fields.Datetime.from_string('2019-12-23'),
+            'request_date_to': fields.Datetime.from_string('2019-12-23'),
+        })
+
+        self.assertEqual(leave2.number_of_hours, 8)
+
+        leave3 = self.env['hr.leave'].create({
+            'name': 'Holiday 1/2 Day',
+            'employee_id': employee.id,
+            'holiday_status_id': leave_type.id,
+            'request_date_from': fields.Datetime.from_string('2019-12-24'),
+            'request_unit_half': True,
+        })
+
+        self.assertEqual(leave3.number_of_hours, 4)
+
+        leave4 = self.env['hr.leave'].create({
+            'name': 'Holiday 3 Hours',
+            'employee_id': employee.id,
+            'holiday_status_id': leave_type.id,
+            'request_date_from': fields.Datetime.from_string('2019-12-25'),
+            'request_unit_hours': True,
+            'request_hour_from': 7,
+            'request_hour_to': 10,
+        })
+
+        self.assertEqual(leave4.number_of_hours, 3)
+
+        leave5 = self.env['hr.leave'].create({
+            'name': 'Holiday 10 hours',
+            'employee_id': employee.id,
+            'holiday_status_id': leave_type.id,
+            'request_date_from': fields.Datetime.from_string('2019-12-26'),
+            'request_unit_hours': True,
+            'request_hour_from': 7,
+            'request_hour_to': 17,
+        })
+
+        self.assertEqual(leave5.number_of_hours, 8)
+
     def test_number_of_hours_display_global_leave(self):
         # Check that the field number_of_hours
         # takes the global leaves into account, even


### PR DESCRIPTION
Issue: we you have a flex calendar the time off duration will depend on the attendance_ids even if they are hidden from the calendar view

reporduce: create a new calendar and change the attendance before turing it into flex and then change the `hours_per_day`. then use this calendar on one of the employees and try to givce him a time off. the duration will be calculated based on the attendance you set before marking the calendar flex

Solve:
- update the `_get_durations` method to check if the calendar is flex and then use the `hours_per_day`

Notes:
this flex calendars does not have a weekdays and weekends so all the days that is selected in the leave would be counted

Task: 4535351


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
