### PR TITLE
[FIX] web: waves and bubble external layout fix

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -661,7 +661,7 @@
 
         <!-- Footer -->
         <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}">
-            <svg t-attf-class="{{report_type == 'pdf' and 'position-fixed top-0 start-0'}} w-100" preserveAspectRatio="none" t-att-height="report_type == 'pdf' and '180'" viewBox="0 0 1000 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <svg t-attf-class="{{report_type == 'pdf' and 'position-fixed start-0'}} w-100" preserveAspectRatio="none" t-att-height="report_type == 'pdf' and '180'" viewBox="0 0 1000 180" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M427.731 19.757C686.904 51.3469 898.971 38.039 1000 27.6922V180H0V8.20934C66.363 -0.991089 198.347 -8.20218 427.731 19.757Z" t-att-fill="company.secondary_color" fill-opacity=".1"/>
             </svg>
             <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-5 text-center">
@@ -727,7 +727,7 @@
 
         <!-- Footer -->
         <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}">
-            <svg t-attf-class="{{report_type == 'pdf' and 'position-fixed top-0 start-0'}}" width="500" height="228" viewBox="0 0 500 228" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <svg t-attf-class="{{report_type == 'pdf' and 'position-fixed start-0'}}" width="500" height="228" viewBox="0 0 500 228" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M500 228H0V6.52743C26.3323 2.23278 53.3561 0 80.9008 0C256.522 0 410.969 90.7656 500 228Z" t-att-fill="company.secondary_color" fill-opacity=".1"/>
             </svg>
             <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-4 text-center">


### PR DESCRIPTION
Before this commit the wave and bubble layouts did not play well in the report editor. The svg was set to be an overlay, in fixed position, with a top = 0 property.

In wkhtmltopdf it did work because we render the header and footer in their own viewport. In the report editor however, the viewport is unique and the svg was then fixed to the top of the page.

After this commit, the report layouts continue to work in wkhtmltopdf, but we removed the top = 0 attribute. Following https://stackoverflow.com/a/12282107 it should work in the contexts: (TLDR: in position fixed, if top and bottom are not specified, the default position is the one the block should have taken if it were staticly positioned)

- wkhtmltopdf: the footer is rendered in its own viewport and consequently the top of the viewport is also the top of the footer and thus the original static position
- action report of type HTML: no worries here, this fix doesn't apply because of ifs in the qweb expressions
- report editor in edition mode: The SVG is inisible anyway because it needs a fill value which is not present in that context. The svg is located outside of the iframe's port in practice with the fix.
- report editor in preview mode: works because the iframe cannot be interacted with and that the default static position is within the footer

opw-4508900

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
