### PR TITLE
[IMP] project: improve milestone icon color for kanban card

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -2,6 +2,8 @@
 
 import ast
 import json
+
+from collections import defaultdict
 from datetime import timedelta
 
 from odoo import api, Command, fields, models
@@ -208,19 +210,46 @@ class ProjectProject(models.Model):
 
     @api.depends('milestone_ids', 'milestone_ids.is_reached', 'milestone_ids.deadline')
     def _compute_next_milestone_id(self):
-        milestone_ids_per_project_id = {
-            project.id: milestone_ids
-            for project, milestone_ids in self.env['project.milestone']._read_group(
+        milestones_per_project_id = {
+            project.id: milestones
+            for project, milestones in self.env['project.milestone']._read_group(
                 [('project_id', 'in', self.ids), ('is_reached', '=', False)],
                 ['project_id'],
                 ['id:recordset'],
             )
         }
+        milestones = self.env['project.milestone'].concat(*milestones_per_project_id.values())
+        task_read_group = self.env['project.task']._read_group(
+            [('milestone_id', 'in', milestones.ids)],
+            ['milestone_id', 'state'],
+            ['__count'],
+        )
+        task_count_per_milestones = defaultdict(lambda: (0, 0))
+        for milestone, state, count in task_read_group:
+            opened_task_count, closed_task_count = task_count_per_milestones[milestone.id]
+            if state in CLOSED_STATES:
+                closed_task_count += count
+            else:
+                opened_task_count += count
+            task_count_per_milestones[milestone.id] = opened_task_count, closed_task_count
         for project in self:
-            milestone = milestone_ids_per_project_id.get(project.id, self.env['project.milestone'])[:1]
-            project.next_milestone_id = milestone
-            project.can_mark_milestone_as_done = milestone.can_be_marked_as_done
-            project.is_milestone_deadline_exceeded = milestone.is_deadline_exceeded
+            milestones = milestones_per_project_id.get(project.id, self.env['project.milestone'])
+            project.next_milestone_id = milestones[:1]
+            milestone_deadline_exceeded = False
+            milestone_marked_as_done = False
+            for m in milestones:
+                opened_task_count, closed_task_count = task_count_per_milestones[m.id]
+                if (
+                    not milestone_deadline_exceeded
+                    and m.is_deadline_exceeded
+                    and (opened_task_count > 0 or closed_task_count == 0)
+                ):
+                    milestone_deadline_exceeded = True
+                    break
+                if not milestone_marked_as_done and opened_task_count == 0 and closed_task_count > 0:
+                    milestone_marked_as_done = True
+            project.is_milestone_deadline_exceeded = milestone_deadline_exceeded
+            project.can_mark_milestone_as_done = milestone_marked_as_done
 
     def _compute_access_url(self):
         super()._compute_access_url()

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -383,6 +383,8 @@
                     <field name="rating_active" />
                     <field name="privacy_visibility"/>
                     <field name="last_update_color"/>
+                    <field name="is_milestone_deadline_exceeded"/>
+                    <field name="can_mark_milestone_as_done"/>
                     <progressbar field="last_update_status" colors='{"on_track": "success", "at_risk": "warning", "off_track": "danger", "on_hold": "info", "done": "purple"}'/>
                     <field name="sequence" widget="handle"/>
                     <templates>
@@ -475,7 +477,7 @@
                                             </div>
                                         </a>
                                         <a groups='project.group_project_milestone' t-if="record.allow_milestones and record.allow_milestones.raw_value and record.milestone_count.raw_value &gt; 0"
-                                            class="d-inline-block btn-link text-dark small me-1"
+                                            t-attf-class="d-inline-block small me-1 text-{{ record.is_milestone_deadline_exceeded.raw_value ? 'danger' : (record.can_mark_milestone_as_done.raw_value ? 'success' : 'muted') }}"
                                             role="button"
                                             name="action_get_list_view"
                                             type="object"


### PR DESCRIPTION
This commit enhances the milestone icon colors on kanban and list view. After this update the behavior is as follows:
let there are 3 un-reached milestones in a project then:
- If one of them misses the deadline and task is not done then it should display red. 
- If no milestone misses the deadline and any tasks in the closed stage it should display green.
- and when all milestones are still in progress it should display as muted

task-4444627



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
