### PR TITLE
[FIX] account: studio edit report w/o any invoice


### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -273,7 +273,7 @@
                                 </div>
 
                                 <!-- Tax totals summary (company currency) -->
-                                <t t-if="o.tax_totals.get('display_in_company_currency')">
+                                <t t-if="o.tax_totals and o.tax_totals.get('display_in_company_currency')">
                                     <t t-set="tax_totals" t-value="o.tax_totals"/>
                                     <t t-call="account.document_tax_totals_company_currency_template"/>
                                 </t>


### PR DESCRIPTION

Scenario:
- create a new company and switch to it
- use studio to edit the invoice report "PDF without Payment"
- click on "Edit Sources"
=> in preview we see "The report could not be rendered due to an error"
   or a traceback if in debug mode

- then edit the report xml and save
=> we see this error message

> Report edition failed
> …
> This could also be due to the absence of a real record to render the
> report with.

Fix: make the invoice report work with empty recordset that studio is
     using to preview and verify the report is valid when there is not
     any available record.

Note: fixing it in master, since this is adding risk by modifying XPath
for very little benefit (a particular case just in studio, with a clear
error message and an even clearer warning when saving XML edition).

opw-4463707
