### PR TITLE
[IMP] hr_holidays_attendance: extra hours available text wrap

### DIFF
--- a/addons/hr_holidays_attendance/views/hr_leave_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_leave_views.xml
@@ -5,9 +5,8 @@
         <field name="inherit_id" ref="hr_holidays.hr_leave_view_form_manager" />
         <field name="arch" type="xml">
             <field name='duration_display' position="after">
-                <div invisible="not employee_id or not overtime_deductible or employee_overtime &lt;= 0">
-                    <field name="employee_overtime" nolabel="1" widget="float_time" class="text-success" style="width: 6rem;" /> Extra Hours Available
-                </div>
+                    <field name="employee_overtime" string="Extra Hours Available" widget="float_time" class="text-success" style="width: 6rem;"
+                        invisible="not employee_id or not overtime_deductible or employee_overtime &lt;= 0"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
With this commit, the line `Extra Hours Available` is no longer wrapped.

task-4526451

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
