### PR TITLE
[FIX] point_of_sale: prevent error with 0 decimal places

### DIFF
--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -130,7 +130,7 @@ export function parseUTCString(utcStr) {
 }
 
 export function floatCompare(a, b, { decimals } = {}) {
-    if (!decimals) {
+    if (decimals === undefined) {
         throw new Error("decimals must be provided");
     }
     a = roundDecimals(a, decimals);


### PR DESCRIPTION
Before this commit, if a currency had zero decimal places, it would cause an error when selling products.

opw-4543742

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
