### PR TITLE
[FIX] web_editor: preserve spaces in composed CSS values

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -1718,7 +1718,7 @@ function _normalizeStyle(style) {
  */
 function correctBorderAttributes(style) {
     const stylesObject = style
-        .replace(/\s+/g, "")
+        .replace(/\s+/g, " ")
         .split(";")
         .reduce((styles, styleString) => {
             const [attribute, value] = styleString.split(":").map((str) => str.trim());


### PR DESCRIPTION
**Problem**:
Removing spaces impacts composed values like
(`padding: 10px 20px` → `padding: 10px20px`), making them invalid.

**Solution**:
Replace multiple spaces with a single space instead of removing them, to ensure composed values remain intact.

**Steps to Reproduce**:
1. Open Email Templates > any template.
2. Add `padding: 10px 20px` to a `tr` element.
3. Save the template.
4. Observe that padding is not applied.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
