### PR TITLE
[IMP] stock: forecast ui improvement

### DIFF
--- a/addons/mrp/report/stock_forecasted.py
+++ b/addons/mrp/report/stock_forecasted.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-from odoo import api, models
+from odoo import models
 
 
 class StockForecasted_Product_Product(models.AbstractModel):
@@ -22,28 +19,68 @@ class StockForecasted_Product_Product(models.AbstractModel):
         out_domain += [('raw_material_production_id', '=', False)]
         return in_domain, out_domain
 
-    def _get_report_header(self, product_template_ids, product_ids, wh_location_ids):
-        res = super()._get_report_header(product_template_ids, product_ids, wh_location_ids)
-        res['draft_production_qty'] = {}
+    def _get_report_data(self, product_template_ids=False, product_ids=False):
+        res = super()._get_report_data(product_template_ids, product_ids)
+        mo_warehouse_data = self._get_draft_production_data(product_template_ids, product_ids, res['warehouse_view_locations'])
+        if res['multiple_warehouses']:
+            for warehouse in res['warehouses']:
+                warehouse['draft_production_qty'] = {
+                    'in': 0.0,
+                    'out': 0.0
+                }
+                warehouse_data = mo_warehouse_data.get(warehouse['id'])
+                if warehouse_data:
+                    warehouse['draft_production_qty'].update({
+                        'in': warehouse_data['production_qty_in'],
+                        'out': warehouse_data['production_qty_out']
+                    })
+
+                    # update total quantities
+                    warehouse['qty']['in'] += warehouse['draft_production_qty']['in']
+                    warehouse['qty']['out'] += warehouse['draft_production_qty']['out']
+        else:
+            warehouse_id = res['warehouses'][0]['id']
+            warehouse_data = mo_warehouse_data.get(warehouse_id, {})
+            res['draft_production_qty'] = {
+                'in': warehouse_data.get('production_qty_in', 0.0),
+                'out': warehouse_data.get('production_qty_out', 0.0)
+            }
+            res['qty']['in'] += res['draft_production_qty']['in']
+            res['qty']['out'] += res['draft_production_qty']['out']
+        return res
+
+    def _get_draft_production_data(self, product_template_ids=False, product_ids=False, wh_locations=False):
+        """
+        Draft production data grouped by warehouse
+        :return: Dictionary mapping warehouse_id to draft production data
+        :rtype: dict[int, dict[float]]
+        """
         domain = self._product_domain(product_template_ids, product_ids)
         domain += [('state', '=', 'draft')]
 
         # Pending incoming quantity.
-        mo_domain = domain + [('location_dest_id', 'in', wh_location_ids)]
-        [product_qty] = self.env['mrp.production']._read_group(mo_domain, aggregates=['product_qty:sum'])[0]
-        res['draft_production_qty']['in'] = product_qty or 0.0
+        mo_domain = domain + [('location_dest_id', 'in', wh_locations)]
+        grouped_in_data = dict(
+            self.env['mrp.production']._read_group(mo_domain, ['warehouse_id'], aggregates=['product_qty:sum'])
+        )
 
         # Pending outgoing quantity.
         move_domain = domain + [
             ('raw_material_production_id', '!=', False),
-            ('location_id', 'in', wh_location_ids),
+            ('location_id', 'in', wh_locations),
         ]
-        [product_qty] = self.env['stock.move']._read_group(move_domain, aggregates=['product_qty:sum'])[0]
-        res['draft_production_qty']['out'] = product_qty or 0.0
-        res['qty']['in'] += res['draft_production_qty']['in']
-        res['qty']['out'] += res['draft_production_qty']['out']
+        grouped_out_data = dict(
+            self.env['stock.move']._read_group(move_domain, ['warehouse_id'], aggregates=['product_qty:sum'])
+        )
+        all_warehouse_ids = set(grouped_in_data.keys()) | set(grouped_out_data.keys())
 
-        return res
+        production_data_by_warehouse = {}
+        for warehouse in all_warehouse_ids:
+            production_data_by_warehouse[warehouse.id] = {
+                'production_qty_in': grouped_in_data.get(warehouse, 0.0),
+                'production_qty_out': grouped_out_data.get(warehouse, 0.0),
+            }
+        return production_data_by_warehouse
 
     def _get_reservation_data(self, move):
         if move.production_id:

--- a/addons/mrp/static/src/mrp_forecasted/forecasted_details.xml
+++ b/addons/mrp/static/src/mrp_forecasted/forecasted_details.xml
@@ -1,16 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<templates id="template">
-    <t t-name="mrp.ForecastedDetails" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
-        <xpath expr="//tr[@name='draft_picking_in']" position="after">
-            <tr t-if="props.docs.draft_production_qty.in" name="draft_mo_in">
+<templates id="template" xml:space="preserve">
+    <t t-name="mrp.ForecastedDetailsTable" t-inherit="stock.ForecastedDetailsTable" t-inherit-mode="extension">
+        <xpath expr="//tbody/tr[@name='draft_picking_in']" position="after">
+            <tr t-if="docs.draft_production_qty and docs.draft_production_qty.in" name="draft_mo_in">
                 <td colspan="2">Production of Draft MO</td>
-                <td t-out="_formatFloat(props.docs.draft_production_qty.in)" class="text-end"/>
+                <td t-if="docs.multiple_product"/>
+                <td t-out="_formatFloat(docs.draft_production_qty.in)" class="text-end"/>
+                <td/>
             </tr>
         </xpath>
