### PR TITLE
[REV]{*_}loyalty,sale: fix amount per tax

### DIFF
--- a/addons/loyalty/views/loyalty_reward_views.xml
+++ b/addons/loyalty/views/loyalty_reward_views.xml
@@ -37,14 +37,7 @@
 
                         <group string="Discount" invisible="reward_type != 'discount' or program_type in ('gift_card','ewallet')">
                             <field name="discount_max_amount"/>
-                            <field
-                                name="tax_ids"
-                                placeholder="Untaxed discount"
-                                widget="many2many_tags"
-                                options="{'no_create': True}"
-                                invisible="discount_applicability != 'order' or
-                                    discount_mode not in ('per_order','per_point')"
-                            />
+                            <field name="tax_ids" invisible="1"/>
                             <field name="discount_product_domain" groups="base.group_no_one" widget="domain" options="{'model': 'product.product', 'in_dialog': true}" invisible="discount_applicability != 'specific'"/>
                             <field name="discount_product_ids" widget="many2many_tags" invisible="discount_applicability != 'specific'"/>
                             <field name="discount_product_category_id" invisible="discount_applicability != 'specific'"/>
@@ -83,7 +76,7 @@
         <field name="model">loyalty.reward</field>
         <field name="arch" type="xml">
             <kanban>
-                <field name="company_id"/>
+                <field name="company_id" invisible="1"/>
                 <field name="currency_id"/>
                 <field name="reward_type"/>
                 <field name="discount_applicability"/>

--- a/addons/pos_loyalty/models/loyalty_reward.py
+++ b/addons/pos_loyalty/models/loyalty_reward.py
@@ -24,7 +24,7 @@ class LoyaltyReward(models.Model):
     def _load_pos_data_fields(self, config_id):
         return ['description', 'program_id', 'reward_type', 'required_points', 'clear_wallet', 'currency_id',
                 'discount', 'discount_mode', 'discount_applicability', 'all_discount_product_ids', 'is_global_discount',
-                'discount_max_amount', 'discount_line_product_id', 'reward_product_id', 'tax_ids',
+                'discount_max_amount', 'discount_line_product_id', 'reward_product_id',
                 'multi_product', 'reward_product_ids', 'reward_product_qty', 'reward_product_uom_id', 'reward_product_domain']
 
     def _load_pos_data(self, data):

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -3,10 +3,7 @@ import { patch } from "@web/core/utils/patch";
 import { roundDecimals, roundPrecision } from "@web/core/utils/numbers";
 import { _t } from "@web/core/l10n/translation";
 import { loyaltyIdsGenerator } from "./pos_store";
-import {
-    compute_price_force_price_include,
-    getTaxesAfterFiscalPosition,
-} from "@point_of_sale/app/models/utils/tax_utils";
+import { compute_price_force_price_include } from "@point_of_sale/app/models/utils/tax_utils";
 const { DateTime } = luxon;
 
 function _newRandomRewardCode() {
@@ -1145,66 +1142,6 @@ patch(PosOrder.prototype, {
                 },
             ];
         }
