### PR TITLE
[FIX] web: make full dropdown selection clickable in kanban

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -564,10 +564,12 @@
         top: map-get($spacers, 3);
     }
 
-    .o_column_quick_create,
-    .o_kanban_group:not(.o_column_folded) .o_kanban_header_title {
-        // Makes them come on top of the "no-content" background gradient.
-        z-index: calc(var(--o-view-nocontent-zindex) + 1);
+    &:has(> .o_view_nocontent) {
+        .o_column_quick_create,
+        .o_kanban_group:not(.o_column_folded) .o_kanban_header_title {
+            // Makes them come on top of the "no-content" background gradient.
+            z-index: calc(var(--o-view-nocontent-zindex) + 1);
+        }
     }
 
     .o_group_draggable .o_column_title {


### PR DESCRIPTION
![hasdropdownissue](https://github.com/user-attachments/assets/dc2092ec-a918-416e-bb7b-6b989bf04027)

In some kanban views (helpdesk.ticket, project.task, event.event),
the right part of the selection dropdown can sometimes be inoperative
because it falls below the `o_column_quick_create` element. This
element has a higher z-index than the `o_kanban_group` which the
dropdown is part of.


opw-4507121
