### PR TITLE
[FIX] account: limit the number of outstanding credits displayed

### DIFF
--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -58,6 +58,9 @@
                     </tr>
                 </t>
             </table>
+            <t t-if="outstanding and has_more">
+                <button type="button" class="btn btn-link" t-on-click="() => this.loadMore()">Load more</button>
+            </t>
         </div>
     </t>
 


### PR DESCRIPTION
Currently, there is no mechanism to limit the number of outstanding credits displayed on an invoice. This can cause the page to crash if there are too many outstanding credits.

**Steps to reproduce:**
1. Create an invoice
2. Create a large number of payments for the customer linked to the invoice
3. Try to load the invoice

This fix aims to limit the number of outstanding credits displayed. A “Load more” button is available to load more payments (40 by 40).

**Benchmark:**

| Number of outstanding credits | Server response duration | Display duration (without the fix) - LCP | Display duration (with the fix) - LCP |
 | ------------------------------- | ------------------------ | ---------------------------------------- | ------------------------------------- |
| 1,000                           | 0,5s                     | 1,67s                                    | 1,7s                                  |
| 60 000                          | 0,8s                     | +-30s                                    | 2,8s                                  |
| 120 000                         | 1,23s                    | crash                                    | 3,91s                                 |
| 300,000                         | 3,29s                    | Crash                                    | 8,36s                                 |

opw-4522683
