### PR TITLE
[FIX] web_tour: drop inside an iframe

### DIFF
--- a/addons/web_tour/static/src/tour_pointer/tour_pointer.js
+++ b/addons/web_tour/static/src/tour_pointer/tour_pointer.js
@@ -95,11 +95,20 @@ export class TourPointer extends Component {
                 // Check is the pointed element is a zone
                 if (this.props.pointerState.isZone) {
                     const { anchor } = this.props.pointerState;
+                    let offsetLeft,
+                        offsetTop = 0;
+                    if (document !== anchor.ownerDocument) {
+                        const iframe = [...document.querySelectorAll("iframe")].filter(
+                            (e) => e.contentDocument === anchor.ownerDocument
+                        )[0];
+                        offsetLeft = iframe.getBoundingClientRect().left;
+                        offsetTop = iframe.getBoundingClientRect().top;
+                    }
                     const { left, top, width, height } = anchor.getBoundingClientRect();
                     zone.style.minWidth = width + "px";
                     zone.style.minHeight = height + "px";
-                    zone.style.left = left + "px";
-                    zone.style.top = top + "px";
+                    zone.style.left = left + offsetLeft + "px";
+                    zone.style.top = top + offsetTop + "px";
                 }
 
                 // Content changed: we must re-measure the dimensions of the text.

--- a/addons/web_tour/static/src/tour_service/tour_interactive.js
+++ b/addons/web_tour/static/src/tour_service/tour_interactive.js
@@ -354,7 +354,15 @@ export class TourInteractive {
         if (runCommand === "drop") {
             consumeEvents.push({
                 name: "pointerup",
-                target: document,
+                target: element.ownerDocument,
+                conditional: (ev) =>
+                    element.ownerDocument
+                        .elementsFromPoint(ev.clientX, ev.clientY)
+                        .includes(element),
+            });
+            consumeEvents.push({
+                name: "drop",
+                target: element.ownerDocument,
                 conditional: (ev) =>
                     element.ownerDocument
                         .elementsFromPoint(ev.clientX, ev.clientY)
@@ -374,8 +382,10 @@ export class TourInteractive {
         if (consumeEvent === "drag") {
             // jQuery-ui draggable triggers 'drag' events on the .ui-draggable element,
             // but the tip is attached to the .ui-draggable-handle element which may
-            // be one of its children (or the element itself)
-            return el.closest(".ui-draggable, .o_draggable, .o_we_draggable, .o-draggable");
+            // be one of its children (or the element itself
+            return el.closest(
+                ".ui-draggable, .o_draggable, .o_we_draggable, .o-draggable, [draggable='true']"
+            );
         }
 
         if (consumeEvent === "input" && !["textarea", "input"].includes(el.tagName.toLowerCase())) {


### PR DESCRIPTION
Before this commit, only pointerup was listened and was on the global document. Now, the event is listened on the ownerDocument of the element.

Like that, if the element is inside an iframe, it will be correctly listened. The "drop" is also added to the listened events, because sign doesn't use the draggable hook of owl, instead it uses the vanilla drag and drop system of javascript.

The dropzone shown during an onboarding tour is also fixed and takes into account the offset of the iframe in the top document.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
