### PR TITLE
[FIX] web_editor: preserve video selector parameters

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/video_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.js
@@ -3,6 +3,7 @@
 import { useService } from '@web/core/utils/hooks';
 import { throttle } from '@web/core/utils/timing';
 import { qweb } from 'web.core';
+import { getUrlParams } from "@web_editor/js/editor/odoo-editor/src/utils/utils";
 
 import { Component, useState, useRef, onMounted, onWillStart } from "@odoo/owl";
 
@@ -134,7 +135,7 @@ export class VideoSelector extends Component {
         }
         const url = embedMatch ? embedMatch[1] : this.state.urlInput;
 
-        const options = {};
+        let options = {};
         if (this.props.isForBgVideo) {
             Object.keys(this.OPTIONS).forEach(key => {
                 options[key] = true;
@@ -144,6 +145,11 @@ export class VideoSelector extends Component {
                 options[option.id] = option.value;
             }
         }
+
+        if (!Object.keys(options).length) {
+            options = getUrlParams(url);
+        }
+
         const { embed_url: src, platform } = await this._getVideoURLData(url, options);
 
         if (!src) {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1806,6 +1806,31 @@ export function getUrlsInfosInString(string) {
     return infos;
 }
 
+/**
+ * Extracts options as a boolean object based on the presence of
+ * urlParameter in the URL.
+ */
+export function getUrlParams(url) {
+    const params = [
+        "autoplay",
+        "loop",
+        "hide_controls",
+        "hide_fullscreen",
+        "hide_dm_logo",
+        "hide_dm_share",
+    ];
+    const urlParams = new URLSearchParams(new URL(url).search);
+    return params.reduce((options, param) => {
+        const value = urlParams.get(param);
+        if (param === "hide_controls") {
+            options[param] = value === "0" || urlParams.get("controls") === "0";
+        } else {
+            options[param] = value === "1";
+        }
+        return options;
+    }, {});
+}
+
 // optimize: use the parent Oid to speed up detection
 export function getOuid(node, optimize = false) {
     while (node && !isUnbreakable(node)) {

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -25,7 +25,7 @@ const weUtils = require('web_editor.utils');
 const { PeerToPeer, RequestError } = require('@web_editor/js/wysiwyg/PeerToPeer');
 const { Mutex } = require('web.concurrency');
 const snippetsOptions = require('web_editor.snippets.options');
-const { peek } = require('@web_editor/js/editor/odoo-editor/src/utils/utils');
+const { peek, getUrlParams } = require('@web_editor/js/editor/odoo-editor/src/utils/utils');
 var _t = core._t;
 const QWeb = core.qweb;
 
@@ -180,9 +180,10 @@ const Wysiwyg = Widget.extend({
         }
 
         const getYoutubeVideoElement = async (url) => {
+            const options = getUrlParams(url);
             const { embed_url: src } = await this._rpc({
-                route: '/web_editor/video_url/data',
-                params: { video_url: url },
+                route: "/web_editor/video_url/data",
+                params: { video_url: url, ...options },
             });
             const [savedVideo] = VideoSelector.createElements([{src}]);
             savedVideo.classList.add(...VideoSelector.mediaSpecificClasses);

--- a/addons/web_editor/tests/test_tools.py
+++ b/addons/web_editor/tests/test_tools.py
@@ -90,12 +90,12 @@ class TestVideoUtils(common.BaseCase):
         for key in ['vimeo', 'vimeo_player']:
             self.assertEqual(tools.get_video_url_data(TestVideoUtils.urls[key]), {
                 'platform': 'vimeo',
-                'embed_url': '//player.vimeo.com/video/395399735?autoplay=0'
+                'embed_url': 'https://player.vimeo.com/video/395399735?autoplay=0'
             })
         for key in ['vimeo_unlisted_video', 'vimeo_player_unlisted_video']:
             self.assertEqual(tools.get_video_url_data(TestVideoUtils.urls[key]), {
                 'platform': 'vimeo',
-                'embed_url': '//player.vimeo.com/video/795669787?autoplay=0&h=0763fdb816'
+                'embed_url': 'https://player.vimeo.com/video/795669787?autoplay=0&h=0763fdb816'
             })
         #dailymotion
         self.assertEqual('dailymotion', tools.get_video_url_data(TestVideoUtils.urls['dailymotion'])['platform'])

--- a/addons/web_editor/tools.py
+++ b/addons/web_editor/tools.py
@@ -88,7 +88,7 @@ def get_video_url_data(video_url, autoplay=False, loop=False, hide_controls=Fals
         if hide_fullscreen:
             params['fs'] = 0
         yt_extra = platform_match[1] or ''
-        embed_url = f'//www.youtube{yt_extra}.com/embed/{video_id}'
+        embed_url = f'https://www.youtube{yt_extra}.com/embed/{video_id}'
     elif platform == 'vimeo':
         params['autoplay'] = autoplay and 1 or 0
         if autoplay:
@@ -105,7 +105,7 @@ def get_video_url_data(video_url, autoplay=False, loop=False, hide_controls=Fals
             url_params = parse_qs(groups['params'])
             if 'h' in url_params:
                 params['h'] = url_params['h'][0]
-        embed_url = f'//player.vimeo.com/video/{video_id}'
+        embed_url = f'https://player.vimeo.com/video/{video_id}'
     elif platform == 'dailymotion':
         params['autoplay'] = autoplay and 1 or 0
         if autoplay:
@@ -116,11 +116,11 @@ def get_video_url_data(video_url, autoplay=False, loop=False, hide_controls=Fals
             params['ui-logo'] = 0
         if hide_dm_share:
             params['sharing-enable'] = 0
-        embed_url = f'//www.dailymotion.com/embed/video/{video_id}'
+        embed_url = f'https://www.dailymotion.com/embed/video/{video_id}'
     elif platform == 'instagram':
-        embed_url = f'//www.instagram.com/p/{video_id}/embed/'
+        embed_url = f'https://www.instagram.com/p/{video_id}/embed/'
     elif platform == 'youku':
-        embed_url = f'//player.youku.com/embed/{video_id}'
+        embed_url = f'https://player.youku.com/embed/{video_id}'
 
     if params:
         embed_url = f'{embed_url}?{url_encode(params)}'


### PR DESCRIPTION
 **Step to reproduce :**
    
  1. Drop the Video snippet.
  2. Double-click on the snippet and toggle a few options (e.g., "Loop").
  3. Save the video configuration
  4. Double-click on the snippet again to open the video configurator.
  5. Save without making any changes.
  -> you will see the options is reset, now.
  
  **Issue:**
  
  When modifying the options and clicking the "Add" button, the videoSelector component is destroyed, causing the selected 
  parameters to reset.
  
  **Solution:**
  
  Now, when no options are provided, the options are derived from the URL if any parameters are present.
  
  task-4529118
