### PR TITLE
[FIX] account: Prevent cancellation of already posted documents

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -9720,6 +9720,13 @@ msgstr ""
 #. module: account
 #. odoo-python
 #: code:addons/account/models/account_move.py:0
+#, python-format
+msgid "Only draft journal entries can be cancelled."
+msgstr ""
+
+#. module: account
+#. odoo-python
+#: code:addons/account/models/account_move.py:0
 #: code:addons/account/models/ir_actions_report.py:0
 #, python-format
 msgid "Only invoices could be printed."
@@ -12380,6 +12387,13 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__module_snailmail_account
 msgid "Snailmail"
+msgstr ""
+
+#. module: account
+#. odoo-python
+#: code:addons/account/models/account_move.py:0
+#, python-format
+msgid "Some journal entries cannot be reset to draft because they are validated in AFIP"
 msgstr ""
 
 #. module: account

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -783,7 +783,7 @@ class TestSequenceMixinConcurrency(TransactionCase):
         with self.env.registry.cursor() as cr:
             env = api.Environment(cr, SUPERUSER_ID, {})
             moves = env['account.move'].browse(self.data['move_ids'])
-            moves.button_draft()
+            moves.filtered(lambda x: x.state in ('posted', 'cancel')).button_draft()
             moves.posted_before = False
             moves.unlink()
             journal = env['account.journal'].browse(self.data['journal_id'])


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR addresses the issue where a document in the 'posted' state could be canceled by users, causing inconsistencies when multiple users interact with the same record. Specifically, for the Argentina localization, invoices are sent to the tax regulatory organization (AFIP) once they are posted, and they cannot remain in a canceled state after being sent.

Current behavior before PR:

Users could cancel a document even if it was already posted, which could result in issues when the invoice was already sent to AFIP. Invoices sent to AFIP cannot be reverted to a canceled state, causing potential problems with tax reporting.

Desired behavior after PR is merged:

The document can no longer be canceled if it is already in the 'posted' state. A UserError will be raised to inform the user that cancellation is not allowed for posted documents, especially when they have been sent to AFIP. This ensures compliance with tax regulations and avoids inconsistencies.


Steps to reproduce the error:

1. User A creates a new invoice and leaves it in the 'draft' state.
2. User B also opens the same invoice in 'draft' state at the same time.
3. User A validates the invoice and posts it, triggering the sending of data to AFIP.
4. Before the system can confirm the posting, User B clicks the "Cancel" button to cancel the invoice.
5. The system allows User B to cancel the invoice, even though it has already been posted by User A and sent to AFIP, causing potential inconsistencies.

This issue arises when two users are consulting and interacting with the same invoice simultaneously: one validates and posts the invoice just a few seconds before the other tries to cancel it.

Video 
https://drive.google.com/file/d/17PQIX6Bc8hhMOZyRsHfEEDv-DI68Jchq/view

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