-        <xpath expr="//tr[@name='draft_picking_out']" position="after">
-            <tr t-if="props.docs.draft_production_qty.out" name="draft_mo_out">
+        <xpath expr="//tbody/tr[@name='draft_picking_out']" position="after">
+            <tr t-if="docs.draft_production_qty and docs.draft_production_qty.out" name="draft_mo_out">
                 <td colspan="2">Component of Draft MO</td>
-                <td t-out="_formatFloat(-props.docs.draft_production_qty.out)" class="text-end"/>
+                <td t-if="docs.multiple_product"/>
+                <td t-out="_formatFloat(docs.draft_production_qty.out)" class="text-end"/>
+                <td/>
             </tr>
         </xpath>
         <xpath expr="//button[@name='change_priority_link']" position="after">

--- a/addons/product_expiry/static/src/forecasted_details.xml
+++ b/addons/product_expiry/static/src/forecasted_details.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<templates xml:space="preserve">
+<templates id="template" xml:space="preserve">
 
-    <t t-name="product_expiry.ForecastedDetails" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
+    <t t-name="product_expiry.ForecastedDetails" t-inherit="stock.ForecastedDetailsTable" t-inherit-mode="extension">
         <xpath expr="//t[@t-out='freeStockLabel']" position="before">
             <t t-elif="line.removal_date">
                 <t t-if="line.removal_date === -1">

--- a/addons/purchase_stock/report/stock_forecasted.py
+++ b/addons/purchase_stock/report/stock_forecasted.py
@@ -7,8 +7,32 @@ from odoo import models
 class StockForecasted_Product_Product(models.AbstractModel):
     _inherit = 'stock.forecasted_product_product'
 
-    def _get_report_header(self, product_template_ids, product_ids, wh_location_ids):
-        res = super()._get_report_header(product_template_ids, product_ids, wh_location_ids)
+    def _get_report_data(self, product_template_ids=False, product_ids=False):
+        res = super()._get_report_data(product_template_ids, product_ids)
+        if res['multiple_warehouses']:
+            for warehouse in res['warehouses']:
+                purchase_data = self.with_context(warehouse_id=warehouse['id'])._get_draft_purchase_order_data(product_template_ids, product_ids)
+                warehouse.update({**purchase_data})
+                warehouse['qty']['in'] += purchase_data['draft_purchase_qty']
+        else:
+            purchase_data = self.with_context(warehouse_id=res['warehouses'][0]['id'])._get_draft_purchase_order_data(product_template_ids, product_ids)
+            res.update({
+                **purchase_data
+            })
+            res['qty']['in'] += purchase_data['draft_purchase_qty']
+        return res
+
+    def _product_purchase_domain(self, product_template_ids, product_ids):
+        if product_ids:
+            return [('product_id', 'in', product_ids)]
+        elif product_template_ids:
+            subquery_products = self.env['product.product']._search(
+                [('product_tmpl_id', 'in', product_template_ids)]
+            )
+            return [('product_id', 'in', subquery_products)]
+
+    def _get_draft_purchase_order_data(self, product_template_ids=False, product_ids=False):
+        """ Draft purchase order data get by warehouse"""
         domain = [('state', 'in', ['draft', 'sent', 'to approve'])]
         domain += self._product_purchase_domain(product_template_ids, product_ids)
         warehouse_id = self.env.context.get('warehouse_id', False)
@@ -20,17 +44,8 @@ class StockForecasted_Product_Product(models.AbstractModel):
         domain += [('company_id', '=', company.id)]
         po_lines = self.env['purchase.order.line'].sudo().search(domain)
         in_sum = sum(po_lines.mapped('product_uom_qty'))
-        res['draft_purchase_qty'] = in_sum
-        res['draft_purchase_orders'] = po_lines.mapped("order_id").sorted(key=lambda po: po.name).read(fields=['id', 'name'])
-        res['draft_purchase_orders_matched'] = self.env.context.get('purchase_line_to_match_id') in po_lines.ids
-        res['qty']['in'] += in_sum
-        return res
-
-    def _product_purchase_domain(self, product_template_ids, product_ids):
-        if product_ids:
-            return [('product_id', 'in', product_ids)]
-        elif product_template_ids:
-            subquery_products = self.env['product.product']._search(
-                [('product_tmpl_id', 'in', product_template_ids)]
-            )
-            return [('product_id', 'in', subquery_products)]
+        return {
+            'draft_purchase_qty': in_sum,
+            'draft_purchase_orders': po_lines.mapped("order_id").sorted(key=lambda po: po.name).read(fields=['id', 'name']),
+            'draft_purchase_orders_matched': self.env.context.get('purchase_line_to_match_id') in po_lines.ids,
+        }

