### PR TITLE
[FIX] account: Fix cash rounding multicompany

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1882,6 +1882,7 @@ class AccountMove(models.Model):
         having the biggest balance.
         '''
         self.ensure_one()
+        self = self.with_company(self.company_id.id)
         def _compute_cash_rounding(self, total_amount_currency):
             ''' Compute the amount differences due to the cash rounding.
             :param self:                    The current account.move record.

--- a/addons/account/tests/test_invoice_tax_totals.py
+++ b/addons/account/tests/test_invoice_tax_totals.py
@@ -845,6 +845,44 @@ class TestTaxTotals(AccountTestInvoicingCommon):
         for move in moves_rounding:
             self.assertEqual(sum(move.line_ids.filtered(lambda line: line.display_type == 'rounding').mapped('balance')), moves_rounding[move])
 
+    def test_recompute_cash_rounding_lines_multi_company(self):
+        """
+        Ensure that when a move is created with cash rounding that will add an invoice line, the cash rounding accounts
+        will be that of the move's company and not the user's company.
+        """
+        cash_rounding_tbl = self.env['account.cash.rounding'].with_company(self.company_data["company"])
+        cash_rounding_add_invoice_line = cash_rounding_tbl.create({
+            'name': 'Add invoice line Rounding UP',
+            'rounding': 1,
+            'rounding_method': 'UP',
+            'strategy': 'add_invoice_line',
+            'profit_account_id': self.company_data['default_account_revenue'].id,
+            'loss_account_id': self.company_data['default_account_expense'].id,
+        })
+
+        cash_rounding_add_invoice_line.with_company(self.company_data_2["company"]).write({
+            'profit_account_id': self.company_data_2['default_account_revenue'].id,
+            'loss_account_id': self.company_data_2['default_account_expense'].id,
+        })
+
+        move = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-01-01',
+            'company_id': self.company_data_2['company'].id,
+            'invoice_cash_rounding_id': cash_rounding_add_invoice_line.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'line',
+                    'display_type': 'product',
+                    'price_unit': 99.5,
+                })
+            ],
+        })
+
+        rounding_line_account = move.line_ids.filtered(lambda line: line.display_type == 'rounding').mapped('account_id')
+        self.assertEqual(rounding_line_account, self.company_data_2['default_account_revenue'])
+
     def test_cash_rounding_amount_total_rounded_foreign_currency(self):
         tax_15 = self.env['account.tax'].create({
             'name': "tax_15",


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
A bug occurred when the system attempted to automatically add a rounding line to an invoice in a multi-company environment. The company-dependent field was being updated without properly considering the invoice’s company context.

Current behavior before PR:
An error was raised when trying to create the rounding line because the system looked up the accounts for Company 1 instead of the invoice’s assigned company.

Desired behavior after PR is merged:
No error was raised


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
