### PR TITLE
[IMP] web: make dbname more visible to user

### DIFF
--- a/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.js
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.js
@@ -3,6 +3,7 @@ import { useService } from "@web/core/utils/hooks";
 import { SettingsBlock } from "../settings/settings_block";
 import { Setting } from "../../../views/form/setting/setting";
 
+import { session } from "@web/session";
 import { Component, onWillStart } from "@odoo/owl";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 import { router } from "@web/core/browser/router";
@@ -23,6 +24,7 @@ export class ResConfigDevTool extends Component {
     };
 
     setup() {
+        this.dbName = session.db;
         this.isDebug = Boolean(odoo.debug);
         this.isAssets = odoo.debug.includes("assets");
         this.isTests = odoo.debug.includes("tests");

--- a/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.xml
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.xml
@@ -4,6 +4,7 @@
         <div id="developer_tool">
             <SettingsBlock title.translate="Developer Tools">
                 <Setting addLabel="false">
+                        <p t-if="isDebug">Database name: <t t-esc="dbName"/></p>
                         <a t-if="!isDebug" class="d-block" t-on-click="() => this.activateDebug(1)" href="#">Activate the developer mode</a>
                         <a t-if="!isAssets" class="d-block" t-on-click="() => this.activateDebug('assets')" href="#">Activate the developer mode (with assets)</a>
                         <a t-if="!isTests" class="d-block" t-on-click="() => this.activateDebug('assets,tests')" href="#">Activate the developer mode (with tests assets)</a>

--- a/addons/web/static/src/webclient/user_menu/user_menu.xml
+++ b/addons/web/static/src/webclient/user_menu/user_menu.xml
@@ -9,7 +9,7 @@
                         <img class="o_avatar o_user_avatar rounded" t-att-src="source" alt="User"/>
                         <small class="oe_topbar_name d-none ms-2 text-start smaller lh-1 text-truncate"  t-att-class="{'d-lg-inline-block' : env.debug}" style="max-width: 200px">
                             <t t-esc="userName"/>
-                            <mark class="d-block font-monospace text-truncate">
+                            <mark class="d-block font-monospace text-truncate"  t-att-title="dbName">
                                 <i class="fa fa-database oi-small me-1"/><t t-esc="dbName"/>
                             </mark>
                         </small>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

If the database name is too long, it may not be shown in its entirety below the username when the developer mode is active. There's no other place in the database where this information is visible. 

The behaviour was noticed on the following ticket: https://www.odoo.com/odoo/project/12724/tasks/4524629

Current behavior before PR:

Database name may appear shortened if it's too long. There's no other way to see the DB's name

<img width="350" alt="Captura de pantalla 2025-02-04 a la(s) 8 51 17 a m" src="https://github.com/user-attachments/assets/16de3960-c532-460c-9389-474bfd674bb7" />

Desired behavior after PR is merged:

With this commit, we display the name of the DB on the settings page and make the name appear when hovering on the DB name below the user.

<img width="444" alt="Captura de pantalla 2025-02-04 a la(s) 8 48 15 a m" src="https://github.com/user-attachments/assets/ef4f7634-8dc5-4551-9449-c857c971eb45" />

<img width="658" alt="Captura de pantalla 2025-02-04 a la(s) 8 53 05 a m" src="https://github.com/user-attachments/assets/b159fb6d-8a58-406d-bc44-56ea12bddad2" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
