### PR TITLE
[IMP] project: include by default subtasks in main views of tasks

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -37,7 +37,7 @@ class ProjectProject(models.Model):
         count_fields = {fname for fname in self._fields if 'count' in fname}
         if count_field not in count_fields:
             raise ValueError(f"Parameter 'count_field' can only be one of {count_fields}, got {count_field} instead.")
-        domain = [('project_id', 'in', self.ids), ('display_in_project', '=', True)]
+        domain = [('project_id', 'in', self.ids)]
         if additional_domain:
             domain = AND([domain, additional_domain])
         tasks_count_by_project = dict(self.env['project.task'].with_context(

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1347,15 +1347,6 @@ class ProjectTask(models.Model):
                 task.recurrence_id.unlink()
         return super().unlink()
 
-    def _where_calc(self, domain, active_test=True):
-        """ Tasks views don't show the sub-tasks / ('display_in_project', '=', True).
-            The pseudo-filter "Show Sub-tasks" adds the key 'show_subtasks' in the context.
-            In that case, we pop the leaf from the domain.
-        """
-        if self.env.context.get('show_subtasks'):
-            domain = filter_domain_leaf(domain, lambda field: field != 'display_in_project')
-        return super()._where_calc(domain, active_test)
-
     def update_date_end(self, stage_id):
         project_task_type = self.env['project.task.type'].browse(stage_id)
         if project_task_type.fold:

--- a/addons/project/report/project_report.py
+++ b/addons/project/report/project_report.py
@@ -4,7 +4,6 @@
 from odoo import fields, models, tools
 
 from odoo.addons.rating.models.rating_data import RATING_LIMIT_MIN
-from odoo.addons.resource.models.utils import filter_domain_leaf
 
 
 class ReportProjectTaskUser(models.Model):
@@ -151,12 +150,3 @@ class ReportProjectTaskUser(models.Model):
           WHERE %s
        GROUP BY %s
         """ % (self._table, self._select(), self._from(), self._where(), self._group_by()))
-
-    def _where_calc(self, domain, active_test=True):
-        """ Tasks views don't show the sub-tasks / ('display_in_project', '=', True).
-            The pseudo-filter "Show Sub-tasks" adds the key 'show_subtasks' in the context.
-            In that case, we pop the leaf from the domain.
-        """
-        if self.env.context.get('show_subtasks'):
-            domain = filter_domain_leaf(domain, lambda field: field != 'display_in_project')
-        return super()._where_calc(domain, active_test)

--- a/addons/project/report/project_report_views.xml
+++ b/addons/project/report/project_report_views.xml
@@ -75,7 +75,7 @@
             <field name="name">Tasks Analysis</field>
             <field name="res_model">report.project.task.user</field>
             <field name="path">tasks-analysis</field>
-            <field name="domain">[('display_in_project', '=', True)]</field>
+            <field name="domain">[]</field>
             <field name="view_mode">graph,pivot</field>
             <field name="search_view_id" ref="view_task_project_user_search"/>
             <field name="context">{'group_by': [], 'graph_measure': '__count__'}</field>

--- a/addons/project/tests/test_project_base.py
+++ b/addons/project/tests/test_project_base.py
@@ -489,9 +489,9 @@ class TestProjectBase(TestProjectCommon):
                 ]}),
             ]}
         ])
-        self.assertEqual(project1.task_count, 3)
-        self.assertEqual(project1.open_task_count, 2)
-        self.assertEqual(project1.closed_task_count, 1)
+        self.assertEqual(project1.task_count, 9)
+        self.assertEqual(project1.open_task_count, 5)
+        self.assertEqual(project1.closed_task_count, 4)
         self.assertEqual(project2.task_count, 2)
         self.assertEqual(project2.open_task_count, 2)
         self.assertEqual(project2.closed_task_count, 0)

--- a/addons/project/tests/test_project_subtasks.py
+++ b/addons/project/tests/test_project_subtasks.py
@@ -500,24 +500,6 @@ class TestProjectSubtasks(TestProjectCommon):
         self.assertEqual(task.project_id, self.task_1.project_id, "project_id should be affected")
         self.assertTrue(task.display_in_project, "display_in_project should be True when there is no parent task")
 
-    def test_filter_see_subtasks(self):
-        task = self.task_1
-        task.create({
-            'name': 'chcacs',
-            'parent_id': task.id,
-            'project_id': task.project_id.id,
-        })
-
-        def get_parent_ids(read_from):
-            return read_from._read_group([
-                ("project_id", "=", task.project_id.id),
-                ("display_in_project", "=", True),
-                ("is_closed", "=", False),
-            ], [], ["parent_id:recordset"])[0][0]
-
-        self.assertFalse(get_parent_ids(task))
-        self.assertTrue(get_parent_ids(task.with_context(show_subtasks=True)))
-
     def test_invisible_subtask_became_visible_when_converted_to_task(self):
         task = self.env['project.task'].create({
             'name': 'Parent task',

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -331,7 +331,7 @@
         <field name="path">project_sharing</field>
         <field name="view_mode">kanban,list,form</field>
         <field name="search_view_id" ref="project.project_sharing_project_task_view_search"/>
-        <field name="domain">[('project_id', '=', active_id), ('display_in_project', '=', True)]</field>
+        <field name="domain">[('project_id', '=', active_id)]</field>
         <field name="context">{
             'default_project_id': active_id,
             'active_id_chatter': active_id,

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -31,7 +31,7 @@
                         <filter name="create_date_last_365_days" string="Last 365 Days" domain="[('date_last_stage_update', '&gt;', datetime.datetime.combine(context_today() - relativedelta(days=365), datetime.time(23, 59, 59)).to_utc())]"/>
                     </filter>
                     <separator/>
-                    <filter string="Show Sub-tasks" name="show_subtasks" context="{'show_subtasks': True}" invisible="'my_tasks' in context"/>
+                    <filter string="Hide Sub-tasks" name="hide_subtasks" domain="[('display_in_project', '=', True)]"/>
                     <group expand="0" string="Group By">
                         <filter string="Stage" name="stage" context="{'group_by': 'stage_id'}"/>
                         <filter string="Milestone" name="milestone" context="{'group_by': 'milestone_id'}" groups="project.group_project_milestone"/>
@@ -112,7 +112,7 @@
                 <filter name="my_tasks" position="before">
                     <field string="Properties" name="task_properties"/>
                 </filter>
-                <filter name="show_subtasks" position="after">
+                <filter name="hide_subtasks" position="after">
                     <separator/>
                     <filter string="Unread Messages" name="message_needaction" domain="[('message_needaction', '=', True)]" groups="mail.group_mail_notification_type_inbox"/>
                     <separator/>
@@ -203,7 +203,7 @@
             <field name="path">tasks</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">kanban,list,form,calendar,pivot,graph,activity</field>
-            <field name="domain">[('project_id', '=', active_id), ('display_in_project', '=', True)]</field>
+            <field name="domain">[('project_id', '=', active_id)]</field>
             <field name="context">{
                 'default_project_id': active_id,
                 'show_project_update': True,
@@ -860,7 +860,7 @@
             <field name="res_model">project.task</field>
             <field name="view_mode">kanban,list,form,calendar,pivot,graph,activity</field>
             <field name="context">{'search_default_my_tasks': 1}</field>
-            <field name="domain">[('project_id', '!=', False), ('display_in_project', '=', True)]</field>
+            <field name="domain">[('project_id', '!=', False)]</field>
             <field name="search_view_id" ref="view_task_search_form"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
@@ -1062,7 +1062,7 @@
             <field name="res_model">project.task</field>
             <field name="path">all-tasks</field>
             <field name="view_mode">list,kanban,form,calendar,pivot,graph,activity</field>
-            <field name="domain">[('display_in_project', '=', True)]</field>
+            <field name="domain">[]</field>
             <field name="context">{'search_default_open_tasks': 1, 'default_user_ids': [(4, uid)]}</field>
             <field name="search_view_id" ref="view_task_search_form"/>
             <field name="help" type="html">
@@ -1199,7 +1199,7 @@
             <field name="name">Overpassed Tasks</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">list,form,calendar,graph,kanban</field>
-            <field name="domain">[('is_closed', '=', False), ('date_deadline','&lt;',time.strftime('%Y-%m-%d')), ('project_id', '!=', False), ('display_in_project', '=', True)]</field>
+            <field name="domain">[('is_closed', '=', False), ('date_deadline','&lt;',time.strftime('%Y-%m-%d')), ('project_id', '!=', False)]</field>
             <field name="filter" eval="True"/>
             <field name="search_view_id" ref="view_task_search_form"/>
         </record>
@@ -1209,7 +1209,7 @@
             <field name="res_model">project.task</field>
             <field name="name">Project's tasks</field>
             <field name="view_mode">list,form,calendar,graph,kanban</field>
-            <field name="domain">[('project_id', '=', active_id), ('display_in_project', '=', True)]</field>
+            <field name="domain">[('project_id', '=', active_id)]</field>
             <field name="context">{'project_id':active_id}</field>
         </record>
 

--- a/addons/project/wizard/project_task_type_delete.py
+++ b/addons/project/wizard/project_task_type_delete.py
@@ -59,7 +59,7 @@ class ProjectTaskTypeDeleteWizard(models.TransientModel):
 
         if project_id:
             action = self.env["ir.actions.actions"]._for_xml_id("project.action_view_task")
-            action['domain'] = [('project_id', '=', project_id), ('display_in_project', '=', 'True')]
+            action['domain'] = [('project_id', '=', project_id)]
             action['context'] = str({
                 'pivot_row_groupby': ['user_ids'],
                 'default_project_id': project_id,


### PR DESCRIPTION
Before this commit, the subtasks are hidden by default when the user goes into a project to see the tasks linked to that project. The problem is it is difficult to notify the sub-tasks are not displayed in the view and it is also difficult to know how to show them. The user has to discover the new filter `Show sub-tasks` in the search view.

This commit will now display all tasks (sub-tasks included) linked to the project to be sure the user will see all information first. If the user would like to hide the sub-tasks then he will just have to select the filter `Hide Sub-Tasks`.

task-4547389
