### PR TITLE
[IMP] stock_picking_batch, stock_fleet: improve batch and dispatch management

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -131,12 +131,12 @@ class StockMoveLine(models.Model):
             if line.picking_id:
                 line.picking_type_id = line.picking_id.picking_type_id
 
-    @api.depends('move_id', 'move_id.location_id', 'move_id.location_dest_id')
+    @api.depends('move_id', 'move_id.location_id', 'move_id.location_dest_id', 'picking_id')
     def _compute_location_id(self):
         for line in self:
-            if not line.location_id:
+            if not line.location_id or line._origin.picking_id.location_id != line.picking_id.location_id:
                 line.location_id = line.move_id.location_id or line.picking_id.location_id
-            if not line.location_dest_id:
+            if not line.location_dest_id or line._origin.picking_id.location_dest_id != line.picking_id.location_dest_id:
                 line.location_dest_id = line.move_id.location_dest_id or line.picking_id.location_dest_id
 
     def _search_picking_type_id(self, operator, value):

--- a/addons/stock_fleet/__init__.py
+++ b/addons/stock_fleet/__init__.py
@@ -1,1 +1,12 @@
 from . import models
+
+
+def _enable_dispatch_management(env):
+    for delivery_steps, warehouses in env['stock.warehouse']._read_group([], ['delivery_steps'], ['id:recordset']):
+        if delivery_steps == 'pick_pack_ship':
+            warehouses.pack_type_id.dispatch_management = True
+        elif delivery_steps == 'pick_ship':
+            warehouses.pick_type_id.dispatch_management = True
+
+        warehouses.out_type_id.dispatch_management = True
+        warehouses.in_type_id.dispatch_management = True

--- a/addons/stock_fleet/__manifest__.py
+++ b/addons/stock_fleet/__manifest__.py
@@ -19,4 +19,5 @@
     ],
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'post_init_hook': '_enable_dispatch_management',
 }

--- a/addons/stock_fleet/models/__init__.py
+++ b/addons/stock_fleet/models/__init__.py
@@ -2,3 +2,4 @@ from . import fleet_vehicle_model
 from . import stock_picking_batch
 from . import stock_picking
 from . import stock_location
+from . import stock_warehouse

--- a/addons/stock_fleet/models/stock_picking.py
+++ b/addons/stock_fleet/models/stock_picking.py
@@ -3,6 +3,15 @@
 from odoo import fields, models
 
 
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    dispatch_management = fields.Boolean(
+        'Dispatch Management',
+        help="Enable this option to display dispatch management related details in the batch/wave form view and operations kanban overview."
+    )
+
+
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 

--- a/addons/stock_fleet/models/stock_warehouse.py
+++ b/addons/stock_fleet/models/stock_warehouse.py
@@ -1,0 +1,21 @@
+from odoo import models
+
+
+class StockWarehouse(models.Model):
+    _inherit = 'stock.warehouse'
+
+    def _get_picking_type_update_values(self):
+        values = super()._get_picking_type_update_values()
+        if self.delivery_steps == 'pick_pack_ship':
+            if values.get('pack_type_id'):
+                values['pack_type_id']['dispatch_management'] = True
+        elif self.delivery_steps == 'pick_ship':
+            if values.get('pick_type_id'):
+                values['pick_type_id']['dispatch_management'] = True
+
+        if values.get('out_type_id'):
+            values['out_type_id']['dispatch_management'] = True
+        if values.get('in_type_id'):
+            values['in_type_id']['dispatch_management'] = True
+
+        return values

--- a/addons/stock_fleet/views/stock_picking_batch.xml
+++ b/addons/stock_fleet/views/stock_picking_batch.xml
@@ -27,7 +27,7 @@
         <field name="inherit_id" ref="stock_picking_batch.stock_picking_batch_form"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@id='batch_delivery_data']" position="after">