--- a/addons/purchase_stock/static/src/purchase_stock_forecasted/forecasted_details.xml
+++ b/addons/purchase_stock/static/src/purchase_stock_forecasted/forecasted_details.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template" xml:space="preserve">
-     <t t-name="purchase_stock.ForecastedDetails" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
-         <xpath expr="//tr[@name='draft_picking_in']" position="after">
-            <tr t-if="props.docs.draft_purchase_qty" name="draft_po_in" t-attf-class="#{props.docs.draft_purchase_orders_matched and 'table-info'}">
-                <td colspan="2">Requests for quotation</td>
-                <td t-out="_formatFloat(props.docs.draft_purchase_qty)" class="text-end"/>
+    <t t-name="purchase_stock.ForecastedDetailsTable" t-inherit="stock.ForecastedDetailsTable" t-inherit-mode="extension">
+        <xpath expr="//tbody/tr[@name='draft_picking_in']" position="after">
+            <tr t-if="docs.draft_purchase_qty" name="draft_po_in" t-attf-class="#{docs.draft_purchase_orders_matched and 'table-info'}">
+                <td colspan="2">Requests for Quotation</td>
+                <td t-if="docs.multiple_product"/>
+                <td t-out="_formatFloat(docs.draft_purchase_qty)" class="text-end"/>
                 <td>
-                    <t t-foreach="props.docs.draft_purchase_orders" t-as="purchase_order" t-key="purchase_order_index">
+                    <t t-foreach="docs.draft_purchase_orders" t-as="purchase_order" t-key="purchase_order_index">
                         <t t-if="purchase_order_index > 0"> | </t>
                         <a t-attf-href="#" t-out="purchase_order.name"
-                            class="fw-bold"
-                            t-on-click.prevent="() => this.props.openView('purchase.order', 'form', purchase_order.id)"/>
+                           class="fw-bold"
+                           t-on-click.prevent="() => this.props.openView('purchase.order', 'form', purchase_order.id)"/>
                     </t>
                 </td>
+                <td/>
             </tr>
         </xpath>
     </t>

--- a/addons/sale_stock/report/stock_forecasted.py
+++ b/addons/sale_stock/report/stock_forecasted.py
@@ -30,19 +30,23 @@ class StockForecasted_Product_Product(models.AbstractModel):
             })
         return line
 
-    def _get_report_header(self, product_template_ids, product_ids, wh_location_ids):
-        res = super()._get_report_header(product_template_ids, product_ids, wh_location_ids)
-        domain = self._product_sale_domain(product_template_ids, product_ids)
-        so_lines = self.env['sale.order.line'].sudo().search(domain)
-        out_sum = 0
-        if so_lines:
-            product_uom = so_lines[0].product_id.uom_id
-            quantities = so_lines.mapped(lambda line: line.product_uom_id._compute_quantity(line.product_uom_qty, product_uom))
-            out_sum = sum(quantities)
-        res['draft_sale_qty'] = out_sum
-        res['draft_sale_orders'] = so_lines.mapped("order_id").sorted(key=lambda so: so.name).read(fields=['id', 'name'])
-        res['draft_sale_orders_matched'] = self.env.context.get('sale_line_to_match_id') in so_lines.ids
-        res['qty']['out'] += out_sum
+    def _get_report_data(self, product_template_ids=False, product_ids=False):
+        res = super()._get_report_data(product_template_ids, product_ids)
+        sale_warehouse_data = self._get_draft_sale_order_data(product_template_ids, product_ids)
+        if res['multiple_warehouses']:
+            for warehouse in res['warehouses']:
+                warehouse_sale_data = sale_warehouse_data.get(warehouse['id'])
+                if warehouse_sale_data:
+                    warehouse.update({**warehouse_sale_data})
+                    warehouse['qty']['out'] += warehouse_sale_data['draft_sale_qty']
+        else:
+            warehouse_id = res['warehouses'][0]['id']
+            warehouse_sale_data = sale_warehouse_data.get(warehouse_id)
+            if warehouse_sale_data:
+                res.update({
+                    **warehouse_sale_data
+                })
+                res['qty']['out'] += warehouse_sale_data['draft_sale_qty']
         return res
 
     def _product_sale_domain(self, product_template_ids, product_ids):
@@ -51,7 +55,30 @@ class StockForecasted_Product_Product(models.AbstractModel):
             domain += [('product_template_id', 'in', product_template_ids)]
         elif product_ids:
             domain += [('product_id', 'in', product_ids)]
-        warehouse_id = self.env.context.get('warehouse_id', False)
-        if warehouse_id:
-            domain += [('warehouse_id', '=', warehouse_id)]
         return domain
+
+    def _get_draft_sale_order_data(self, product_template_ids=False, product_ids=False):
+        """
+        Draft sale order data grouped by warehouse
+        :return: Dictionary mapping warehouse_id to draft sale data
+        :rtype: dict[int, dict[float | list | bool]]
+        """
+        domain = self._product_sale_domain(product_template_ids, product_ids)
+        grouped_data = dict(
+            self.env['sale.order.line'].sudo()._read_group(domain, ['warehouse_id'], aggregates=['id:recordset'])
+        )
+
+        sale_data_by_warehouse = {}
+        for warehouse in grouped_data:
+            so_lines = grouped_data[warehouse]
+            out_sum = 0
+            if so_lines:
+                product_uom = so_lines[0].product_id.uom_id
+                quantities = so_lines.mapped(lambda line: line.product_uom_id._compute_quantity(line.product_uom_qty, product_uom))
+                out_sum = sum(quantities)
+            sale_data_by_warehouse[warehouse.id] = {
+                'draft_sale_qty': out_sum,
+                'draft_sale_orders': so_lines.mapped("order_id").sorted(key=lambda so: so.name).read(fields=['id', 'name']),
+                'draft_sale_orders_matched': self.env.context.get('sale_line_to_match_id') in so_lines.ids
+            }
+        return sale_data_by_warehouse

