### PR TITLE
[FIX] hr: move some resource calendar code from hr_payroll to hr

### DIFF
--- a/addons/hr/models/__init__.py
+++ b/addons/hr/models/__init__.py
@@ -20,4 +20,5 @@ from . import res_users
 from . import res_company
 from . import res_partner
 from . import resource
+from . import resource_calendar
 from . import ir_ui_menu

--- a/addons/hr/models/resource_calendar.py
+++ b/addons/hr/models/resource_calendar.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+from odoo.tools import float_compare
+
+
+class ResourceCalendar(models.Model):
+    _inherit = 'resource.calendar'
+
+    def _calculate_hours_per_week(self):
+        self.ensure_one()
+        sum_hours = sum(
+            (a.hour_to - a.hour_from) for a in self.attendance_ids.filtered(lambda a: a.day_period != 'lunch'))
+        return sum_hours / 2 if self.two_weeks_calendar else sum_hours
+
+    def _calculate_is_fulltime(self):
+        self.ensure_one()
+        return not float_compare(self.full_time_required_hours, self._calculate_hours_per_week(), 3)


### PR DESCRIPTION
Currently, we are getting an attribute error while executing the below lines of code.

https://github.com/odoo/enterprise/blob/a0215115c13d5e32f1ba3c821f138b188083e76b/hr_recruitment_integration_monster/wizard/hr_recruitment_post.py#L16

https://github.com/odoo/enterprise/blob/a0215115c13d5e32f1ba3c821f138b188083e76b/hr_recruitment_integration_monster/wizard/hr_recruitment_post.py#L31

Error:-
```
AttributeError: 'resource.calendar' object has no attribute 'hours_per_week'
```

This is because the `hours_per_week`, `is_fulltime` are defined in the `hr_payroll`. 
But they are used in the `hr_recruitment_integration_monster`. 

Which is not dependent directly/indirectly on `hr_payroll`.

https://github.com/odoo/enterprise/blob/a0215115c13d5e32f1ba3c821f138b188083e76b/hr_payroll/models/resource_calendar.py#L20-L21

So this will lead to the above traceback.

We can resolve this issue by moving the hr_payroll code of calculating the `hours_per_week` and `is_fulltime` to hr module.

sentry-6267814511

Related Enterprise PR:-https://github.com/odoo/enterprise/pull/78521