-
-        if (
-            rewardAppliesTo === "order" &&
-            ["per_point", "per_order"].includes(reward.discount_mode)
-        ) {
-            const rewardLineValues = [
-                {
-                    product_id: discountProduct,
-                    price_unit: -Math.min(maxDiscount, discountable),
-                    qty: 1,
-                    reward_id: reward,
-                    is_reward_line: true,
-                    coupon_id: coupon_id,
-                    points_cost: pointCost,
-                    reward_identifier_code: rewardCode,
-                    tax_ids: [],
-                },
-            ];
-
-            let rewardTaxes = reward.tax_ids;
-            if (rewardTaxes.length > 0) {
-                if (this.fiscal_position_id) {
-                    rewardTaxes = getTaxesAfterFiscalPosition(
-                        rewardTaxes,
-                        this.fiscal_position_id,
-                        this.models
-                    );
-                }
-
-                // Check for any order line where its taxes exactly match rewardTaxes
-                const matchingLines = this.get_orderlines().filter(
-                    (line) =>
-                        !line.is_delivery &&
-                        line.tax_ids.length === rewardTaxes.length &&
-                        line.tax_ids.every((tax_id) => rewardTaxes.includes(tax_id))
-                );
-
-                if (matchingLines.length == 0) {
-                    return _t("No product is compatible with this promotion.");
-                }
-
-                const untaxedAmount = matchingLines.reduce(
-                    (sum, line) => sum + line.get_price_without_tax(),
-                    0
-                );
-                // Discount amount should not exceed total untaxed amount of the matching lines
-                rewardLineValues[0].price_unit = Math.max(
-                    -untaxedAmount,
-                    rewardLineValues[0].price_unit
-                );
-
-                rewardLineValues[0].tax_ids = rewardTaxes;
-            }
-            // Discount amount should not exceed the untaxed amount on the order
-            if (Math.abs(rewardLineValues[0].price_unit) > this.amount_untaxed) {
-                rewardLineValues[0].price_unit = -this.amount_untaxed;
-            }
-            return rewardLineValues;
-        }
-
         const discountFactor = discountable ? Math.min(1, maxDiscount / discountable) : 1;
         const result = Object.entries(discountablePerTax).reduce((lst, entry) => {
             // Ignore 0 price lines

--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -1803,6 +1803,12 @@ msgid "Discount on lines"
 msgstr ""
 
 #. module: sale
+#. odoo-python
+#: code:addons/sale/wizard/sale_order_discount.py:0
+msgid "Discount- On products with the following taxes %(taxes)s"
+msgstr ""
+
+#. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 msgid "Discount:"
 msgstr ""

--- a/addons/sale/tests/test_sale_order_discount.py
+++ b/addons/sale/tests/test_sale_order_discount.py
@@ -30,24 +30,6 @@ class TestSaleOrderDiscount(SaleCommon):
         self.assertEqual(discount_line.product_uom_qty, 1.0)
         self.assertFalse(discount_line.tax_id)
 
-    def test_amount_with_manual_tax(self):
-        self.tax_15pc_excl = self.env['account.tax'].create({
-            'name': "15% Tax excl",
-            'amount_type': 'percent',
-            'amount': 15,
-        })
-        self.wizard.write({
-            'discount_amount': 55,
-            'discount_type': 'amount',
-            'tax_ids': [(6, 0, (self.tax_15pc_excl.id,))],
-        })
-        self.wizard.action_apply_discount()
-
-        discount_line = self.sale_order.order_line[-1]
-        self.assertEqual(discount_line.price_unit, -55)
-        self.assertEqual(discount_line.product_uom_qty, 1.0)
-        self.assertEqual(discount_line.price_total, -63.25)
-
     def test_so_discount(self):
         solines = self.sale_order.order_line
         amount_before_discount = self.sale_order.amount_total

--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -103,7 +103,7 @@ class SaleOrderDiscount(models.TransientModel):
                 self._prepare_discount_line_values(
                     product=discount_product,
                     amount=self.discount_amount,
-                    taxes=self.tax_ids,
+                    taxes=self.env['account.tax'],
                 )
             ]
         else: # so_discount

--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -99,54 +99,55 @@ class SaleOrderDiscount(models.TransientModel):
         discount_product = self._get_discount_product()
 
         if self.discount_type == 'amount':
+            if not self.sale_order_id.amount_total:
+                return
+            discount_percentage = self.discount_amount / self.sale_order_id.amount_total
+        else: # so_discount
+            discount_percentage = self.discount_percentage
+        total_price_per_tax_groups = defaultdict(float)
+        for line in self.sale_order_id.order_line:
+            if not line.product_uom_qty or not line.price_unit:
+                continue
+            discounted_price = line.price_unit * (1 - (line.discount or 0.0)/100)
+            total_price_per_tax_groups[line.tax_id] += (discounted_price * line.product_uom_qty)
+
+        discount_dp = self.env['decimal.precision'].precision_get('Discount')
+        if not total_price_per_tax_groups:
+            # No valid lines on which the discount can be applied
+            return
+        if len(total_price_per_tax_groups) == 1:
+            # No taxes, or all lines have the exact same taxes
+            taxes = next(iter(total_price_per_tax_groups.keys()))
+            subtotal = total_price_per_tax_groups[taxes]
+            vals_list = [{
+                **self._prepare_discount_line_values(
+                    product=discount_product,
+                    amount=subtotal * discount_percentage,
+                    taxes=taxes,
+                    description=_(
+                        "Discount %(percent)s%%",
+                        percent=float_repr(discount_percentage * 100, discount_dp),
+                    ),
+                ),
+            }]
+        else:
             vals_list = [
                 self._prepare_discount_line_values(
                     product=discount_product,
-                    amount=self.discount_amount,
-                    taxes=self.env['account.tax'],
-                )
+                    amount=subtotal * discount_percentage,
+                    taxes=taxes,
+                    description=_(
+                        "Discount %(percent)s%%"
+                        "- On products with the following taxes %(taxes)s",
+                        percent=float_repr(discount_percentage * 100, discount_dp),
+                        taxes=", ".join(taxes.mapped('name')),
+                    ) if self.discount_type != 'amount' else _(
+                        "Discount"
+                        "- On products with the following taxes %(taxes)s",
+                        taxes=", ".join(taxes.mapped('name')),
+                    )
+                ) for taxes, subtotal in total_price_per_tax_groups.items()
             ]
