### PR TITLE
[IMP] test: flush after each transactional test

### DIFF
--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -57,6 +57,8 @@ class TestStructure(TransactionCase):
             with self.assertRaises(ValidationError), self.env.cr.savepoint():
                 company.vat = "BE0987654321"  # VIES refused, don't fallback on other check
             company.vat = "BE0477472701"
+        # prevent flushing
+        self.env.transaction.clear()
 
     def test_vat_syntactic_validation(self):
         """ Tests VAT validation (both successes and failures), with the different country

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -506,6 +506,7 @@ class TestMrpOrder(TestMrpCommon):
                 'workcenter_id': self.workcenter_1.id,
                 'product_uom_id': product_uom_id,
                 'production_id': mo_no_company.id,
+                'date_start': fields.Date.today(),
                 'duration': 60,
             } for n in range(300)
         ]

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -1404,6 +1404,10 @@ class TestVariantWrite(TransactionCase):
         variant1.active = False
         self.assertEqual(template.product_variant_ids, variant2)
 
+        # remove changes because adding a second variant like this is not valid
+        # combination_indices are violated
+        self.env.transaction.clear()
+
     def test_write_inherited_field(self):
         product = self.env['product.product'].create({'name': 'Foo', 'sequence': 1})
         self.assertEqual(product.name, 'Foo')

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -634,7 +634,9 @@ class TestWarehouse(TestStockCommon):
 
         companies_before = wh.mapped(lambda w: (w.id, w.company_id))
         # writing on any field should change the company of warehouses
-        wh.write({"name": "whatever"})
+        for i, w in enumerate(wh):
+            # name must be unique per company
+            w.write({"name": f"whatever {i}"})
         companies_after = wh.mapped(lambda w: (w.id, w.company_id))
 
         self.assertEqual(companies_after, companies_before)

--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -470,6 +470,8 @@ if env.context.get('old_values', None):  # on write
         ]
 
         def _patch(*args, **kwargs):
+            if not automations:
+                return
             self.assertEqual(args[0], automations.pop(0))
 
         patcher = patch('odoo.addons.base_automation.models.base_automation.BaseAutomation._process', _patch)

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -470,6 +470,9 @@ class TestMailMail(MailCommon):
             self.assertEqual(notification.failure_type, 'mail_from_invalid')
             self.assertEqual(notification.notification_status, 'exception')
 
+        # don't try to flush the changes as they will fail
+        self.env.transaction.clear()
+
     @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_mail_mail_send_exceptions_recipients_emails(self):
         """ Test various use case with exceptions and errors and see how they are

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -944,6 +944,11 @@ class TransactionCase(BaseCase):
         self.cr.execute('SAVEPOINT test_%d' % self._savepoint_id)
         self.addCleanup(self.cr.execute, 'ROLLBACK TO SAVEPOINT test_%d' % self._savepoint_id)
 
+    def tearDown(self):
+        # flush remaining computations after the test ran
+        self.env.flush_all()
+        super().tearDown()
+
     @contextmanager
     def enter_registry_test_mode(self):
         """


### PR DESCRIPTION
Flush at the end of each tests to check that the data can be written to the database. Without this, we may have a test running fine and crash when executing in reality when we try to flush/commit.

odoo/enterprise#78423

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
