### PR TITLE
[IMP] im_livechat: Change arrow to 'continue' when livechat ended

### DIFF
--- a/addons/im_livechat/static/src/core/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/core/common/chat_window_patch.xml
@@ -10,7 +10,7 @@
         <xpath expr="//Composer" position="replace">
             <t t-if="thread?.composerDisabled and !thread?.isTransient and store.self.notEq(thread?.livechatVisitorMember?.persona)">$0</t>
             <div t-if="thread?.composerDisabled" class="bg-200 py-1 text-center d-flex fst-italic fw-bold text-muted" t-ref="composerDisabledContainer">
-                <span class="flex-grow-1"/>
+                <span t-if="!showGiveFeedbackBtn" class="flex-grow-1"/>
                 <span t-esc="thread.composerDisabledText"/>
                 <span class="flex-grow-1"/>
             </div>

--- a/addons/im_livechat/static/src/embed/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/chat_window_patch.xml
@@ -14,7 +14,7 @@
             <attribute name="t-attf-style" add="color: {{ livechatService.options.title_color }}; background-color: {{ livechatService.options.header_background_color }} !important;" separator=" "/>
         </xpath>
         <xpath expr="//*[@t-ref='composerDisabledContainer']" position="inside">
-            <button t-if="showGiveFeedbackBtn" class="btn btn-link p-0" title="Give your feedback" t-on-click="() => this.onClickFeedback()"><i class="oi oi-arrow-right"/></button>
+            <button t-if="showGiveFeedbackBtn" class="btn btn-link p-0" title="Give your feedback" t-on-click="() => this.onClickFeedback()">Continue</button>
         </xpath>
         <xpath expr="//*[@t-ref='composerDisabledContainer']" position="attributes">
             <attribute name="t-attf-class" add="{{ showGiveFeedbackBtn ? 'px-2' : '' }}" separator=" "/>


### PR DESCRIPTION
**Purpose of the PR:**

Change the arrow icon to 'Continue' when a live chat conversation has ended to improve user clarity.

task-4535875

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr