### PR TITLE
[FIX] website: fix datepickerInitialized variable name

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -49,14 +49,14 @@ export class Form extends Interaction {
         },
         ".s_website_form_datetime, .o_website_form_datetime, .s_website_form_date, .o_website_form_date": {
             "t-att-class": () => ({
-                "s_website_form_datepicker_initialized": this.datapickerInitialized,
+                "s_website_form_datepicker_initialized": this.datepickerInitialized,
             }),
         },
     };
 
     setup() {
         this.isHidden = false;
-        this.datapickersInitialized = false;
+        this.datepickerInitialized = false;
         this.recaptcha = new ReCaptcha();
         this.initialValues = new Map();
         this.disabledStates = new Map();
@@ -197,7 +197,7 @@ export class Form extends Interaction {
                 },
             }).enable());
         }
-        this.datapickerInitialized = true
+        this.datepickerInitialized = true;
     }
 
     prefillValues() {


### PR DESCRIPTION
When the website form public widget was converted into interactions in [1], the variable that tracks the initialization of datepickers was wronly named.

This commit fixes that name.

[1]: https://github.com/odoo/odoo/commit/b9b3a605e0f4c5da3a258c980107d6162da7f44f

task-4367641
