### PR TITLE
[FIX] hr, hr_attendance: prevent parseError while loading the sample data

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -679,7 +679,7 @@ class HrEmployeePrivate(models.Model):
         demo_tag = self.env.ref('hr.employee_category_demo', raise_if_not_found=False)
         if demo_tag:
             return
-        convert.convert_file(self.env, 'hr', 'data/scenarios/hr_scenario.xml', None, mode='init', kind='data')
+        convert.convert_file(self.sudo().env, 'hr', 'data/scenarios/hr_scenario.xml', None, mode='init', kind='data')
 
     # ---------------------------------------------------------
     # Business Methods

--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -468,7 +468,7 @@ class HrAttendance(models.Model):
             return
         self.env['hr.employee']._load_scenario()
         # Load employees, schedules, departments and partners
-        convert.convert_file(self.env, 'hr_attendance', 'data/scenarios/hr_attendance_scenario.xml', None, mode='init', kind='data')
+        convert.convert_file(self.sudo().env, 'hr_attendance', 'data/scenarios/hr_attendance_scenario.xml', None, mode='init', kind='data')
 
         employee_sj = self.env.ref('hr.employee_sj')
         employee_mw = self.env.ref('hr.employee_mw')


### PR DESCRIPTION
Currently, an error occurs when a user without contact creation access tries to load the sample data in hr_attendance.

Steps to produce:

1) Install the hr and hr_attendance modules.
2) Create a user without contact creation access.
3) Log in with the newly created user.
4) Open the hr_attendance module.
5) Attempt to load the sample data.
6) An error occurs.

ValueError
ParseError(`while parsing /home/odoo/src/odoo/saas-18.1/addons/hr/data/scenarios /hr_scenario.xml:79, somewhere inside`)

This error occurs when a user tries to load sample data in the hr_attendance module without having contact creation access due to security restrictions.

This commit resolves the issue by using `sudo()` to grant the necessary access to the user while loading data in `hr.attendance`.

[1] -https://github.com/odoo/odoo/blob/b286d47554f6eec940e1d69e9400cb2f359031b6/addons/hr/data/scenarios/hr_scenario.xml#L79-L93

sentry - 6152261332

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
