### PR TITLE
[FIX] website_sale{,_delivery}: ensure state is in the correct country

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1287,6 +1287,7 @@ class WebsiteSale(http.Controller):
         ], limit=1)
         state = request.env["res.country.state"].search([
             ('code', '=', address.pop('state')),
+            ('country_id', '=', country.id),
         ], limit=1)
         address.update(country_id=country, state_id=state)
 

--- a/addons/website_sale_delivery/tests/test_express_checkout_flows.py
+++ b/addons/website_sale_delivery/tests/test_express_checkout_flows.py
@@ -75,6 +75,14 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(HttpCaseWithUserDemo):
             'country': 'US',
             'state': 'AL',
         }
+        # Ensure demo user address exists and is valid
+        cls.user_demo.write({
+            'street': "215 Vine St",
+            'city': "Scranton",
+            'zip': "18503",
+            'country_id': cls.env.ref('base.us').id,
+            'state_id': cls.env.ref('base.state_us_39').id,
+        })
 
     def setUp(self):
         super().setUp()
@@ -107,6 +115,20 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(HttpCaseWithUserDemo):
             'state': self.user_demo.partner_id.state_id.code,
         }
 
+    def assertPartnerShippingValues(self, partner, shipping_values):
+        for key, expected in shipping_values.items():
+            if key in ('state', 'country'):
+                value = partner[f'{key}_id'].code
+            else:
+                value = partner[key]
+            self.assertEqual(value, expected, "Shipping value should match")
+        if partner.state_id:
+            self.assertEqual(
+                partner.state_id.country_id,
+                partner.country_id,
+                "Partner's state should be within partner's country",
+            )
+
     def _make_json_rpc_request(self, url, data=None):
         """ Make a JSON-RPC request to the provided URL.
 
@@ -125,6 +147,7 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(HttpCaseWithUserDemo):
             url,
             data=json.dumps(rpc_request).encode(),
             headers={"Content-Type": "application/json"},
+            timeout=None,
         )
 
         if not result.ok:
@@ -153,15 +176,10 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(HttpCaseWithUserDemo):
             new_partner = self.sale_order.partner_shipping_id
             self.assertNotEqual(new_partner, self.website.user_id.partner_id)
             self.assertTrue(new_partner.name.endswith(self.sale_order.name))
-            for k in self.express_checkout_anonymized_shipping_values:
-                if k in ['state', 'country']:
-                    # State and country are stored as ids in `new_partner` and therefore cannot be
-                    # compared.
-                    continue
-                self.assertEqual(
-                    new_partner[k],
-                    self.express_checkout_anonymized_shipping_values[k]
-                )
+            self.assertPartnerShippingValues(
+                new_partner,
+                self.express_checkout_anonymized_shipping_values,
+            )
 
     def test_express_checkout_public_user_shipping_address_change_twice(self):
         """ Test that when using express checkout as a public user and selecting a shipping address
@@ -191,15 +209,10 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(HttpCaseWithUserDemo):
                 }
             )
             self.assertEqual(new_partner.id, self.sale_order.partner_shipping_id.id)
-            for k in self.express_checkout_anonymized_shipping_values_2:
-                if k in ['state', 'country']:
-                    # State and country are stored as ids in `new_partner` and therefore cannot be
-                    # compared.
-                    continue
-                self.assertEqual(
-                    new_partner[k],
-                    self.express_checkout_anonymized_shipping_values_2[k]
-                )
+            self.assertPartnerShippingValues(
+                new_partner,
+                self.express_checkout_anonymized_shipping_values_2,
+            )
 
     def test_express_checkout_registered_user_exisiting_shipping_address_change(self):
         """ Test that when using express checkout as a registered user and selecting an exisiting
@@ -246,15 +259,10 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(HttpCaseWithUserDemo):
             self.assertEqual(self.sale_order.partner_id.id, self.user_demo.partner_id.id)
             self.assertNotEqual(new_partner.id, self.user_demo.partner_id.id)
             self.assertTrue(new_partner.name.endswith(self.sale_order.name))
-            for k in self.express_checkout_anonymized_shipping_values:
-                if k in ['state', 'country']:
-                    # State and country are stored as ids in `new_partner` and therefore cannot be
-                    # compared.
-                    continue
-                self.assertEqual(
-                    new_partner[k],
-                    self.express_checkout_anonymized_shipping_values[k]
-                )
+            self.assertPartnerShippingValues(
+                new_partner,
+                self.express_checkout_anonymized_shipping_values,
+            )
 
     def test_express_checkout_registered_user_new_shipping_address_change_twice(self):
         """ Test that when using express checkout as a registered user and selecting a new
@@ -285,15 +293,10 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(HttpCaseWithUserDemo):
                 }
             )
             self.assertEqual(new_partner.id, self.sale_order.partner_shipping_id.id)
-            for k in self.express_checkout_anonymized_shipping_values_2:
-                if k in ['state', 'country']:
-                    # State and country are stored as ids in `new_partner` and therefore cannot be
-                    # compared.
-                    continue
-                self.assertEqual(
-                    new_partner[k],
-                    self.express_checkout_anonymized_shipping_values_2[k]
-                )
+            self.assertPartnerShippingValues(
+                new_partner,
+                self.express_checkout_anonymized_shipping_values_2
+            )
 
     def test_express_checkout_partial_delivery_address_context_key(self):
         """ Test that when using express checkout with only partial delivery information,


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Enable Stripe Express Checkout;
2. go to eCommerce as Public User;
3. pay via express checkout for a deliverable item;
4. in Stripe, set shipping address to somewhere in California;
5. finish payment.

Issue
-----
The new partner is created with its state set to Cadiz instead of California.

Cause
-----
When searching for a state using its code, it fetches the first matching item. The problem is that unlike country codes, state codes aren't unique, e.g. there are 4 states that match the 'CA' code (only one of them being in the United States).

Solution
--------
Add `country_id` to the search domain to ensure the fetched state belongs to the relevant country.

opw-4396024
