### PR TITLE
[FIX] barcodes_gs1_nomenclature,product: skip GS1 preprocessing when not needed

### DIFF
--- a/addons/barcodes_gs1_nomenclature/tests/test_barcodes_gs1_nomenclature.py
+++ b/addons/barcodes_gs1_nomenclature/tests/test_barcodes_gs1_nomenclature.py
@@ -1,4 +1,5 @@
 from odoo.exceptions import ValidationError
+from odoo.fields import Domain
 from odoo.tests.common import TransactionCase
 
 
@@ -128,3 +129,10 @@ class TestBarcodeGS1Nomenclature(TransactionCase):
         barcode_rule.pattern = r'(300)(.*)'
         with self.assertRaises(ValidationError):
             res = barcode_nomenclature.gs1_decompose_extanded('300bilou4000')
+
+    def test_preprocess_gs1_search_args_product(self):
+        company = self.env.company
+        company.nomenclature_id = self.env.ref('barcodes_gs1_nomenclature.default_gs1_nomenclature')
+        domain = [('barcode', 'in', [])]
+        res = self.env['barcode.nomenclature']._preprocess_gs1_search_args(domain, ['product'])
+        self.assertEqual(res, Domain(domain))

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -236,9 +236,10 @@ class ProductProduct(models.Model):
         """ With GS1 nomenclature, products and packagings use the same pattern. Therefore, we need
         to ensure the uniqueness between products' barcodes and packagings' ones"""
         # Barcodes should only be unique within a company
-        for company_id, barcodes_within_company in self._get_barcodes_by_company():
-            self._check_duplicated_product_barcodes(barcodes_within_company, company_id)
-            self._check_duplicated_packaging_barcodes(barcodes_within_company, company_id)
+        self_ctx = self.with_context(skip_preprocess_gs1=True)
+        for company_id, barcodes_within_company in self_ctx._get_barcodes_by_company():
+            self_ctx._check_duplicated_product_barcodes(barcodes_within_company, company_id)
+            self_ctx._check_duplicated_packaging_barcodes(barcodes_within_company, company_id)
 
     @api.constrains('company_id')
     def _check_company_id(self):


### PR DESCRIPTION
Currently, an exception is generated when a user tries to save a product record without a barcode, whether it is a newly created record or an existing one.

Steps to reproduce:

1. Install the Inventory module.
2. Go to Inventory settings.
3. Set Barcode Nomenclature to Default GS1 Nomenclature.
4.  Go to Inventory -> Products, create a product with a barcode, and save it.
5. Edit the same product, remove the barcode, and save it again.
6. An error occurs.

Error: `StopIteration`

This issue [1] occurs because when a user tries to save the record without a barcode, the value is false, and an false value is not iterable.

[1] - https://github.com/odoo/odoo/blob/9eb6c16cd7d4fe9364d043e2af96876bf82a44d4/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py#L163

This fix resolves an issue where GS1 preprocessing was always applied when checking for duplicate product barcodes. By introducing the skip_preprocess_gs1 context flag, the GS1 preprocessing step is now bypassed when verifying barcode uniqueness.

Related Enterprise PR:- https://github.com/odoo/enterprise/pull/80544

sentry-6267124218

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
