### PR TITLE
[FIX] base_import: fix for import of some date like "2500/1222" guessed as "%Y.%m.%d" format

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1632,6 +1632,7 @@ def check_patterns(patterns, values):
 def to_re(pattern):
     """ cut down version of TimeRE converting strptime patterns to regex
     """
+    pattern = re.sub(r"([\\.^$*+?\(\){}\[\]|])", r"\\\1", pattern)
     pattern = re.sub(r'\s+', r'\\s+', pattern)
     pattern = re.sub('%([a-z])', _replacer, pattern, flags=re.IGNORECASE)
     pattern = '^' + pattern + '$'

--- a/addons/base_import/tests/test_base_import.py
+++ b/addons/base_import/tests/test_base_import.py
@@ -511,6 +511,64 @@ class test_convert_import_data(TransactionCase):
         # if results empty, no errors
         self.assertItemsEqual(results['messages'], [])
 
+    def test_date_fields_with_slash_ymd(self):
+        import_wizard = self.env['base_import.import'].with_context(lang='de_DE').create({
+            'res_model': 'res.partner',
+            'file': 'name,ref,date,create_date\n'
+                    '"foo","255/2025","2023/01/01","2023.01.01 15:15:15"\n',
+            'file_type': 'text/csv',
+        })
+
+        opts = {
+            'date_format': '',
+            'datetime_format': '',
+            'quoting': '"',
+            'separator': ',',
+            'float_decimal_separator': '.',
+            'float_thousand_separator': ',',
+            'has_headers': True
+        }
+        result_parse = import_wizard.parse_preview({**opts})
+
+        opts = result_parse['options']
+        results = import_wizard.execute_import(
+            ['name', 'ref', 'date', 'create_date'],
+            [],
+            {**opts}
+        )
+
+        # if results empty, no errors
+        self.assertItemsEqual(results['messages'], [])
+
+    def test_date_fields_with_slash_dmy(self):
+        import_wizard = self.env['base_import.import'].with_context(lang='de_DE').create({
+            'res_model': 'res.partner',
+            'file': 'name,ref,date,create_date\n'
+                    '"foo","255/2025","01/01/2023","2023.01.01 15:15:15"\n',
+            'file_type': 'text/csv',
+        })
+
+        opts = {
+            'date_format': '',
+            'datetime_format': '',
+            'quoting': '"',
+            'separator': ',',
+            'float_decimal_separator': '.',
+            'float_thousand_separator': ',',
+            'has_headers': True
+        }
+        result_parse = import_wizard.parse_preview({**opts})
+
+        opts = result_parse['options']
+        results = import_wizard.execute_import(
+            ['name', 'ref', 'date', 'create_date'],
+            [],
+            {**opts}
+        )
+
+        # if results empty, no errors
+        self.assertItemsEqual(results['messages'], [])
+
     def test_parse_relational_fields(self):
         """ Ensure that relational fields float and date are correctly
         parsed during the import call.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:
If you try to import an excel sheet for example with these column on sale order, but the issue is at every model: (this is an example)
![image](https://github.com/user-attachments/assets/7747b0ee-fb36-43d1-bfde-5f3ad29ce77d)

First column: Client ref
Second column: committment date
Third column: Customer

## Current behavior before PR:

When you upload the file to import, the extract_header_types calls _try_match_date_time that try to guess the date column. 
The first column makes the _try_match_date_time to guess that the format is %Y.%m.%d  format .
This is an error because that column does not contain a date .
The reason is that check_patterns when convert the pattern to reg ex using
`def to_re(pattern):`
on base_import/base_import.py, does not escape the "." so it works as "every char" wildcard character on regex .


## Desired behavior after PR is merged:
No error should appear and the correct date format from the right date column should be guessed 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
