### PR TITLE
[FIX] website_sale: display VAT field for electronic invoicing in specific localizations

### DIFF
--- a/addons/l10n_ec_website_sale/controllers/main.py
+++ b/addons/l10n_ec_website_sale/controllers/main.py
@@ -54,3 +54,7 @@ class L10nECWebsiteSale(WebsiteSale):
             payment_methods = payment_values['payment_methods_sudo'].filtered(lambda pm: bool(pm.l10n_ec_sri_payment_id))
             payment_values['payment_methods_sudo'] = payment_methods
         return payment_values
+
+    def _vat_required(self, country_code):
+        """ Colombia requires VAT for all partners """
+        return country_code == 'EC'

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1165,16 +1165,27 @@ class WebsiteSale(payment_portal.PaymentPortal):
             ),
             'show_vat': (
                 (address_type == 'billing' or use_delivery_as_billing)
-                and (
+                and ((
                     is_anonymous_cart  # Allow inputting VAT on the new main address.
                     or (
                         partner_sudo == order_sudo.partner_id
                         and (can_edit_vat or partner_sudo.vat)
                     )  # On the main partner only, if the VAT was set.
                 )
+                or self._vat_required(country_sudo.code))
             ),
             'vat_label': request.env._("VAT"),
         }
+
+    def _vat_required(self, country_code):
+        """ Check if the VAT number is always required for the current localisation.
+
+        :return: True if the VAT number is required, False otherwise.
+        :rtype: bool
+        This will be overridden in the l10n modules.
+        """
+
+        return False
 
     @route(
         '/shop/address/submit', type='http', methods=['POST'], auth='public', website=True,


### PR DESCRIPTION
In some localizations, such as Colombia and Ecuador, the VAT (Identification Number) is mandatory for all electronic invoices. To comply with these requirements, the VAT field is now displayed to users in billing mode when operating in these localizations.

For example, in Colombia, customers must provide both an Identification Type and an Identification Number (VAT) for electronic invoicing, as these details are mandatory for all sales. Additionally, these fields must also be visible and required for extra billing addresses.

The `show_vat` logic has been updated to ensure the VAT field is displayed and required for users in Colombia, Ecuador, and we can add it where electronic invoicing regulations apply.

opw-4309448



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
