### PR TITLE
[FIX] hr: message post departure reason traceback

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -462,9 +462,10 @@ class HrEmployeePrivate(models.Model):
                 ('subscription_department_ids', 'in', department_id)
             ])._subscribe_users_automatically()
         if vals.get('departure_description'):
-            self.message_post(body=_(
-                'Additional Information: \n %(description)s',
-                description=vals.get('departure_description')))
+            for employee in self:
+                employee.message_post(body=_(
+                    'Additional Information: \n %(description)s',
+                    description=vals.get('departure_description')))
         return res
 
     def unlink(self):


### PR DESCRIPTION
Since the function message_post on mail thread has been built to be called on exactly one record and the function write on employee is for multiple records, we need to call it for each employee we are writing on.

It has been introduced in: https://github.com/odoo/odoo/pull/143217

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
