### PR TITLE
[FIX] hr_attendance: hide refuse/approve buttons if no extra hours

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -17,6 +17,7 @@ from odoo.osv.expression import AND, OR
 from odoo.tools.float_utils import float_is_zero
 from odoo.exceptions import AccessError
 from odoo.tools import convert, format_duration, format_time, format_datetime
+from odoo.tools.float_utils import float_compare
 
 def get_google_maps_url(latitude, longitude):
     return "https://maps.google.com?q=%s,%s" % (latitude, longitude)
@@ -46,6 +47,7 @@ class HrAttendance(models.Model):
                                                   ('approved', "Approved"),
                                                   ('refused', "Refused")], compute="_compute_overtime_status", store=True, tracking=True)
     validated_overtime_hours = fields.Float(string="Extra Hours", compute='_compute_validated_overtime_hours', store=True, readonly=False, tracking=True)
+    no_validated_overtime_hours = fields.Boolean(compute='_compute_no_validated_overtime_hours')
     in_latitude = fields.Float(string="Latitude", digits=(10, 7), readonly=True, aggregator=None)
     in_longitude = fields.Float(string="Longitude", digits=(10, 7), readonly=True, aggregator=None)
     in_country_name = fields.Char(string="Country", help="Based on IP Address", readonly=True)
@@ -165,6 +167,10 @@ class HrAttendance(models.Model):
 
         for attendance in no_validation:
             attendance.validated_overtime_hours = attendance.overtime_hours
+
+    @api.depends('validated_overtime_hours')
+    def _compute_no_validated_overtime_hours(self):
+        self.no_validated_overtime_hours = not float_compare(self.validated_overtime_hours, 0.0, precision_digits=5)
 
     @api.depends('employee_id')
     def _compute_overtime_status(self):

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -69,7 +69,8 @@
         <field name="arch" type="xml">
             <form string="Employee attendances" duplicate="false">
                 <header>
-                    <field name="overtime_status" widget="statusbar" readonly="0" options="{'clickable': '1'}"/>
+                    <field name="overtime_status" widget="statusbar" invisible="no_validated_overtime_hours" readonly="0" options="{'clickable': '1'}"/>
+                    <field name="overtime_status" widget="statusbar" invisible="not no_validated_overtime_hours" statusbar_visible="approved,refused" readonly="0" options="{'clickable': '1'}"/>
                 </header>
                 <sheet>
                     <group>
@@ -91,8 +92,8 @@
                                     string="Extra Hours"
                                     readonly="overtime_status == 'refused'"
                                     />
-                                    <button class="oe_stat_button" string="Approve" invisible="overtime_status not in ['to_approve', 'refused']" name="action_approve_overtime" icon="fa-check" type="object"/>
-                                    <button class="oe_stat_button" string="Refuse" invisible="overtime_status not in ['to_approve', 'approved']" name="action_refuse_overtime" icon="fa-times" type="object"/>
+                                    <button class="oe_stat_button" string="Approve" invisible="overtime_status not in ['to_approve', 'refused'] or no_validated_overtime_hours" name="action_approve_overtime" icon="fa-check" type="object"/>
+                                    <button class="oe_stat_button" string="Refuse" invisible="overtime_status not in ['to_approve', 'approved'] or no_validated_overtime_hours" name="action_refuse_overtime" icon="fa-times" type="object"/>
                                 </div>
                             </group>
                         </group>


### PR DESCRIPTION
Since logging new attendance is approved by default, the refuse/approve buttons for rejecting/approving extra zero hours
should be invisible.

task-4320142

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
