### PR TITLE
[FIX] payment_adyen: log refusal reason for refused payments

### DIFF
--- a/addons/payment_adyen/models/payment_transaction.py
+++ b/addons/payment_adyen/models/payment_transaction.py
@@ -460,6 +460,7 @@ class PaymentTransaction(models.Model):
                     self._log_message_on_linked_documents(_(
                         "The capture of the transaction with reference %s failed.", self.reference
                     ))
+        elif payment_state in const.RESULT_CODES_MAPPING['refused']:
             _logger.warning(
                 "the transaction with reference %s was refused. reason: %s",
                 self.reference, refusal_reason


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Enable Adyen as payment provider in test mode;
2. do an eCommerce checkout;
3. select Adyen as payment option;
4. use the following card details[^1]:
    - card number: 4111111111111111
    - expiry: 03/30
    - cvc: 737
    - name on card: CARD_EXPIRED
5. click Pay Now;
6. check order chatter on the backend.

Issue
-----
> Error: Adyen: Received data with invalid payment state: Refused

Refusal shouldn't be an invalid payment state.

Cause
-----
Commit 04f75728fd3e accidentally removed an `elif` branch that was added by commit 4d340a330462e specifically to handle refused payments.

Solution
--------
Re-add the `elif` branch.

opw-4481602

[^1]: https://docs.adyen.com/development-resources/testing/result-codes#values-for-testing-result-reasons