### PR TITLE
[FIX] mrp: acces bom overview for dynamic product variant

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -657,7 +657,7 @@ class MrpBomLine(models.Model):
                 - always and dynamic: match_all_variant_values()
         """
         self.ensure_one()
-        if product._name == 'product.template':
+        if not product or product._name == 'product.template':
             return False
 
         # attributes create_variant 'always' and 'dynamic'
@@ -788,7 +788,7 @@ class MrpByProduct(models.Model):
         custom control.
         """
         self.ensure_one()
-        if product._name == 'product.template':
+        if not product or product._name == 'product.template':
             return False
         return not product._match_all_variant_values(self.bom_product_template_attribute_value_ids)
 

--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -172,7 +172,7 @@ class MrpRoutingWorkcenter(models.Model):
         # skip operation line if archived
         if not self.active:
             return True
-        if product._name == 'product.template':
+        if not product or product._name == 'product.template':
             return False
         return not product._match_all_variant_values(self.bom_product_template_attribute_value_ids)
 

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -2543,6 +2543,46 @@ class TestBoM(TestMrpCommon):
         self.assertEqual(bom.bom_line_ids[1].operation_id, ope_2)
         self.assertEqual(bom.byproduct_ids[1].operation_id, ope_2)
 
+    def test_bom_overview_for_product_template_with_dynamic_variants(self):
+        """
+        This test checks if the bom overview report is generated when we have a product with dynamic create variants
+        meaning the product variants are only created on adding them to a sales order
+        """
+        dynamic_attribute = self.env['product.attribute'].create({
+            'name': 'Dynamic',
+            'create_variant': 'dynamic',
+            'value_ids': [
+                Command.create({'name': 'red', 'sequence': 1}),
+            ]
+        })
+        attr_val = dynamic_attribute['value_ids'][0]
+        product_with_dynamic_variant = self.env['product.template'].create({
+            'name': 'John Cutter',
+            'attribute_line_ids': [Command.create({
+                'attribute_id': dynamic_attribute.id,
+                'value_ids': [attr_val.id]
+            })],
+        })
+        bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': product_with_dynamic_variant.id,
+            'operation_ids': [
+                Command.create({'name': 'Rub it gently with a cloth two at once', 'workcenter_id': self.workcenter_3.id}),
+            ],
+            'bom_line_ids': [
+                Command.create({
+                    'product_id': self.product_1.id,
+                })
+            ],
+            'byproduct_ids': [
+                Command.create({
+                    'product_id': self.product_1.id
+                }),
+            ]
+        })
+        bom_overview = self.env['report.mrp.report_bom_structure']._get_report_data(bom.id)['lines']
+        self.assertTrue(bom_overview['byproducts'])
+        self.assertFalse(bom_overview['product'])
+        self.assertTrue(bom_overview['components'])
 
 @tagged('-at_install', 'post_install')
 class TestTourBoM(HttpCase):


### PR DESCRIPTION
Steps to reproduce the bug:
 - Ceate a product
 - add a new attribute with "variant creation mode" = "Dynamic"
 - create a BoM for this product
 - make sure to add an operation in the operational lines of the bom
 - Click on the BoM smart button then BoM overview smart button

Problem:
Traceback is raise, because in the BoM overview it creates a BoM report, and it adds the operational lines(operations) to the report, some operations are skipped based on the function `_match_all_variant_values` that checks if the product has all the variant values. This function expects a product to run on, but in case of dynamic attribute a product will only be created if it is included in a sales order, hence the product is empty and the function raise the exception.

Since the BoM report is for the product variants, then we can skip the operational line if no product is used in the BoM, and hence the `_match_all_variant_values` won't be called over empty product.

opw-4518723

**Possible approaches for the Issue**:
   1- Change the product variable in the bom object in the _get_bom_data function to be the product.template instead of the concrete product, this will affect many other functions in the generating of the bom report as **_get_resupply_route_info** function that calls **_get_rules_from_location** which is not a function on the 'product.template' model. 
   Considering that approach requires anticipating the case of having the product.template in the bom in all the sections in the bom report.

  2- Keep the porduct in the bom object empty one since we don't have with dynamic attributes. And we just skip operational lines if the porduct is empty so the **_match_all_variant_values** is not called. [**IMPLEMENTED**]
  (This change doesn't require more changes as everything will be still working with the expected model type 'product.product' but the operations and other data will be empty in the report which make sense because they are variant related )

Current behavior before PR: the app show error whenever a BoM overview smart button is clicked for a BoM of a product with dynamic attribute variants

Desired behavior after PR is merged: The BoM overview report should be shown normally with no problems.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
