### PR TITLE
[FIX] point_of_sale: initialize the synchronization class at startup

### DIFF
--- a/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
@@ -72,3 +72,16 @@ export function fillTextArea(target, value) {
 export function createFloatingOrder() {
     return { trigger: ".pos-leftheader .list-plus-btn", run: "click" };
 }
+
+export function waitRequest() {
+    return [
+        {
+            content: "Request Start",
+            trigger: "body:has(.fa-circle-o-notch)",
+        },
+        {
+            content: "Wait for request to finish",
+            trigger: "body:not(:has(.fa-circle-o-notch))",
+        },
+    ];
+}


### PR DESCRIPTION
Initialize the synchronization class at startup of the PoS before making any request to the server. This will ensure that the synchronization class is ready to handle the requests.

