### PR TITLE
[FIX] rating: Extra border line on the rating image

### DIFF
--- a/addons/rating/static/src/scss/rating_templates.scss
+++ b/addons/rating/static/src/scss/rating_templates.scss
@@ -11,6 +11,7 @@
     }
     .o_rating_label {
         opacity: 0.5;
+        border: none !important;
         &:hover {
             transform: scale(1.1);
         }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Related ticket: https://www.odoo.com/odoo/my-tasks/4482430

The 'btn' class was incorrectly applied to the rating label in rating_templates.xml, which affected the styling, making extra border line displaying on the rating image. Removing this class restores the expected appearance.

Current behavior before PR: there will be weird border on the rating page

![image](https://github.com/user-attachments/assets/0b8fa198-1995-40d0-b95e-c0de555af47c)

Desired behavior after PR is merged:

The border will be invisible and everything else still functional without any influence


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
