### PR TITLE
[FIX] account_peppol: refresh token reuse err message

### DIFF
--- a/addons/account_edi_proxy_client/i18n/account_edi_proxy_client.pot
+++ b/addons/account_edi_proxy_client/i18n/account_edi_proxy_client.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-26 21:55+0000\n"
-"PO-Revision-Date: 2023-10-26 21:55+0000\n"
+"POT-Creation-Date: 2025-02-03 15:44+0000\n"
+"PO-Revision-Date: 2025-02-03 15:44+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -93,6 +93,16 @@ msgstr ""
 #. module: account_edi_proxy_client
 #: model:ir.model.fields,field_description:account_edi_proxy_client.field_account_edi_proxy_client_user__id_client
 msgid "Id Client"
+msgstr ""
+
+#. module: account_edi_proxy_client
+#. odoo-python
+#: code:addons/account_edi_proxy_client/models/account_edi_proxy_user.py:0
+#, python-format
+msgid ""
+"Invalid signature for request. This might be due to another connection to odoo Access Point server. It can occur if you have duplicated your database. \n"
+"\n"
+"If you are not sure how to fix this, please contact our support."
 msgstr ""
 
 #. module: account_edi_proxy_client

--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -147,6 +147,13 @@ class AccountEdiProxyClientUser(models.Model):
             if error_code == 'no_such_user':
                 # This error is also raised if the user didn't exchange data and someone else claimed the edi_identificaiton.
                 self.sudo().active = False
+            if error_code == 'invalid_signature':
+                raise AccountEdiProxyError(
+                    error_code,
+                    _("Invalid signature for request. This might be due to another connection to odoo Access Point "
+                      "server. It can occur if you have duplicated your database. \n\n"
+                      "If you are not sure how to fix this, please contact our support."),
+                )
             raise AccountEdiProxyError(error_code, proxy_error['message'] or False)
 
         return response['result']


### PR DESCRIPTION
Lately we have been encountering increasing issues with on-prem databases which are being duplicated without running neutralization scripts, and thus when one of the two instances renews its refresh token, the other database's refresh token gets out of sync and we end up with a cryptic error `Invalid signature for request to the account_edi proxy`.

1. Prod and Staging both have refresh token RT1
2. Staging needs new refresh token: sends RT1 to IAP and gets RT2
3. IAP invalidates RT1
4. Prod still has RT1 and tries to refresh
5. IAP rejects RT1 because it is no longer aware of RT1
6. Test cannot get a new token and loses access with this error as the signature is no longer valid

This commit simply improves this error message and redirects users to odoo support.

task-4531587