### PR TITLE
[FIX] account: trigger computation on report "report_invoice_with_payments"

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -47,7 +47,8 @@ class IrActionsReport(models.Model):
         return collected_streams
 
     def _is_invoice_report(self, report_ref):
-        return self._get_report(report_ref).is_invoice_report
+        report = self._get_report(report_ref)
+        return report.is_invoice_report or report.report_name == 'account.report_invoice'
 
     def _get_splitted_report(self, report_ref, content, report_type):
         if report_type == 'html':

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -542,7 +542,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
             'extra_edis': False,
             'extra_edi_checkboxes': False,
             'pdf_report_id': wizard._get_default_pdf_report_id(invoice).id,
-            'display_pdf_report_id': True,
+            'display_pdf_report_id': False,
             'mail_template_id': wizard._get_default_mail_template_id(invoice).id,
             'mail_lang': 'en_US',
             'mail_partner_ids': wizard.move_id.partner_id.ids,

--- a/addons/account/views/account_report.xml
+++ b/addons/account/views/account_report.xml
@@ -34,7 +34,6 @@
             <field name="report_type">qweb-pdf</field>
             <field name="report_name">account.report_invoice</field>
             <field name="report_file">account.report_invoice</field>
-            <field name="is_invoice_report">True</field>
             <field name="print_report_name">(object._get_report_base_filename())</field>
             <field name="attachment"/>
             <field name="binding_model_id" ref="model_account_move"/>


### PR DESCRIPTION
Steps to reproduce:
- Install "l10n_ch" and switch to a Swiss company
- Create a new invoice with a Swiss customer
- Confirm
- In the actions, select "PDF without payments"
- The generated PDF has a blank page at the end

Cause:
Some computation looks for report applicable to invoices.
PDF without payment (`report_invoice_with_payments`) is a
special case of such report. We don't want it to be used as an
official report template for invoices, but we want to allow the
Swiss case where the payment QR code should be possible to add.

The bug appears after this commit which modified the
`_is_invoice_report` method to only validate report with
is_invoice_report=True.
https://github.com/odoo/odoo/commit/bb60952c944db27d71d7fe32ead2dff05c3fe922#diff-b6e108b605fbefba066e3b20f8e030ea78881bbed816f8ac5cb38e745c542739R50

Solution:
Fix the method _is_invoice_report to recognize PDF without payment,
without setting the latter to is_invoice_report=True (which triggers
undesirable behaviors surch as showing multiple templates in the
Print & Send wizard).

opw-4467250