-                <group>
+                <group invisible="not has_dispatch_management">
                     <field name="dock_id" groups="stock.group_stock_multi_locations"/>
                     <field name="vehicle_id" placeholder="Third Party Provider"/>
                     <field name="vehicle_category_id" placeholder="semi-truck"/>

--- a/addons/stock_fleet/views/stock_picking_type.xml
+++ b/addons/stock_fleet/views/stock_picking_type.xml
@@ -7,8 +7,11 @@
             <field name="inherit_id" ref="stock.stock_picking_type_kanban"/>
             <field name="arch" type="xml">
                 <data>
+                    <xpath expr="//kanban" position="inside">
+                        <field name="dispatch_management" invisible="1"/>
+                    </xpath>
                     <xpath expr="//div[@name='kanban_menu_section']" position="after">
-                        <t t-if="record.code.raw_value == 'incoming' or record.code.raw_value == 'outgoing'">
+                        <t t-if="record.dispatch_management.raw_value">
                             <div class="col-6">
                                 <h5 role="menuitem" class="o_kanban_card_manage_title" style="white-space: nowrap;">
                                     <a>Transport Management</a>
@@ -35,4 +38,16 @@
             </field>
         </record>
     </data>
+
+    <record id="view_picking_type_form" model="ir.ui.view">
+        <field name="name">stock.picking.type.form.inherit.stock_fleet</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='auto_batch']" position="before">
+                <field name="dispatch_management"/>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>

--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -43,11 +43,15 @@ class StockPickingType(models.Model):
             record.count_picking_batch = count.get((record.id, False), 0)
 
     def action_batch(self):
-        action = self.env['ir.actions.act_window']._for_xml_id("stock_picking_batch.stock_picking_batch_action")
+        action = self._get_action('stock_picking_batch.stock_picking_batch_action')
         if self.env.context.get("view_mode"):
             del action["mobile_view_mode"]
             del action["views"]
             action["view_mode"] = self.env.context["view_mode"]
+        return action
+
+    def action_wave(self):
+        action = self._get_action('stock_picking_batch.action_picking_tree_wave')
         return action
 
     @api.model

--- a/addons/stock_picking_batch/tests/test_batch_picking.py
+++ b/addons/stock_picking_batch/tests/test_batch_picking.py
@@ -787,35 +787,6 @@ class TestBatchPicking02(TransactionCase):
         ])
         self.assertEqual(pickings.move_line_ids.result_package_id, package)
 
-    def test_add_batch_move_line(self):
-        """
-        Adding a stock move line in a batch form triggers a calculation of the
-        default dest location. This test checks if that calculation doesn't
-        raise any exceptions for a new, empty StockMoveLine object.
-        """
-        loc1, loc2 = self.stock_location.child_ids
-        picking = self.env['stock.picking'].create({
-            'location_id': loc1.id,
-            'location_dest_id': loc2.id,
-            'picking_type_id': self.picking_type_internal.id,
-            'state': 'draft',
-        })
-        batch_form = Form(self.env['stock.picking.batch'])
-        batch_form.picking_ids.add(picking)
-        batch = batch_form.save()
-        batch.action_confirm()
-        confirmed_form = Form(batch)
-        # Adding a new line should not raise an error
-        confirmed_form.move_line_ids.new()
-        # Adding a line should work also for users in multi_locations (former storage categories) group
-        self.env.user.group_ids += self.env.ref('stock.group_stock_multi_locations')
-        batch_form = Form(self.env['stock.picking.batch'])
-        batch_form.picking_ids.add(picking)
-        batch = batch_form.save()
-        batch.action_confirm()
-        confirmed_form = Form(batch)
-        confirmed_form.move_line_ids.new()
-
     def test_batch_validation_without_backorder(self):
         loc1, loc2 = self.stock_location.child_ids
         self.env['stock.quant']._update_available_quantity(self.productA, loc1, 10)

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -24,6 +24,7 @@
         <field name="arch" type="xml">
             <xpath expr="//list" position="attributes">
                 <attribute name="delete">0</attribute>