--- a/addons/sale_stock/static/src/sale_stock_forecasted/forecasted_details.xml
+++ b/addons/sale_stock/static/src/sale_stock_forecasted/forecasted_details.xml
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="sale_stock.ForecastedDetails" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
-        <xpath expr="//tr[@name='draft_picking_out']" position="after">
-            <tr t-if="props.docs.draft_sale_qty" name="draft_so_out" t-attf-class="#{props.docs.draft_sale_orders_matched and 'table-info'}">
+    <t t-name="sale_stock.ForecastedDetailsTable" t-inherit="stock.ForecastedDetailsTable" t-inherit-mode="extension">
+        <xpath expr="//tbody/tr[@name='draft_picking_out']" position="after">
+            <tr t-if="docs.draft_sale_qty" name="draft_so_out" t-attf-class="#{docs.draft_sale_orders_matched and 'table-info'}">
                 <td colspan="2">Quotations</td>
-                <td t-out="_formatFloat(-props.docs.draft_sale_qty)" class="text-end"/>
+                <td t-if="docs.multiple_product"/>
+                <td t-out="_formatFloat(docs.draft_sale_qty)" class="text-end"/>
                 <td>
-                    <t t-foreach="props.docs.draft_sale_orders" t-as="sale_order" t-key="sale_order_index">
+                    <t t-foreach="docs.draft_sale_orders or []" t-as="sale_order" t-key="sale_order.id">
                         <t t-if="sale_order_index > 0"> | </t>
-                        <a t-attf-href="#" t-out="sale_order.name"
-                            class="fw-bold"
-                            t-on-click.prevent="() => this.props.openView('sale.order', 'form', sale_order.id)"/>
+                        <a href="#" t-out="sale_order.name" class="fw-bold"
+                           t-on-click.prevent="() => this.props.openView('sale.order', 'form', sale_order.id)"/>
                     </t>
                 </td>
             </tr>
         </xpath>
+
         <xpath expr="//td[@name='usedby_cell']" position="inside">
             <span t-if="line.move_out and line.move_out.picking_id and line.move_out.picking_id.sale_id">
                 | <span t-out="_formatMonetary(line.move_out.picking_id.sale_id.amount_untaxed, line.move_out.picking_id.sale_id.currency_id.id)" class="fw-bold"/>

--- a/addons/stock/static/src/stock_forecasted/forecasted_buttons.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_buttons.js
@@ -1,6 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import { Component, markup } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 
 export class ForecastedButtons extends Component {
     static template = "stock.ForecastedButtons";
@@ -44,17 +44,6 @@ export class ForecastedButtons extends Component {
             target: 'new',
             context: context,
         };
-        return this.actionService.doAction(action, { onClose: this._onClose.bind(this) });
-    }
-
-    async _onClickUpdateQuantity() {
-        const action = await this.orm.call(this.resModel, "action_open_quants", [[this.productId]]);
-        if (action.res_model === "stock.quant") { // Quant view in inventory mode.
-            action.views = [[false, "list"]];
-        }
-        if (action.help) {
-            action.help = markup(action.help);
-        }
         return this.actionService.doAction(action, { onClose: this._onClose.bind(this) });
     }
 }

--- a/addons/stock/static/src/stock_forecasted/forecasted_buttons.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_buttons.xml
@@ -6,10 +6,6 @@
             class="o_forecasted_replenish_btn btn btn-primary">
             Replenish
         </button>
-        <button title="Update Quantity" t-on-click="_onClickUpdateQuantity"
-            class="o_forecasted_update_qty_btn btn btn-secondary">
-            Update Quantity
-        </button>
     </t>
 
 </templates>

--- a/addons/stock/static/src/stock_forecasted/forecasted_details.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.xml
@@ -1,119 +1,161 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="stock.ForecastedDetails">
-        <table class="table table-bordered bg-view">
-            <thead>
-                <tr class="bg-light">
-                    <td>Replenishment</td>
-                    <td>Receipt</td>
-                    <td t-if="props.docs.multiple_product">Product</td>
-                    <td class="text-end"><t t-out="props.docs.uom"/></td>
-                    <td>Used by</td>
-                    <td>Delivery</td>
-                </tr>
-            </thead>
-            <tbody>
-                <tr t-if="onHandCondition">
-                    <td>Inventory On Hand</td>
-                    <td/>
-                    <td t-if="props.docs.multiple_product"/>
-                    <td class="text-end">0</td>
-                    <td/>
-                    <td/>
-                    <td/>
-                    <td/>
-                </tr>
-                <tr t-foreach="props.docs.lines" t-as="line" t-key="line_index" t-attf-class="#{line.is_matched and 'table-info'}">
-                    <td t-attf-class="#{line.is_late and 'table-danger' or classForLine(line)}">
-                        <a t-if="line.document_in"
-                            href="#"
-                            t-on-click.prevent="() => this.props.openView(line.document_in._name, 'form', line.document_in.id)"
-                            t-out="line.document_in.name"
-                            class="fw-bold"/>
-
-                        <t t-elif="line.reservation">
-                            <a t-out="line.reservation.name" href="#" class="fw-bold"
-                               t-on-click.prevent="() => this.props.openView(line.reservation._name, 'form', line.reservation.id)"
-                                /> reserved
-                            <button t-if="displayReserve(line)"
+    <t t-name="stock.ForecastedDetailsTable">
+        <tbody>
+            <tr t-if="onHandCondition">
+                <td>Inventory On Hand</td>
+                <td/>
+                <td t-if="docs.multiple_product"/>
+                <td class="text-end">0</td>
+                <td/>
+                <td/>
+            </tr>
+            <tr t-foreach="lines" t-as="line" t-key="line_index" t-attf-class="#{line.is_matched and 'table-info'}">
+                <td t-attf-class="#{line.is_late and 'table-danger'}">
+                    <a t-if="line.document_in"
+                        href="#"
+                        t-on-click.prevent="() => this.props.openView(line.document_in._name, 'form', line.document_in.id)"
+                        t-out="line.document_in.name"
+                        class="fw-bold"/>
+                    <t t-elif="line.reservation">
+                        <a t-out="line.reservation.name" href="#" class="fw-bold"
+                           t-on-click.prevent="() => this.props.openView(line.reservation._name, 'form', line.reservation.id)"/> reserved
+                        <button t-if="displayReserve(line)"
                                 class="btn btn-sm btn-primary o_report_replenish_unreserve"
                                 name="unreserve_link"
                                 t-on-click="() => this._unreserve(line.move_out.id)">
