### PR TITLE
[FIX] payment_worldline: show error codes in chatter

### DIFF
--- a/addons/payment_worldline/i18n/payment_worldline.pot
+++ b/addons/payment_worldline/i18n/payment_worldline.pot
@@ -72,7 +72,9 @@ msgstr ""
 #. module: payment_worldline
 #. odoo-python
 #: code:addons/payment_worldline/models/payment_transaction.py:0
-msgid "Received invalid transaction status %(status)s."
+msgid ""
+"Received invalid transaction status %(status)s with error code "
+"%(error_code)s."
 msgstr ""
 
 #. module: payment_worldline
@@ -90,6 +92,18 @@ msgstr ""
 #. odoo-python
 #: code:addons/payment_worldline/models/payment_transaction.py:0
 msgid "The transaction is not linked to a token."
+msgstr ""
+
+#. module: payment_worldline
+#. odoo-python
+#: code:addons/payment_worldline/models/payment_transaction.py:0
+msgid "Transaction cancelled with error code %(error_code)s."
+msgstr ""
+
+#. module: payment_worldline
+#. odoo-python
+#: code:addons/payment_worldline/models/payment_transaction.py:0
+msgid "Transaction declined with error code %(error_code)s."
 msgstr ""
 
 #. module: payment_worldline


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Go to eCommerce;
2. add items to cart;
3. go to checkout;
4. pay with Worldline;
5. on Worldline's site, cancel transaction;
6. open order in the backend.

Issue
-----
Chatter displays:
> Error: Worldline: Received invalid transaction status CANCELLED

Cause
-----
The cancel & declined statuses aren't handled when processing Worldline's response, leading to them being displayed as invalid.

Solution
--------
Handle the `cancel` and `declined` statuses and display the given error code.

Also, when canceled, call `_set_canceled` instead of `_set_error`.

opw-4481602