### PR TITLE
[FIX] pos_loyalty: avoid setting expiration date

### DIFF
--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -95,7 +95,7 @@ class PosOrder(models.Model):
             'partner_id': get_partner_id(p.get('partner_id', False)),
             'code': p.get('code') or p.get('barcode') or self.env['loyalty.card']._generate_code(),
             'points': 0,
-            'expiration_date': p.get('date_to'),
+            'expiration_date': p.get('date_to', False),
             'source_pos_order_id': self.id,
             'expiration_date': p.get('expiration_date')
         } for p in coupons_to_create.values()]

--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -109,7 +109,6 @@ patch(PaymentScreen.prototype, {
                 couponData[couponId] = {
                     points: 0,
                     program_id: reward.program_id.id,
-                    expiration_date: reward.program_id.date_to,
                     coupon_id: couponId,
                     barcode: false,
                 };


### PR DESCRIPTION
In commit https://github.com/odoo/odoo/commit/837e67e82d4cf662b2dcd5d5750253dbc080bd96 we prevent setting expiration date
on `loyalty` type programs for UI and wanted to ensure expiration
date is not set on loyalty cards.

This PR remove a line which is setting expiration date on
`loyalty` type program in POS which missed during forward port
PR https://github.com/odoo/odoo/pull/183044