+                <attribute name="create">false</attribute>
             </xpath>
             <xpath expr="//field[@name='product_id']" position="after">
                 <field name="picking_id"
@@ -32,10 +33,11 @@
                     domain="[('id', 'in', parent.picking_ids)]"
                     options="{'no_create_edit': True}"/>
             </xpath>
-            <xpath expr="//field[@name='quantity']" position="attributes">
-                <attribute name="readonly">1</attribute>
+            <xpath expr="//field[@name='picked']" position="attributes">
+                <attribute name="column_invisible">1</attribute>
             </xpath>
             <xpath expr="//field[@name='product_uom']" position="after">
+                <field name="picked" optional="hide"/>
                 <button name="action_show_details" type="object" title="Details"
                         icon="fa-list" invisible="not show_details_visible"/>
             </xpath>
@@ -47,23 +49,34 @@
         <field name="model">stock.move.line</field>
         <field name="arch" type="xml">
             <list editable="top" decoration-muted="state == 'cancel'" string="Move Lines" default_order="location_id">
+                <header>
+                    <button class="btn-primary" name="action_put_in_pack" type="object" string="Put in Pack" groups="stock.group_tracking_lot"/>
+                </header>
                 <field name="tracking" column_invisible="True"/>
                 <field name="state" column_invisible="True"/>
                 <field name="company_id" column_invisible="True"/>
                 <field name="product_id" context="{'default_is_storable': True}" required="1" readonly="id"/>
                 <field name="picking_id" required="1" readonly="id"
-                    options="{'no_create_edit': True}" domain="[('id', 'in', parent.picking_ids)]"/>
-                <field name="lot_id"   groups="stock.group_production_lot" readonly="tracking not in ['lot', 'serial']" column_invisible="parent.show_lots_text" />
+                    options="{'no_create_edit': True}" domain="[('id', 'in', context.get('picking_ids', []))]"/>
+                <field name="lot_id"   groups="stock.group_production_lot" readonly="tracking not in ['lot', 'serial']" column_invisible="context.get('picking_code') != 'incoming' or context.get('show_lots_text')"/>
                 <field name="lot_name" string="Lot/Serial Number" groups="stock.group_production_lot"
-                       readonly="tracking not in ['lot', 'serial']" column_invisible="not parent.show_lots_text"/>
-                <field name="location_id"/>
+                       readonly="tracking not in ['lot', 'serial']" column_invisible="context.get('picking_code') != 'incoming' or not context.get('show_lots_text')"/>
+                <field name="quant_id" column_invisible="context.get('picking_code') == 'incoming'"
+                        domain="[('product_id', '=', product_id), ('location_id', 'child_of', picking_location_id)]"
+                        context="{'default_location_id': location_id, 'default_product_id': product_id, 'search_view_ref': 'stock.quant_search_view', 'list_view_ref': 'stock.view_stock_quant_tree_simple', 'form_view_ref': 'stock.view_stock_quant_form', 'readonly_form': False}"
+                        readonly="state in ('done', 'cancel') and is_locked"
+                        widget="pick_from"
+                        options="{'no_open': True}"/>
+                <field name="location_id" column_invisible="True"/>
                 <field name="location_dest_id"/>
-                <field name="package_id" groups="stock.group_tracking_lot"/>
+                <field name="package_id" groups="stock.group_tracking_lot" column_invisible="True"/>
                 <field name="result_package_id" groups="stock.group_tracking_lot"/>
+                <field name="quantity"/>
                 <field name="product_uom_id" options="{'no_create': True}" widget="many2one_uom"
                     groups="uom.group_uom" readonly="1" force_save="1"/>
-                <field name="quantity"/>
                 <field name="company_id" groups="base.group_multi_company" force_save="1"/>
+                <field name="is_locked" column_invisible="True"/>
+                <field name="picking_location_id" column_invisible="True"/>
             </list>
         </field>
     </record>
