### PR TITLE
[FIX] project: remove hardcoded column size for task id field

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -724,7 +724,7 @@
                     <field name="allow_milestones" column_invisible="True"/>
                     <field name="subtask_count" column_invisible="True"/>
                     <field name="closed_subtask_count" column_invisible="True"/>
-                    <field name="id" optional="hide" options="{'enable_formatting': False}" width="30px"/>
+                    <field name="id" optional="hide" options="{'enable_formatting': False}"/>
                     <field name="priority" widget="priority" nolabel="1" width="20px"/>
                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px" options="{'is_toggle_mode': false}"/>
                     <field name="name" string="Title" widget="name_with_subtask_count"/>


### PR DESCRIPTION
Before this commit, the column of task id displayed in list view of all tasks menu is too small when there are many tasks stored in DB. Moreover, if the user wants to sort the tasks by ID, the column collapses.

This commit reverts the hardcoded size set on that column to let the framework computes the column size.

Steps to reproduce the issue:
----------------------------

1. Create a good amount of task (over 1000)
2. Go to Projects > Tasks > All tasks
3. Display the ID column in the list view.
4. Sort by ID

Expected Behavior
-----------------

The content of the column should still be visible.

Current Behavior
----------------

The column size is recomputed and the size is too small to directly see its content.

opw-4524749