### PR TITLE
[FIX] point_of_sale: fix incorrect count in session report

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1080,7 +1080,7 @@ class PosSession(models.Model):
         destination_account = self._get_receivable_account(payment_method)
 
         account_payment = self.env['account.payment'].with_context(pos_payment=True).create({
-            'amount': abs(amounts['amount']),
+            'amount': abs(amounts['amount']) + diff_amount,
             'journal_id': payment_method.journal_id.id,
             'force_outstanding_account_id': outstanding_account.id,
             'destination_account_id': destination_account.id,


### PR DESCRIPTION


- In POS, open a register and add Product A with a price of 100. Proceed with the payment using a card.

- Close the register, increase the cash count by 20, and reduce the card count to 80.

In the session report, the difference in the card payment is not displayed correctly. It shows the expected amount as 100 and the counted amount as 100, whereas it should be expected at 100 and counted at 80.

Commit https://github.com/odoo/odoo/commit/01b87f1230beac0568f4e3b1b76e547909506892#diff-143d17de807d23650088a8c12f0a5b5cc2246b1b51e0bb7634e85247b6e535ea  made journal entry optional for payments and removed the `synchronize_from_moves` method from `account_payment`. This mean that there is no longer a synchronization between account_payment and its potential journal entries. The source (here pos_session) is now responsible for creating and linking the moves to the payment. The amount field of account_payment, which is used to construct the session report and created in `_create_combine_account_payment` was not updated with the new balance created in `_apply_diff_on_account_payment_move`.

opw-4494656



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
