### PR TITLE
[IMP] base: autovacuum progress API

### DIFF
--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -95,9 +95,8 @@ class BusBus(models.Model):
         timeout_ago = fields.Datetime.now() - datetime.timedelta(seconds=TIMEOUT*2)
         domain = [('create_date', '<', timeout_ago)]
         records = self.search(domain, limit=GC_UNLINK_LIMIT)
-        if len(records) >= GC_UNLINK_LIMIT:
-            self.env.ref('base.autovacuum_job')._trigger()
-        return records.unlink()
+        records.unlink()
+        return len(records), len(records) == GC_UNLINK_LIMIT  # done, remaining
 
     @api.model
     def _sendone(self, target, notification_type, message):

--- a/addons/mail/models/mail_notification.py
+++ b/addons/mail/models/mail_notification.py
@@ -87,9 +87,8 @@ class MailNotification(models.Model):
             ('notification_status', 'in', ('sent', 'canceled'))
         ]
         records = self.search(domain, limit=GC_UNLINK_LIMIT)
-        if len(records) >= GC_UNLINK_LIMIT:
-            self.env.ref('base.autovacuum_job')._trigger()
-        return records.unlink()
+        records.unlink()
+        return len(records), len(records) == GC_UNLINK_LIMIT  # done, remaining
 
     # ------------------------------------------------------------
     # TOOLS

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -503,7 +503,7 @@ class TestLotValuation(TestStockValuationCommon):
             {'value': -13.5, 'lot_id': self.lot3.id, 'quantity': -3},
         ])
 
-    def test_lot_fifo_vaccum(self):
+    def test_lot_fifo_vacuum(self):
         """ Test lot fifo vacuum"""
         self.product1.standard_price = 9
         self._make_out_move(self.product1, 2, lot_ids=[self.lot1])

--- a/addons/website/tests/test_disable_unused_snippets_assets.py
+++ b/addons/website/tests/test_disable_unused_snippets_assets.py
@@ -49,7 +49,7 @@ class TestDisableSnippetsAssets(TransactionCase):
 
         unwanted_snippets_assets_changes = set(self.initial_active_snippets_assets) - set(self._get_active_snippets_assets()) - set([s_image_gallery_000.path])
 
