### PR TITLE
[FIX] website_sale: fix parsing issue in "add to cart" snippet

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_configurators.js
+++ b/addons/website_sale/static/src/js/website_sale_configurators.js
@@ -92,7 +92,7 @@ WebsiteSale.include({
             isFrontend: true,
             options: {
                 isMainProductConfigurable: !isOnProductPage,
-                showQuantity: Boolean(this.$form?.[0].querySelector('.css_quantity')),
+                showQuantity: Boolean(document.querySelector('.js_add_cart_json')),
             },
             save: async (mainProduct, optionalProducts, options) => {
                 this._trackProducts([mainProduct, ...optionalProducts]);
@@ -123,7 +123,7 @@ WebsiteSale.include({
             edit: false,
             isFrontend: true,
             options: {
-                showQuantity: Boolean(this.$form?.[0].querySelector('.css_quantity')),
+                showQuantity: Boolean(document.querySelector('.js_add_cart_json')),
             },
             save: (comboProductData, selectedComboItems, options) =>
                 this.addComboProductToCart(

--- a/addons/website_sale/static/src/snippets/s_add_to_cart/000.js
+++ b/addons/website_sale/static/src/snippets/s_add_to_cart/000.js
@@ -23,7 +23,7 @@ publicWidget.registry.AddToCartSnippet = WebsiteSale.extend(cartHandlerMixin, {
         const action = dataset.action;
         const productId = parseInt(dataset.productVariantId);
         const productTemplateId = parseInt(dataset.productTemplateId);
-        const isCombo = dataset.isCombo;
+        const isCombo = dataset.isCombo === 'true';
 
         if (!productId || isCombo) {
             this.rootProduct = {

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
@@ -145,7 +145,7 @@ const DynamicSnippetProductsCard = WebsiteSale.extend({
      */
     async _onClickAddToCart(ev) {
         const button = ev.currentTarget
-        if (!button.dataset.productSelected || button.dataset.isCombo) {
+        if (!button.dataset.productSelected || button.dataset.isCombo === 'True') {
             const dummy_form = document.createElement('form');
             dummy_form.setAttribute('method', 'post');
             dummy_form.setAttribute('action', '/shop/cart/update');


### PR DESCRIPTION
We forgot to parse a boolean which was stored as a string so it was always
considered true (both the strings `'true'` and `'false'` evaluate to `true` in a
boolean context.

This change also fixes the `showQuantity` computation in the product and combo
configurators (the computation assumed the user was on the product page, which
isn't necessarily the case for "add to cart" snippets).