### PR TITLE
[FIX] l10n_es_edi_sii: VAT 12% (agriculture) exemption in bills

### DIFF
--- a/addons/l10n_es_edi_sii/data/account_tax_data.xml
+++ b/addons/l10n_es_edi_sii/data/account_tax_data.xml
@@ -317,7 +317,7 @@
     </record>
     <record id="l10n_es.account_tax_template_p_iva105_gan" model="account.tax.template">
         <field name="name">10,5% IVA Soportado régimen ganadero o pesca</field>
-        <!-- TODO: could not find anything back -->
+        <field name="l10n_es_type">sujeto_agricultura</field>
     </record>
     <record id="l10n_es.account_tax_template_s_iva0_e" model="account.tax.template">
         <field name="name">IVA 0% Exportaciones</field>

--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -180,7 +180,12 @@ class AccountEdiFormat(models.Model):
                     tax_info = {
                         'BaseImponible': round(base_amount, 2),
                     }
-                    if tax_values['applied_tax_amount'] > 0.0:
+                    if tax_values['l10n_es_type'] == 'sujeto_agricultura':
+                        tax_info.update({
+                            'PorcentCompensacionREAGYP': tax_values['applied_tax_amount'],
+                            'ImporteCompensacionREAGYP': round(math.copysign(tax_values['tax_amount'], base_amount), 2),
+                        })
+                    elif tax_values['applied_tax_amount'] > 0.0:
                         tax_info.update({
                             'TipoImpositivo': tax_values['applied_tax_amount'],
                             'CuotaSoportada': round(math.copysign(tax_values['tax_amount'], base_amount), 2),
@@ -281,6 +286,7 @@ class AccountEdiFormat(models.Model):
             # === Invoice ===
 
             invoice_node['DescripcionOperacion'] = invoice.invoice_origin[:500] if invoice.invoice_origin else 'manual'
+            reagyp = invoice.invoice_line_ids.tax_ids.filtered(lambda t: t.l10n_es_type == 'sujeto_agricultura')
             if invoice.is_sale_document():
                 nif = invoice.company_id.vat[2:] if invoice.company_id.vat.startswith('ES') else invoice.company_id.vat
                 info['IDFactura']['IDEmisorFactura'] = {'NIF': nif}
@@ -322,7 +328,12 @@ class AccountEdiFormat(models.Model):
                 mod_303_11 = self.env.ref('l10n_es.mod_303_11')
                 tax_tags = invoice.invoice_line_ids.tax_ids.invoice_repartition_line_ids.tag_ids
                 intracom = bool(tax_tags & (mod_303_10 + mod_303_11))
-                invoice_node['ClaveRegimenEspecialOTrascendencia'] = '09' if intracom else '01'
+                if intracom:
+                    invoice_node['ClaveRegimenEspecialOTrascendencia'] = '09'
+                elif reagyp:
+                    invoice_node['ClaveRegimenEspecialOTrascendencia'] = '02'
+                else:
+                    invoice_node['ClaveRegimenEspecialOTrascendencia'] = '01'
 
             if invoice.move_type == 'out_invoice':
                 invoice_node['TipoFactura'] = 'F2' if is_simplified else 'F1'
@@ -330,7 +341,10 @@ class AccountEdiFormat(models.Model):
                 invoice_node['TipoFactura'] = 'R5' if is_simplified else 'R1'
                 invoice_node['TipoRectificativa'] = 'I'
             elif invoice.move_type == 'in_invoice':
-                invoice_node['TipoFactura'] = 'F1'
+                if reagyp:
+                    invoice_node['TipoFactura'] = 'F6'
+                else:
+                    invoice_node['TipoFactura'] = 'F1'
             elif invoice.move_type == 'in_refund':
                 invoice_node['TipoFactura'] = 'R4'
                 invoice_node['TipoRectificativa'] = 'I'

--- a/addons/l10n_es_edi_sii/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_sii/tests/test_edi_xml.py
@@ -1181,3 +1181,52 @@ class TestEdiXmls(TestEsEdiCommon):
                 },
                 'PeriodoLiquidacion': {'Periodo': '01', 'Ejercicio': '2019'}
             })
+
+    def test_200_in_invoice_p_iva12_agr(self):
+        """ For bills with the 12% agricuture tax the Clave Regime Special should be E2
+        """
+        with freeze_time(self.frozen_today), \
+             patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
+                   new=mocked_l10n_es_edi_call_web_service_sign):
+            invoice = self.create_invoice(
+                move_type='in_invoice',
+                ref='sup0001',
+                partner_id=self.partner_a.id,
+                l10n_es_registration_date='2019-01-02',
+                invoice_line_ids=[
+                    {
+                        'price_unit': 200.0,
+                        'tax_ids': [(6, 0, self._get_tax_by_xml_id('p_iva12_agr').ids)],
+                    },
+                ],
+            )
+            invoice.action_post()
+
+            generated_files = self._process_documents_web_services(invoice, {'es_sii'})
+            self.assertTrue(generated_files)
+
+            json_file = json.loads(generated_files[0].decode())[0]
+            self.assertEqual(json_file, {
+                'IDFactura': {
+                    'FechaExpedicionFacturaEmisor': '01-01-2019',
+                    'NumSerieFacturaEmisor': 'sup0001',
+                    'IDEmisorFactura': {'IDOtro': {'IDType': '02', 'ID': 'BE0477472701'}, 'NombreRazon': 'partner_a'}
+                },
+                'FacturaRecibida': {
+                    'TipoFactura': 'F6',
+                    'Contraparte': {'IDOtro': {'IDType': '02', 'ID': 'BE0477472701'}, 'NombreRazon': 'partner_a'},
+                    'DescripcionOperacion': 'manual',
+                    'ClaveRegimenEspecialOTrascendencia': '02',
+                    'ImporteTotal': 224.0,
+                    'FechaRegContable': '02-01-2019',
+                    'DesgloseFactura': {
+                        'DesgloseIVA': {
+                            'DetalleIVA': [
+                                {'BaseImponible': 200.0, 'ImporteCompensacionREAGYP': 24.0, 'PorcentCompensacionREAGYP': 12.0},
+                            ]
+                        }
+                    },
+                    'CuotaDeducible': 0.0
+                },
+                'PeriodoLiquidacion': {'Periodo': '01', 'Ejercicio': '2019'}
+            })


### PR DESCRIPTION
Currently, using the tax '12% agri' on a Vendor Bill makes the document
impossible to validate because of the error
`1166 - Valor del campo Tipoimpositivo no está incluido en la lista de
valores permitidos`

Steps to reproduce:
- Have l10n_es_edi_sii module installed and have a tax agency selected.
- Make a Bill using '12% agri' tax

Issue: When sending the bill for validation the error is raised.

This occurs because the field "ClaveRegimenEspecialOTrascendencia" is set to "01",
when it should be "02" for exempt taxes.
Also, in this case TipoImpositivo and CuotaSoportada should be replaced
by PorcentCompensacionREAGYP and ImporteCompensacionREAGYP
https://sede.agenciatributaria.gob.es/Sede/iva/regimenes-tributacion-iva/regimen-especial-agricultura-ganaderia-pesca/que-consiste-regimen-especial-agricultura-pesca.html
https://sede.agenciatributaria.gob.es/static_files/Sede/Procedimiento_ayuda/G417/FicherosSuministros/V_1_1/Validaciones_ErroresSII_v1.1.pdf

opw-4486190