### PR TITLE
[FIX] payment_razorpay: prevent error when webhook secret  is not provided

### DIFF
--- a/addons/payment_razorpay/controllers/main.py
+++ b/addons/payment_razorpay/controllers/main.py
@@ -84,6 +84,9 @@ class RazorpayController(http.Controller):
         expected_signature = tx_sudo.provider_id._razorpay_calculate_signature(
             notification_data, is_redirect=is_redirect
         )
-        if not hmac.compare_digest(received_signature, expected_signature):
+        if (
+            expected_signature is None
+            or not hmac.compare_digest(received_signature, expected_signature)
+        ):
             _logger.warning("Received notification with invalid signature.")
             raise Forbidden()

--- a/addons/payment_razorpay/models/payment_provider.py
+++ b/addons/payment_razorpay/models/payment_provider.py
@@ -135,6 +135,9 @@ class PaymentProvider(models.Model):
             ).hexdigest()
         else:  # Notification data.
             secret = self.razorpay_webhook_secret
+            if not secret:
+                _logger.warning("Missing webhook secret; aborting signature calculation.")
+                return None
             return hmac.new(secret.encode(), msg=data, digestmod=hashlib.sha256).hexdigest()
 
     def _get_default_payment_method_codes(self):


### PR DESCRIPTION
This error occurs when a user does not enter a Webhook Secret. As a result, when processing the payment, the missing secret causes the verification to fail, leading to a payment failure.

- Install the `eCommerce` module without demo data and with Indian localization.
- Install `Razorpay payment provider` and activate `developer mode`.
- Add `Key ID` and `Key Secret` in Razorpay payment `provider`.
- Set up webhook in Razorpay dashboard with a random `Webhook Secret`.
- Go to the `website`, add the product to the cart, and proceed to payment using
 `UPI`.`

`Error: 'bool' object has no attribute 'encode'`

This issue occurs because the Webhook Secret is missing, returning False and causing payment verification to fail.

This commit solves the error by handling missing `Webhook Secret` values by
logging a warning and skipping the signature check instead of returning a False.

Sentry: 6208134651

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
