### PR TITLE
[FIX] l10n_hu_edi: Cleanup post-init code

### DIFF
--- a/addons/l10n_hu_edi/__init__.py
+++ b/addons/l10n_hu_edi/__init__.py
@@ -1,14 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import logging
-import psycopg2.errors
-
-from odoo import _
-
 from . import models
 from . import wizard
-
-_logger = logging.getLogger(__name__)
 
 
 def post_init(env):
@@ -17,18 +10,10 @@ def post_init(env):
         company._l10n_hu_edi_configure_company()
 
         # Set Hungarian fields on taxes
-        sql_logger = logging.getLogger('odoo.sql_db')
-        previous_level = sql_logger.level
-        sql_logger.setLevel(logging.CRITICAL)
-        try:
-            with env.cr.savepoint():
-                env['account.chart.template'].with_company(company)._load_data({
-                    'account.tax': env['account.chart.template']._get_hu_account_tax()
-                })
-        except psycopg2.errors.NotNullViolation:
-            _logger.warning(_(
-                'Could not set NAV tax types on taxes because some taxes from l10n_hu are missing.\n'
-                'You should set the type manually or reload the CoA before sending invoices to NAV.'
-            ))
-        finally:
-            sql_logger.setLevel(previous_level)
+        env['account.chart.template'].with_company(company)._load_data({
+            'account.tax': {
+                xmlid: vals
+                for xmlid, vals in env['account.chart.template']._get_hu_account_tax().items()
+                if env['account.chart.template'].with_company(company).ref(xmlid, raise_if_not_found=False)
+            }
+        })


### PR DESCRIPTION
This commit comes as an apology for the horrible code I wrote in PR #166043 in order for the installation of `l10n_hu_edi` to not fail if some of the default Hungarian taxes (defined in `l10n_hu`) had been deleted.

Instead of rolling back the loading of the EDI-specific fields if some taxes don't exist, we can just load those fields on the taxes that do exist. Which is a lot cleaner and simpler. Sorry again!

task-none