@@ -96,6 +109,15 @@
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
+                        <button name="action_batch_detailed_operations"
+                                class="oe_stat_button"
+                                icon="fa-bars"
+                                type="object"
+                                help="List view of detailed operations">
+                                <div class="o_form_field o_stat_info">
+                                    <span class="o_stat_text">Moves</span>
+                                </div>
+                        </button>
                         <button name="action_view_reception_report" string="Allocation" type="object"
                             class="oe_stat_button" icon="fa-list"
                             invisible="not show_allocation"
@@ -108,19 +130,15 @@
                         <group id="batch_delivery_data">
                             <field name="user_id" readonly="state not in ['draft', 'in_progress']"/>
                             <field name="picking_type_id" readonly="state != 'draft'"/>
-                            <field name="company_id" groups="base.group_multi_company" readonly="picking_ids" force_save="1"/>
                             <field name="scheduled_date" readonly="state in ['cancel', 'done']"/>
                             <field name="description"/>
                         </group>
                         <field name="properties" nolabel="1" columns="2" hideAddButton="1"/>
                     </group>
                     <notebook>
-                        <page string="Detailed Operations" name="page_detailed_operations" invisible="state == 'draft'">
-                            <field name="move_line_ids" context="{'list_view_ref': 'stock_picking_batch.view_move_line_tree'}" readonly="state not in ['draft', 'in_progress']"/>
-                            <button class="oe_highlight" name="action_put_in_pack" type="object" string="Put in Pack" invisible="state in ('draft', 'done', 'cancel')" groups="stock.group_tracking_lot"/>
-                        </page>
                         <page string="Operations" name="page_operations" invisible="state == 'draft'">
-                            <field name="move_ids" context="{'list_view_ref': 'stock_picking_batch.view_picking_move_tree_inherited'}"/>
+                            <field name="move_ids" readonly="state == 'done'" context="{'list_view_ref': 'stock_picking_batch.view_picking_move_tree_inherited'}"/>
+                            <button class="oe_highlight float-end" name="action_put_in_pack" type="object" string="Put in Pack" invisible="state in ('draft', 'done', 'cancel')" groups="stock.group_tracking_lot"/>
                         </page>
                         <page string="Transfers" name="page_transfers">
                             <field name="allowed_picking_ids" invisible="1"/>

--- a/addons/stock_picking_batch/views/stock_picking_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_views.xml
@@ -56,6 +56,9 @@
             <field name="scheduled_date" position="attributes">
                 <attribute name="optional">hide</attribute>
             </field>
+            <field name="priority" position="attributes">
+                <attribute name="optional">hide</attribute>
+            </field>
         </field>
     </record>
 </odoo>

--- a/addons/stock_picking_batch/views/stock_picking_wave_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_wave_views.xml
@@ -120,7 +120,7 @@
             </xpath>
             <xpath expr="//div[@name='picking_type_backorder_count']" class="row" position="after">
                 <div class="row">
-                    <a class="col-8 offset-4 text-truncate" name="%(stock_picking_batch.action_picking_tree_wave)d" type="action">
+                    <a class="col-8 offset-4 text-truncate" name="action_wave" type="object">
                         <div t-if="record.count_picking_wave.raw_value > 0"  class="row">
                             <span class="col-6">Waves</span>
                             <field name="count_picking_wave" class="col-2 text-end"/>


### PR DESCRIPTION
With this commit
=======================

- Improved batch form view for better user experience.
- Inventory dashboard enhancements: 
      - Filtered batches by operation type in the list view.
      - Added a 'Transport Management' section for internal transfers, shown 
        only if dispatch_management is enabled.
 - Introduced dispatch_management boolean in stock_picking_type to 
   display stock_fleet-related data in batch form and dashboard.
- end_date now defaults to 1 hour after scheduled_date and updates dynamically.

Task - [4455158](https://www.odoo.com/odoo/my-tasks/4455158)
