### PR TITLE
[FIX] mail: add seen indicators on message with only attachments

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -107,12 +107,14 @@
                                     </t>
                                     <t t-if="!message.is_note and !message.isPending and message.hasTextContent and !env.inChatWindow" t-call="mail.Message.actions"/>
                                 </div>
-                                <AttachmentList
-                                    t-if="message.attachment_ids.length > 0"
-                                    attachments="message.attachment_ids.map((a) => a)"
-                                    unlinkAttachment.bind="onClickAttachmentUnlink"
-                                    imagesHeight="message.attachment_ids.length === 1 ? 300 : 75"
-                                    messageSearch="props.messageSearch"/>
+                                <div class="position-relative">
+                                    <AttachmentList
+                                        t-if="message.attachment_ids.length > 0"
+                                        attachments="message.attachment_ids.map((a) => a)"
+                                        unlinkAttachment.bind="onClickAttachmentUnlink"
+                                        imagesHeight="message.attachment_ids.length === 1 ? 300 : 75"
+                                        messageSearch="props.messageSearch"/>
+                                </div>
                                 <LinkPreviewList t-if="message.link_preview_ids.length > 0 and store.hasLinkPreviewFeature and !message.linkPreviewSquash" linkPreviews="message.link_preview_ids" deletable="props.message.editable"/>
                             </div>
                             <t t-if="!message.is_note and !message.isPending and (!message.hasTextContent or env.inChatWindow)" t-call="mail.Message.actions"/>

--- a/addons/mail/static/src/discuss/core/common/message_patch.xml
+++ b/addons/mail/static/src/discuss/core/common/message_patch.xml
@@ -10,5 +10,14 @@
                 />
             </div>
         </xpath>
+        <xpath expr="//AttachmentList" position="after">
+            <div t-if="props.message.isBodyEmpty and message.attachment_ids.length > 0" class="o-mail-Message-seenContainer position-absolute bg-white ratio-1x1 rounded-circle p-1">
+                <MessageSeenIndicator
+                    t-if="showSeenIndicator"
+                    message="props.message"
+                    thread="props.thread"
+                />
+            </div>
+        </xpath>
     </t>
 </templates>


### PR DESCRIPTION
Before this PR, messages with only attachments did not show the seen message indicator.
It is shown on the message body, which is missing in this case.

This PR shows the message seen indicator inside the attachment list if it's the only content of the message.

