### PR TITLE
[IMP] base, web: add invisible field to bound actions

### DIFF
--- a/addons/web/static/src/views/view_service.js
+++ b/addons/web/static/src/views/view_service.js
@@ -1,6 +1,8 @@
 import { rpcBus } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import { UPDATE_METHODS } from "@web/core/orm_service";
+import { user } from "@web/core/user";
+import { evaluateBooleanExpr } from "@web/core/py_js/py";
 
 /**
  * @typedef {Object} IrFilter
@@ -118,7 +120,17 @@ export const viewService = {
                             const { arch, toolbar, id, filters, custom_view_id } = views[viewType];
                             const viewDescription = { arch, id, custom_view_id };
                             if (toolbar) {
-                                viewDescription.actionMenus = toolbar;
+                                const actionMenus = toolbar;
+                                if (actionMenus.action) {
+                                    actionMenus.action = actionMenus.action.filter(
+                                        (action) =>
+                                            !evaluateBooleanExpr(
+                                                action.binding_invisible,
+                                                user.evalContext
+                                            )
+                                    );
+                                }
+                                viewDescription.actionMenus = actionMenus;
                             }
                             if (filters) {
                                 viewDescription.irFilters = filters;

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -1660,11 +1660,30 @@ export class Model extends Array {
         /** @type {typeof this.views} */
         const result = {};
 
