### PR TITLE
[IMP] stock_account: show confirmation dialog when valuation exists

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -34,6 +34,7 @@ class ProductTemplate(models.Model):
         compute='_compute_lot_valuated', store=True, readonly=False,
         help="If checked, the valuation will be specific by Lot/Serial number.",
     )
+    product_tmpl_valuation_layer_ids = fields.One2many('stock.valuation.layer', 'product_tmpl_id')
 
     @api.depends('tracking')
     def _compute_lot_valuated(self):

--- a/addons/stock_account/static/src/fields/boolean_confirm.js
+++ b/addons/stock_account/static/src/fields/boolean_confirm.js
@@ -35,9 +35,11 @@ export class BooleanToggleConfirm extends BooleanToggleField {
             this.props.record.update({ [this.props.name]: value }, { save: true });
         };
 
-        if (record.lot_valuated && !value) {
+        if (record.lot_valuated && !value && record.product_tmpl_valuation_layer_ids.count) {
             this.dialogService.add(ConfirmationDialog, {
-                body: _t("This operation might lead in a loss of data. Valuation will be identical for all lots/SN. Do you want to proceed ? "),
+                title: _t("Remove valuation by Lot/Serial Number"),
+                body: _t("Removing this option means all specific valuations per lot or serial number will definitely be lost. Are you sure you want to proceed? "),
+                confirmLabel: _t("Yes, set to the same value"),
                 confirm: updateAndSave,
                 cancel: () => {},
             });

--- a/addons/stock_account/views/product_views.xml
+++ b/addons/stock_account/views/product_views.xml
@@ -78,5 +78,16 @@
                 </field>
             </field>
         </record>
+
+        <record id="product_template_form_view_inherit_stock_account" model="ir.ui.view">
+            <field name="name">product.template.form.inherit.stock.account</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_form_view"/>
+            <field name="arch" type="xml">
+                <field name="company_id" position="after">
+                    <field name="product_tmpl_valuation_layer_ids" groups="stock.group_stock_manager" invisible="1"/>
+                </field>
+            </field>
+        </record>
    </data>
 </odoo>


### PR DESCRIPTION
The confirmation dialog for unchecking `Valuation by Lot/SN` is now shown
only if the product has `related valuation layers`. This avoids unnecessary
`interruptions` for products with `no valuation history`. It makes the UI more
intuitive and reduces confusion for users during product configuration.

TaskId: 4417432