### PR TITLE
[FIX] auth_signup: reset password spinner

### DIFF
--- a/addons/auth_signup/static/src/js/reset_password.js
+++ b/addons/auth_signup/static/src/js/reset_password.js
@@ -2,7 +2,7 @@
 
 import publicWidget from "@web/legacy/js/public/public_widget";
 
-publicWidget.registry.SignUpForm = publicWidget.Widget.extend({
+publicWidget.registry.ResetPasswordForm = publicWidget.Widget.extend({
     selector: '.oe_reset_password_form',
     events: {
         'submit': '_onSubmit',


### PR DESCRIPTION
Currently signup.js also defines SignUpForm, which overrides the reset password behavior. This bug is not present in 16.0, so I used the same name for the registry that is being used in 16.0.