### PR TITLE
[FIX] mrp: prevent typeerror when an mo is overviewed

### DIFF
--- a/addons/mrp/report/mrp_report_mo_overview.py
+++ b/addons/mrp/report/mrp_report_mo_overview.py
@@ -606,7 +606,7 @@ class ReportMrpReport_Mo_Overview(models.AbstractModel):
             return self._format_receipt_date('available')
 
         replenishments_with_date = list(filter(lambda r: r.get('summary', {}).get('receipt', {}).get('date'), replenishments))
-        max_date = max([get(rep, 'date', True) for rep in replenishments_with_date], default=fields.Date.today())
+        max_date = max([get(rep, 'date', True) for rep in replenishments_with_date], default=fields.Datetime.today())
         if has_to_order_line or any(get(rep, 'type', True) == 'estimated' for rep in replenishments):
             return self._format_receipt_date('estimated', max_date)
         else:


### PR DESCRIPTION
Currently a `TypeError` appears when the user opens 'Overview' of an 'Manufacturing Order'.

### Error: 
```TypeError: can't compare datetime.datetime to datetime.date```

The error occurs because when 'Overview' is opened of an MO, a comparison is made between `Datetime & Date`,i.e `mo_planned_start` and `receipt['date'],` which raises the above error.

This commit resolves the issue by keeping date format same of both the fields.

sentry-6250719075