### PR TITLE
[FIX] hr_recruitment: fix applications count

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -139,7 +139,7 @@ class Applicant(models.Model):
     @api.depends('candidate_id')
     def _compute_other_applications_count(self):
         for applicant in self:
-            same_candidate_applications = max(len(applicant.candidate_id.applicant_ids) - 1, 0)
+            same_candidate_applications = max(len(applicant.with_context(active_test=False).candidate_id.applicant_ids) - 1, 0)
             if applicant.candidate_id:
                 domain = applicant.candidate_id._get_similar_candidates_domain()
                 similar_candidates = self.env['hr.candidate'].with_context(active_test=False).search(domain) - applicant.candidate_id
@@ -518,7 +518,7 @@ class Applicant(models.Model):
             'type': 'ir.actions.act_window',
             'res_model': 'hr.applicant',
             'view_mode': 'list,kanban,form,pivot,graph,calendar,activity',
-            'domain': [('id', 'in', (self.candidate_id.applicant_ids - self + similar_candidates.applicant_ids).ids)],
+            'domain': [('id', 'in', (self.candidate_id.applicant_ids + similar_candidates.applicant_ids).ids)],
             'context': {
                 'active_test': False,
                 'search_default_stage': 1,


### PR DESCRIPTION
To reproduce:
=============
- create 3 applications for same candidate
- open one application and archive/refuse it
- refresh the page -> smart button **Other Applications** displays 2
- click on the smart button -> only 2 applications are listed

Problem:
=======
- when refreshing the page, the context is lost so `other_applications_count` is computed without `active_test=False` so non active records are excluded
- when clicking on the smart button, the current record is excluded from the domain

Solution:
=========
- compute `other_applications_count` with `active_test=False`
- add the current record in the domain when clicking on the smart button

opw-4488834

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
