### PR TITLE
[MOV] mail: move forward and reply-all actions to the web

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -7,9 +7,9 @@ import { MessageNotificationPopover } from "@mail/core/common/message_notificati
 import { MessageReactionMenu } from "@mail/core/common/message_reaction_menu";
 import { MessageReactions } from "@mail/core/common/message_reactions";
 import { RelativeTime } from "@mail/core/common/relative_time";
-import { getNonEditableMentions, htmlToTextContentInline, parseEmail } from "@mail/utils/common/format";
+import { htmlToTextContentInline } from "@mail/utils/common/format";
 import { isEventHandled, markEventHandled } from "@web/core/utils/misc";
-import { renderToMarkup, renderToElement } from "@web/core/utils/render";
+import { renderToElement } from "@web/core/utils/render";
 
 import {
     Component,
@@ -453,30 +453,6 @@ export class Message extends Component {
         });
     }
 
-    openFullComposer(name, context) {
-        const actionContext = {
-            ...context,
-            default_model: this.props.thread.model,
-            default_res_ids: [this.props.thread.id],
-            default_subject: this.message.subject || this.message.default_subject,
-            default_subtype_xmlid: "mail.mt_comment",
-        };
-        const action = {
-            name: name,
-            type: "ir.actions.act_window",
-            res_model: "mail.compose.message",
-            view_mode: "form",
-            views: [[false, "form"]],
-            target: "new",
-            context: actionContext,
-        };
-        this.env.services.action.doAction(action, {
-            onClose: () => {
-                this.props.thread.fetchNewMessages();
-            },
-        });
-    }
-
     /** @param {MouseEvent} [ev] */
     openMobileActions(ev) {
         if (!isMobileOS()) {
@@ -519,78 +495,6 @@ export class Message extends Component {
         }
         this.state.showTranslation =
             !this.state.showTranslation && Boolean(message.translationValue);
-    }
-
-    async onClickMessageForward() {
-        const email_from = this.message.author?.email ? this.message.author.email : this.message.email_from;
-        const [name, email] = parseEmail(email_from);
-        const datetimeFormatted = _t("%(date)s at %(time)s", {
-            date: this.message.datetime.toFormat("ccc, MMM d, yyyy"),
-            time: this.message.datetime.toFormat("hh:mm a"),
-        });
-
-        const body = renderToMarkup(
-            "mail.Message.bodyInForward",
-            {
-                body: getNonEditableMentions(this.message.body),
-                date: datetimeFormatted,
-                email,
-                message: this.message,
-                name: name || email,
-            }
-        );
-
-        const attachmentIds = this.message.attachment_ids.map((attachment) => attachment.id);
-        const newAttachmentIds = await this.env.services.orm.call(
-            "ir.attachment",
-            "copy",
-            [attachmentIds],
-            {
-                default: { res_model: "mail.compose.message", res_id: 0 },
-            }
-        );
-
-        const context = {
-            default_attachment_ids: newAttachmentIds,
-            default_body: body,
-            default_composition_mode: "comment",
-            default_composition_comment_option: "forward",
-        };
-        this.openFullComposer(_t("Forward message"), context);
-    }
-
-    async onClickMessageReplyAll() {
-        const partners = await rpc("/mail/thread/recipients", {
-            thread_model: this.props.thread.model,
-            thread_id: this.props.thread.id,
-            message_id: this.message.id,
-        });
-        const recipientIds = partners.map((data) => data.id);
-        const email_from = this.message.author?.email ? this.message.author.email : this.message.email_from;
-        const [name, email] = parseEmail(email_from);
-        const datetimeFormatted = _t("%(date)s at %(time)s", {
-            date: this.message.datetime.toFormat("ccc, MMM d, yyyy"),
-            time: this.message.datetime.toFormat("hh:mm a"),
-        });
-
-        const body = renderToMarkup(
-            "mail.Message.bodyInReply",
-            {
-                body: getNonEditableMentions(this.message.body),
-                date: datetimeFormatted,
-                email,
-                message: this.message,
-                name: name || email,
-            }
-        );
-
-        const context = {
-            default_body: body,
-            default_composition_mode: "comment",
-            default_composition_comment_option: "reply_all",
-            default_partner_ids: recipientIds,
-        };
-        this.openFullComposer(_t("Reply All"), context);
     }
 }
 

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -175,25 +175,6 @@
     </div>
 </t>
 