-                                Unreserve
-                            </button>
-                        </t>
-                        <t t-elif="line.in_transit">
-                            <t t-if="line.move_out">
-                                <span>Stock In Transit</span>
-                            </t>
-                            <t t-else="">
-                                <span>Free Stock in Transit</span>
-                            </t>
-                        </t>
-                        <t t-elif="line.replenishment_filled">
-                            <t t-if="line.document_out">Inventory On Hand
-                                <button t-if="displayReserve(line)"
+                            Unreserve
+                        </button>
+                    </t>
+                    <t t-elif="line.in_transit">
+                        <t t-if="line.move_out"><span>Stock In Transit</span></t>
+                        <t t-else=""><span>Free Stock in personally</span></t>
+                    </t>
+                    <t t-elif="line.replenishment_filled">
+                        <t t-if="line.document_out">Inventory On Hand
+                            <button t-if="displayReserve(line)"
                                     class="btn btn-sm btn-primary"
                                     name="reserve_link"
                                     t-on-click="() => this._reserve(line.move_out.id)">
-                                    Reserve
-                                </button>
-                            </t>
-                            <t t-else="" t-out="freeStockLabel"/>
+                                Reserve
+                            </button>
                         </t>
-                        <span t-else="" class="text-muted">Not Available</span>
-                    </td>
-                    <td t-out="line.receipt_date or ''"
-                        t-attf-class="#{line.is_late and 'table-danger' or classForLine(line)}"/>
-                    <td t-if="props.docs.multiple_product" t-out="line.product.display_name" t-att-class="classForLine(line)"/>
-                    <td class="text-end" t-att-class="classForLine(line)"><t t-if="! line.replenishment_filled">- </t><t t-out="_formatFloat(line.quantity)"/></td>
-                    <td t-attf-class="#{! line.replenishment_filled and 'table-danger'}" name="usedby_cell">
-                        <button t-if="line.move_out and line.move_out.picking_id"
+                        <t t-else="" t-out="freeStockLabel"/>
+                    </t>
+                    <span t-else="" class="text-muted">Not Available</span>
+                </td>
+                <td t-out="line.receipt_date or ''" t-attf-class="#{line.is_late and 'table-danger'}"/>
+                <td t-if="docs.multiple_product" t-out="line.product.display_name" t-att-class="classForLine(line)"/>
+                <td class="text-end"><t t-if="! line.replenishment_filled">- </t><t t-out="_formatFloat(line.quantity)"/></td>
+                <td t-attf-class="#{! line.replenishment_filled and 'table-danger'}" name="usedby_cell">
+                    <button t-if="line.move_out and line.move_out.picking_id"
                             t-attf-class="o_priority o_priority_star me-1 fa fa-star#{line.move_out.picking_id.priority=='1' ? '' : '-o'}"
                             t-on-click="() => this._onClickChangePriority('stock.picking', line.move_out.picking_id)"
                             name="change_priority_link"/>
