### PR TITLE
[FIX] stock: 2-step delivery destination location

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1414,6 +1414,7 @@ Please change the quantity done or the rounding precision of your unit of measur
             'picking_type_id': self.mapped('picking_type_id').id,
             'location_id': self.mapped('location_id').id,
         }
+        self.env.add_to_compute(self._fields['location_dest_id'], self)
         if self.location_dest_id.ids:
             vals['location_dest_id'] = self.location_dest_id.id
         return vals


### PR DESCRIPTION
to reproduce:
=============
- make warehouse with 2-step delivery
- create contact with Customer Location = Partners/Customers/Test (make sure location type = Customer location)
- create a sale order with this contact
- confirm the sale order
- confirm first delivery -> the second delivery is created but the destination location is set to **Partners/Customers** instead of **Partners/Customers/Test**

Problem:
========
- starting from 17.2 the second pick is created after validating the first one at creation used vals received from the move has the wrong destination location, it will be recomputed after creating the second pick but it's too late to change the destination location of the second pick

Solution:
=========
- recompute the destination location of move when preparing vals of the second pick

opw-4374075

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