-<t t-name="mail.Message.bodyInForward">
-    <div>
-        <span>---------- Forwarded message ----------</span><br/>
-        <span>Date: <t t-esc="date"/></span><br/>
-        <span>From: <t t-esc="name"/> <a t-att-href="'mailto:' + email" target="_blank">&lt;<t t-esc="email"/>&gt;</a></span><br/>
-        <span>Subject: <t t-esc="message.subject || message.default_subject"/></span><br/>
-        <t t-out="body"/>
-    </div>
-</t>
-
-<t t-name="mail.Message.bodyInReply">
-    <div class="o_mail_reply_content">
-        <div class="d-none">
-            <span>On <t t-esc="date"/> <t t-esc="name"/> <a t-att-href="'mailto:' + email" target="_blank">&lt;<t t-esc="email"/>&gt;</a>wrote</span>
-            <blockquote t-out="body"/>
-        </div>
-    </div>
-</t>
-
 <t t-name="mail.Message.expandAction">
     <button class="btn border-0 rounded-0 o-mail-Message-expandBtn" t-att-title="expandText" t-on-click="openMobileActions" t-att-class="{
         'o-mail-Message-openActionMobile opacity-25 p-2 mt-n2 rounded-circle user-select-none': isMobileOS and !mobileExpanded,

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -88,26 +88,6 @@ messageActionsRegistry
         onClick: (component) => component.props.message.unfollow(),
         sequence: 60,
     })