+        const binding_actions = MockServer.current.actions.filter(
+            // In hoot, the actions are a list of objects, not real models.
+            // We can't use a "normal" reference. So in this case we do the reference by the name of the model.
+            (action) => action.binding_model_id === this._name
+        );
+
         // Determine all the models/fields used in the views
         // modelFields = {modelName: {fields: Set([...fieldNames])}}
         const modelFields = {};
         views.forEach(([viewId, viewType]) => {
             result[viewType] = getView(this, [viewId, viewType], kwargs);
+            if (options.toolbar) {
+                const toolbarAction = binding_actions.filter((action) =>
+                    action.binding_view_types.split(",").includes(viewType)
+                );
+                if (toolbarAction.length) {
+                    result[viewType].toolbar.action = toolbarAction.map((action) => ({
+                        id: action.id,
+                        name: action.name,
+                        binding_view_types: action.binding_view_types,
+                        binding_invisible: action.binding_invisible,
+                    }));
+                }
+            }
             for (const [modelName, fields] of Object.entries(result[viewType].models)) {
                 modelFields[modelName] ||= { fields: new Set() };
                 for (const field of fields) {

--- a/addons/web/static/tests/views/view_service.test.js
+++ b/addons/web/static/tests/views/view_service.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "@odoo/hoot";
 import {
+    defineActions,
     defineModels,
     getService,
     makeMockEnv,
@@ -22,6 +23,85 @@ class IrUiView extends models.Model {
 
 defineModels([TakeFive, IrUiView]);
 
+test("evaluate actionmenus", async () => {
+    defineActions([
+        {
+            id: 1,
+            name: "Fist Action",
+            res_model: "take.five",
+            search_view_id: [false, "search"],
+            views: [[99, "list"]],
+            binding_model_id: "take.five",
+            binding_view_types: "list",
+        },
+        {
+            id: 2, // not binded action
+            name: "Second Action",
+            res_model: "take.five",
+            search_view_id: [false, "search"],
+            views: [[99, "list"]],
+        },
+        {
+            id: 3,
+            name: "Third Action",
+            res_model: "take.five",
+            views: [[99, "list"]],
+            binding_model_id: "anoter.model",
+            binding_view_types: "list",
+        },
+        {
+            id: 4,
+            name: "Fist Invisible Action",
+            res_model: "take.five",
+            search_view_id: [false, "search"],
+            views: [[99, "list"]],
+            binding_model_id: "take.five",
+            binding_view_types: "list",
+            binding_invisible: true,
+        },
+        {
+            id: 5,
+            name: "Invisible with context",
+            res_model: "take.five",
+            search_view_id: [false, "search"],
+            views: [[99, "list"]],
+            binding_model_id: "take.five",
+            binding_view_types: "list",
+            binding_invisible: "companies.active_id == 1",
+        },
+        {
+            id: 6,
+            name: "Visible with context",
+            res_model: "take.five",
+            search_view_id: [false, "search"],
+            views: [[99, "list"]],
+            binding_model_id: "take.five",
+            binding_view_types: "list",
+            binding_invisible: "companies.active_id == 2",
+        },
+    ]);
+    await makeMockEnv();
+    const res = await getService("view").loadViews(
+        {
+            resModel: "take.five",
+            views: [[99, "list"]],
+        },
+        { loadActionMenus: true }
+    );
+    expect(res.views.list.actionMenus.action).toEqual([
+        {
+            binding_view_types: "list",
+            id: 1,
+            name: "Fist Action",
+        },
+        {
+            binding_invisible: "companies.active_id == 2",
+            binding_view_types: "list",
+            id: 6,
+            name: "Visible with context",
+        },
+    ]);
+});
 test("stores calls in cache in success", async () => {
     expect.assertions(1);
     onRpc("get_views", () => {

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -74,6 +74,10 @@ class IrActionsActions(models.Model):
                                      ('report', 'Report')],
                                     required=True, default='action')
     binding_view_types = fields.Char(default='list,form')
+    binding_invisible = fields.Char(
+        string="Invisible attribute",
+        help="Python expression, when evaluated as true, the action isn't shown in the action menu.",
+    )
 
     @api.constrains('path')
     def _check_path(self):
@@ -197,7 +201,7 @@ class IrActionsActions(models.Model):
         for action_id, action_model, binding_type in cr.fetchall():
             try:
                 action = self.env[action_model].sudo().browse(action_id)
-                fields = ['name', 'binding_view_types']
+                fields = ['name', 'binding_view_types', 'binding_invisible']
                 for field in ('groups_id', 'res_model', 'sequence', 'domain'):
                     if field in action._fields:
                         fields.append(field)

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -422,7 +422,7 @@ ZeroDivisionError: division by zero""" % self.test_server_action.id
         self.env.user.write({'groups_id': [Command.link(group0.id)]})
 
         bindings = Actions.get_bindings('res.country')
-        self.assertItemsEqual(bindings.get('action'), self.action.read(['name', 'sequence', 'binding_view_types']))
+        self.assertItemsEqual(bindings.get('action'), self.action.read(['name', 'sequence', 'binding_view_types', 'binding_invisible']))
 
         self.action.with_context(self.context).run()
         self.assertEqual(self.test_country.vat_label, 'VatFromTest', 'vat label should be changed to VatFromTest')

--- a/odoo/addons/test_action_bindings/tests/test_bindings.py
+++ b/odoo/addons/test_action_bindings/tests/test_bindings.py
@@ -23,12 +23,12 @@ class TestActionBindings(common.TransactionCase):
         bindings = Actions.get_bindings('res.partner')
         self.assertItemsEqual(
             bindings['action'],
-            (action1 + action2).read(['name', 'binding_view_types']),
+            (action1 + action2).read(['name', 'binding_view_types', 'binding_invisible']),
             "Wrong action bindings",
         )
         self.assertItemsEqual(
             bindings['report'],
-            action3.read(['name', 'binding_view_types']),
+            action3.read(['name', 'binding_view_types', 'binding_invisible']),
             "Wrong action bindings",
         )
 
@@ -40,12 +40,12 @@ class TestActionBindings(common.TransactionCase):
         bindings = Actions.get_bindings('res.partner')
         self.assertItemsEqual(
             bindings['action'],
-            action1.read(['name', 'binding_view_types']),
+            action1.read(['name', 'binding_view_types', 'binding_invisible']),
             "Wrong action bindings",
         )
         self.assertItemsEqual(
             bindings['report'],
-            action3.read(['name', 'binding_view_types']),
+            action3.read(['name', 'binding_view_types', 'binding_invisible']),
             "Wrong action bindings",
         )
 


### PR DESCRIPTION
This commit adds the ability to conditionally render a view's bound action (the actions that appear in the action cog menu when selecting records).

This is done by adding a new field: `binding_invisible`. Note that, this field accepts True, False, 1, 0 or a Python expression.

task-id: 4250356