-                        <a t-if="line.document_out"
-                            href="#"
-                            t-on-click.prevent="() => this.props.openView(line.document_out._name, 'form', line.document_out.id)"
-                            t-out="line.document_out.name"
-                            class="fw-bold"/>
-                    </td>
-                    <td t-out="line.delivery_date or ''"
-                        t-attf-class="#{! line.replenishment_filled and 'table-danger'}"/>
-                </tr>
-                <tr t-if="this.props.docs.qty_to_order">
-                    <td>To Order</td>
-                    <td t-out="this.props.docs.lead_days_date"/>
-                    <td t-out="_formatFloat(this.props.docs.qty_to_order)" class="text-end"/>
-                </tr>
-                <tr t-if="this.props.docs.qty_to_order !== this.props.docs.qty_to_order_with_visibility_days">
-                    <td>To Order with Visibility Days</td>
-                    <td t-out="this.props.docs.visibility_days_date"/>
-                    <td t-out="_formatFloat(this.props.docs.qty_to_order_with_visibility_days)" class="text-end"/>
-                </tr>
-            </tbody>
-            <thead>
-                <tr class="o_forecasted_row bg-200">
-                    <td colspan="2">Forecasted Inventory</td>
-                    <td t-out="_formatFloat(this.props.docs.virtual_available)" class="text-end"/>
-                </tr>
-            </thead>
-            <tbody t-if="props.docs.qty.in or props.docs.qty.out">
-                <tr t-if="props.docs.draft_picking_qty.in" name="draft_picking_in">
-                    <td colspan="2">Incoming Draft Transfer</td>
-                    <td t-out="_formatFloat(this.props.docs.draft_picking_qty.in)" class="text-end"/>
-                </tr>
-                <tr t-if="props.docs.draft_picking_qty.out" name="draft_picking_out">
-                    <td colspan="2">Outgoing Draft Transfer</td>
-                    <td t-out="_formatFloat(this.props.docs.draft_picking_qty.out)" class="text-end"/>
-                </tr>
-            </tbody>
-            <thead>
-                <tr class="o_forecasted_row bg-200">
-                    <td colspan="2">Forecasted with Pending</td>
-                    <td t-out="_formatFloat(futureVirtualAvailable)" class="text-end"/>
-                </tr>
-            </thead>
-        </table>
+                    <a t-if="line.document_out"
+                        href="#"
+                        t-on-click.prevent="() => this.props.openView(line.document_out._name, 'form', line.document_out.id)"
+                        t-out="line.document_out.name"
+                        class="fw-bold"/>
+                </td>
+                <td t-out="line.delivery_date or ''" t-attf-class="#{! line.replenishment_filled and 'table-danger'}"/>
+            </tr>
+            <tr t-if="docs.qty_to_order">
+                <td>To Order</td>
+                <td t-out="docs.lead_days_date"/>
+                <td t-if="docs.multiple_product"/>
+                <td t-out="_formatFloat(docs.qty_to_order)" class="text-end"/>
+                <td/>
+                <td/>
+            </tr>
+            <tr t-if="docs.qty_to_order !== docs.qty_to_order_with_visibility_days">
+                <td>To Order with Visibility Days</td>
+                <td t-out="docs.visibility_days_date"/>
+                <td t-if="docs.multiple_product"/>
+                <td t-out="_formatFloat(docs.qty_to_order_with_visibility_days)" class="text-end"/>
+                <td/>
+                <td/>
+            </tr>
+        </tbody>
+        <thead>
+            <tr class="o_forecasted_row bg-200">
+                <td colspan="2">Forecasted Inventory</td>
+                <td t-if="docs.multiple_product"/>
+                <td t-out="_formatFloat(docs.virtual_available)" class="text-end"/>
+                <td colspan="2"/>
+            </tr>
+        </thead>
+        <tbody>
+            <tr t-if="docs.draft_picking_qty.in" name="draft_picking_in">
+                <td colspan="2">Incoming Draft Transfer</td>
+                <td t-if="docs.multiple_product"/>
+                <td t-out="_formatFloat(docs.draft_picking_qty.in)" class="text-end"/>
+                <td colspan="2"/>
+            </tr>
+            <tr t-if="docs.draft_picking_qty.out" name="draft_picking_out">
+                <td colspan="2">Outgoing Draft Transfer</td>
+                <td t-if="docs.multiple_product"/>
+                <td t-out="_formatFloat(docs.draft_picking_qty.out)" class="text-end"/>
+                <td colspan="2"/>
+            </tr>
+        </tbody>
+        <thead>
+            <tr class="o_forecasted_row bg-200">
+                <td colspan="2">Forecasted with Pending</td>
+                <td t-if="docs.multiple_product"/>
+                <td t-out="_formatFloat(future_virtual_available)" class="text-end"/>
+                <td colspan="2"/>
+            </tr>
+        </thead>
+    </t>
+
+    <!-- Main Template -->
+    <t t-name="stock.ForecastedDetails">
+        <div class="stock_forecast_container">
+            <table class="table table-bordered bg-view">
+                <thead>
+                    <tr class="bg-light">
+                        <td>Replenishment</td>
+                        <td>Receipt</td>
+                        <td>Product</td>
+                        <!-- <td class="text-end"><t t-out="props.docs.uom"/></td> -->
+                        <td>Used by</td>
+                        <td>Delivery</td>
+                    </tr>
+                </thead>
+                <!-- Single Warehouse Case -->
+                <t t-if="!props.docs.multiple_warehouses">
+                    <t t-set="docs" t-value="props.docs"/>
+                    <t t-set="lines" t-value="props.docs.lines"/>
+                    <t t-set="future_virtual_available" t-value="futureVirtualAvailable"/>
+                    <t t-call="stock.ForecastedDetailsTable"/>
+                </t>
+                <!-- Multiple Warehouses Case -->
+                <t t-if="props.docs.multiple_warehouses">
+                    <t t-foreach="props.docs.warehouses" t-as="warehouse" t-key="warehouse.id">
+                        <tbody>
+                            <tr>
+                                <td colspan="6" class="p-1 m-1">
+                                    <div class="d-flex">
+                                        <span t-on-click="() => this.toggleFolded(warehouse.id)" style="margin-right: 5px"
+                                             t-attf-title="{{ this.isFolded(warehouse.id) ? 'Expand Warehouse' : 'Collapse Warehouse' }}"
+                                             t-attf-aria-label="{{ this.isFolded(warehouse.id) ? 'Expand Warehouse' : 'Collapse Warehouse' }}">
+                                            <i t-attf-class="fa fa-fw fa-caret-{{ this.isFolded(warehouse.id) ? 'right' : 'down' }}"/>
+                                        </span>
+                                        <p t-esc="warehouse.name" class="p-0 m-0 fw-bold"/>
+                                    </div>
+                                </td>
+                            </tr>
+                        </tbody>
+                        <t t-if="!this.isFolded(warehouse.id)">
+                            <t t-set="docs" t-value="warehouse"/>
+                            <t t-set="lines" t-value="warehouse.lines"/>
+                            <t t-set="future_virtual_available" t-value="warehouse.virtual_available + warehouse.draft_picking_qty.in - warehouse.draft_picking_qty.out"/>
+                            <t t-call="stock.ForecastedDetailsTable"/>
+                        </t>
+                    </t>
+                </t>
+            </table>
+        </div>
     </t>
 </templates>

