### PR TITLE
[FIX] point_of_sale: fix mocked function

### DIFF
--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1660,7 +1660,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         partner_test_a = self.env["res.partner"].create({"name": "APartner"})
         self.env["res.partner"].create({"name": "BPartner", "zip": 1111})
 
-        def mocked_get_limited_partners_loading(self):
+        def mocked_get_limited_partners_loading(self, offset=0):
             return [(partner_test_a.id,)]
 
         self.main_pos_config.with_user(self.pos_user).open_ui()


### PR DESCRIPTION
Fix args missing in a mocked method in the test.

rb error: 114229

