### PR TITLE
[FIX] hr, hr_skills, hr_attendance: prevent error while loading the sample data

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -466,9 +466,10 @@ class HrAttendance(models.Model):
     def _load_demo_data(self):
         if self.has_demo_data():
             return
-        self.env['hr.employee']._load_scenario()
+        env_sudo = self.sudo().with_context({}).env
+        env_sudo['hr.employee']._load_scenario()
         # Load employees, schedules, departments and partners
-        convert.convert_file(self.env, 'hr_attendance', 'data/scenarios/hr_attendance_scenario.xml', None, mode='init', kind='data')
+        convert.convert_file(env_sudo, 'hr_attendance', 'data/scenarios/hr_attendance_scenario.xml', None, mode='init', kind='data')
 
         employee_sj = self.env.ref('hr.employee_sj')
         employee_mw = self.env.ref('hr.employee_mw')


### PR DESCRIPTION
Currently, an error occurs when a user without Employees value tries to load the sample data in hr_attendance.

Steps to produce:

1) Install the hr and hr_attendance modules.
2) Create a user without Employees value.
3) Log in with the newly created user.
4) Open the hr_attendance module.
5) Attempt to load the sample data.
6) An error occurs.

ValueError
ParseError('while parsing /home/odoo/src/odoo/saas-18.1/addons/hr/data/scenarios /hr_scenario.xml:5, somewhere inside`)

This error occurs when a user tries to load sample data in the hr_attendance module without having the necessary Employees permissions due to security restrictions.

This commit resolves the issue by using sudo() to grant the necessary access to the user while loading data in hr.attendance, preventing a ParseError.

[1] -https://github.com/odoo/odoo/blob/9e5e1fc68001c71538ceb6d4033f2fd6f6f256ee/addons/hr/data/scenarios/hr_scenario.xml#L5-L8

sentry - 6264589252

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
