### PR TITLE
[IMP] web: use user.evalContext to evaluate action domains

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -399,7 +399,7 @@ export function makeActionManager(env, router = _router) {
         const domain = action.domain || [];
         action.domain =
             typeof domain === "string"
-                ? evaluateExpr(domain, Object.assign({}, user.context, action.context))
+                ? evaluateExpr(domain, Object.assign({}, user.evalContext, action.context))
                 : domain;
         if (action.help) {
             const htmlHelp = document.createElement("div");

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -597,14 +597,12 @@ test("Props are updated and kept when switching/restoring views", async () => {
             </group>
         </form>`;
 
-    onRpc("get_formview_action", ({ args, model }) => {
-        return {
-            res_id: args[0][0],
-            res_model: model,
-            type: "ir.actions.act_window",
-            views: [[false, "form"]],
-        };
-    });
+    onRpc("get_formview_action", ({ args, model }) => ({
+        res_id: args[0][0],
+        res_model: model,
+        type: "ir.actions.act_window",
+        views: [[false, "form"]],
+    }));
 
     await mountWithCleanup(WebClient);
     await getService("action").doAction(3);
@@ -1224,15 +1222,13 @@ test("requests for execute_action of type object: disable buttons", async () => 
 
 test.tags("desktop");
 test("action with html help returned by a call_button", async () => {
-    onRpc("/web/dataset/call_button/*", () => {
-        return {
-            res_model: "partner",
-            type: "ir.actions.act_window",
-            views: [[false, "list"]],
-            help: "<p>I am not a helper</p>",
-            domain: [[0, "=", 1]],
-        };
-    });
+    onRpc("/web/dataset/call_button/*", () => ({
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        views: [[false, "list"]],
+        help: "<p>I am not a helper</p>",
+        domain: [[0, "=", 1]],
+    }));
 
     await mountWithCleanup(WebClient);
     await getService("action").doAction(3);
@@ -1409,15 +1405,13 @@ test("can open a many2one external window", async () => {
         </form>`;
 
     stepAllNetworkCalls();
-    onRpc("get_formview_action", () => {
-        return {
-            name: "Partner",
-            res_model: "partner",
-            type: "ir.actions.act_window",
-            res_id: 3,
-            views: [[false, "form"]],
-        };
-    });
+    onRpc("get_formview_action", () => ({
+        name: "Partner",
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        res_id: 3,
+        views: [[false, "form"]],
+    }));
     await mountWithCleanup(WebClient);
     await getService("action").doAction(3);
     // open first record in form view
@@ -1890,14 +1884,12 @@ test("execute action from dirty, new record, and come back", async () => {
             <field name="bar" readonly="1"/>
         </form>`;
 
-    onRpc("get_formview_action", () => {
-        return {
-            res_id: 1,
-            res_model: "partner",
-            type: "ir.actions.act_window",
-            views: [[false, "form"]],
-        };
-    });
+    onRpc("get_formview_action", () => ({
+        res_id: 1,
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        views: [[false, "form"]],
+    }));
     stepAllNetworkCalls();
 
     await mountWithCleanup(WebClient);
@@ -1993,14 +1985,12 @@ test("go back to action with form view as main view, and res_id", async () => {
     ]);
     Partner._views["form,44"] = '<form><field name="m2o"/></form>';
 
-    onRpc("get_formview_action", () => {
-        return {
-            res_id: 3,
-            res_model: "partner",
-            type: "ir.actions.act_window",
-            views: [[false, "form"]],
-        };
-    });
+    onRpc("get_formview_action", () => ({
+        res_id: 3,
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        views: [[false, "form"]],
+    }));
 
     await mountWithCleanup(WebClient);
     await getService("action").doAction(999);
@@ -2033,9 +2023,7 @@ test("action with res_id, load another res_id, do new action, restore previous",
     defineActions([action]);
 
     Partner._views["form,44"] = '<form><field name="m2o"/></form>';
-    onRpc("get_formview_action", () => {
-        return { ...action, res_id: 3 };
-    });
+    onRpc("get_formview_action", () => ({ ...action, res_id: 3 }));
 
     await mountWithCleanup(WebClient);
     await getService("action").doAction(999, { props: { resIds: [1, 2] } });
@@ -2222,16 +2210,14 @@ test.tags("desktop");
 test("executing a window action with onchange warning does not hide it", async () => {
     Partner._views["form,false"] = `<form><field name="foo"/></form>`;
 
-    onRpc("onchange", () => {
-        return {
-            value: {},
-            warning: {
-                title: "Warning",
-                message: "Everything is alright",
-                type: "dialog",
-            },
-        };
-    });
+    onRpc("onchange", () => ({
+        value: {},
+        warning: {
+            title: "Warning",
+            message: "Everything is alright",
+            type: "dialog",
+        },
+    }));
 
     await mountWithCleanup(WebClient);
     await getService("action").doAction(3);
@@ -2683,27 +2669,25 @@ test("sample server: populate groups", async () => {
             </pivot>`,
         search: `<search/>`,
     };
-    onRpc("web_read_group", () => {
-        return {
-            groups: [
-                {
-                    date_count: 0,
-                    "write_date:month": "December 2022",
-                    __range: {
-                        "write_date:month": {
-                            from: "2022-12-01",
-                            to: "2023-01-01",
-                        },
+    onRpc("web_read_group", () => ({
+        groups: [
+            {
+                date_count: 0,
+                "write_date:month": "December 2022",
+                __range: {
+                    "write_date:month": {
+                        from: "2022-12-01",
+                        to: "2023-01-01",
                     },
-                    __domain: [
-                        ["write_date", ">=", "2022-12-01"],
-                        ["write_date", "<", "2023-01-01"],
-                    ],
                 },
-            ],
-            length: 1,
-        };
-    });
+                __domain: [
+                    ["write_date", ">=", "2022-12-01"],
+                    ["write_date", "<", "2023-01-01"],
+                ],
+            },
+        ],
+        length: 1,
+    }));
 
     await mountWithCleanup(WebClient);
     await getService("action").doAction({
@@ -2800,4 +2784,23 @@ test("execute a window action with mobile_view_mode", async () => {
         ],
     });
     expect(".o_list_view").toHaveCount(1);
+});
+
+test("can use user evalContext (companies) on action domain", async () => {
+    onRpc("web_search_read", ({ kwargs }) => {
+        expect.step(kwargs.domain);
+    });
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction({
+        res_id: 1,
+        type: "ir.actions.act_window",
+        target: "current",
+        res_model: "partner",
+        views: [
+            [false, "kanban"],
+            [false, "pivot"],
+        ],
+        domain: "[('employee_id', '=', companies.active_ids)]",
+    });
+    expect.verifySteps([[["employee_id", "=", [1]]]]);
 });


### PR DESCRIPTION
Before this commit, the code to evaluate action domains in the action service used user.context. The issue is that it is missing the new `companies` evaluation context key [1,2];

Now, we use `user.evalContext`.

[1]: https://github.com/odoo/odoo/commit/22e9d822e8cab08114c006eb8c4054c4de0c40f2
[2]: https://github.com/odoo/odoo/commit/c4d67df63dab3091d63f5ab237d4dd6e4c09dd7e

part-of-task-id 4250356