### PR TITLE
[FIX] hr_recruitment: prevent error when installing the Recruitment module

### DIFF
--- a/addons/hr_recruitment/__manifest__.py
+++ b/addons/hr_recruitment/__manifest__.py
@@ -15,6 +15,7 @@
         'attachment_indexation',
         'web_tour',
         'digest',
+        'sms',
     ],
     'data': [
         'security/hr_recruitment_security.xml',


### PR DESCRIPTION
Currently, an error occurs when upgrading the `hr_recruitment` module, if the `sms` module is not installed.

Steps to produce:
- Install `hr_recruitment`.
- Uninstall `sms`.
- Upgrade `hr_recruitment`.
- Observe the error.

```
ParseError:  while parsing /home/odoo/src/odoo/saas18.1/addons/hr_recruitment/
views/hr_candidate_views.xml:220
Invalid template name “sms.composer” in action definition.

View error context:
'-no context-'
```

An error occurs when attempting to access the `sms.composer` - [1], without ensuring `sms` module is installed. If `sms` is not installed, this causes a `ParseError` when installing `hr_recruitment`.

[1] - https://github.com/odoo/odoo/blob/eb1b38723363b4dc54dbfadaed2831d41f688c29/addons/hr_recruitment/views/hr_candidate_views.xml#L222

This commit resolves the issue by adding `sms` module as a dependency, ensuring that `hr_recruitment` has the required model installed.

sentry - 6258561025

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
