### PR TITLE
[FIX] l10n_es_edi_facturae: fix update from 16

### DIFF
--- a/addons/l10n_es_edi_facturae/models/account_chart_template.py
+++ b/addons/l10n_es_edi_facturae/models/account_chart_template.py
@@ -7,4 +7,11 @@ class AccountChartTemplate(models.AbstractModel):
 
     @template('es_common', 'account.tax')
     def _get_es_facturae_account_tax(self):
-        return self._parse_csv('es_common', 'account.tax', module='l10n_es_edi_facturae')
+        taxes = self._parse_csv('es_common', 'account.tax', module='l10n_es_edi_facturae')
+        # only return existing taxes
+        taxes = {
+            key: value
+            for key, value in taxes.items()
+            if self.env['account.chart.template'].ref(key, raise_if_not_found=False)
+        }
+        return taxes


### PR DESCRIPTION
Tax account_tax_template_s_iva0_g_i was added in 17.0.
Init hook will load the data from account.tax-es_common.csv (_l10n_es_edi_facturae_post_init_hook) when upgrading from 16.0 and fail because account_tax_template_s_iva0_g_i does not exists yet.
Removing account_tax_template_s_iva0_g_i from account.tax-es_common.csv prevent the bug and l10n_es_edi_facturae_tax_type will still be set to 1 as it is the default value.

Runbot error: https://runbot.odoo.com/odoo/runbot.build.error/114680