### PR TITLE
[FIX] Accounting: Rounding line with multi company fails

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1875,6 +1875,7 @@ class AccountMove(models.Model):
         2) Add the rounding in the biggest tax amount: The cash rounding line is added as a new tax line on the tax
         having the biggest balance.
         '''
+        self = self.with_company(self.company_id)
         self.ensure_one()
         def _compute_cash_rounding(self, total_amount_currency):
             ''' Compute the amount differences due to the cash rounding.


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
A bug occurred when the system attempted to automatically add a rounding line to an invoice in a multi-company environment. The company-dependent field was being updated without properly considering the invoice’s company context.

Current behavior before PR:
An error was raised when trying to create the rounding line because the system looked up the accounts for Company 1 instead of the invoice’s assigned company.

Desired behavior after PR is merged:
No error was raised



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
