### PR TITLE
[IMP] website, *: hide website dropdown when only one website exists

### DIFF
--- a/addons/test_website/static/tests/tours/systray.js
+++ b/addons/test_website/static/tests/tours/systray.js
@@ -152,6 +152,20 @@ const canEditButCannotChange = () => [
     },
 ];
 
+const ensureWebsiteSwitcherIsNotVisible = [
+    {
+        content: "Ensure website switcher is hidden when only one website exists",
+        trigger: ".o_menu_systray:not(:has(.o_website_switcher_container))",
+    },
+];
+
+const ensureWebsiteSwitcherIsVisible = [
+    {
+        content: "Ensure website switcher is present when multiple website exists",
+        trigger: ".o_menu_systray:has(.o_website_switcher_container)",
+    },
+];
+
 const register = (title, steps) => {
     registerWebsitePreviewTour(title, {
         url: "/test_model/1",
@@ -202,3 +216,7 @@ register("test_systray_not_reditor_not_tester", () => [
     ...canViewInBackEnd(),
     ...cannotEdit(),
 ]);
+
+register("test_systray_single_website", () => ensureWebsiteSwitcherIsNotVisible);
+
+register("test_systray_multi_website", () => ensureWebsiteSwitcherIsVisible);

--- a/addons/test_website/tests/test_systray.py
+++ b/addons/test_website/tests/test_systray.py
@@ -65,3 +65,19 @@ class TestSystray(HttpCase):
         self.assertNotIn(self.group_restricted_editor.id, self.user_test.group_ids.ids, "User should not be a group_restricted_editor")
         self.assertNotIn(self.group_tester.id, self.user_test.group_ids.ids, "User should not be a group_tester")
         self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_not_reditor_not_tester', login="testtest")
+
+    @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
+    def test_06_single_website(self):
+        if self.env['website'].search_count([]) > 1:
+            website = self.env['website'].search([], limit=1)
+            websites_to_remove = self.env['website'].search([('id', '!=', website.id)])
+            websites_to_remove.unlink()
+        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_single_website', login="admin")
+
+    @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
+    def test_07_multi_website(self):
+        if self.env['website'].search_count([]) == 1:
+            self.env['website'].create({
+                'name': 'My Website 2',
+            })
+        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_multi_website', login="admin")

--- a/addons/website/static/src/systray_items/website_switcher.js
+++ b/addons/website/static/src/systray_items/website_switcher.js
@@ -77,7 +77,7 @@ export class WebsiteSwitcherSystray extends Component {
 
 export const systrayItem = {
     Component: WebsiteSwitcherSystray,
-    isDisplayed: env => env.services.website.hasMultiWebsites,
+    isDisplayed: (env) => env.services.website.websites.length > 1,
 };
 
 registry.category("website_systray").add("WebsiteSwitcher", systrayItem, { sequence: 12 });


### PR DESCRIPTION
*: test_website

Steps to reproduce:
1. Go to Configuration → Websites.
2. Keep only one website and delete the rest.

Issue:
1. Go to homepage. The website dropdown is still shown in the top bar, even though there’s only one website to pick from.
2. Go to Configuration → Menus and create a new menu. The Website field is still visible, even though there’s only one website to pick from.

Reason:
The website switcher currently appears based on the `website.group_multi_website` group, which is implied when multiple
websites exist. We're using `hasGroup()`, which relies on cached user data. This causes issues: adding or removing websites doesn't immediately update switcher visibility due to caching.

Key Changes:

1. Instead of using user groups to show or hide the website switcher, we now check if `websites.length > 1`. This helps avoid issues with group-based caching.
2. In the Website menu, we now show the default website in the dropdown if there's only one website to choose from.
3. In `_compute_display_name`, we set `menu.name` to an empty string if it's not a proper string (like when it's `false`) to avoid errors when adding the website name to it.

This PR aims to hide website dropdown on the home page when only one website exists and sets the default website in the website menu form if there is only one option.

task-4350420