### PR TITLE
[FIX] account: improve support for overriding sequence regex

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -74,6 +74,10 @@ class AccountMove(models.Model):
         return self.journal_id.sequence_override_regex or super()._sequence_yearly_regex
 
     @property
+    def _sequence_year_range_regex(self):
+        return self.journal_id.sequence_override_regex or super()._sequence_year_range_regex
+
+    @property
     def _sequence_fixed_regex(self):
         return self.journal_id.sequence_override_regex or super()._sequence_fixed_regex
 

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -437,6 +437,39 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         next_move.action_post()
         self.assertEqual(next_move.name, '00000001-G 0002/2017')
 
+    def test_journal_override_sequence_regex_year(self):
+        """Override the sequence regex with a year syntax not matching the draft invoice name"""
+        move = self.create_move(date='2020-01-01')
+        move.journal_id.sequence_override_regex = (
+            '^'
+            r'(?P<prefix1>.*?)'
+            r'(?P<year>(?:(?<=\D)|(?<=^))\d{4})?'
+            r'(?P<prefix2>(?<=\d{4}).*?)?'
+            r'(?P<seq>\d{0,9})'
+            r'(?P<suffix>\D*?)'
+            '$'
+        )
+
+        # check if the default year_range regex is not used
+        next_move = self.create_move(date='2020-01-01', name='MISC/2020/21/00001')
+        next_move.action_post()
+        self.assertEqual(next_move.name, 'MISC/2020/21/00001')
+
+        # check the next sequence
+        next_move = self.create_move(date='2020-01-01')
+        next_move.action_post()
+        self.assertEqual(next_move.name, 'MISC/2020/21/00002')
+
+        # check for another year
+        next_move = self.create_move(date='2021-01-01')
+        next_move.action_post()
+        self.assertEqual(next_move.name, 'MISC/2021/21/00001')
+
+        # check if year is correctly extracted
+        with self.assertRaises(ValidationError):
+            self.create_move(date='2022-01-01', name='MISC/2021/22/00001') # year does not match
+        self.create_move(date='2022-01-01', name='MISC/2022/22/00001')  # fix the year in the name
+
     def test_journal_sequence_ordering(self):
         """Entries are correctly sorted when posting multiple at once."""
         self.test_move.name = 'XMISC/2016/00001'

--- a/doc/cla/individual/m7913d.md
+++ b/doc/cla/individual/m7913d.md
@@ -1,0 +1,11 @@
+Belgium, 2025-02-01
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+m7913d m7913d@my-dreams.be https://github.com/m7913d


### PR DESCRIPTION
Current behavior before PR:
 - If a sequence_override_regex is set to a custom year regex, the default year_range regex is used instead if it matches the invoice name too.
 - Creating a new invoice fails if the custom sequence regex doesn't accept an empty or draft (i.e. '/') invoice name.

Desired behavior after PR is merged:
 - If a sequence_override_regex is set, the default regexes are never used. 
 - Creating a new invoice succeeds even if the custom sequence regex doesn't accept an empty or draft (i.e. '/') invoice name.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
