### PR TITLE
[FIX] point_of_sale: fix preparation ticket combo

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -1808,6 +1808,7 @@ export class Order extends PosModel {
                         attribute_value_ids: orderline.attribute_value_ids,
                         quantity: quantityDiff,
                         note: note,
+                        isPartOfCombo: orderline.comboParent !== undefined,
                     };
                     changesCount += quantityDiff;
                     changeAbsCount += Math.abs(quantityDiff);

--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -46,7 +46,7 @@
                 <br />
                 <br />
                 <t t-foreach="changes.new" t-as="change" t-key="change_index">
-                    <div class="multiprint-flex">
+                    <div class="multiprint-flex" t-attf-class="{{change.isPartOfCombo ? 'mx-5' : ''}}">
                         <span class="product-quantity" t-esc="change.quantity"/>
                         <span class="product-name" t-esc="change.name"/>
                     </div>

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant.js
@@ -10,6 +10,7 @@ import * as ProductScreenPos from "@point_of_sale/../tests/tours/helpers/Product
 import * as ProductScreenResto from "@pos_restaurant/../tests/tours/helpers/ProductScreenTourMethods";
 import * as Order from "@point_of_sale/../tests/tours/helpers/generic_components/OrderWidgetMethods";
 import * as TicketScreen from "@point_of_sale/../tests/tours/helpers/TicketScreenTourMethods";
+import * as combo from "@point_of_sale/../tests/tours/helpers/ComboPopupMethods";
 import { inLeftSide, negateStep } from "@point_of_sale/../tests/tours/helpers/utils";
 import { registry } from "@web/core/registry";
 
@@ -236,4 +237,29 @@ registry.category("web_tour.tours").add("BillScreenTour", {
         PaymentScreen.clickValidate(),
         BillScreen.isQRCodeShown(),
     ].flat(),
+});
+
+registry.category("web_tour.tours").add("ComboPreparationReceiptTour", {
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickHomeCategory(),
+            ProductScreen.clickDisplayedProduct("Office Combo"),
+            combo.select("Combo Product 2"),
+            combo.select("Combo Product 4"),
+            combo.select("Combo Product 6"),
+            combo.confirm(),
+            {
+                trigger: ".actionpad .submit-order.highlight.btn-primary",
+            },
+            ProductScreen.clickOrderButton(),
+            {
+                trigger: ".render-container .mx-5:contains('Combo Product 2')",
+            },
+            {
+                trigger: ".render-container .multiprint-flex:not(.mx-5):contains('Office Combo')",
+            },
+            ProductScreen.orderlinesHaveNoChange(),
+        ].flat(),
 });

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.tests
+from odoo import Command
 from odoo.addons.point_of_sale.tests.common_setup_methods import setup_pos_combo_items
 from odoo.addons.point_of_sale.tests.common import archive_products
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -326,3 +327,19 @@ class TestFrontend(TestFrontendCommon):
         self.env.company.point_of_sale_use_ticket_qr_code = True
         self.pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.pos_config.id, 'BillScreenTour', login="pos_admin")
+
+    def test_combo_preparation_receipt(self):
+        setup_pos_combo_items(self)
+        self.env['product.product'].search([('name', 'ilike', 'Combo')]).write({'pos_categ_ids': [(Command.set(self.env['pos.category'].search([], limit=1).ids))]})
+        self.env['pos.printer'].create({
+            'name': 'Printer',
+            'printer_type': 'epson_epos',
+            'epson_printer_ip': '0.0.0.0',
+            'product_categories_ids': [Command.set(self.env['pos.category'].search([]).ids)],
+        })
+        self.pos_config.write({
+            'is_order_printer': True,
+            'printer_ids': [Command.set(self.env['pos.printer'].search([]).ids)],
+        })
+        self.pos_config.with_user(self.pos_admin).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.pos_config.id}", 'ComboPreparationReceiptTour', login="pos_admin")


### PR DESCRIPTION
When sending a combo to a preparation printer, the combo items where not indented correctly. This was leading to a preparation ticket that made it look like all items were normal items, instead of being part of a combo.

Steps to reproduce:
-------------------
* Create a combo product A
* Setup a kitchen printer in the PoS
* Open PoS and add the combo product A
* Send the order to the kitchen printer
> Observation: The preparation ticket does not show the combo items
> indented correctly

Why the fix:
------------
We add a new fields in the `changes` that state if the line is part of a combo. If it is part of a combo, we add a css class that will indent the line accordingly.

opw-4459211