### PR TITLE
[FIX] account: Chart Templates translations

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -1304,9 +1304,9 @@ class AccountChartTemplate(models.AbstractModel):
 
         # Gather translations for records that are created from the chart_template data
         for chart_template, chart_companies in groupby(companies, lambda c: c.chart_template):
-            template_data = template_data or self.env['account.chart.template']._get_chart_template_data(chart_template)
-            template_data.pop('template_data', None)
-            for mname, data in template_data.items():
+            chart_template_data = template_data or self.env['account.chart.template']._get_chart_template_data(chart_template)
+            chart_template_data.pop('template_data', None)
+            for mname, data in chart_template_data.items():
                 for _xml_id, record in data.items():
                     fnames = {fname.split('@')[0] for fname in record if fname != '__translation_module__'}
                     for lang in langs:


### PR DESCRIPTION
Fixes a small issue when loading translations of
multiple chart templates at once.
An update to that method added a parameter with
the same name as a local variable, and the way
it has been done means that the template_data
used in each subsequent loop will always be
the ones from the first loop only, effectively
ignoring the other chart templates.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
