### PR TITLE
[FIX] html_editor: update selection after text insertion

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -343,6 +343,9 @@ export class ClipboardPlugin extends Plugin {
                 });
             });
             this.dependencies.dom.insert(modifiedTextFragment);
+            // The selection must be updated after calling insert, as the insertion
+            // process modifies the selection.
+            selection = this.dependencies.selection.getEditableSelection();
             if (textIndex < textFragments.length) {
                 // Break line by inserting new paragraph and
                 // remove current paragraph's bottom margin.

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -364,6 +364,16 @@ describe("Simple text", () => {
                 contentAfter: '<div>2a<span class="a">bx[]</span>e<br>f</div>',
             });
         });
+
+        test("should paste a text when content contains line breaks", async () => {
+            await testEditor({
+                contentBefore: "<div>[abc]</div>",
+                stepFunction: async (editor) => {
+                    pasteText(editor, "ab\ncd");
+                },
+                contentAfter: "<div>ab</div><div>cd[]</div>",
+            });
+        });
     });
 });
 


### PR DESCRIPTION
**Problem**:
When pasting text containing line breaks (`\n`), after executing `this.dependencies.dom.insert(modifiedTextFragment);`, the selection collapses to the end of the newly inserted content. At this step, `selection` becomes stale and needs to be updated.

**Solution**:
Update the selection after inserting the text node.

**Steps to Reproduce**:
1. Copy text content with line breaks (`\n`).
2. Select some text in the editor.
3. Paste the copied text.
4. Traceback.

opw-4481257

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
