### PR TITLE
[FIX] point_of_sale: add html field to manifest

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -178,6 +178,12 @@
             ('remove', 'web/static/src/webclient/actions/reports/layout_assets/**/*'),
             ('remove', 'web/static/src/webclient/actions/**/*css'),
             'web/static/src/webclient/company_service.js',
+
+            'web/static/lib/dompurify/DOMpurify.js',
+            'html_editor/static/src/**/*',
+            ('include', 'html_editor.assets_media_dialog'),
+            ('remove', 'html_editor/static/src/components/history_dialog/history_dialog.dark.scss'),
+            ('remove', 'html_editor/static/src/main/toolbar/toolbar.dark.scss'),
         ],
         'point_of_sale.base_tests': [
             "web/static/lib/hoot-dom/**/*",


### PR DESCRIPTION
Before this commit comment field in calendar_event_view_form_gantt_booking
 used in pos restaurant does not display properly html field.

Fixed by importing the html editor to the point_of_sale manifest.

task-4547369

https://github.com/odoo/enterprise/pull/78536
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
