### PR TITLE
[IMP] mail: Hide mentioned conversations from 'Recent' in command palette

### DIFF
--- a/addons/mail/static/src/discuss/core/web/discuss_command_palette_patch.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_command_palette_patch.js
@@ -30,7 +30,11 @@ patch(DiscussCommandPalette.prototype, {
                 }
             }
             const limitedRecent = recentChannels
-                .filter((channel) => !mentionedSet.has(channel))
+                .filter(
+                    (channel) =>
+                        !mentionedSet.has(channel) &&
+                        !mentionedSet.has(channel.correspondent?.persona)
+                )
                 .slice(0, CATEGORY_LIMIT);
             for (const channel of limitedRecent) {
                 this.commands.push(this.makeDiscussCommand(channel, DISCUSS_RECENT));

--- a/addons/mail/static/tests/discuss/core/web/command_palette.test.js
+++ b/addons/mail/static/tests/discuss/core/web/command_palette.test.js
@@ -131,3 +131,28 @@ test("only partners with dedicated users will be displayed in command palette", 
     await contains(".o_command_name", { text: "Create Chat" });
     await contains(".o_command_name", { text: "Portal", count: 0 });
 });
+
+test("hide conversations in recent if they have mentions", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: serverState.odoobotId }),
+        ],
+        channel_type: "chat",
+    });
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        model: "discuss.channel",
+        res_id: channelId,
+        body: "@OdooBot",
+    });
+    await start();
+    triggerHotkey("control+k");
+    await insertText(".o_command_palette_search input", "@", { replace: true });
+    await contains(".o_command_category span.fw-bold", { text: "Mentions" });
+    await contains(".o_command_palette .o_command_category .o_command_name", {
+        text: "OdooBot",
+        count: 1,
+    });
+});


### PR DESCRIPTION
**Current behavior before PR:**

Same conversations appeared in both 'recent' and 'mentions', causing redundancy.

**Desired behavior after PR is merged:**

now 'Recent' no longer shows conversations already in 'mentions' in command palette.

task-4510209

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
