### PR TITLE
[FIX] web, web_editor: fix confusing overlay action buttons

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -165,6 +165,24 @@ var SnippetEditor = Widget.extend({
         // a flickering when not needed.
         this.$target.on('transitionend.snippet_editor, animationend.snippet_editor', this.postAnimationCover);
 
+        // TODO: remove in master, handle the same in respective template.
+        const overlayButtonsTooltips = {
+            "div.o_front_back.o_send_back": _t("Send back"),
+            "div.o_front_back.o_bring_front": _t("Bring forward"),
+            "div.o_move_handle.fa-arrows": _t("Drag and move"),
+            "button.oe_snippet_remove.fa-trash": _t("Delete"),
+        };
+
+        for (const [selector, tooltip] of Object.entries(overlayButtonsTooltips)) {
+            const buttonEl = this.el.querySelector(selector);
+            if (buttonEl) {
+                Object.assign(buttonEl.dataset, {
+                    tooltip,
+                    tooltipPosition: "top"
+                });
+            }
+        }
+
         return Promise.all(defs).then(() => {
             this.__isStartedResolveFunc(this);
         });

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5720,11 +5720,27 @@ registry.SnippetMove = SnippetOptionWidget.extend(ColumnLayoutMixin, {
      * @override
      */
     start: function () {
-        var $buttons = this.$el.find('we-button');
+        // TODO: remove in master, handle the same in respective template.
+        const tooltips = {
+            move_up_opt: _t("Move up"),
+            move_down_opt: _t("Move down"),
+            move_left_opt: _t("Move left"),
+            move_right_opt: _t("Move right"),
+        };
+        const buttonEls = this.el.querySelectorAll("we-button");
+        for (const buttonEl of buttonEls) {
+            const tooltip = tooltips[buttonEl.dataset.name];
+            if (tooltip) {
+                Object.assign(buttonEl.dataset, {
+                    tooltip,
+                    tooltipPosition: "top"
+                });
+            }
+        }
         var $overlayArea = this.$overlay.find('.o_overlay_move_options');
         // Putting the arrows side by side.
-        $overlayArea.prepend($buttons[1]);
-        $overlayArea.prepend($buttons[0]);
+        $overlayArea.prepend(buttonEls[1]);
+        $overlayArea.prepend(buttonEls[0]);
 
         // Needed for compatibility (with already dropped snippets).
         const parentEl = this.$target[0].parentElement;

--- a/addons/website/static/src/scss/bootstrap_overridden.scss
+++ b/addons/website/static/src/scss/bootstrap_overridden.scss
@@ -325,7 +325,7 @@ $accordion-icon-active-color: $accordion-button-active-color !default;
 // Popovers
 $popover-bg: $body-bg !default;
 $popover-border-color: $border-color !default;
-$popover-arrow-color: $body-bg !default;
+$popover-arrow-color: var(--popover-arrow-color, #{$popover-bg}) !default;
 $popover-arrow-outer-color: $border-color !default;
 
 // Shadows


### PR DESCRIPTION
The overlay action buttons for sending a snippet to the back or front in the website editor were unclear. This commit adds tooltips to these buttons, providing better clarity on their functionality.

Steps to reproduce issue:
1. Drop text-block using website editor.
2. Click on the text-block and increase the no. of columns to 3.
3. Convert to grid mode.
4. Now click on the text-block and check the action buttons for send back and bring front.

Before this PR:
- It was confusing to identify which button would send the snippet to the back or bring it to the front. Additionally, the icons were
insufficient in conveying the button's purpose
- The tooltip arrow color was not according to the tooltip's background color.

After this PR:
- Tooltips have been added to the overlay action buttons, providing clear descriptions of their functions. Additionally, tooltips have been added to the rest of the overlay action buttons.
- Fixes an issue with the color of the tooltip arrow, it is now based on the tooltip's background color.

task-4497684