### PR TITLE
[FIX] Account: make customer/vendor field required in payment form.

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -252,10 +252,12 @@
                                        readonly="state != 'draft'"/>
                                 <field name="partner_id" context="{'default_is_company': True}" string="Customer"
                                        options="{'no_quick_create': True}"
+                                       required="partner_type == 'customer'"
                                        invisible="partner_type != 'customer'"
                                        readonly="state != 'draft'"/>
                                 <field name="partner_id" context="{'default_is_company': True}" string="Vendor"
                                        options="{'no_quick_create': True}"
+                                       required="partner_type == 'supplier'"
                                        invisible="partner_type != 'supplier'"
                                        readonly="state != 'draft'"/>
                                 <label for="amount"/>


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
User able to create and post payments without selecting customer/vendor.

Current behavior before PR:
Ability to create payments with selecting partner.

Desired behavior after PR is merged:
Prevent user to create a payment without customer/vendor.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
