### PR TITLE
[FIX] website: disable arrow keys to slide carousel in edit mode

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1759,6 +1759,9 @@ options.registry.Carousel = options.Class.extend({
         // Handle the sliding manually.
         this.__onControlClick = _.throttle(this._onControlClick.bind(this), 1000);
         this.$controls.on("click.carousel_option", this.__onControlClick);
+        for (const controlEl of this.$controls) {
+            controlEl.addEventListener("keydown", this._onControlKeyDown);
+        }
 
         return this._super.apply(this, arguments);
     },
@@ -1769,6 +1772,9 @@ options.registry.Carousel = options.Class.extend({
         this._super.apply(this, arguments);
         this.$bsTarget.off('.carousel_option');
         this.$controls.off(".carousel_option");
+        for (const controlEl of this.$controls) {
+            controlEl.removeEventListener("keydown", this._onControlKeyDown);
+        }
     },
     /**
      * @override
@@ -1932,6 +1938,20 @@ options.registry.Carousel = options.Class.extend({
             this.options.wysiwyg.odooEditor.historyUnpauseSteps();
             this.options.wysiwyg.odooEditor.historyStep();
         }});
+    },
+    /**
+     * Since carousel controls are disabled in edit mode because slides are
+     * handled manually, we disable the left and right keydown events to prevent
+     * sliding this way.
+     *
+     * @private
+     * @param {Event} ev
+     */
+    _onControlKeyDown(ev) {
+        if (["ArrowLeft", "ArrowRight"].includes(ev.code)) {
+            ev.preventDefault();
+            ev.stopPropagation();
+        }
     },
 });
 


### PR DESCRIPTION
Steps to reproduce:

- Enter edit mode.
- Drag and drop a carousel into the page.
- Use the arrow keys to slide the carousel.
- Bug: a traceback occurs.

Just like we disabled Bootstrap for sliding the carousel in edit mode and instead handle it manually (see this commit [1]), in this commit, we also disable sliding the carousel by pressing the left and right arrow keys on the keyboard.

[1]: https://github.com/odoo/odoo/commit/93ec3ac285dc9ffd363e185a1dc238c6135d79dd

opw-4373535
