### PR TITLE
[FIX] point_of_sale: Don't archive POS config's default pricelist

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -115,3 +115,18 @@ class Uom(models.Model):
     _inherit = 'uom.uom'
 
     is_pos_groupable = fields.Boolean(related='category_id.is_pos_groupable', readonly=False)
+
+
+class ProductPricelist(models.Model):
+    _inherit = 'product.pricelist'
+
+    def write(self, vals):
+        if 'active' in vals and not vals['active']:
+            self._check_active_pos()
+        super().write(vals)
+
+    def _check_active_pos(self):
+        for record in self:
+            pos_configs = self.env['pos.config'].sudo().search([('pricelist_id', '=', record.id)])
+            if pos_configs:
+                raise UserError(_('This pricelist is in use by POS configuration %s.', ",".join(pos.name for pos in pos_configs)))

--- a/addons/product/tests/common.py
+++ b/addons/product/tests/common.py
@@ -54,7 +54,13 @@ class ProductCommon(
         else:
             archive_context = nullcontext()
 
-        with archive_context:
+        point_of_sale = cls.env['ir.module.module']._get('point_of_sale')
+        if point_of_sale.state == 'installed':
+            pos_context = patch('odoo.addons.point_of_sale.models.product.ProductPricelist._check_active_pos')
+        else:
+            pos_context = nullcontext()
+
+        with archive_context, pos_context:
             cls.env['product.pricelist'].search([
                 ('id', '!=', cls.pricelist.id),
             ]).action_archive()


### PR DESCRIPTION
A pricelist can be archived even if it's been used as the default pricelist for some POS config. Since the archived pricelist will be filtered out from the available pricelists, trying to write on the record might trigger the error 
`The default pricelist must be included in the available pricelists.`

This can happen during an upgrade, when a record is being updated making the upgrade fail.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