-    .add("reply-all", {
-        condition: (component) =>
-            component.props.message.canReplyAllandForward(component.props.thread),
-        icon: "fa fa-reply",
-        title: _t("Reply All"),
-        onClick: (component) => {
-            component.onClickMessageReplyAll();
-        },
-        sequence: 71,
-    })
-    .add("forward", {
-        condition: (component) =>
-            component.props.message.canReplyAllandForward(component.props.thread),
-        icon: "fa fa-share",
-        title: _t("Forward"),
-        onClick: (component) => {
-            component.onClickMessageForward();
-        },
-        sequence: 72,
-    })
     .add("edit", {
         condition: (component) => component.props.message.editable,
         icon: "fa fa-pencil",

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -379,15 +379,6 @@ export class Message extends Record {
     }
 
     /** @param {import("models").Thread} thread the thread where the message is shown */
-    canReplyAllandForward(thread) {
-        return (
-            !["discuss.channel", "mail.box"].includes(thread.model) &&
-            ["comment", "email"].includes(this.message_type) &&
-            !this.is_note
-        );
-    }
-
-    /** @param {import("models").Thread} thread the thread where the message is shown */
     canUnfollow(thread) {
         return Boolean(this.thread?.selfFollower && thread?.model === "mail.box");
     }

--- a/addons/mail/static/src/core/web/message_actions_patch.js
+++ b/addons/mail/static/src/core/web/message_actions_patch.js
@@ -1,0 +1,24 @@
+import { messageActionsRegistry } from "@mail/core/common/message_actions";
+import { _t } from "@web/core/l10n/translation";
+
+messageActionsRegistry
+    .add("reply-all", {
+        condition: (component) =>
+            component.props.message.canReplyAllandForward(component.props.thread),
+        icon: "fa fa-reply",
+        title: _t("Reply All"),
+        onClick: (component) => {
+            component.onClickMessageReplyAll();
+        },
+        sequence: 71,
+    })
+    .add("forward", {
+        condition: (component) =>
+            component.props.message.canReplyAllandForward(component.props.thread),
+        icon: "fa fa-share",
+        title: _t("Forward"),
+        onClick: (component) => {
+            component.onClickMessageForward();
+        },
+        sequence: 72,
+    });

--- a/addons/mail/static/src/core/web/message_model_patch.js
+++ b/addons/mail/static/src/core/web/message_model_patch.js
@@ -1,0 +1,16 @@
+import { Message } from "@mail/core/common/message_model";
+
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").Message} */
+const messagePatch = {
+    /** @param {import("models").Thread} thread the thread where the message is shown */
+    canReplyAllandForward(thread) {
+        return (
+            !["discuss.channel", "mail.box"].includes(thread.model) &&
+            ["comment", "email"].includes(this.message_type) &&
+            !this.is_note
+        );
+    },
+};
+patch(Message.prototype, messagePatch);

--- a/addons/mail/static/src/core/web/message_patch.js
+++ b/addons/mail/static/src/core/web/message_patch.js
@@ -1,5 +1,7 @@
 import { Message } from "@mail/core/common/message";
+import { getNonEditableMentions, parseEmail } from "@mail/utils/common/format";
 import { markEventHandled } from "@web/core/utils/misc";
+import { renderToMarkup } from "@web/core/utils/render";
 
 import {
     deserializeDate,
@@ -8,6 +10,7 @@ import {
     formatDateTime,
 } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
+import { rpc } from "@web/core/network/rpc";
 import {
     formatChar,
     formatFloat,
@@ -61,6 +64,101 @@ patch(Message.prototype, {
             }
         }
     },
+
+    async onClickMessageForward() {
+        const email_from = this.message.author?.email
+            ? this.message.author.email
+            : this.message.email_from;
+        const [name, email] = parseEmail(email_from);
+        const datetimeFormatted = _t("%(date)s at %(time)s", {
+            date: this.message.datetime.toFormat("ccc, MMM d, yyyy"),
+            time: this.message.datetime.toFormat("hh:mm a"),
+        });
+
+        const body = renderToMarkup("mail.Message.bodyInForward", {
+            body: getNonEditableMentions(this.message.body),
+            date: datetimeFormatted,
+            email,
+            message: this.message,
+            name: name || email,
+        });
+
+        const attachmentIds = this.message.attachment_ids.map((attachment) => attachment.id);
+        const newAttachmentIds = await this.env.services.orm.call(
+            "ir.attachment",
+            "copy",
+            [attachmentIds],
+            {
+                default: { res_model: "mail.compose.message", res_id: 0 },
+            }
+        );
+
+        const context = {
+            default_attachment_ids: newAttachmentIds,
+            default_body: body,
+            default_composition_mode: "comment",
+            default_composition_comment_option: "forward",
+        };
+        this.openFullComposer(_t("Forward message"), context);
+    },
+
+    async onClickMessageReplyAll() {
+        const partners = await rpc("/mail/thread/recipients", {
+            thread_model: this.props.thread.model,
+            thread_id: this.props.thread.id,
+            message_id: this.message.id,
+        });
+        const recipientIds = partners.map((data) => data.id);
+        const email_from = this.message.author?.email
+            ? this.message.author.email
+            : this.message.email_from;
+        const [name, email] = parseEmail(email_from);
+        const datetimeFormatted = _t("%(date)s at %(time)s", {
+            date: this.message.datetime.toFormat("ccc, MMM d, yyyy"),
+            time: this.message.datetime.toFormat("hh:mm a"),
+        });
+
+        const body = renderToMarkup("mail.Message.bodyInReply", {
+            body: getNonEditableMentions(this.message.body),
+            date: datetimeFormatted,
+            email,
+            message: this.message,
+            name: name || email,
+        });
+
+        const context = {
+            default_body: body,
+            default_composition_mode: "comment",
+            default_composition_comment_option: "reply_all",
+            default_partner_ids: recipientIds,
+        };
+        this.openFullComposer(_t("Reply All"), context);
+    },
+
+    openFullComposer(name, context) {
+        const actionContext = {
+            ...context,
+            default_model: this.props.thread.model,
+            default_res_ids: [this.props.thread.id],
+            default_subject: this.message.subject || this.message.default_subject,
+            default_subtype_xmlid: "mail.mt_comment",
+        };
+        const action = {
+            name: name,
+            type: "ir.actions.act_window",
+            res_model: "mail.compose.message",
+            view_mode: "form",
+            views: [[false, "form"]],
+            target: "new",
+            context: actionContext,
+        };
+        this.env.services.action.doAction(action, {
+            onClose: () => {
+                this.props.thread.fetchNewMessages();
+            },
+        });
+    },
+
     openRecord() {
         this.message.thread.open({ focus: true });
     },

--- a/addons/mail/static/src/core/web/message_patch.xml
+++ b/addons/mail/static/src/core/web/message_patch.xml
@@ -35,4 +35,22 @@
             <attribute name="t-on-click">ev => this.onClickAuthor(ev)</attribute>
         </xpath>
     </t>
+    <t t-name="mail.Message.bodyInForward">
+        <div>
+            <span>---------- Forwarded message ----------</span><br/>
+            <span>Date: <t t-esc="date"/></span><br/>
+            <span>From: <t t-esc="name"/> <a t-att-href="'mailto:' + email" target="_blank">&lt;<t t-esc="email"/>&gt;</a></span><br/>
+            <span>Subject: <t t-esc="message.subject || message.default_subject"/></span><br/>
+            <t t-out="body"/>
+        </div>
+    </t>
+
+    <t t-name="mail.Message.bodyInReply">
+        <div class="o_mail_reply_content">
+            <div class="d-none">
+                <span>On <t t-esc="date"/> <t t-esc="name"/> <a t-att-href="'mailto:' + email" target="_blank">&lt;<t t-esc="email"/>&gt;</a>wrote</span>
+                <blockquote t-out="body"/>
+            </div>
+        </div>
+    </t>
 </templates>


### PR DESCRIPTION
Since odoo/odoo#186875, forward and reply-all actions have been added to the message actions. These actions use the full composer and the full composer is a web feature (at least for now). This PR moves the related files to `mail/static/src/core/web`.
