### PR TITLE
[FIX] l10n_es_edi_facturae: only show FACe section on invoice for ES companies

### DIFF
--- a/addons/l10n_es_edi_facturae/views/account_move_views.xml
+++ b/addons/l10n_es_edi_facturae/views/account_move_views.xml
@@ -8,7 +8,8 @@
             <field name="arch" type="xml">
                 <xpath expr="//page[@name='other_info']" position="inside">
                         <group string="Factura-e"
-                               name="l10n_es_facturae_invoicing_period">
+                               name="l10n_es_facturae_invoicing_period"
+                               invisible="country_code != 'ES'">
                             <field name="l10n_es_invoicing_period_start_date"/>
                             <field name="l10n_es_invoicing_period_end_date"/>
                             <field name="l10n_es_payment_means"/>


### PR DESCRIPTION
We should show the FACe/Factura-e section on invoice when the related company is located in Spain.

opw-4397651

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
