### PR TITLE
[FIX] core: log useful connection closes

### DIFF
--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -701,8 +701,9 @@ class ConnectionPool(object):
                 cnx.close()
                 last = self._connections.pop(i)[0]
                 count += 1
-        _logger.info('%r: Closed %d connections %s', self, count,
-                    (dsn and last and 'to %r' % last.dsn) or '')
+        if count:
+            _logger.info('%r: Closed %d connections %s', self, count,
+                        (dsn and last and 'to %r' % last.dsn) or '')
 
     def _dsn_equals(self, dsn1, dsn2):
         alias_keys = {'dbname': 'database'}


### PR DESCRIPTION
On a server with low activity, the log is bloated with messages containing `[...] Closed 0 connections`.

It is only useful to know if a connection was closed, so we skip logging otherwise.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
