### PR TITLE
[FIX] base: ensure company matches commercial partner one

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -476,6 +476,11 @@ class ResPartner(models.Model):
             raise ValidationError(_('You cannot create recursive Partner hierarchies.'))
 
     @api.constrains('company_id')
+    def _check_commercial_parnter_company(self):
+        if self.commercial_partner_id.company_id and self.company_id != self.commercial_partner_id.company_id:
+            raise ValidationError(_('The commercial partner has a different company.'))
+
+    @api.constrains('company_id')
     def _check_partner_company(self):
         """
         Check that for every partner which has a company,
@@ -756,8 +761,6 @@ class ResPartner(models.Model):
                     if len(companies) > 1 or company not in companies:
                         raise UserError(
                             self.env._("The selected company is not compatible with the companies of the related user(s)"))
-                if partner.child_ids:
-                    partner.child_ids.write({'company_id': company_id})
         result = True
         # To write in SUPERUSER on field is_company and avoid access rights problems.
         if 'is_company' in vals and not self.env.su and self.env.user.has_group('base.group_partner_manager'):
@@ -765,6 +768,8 @@ class ResPartner(models.Model):
             del vals['is_company']
         result = result and super().write(vals)
         for partner in self:
+            if 'company_id' in vals and partner.child_ids:
+                partner.child_ids.write({'company_id': vals["company_id"]})
             if any(u._is_internal() for u in partner.user_ids if u != self.env.user):
                 self.env['res.users'].check_access('write')
             partner._fields_sync(vals)


### PR DESCRIPTION
Steps to reproduce:
1. Setup a clean DB with `contacts` installed (no demo)
2. Add a new company (from now on we have C1 and C2 as companies) and check both in the context
3. Create a contact A0 of type company and set its company as C1
4. Create a contact A1 of type individual
5. Open A1 in two sessions (different browsers, or at least incognito, S1, S2)
6. In S2 pick C2 as company of A1 (do not save yet)
7. In S1 set the parent contact of A1 to be A0 and save (note that A1 got C1 as company)
8. Save in S2 (note that A1 got C2 as company)

Then we arrived to the situation where the parent and child contacts are on different companies.
```
test_m=> select id,name,is_company,parent_id,commercial_partner_id,company_id from res_partner where name in ('A0', 'A1')
+----+------+------------+-----------+-----------------------+------------+
| id | name | is_company | parent_id | commercial_partner_id | company_id |
|----+------+------------+-----------+-----------------------+------------|
| 7  | A0   | True       | <null>    | 7                     | 1          |
| 8  | A1   | False      | 7         | 7                     | 2          |
+----+------+------------+-----------+-----------------------+------------+
```

The company mismatch causes issues in other places, e.g. https://github.com/odoo/odoo/blob/095819c76361880e106aaa9e4ac9eca84fddab02/addons/account/models/partner.py#L652-L657

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