-        # The vaccuum should not have activated/deactivated any other snippet asset than the original ones
+        # The vacuum should not have activated/deactivated any other snippet asset than the original ones
         self.assertEqual(
             len(unwanted_snippets_assets_changes),
             0,

--- a/odoo/addons/base/models/ir_autovacuum.py
+++ b/odoo/addons/base/models/ir_autovacuum.py
@@ -1,10 +1,10 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import collections
 import inspect
 import logging
-import warnings
-import traceback
+import random
+import time
 
 from odoo import api, models
 from odoo.exceptions import AccessDenied
@@ -29,19 +29,37 @@ class IrAutovacuum(models.AbstractModel):
         Perform a complete database cleanup by safely calling every
         ``@api.autovacuum`` decorated method.
         """
-        if not self.env.is_admin():
+        if not self.env.is_admin() or not self.env.context.get('cron_id'):
             raise AccessDenied()
 
-        for model in self.env.values():
-            cls = self.env.registry[model._name]
-            for attr, func in inspect.getmembers(cls, is_autovacuum):
-                _logger.debug('Calling %s.%s()', model, attr)
-                try:
-                    func(model)
-                    self.env.cr.commit()
-                except Exception:
-                    _logger.exception("Failed %s.%s()", model, attr)
-                    self.env.cr.rollback()
+        all_methods = [
+            (model, attr, func)
+            for model in self.env.values()
+            for attr, func in inspect.getmembers(model.__class__, is_autovacuum)
+        ]
+        # shuffle methods at each run, prevents one blocking method from always
+        # starving the following ones
+        random.shuffle(all_methods)
+        queue = collections.deque(all_methods)
+        while queue and self.env['ir.cron']._commit_progress(remaining=len(queue)):
+            model, attr, func = queue.pop()
+            _logger.debug('Calling %s.%s()', model, attr)
+            try:
+                start_time = time.monotonic()
+                result = func(model)
+                self.env['ir.cron']._commit_progress(1)
+                if isinstance(result, tuple) and len(result) == 2:
+                    func_done, func_remaining = result
+                    _logger.debug(
+                        '%s.%s  vacuumed %r records, remaining %r',
+                        model, attr, func_done, func_remaining,
+                    )
+                    if func_remaining:
+                        queue.appendleft((model, attr, func))
+                _logger.debug("%s.%s  took %.2fs", model, attr, time.monotonic() - start_time)
+            except Exception:
+                _logger.exception("Failed %s.%s()", model, attr)
+                self.env.cr.rollback()
 
     @api.autovacuum
     def _gc_orm_signaling(self):

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -826,9 +826,8 @@ class IrCronTrigger(models.Model):
     def _gc_cron_triggers(self):
         domain = [('call_at', '<', datetime.now() + relativedelta(weeks=-1))]
         records = self.search(domain, limit=GC_UNLINK_LIMIT)
-        if len(records) >= GC_UNLINK_LIMIT:
-            self.env.ref('base.autovacuum_job')._trigger()
-        return records.unlink()
+        records.unlink()
+        return len(records), len(records) == GC_UNLINK_LIMIT  # done, remaining
 
 
 class IrCronProgress(models.Model):
@@ -844,4 +843,6 @@ class IrCronProgress(models.Model):
 
     @api.autovacuum
     def _gc_cron_progress(self):
-        self.search([('create_date', '<', datetime.now() - relativedelta(weeks=1))]).unlink()
+        records = self.search([('create_date', '<', datetime.now() - relativedelta(weeks=1))], limit=GC_UNLINK_LIMIT)
+        records.unlink()
+        return len(records), len(records) == GC_UNLINK_LIMIT  # done, remaining

--- a/odoo/addons/base/models/ir_profile.py
+++ b/odoo/addons/base/models/ir_profile.py
@@ -12,6 +12,7 @@ from odoo import fields, models, api, _
 from odoo.exceptions import UserError
 from odoo.http import request
 from odoo.tools.misc import str2bool
+from odoo.tools.constants import GC_UNLINK_LIMIT
 from odoo.tools.profiler import make_session
 from odoo.tools.speedscope import Speedscope
 
@@ -47,7 +48,9 @@ class IrProfile(models.Model):
     def _gc_profile(self):
         # remove profiles older than 30 days
         domain = [('create_date', '<', fields.Datetime.now() - datetime.timedelta(days=30))]
-        return self.sudo().search(domain).unlink()
+        records = self.sudo().search(domain, limit=GC_UNLINK_LIMIT)
+        records.unlink()
+        return len(records), len(records) == GC_UNLINK_LIMIT  # done, remaining
 
     @api.depends('init_stack_trace')
     def _compute_speedscope(self):

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -2254,8 +2254,14 @@ class Test_New_ApiAutovacuumed(models.Model):
     expire_at = fields.Datetime('Expires at')
 
     @api.autovacuum
-    def _gc(self):
+    def _gc_simple(self):
         self.search([('expire_at', '<', datetime.datetime.now() - datetime.timedelta(days=1))]).unlink()
+
+    @api.autovacuum
+    def _gc_proper(self, limit=5):
+        records = self.search([('expire_at', '<', datetime.datetime.now() - datetime.timedelta(days=1))], limit=limit)
+        records.unlink()
+        return len(records), len(records) == limit
 
 
 class Test_New_ApiSharedCompute(models.Model):

--- a/odoo/addons/test_new_api/tests/test_autovacuum.py
+++ b/odoo/addons/test_new_api/tests/test_autovacuum.py
@@ -10,8 +10,7 @@ class TestAutovacuum(common.TransactionCase):
 
         # Run the autovacuum cron
         with self.enter_registry_test_mode():
-            env = self.env(cr=self.registry.cursor())
-            env.ref('base.autovacuum_job').method_direct_trigger()
+            self.env.ref('base.autovacuum_job').method_direct_trigger()
 
         # Check the record has been vacuumed.
         self.assertFalse(instance.exists())

--- a/odoo/orm/decorators.py
+++ b/odoo/orm/decorators.py
@@ -267,6 +267,9 @@ def autovacuum(method: C) -> C:
     Decorate a method so that it is called by the daily vacuum cron job (model
     ``ir.autovacuum``).  This is typically used for garbage-collection-like
     tasks that do not deserve a specific cron job.
+
+    A return value can be a tuple (done, remaining) which have simular meaning
+    as in :meth:`~odoo.addons.base.models.ir_cron.IrCron._commit_progress`.
     """
     assert method.__name__.startswith('_'), "%s: autovacuum methods must be private" % method.__name__
     method._autovacuum = True  # type: ignore


### PR DESCRIPTION
The `autovacuum` methods can now return if there are remaining records to be vacuumed. This allows to stop the function early and each function gets called a fair amount of times.

The cron responsible for autovacuum uses the progress API to signal whether it could process all funtions. It executes them in a random order now, so if one function is misbehaving (blocking), there is a lower probablility to starve the same set of functions at each call.

An example of implementation:
```python
@api.autovacuum
def _gc_something(self, limit=1000):
  # find records to remove (set a limit to avoid fetching all)
  records = self.search(..., limit=limit)
  records.unlink()
  # return number of records and whether there are remaining ones
  return len(records), len(records) == limit
```

task-4472661

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
