### PR TITLE
[IMP] web: use user.evalContext to evaluate domain in searchModel

### DIFF
--- a/addons/web/static/src/core/domain_selector_dialog/domain_selector_dialog.js
+++ b/addons/web/static/src/core/domain_selector_dialog/domain_selector_dialog.js
@@ -80,7 +80,7 @@ export class DomainSelectorDialog extends Component {
         let domain;
         let isValid;
         try {
-            const evalContext = { ...user.context, ...this.props.context };
+            const evalContext = { ...user.evalContext, ...this.props.context };
             domain = new Domain(this.state.domain).toList(evalContext);
         } catch {
             isValid = false;

--- a/addons/web/static/src/core/user.js
+++ b/addons/web/static/src/core/user.js
@@ -197,7 +197,11 @@ export function _makeUser(session) {
             return Object.assign({}, context, { uid: this.userId });
         },
         get evalContext() {
-            return { uid: this.userId, companies: companyEvalContext };
+            return {
+                uid: this.userId,
+                companies: companyEvalContext,
+                allowed_company_ids: this.context.allowed_company_ids, // For backwards compatibility cases. Deprecated as of 19.0.
+            };
         },
         get lang() {
             return lang;

--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -300,10 +300,13 @@ export class SearchBar extends Component {
      */
     async computeSubItems(searchItem, query) {
         const field = this.fields[searchItem.fieldName];
-        const context = { ...this.env.searchModel.domainEvalContext, ...field.context };
         let domain = [];
         if (searchItem.domain) {
-            domain = new Domain(searchItem.domain).toList(context);
+            const domainEvalContext = {
+                ...this.env.searchModel.domainEvalContext,
+                ...field.context,
+            };
+            domain = new Domain(searchItem.domain).toList(domainEvalContext);
         }
         const relation =
             searchItem.type === "field_property"
@@ -319,7 +322,7 @@ export class SearchBar extends Component {
         const options = await this.orm.call(relation, "name_search", [], {
             args: domain,
             operator: nameSearchOperator,
-            context,
+            context: { ...this.env.searchModel.globalContext, ...field.context },
             limit: limitToFetch,
             name: query.trim(),
         });

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -397,7 +397,7 @@ export class SearchModel extends EventBus {
     }
 
     get domainEvalContext() {
-        return Object.assign({}, this.globalContext, user.context);
+        return Object.assign({}, this.globalContext, user.evalContext);
     }
 
     get facets() {

--- a/addons/web/static/tests/core/domain_selector/domain_selector_dialog.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector_dialog.test.js
@@ -63,6 +63,22 @@ test("a domain with a user context dynamic part is valid", async () => {
     expect.verifySteps(["validation", "confirmed"]);
 });
 
+test("a domain with a company eval context is valid", async () => {
+    await makeDomainSelectorDialog({
+        domain: "[('foo', '=', companies.active_id)]",
+        onConfirm(domain) {
+            expect(domain).toBe("[('foo', '=', companies.active_id)]");
+            expect.step("confirmed");
+        },
+    });
+    onRpc("/web/domain/validate", () => {
+        expect.step("validation");
+        return true;
+    });
+    await contains(".o_dialog footer button").click();
+    expect.verifySteps(["validation", "confirmed"]);
+});
+
 test("can extend eval context", async () => {
     await makeDomainSelectorDialog({
         domain: "['&', ('foo', '=', uid), ('bar', '=', var)]",

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -1633,6 +1633,72 @@ test("select autocompleted many2one with allowed_company_ids domain (cids: 1)", 
     ]);
 });
 
+test("select autocompleted many2one with companies.active_ids domain (cids: 1-5)", async () => {
+    cookie.set("cids", "1-5");
+    serverState.companies = [
+        ...serverState.companies,
+        {
+            id: 5,
+            name: "Hierophant",
+        },
+    ];
+
+    await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+        searchViewArch: `
+            <search>
+                <field name="bar" domain="[('company', 'in', companies.active_ids)]"/>
+            </search>
+        `,
+    });
+
+    await editSearch("rec");
+    await contains(`.o_expand`).click();
+    expect(queryAllTexts(`.o_searchview_autocomplete .o-dropdown-item`)).toEqual([
+        "Search Bar for: rec",
+        "Second record",
+        "Third record",
+        "Add Custom Filter",
+    ]);
+});
+
+test("select autocompleted many2one with companies.active_ids domain (cids: 1)", async () => {
+    cookie.set("cids", "1");
+    serverState.companies = [
+        ...serverState.companies,
+        {
+            id: 5,
+            name: "Hierophant",
+        },
+    ];
+
+    await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+        searchViewArch: `
+            <search>
+                <field name="bar" domain="[('company', 'in', companies.active_ids)]"/>
+            </search>
+        `,
+    });
+
+    await click(".o_searchview input");
+    await clear();
+    await animationFrame();
+
+    await editSearch("rec");
+    await contains(`.o_expand`).click();
+    await runAllTimers();
+    expect(queryAllTexts(`.o_searchview_autocomplete .o-dropdown-item`)).toEqual([
+        "Search Bar for: rec",
+        "Second record",
+        "Add Custom Filter",
+    ]);
+});
+
 test("throw error when domain can not be parsed", async () => {
     expect.errors(1);
     await mountWithSearch(SearchBar, {


### PR DESCRIPTION
Before this commit, the code to evaluate domain in the searchModel used user.context. The issue is that it is missing the new `companies` evaluation context key [1,2];

Now, we use `user.evalContext`.

[1]: https://github.com/odoo/odoo/commit/22e9d822e8cab08114c006eb8c4054c4de0c40f2
[2]: https://github.com/odoo/odoo/commit/c4d67df63dab3091d63f5ab237d4dd6e4c09dd7e

part-of-task-id 4250356
