### PR TITLE
[FIX] mass_mailing: make unsubcription page work in website

### DIFF
--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -72,7 +72,8 @@ class MassMailController(http.Controller):
                 </div>
             </t>
         """)
-        return request.render(template, {
+        return request.env['ir.qweb']._render(template, {
+            'main_object': mailing,
             'token': token,
             'email': email,
             'mailing_id': mailing_id,


### PR DESCRIPTION
A recent change modified the unsubscription flow to make it more resilient to automated security agents. Unfortunately, the implementation of this change breaks if the Website module is installed, and the flow becomes unusable.

This commit makes it so that the unsubscription flow works once more, without compromising on resilience to security agents.

task-4364446
