### PR TITLE
[IMP] hw_posbox_homepage,hw_drivers: add qr codes

### DIFF
--- a/addons/hw_drivers/tools/wifi.py
+++ b/addons/hw_drivers/tools/wifi.py
@@ -2,14 +2,17 @@
 NetworkManager and ``nmcli`` tool.
 """
 
+import base64
+from io import BytesIO
 import logging
+import qrcode
 import secrets
 import subprocess
 import time
 from pathlib import Path
 from functools import cache
 
-from .helpers import get_ip, get_mac_address, writable
+from .helpers import get_ip, get_mac_address, writable, get_conf
 
 _logger = logging.getLogger(__name__)
 
@@ -269,3 +272,50 @@ def is_access_point():
     # We only get the first line as `lo` can still be active when `wlan0` is up
     device = _nmcli(['-g', 'device', 'connection', 'show', '--active'], sudo=True).splitlines()[0]
     return device == 'lo'
+
+@cache
+def generate_qr_code_image(qr_code_data):
+    """Generate a QR code based on data argument and return it in base64 image format
+    Cached to avoir regenerating the same QR code multiple times
+
+    :param str qr_code_data: Data to encode in the QR code
+    :return: The QR code image in base64 format ready to be used in json format
+    """
+    qr_code = qrcode.QRCode(
+        version=1,
+        error_correction=qrcode.constants.ERROR_CORRECT_L,
+        box_size=6,
+        border=0,
+    )
+    qr_code.add_data(qr_code_data)
+    
+    qr_code.make(fit=True)
+    img = qr_code.make_image(fill_color="black", back_color="transparent")
+    buffered = BytesIO()
+    img.save(buffered, format="PNG")
+    img_base64 = base64.b64encode(buffered.getvalue()).decode()
+    return f"data:image/png;base64,{img_base64}"
+
+def generate_network_qr_codes():
+    """Generate a QR codes for the IoT Box network and its homepage and return them in base64 image format in a dictionary
+    
+    :return: A dictionary containing the QR codes in base64 format
+    :rtype: dict
+    """
+    qr_code_images = {
+        'qr_wifi' : None,
+        'qr_url' : generate_qr_code_image(f'http://{get_ip()}'),
+    }
+    
+    # Generate QR codes which can be used to connect to the IoT Box Wi-Fi network
+    if not is_access_point():
+        wifi_ssid = get_conf('wifi_ssid')
+        wifi_password = get_conf('wifi_password')
+        if wifi_ssid and wifi_password:
+            wifi_data = f"WIFI:S:{wifi_ssid};T:WPA;P:{wifi_password};;;"
+            qr_code_images['qr_wifi'] = generate_qr_code_image(wifi_data)
+    else:
+        access_point_data = f"WIFI:S:{get_access_point_ssid()};T:nopass;;;"
+        qr_code_images['qr_wifi'] = generate_qr_code_image(access_point_data)
+        
+    return qr_code_images

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -154,6 +154,7 @@ class IotBoxOwlHomePage(http.Controller):
         }
 
         six_terminal = helpers.get_conf('six_payment_terminal') or 'Not Configured'
+        network_qr_codes = wifi.generate_network_qr_codes()
 
         return json.dumps({
             'db_uuid': helpers.get_conf('db_uuid'),
@@ -171,6 +172,9 @@ class IotBoxOwlHomePage(http.Controller):
             'system': platform.system(),
             'is_certificate_ok': is_certificate_ok,
             'certificate_details': certificate_details,
+            'wifi_ssid': helpers.get_conf('wifi_ssid'),
+            'qr_code_wifi' : network_qr_codes['qr_wifi'],
+            'qr_code_url' : network_qr_codes['qr_url'],
         })
 
     @http.route('/hw_posbox_homepage/wifi', auth="none", type="http", cors='*')

--- a/addons/hw_posbox_homepage/static/src/app/css/status_display.css
+++ b/addons/hw_posbox_homepage/static/src/app/css/status_display.css
@@ -6,6 +6,21 @@ body {
     background-size: cover;
     height: 100vh;
 }
+.qr-code-box {
+    position: absolute;
+    left: 20px;
+    bottom: 20px;
+}
+.qr-code {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+.qr-code img {
+    width: 150px; /* Ensure wifi and url QR code images appear as same size */
+    height: 150px;
+    object-fit: contain; 
+}
 .status-display-boxes {
     position: absolute;
     right: 20px;

--- a/addons/hw_posbox_homepage/static/src/app/status.js
+++ b/addons/hw_posbox_homepage/static/src/app/status.js
@@ -35,6 +35,56 @@ class StatusPage extends Component {
         <div class="text-center pt-5">
             <img class="odoo-logo" src="/web/static/img/logo2.png" alt="Odoo logo"/>
         </div>
+        <!-- QR Codes shown on status page -->
+        <div class="qr-code-box">
+            <div class="status-display-box qr-code">
+                <div>
+                    <h4 class="text-center mb-1">IoT Box Configuration</h4>
+                    <hr/>
+                    <!-- If the IoT Box is connected to internet -->
+                    <div t-if="!state.data.is_access_point_up and state.data.qr_code_url">
+                        <p>
+                            1. Connect to
+                            <!-- Only wifi connection is shown as ethernet connections look like "Wired connection 2" -->
+                            <t t-if="state.data.wifi_ssid">
+                                <b>
+                                    <t t-out="state.data.wifi_ssid"/>
+                                </b>
+                            </t>
+                            <t t-else=""> the IoT Box network</t>
+                            <br/>
+                            <br/>
+                            <div t-if="state.data.qr_code_wifi" class="qr-code">
+                                <img t-att-src="state.data.qr_code_wifi" alt="QR Code Wi-FI"/>
+                            </div>
+                        </p>
+                        <p>
+                            2. Open the IoT Box setup page
+                            <br/>
+                            <br/>
+                            <div class="qr-code">
+                                <img t-att-src="state.data.qr_code_url" alt="QR Code Homepage"/>
+                            </div>
+                        </p>
+                    </div>
+                    <!-- If the IoT Box is in access point and not connected to internet yet -->
+                    <div t-elif="state.data.is_access_point_up and state.data.qr_code_url and state.data.qr_code_url"> 
+                        <p>1. Connect to the IoT Box network</p>
+                        <div class="qr-code">
+                            <img t-att-src="state.data.qr_code_wifi" alt="QR Code Access Point"/>
+                        </div>
+                        <br/>
+                        <br/>
+                        <p>2. Configure Wi-Fi connection</p>
+                        <div class="qr-code">
+                            <img t-att-src="state.data.qr_code_url" alt="QR Code Wifi Config"/>
+                        </div>
+                        <br/>
+                        <br/>
+                    </div>
+                </div>
+            </div>
+        </div>
         <div class="status-display-boxes">
             <div t-if="state.data.pairing_code and !state.data.is_access_point_up" class="status-display-box">
                 <h4 class="text-center mb-3">Pairing Code</h4>


### PR DESCRIPTION
This PR adds a possibility to easily use smartphone QR codes scanning feature to configure their IoT Boxes

It adds QR codes to the hdmi connected screen which will help the user to connect their IoT Boxes / configure wifi / reach their IoT Box homepage

3 possible scenarios are covered:

**1. The IoT Box is connected to a wifi network**
- 1st QR code is displayed which, when scanned connects the user to the same wifi network as the IoT Box
- 2nd QR code is displayed which, when scanned redirects users to the IoT Box homepage
![image](https://github.com/user-attachments/assets/b46694ee-fe60-4128-b0ab-7caf1bb8c324)

**2. The IoT Box is connected to internet with ethernet cable**
- Since we don't have access to the network's ssid /password in this case, we only display one QR code which redirects to the IoT Box homepage along with a message "Connect to the IoT Box network"
![image](https://github.com/user-attachments/assets/1f0dbcee-7d08-4c02-901b-c8cc359aa31a)

**3. The IoT Box is in access mode and has no internet connection**
- 1st QR code is displayed which, when scanned connects the user to the IoT Box access point wifi
- 2nd QR code is displayed which, when scanned redirects user to `10.11.12.1` access point homepage / wifi configuration page (this is needed as on the smartphones you don't necessarily get the the popup which offers you to open "10.11.12.1" page
![image](https://github.com/user-attachments/assets/7cb262d8-67ec-4fd0-ad83-c2e41d8d0c16)

task-4536759


