### PR TITLE
[IMP] im_livechat: use operator_id for "my sessions"

### DIFF
--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <search string="Search history">
                     <field name="name" string="Participant"/>
-                    <filter name="filter_my_sessions" domain="[('is_member', '=', True)]" string="My Sessions"/>
+                    <filter name="filter_my_sessions" domain="[('livechat_operator_id.user_id', '=', uid)]" string="My Sessions"/>
                     <separator/>
                     <filter name="filter_session_date" date="create_date" string="Session Date"/>
                     <separator/>


### PR DESCRIPTION
Before this PR, the "My Sessions" filter used is_member. This doesn't include the
closed livechat sessions.

This PR uses livechat_operator_id to display all the sessions.

Task-4536751
