### PR TITLE
[FIX] point_of_sale: fix customer display remote mode

### DIFF
--- a/addons/point_of_sale/static/src/customer_display/customer_display_adapter.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display_adapter.js
@@ -23,9 +23,9 @@ export class CustomerDisplayPosAdapter {
 
         if (pos.config.customer_display_type === "remote") {
             pos.data.call("pos.config", "update_customer_display", [
-                [this.pos.config.id],
+                [pos.config.id],
                 this.data,
-                this.pos.config.access_token,
+                pos.config.access_token,
             ]);
         }
 


### PR DESCRIPTION
In the refactor from 59700fe a bug was introduced that prevented the pos to work with the customer display option set to remote.

Steps to reproduce:
1. Set the pos config, change the setting "Show checkout to customers through a second display" to "Another device"
2. Open the pos and try to add any product to the cart
3. Observe the traceback



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
