### PR TITLE
[FIX] purchase_stock: no extra SVL on return of return with exch. diff

### DIFF
--- a/addons/purchase_stock/models/account_move_line.py
+++ b/addons/purchase_stock/models/account_move_line.py
@@ -311,7 +311,13 @@ class AccountMoveLine(models.Model):
                     # the returned one, the accounting entries are already compensated, and we don't want to impact
                     # the stock valuation. So, let's fake the layer price unit with the POL one as everything is
                     # already ok
-                    layer_price_unit = po_line._get_gross_price_unit()
+                    layer_price_unit = po_line.currency_id._convert(
+                        po_line._get_gross_price_unit(),
+                        layer.currency_id,
+                        layer.company_id,
+                        layer.create_date.date(),
+                        round=False
+                    )
 
                 aml = self
 

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -3605,3 +3605,55 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                 {'account_id': account_payable_account.id,   'debit': 0.0,      'credit': 1380.0},
             ]
         )
+
+    def test_return_a_return_avco_prod_with_exchange_diff(self):
+        """ When there is some return of a return, we expect `_generate_price_difference_vals` to
+        assume any pdiff existing in the relevant transfers' SVL records has already been
+        compensated for. This should remain true in the case where the underlying purchase order
+        has some currency exchange diff.
+        """
+        self.product1.categ_id.property_cost_method = 'average'
+        avco_prod = self.product1
+        (self.env.ref('base.EUR') + self.env.ref('base.CHF')).active = True
+        euro_id = self.env.ref('base.EUR').id
+        franc_id = self.env.ref('base.CHF').id
+        self.env['res.currency.rate'].create([
+            {'currency_id': euro_id, 'rate': 0.95},
+            {'currency_id': franc_id, 'rate': 0.8},
+        ])
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'currency_id': euro_id,
+            'order_line': [Command.create({
+                'product_id': avco_prod.id,
+                'product_uom_qty': 5,
+                'price_unit': 10,
+            })],
+        })
+        purchase_order.button_confirm()
+        receipt1 = purchase_order.picking_ids
+        receipt1.move_ids.quantity_done = 5
+        receipt1.button_validate()
+
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_b.id,
+            'currency_id': franc_id,
+            'order_line': [Command.create({
+                'product_id': avco_prod.id,
+                'product_uom_qty': 5,
+            })],
+        })
+        purchase_order.button_confirm()
+        receipt2 = purchase_order.picking_ids
+        receipt2.move_ids.quantity_done = 5
+        receipt2.button_validate()
+
+        receipt2_return1 = self._return(receipt2)
+        # return the initial return
+        self._return(receipt2_return1)
+        pre_bill_cost = avco_prod.standard_price
+        purchase_order.action_create_invoice()
+        bill = purchase_order.invoice_ids
+        bill.invoice_date = fields.Date.today()
+        bill.action_post()
+        self.assertEqual(avco_prod.standard_price, pre_bill_cost)


### PR DESCRIPTION
**Current behavior:**
For `real_time`, `avco` prod:
When posting the bill of a reception which originated from a PO with a foreign currency, if a return for the receipt was generated as well as a return for that return, there will be an extraneous SVL created which illogically affects the product's `standard_price` (product value has increased from nowhere).

**Expected behavior:**
The product cost prior to posting the bill and after posting the bill is equal.

**Steps to reproduce:**
1. Create an `avco` + `real_time` costing/valuated productA

2. Activate 2 additional currencies + give them unique exchange rates

3. Create a purchase order in the first of the two additional currencies, for `N` units of productA at $`price_unit`

4. Confirm the PO -> receive the product

5. Create another purchase order in the second of the two currencies, again `N` units @ $`price_unit`

6. Confirm + receive, then generate a return for this reception

7. Generate a return for the return of step 6

8. Note the current `standar_price` of ProductA

9. For the second purchase order (the one with the returns) create the vendor bill

10. Observe that the `standard_price` of ProductA has increased without any legitimate basis

**Cause of the issue:**
In `_generate_price_difference_vals`:
https://github.com/odoo/odoo/blob/55658e7f43375d7e1af07293e2cd9d1cc4b33883/addons/purchase_stock/models/account_move_line.py#L307-L314 We operate with the assumption that, because we are in a return of a return, any existing pdiff will have already been compensated for- so we take the POL price unit at face value to compare with the AML price unit.

But, in case the POL and AML are in different currencies, this will fail to prevent a pdiff SVL from being created.

**Fix:**
Convert the purchase line's returned price unit to the currency used by the layer for which we are finding the pdiff.

opw-4334372