### PR TITLE
[FIX] spreadsheet_dashboard_account: Fix format on measure

### DIFF
--- a/addons/spreadsheet_dashboard_account/data/files/invoicing_dashboard.json
+++ b/addons/spreadsheet_dashboard_account/data/files/invoicing_dashboard.json
@@ -863,8 +863,7 @@
       "measures": [
         {
           "id": "price_subtotal",
-          "fieldName": "price_subtotal",
-          "format": "0%"
+          "fieldName": "price_subtotal"
         }
       ],
       "model": "account.invoice.report",
@@ -915,8 +914,7 @@
       "measures": [
         {
           "id": "price_subtotal",
-          "fieldName": "price_subtotal",
-          "format": "0%"
+          "fieldName": "price_subtotal"
         }
       ],
       "model": "account.invoice.report",
@@ -967,8 +965,7 @@
       "measures": [
         {
           "id": "price_subtotal",
-          "fieldName": "price_subtotal",
-          "format": "0%"
+          "fieldName": "price_subtotal"
         }
       ],
       "model": "account.invoice.report",
@@ -1019,8 +1016,7 @@
       "measures": [
         {
           "id": "price_subtotal",
-          "fieldName": "price_subtotal",
-          "format": "0%"
+          "fieldName": "price_subtotal"
         }
       ],
       "model": "account.invoice.report",


### PR DESCRIPTION
Some pivots were defined with a wrong format on their measure, namely a display of percentage on the subtotal of account reports which makes no sense.

task -4546273

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
