### PR TITLE
[FIX] account: Fix round globally for Portuguese certification

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -964,7 +964,7 @@ class AccountMoveLine(models.Model):
             else:
                 line.epd_key = False
 
-    @api.depends('move_id.needed_terms', 'account_id', 'analytic_distribution', 'tax_ids', 'tax_tag_ids', 'company_id')
+    @api.depends('move_id.needed_terms', 'account_id', 'analytic_distribution', 'tax_ids', 'tax_tag_ids', 'company_id', 'price_subtotal')
     def _compute_epd_needed(self):
         # TODO: The computation of early payment is weird because based on the 'price_subtotal'
         # that already have it's own taxes computation (by design because the sync_dynamic lines only

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -557,6 +557,7 @@ export const accountTaxHelpers = {
     round_base_lines_tax_details(base_lines, company) {
         const total_per_tax = {};
         const total_per_base = {};
+        const country_code = company.account_fiscal_country_id.code;
 
         for (const base_line of base_lines) {
             const currency = base_line.currency_id;
@@ -616,6 +617,8 @@ export const accountTaxHelpers = {
                         tax_amount: 0.0,
                         raw_tax_amount_currency: 0.0,
                         raw_tax_amount: 0.0,
+                        raw_total_amount_currency: 0.0,
+                        raw_total_amount: 0.0,
                         base_lines: [],
                     };
                 }
@@ -629,28 +632,39 @@ export const accountTaxHelpers = {
                 tax_amounts.raw_base_amount_currency += tax_data.raw_base_amount_currency;
                 tax_amounts.base_amount += tax_data.base_amount;
                 tax_amounts.raw_base_amount += tax_data.raw_base_amount;
+                tax_amounts.raw_total_amount_currency += tax_data.raw_base_amount_currency + tax_data.raw_tax_amount_currency;
+                tax_amounts.raw_total_amount += tax_data.raw_base_amount + tax_data.raw_tax_amount;
                 if (!base_line.special_type) {
                     tax_amounts.base_lines.push(base_line);
                 }
 
+                const base_rounding_key = [currency.id, base_line.is_refund];
+                if (!(base_rounding_key in total_per_base)) {
+                    total_per_base[base_rounding_key] = {
+                        currency: currency,
+                        tax_amount_currency: 0.0,
+                        tax_amount: 0.0,
+                        base_amount_currency: 0.0,
+                        base_amount: 0.0,
+                        raw_base_amount_currency: 0.0,
+                        raw_base_amount: 0.0,
+                        raw_total_amount_currency: 0.0,
+                        raw_total_amount: 0.0,
+                        base_lines: [],
+                    };
+                }
+                const base_amounts = total_per_base[base_rounding_key];
+                base_amounts.tax_amount_currency += tax_data.tax_amount_currency;
+                base_amounts.tax_amount += tax_data.tax_amount;
+                base_amounts.raw_total_amount_currency += tax_data.raw_tax_amount_currency;
+                base_amounts.raw_total_amount += tax_data.raw_tax_amount;
                 if (index === 0) {
-                    const base_rounding_key = [currency.id, base_line.is_refund];
-                    if (!(base_rounding_key in total_per_base)) {
-                        total_per_base[base_rounding_key] = {
-                            currency: currency,
-                            base_amount_currency: 0.0,
-                            base_amount: 0.0,
-                            raw_base_amount_currency: 0.0,
-                            raw_base_amount: 0.0,
-                            base_lines: [],
-                        };
-                    }
-
-                    const base_amounts = total_per_base[base_rounding_key];
                     base_amounts.base_amount_currency += tax_data.base_amount_currency;
                     base_amounts.raw_base_amount_currency += tax_data.raw_base_amount_currency;
                     base_amounts.base_amount += tax_data.base_amount;
                     base_amounts.raw_base_amount += tax_data.raw_base_amount;
+                    base_amounts.raw_total_amount_currency += tax_data.raw_base_amount_currency;
+                    base_amounts.raw_total_amount += tax_data.raw_base_amount;
                     if (!base_line.special_type) {
                         base_amounts.base_lines.push(base_line);
                     }
@@ -674,6 +688,8 @@ export const accountTaxHelpers = {
                         tax_amount: 0.0,
                         raw_tax_amount_currency: 0.0,
                         raw_tax_amount: 0.0,
+                        raw_total_amount_currency: 0.0,
+                        raw_total_amount: 0.0,
                         base_lines: []
                     };
                 }
@@ -682,6 +698,8 @@ export const accountTaxHelpers = {
                 tax_amounts.raw_base_amount_currency += tax_details.raw_total_excluded_currency;
                 tax_amounts.base_amount += tax_details.total_excluded;
                 tax_amounts.raw_base_amount += tax_details.raw_total_excluded;
+                tax_amounts.raw_total_amount_currency += tax_details.raw_total_excluded_currency;
+                tax_amounts.raw_total_amount += tax_details.raw_total_excluded;
                 if(!base_line.special_type){
                     tax_amounts.base_lines.push(base_line);
                 }
@@ -690,10 +708,14 @@ export const accountTaxHelpers = {
                 if (!(base_rounding_key in total_per_base)) {
                     total_per_base[base_rounding_key] = {
                         currency: currency,
+                        tax_amount_currency: 0.0,
+                        tax_amount: 0.0,
                         base_amount_currency: 0.0,
                         base_amount: 0.0,
                         raw_base_amount_currency: 0.0,
                         raw_base_amount: 0.0,
+                        raw_total_amount_currency: 0.0,
+                        raw_total_amount: 0.0,
                         base_lines: []
                     };
                 }
@@ -702,6 +724,8 @@ export const accountTaxHelpers = {
                 base_amounts.raw_base_amount_currency += tax_details.raw_total_excluded_currency;
                 base_amounts.base_amount += tax_details.total_excluded;
                 base_amounts.raw_base_amount += tax_details.raw_total_excluded;
+                base_amounts.raw_total_amount_currency += tax_details.raw_total_excluded_currency;
+                base_amounts.raw_total_amount += tax_details.raw_total_excluded;
                 if(!base_line.special_type){
                     base_amounts.base_lines.push(base_line);
                 }
@@ -709,33 +733,49 @@ export const accountTaxHelpers = {
         }
 
         // Round 'total_per_tax'.
-        for (const amounts of Object.values(total_per_tax)) {
-            amounts.raw_tax_amount_currency = roundPrecision(
-                amounts.raw_tax_amount_currency,
-                amounts.currency.rounding
+        for (const tax_amounts of Object.values(total_per_tax)) {
+            tax_amounts.raw_tax_amount_currency = roundPrecision(
+                tax_amounts.raw_tax_amount_currency,
+                tax_amounts.currency.rounding
             );
-            amounts.raw_tax_amount = roundPrecision(
-                amounts.raw_tax_amount,
+            tax_amounts.raw_tax_amount = roundPrecision(
+                tax_amounts.raw_tax_amount,
                 company.currency_id.rounding
             );
-            amounts.raw_base_amount_currency = roundPrecision(
-                amounts.raw_base_amount_currency,
-                amounts.currency.rounding
+            tax_amounts.raw_base_amount_currency = roundPrecision(
+                tax_amounts.raw_base_amount_currency,
+                tax_amounts.currency.rounding
             );
-            amounts.raw_base_amount = roundPrecision(
-                amounts.raw_base_amount,
+            tax_amounts.raw_base_amount = roundPrecision(
+                tax_amounts.raw_base_amount,
+                company.currency_id.rounding
+            );
+            tax_amounts.raw_total_amount_currency = roundPrecision(
+                tax_amounts.raw_total_amount_currency,
+                tax_amounts.currency.rounding
+            );
+            tax_amounts.raw_total_amount = roundPrecision(
+                tax_amounts.raw_total_amount,
                 company.currency_id.rounding
             );
         }
 
         // Round 'total_per_base'.
-        for (const amounts of Object.values(total_per_base)) {
-            amounts.raw_base_amount_currency = roundPrecision(
-                amounts.raw_base_amount_currency,
-                amounts.currency.rounding
+        for (const base_amounts of Object.values(total_per_base)) {
+            base_amounts.raw_base_amount_currency = roundPrecision(
+                base_amounts.raw_base_amount_currency,
+                base_amounts.currency.rounding
             );
-            amounts.raw_base_amount = roundPrecision(
-                amounts.raw_base_amount,
+            base_amounts.raw_base_amount = roundPrecision(
+                base_amounts.raw_base_amount,
+                company.currency_id.rounding
+            );
+            base_amounts.raw_total_amount_currency = roundPrecision(
+                base_amounts.raw_total_amount_currency,
+                base_amounts.currency.rounding
+            );
+            base_amounts.raw_total_amount = roundPrecision(
+                base_amounts.raw_total_amount,
                 company.currency_id.rounding
             );
         }
@@ -759,8 +799,8 @@ export const accountTaxHelpers = {
                 .sort((a, b) => b.tax_details.total_included_currency - a.tax_details.total_included_currency)
                 .map(base_line => [
                     base_line,
-                    base_line.tax_details.taxes_data.find(
-                        tax_data => tax_data.tax.id === tax.id && tax_data.is_reverse_charge === is_reverse_charge
+                    base_line.tax_details.taxes_data.map((tax_data, index) => [index, tax_data]).find(
+                        ([index, tax_data]) => tax_data.tax.id === tax.id && tax_data.is_reverse_charge === is_reverse_charge
                     ) || null
                 ]);
 
@@ -787,12 +827,14 @@ export const accountTaxHelpers = {
                 let nb_of_errors = Math.round(Math.abs(delta / delta_currency.rounding));
                 let remaining_errors = nb_of_errors;
 
-                for (const [base_line, tax_data] of tax_amounts.sorted_base_line_x_tax_data) {
+                for (const [base_line, index_tax_data] of tax_amounts.sorted_base_line_x_tax_data) {
                     const tax_details = base_line.tax_details;
-                    if (!remaining_errors || !tax_data) {
+                    if (!remaining_errors || !index_tax_data) {
                         break;
                     }
 
+                    const index = index_tax_data[0];
+                    const tax_data = index_tax_data[1];
                     const nb_of_amount_to_distribute = Math.min(
                         Math.ceil(Math.abs(tax_details.total_included_currency * nb_of_errors / tax_amounts.total_included_currency)),
                         remaining_errors
@@ -800,6 +842,13 @@ export const accountTaxHelpers = {
                     remaining_errors -= nb_of_amount_to_distribute;
                     const amount_to_distribute = sign * nb_of_amount_to_distribute * delta_currency.rounding;
                     tax_data[delta_field] += amount_to_distribute;
+                    tax_amounts[delta_field] += amount_to_distribute;
+
+                    if (index === 0) {
+                         const base_rounding_key = [tax_amounts.currency.id, base_line.is_refund];
+                         const base_amounts = total_per_base[base_rounding_key];
+                         base_amounts[delta_field] += amount_to_distribute;
+                     }
                 }
             }
         }
@@ -817,8 +866,16 @@ export const accountTaxHelpers = {
                 continue;
             }
 
-            const delta_base_amount_currency = tax_amounts.raw_base_amount_currency - tax_amounts.base_amount_currency;
-            const delta_base_amount = tax_amounts.raw_base_amount - tax_amounts.base_amount;
+            let delta_base_amount_currency;
+            let delta_base_amount;
+            if (country_code === "PT") {
+                delta_base_amount_currency = tax_amounts.raw_total_amount_currency - tax_amounts.base_amount_currency - tax_amounts.tax_amount_currency;
+                delta_base_amount = tax_amounts.raw_total_amount - tax_amounts.base_amount - tax_amounts.tax_amount;
+            } else {
+                delta_base_amount_currency = tax_amounts.raw_base_amount_currency - tax_amounts.base_amount_currency;
+                delta_base_amount = tax_amounts.raw_base_amount - tax_amounts.base_amount;
+            }
+
             for (const [delta, delta_currency_indicator, delta_currency] of [
                 [delta_base_amount_currency, '_currency', currency],
                 [delta_base_amount, '', company.currency_id]
@@ -831,7 +888,7 @@ export const accountTaxHelpers = {
                 let nb_of_errors = Math.round(Math.abs(delta / delta_currency.rounding));
                 let remaining_errors = nb_of_errors;
 
-                for (const [base_line, tax_data] of tax_amounts.sorted_base_line_x_tax_data) {
+                for (const [base_line, index_tax_data] of tax_amounts.sorted_base_line_x_tax_data) {
                     const tax_details = base_line.tax_details;
                     if (!remaining_errors) {
                         break;
@@ -844,7 +901,8 @@ export const accountTaxHelpers = {
                     remaining_errors -= nb_of_amount_to_distribute;
                     const amount_to_distribute = sign * nb_of_amount_to_distribute * delta_currency.rounding;
 
-                    if (tax_data) {
+                    if (index_tax_data) {
+                        const tax_data = index_tax_data[1];
                         tax_data[`base_amount${delta_currency_indicator}`] += amount_to_distribute;
                     } else {
                         tax_details[`delta_total_excluded${delta_currency_indicator}`] += amount_to_distribute;
@@ -879,8 +937,16 @@ export const accountTaxHelpers = {
             )[0];
 
             const tax_details = base_line.tax_details;
-            const delta_base_amount_currency = base_amounts.raw_base_amount_currency - base_amounts.base_amount_currency;
-            const delta_base_amount = base_amounts.raw_base_amount - base_amounts.base_amount;
+            let delta_base_amount_currency;
+            let delta_base_amount;
+            if (country_code === "PT") {
+                delta_base_amount_currency = base_amounts.raw_total_amount_currency - base_amounts.base_amount_currency - base_amounts.tax_amount_currency;
+                delta_base_amount = base_amounts.raw_total_amount - base_amounts.base_amount - base_amounts.tax_amount;
+            } else {
+                delta_base_amount_currency = base_amounts.raw_base_amount_currency - base_amounts.base_amount_currency;
+                delta_base_amount = base_amounts.raw_base_amount - base_amounts.base_amount;
+            }
+
             if (floatIsZero(delta_base_amount_currency, base_amounts.currency.decimal_places) && floatIsZero(delta_base_amount, company.currency_id.decimal_places)) {
                 continue;
             }

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -885,6 +885,12 @@ class TestTaxCommon(AccountTestInvoicingHttpCommon):
             'tax_group_id': self._jsonify_tax_group(tax.tax_group_id),
         }
 
+    def _jsonify_country(self, country):
+        return {
+            'id': country.id,
+            'code': country.code,
+        }
+
     def _jsonify_currency(self, currency):
         return {
             'id': currency.id,
@@ -935,6 +941,7 @@ class TestTaxCommon(AccountTestInvoicingHttpCommon):
         return {
             'id': company.id,
             'tax_calculation_rounding_method': company.tax_calculation_rounding_method,
+            'account_fiscal_country_id': self._jsonify_country(company.account_fiscal_country_id),
             'currency_id': self._jsonify_currency(company.currency_id),
         }
 

--- a/addons/account/tests/test_taxes_tax_totals_summary.py
+++ b/addons/account/tests/test_taxes_tax_totals_summary.py
@@ -1377,9 +1377,12 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
     def _test_taxes_l10n_pt(self):
         """ !!!! THOSE TESTS ARE THERE TO CERTIFY THE USE OF ODOO INVOICING IN PORTUGAL.
         Therefore, they have to stay like this to stay compliant.
-        Note: this is a work in progress. The remaining stuff is coming...
         """
         self.env.company.tax_calculation_rounding_method = 'round_globally'
+        self.change_company_country(self.env.company, self.env.ref('base.pt'))
+        self.env['decimal.precision'].search([('name', '=', "Product Price")]).digits = 6
+        tax_0 = self.percent_tax(0, tax_group_id=self.tax_groups[0].id)
+        tax_6 = self.percent_tax(6, tax_group_id=self.tax_groups[1].id)
         tax_13 = self.percent_tax(13, tax_group_id=self.tax_groups[2].id)
         tax_23 = self.percent_tax(23, tax_group_id=self.tax_groups[3].id)
 
@@ -1445,13 +1448,13 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
         expected_values = {
             'same_tax_base': False,
             'currency_id': self.currency.id,
-            'base_amount_currency': 293.79,
+            'base_amount_currency': 293.78,
             'tax_amount_currency': 52.89,
-            'total_amount_currency': 346.68,
+            'total_amount_currency': 346.67,
             'subtotals': [
                 {
                     'name': "Untaxed Amount",
-                    'base_amount_currency': 293.79,
+                    'base_amount_currency': 293.78,
                     'tax_amount_currency': 52.89,
                     'tax_groups': [
                         {
@@ -1471,6 +1474,573 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
             ],
         }
         yield 3, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 1.0, 'price_unit': 0.5, 'tax_ids': tax_23},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 147.40,
+            'tax_amount_currency': 33.9,
+            'total_amount_currency': 181.30,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 147.40,
+                    'tax_amount_currency': 33.9,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 147.40,
+                            'tax_amount_currency': 33.9,
+                            'display_base_amount_currency': 147.40,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 4, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_0},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_0},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_6},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_6},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 1175.16,
+            'tax_amount_currency': 123.39,
+            'total_amount_currency': 1298.55,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 1175.16,
+                    'tax_amount_currency': 123.39,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[0].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 0.0,
+                            'display_base_amount_currency': 293.79,
+                        },
+                        {
+                            'id': self.tax_groups[1].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 17.63,
+                            'display_base_amount_currency': 293.79,
+                        },
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 38.19,
+                            'display_base_amount_currency': 293.79,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 67.57,
+                            'display_base_amount_currency': 293.79,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 5, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+                {'quantity': 1, 'price_unit': 0.5, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 294.29,
+            'tax_amount_currency': 67.69,
+            'total_amount_currency': 361.98,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 294.29,
+                    'tax_amount_currency': 67.69,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 294.29,
+                            'tax_amount_currency': 67.69,
+                            'display_base_amount_currency': 294.29,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 6, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_0},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_6},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 881.37,
+            'tax_amount_currency': 114.57,
+            'total_amount_currency': 995.94,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 881.37,
+                    'tax_amount_currency': 114.57,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[0].id,
+                            'base_amount_currency': 146.89,
+                            'tax_amount_currency': 0.0,
+                            'display_base_amount_currency': 146.89,
+                        },
+                        {
+                            'id': self.tax_groups[1].id,
+                            'base_amount_currency': 146.90,
+                            'tax_amount_currency': 8.81,
+                            'display_base_amount_currency': 146.90,
+                        },
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 38.19,
+                            'display_base_amount_currency': 293.79,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 67.57,
+                            'display_base_amount_currency': 293.79,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 7, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 5.55, 'price_unit': 1.09, 'tax_ids': tax_23},
+                {'quantity': 5.5, 'price_unit': 1.09, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 12.04,
+            'tax_amount_currency': 2.77,
+            'total_amount_currency': 14.81,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 12.04,
+                    'tax_amount_currency': 2.77,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 12.04,
+                            'tax_amount_currency': 2.77,
+                            'display_base_amount_currency': 12.04,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 8, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_0},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_0},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_6},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_6},
+                {'quantity': 13.13, 'price_unit': 12.12, 'tax_ids': tax_13},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
+                {'quantity': 13.13, 'price_unit': 12.12, 'tax_ids': tax_23},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 1199.64,
+            'tax_amount_currency': 127.80,
+            'total_amount_currency': 1327.44,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 1199.64,
+                    'tax_amount_currency': 127.80,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[0].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 0.0,
+                            'display_base_amount_currency': 293.79,
+                        },
+                        {
+                            'id': self.tax_groups[1].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 17.63,
+                            'display_base_amount_currency': 293.79,
+                        },
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 306.03,
+                            'tax_amount_currency': 39.78,
+                            'display_base_amount_currency': 306.03,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 306.03,
+                            'tax_amount_currency': 70.39,
+                            'display_base_amount_currency': 306.03,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 9, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 501.0, 'price_unit': 3.0, 'tax_ids': tax_6},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 1503.0,
+            'tax_amount_currency': 90.18,
+            'total_amount_currency': 1593.18,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 1503.0,
+                    'tax_amount_currency': 90.18,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[1].id,
+                            'base_amount_currency': 1503.0,
+                            'tax_amount_currency': 90.18,
+                            'display_base_amount_currency': 1503.0,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 10, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 146.89,
+            'tax_amount_currency': 33.79,
+            'total_amount_currency': 180.68,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 146.89,
+                    'tax_amount_currency': 33.79,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 146.89,
+                            'tax_amount_currency': 33.79,
+                            'display_base_amount_currency': 146.89,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 11, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 50.0, 'price_unit': 2.0, 'tax_ids': tax_13},
+                {'quantity': 100.0, 'price_unit': 1.0, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 200.0,
+            'tax_amount_currency': 36.0,
+            'total_amount_currency': 236.0,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 200.0,
+                    'tax_amount_currency': 36.0,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 100.0,
+                            'tax_amount_currency': 13.0,
+                            'display_base_amount_currency': 100.0,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 100.0,
+                            'tax_amount_currency': 23.0,
+                            'display_base_amount_currency': 100.0,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 12, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 1.0, 'price_unit': 1.0, 'tax_ids': tax_0},
+                {'quantity': 1.0, 'price_unit': 4.0, 'tax_ids': tax_0},
+                {'quantity': 10.0, 'price_unit': 3.0, 'tax_ids': tax_6},
+                {'quantity': 1.0, 'price_unit': 2.0, 'tax_ids': tax_13},
+                {'quantity': 1.0, 'price_unit': 1.0, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 38.0,
+            'tax_amount_currency': 2.29,
+            'total_amount_currency': 40.29,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 38.0,
+                    'tax_amount_currency': 2.29,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[0].id,
+                            'base_amount_currency': 5.0,
+                            'tax_amount_currency': 0.0,
+                            'display_base_amount_currency': 5.0,
+                        },
+                        {
+                            'id': self.tax_groups[1].id,
+                            'base_amount_currency': 30.0,
+                            'tax_amount_currency': 1.8,
+                            'display_base_amount_currency': 30.0,
+                        },
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 2.0,
+                            'tax_amount_currency': 0.26,
+                            'display_base_amount_currency': 2.0,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 1.0,
+                            'tax_amount_currency': 0.23,
+                            'display_base_amount_currency': 1.0,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 13, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 50.0, 'price_unit': 1.09, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 54.5,
+            'tax_amount_currency': 12.54,
+            'total_amount_currency': 67.04,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 54.5,
+                    'tax_amount_currency': 12.54,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 54.5,
+                            'tax_amount_currency': 12.54,
+                            'display_base_amount_currency': 54.5,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 14, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 100.0, 'price_unit': 0.55, 'discount': 8.8, 'tax_ids': tax_23},
+                {'quantity': 10.0, 'price_unit': 2.0, 'tax_ids': tax_23},
+                {'quantity': 1.0, 'price_unit': -7.016, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 63.15,
+            'tax_amount_currency': 14.52,
+            'total_amount_currency': 77.67,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 63.15,
+                    'tax_amount_currency': 14.52,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 63.15,
+                            'tax_amount_currency': 14.52,
+                            'display_base_amount_currency': 63.15,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 15, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 12.12, 'price_unit': 12.12, 'discount': 6.6, 'tax_ids': tax_13},
+                {'quantity': 12.12, 'price_unit': 12.12, 'discount': 6.6, 'tax_ids': tax_13},
+                {'quantity': 12.12, 'price_unit': 12.12, 'discount': 8.8, 'tax_ids': tax_23},
+                {'quantity': 12.12, 'price_unit': 12.12, 'discount': 8.8, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 542.33,
+            'tax_amount_currency': 97.30,
+            'total_amount_currency': 639.63,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 542.33,
+                    'tax_amount_currency': 97.30,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 274.4,
+                            'tax_amount_currency': 35.67,
+                            'display_base_amount_currency': 274.4,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 267.93,
+                            'tax_amount_currency': 61.63,
+                            'display_base_amount_currency': 267.93,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 16, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 13.13, 'price_unit': 13.13, 'tax_ids': tax_13},
+                {'quantity': 1.0, 'price_unit': 0.5, 'tax_ids': tax_13},
+                {'quantity': 1.0, 'price_unit': 0.5, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 173.39,
+            'tax_amount_currency': 22.6,
+            'total_amount_currency': 195.99,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 173.39,
+                    'tax_amount_currency': 22.6,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 172.89,
+                            'tax_amount_currency': 22.48,
+                            'display_base_amount_currency': 172.89,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 0.5,
+                            'tax_amount_currency': 0.12,
+                            'display_base_amount_currency': 0.5,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 17, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 1.0, 'price_unit': 0.5, 'tax_ids': tax_13},
+                {'quantity': 1.0, 'price_unit': 0.5, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 0.99,
+            'tax_amount_currency': 0.19,
+            'total_amount_currency': 1.18,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 0.99,
+                    'tax_amount_currency': 0.19,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 0.5,
+                            'tax_amount_currency': 0.07,
+                            'display_base_amount_currency': 0.5,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 0.5,
+                            'tax_amount_currency': 0.12,
+                            'display_base_amount_currency': 0.5,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 18, document, expected_values
 
     def test_taxes_l10n_pt_generic_helpers(self):
         for test_index, document, expected_values in self._test_taxes_l10n_pt():


### PR DESCRIPTION
Compute the delta for base amounts in '_round_base_lines_tax_details' from the total instead of from the base amounts only.

See test in this commit.

task-4457168
