### PR TITLE
[FIX] web: Accounting Reports Column Selection

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -1857,6 +1857,7 @@ export class ListRenderer extends Component {
         this.saveOptionalActiveFields(
             this.allColumns.filter((col) => this.optionalActiveFields[col.name] && col.optional)
         );
+        this.columns = this.getActiveColumns(this.props.list);
         this.render();
     }
 


### PR DESCRIPTION
When toggling columns in any Accounting Report list view, it requires a manual refresh to see the changes.
this is caused because this [commit](https://github.com/odoo/enterprise/pull/56589/commits/adc4bb7394cd7f25cffd15330fa699777bf2aac1) removed automatic reactivity, so we need to explicitly recompute the columns after updating `optionalActiveFields`

Steps to reproduce:
0. Activate developer mode
1. Navigate to the 'Accounting Reports' menu in accounting.
2. Open a report (e.g. the balance sheet)
3. Use the column selector to add or remove additional columns

OPW-4352833

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