--- a/addons/stock/static/src/stock_forecasted/forecasted_graph.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_graph.js
@@ -9,6 +9,7 @@ export class StockForecastedGraphRenderer extends GraphRenderer {
 export const StockForecastedGraphView = {
     ...graphView,
     Renderer: StockForecastedGraphRenderer,
+    buttonTemplate: "stock.StockForecastGraphView.Buttons",
 };
 
 registry.category("views").add("stock_forecasted_graph", StockForecastedGraphView);

--- a/addons/stock/static/src/stock_forecasted/forecasted_graph.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_graph.xml
@@ -5,4 +5,7 @@
             <attribute name="height">300</attribute>
         </xpath>
     </t>
+    <t t-name="stock.StockForecastGraphView.Buttons">
+        <t t-if="props.model.searchParams.context.show_graph_buttons" t-call="web.GraphView.Buttons"/>
+    </t>
 </templates>

--- a/addons/stock/static/src/stock_forecasted/forecasted_header.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.js
@@ -21,4 +21,23 @@ export class ForecastedHeader extends Component {
         }
         return this.action.doAction(action);
     }
+
+    async _onClickTransfers(type){
+        const action = await this.orm.call(
+            'stock.picking', this._getPickingActionMethod(type), [], {}
+        );
+        action.domain = [['product_id', 'in', this.props.docs.product_variants_ids]];
+        if (action.help) {
+            action.help = markup(action.help);
+        }
+        return this.action.doAction(action);
+    }
+
+    _getPickingActionMethod(type){
+        const methodMap = {
+            incoming: 'get_action_picking_tree_incoming',
+            outgoing: 'get_action_picking_tree_outgoing',
+        }
+        return methodMap[type];
+    }
 }

--- a/addons/stock/static/src/stock_forecasted/forecasted_header.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.xml
@@ -41,14 +41,18 @@
                 <div class="h3 col-md-auto text-center">+</div>
                 <div t-attf-class="col-md-auto text-center #{props.docs.incoming_qty}">
                     <div class="h3">
-                        <t t-out="_formatFloat(this.props.docs.incoming_qty)"/>
+                        <a href="#"
+                            t-on-click.prevent="(ev) => this._onClickTransfers('incoming')"
+                           t-out="_formatFloat(this.props.docs.incoming_qty)"/>
                     </div>
                     <div>Incoming</div>
                 </div>
                 <div class="h3 col-md-auto text-center">-</div>
                 <div t-attf-class="col-md-auto text-center #{props.docs.outgoing_qty}">
                     <div class="h3">
-                        <t t-out="_formatFloat(this.props.docs.outgoing_qty)"/>
+                        <a href="#"
+                            t-on-click.prevent="(ev) => this._onClickTransfers('outgoing')"
+                           t-out="_formatFloat(this.props.docs.outgoing_qty)"/>
                     </div>
                     <div>Outgoing</div>
                 </div>

--- a/addons/stock/static/src/stock_forecasted/forecasted_header.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.xml
@@ -19,15 +19,6 @@
                         </t>
                     </t>
                 </h3>
-                <h6 t-if="props.docs.product_templates and props.docs.product_variants and props.docs.product_templates.length != props.docs.product_variants.length"
-                    name="product_variants">
-                    <t t-foreach="props.docs.product_variants" t-as="product_variant" t-key="product_variant.id">
-                        <a href="#"
-                        t-on-click.prevent="() => this.props.openView('product.product', 'form', product_variant.id)">
-                            [<t t-out="product_variant.combination_name"/>]
-                        </a>
-                    </t>
-                </h6>
             </div>
             <div class="row">
                 <div class="col-md-auto text-center" name="on_hand">

--- a/addons/stock/static/src/stock_forecasted/forecasted_product_variant_filter.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_product_variant_filter.js
@@ -1,0 +1,48 @@
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { useService } from "@web/core/utils/hooks";
+import { Component, onWillStart } from "@odoo/owl";
+
+
+export class ForecastedProductVariantFilter extends Component {
+    static template = "stock.ForecastedProductVariantFilter";
+    static components = { Dropdown, DropdownItem };
+    static props = { action: Object, setVariantInContext: Function, variants: Array };
+
+    setup() {
+        this.orm = useService("orm");
+        this.context = this.props.action.context;
+        this.variants = this.props.variants;
+        onWillStart(this.onWillStart)
+    }
+
+    async onWillStart() {
+        this.displayProductVariantFilter =
+          this.context.active_model == "product.template" &&
+          this.context.variant_id !== undefined;
+    }
+
+    _onSelected(id){
+        this.props.setVariantInContext(Number(id));
+    }
+
+    get activeVariant() {
+        let variantIds = null;
+        if (Array.isArray(this.context.variant_id)) {
+            variantIds = this.context.variant_id;
+        } else {
+            variantIds = [this.context.variant_id];
+        }
+        return variantIds
+            ? this.variants.find((variant) => variantIds.includes(variant.id))
+            : this.variants[0];
+    }
+
+    get variantItems() {
+        return this.variants.map(variant => ({
+            id: variant.id,
+            label: variant.display_name,
+            onSelected: () => this._onSelected(variant.id),
+        }));
+    }
+}

