### PR TITLE
[FIX] account_edi_ubl_cii: better display of the EAS field

### DIFF
--- a/addons/account_edi_ubl_cii/static/src/scss/account_edi_ubl_cii.scss
+++ b/addons/account_edi_ubl_cii/static/src/scss/account_edi_ubl_cii.scss
@@ -3,5 +3,5 @@
     font-weight: $font-weight-bold;
 }
 .o_field_peppol_eas_selection {
-  width: 180px;
+  min-width: 200px;
 }


### PR DESCRIPTION
Let's increase the label size since the EAS are quite long.

task-no

Before:
![image](https://github.com/user-attachments/assets/9dc51ce9-37e3-4c33-8f7f-d076d246360d)

After:
![image](https://github.com/user-attachments/assets/384ebe11-3b7d-4723-b8b5-a1927cdbdd15)