-        else: # so_discount
-            total_price_per_tax_groups = defaultdict(float)
-            for line in self.sale_order_id.order_line:
-                if not line.product_uom_qty or not line.price_unit:
-                    continue
-                discounted_price = line.price_unit * (1 - (line.discount or 0.0)/100)
-                total_price_per_tax_groups[line.tax_id] += (discounted_price * line.product_uom_qty)
-
-            discount_dp = self.env['decimal.precision'].precision_get('Discount')
-            if not total_price_per_tax_groups:
-                # No valid lines on which the discount can be applied
-                return
-            elif len(total_price_per_tax_groups) == 1:
-                # No taxes, or all lines have the exact same taxes
-                taxes = next(iter(total_price_per_tax_groups.keys()))
-                subtotal = total_price_per_tax_groups[taxes]
-                vals_list = [{
-                    **self._prepare_discount_line_values(
-                        product=discount_product,
-                        amount=subtotal * self.discount_percentage,
-                        taxes=taxes,
-                        description=_(
-                            "Discount %(percent)s%%",
-                            percent=float_repr(self.discount_percentage * 100, discount_dp),
-                        ),
-                    ),
-                }]
-            else:
-                vals_list = [
-                    self._prepare_discount_line_values(
-                        product=discount_product,
-                        amount=subtotal * self.discount_percentage,
-                        taxes=taxes,
-                        description=_(
-                            "Discount %(percent)s%%"
-                            "- On products with the following taxes %(taxes)s",
-                            percent=float_repr(self.discount_percentage * 100, discount_dp),
-                            taxes=", ".join(taxes.mapped('name')),
-                        ),
-                    ) for taxes, subtotal in total_price_per_tax_groups.items()
-                ]
         return self.env['sale.order.line'].create(vals_list)
 
     def action_apply_discount(self):

--- a/addons/sale/wizard/sale_order_discount_views.xml
+++ b/addons/sale/wizard/sale_order_discount_views.xml
@@ -21,13 +21,7 @@
                                 <field name="discount_percentage"
                                        invisible="discount_type not in ('so_discount', 'sol_discount')"
                                        widget="percentage" nolabel="1"/>
-                                <field
-                                    name="tax_ids"
-                                    placeholder="Untaxed discount"
-                                    widget="many2many_tags"
-                                    options="{'no_create': True}"
-                                    invisible="discount_type != 'amount'"
-                                />
+                                <field name="tax_ids" invisible="1"/>
                             </group>
                         </div>
                         <div class="col-sm-7 col-md-8 col-lg-8 col-8">

--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -567,41 +567,6 @@ class SaleOrder(models.Model):
                     })
             return [reward_line_values]
 
-        if reward_applies_on == 'order' and reward.discount_mode in ['per_point', 'per_order']:
-            reward_line_values = {
-                **base_reward_line_values,
-                'price_unit': -min(max_discount, discountable),
-                'points_cost': point_cost,
-            }
-
-            reward_taxes = reward.tax_ids._filter_taxes_by_company(self.company_id)
-            if reward_taxes:
-                mapped_taxes = self.fiscal_position_id.map_tax(reward_taxes)
-
-                # Check for any order line where its taxes exactly match reward_taxes
-                matching_lines = [
-                    line for line in self.order_line
-                    if not line._is_delivery() and set(line.tax_id) == set(mapped_taxes)
-                ]
-
-                if not matching_lines:
-                    raise ValidationError(_("No product is compatible with this promotion."))
-
-                untaxed_amount = sum(line.price_subtotal for line in matching_lines)
-                # Discount amount should not exceed total untaxed amount of the matching lines
-                reward_line_values['price_unit'] = max(
-                    -untaxed_amount,
-                    reward_line_values['price_unit']
-                )
-
-                reward_line_values['tax_id'] = [Command.set(mapped_taxes.ids)]
-
-            # Discount amount should not exceed the untaxed amount on the order
-            if abs(reward_line_values['price_unit']) > self.amount_untaxed:
-                reward_line_values['price_unit'] = -self.amount_untaxed
-
-            return [reward_line_values]
-
         discount_factor = min(1, (max_discount / discountable)) if discountable else 1
         reward_dict = {}
         for tax, price in discountable_per_tax.items():

--- a/addons/sale_loyalty/tests/test_program_numbers.py
+++ b/addons/sale_loyalty/tests/test_program_numbers.py
@@ -613,52 +613,6 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(order.amount_total, 65.0, "The coupon should not be removed from the order")
 
