### PR TITLE
[FIX] pos_self_order: 'False' in unique code for self order

### DIFF
--- a/addons/pos_self_order/models/pos_session.py
+++ b/addons/pos_self_order/models/pos_session.py
@@ -33,6 +33,12 @@ class PosSession(models.Model):
     def _load_pos_self_data_domain(self, data):
         return [('config_id', '=', data['pos.config']['data'][0]['id']), ('state', '=', 'opened')]
 
+    def _load_pos_self_data(self, data):
+        result = super()._load_pos_self_data(data)
+        if result['data']:
+            result['data'][0]['_base_url'] = self.get_base_url()
+        return result
+
     def _load_pos_data(self, data):
         sessions = super()._load_pos_data(data)
         sessions['data'][0]['_self_ordering'] = (

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -13,7 +13,7 @@ import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/
 import { HWPrinter } from "@point_of_sale/app/printer/hw_printer";
 import { renderToElement } from "@web/core/utils/render";
 import { TimeoutPopup } from "@pos_self_order/app/components/timeout_popup/timeout_popup";
-import { constructFullProductName, deduceUrl } from "@point_of_sale/utils";
+import { constructFullProductName, deduceUrl, random5Chars } from "@point_of_sale/utils";
 import { computeComboItems } from "@point_of_sale/app/models/utils/compute_combo_items";
 import {
     getTaxesAfterFiscalPosition,
@@ -395,6 +395,7 @@ export class SelfOrder extends Reactive {
 
         const newOrder = this.models["pos.order"].create({
             company_id: this.company,
+            ticket_code: random5Chars(),
             session_id: this.session,
             config_id: this.config,
             fiscal_position_id: fiscalPosition,


### PR DESCRIPTION
Steps:
===
- Open the restaurant's POS system.
- Configure it for self-invoicing with QR code + link.
- Access the restaurant's mobile menu.
- Place an order and download the receipt.

Issue:
===
- The receipt shows an incorrect unique code.
- The QR code and link redirect to `undefined/pos/ticket`.

Fix:
===
- Corrected the system to generate a valid unique code for each order.
- Fixed the QR code and link to properly redirect to the correct page.

Task: 4512074