### PR TITLE
[FIX] mass_mailing: avoid automatic unsubscribe from mail,

### DIFF
--- a/addons/mass_mailing/i18n/mass_mailing.pot
+++ b/addons/mass_mailing/i18n/mass_mailing.pot
@@ -960,6 +960,20 @@ msgstr ""
 
 #. module: mass_mailing
 #. odoo-python
+#: code:addons/mass_mailing/controllers/main.py:0
+#, python-format
+msgid "Are you sure you want to unsubscribe from our mailing list?"
+msgstr ""
+
+#. module: mass_mailing
+#. odoo-python
+#: code:addons/mass_mailing/controllers/main.py:0
+#, python-format
+msgid "Are you sure you want to unsubscribe from the mailing list \"%(unsubscribed_lists)s\"?"
+msgstr ""
+
+#. module: mass_mailing
+#. odoo-python
 #: code:addons/mass_mailing/models/mailing_list.py:0
 msgid ""
 "At least one of the mailing list you are trying to archive is used in an "
@@ -2984,6 +2998,13 @@ msgid "Manage mass mailing campaigns"
 msgstr ""
 
 #. module: mass_mailing
+#. odoo-python
+#: code:addons/mass_mailing/controllers/main.py:0
+#, python-format
+msgid "Manage Subscriptions"
+msgstr ""
+
+#. module: mass_mailing
 #: model:ir.model.fields.selection,name:mass_mailing.selection__utm_campaign__ab_testing_winner_selection__manual
 msgid "Manual"
 msgstr ""
@@ -4405,6 +4426,7 @@ msgid "Subscriptions"
 msgstr ""
 
 #. module: mass_mailing
+#: code:addons/mass_mailing/controllers/main.py:0
 #: model_terms:ir.ui.view,arch_db:mass_mailing.unsubscribe_form
 msgid "Successfully Unsubscribed"
 msgstr ""
@@ -4772,6 +4794,13 @@ msgstr ""
 #. module: mass_mailing
 #: model:ir.model.fields.selection,name:mass_mailing.selection__mailing_trace__failure_type__unknown
 msgid "Unknown error"
+msgstr ""
+
+#. module: mass_mailing
+#. odoo-python
+#: code:addons/mass_mailing/controllers/main.py:0
+#, python-format
+msgid "Unsubscribe"
 msgstr ""
 
 #. module: mass_mailing

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1049,7 +1049,7 @@ class MailingMailing(models.Model):
 
     def _get_unsubscribe_url(self, email_to, res_id):
         url = werkzeug.urls.url_join(
-            self.get_base_url(), 'mailing/%(mailing_id)s/unsubscribe?%(params)s' % {
+            self.get_base_url(), 'mailing/%(mailing_id)s/confirm_unsubscribe?%(params)s' % {
                 'mailing_id': self.id,
                 'params': werkzeug.urls.url_encode({
                     'document_id': res_id,

--- a/addons/test_mail_full/tests/test_mass_mailing.py
+++ b/addons/test_mail_full/tests/test_mass_mailing.py
@@ -107,7 +107,7 @@ class TestMassMailing(TestMailFullCommon):
                         email['body'])
                     # rendered unsubscribe
                     self.assertIn(
-                        '%s/mailing/%s/unsubscribe' % (mailing.get_base_url(), mailing.id),
+                        '%s/mailing/%s/confirm_unsubscribe' % (mailing.get_base_url(), mailing.id),
                         email['body'])
                     unsubscribe_href = self._get_href_from_anchor_id(email['body'], "url6")
                     unsubscribe_url = werkzeug.urls.url_parse(unsubscribe_href)


### PR DESCRIPTION
add intercalate unsubscription page

Email clients have begun implementing security measures to protect users from phishing by analyzing email links, and interacting with them (see task-3972953).

This has the side effect of automatically unsubscribing email recipients from mailing lists by clicking the link in the footer of the emails.

This commit adds an intermediate step to the process, by requiring users to click on a button before they are unsubscribed.

--

The current unsubscription destination page for emails makes it unclear for the user whether they've been unsubscribed or not.

This is because the "unsubscription confirmed" box is placed below the "manage subscription settings" box on the confirmation page.

To avoid confusion, while ensuring current Studio customizations to stable instances are not impacted, the unsubscription confirmation page will clarify that the user is unsubscribed and offer the option to manage unsubscriptions by reaching the destination page.

task-4364446

X-original-commit: 52b3f53485e3977dea86e7514f2cc1952840af25

Forward-Port-Of: #195913