### PR TITLE
[FIX] portal: prevent unintended scrolling behavior in Chatter

### DIFF
--- a/addons/portal/static/src/chatter/frontend/chatter_patch.js
+++ b/addons/portal/static/src/chatter/frontend/chatter_patch.js
@@ -8,10 +8,12 @@ patch(Chatter.prototype, {
         super.setup(...arguments);
         this.topRef = useRef("top");
         onWillPatch(() => {
-            // Keep the composer position under the page header on scrolling
-            if (!this.props.twoColumns) {
-                const paddingTop = document.querySelector("#wrapwrap header")
-                    ? document.querySelector("#wrapwrap header").getBoundingClientRect().height +
+            // Keep the composer position under the page header on scrolling 
+            // unless the header is on the side.
+            const headerEl = document.querySelector("#wrapwrap header");
+            if (!this.props.twoColumns && !headerEl.matches(".o_header_sidebar")) {
+                const paddingTop = headerEl
+                    ? headerEl.getBoundingClientRect().height +
                       15 +
                       "px"
                     : "";


### PR DESCRIPTION
Since [1] ensures that the Chatter is positioned under the page header, the introduction of the new "sidebar" header template caused misplacement when scrolling.

This commit adds a check to avoid applying padding when the header is a sidebar (o_header_sidebar), preventing unintended scrolling behavior in the sidebar layout.

Steps to reproduce:

- Install the Sales module.
- On a sales order, add some comments in the Chatter.
- Click on Preview.
- Edit the header template and select the last option, "Sidebar".
- Save the changes.
- Scroll down and observe that the Chatter disappears.

opw-4515419

[1]: https://github.com/odoo/odoo/commit/368eb78a9cedfce0802b64fd2782e1c018541e40
