### PR TITLE
[FIX] point_of_sale: Cash opening not counted expected in column

### DIFF
--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -163,8 +163,7 @@ class ReportSaleDetails(models.AbstractModel):
                             payment['count'] = True
                     else:
                         is_cash_method = True
-                        previous_session = self.env['pos.session'].search([('id', '<', session.id), ('state', '=', 'closed'), ('config_id', '=', session.config_id.id)], limit=1)
-                        payment['final_count'] = payment['total'] + previous_session.cash_register_balance_end_real + session.cash_real_transaction
+                        payment['final_count'] = payment['total'] + session.cash_register_balance_start + session.cash_real_transaction
                         payment['money_counted'] = cash_counted
                         payment['money_difference'] = payment['money_counted'] - payment['final_count']
                         cash_moves = self.env['account.bank.statement.line'].search([('pos_session_id', '=', session.id)])


### PR DESCRIPTION
Current behavior:
The previous closing amount is used instead of the cash opening when printing the session report so the expected cash amount is wrong.

Steps to reproduce:

Open a PoS session with 100€ in the cash register and close it. Reopen the session and enter 50€ in the cash register. Make a sale for 10€, using cash payment.
Close the session and print the session report.
The expected cash amount will be 110€ when it should be 60€.

Fixes opw-4497263