--- a/addons/stock/static/src/stock_forecasted/forecasted_product_variant_filter.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_product_variant_filter.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="stock.ForecastedProductVariantFilter">
+        <div t-if="displayProductVariantFilter" class="btn-group">
+            <Dropdown menuClass="o_filter_menu" items="variantItems">
+                <button class="btn btn-secondary">
+                    <span class="fa fa-sitemap"/> Variant: <t t-out="activeVariant.display_name"/>
+                </button>
+            </Dropdown>
+        </div>
+    </t>
+</templates>

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -120,7 +120,7 @@ export class StockForecasted extends Component {
     }
 
     get graphInfo() {
-        return { noContentHelp: _t("Try to add some incoming or outgoing transfers.") };
+        return { noContentHelp: _t("No History Yet") };
     }
 
     async openView(resModel, view, resId) {

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
@@ -6,8 +6,13 @@
                 <ForecastedButtons action="props.action" reloadReport.bind="reloadReport" resModel="resModel"/>
             </t>
             <t t-set-slot="layout-actions">
-                <div class="btn-group o_search_options position-static" role="search">
-                    <ForecastedWarehouseFilter action="props.action" warehouses="warehouses" setWarehouseInContext.bind="updateWarehouse"/>
+                <div class="d-flex gap-4">
+                    <div class="btn-group o_search_options position-static" role="search">
+                        <ForecastedWarehouseFilter action="props.action" warehouses="warehouses" setWarehouseInContext.bind="updateWarehouse"/>
+                    </div>
+                    <div class="btn-group o_search_options position-static" role="search">
+                        <ForecastedProductVariantFilter action="props.action" variants="variants" setVariantInContext.bind="updateVariant"/>
+                    </div>
                 </div>
             </t>
         </ControlPanel>

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
@@ -19,7 +19,7 @@
                 resModel="'report.stock.quantity'"
                 domain="graphDomain"
                 display="{controlPanel: false}"
-                context="{fill_temporal: false}"
+                context="{fill_temporal: false, show_graph_buttons: docs.quantity_on_hand}"
                 info="graphInfo"
                 useSampleModel="true"
                 />

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
@@ -6,14 +6,10 @@
                 <ForecastedButtons action="props.action" reloadReport.bind="reloadReport" resModel="resModel"/>
             </t>
             <t t-set-slot="layout-actions">
-                <div class="d-flex gap-4">
-                    <div class="btn-group o_search_options position-static" role="search">
-                        <ForecastedWarehouseFilter action="props.action" warehouses="warehouses" setWarehouseInContext.bind="updateWarehouse"/>
-                    </div>
-                    <div class="btn-group o_search_options position-static" role="search">
-                        <ForecastedProductVariantFilter action="props.action" variants="variants" setVariantInContext.bind="updateVariant"/>
-                    </div>
-                </div>
+                <ForecastedProductVariantFilter action="props.action" variants="variants" setVariantInContext.bind="updateVariant"/>
+            </t>
+            <t t-set-slot="control-panel-navigation-additional">
+                <ForecastedWarehouseFilter action="props.action" warehouses="warehouses" setWarehouseInContext.bind="updateWarehouse"/>
             </t>
         </ControlPanel>
         <div class="o-content pt-3 container-fluid overflow-auto o_stock_forecasted_page">

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
@@ -13,7 +13,7 @@
         </ControlPanel>
         <div class="o-content pt-3 container-fluid overflow-auto o_stock_forecasted_page">
             <ForecastedHeader docs="docs" openView.bind="openView"/>
-            <t t-if="context.warehouse_id">
+            <t t-if="context.warehouse_id !== undefined">
                 <View type="'graph'"
                 viewId="stock_report_view_graph"
                 resModel="'report.stock.quantity'"

--- a/addons/stock_account/static/src/stock_account_forecasted/forecasted_header.xml
+++ b/addons/stock_account/static/src/stock_account_forecasted/forecasted_header.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template">
     <t t-name="stock_account.ForecastedHeader" t-inherit="stock.ForecastedHeader" t-inherit-mode="extension">
-        <xpath expr="//h6[@name='product_variants']" position="after">
+        <xpath expr="//div[hasclass('o_product_name')]" position="inside">
             <h6 t-if="() => env.user.has_group('stock.group_stock_manager')">
                 Value On Hand:
                 <a href="#"


### PR DESCRIPTION
With this commit
=============
- Updated the text message for no available data in the forecast report.
- Hidden the graph buttons when no data is available.
- Added links for incoming and outgoing transfers in the forecast headers.
- Introduced an "All Warehouses" option to display data for multiple warehouses.
- Added a filter by variants, including an "All Variants" option.
- Grouped the forecast report table by warehouse when the "All Warehouses" 
  filter is applied.
- Changed the graph interval from days to months, displaying data for up 
  to 3 months.


Task: [4385275](https://www.odoo.com/odoo/my-tasks/4385275)