### PR TITLE
[FIX] web: Prevent pdf flickering

### DIFF
--- a/addons/web/static/lib/pdfjs/web/viewer.js
+++ b/addons/web/static/lib/pdfjs/web/viewer.js
@@ -3665,14 +3665,6 @@ function webViewerInitialized() {
     appConfig.toolbar.viewFind.classList.add("hidden");
   }
 
-  appConfig.mainContainer.addEventListener("transitionend", function (evt) {
-    if (evt.target === this) {
-      eventBus.dispatch("resize", {
-        source: this
-      });
-    }
-  }, true);
-
   try {
     if (file) {
       PDFViewerApplication.open(file);
@@ -10576,6 +10568,8 @@ function _addEventListeners2() {
   this.sidebarContainer.addEventListener("transitionend", evt => {
     if (evt.target === this.sidebarContainer) {
       this.outerContainer.classList.remove("sidebarMoving");
+      // Ensure that rendering is triggered after opening/closing the sidebar.
+      this.eventBus.dispatch("resize", { source: this });
     }
   });
   this.toggleButton.addEventListener("click", () => {


### PR DESCRIPTION
Steps:
    - Install `account_accountant`
    - Open vendor/bills
    - Open a record with a pdf
    - Change zoom to 90%
    - Open page as web app (via chrome for example)
    - PDF is flickering

This problem comes from pdf.js, it has already been fixed in their repository. So the fix is a backport of https://github.com/mozilla/pdf.js/pull/17360/commits/412502370d2efee794d934524ade39a1ddfe79c8.

opw-4402527