### PR TITLE
[IMP] website_sale_comparison: adjust compare btn for cookie bar

### DIFF
--- a/addons/website_sale_comparison/static/src/interactions/cookies_bar.js
+++ b/addons/website_sale_comparison/static/src/interactions/cookies_bar.js
@@ -1,0 +1,96 @@
+import { CookiesBar } from "@website/interactions/cookies/cookies_bar";
+import { patch } from "@web/core/utils/patch";
+import { patchDynamicContent } from "@web/public/utils";
+
+patch(CookiesBar.prototype, {
+    /**
+     * @override
+     */
+    setup() {
+        super.setup();
+        patchDynamicContent(this.dynamicContent, {
+            // When user resizes the window, we need to adjust the position of
+            // the compare button to improve the user experience.
+            _window: {
+                "t-on-resize": this.handleCompareOverlap.bind(this),
+            },
+        });
+        // Listen for the custom event to handle the overlap of the compare
+        // button with the cookies bar modal.
+        this._onCookiesBarShown = this.handleCompareOverlap.bind(this);
+        this.el.addEventListener("COOKIES_BAR_SHOWN", this._onCookiesBarShown);
+    },
+    /**
+     * @override
+     */
+    destroy() {
+        super.destroy();
+        this.el.removeEventListener("COOKIES_BAR_SHOWN", this._onCookiesBarShown);
+    },
+    /**
+     * @override
+     */
+    showPopup() {
+        super.showPopup();
+        // Initially when the modal is shown, its height is 0, so we need to
+        // wait for the modal to be fully rendered before adjusting the position
+        // of the compare button. Through the `--move-cookie-over-modal` CSS
+        // variable, we can dynamically adjust the position of elements based on
+        // modal changes.
+        this.waitForTimeout(() => {
+            this.handleCompareOverlap();
+        }, 0);
+    },
+    /**
+     * @override
+     *
+     * Remove the custom css for `--move-cookie-over-modal`, to position the
+     * compare button at the bottom.
+     */
+    onHideModal() {
+        super.onHideModal();
+        document
+            .querySelector("[name='product_comparison_button']")
+            ?.style.removeProperty("--move-cookie-over-modal");
+    },
+    /**
+     * Resolved the issue where the compare button was hidden due to the modal
+     * appearing over it. Added CSS `--move-cookie-over-modal` to dynamically
+     * adjust the position of elements based on modal changes.
+     */
+    handleCompareOverlap() {
+        const productCompareButtonEl = document.querySelector("[name='product_comparison_button']");
+        if (!productCompareButtonEl) {
+            return;
+        }
+
+        const cookieModelEl = this.el.querySelector(".modal");
+        if (
+            !cookieModelEl ||
+            cookieModelEl.style.display === "none" ||
+            cookieModelEl.classList.contains("o_cookies_popup") ||
+            !cookieModelEl.classList.contains("s_popup_no_backdrop")
+        ) {
+            return;
+        }
+        const cookieModalDialogEl = cookieModelEl.querySelector(".modal-dialog");
+        const isCookiebarLarge =
+            (cookieModalDialogEl.getBoundingClientRect().width -
+                productCompareButtonEl.getBoundingClientRect().width / 2) /
+                window.innerWidth >
+            0.5;
+
+        if (isCookiebarLarge) {
+            const bottom = cookieModalDialogEl.querySelector(".modal-content").offsetHeight
+                ? `${cookieModalDialogEl.querySelector(".modal-content").offsetHeight}px`
+                : "";
+            const padding = getComputedStyle(cookieModalDialogEl).paddingBottom;
+            productCompareButtonEl.style.setProperty(
+                "--move-cookie-over-modal",
+                parseInt(bottom) + parseInt(padding) + "px"
+            );
+        } else {
+            productCompareButtonEl.style.removeProperty("--move-cookie-over-modal");
+        }
+    },
+});

--- a/addons/website_sale_comparison/static/src/js/product_comparison_button/product_comparison_button.js
+++ b/addons/website_sale_comparison/static/src/js/product_comparison_button/product_comparison_button.js
@@ -1,8 +1,9 @@
-import { Component, useState } from '@odoo/owl';
+import { Component, useState, useEffect, onMounted, onWillUnmount } from "@odoo/owl";
 import { useBus } from '@web/core/utils/hooks';
 import { usePopover } from '@web/core/popover/popover_hook';
 import comparisonUtils from '@website_sale_comparison/js/website_sale_comparison_utils';
 import { ProductComparisonPopover } from '../product_comparison_popover/product_comparison_popover';
+import { debounce } from "@web/core/utils/timing";
 
 export class ProductComparisonButton extends Component {
     static template = 'website_sale_comparison.ProductComparisonButton';
@@ -18,6 +19,37 @@ export class ProductComparisonButton extends Component {
             arrow: false,
             position: 'top',
         });
+
+        this.handleScroll = debounce(() => {
+            if (this.popover.isOpen) {
+                this.popover.close();
+            }
+        }, 100);
+        onMounted(() => {
+            window.addEventListener("scroll", this.handleScroll);
+        });
+        onWillUnmount(() => {
+            window.removeEventListener("scroll", this.handleScroll);
+        });
+        useEffect(
+            () => {
+                // Once the productCount state is set, we check if the product
+                // comparison button should be shown.
+                // Trigger cookie bar overlap handling only when the product
+                // count is 1, since that's when the compare button becomes
+                // visible.
+                if (this.state.productCount === 1) {
+                    // Dispatch a custom event when the product comparison
+                    // button is shown to handle the overlap with the cookies
+                    // bar modal.
+                    const cookieBarEl = document.querySelector("#website_cookies_bar");
+                    cookieBarEl?.dispatchEvent(
+                        new CustomEvent("COOKIES_BAR_SHOWN", { bubbles: true })
+                    );
+                }
+            },
+            () => [this.state.productCount]
+        );
         useBus(
             this.props.bus,
             'comparison_products_changed',

--- a/addons/website_sale_comparison/static/src/js/product_comparison_button/product_comparison_button.scss
+++ b/addons/website_sale_comparison/static/src/js/product_comparison_button/product_comparison_button.scss
@@ -1,6 +1,6 @@
 .bottom-centered {
     position: fixed;
-    bottom: 0;
+    bottom: var(--move-cookie-over-modal, 0px);
     left: 50%;
     transform: translateX(-50%);
     z-index: $zindex-fixed;


### PR DESCRIPTION
This PR addresses the positioning of the compare button in relation to the cookie bar to ensure proper visibility and functionality.

Key changes include:
- Ensure the compare button is positioned above the cookie bar modal. On resize, the position of the compare button is
  adjusted to avoid overlap with the cookie bar.
- Maintain the visibility of the hidden compare button popover during the scroll events.
- Reposition the compare button to the bottom of the screen upon acceptance of the cookie bar.

task-3877807
