### PR TITLE
[FIX] mail: play sound when receiving new message

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -6011,6 +6011,12 @@ msgid "Message should be a valid EmailMessage instance"
 msgstr ""
 
 #. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/discuss/core/common/discuss_notification_settings.xml:0
+msgid "Message sound"
+msgstr ""
+
+#. module: mail
 #: model:ir.model.fields,help:mail.field_mail_message_subtype__name
 msgid ""
 "Message subtype gives a more precise type on the message, especially for "

--- a/addons/mail/static/src/core/common/out_of_focus_service.js
+++ b/addons/mail/static/src/core/common/out_of_focus_service.js
@@ -24,6 +24,8 @@ export class OutOfFocusService {
         this.multiTab = services.multi_tab;
         this.notificationService = services.notification;
         this.soundEffectService = services["mail.sound_effects"];
+        /** @type {import("models").Store} */
+        this.store = services["mail.store"];
         this.closeFuncs = [];
     }
 
@@ -143,7 +145,7 @@ export class OutOfFocusService {
     }
 
     _playSound() {
-        if (this.canPlayAudio && this.multiTab.isOnMainTab()) {
+        if (this.canPlayAudio && this.multiTab.isOnMainTab() && this.store.settings.messageSound) {
             this.soundEffectService.play("new-message");
         }
     }
@@ -158,7 +160,7 @@ export class OutOfFocusService {
 }
 
 export const outOfFocusService = {
-    dependencies: ["multi_tab", "notification", "mail.sound_effects"],
+    dependencies: ["multi_tab", "notification", "mail.sound_effects", "mail.store"],
     /**
      * @param {import("@web/env").OdooEnv} env
      * @param {import("services").ServiceFactories} services

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -44,6 +44,9 @@ patch(Thread.prototype, {
                         chatWindow.fold();
                     }
                 }
+                if (this.store.env.services["multi_tab"].isOnMainTab()) {
+                    this.store.env.services["mail.sound_effects"].play("new-message");
+                }
             }
             this.store.env.services["mail.out_of_focus"].notify(message, this);
         }

--- a/addons/mail/static/src/discuss/core/common/discuss_notification_settings.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_notification_settings.js
@@ -23,6 +23,10 @@ export class DiscussNotificationSettings extends Component {
         }
     }
 
+    onChangeMessageSound() {
+        this.store.settings.messageSound = !this.store.settings.messageSound;
+    }
+
     onChangeMuteDuration(ev) {
         if (ev.target.value === "default") {
             return;

--- a/addons/mail/static/src/discuss/core/common/discuss_notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/discuss_notification_settings.xml
@@ -39,6 +39,14 @@
                     </button>
                 </t>
             </div>
+            <hr class="o-discuss-separator my-1"/>
+            <label class="cursor-pointer d-flex align-items-center my-1">
+                <h5>Message sound</h5>
+                <div class="flex-grow-1"/>
+                <div class="form-check form-switch">
+                    <input class="form-check-input" type="checkbox" role="switch" t-att-checked="store.settings.messageSound" t-on-change="onChangeMessageSound"/>
+                </div>
+            </label>
         </div>
     </t>
 </templates>


### PR DESCRIPTION
Before this commit, when push notifications are enabled, receiving a new message in discuss, was not playing the "new-message" sound effect.

This happens because when notifying new message, it plays the sound at the very end of processing of notify. However, the notify code was early returning in case it detects that there's push notification handled by service worker.

This made sense because out-of-focus service has also some code for the showing of push notification, but this is redundant with the service worker behaviour on receiving the push notifcation.

However, the sound playing is still desirable, even though the service worker lacks this part of feature.

This commit fixes the issue by playing the sound effect of new message early.

Also some users really want no sound at all. This commit also adds a new entry "Message sound" in the Notification settings of Discuss to toggle enabling of new message sound (enabled by default).

By the way, the playing of new message sound should not be dependent on whether the user has focus or not: other messaging apps play the sound regardless of focus which makes more sense.

<img width="653" alt="Screenshot 2025-02-17 at 18 13 26" src="https://github.com/user-attachments/assets/33c40f91-0bb2-42ed-9181-7cbbe0b2e7c6" />