-    def test_coupon_discount_with_taxes_applied(self):
-        """Ensure coupon discount with taxes applies correctly
-           and doesn't make the order total go below 0.
-        """
-
-        coupon_program = self.env['loyalty.program'].create({
-            'name': '$300 coupon',
-            'program_type': 'coupons',
-            'trigger': 'with_code',
-            'applies_on': 'current',
-            'reward_ids': [(0, 0, {
-                'reward_type': 'discount',
-                'discount_mode': 'per_point',
-                'discount': 300,
-                'discount_applicability': 'order',
-                'required_points': 1,
-                'tax_ids': [(6, 0, (self.tax_15pc_excl.id,))],
-            })],
-        })
-
-        order = self.empty_order
-        self.env['sale.order.line'].create([
-        {
-            'product_id': self.conferenceChair.id,
-            'name': 'Conference Chair',
-            'product_uom_qty': 1.0,
-            'price_unit': 100.0,
-            'order_id': order.id,
-            'tax_id': [(6, 0, (self.tax_15pc_excl.id,))],
-        },
-        ])
-
-        self.env['loyalty.generate.wizard'].with_context(active_id=coupon_program.id).create({
-            'coupon_qty': 1,
-            'points_granted': 1,
-        }).generate_coupons()
-        coupon = coupon_program.coupon_ids
-        self._apply_promo_code(order, coupon.code)
-
-        self.assertEqual(order.amount_tax, 0.0)
-        self.assertEqual(order.amount_untaxed, 0.0, "The untaxed amount should not go below 0")
-        self.assertEqual(
-            order.amount_total, 0.0,
-            "The promotion program should not make the order total go below 0"
-        )
-
     def test_coupon_and_program_discount_fixed_amount(self):
         """ Ensure coupon and program discount both with
             minimum amount rule can cohexists without making
@@ -773,9 +727,9 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         coupon = coupon_program.coupon_ids
         self._apply_promo_code(order, coupon.code)
         self._auto_rewards(order, self.all_programs)
-        self.assertEqual(order.amount_tax, 13.5)
+        self.assertEqual(order.amount_tax, 0.0)
         self.assertEqual(order.amount_untaxed, 0.0, "The untaxed amount should not go below 0")
-        self.assertEqual(order.amount_total, 13.5, "The promotion program should not make the order total go below 0")
+        self.assertEqual(order.amount_total, 0.0, "The promotion program should not make the order total go below 0")
 
         order.order_line[3:].unlink() #remove all coupon
         order._remove_program_from_points(coupon_program)
@@ -788,13 +742,13 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self._auto_rewards(order, self.all_programs)
         self._apply_promo_code(order, 'test_10pc')
         self._auto_rewards(order, self.all_programs)
-        self.assertAlmostEqual(order.amount_tax, 13.5, 2)
-        self.assertEqual(order.amount_untaxed, 10.35)
+        self.assertAlmostEqual(order.amount_tax, 1.13, 2)
+        self.assertEqual(order.amount_untaxed, 22.72)
         self.assertEqual(order.amount_total, 23.85, "The promotion program should not make the order total go below 0be altered after recomputation")
         # It should stay the same after a recompute, order matters
         self._auto_rewards(order, self.all_programs)
-        self.assertAlmostEqual(order.amount_tax, 13.5, 2)
-        self.assertEqual(order.amount_untaxed, 10.35)
+        self.assertAlmostEqual(order.amount_tax, 1.13, 2)
+        self.assertEqual(order.amount_untaxed, 22.72)
         self.assertEqual(order.amount_total, 23.85, "The promotion program should not make the order total go below 0be altered after recomputation")
 
     def test_coupon_and_coupon_discount_fixed_amount_tax_incl(self):
@@ -859,11 +813,11 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         }).generate_coupons()
         coupon = coupon_program.coupon_ids
         self._apply_promo_code(order, coupon.code)
-        self.assertEqual(order.amount_total, 8.18, "The promotion program should not make the order total go below 0")
-        self.assertEqual(order.amount_tax, 8.18)
+        self.assertEqual(order.amount_total, 0, "The promotion program should not make the order total go below 0")
+        self.assertEqual(order.amount_tax, 0)
         self._auto_rewards(order, self.all_programs)
-        self.assertEqual(order.amount_total, 8.18, "The promotion program should not be altered after recomputation")
-        self.assertEqual(order.amount_tax, 8.18)
+        self.assertEqual(order.amount_total, 0, "The promotion program should not be altered after recomputation")
+        self.assertEqual(order.amount_tax, 0)
 
         order.order_line[3:].unlink() #remove all coupon
         order._remove_program_from_points(coupon_program)
@@ -876,13 +830,13 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self._apply_promo_code(order, 'test_10pc')
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(order.amount_total, 9.0, "The promotion program should not make the order total go below 0")
-        self.assertEqual(order.amount_tax, 8.18)
-        self.assertEqual(order.amount_untaxed, 0.82)
+        self.assertEqual(order.amount_tax, 0.27)
+        self.assertEqual(order.amount_untaxed, 8.73)
         # It should stay the same after a recompute, order matters
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(order.amount_total, 9.0, "The promotion program should not make the order total go below 0")
-        self.assertEqual(order.amount_tax, 8.18)
-        self.assertEqual(order.amount_untaxed, 0.82)
+        self.assertEqual(order.amount_tax, 0.27)
+        self.assertEqual(order.amount_untaxed, 8.73)
 
     def test_program_discount_on_multiple_specific_products(self):
         """ Ensure a discount on multiple specific products is correctly computed.
