### PR TITLE
[IMP] account,base_vat: company registry placeholders

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -11,6 +11,7 @@ from odoo.tools import date_utils, format_list, SQL
 from odoo.tools.mail import is_html_empty
 from odoo.tools.misc import format_date
 from odoo.addons.account.models.account_move import MAX_HASH_VERSION
+from odoo.addons.account.models.partner import _ref_company_registry
 from odoo.addons.base_vat.models.res_partner import _ref_vat
 
 
@@ -261,6 +262,7 @@ class ResCompany(models.Model):
         help="Default on whether the sales price used on the product and invoices with this Company includes its taxes."
     )
     company_vat_placeholder = fields.Char(compute='_compute_company_vat_placeholder')
+    company_registry_placeholder = fields.Char(compute='_compute_company_registry_placeholder')
 
     def get_next_batch_payment_communication(self):
         '''
@@ -1030,3 +1032,12 @@ class ResCompany(models.Model):
                     placeholder = _("%s, or / if not applicable", expected_vat)
 
             company.company_vat_placeholder = placeholder
+
+    @api.depends('country_id', 'account_fiscal_country_id')
+    def _compute_company_registry_placeholder(self):
+        """ Provides a dynamic placeholder on the company registry field for countries that may need it.
+        Add your country and the value you want in the _ref_company_registry map in the partner.py file.
+        """
+        for company in self:
+            country_code = (company.account_fiscal_country_id or company.country_id).code or ''
+            company.company_registry_placeholder = _ref_company_registry.get(country_code.lower(), '')

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -18,6 +18,12 @@ from odoo.addons.base_vat.models.res_partner import _ref_vat
 
 _logger = logging.getLogger(__name__)
 
+
+_ref_company_registry = {
+    'jp': '7000012050002',
+}
+
+
 class AccountFiscalPosition(models.Model):
     _name = 'account.fiscal.position'
     _description = 'Fiscal Position'
@@ -339,6 +345,7 @@ class ResPartner(models.Model):
 
     fiscal_country_codes = fields.Char(compute='_compute_fiscal_country_codes')
     partner_vat_placeholder = fields.Char(compute='_compute_partner_vat_placeholder')
+    partner_company_registry_placeholder = fields.Char(compute='_compute_partner_company_registry_placeholder')
 
     @api.depends('company_id')
     @api.depends_context('allowed_company_ids')
@@ -1011,3 +1018,12 @@ class ResPartner(models.Model):
                     placeholder = _("%s, or / if not applicable", expected_vat)
 
             partner.partner_vat_placeholder = placeholder
+
+    @api.depends('country_id')
+    def _compute_partner_company_registry_placeholder(self):
+        """ Provides a dynamic placeholder on the company registry field for countries that may need it.
+        Add your country and the value you want in the _ref_company_registry map.
+        """
+        for partner in self:
+            country_code = partner.country_id.code or ''
+            partner.partner_company_registry_placeholder = _ref_company_registry.get(country_code.lower(), '')

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -193,6 +193,13 @@
                 <field name="vat" position="attributes">
                     <attribute name="options">{'placeholder_field': 'partner_vat_placeholder'}</attribute>
                 </field>
+
+                <field name="company_registry" position="before">
+                    <field name="partner_company_registry_placeholder" invisible="1"/> <!-- Needed for the placeholder widget -->
+                </field>
+                <field name="company_registry" position="attributes">
+                    <attribute name="options">{'placeholder_field': 'partner_company_registry_placeholder'}</attribute>
+                </field>
             </field>
         </record>
 

--- a/addons/account/views/res_company_views.xml
+++ b/addons/account/views/res_company_views.xml
@@ -17,6 +17,13 @@
             <field name="vat" position="attributes">
                 <attribute name="options">{'placeholder_field': 'company_vat_placeholder'}</attribute>
             </field>
+
+            <field name="company_registry" position="before">
+                <field name="company_registry_placeholder" invisible="1"/> <!-- Needed for the placeholder widget -->
+            </field>
+            <field name="company_registry" position="attributes">
+                <attribute name="options">{'placeholder_field': 'company_registry_placeholder'}</attribute>
+            </field>
         </field>
     </record>
 

--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -80,7 +80,8 @@ _ref_vat = {
     'uy': _lt("Example: '219999830019' (format: 12 digits, all numbers, valid check digit)"),
     've': 'V-12345678-1, V123456781, V-12.345.678-1',
     'xi': 'XI123456782',
-    'sa': _lt('310175397400003 [Fifteen digits, first and last digits should be "3"]')
+    'sa': _lt('310175397400003 [Fifteen digits, first and last digits should be "3"]'),
+    'jp': 'T7000012050002',
 }
 
 _region_specific_vat_codes = {


### PR DESCRIPTION
Add a reference VAT number for Japan using the format of a "Qualified Invoice Issuer
Registration Number".
This will appear as placeholder for the VAT field on the company and partner settings.

Also implement the dynamic placeholder system for
the company registry field in order to allow filling in placeholders for countries in which it would make sense to do so.

Finally, add a placeholder for the company registry for japanese companies and partners.

task-4366584

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
