### PR TITLE
[FIX] sale_pdf_quote_builder: prevent error when uploading document

### DIFF
--- a/addons/sale_pdf_quote_builder/views/sale_order_template_views.xml
+++ b/addons/sale_pdf_quote_builder/views/sale_order_template_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="sale_management.sale_order_template_view_form"/>
         <field name="arch" type="xml">
             <notebook position="inside">
-                <page name="pdf_quote" string="Quote Builder" invisible="not (name)">
+                <page name="pdf_quote" string="Quote Builder" invisible="not (id)">
                     <field
                         name="quotation_document_ids"
                         mode="kanban"


### PR DESCRIPTION
When attempting to upload a file in the ``Quotation Templates`` without saving the template first, an error occurs in the terminal.

Steps to reproduce:
---
- Install the ``sale_management`` module
- Sales > Configuration > Sales Order > Quotation Templates
- Create New > Add a name(Don't save)> Quote Builder > Click on Upload
- Try to upload a file

Traceback:
---
``ValueError: invalid literal for int() with base 10: 'false'``

Previous Behaviour:
---
When entering the name of ``Quotation Templates`` (Don't Save), the Notebook page of ``Quote Builder`` appears, and an error occurs upon uploading the document.

Solution:
---
Initially, we were checking for invisibility based on the name. However, we now display the view when an ID is retrieved, ensuring the page remains hidden until it is saved.

sentry-5963406254

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
