### PR TITLE
[IMP] point_of_sale: prevent cancellation of future orders

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -416,7 +416,9 @@ class PosSession(models.Model):
         return True
 
     def get_session_orders(self):
-        return self.order_ids
+        return self.order_ids.filtered(lambda o:
+            not(o.preset_time and o.preset_time.date() > fields.Date.today())
+        )
 
     def action_pos_session_closing_control(self, balancing_account=False, amount_to_balance=0, bank_payment_method_diffs=None):
         bank_payment_method_diffs = bank_payment_method_diffs or {}

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -460,7 +460,11 @@ export class PosStore extends WithLazyGetterTrap {
                     typeof order.id === "number" &&
                     Object.keys(order.last_order_preparation_change).length > 0
                 ) {
-                    await this.sendOrderInPreparation(order, true, true);
+                    const orderPresetDate = DateTime.fromISO(order.preset_time);
+                    const isSame = DateTime.now().hasSame(orderPresetDate, "day");
+                    if (!order.preset_time || isSame) {
+                        await this.sendOrderInPreparation(order, true, true);
+                    }
                 }
 
                 const cancelled = this.removeOrder(order, false);


### PR DESCRIPTION
Before this commit:
===
- Orders with a preset time in the future (not for today) were automatically canceled in the preparation display when the session was closed.

After this commit:
===
- Future-dated orders are no longer canceled in the preparation display when closing the session.

related-https://github.com/odoo/enterprise/pull/78345
task-4523422
