### PR TITLE
[FIX] project: prevent empty groups in gantt view group by customer

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1392,7 +1392,9 @@ class ProjectTask(models.Model):
             f"{field}.id": "id",
             f"{field}.name": "name",
         })
-        filtered_domain = _change_operator(filtered_domain)
+        if not filtered_domain.is_true():
+            # If domain is not equal to Domain.TRUE then
+            filtered_domain = _change_operator(filtered_domain)
         if not filtered_domain:
             return self.env[comodel]
         if additional_domain:


### PR DESCRIPTION
Steps to Reproduce
- Open Tasks in the Gantt view.
- Grouped the tasks by Customer.
- `YourCompany` still appears as an empty group.

Cause
- After merged this commit: https://github.com/odoo/odoo/pull/194673/commits/5c2e8c58290571a9d8e59e2602db6493b381945e, This change caused the `filter_domain_leaf()` function now returns   `[(1, '=', 1)]` as the default domain. However, the `_change_operator`  method does not correctly handle the `(1, '=', 1)` leaf, resulting in empty groups being displayed.

Solution
- Skip the leaf `(1, '=', 1)` in `_change_operator` to prevent empty groups from appearing in the Gantt view.

task-4244705

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
