### PR TITLE
[FIX] stock_picking_batch: remove responsible from all related picking

### DIFF
--- a/addons/stock_picking_batch/i18n/stock_picking_batch.pot
+++ b/addons/stock_picking_batch/i18n/stock_picking_batch.pot
@@ -879,6 +879,13 @@ msgid "Type of the exception activity on record."
 msgstr ""
 
 #. module: stock_picking_batch
+#. odoo-python
+#: code:addons/stock_picking_batch/models/stock_picking.py:0
+#, python-format
+msgid "Unassigned responsible from %s"
+msgstr ""
+
+#. module: stock_picking_batch
 #: model_terms:ir.ui.view,arch_db:stock_picking_batch.stock_picking_batch_form
 msgid "Validate"
 msgstr ""

--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -247,12 +247,13 @@ class StockPicking(models.Model):
         return super()._package_move_lines(batch_pack)
 
     def assign_batch_user(self, user_id):
-        if not user_id:
-            return
         pickings = self.filtered(lambda p: p.user_id.id != user_id)
         pickings.write({'user_id': user_id})
         for pick in pickings:
-            log_message = _('Assigned to %s Responsible', (pick.batch_id._get_html_link()))
+            if user_id:
+                log_message = _('Assigned to %s Responsible', (pick.batch_id._get_html_link()))
+            else:
+                log_message = _('Unassigned responsible from %s', (pick.batch_id._get_html_link()))
             pick.message_post(body=log_message)
 
     def action_view_batch(self):

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -181,7 +181,7 @@ class StockPickingBatch(models.Model):
             if batch_without_picking_type:
                 picking = self.picking_ids and self.picking_ids[0]
                 batch_without_picking_type.picking_type_id = picking.picking_type_id.id
-        if vals.get('user_id'):
+        if 'user_id' in vals:
             self.picking_ids.assign_batch_user(vals['user_id'])
         return res
 

--- a/addons/stock_picking_batch/tests/test_batch_picking.py
+++ b/addons/stock_picking_batch/tests/test_batch_picking.py
@@ -800,6 +800,13 @@ class TestBatchPicking02(TransactionCase):
             'picking_ids': [(4, picking_1.id), (4, picking_2.id)]
         })
         batch.action_confirm()
+        # assign a responsible to the batch should assign it to the pickings
+        self.assertFalse((picking_1 | picking_2).user_id.id)
+        batch.user_id = self.env.user
+        self.assertEqual((picking_1 | picking_2).user_id, self.env.user)
+        # remove the responsible from the batch should remove it from the pickings
+        batch.user_id = False
+        self.assertFalse((picking_1 | picking_2).user_id.id)
         action = batch.action_done()
         Form(self.env[action['res_model']].with_context(action['context'])).save().process_cancel_backorder()
         self.assertEqual(batch.state, 'done')


### PR DESCRIPTION
Steps to reproduce the bug:
- Create two delivery transfers.
- Add them to a single batch transfer.
- Assign a responsible person to the batch transfer.
- The assigned responsible person will automatically be updated in all related transfers.
- Now, remove the responsible person from the batch transfer.

Problem:
When a responsible person is assigned or modified in a batch transfer, the update is correctly reflected in all related transfers within that batch. However, if the responsible person is removed from the batch transfer, this change is not applied to the individual transfers linked to it.

opw-4519994
