### PR TITLE
[FIX] point_of_sale: prevent screensaver from updating  previousScreen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/saver_screen/saver_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/saver_screen/saver_screen.js
@@ -5,6 +5,7 @@ import { useTime } from "@point_of_sale/app/utils/time_hook";
 export class SaverScreen extends Component {
     static template = "point_of_sale.SaverScreen";
     static storeOnOrder = false;
+    static updatePreviousScreen = false;
     static props = [];
 
     setup() {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1586,8 +1586,13 @@ export class PosStore extends Reactive {
         if (name === "ProductScreen") {
             this.get_order()?.deselect_orderline();
         }
-        this.previousScreen = this.mainScreen.component?.name;
         const component = registry.category("pos_screens").get(name);
+        if (
+            (component.updatePreviousScreen ?? true) &&
+            (this.mainScreen.component?.updatePreviousScreen ?? true)
+        ) {
+            this.previousScreen = this.mainScreen.component?.name;
+        }
         this.mainScreen = { component, props };
         // Save the screen to the order so that it is shown again when the order is selected.
         if (component.storeOnOrder ?? true) {


### PR DESCRIPTION
Before this commit, when the login screen was left idle using an employee login, the screensaver would appear as expected. However, upon user interaction (e.g., moving the mouse), the system would update the previous screen to the screen saver. This causing issues during login where the screensaver would be displayed.

opw-4494087


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
