### PR TITLE
[IMP] hr_contract: Change conatracts menu and smart button access

### DIFF
--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -46,6 +46,14 @@ class HrEmployee(models.Model):
     contracts_count = fields.Integer(compute='_compute_contracts_count', string='Contract Count', groups="hr.group_hr_user")
     contract_warning = fields.Boolean(string='Contract Warning', store=True, compute='_compute_contract_warning', groups="hr.group_hr_user")
     first_contract_date = fields.Date(compute='_compute_first_contract_date', groups="hr.group_hr_user", store=True)
+    show_contract_smart_button = fields.Boolean(compute="_compute_show_contract_smart_button", groups="hr.group_hr_user")
+
+    def _compute_show_contract_smart_button(self):
+        is_contract_manager = self.env.user.has_group("hr_contract.group_hr_contract_manager")
+        is_contract_employee_manager = self.env.user.has_group("hr_contract.group_hr_contract_employee_manager")
+        for employee in self:
+            employee.show_contract_smart_button = is_contract_manager or \
+                (is_contract_employee_manager and self.env.user.id == employee.parent_id.user_id.id)
 
     @api.depends('name')
     def _compute_legal_name(self):

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -40,13 +40,13 @@
                             class="oe_stat_button"
                             icon="fa-book"
                             type="object"
-                            groups="hr_contract.group_hr_contract_manager"
+                            groups="hr.group_hr_user"
                             context="{
                                 'default_employee_id': id,
                                 'default_resource_calendar_id': resource_calendar_id.id or False,
                                 'from_action_open_contract': True,
                             }"
-                            invisible="employee_type not in ['employee', 'student', 'trainee']">
+                            invisible="employee_type not in ['employee', 'student', 'trainee'] or not show_contract_smart_button">
                             <div invisible="not first_contract_date" class="o_stat_info">
                                 <span class="o_stat_text text-success" invisible="contract_warning" title="In Contract Since"> In Contract Since</span>
                                 <span class="o_stat_value text-success" invisible="contract_warning">
@@ -435,7 +435,7 @@
             action="hr_contract.action_hr_contract"
             parent="hr.menu_hr_employee_payroll"
             sequence="6"
-            groups="hr_contract.group_hr_contract_manager"/>
+            groups="hr_contract.group_hr_contract_employee_manager"/>
 
         <menuitem
             id="menu_hr_employee_contracts"


### PR DESCRIPTION
- add field to check the conditions of showing the contract smart button as it requires having 2 groups in the hr, hr_contract
- show the contracts menu item to contract employee managers not only administrators

Task: 4543411


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
