### PR TITLE
[FIX] project_task,hr_recruitment: include ticket author in stage update email BACKPORT

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -593,7 +593,7 @@ class Applicant(models.Model):
         # do not want to explicitly set user_id to False; however we do not
         # want the gateway user to be responsible if no other responsible is
         # found.
-        self = self.with_context(default_user_id=False)
+        self = self.with_context(default_user_id=False, mail_notify_author=True)  # Allows sending stage updates to the author
         stage = False
         if custom_values and 'job_id' in custom_values:
             stage = self.env['hr.job'].browse(custom_values['job_id'])._get_first_stage()

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1442,6 +1442,7 @@ class Task(models.Model):
         # found.
         create_context = dict(self.env.context or {})
         create_context['default_user_ids'] = False
+        create_context['mail_notify_author'] = True  # Allows sending stage updates to the author
         if custom_values is None:
             custom_values = {}
         # Auto create partner if not existant when the task is created from email


### PR DESCRIPTION
Backport of the original issue (ref.1) with the following message:

The issue occurs when an email is sent to create a `project.task`. If the sender of the email is an existing user, this user is later set as the author of any outgoing emails related to that task. Since the system is configured to skip sending emails to the author, no email is delivered to the sender in this scenario.

Reproduce
---
- -i project,contacts
- add `example.com` to domains in the settings
-  create new project with an alias: `project@example.com`
	- Have a stage with some "Email Template" set
- send email creating project tasks as a portal user
- BUG: email about stage update is NOT sent (even tho task appeared in stage)

(ref.1)
[FIX] project_task,hr_recruitment: include ticket author in stage update email c1a430a6ee8ade9c27a0c01d8840139942e168ef

opw-3941928
opw-4262422