### PR TITLE
[FIX] mail: better message highlight

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -219,6 +219,7 @@ export class Message extends Component {
             ),
             "o-actionMenuMobileOpen": this.state.actionMenuMobileOpen,
             "o-editing": this.state.isEditing,
+            "px-3": !this.env.inChatter && !this.props.isInChatWindow,
         };
     }
 

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -1,3 +1,12 @@
+@keyframes highlight {
+    0%, to {
+        background-color: inherit;
+    }
+    50% {
+        background: mix($white, $warning, 65%);
+    }
+}
+
 .o-mail-Message {
     transition: background-color .2s ease-out, opacity .5s ease-out, box-shadow .5s ease-out, transform .2s ease-out;
 
@@ -9,7 +18,11 @@
     }
 
     &.o-highlighted {
-        transform: translateY(-#{map-get($spacers, 3)});
+        animation-name: highlight;
+        animation-duration: 3s;
+        animation-iteration-count: infinite;
+        animation-direction: alternate;
+        background-color: inherit;
     }
 
     &.o-actionMenuMobileOpen {

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -482,7 +482,7 @@ export class Thread extends Component {
 
     getMessageClassName(message) {
         return !message.isNotification && this.messageHighlight?.highlightedMessageId === message.id
-            ? "o-highlighted bg-view shadow-lg pb-1"
+            ? "o-highlighted"
             : "";
     }
 

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Thread">
-    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-5': env.inChatter?.aside, 'pb-4': !env.inChatter?.aside, 'px-3': !env.inChatter and !props.isInChatWindow }" t-ref="messages" tabindex="-1">
+    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-5': env.inChatter?.aside, 'pb-4': !env.inChatter?.aside }" t-ref="messages" tabindex="-1">
         <t t-if="!props.thread.isEmpty or props.thread.loadOlder or props.thread.hasLoadingFailed" name="content">
             <div class="d-flex flex-column position-relative flex-grow-1" t-att-class="{'justify-content-end': !env.inChatter and props.thread.model !== 'mail.box'}">
                 <span class="position-absolute w-100 invisible" t-att-class="props.order === 'asc' ? 'bottom-0' : 'top-0'" t-ref="present-treshold" t-att-style="`height: Min(${PRESENT_THRESHOLD}px, 100%)`"/>

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -267,7 +267,7 @@ export function useVisible(refName, cb, { ready = true } = {}) {
  * @property {number|null} highlightedMessageId
  * @returns {MessageHighlight}
  */
-export function useMessageHighlight(duration = 2000) {
+export function useMessageHighlight(duration = 3000) {
     let timeout;
     const state = useState({
         clearHighlight() {


### PR DESCRIPTION
The current message highlight isn't really visible in dark mode. It's also not really visible at all, and it "breaks" the UI by making the other messages a bit less visible.

This PR removes the translation and creates a highlight animation.

Task-4543530

![image](https://github.com/user-attachments/assets/42b7e6da-1208-4c67-b23b-588e3191ce44)
