### PR TITLE
[FIX] base_setup: remove sms checkbox from settings

### DIFF
--- a/addons/base_setup/views/res_config_settings_views.xml
+++ b/addons/base_setup/views/res_config_settings_views.xml
@@ -104,7 +104,8 @@
                         <div id="contacts_settings">
                             <block title="Contacts" name="contacts_setting_container">
                                 <setting id="sms" string="Send SMS" documentation="/applications/marketing/sms_marketing/pricing/pricing_and_faq.html" help="Send texts to your contacts">
-                                    <field name="module_sms"/>
+                                    <!-- Invisible to avoid breaking any custom inheriting templates -->
+                                    <field name="module_sms" invisible="1"/>
                                 </setting>
                                 <setting help="Automatically enrich your contact base with company data" title="When populating your address book, Odoo provides a list of matching companies. When selecting one item, the company data and logo are auto-filled." id="partner_autocomplete">
                                     <field name="module_partner_autocomplete"/>


### PR DESCRIPTION
This commit removes the module_sms field from the settings view. When it was present unchecking it could potentially remove all the apps installed on a DB. Depending on what was installed. The main issue was that user misinterpreted the use of this checkbox leading to situation where the DB needed to be restarted from a backup.

To fix this issue it was decided for now to remove the checkbox from the settings view. This will prevent these situations to happen again in the future.

task-4526115

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
