### PR TITLE
[FIX] point_of_sale: fix error on Arabic language setting

### DIFF
--- a/addons/point_of_sale/static/src/app/store/devices_synchronisation.js
+++ b/addons/point_of_sale/static/src/app/store/devices_synchronisation.js
@@ -160,7 +160,11 @@ export default class DevicesSynchronisation {
                 "&",
                 ["id", "=", o.id],
                 "|",
-                ["write_date", ">", newDateTime.toFormat("yyyy-MM-dd HH:mm:ss")],
+                [
+                    "write_date",
+                    ">",
+                    newDateTime.toFormat("yyyy-MM-dd HH:mm:ss", { numberingSystem: "latn" }),
+                ],
                 ["state", "!=", o.state],
             ]);
         });


### PR DESCRIPTION
When the Arabic language was selected, the PoS Restaurant module would error due to date formatting using Arabic numerals. This commit forces Latin digits in the date format to prevent the error.

opw-4544010

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
