### PR TITLE
[FIX] stock: Prevent Draft moves on Done picking

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -663,6 +663,10 @@ Please change the quantity done or the rounding precision of your unit of measur
                 picking = self.env['stock.picking'].browse(vals['picking_id'])
                 if picking.group_id:
                     vals['group_id'] = picking.group_id.id
+            if vals.get('picking_id') and vals.get('state'):
+                picking = self.env['stock.picking'].browse(vals['picking_id'])
+                if picking.state == 'done' and vals['state'] != 'done':
+                    vals['state'] = 'done'
         res = super().create(vals_list)
         res._update_orderpoints()
         return res

--- a/addons/stock/tests/test_robustness.py
+++ b/addons/stock/tests/test_robustness.py
@@ -10,6 +10,7 @@ class TestRobustness(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super(TestRobustness, cls).setUpClass()
+        cls.supplier_location = cls.env.ref('stock.stock_location_suppliers')
         cls.stock_location = cls.env.ref('stock.stock_location_stock')
         cls.customer_location = cls.env.ref('stock.stock_location_customers')
         cls.uom_unit = cls.env.ref('uom.product_uom_unit')
@@ -313,3 +314,49 @@ class TestRobustness(TransactionCase):
         self.assertEqual(move.reserved_availability, 0)
         self.assertEqual(move.state, 'confirmed')
         self.assertEqual(quant.reserved_quantity, 0)
+
+    def test_new_move_done_picking(self):
+        """ Ensure that adding a Draft move to a Done picking doesn't change the picking state
+        """
+        categ_id = self.env.ref('product.product_category_all').id
+        product1 = self.env['product.product'].create({'name': 'P1', 'type': 'product', 'categ_id': categ_id})
+        product2 = self.env['product.product'].create({'name': 'P2', 'type': 'product', 'categ_id': categ_id})
+
+        receipt = self.env['stock.picking'].create({
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+        })
+        move1 = self.env['stock.move'].create({
+            'name': 'P1',
+            'location_id': receipt.location_id.id,
+            'location_dest_id': receipt.location_dest_id.id,
+            'picking_id': receipt.id,
+            'product_id': product1.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 1.0,
+        })
+        receipt.action_confirm()
+        receipt.action_assign()
+        move1.move_line_ids.qty_done = 1
+
+        receipt.button_validate()
+
+        self.assertEqual(receipt.state, 'done')
+        self.assertEqual(move1.state, 'done')
+
+        move2 = self.env['stock.move'].create({
+            'name': 'P2',
+            'location_id': receipt.location_id.id,
+            'location_dest_id': receipt.location_dest_id.id,
+            'picking_id': receipt.id,
+            'state': 'draft',
+            'product_id': product2.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 1.0,
+            'quantity_done': 1.0,
+        })
+
+        self.assertEqual(receipt.state, 'done')
+        self.assertEqual(move1.state, 'done')
+        self.assertEqual(move2.state, 'done')


### PR DESCRIPTION
## How to Reproduce:
- Create products P1 & P2, storable
- Create receipt picking for 1 unit of P1 -> Confirm
- Open receipt in 2 browser tabs.
- In Tab 1, add a new operation line for 1 unit of P2. !Do Not Save!
- In Tab 2, validate the receipt.
- In Tab 1, save. => Picking went from Ready -> Done -> Ready. Move P1 state = 'done' while move P2 state ='assigned'

## Solution:
When a move is added to a Done picking, we change the state of the move to done, and the move is treated like it was added to a Done unlocked picking.

OPW-3919976
