### PR TITLE
[FIX] website_slides: course changes in the middle of the tour

### DIFF
--- a/addons/website_slides/static/tests/tours/slides_course_member.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member.js
@@ -141,13 +141,13 @@ registry.category("web_tour.tours").add("course_member", {
             // check that the course is marked as completed
             trigger: 'div:contains("Basics of Gardening") span:contains("Completed")',
         },
-        // eLearning: go back on course and rate it (new rate or update it, both should work)
+        // eLearning: go back on course and rate it
         {
             trigger: 'a:contains("Basics of Gardening")',
             run: "click",
         },
         {
-            trigger: 'button[data-bs-target="#ratingpopupcomposer"]',
+            trigger: 'button[data-bs-target="#ratingpopupcomposer"]:contains("Add Review")',
             run: "click",
         },
         {
@@ -156,7 +156,20 @@ registry.category("web_tour.tours").add("course_member", {
         },
         {
             trigger: ".modal.modal_shown .modal-body textarea",
-            run: "edit This is a great course. Top !",
+            run: "edit This is a great course. Top!",
+        },
+        {
+            trigger: ".modal.modal_shown button:contains(review)",
+            run: "click",
+        },
+        // eLearning: edit the review
+        {
+            trigger: 'button[data-bs-target="#ratingpopupcomposer"]:contains("Edit Review")',
+            run: "click",
+        },
+        {
+            trigger: ".modal.modal_shown .modal-body textarea",
+            run: "edit This is a great course. I highly recommend it!",
         },
         {
             trigger: ".modal.modal_shown button:contains(review)",

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -14,6 +14,12 @@ from odoo.tools.misc import file_open
 
 class TestUICommon(HttpCaseGamification, HttpCaseWithUserPortal):
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # remove demo data
+        cls.env["slide.channel"].search([]).unlink()
+
     def setUp(self):
         super().setUp()
         self.env.ref('gamification.rank_student').description_motivational = """


### PR DESCRIPTION
The slide course member tour tests use  a channel called `Basics of Gardening - Test`. When the course is completed, clicking on `End course` will redirect the user to the courses home page. Since there is already a course (from demo data) called `Basics of Gardening`, the selector in the tour test actually selects this as the first match not the test course and the tour continues with the wrong course. It doesn't crash because both demo and test courses are public, so
 it's possible for demo and portal users to access them anyway and add/update a
 comment is done on the demo course.
 
 By this commit:
 - Demo data is removed in the tests to ensure that there is no collision between demo data and test data.
 - Since there are no predefined messages in the test data (the tour flow relied on the demo data messages before), the `update` does not happen in the tour without demo data. Some extra steps are also added to check the update message .