@@ -1551,13 +1505,13 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self._auto_rewards(order, program)
 
         self.assertEqual(order.amount_total, 7, 'Price should be 12$ - 5$(discount) = 7$')
-        self.assertEqual(float_compare(order.amount_tax, 7 / 4, precision_rounding=3), 0, '20% Tax included on 7$')
+        self.assertEqual(float_compare(order.amount_tax, 7 / 12, precision_rounding=3), 0, '20% Tax included on 7$')
 
         sol.tax_id = self.tax_10pc_base_incl + self.tax_10pc_excl
         self._auto_rewards(order, program)
 
         self.assertAlmostEqual(order.amount_total, 6, 1, msg='Price should be 11$ - 5$(discount) = 6$')
-        self.assertEqual(float_compare(order.amount_tax, 6 / 4, precision_rounding=3), 0, '20% Tax included on 6$')
+        self.assertEqual(float_compare(order.amount_tax, 6 / 12, precision_rounding=3), 0, '20% Tax included on 6$')
 
     def test_fixed_amount_taxes_attribution_multiline(self):
 
@@ -1607,8 +1561,8 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self._auto_rewards(order, program)
 
         self.assertAlmostEqual(order.amount_total, 16, 1, msg='Price should be 21$ - 5$(discount) = 16$')
-        # Tax amount = 10% in 10$ + 10% in 11$
-        self.assertEqual(float_compare(order.amount_tax, 5 / 3, precision_rounding=3), 0)
+        # Tax amount = 10% in 10$ + 10% in 11$ - 10% in 5$ (apply on excluded)
+        self.assertEqual(float_compare(order.amount_tax, 5 / 11, precision_rounding=3), 0)
 
         sol2.tax_id = self.tax_10pc_base_incl + self.tax_10pc_excl
         self._auto_rewards(order, program)
@@ -1905,19 +1859,19 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
 
         self.assertAlmostEqual(
             order.amount_total,
-            self.pedalBin.list_price * (1 + self.tax_20pc_excl.amount / 100),
+            self.pedalBin.list_price * (1 + self.tax_20pc_excl.amount / 100),  # $56.4
             msg="Order total should equal product list price plus taxes",
         )
 
         self._auto_rewards(order, order_program)
         self.assertAlmostEqual(
             order.amount_total,
-            self.pedalBin.list_price * self.tax_20pc_excl.amount / 100,
-            msg="Order total should equal just taxes after applying $50 no-tax discount",
+            self.pedalBin.list_price * (1 + self.tax_20pc_excl.amount / 100) - 50,  # $6.4
+            msg="The order total should be $50 less than initially after the discount is applied.",
         )
 
         self._auto_rewards(order, specific_program)
         self.assertFalse(
             order.amount_total,
-            "Order total should equal zero after applying specific $10 tax-included discount",
+            "Order total should be 0, as a specific discount should have been applied.",
         )


### PR DESCRIPTION
Commit db12319e8b3b662a1498ee9a519fbced457174cc introduced a wrong behaviour for the discounts applied to an order when they are fixed or depending on the number of points. With this commit, the taxes applied would the ones set on the reward product if at least one line in the sale order had these taxes. Disregarding any other taxes applied, or not setting taxes at all. This was done to facilitate the reading of a sale order.

Accounting wise, this is wrong. A product is paid less, so less taxes needs to be recorded. It's not optimization, it's regulation.

Reverting part of db12319e8b3b662a1498ee9a519fbced457174cc to evaluate how to ease the user life without having them getting on the warpath of their accountant.

opw-4486030

TODO in master: take off taxes fields.
