### PR TITLE
[IMP] point_of_sale:  increase preparation ticket text size

### DIFF
--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -15,7 +15,7 @@
                         <t t-else="">Dine In</t>
                     </t>
                 </div>
-                <div class="fs-2">
+                <div style="font-size: 78%;">
                     <span><t t-esc="changes.config_name"/> : <t t-esc="changes.time"/></span><br/>
                     <span>By: <t t-esc="changes.employee_name"/></span>
                 </div>
@@ -24,28 +24,28 @@
                     <t t-if="changes.tracking_number" class="fw-light my-3"> # <strong><t t-esc="changes.tracking_number"/></strong></t>
                 </span>
             </div>
-            <div class="text-center lh-1">---------------------------------------------------------------------</div>
+            <hr style="border: none; border-top: 4px dashed black;"/>
 
             <!-- Receipt Body -->
-            <div class="pos-receipt-body mb-4">
+            <div class="pos-receipt-body pb-5" >
                 <!-- Operational Title -->
                 <t t-if="operational_title">
                     <div class="pos-receipt-title text-center" t-esc="operational_title" />
                 </t>
                 <!-- Order Lines -->
-                <div t-foreach="changedlines" t-as="line" t-key="change_index">
+                <div t-foreach="changedlines" t-as="line" t-key="change_index" style="font-size: 120%;">
                     <div t-attf-class="orderline #{line.isCombo ? 'mx-5 px-2' : 'mx-1'}">
                         <div class="d-flex medium">
                             <span class="me-3" t-esc="line.quantity"/> <span class="product-name" t-esc="line.display_name"/>
                         </div>
-                        <div t-if="line.attribute_value_ids?.length" class="mx-5 fs-2">
+                        <div t-if="line.attribute_value_ids?.length" class="mx-5" style="font-size: 91%;">
                             <t t-foreach="line.attribute_value_ids" t-as="attribute" t-key="attribute.id">
                                 <p class="p-0 m-0">
                                     - <t t-esc="attribute.name" /><br/>
                                 </p>
                             </t>
                         </div>
-                        <div t-if="line.note" class="fs-2 fst-italic">
+                        <div t-if="line.note" class="fst-italic" style="font-size: 91%;">
                             <t t-esc="line.note.split('\n').join(', ')"/><br/>
                         </div>
                     </div>
@@ -53,7 +53,7 @@
                 <!-- General Note -->
                 <!-- if no orderline change that means general note change to handle with less arguments -->
                 <t t-if="(!changedlines.length or fullReceipt) and changes.order_note.length">
-                    <div class="fs-2 my-5 fst-italic">
+                    <div class="mt-5 fst-italic" style="font-size: 109%;">
                         <t t-if="changes.order_note">
                             <t t-esc="changes.order_note.split('\n').join(', ')"/><br/>
                         </t>


### PR DESCRIPTION
This commit increases the text size of the ordered product and notes on the preparation ticket, ensuring better readability.

task-4535901
