### PR TITLE
[IMP] l10n_br_website_sale: always display b2b for Brazil

### DIFF
--- a/addons/l10n_br_website_sale/controllers/main.py
+++ b/addons/l10n_br_website_sale/controllers/main.py
@@ -10,7 +10,7 @@ class WebsiteSaleBr(WebsiteSale):
 
         if request.params.get('country_id'):
             country = request.env['res.country'].browse(int(request.params['country_id']))
-            if request.website.sudo().company_id.country_id.code == "BR" and country.code == "BR" and "vat" not in mandatory_fields and request.website._display_partner_b2b_fields():
+            if request.website.sudo().company_id.country_id.code == "BR" and country.code == "BR" and "vat" not in mandatory_fields:
                 mandatory_fields += ['vat']
             # Needed because the user could put brazil and then change to another country, we don't want the field to stay mandatory
             elif 'vat' in mandatory_fields and country.code != 'BR':

--- a/addons/l10n_br_website_sale/models/__init__.py
+++ b/addons/l10n_br_website_sale/models/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import controllers
-from . import models
+from . import website

--- a/addons/l10n_br_website_sale/models/website.py
+++ b/addons/l10n_br_website_sale/models/website.py
@@ -1,0 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class Website(models.Model):
+    _inherit = 'website'
+
+    def _display_partner_b2b_fields(self):
+        """ Brazil localization must always display b2b fields. """
+        return self.company_id.country_id.code == 'BR' or super()._display_partner_b2b_fields()


### PR DESCRIPTION
This commit make brazilen fields always display in address
form even though b2b fields settings disabled from edition
because in LATAM country `ID Type` and `ID Number` field
are required for billing.

Also revert wrong fixed PR https://github.com/odoo/odoo/pull/194110

task-3628329