### PR TITLE
[FIX] partner_autocomplete: fix unreliability with Clearbit Autocomplete

### DIFF
--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_core.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_core.js
@@ -3,6 +3,7 @@
 
 import { loadJS } from "@web/core/assets";
 import { _t } from "@web/core/l10n/translation";
+import { browser } from "@web/core/browser/browser";
 import { KeepLast } from "@web/core/utils/concurrency";
 import { useService } from "@web/core/utils/hooks";
 import { renderToMarkup } from "@web/core/utils/render";
@@ -19,7 +20,6 @@ export function usePartnerAutocomplete() {
     const keepLastOdoo = new KeepLast();
     const keepLastClearbit = new KeepLast();
 
-    const http = useService("http");
     const notification = useService("notification");
     const orm = useService("orm");
 
@@ -251,7 +251,13 @@ export function usePartnerAutocomplete() {
      */
     async function getClearbitSuggestions(value) {
         const url = `https://autocomplete.clearbit.com/v1/companies/suggest?query=${value}`;
-        const prom = http.get(url);
+        const prom = browser.fetch(
+            url,
+            {
+                method: 'GET',
+                cache: 'no-cache',
+            }
+        ).then((response) => (response['json']()));
         return keepLastClearbit.add(prom);
     }
 

--- a/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
+++ b/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import { browser } from "@web/core/browser/browser";
-import { registry } from "@web/core/registry";
 import {
     click,
     editInput,
@@ -12,8 +11,6 @@ import {
 } from "@web/../tests/helpers/utils";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 import { loadJS } from "@web/core/assets";
-
-const serviceRegistry = registry.category("services");
 
 let target;
 
@@ -38,29 +35,6 @@ QUnit.module('partner_autocomplete', {
         });
 
         setupViewRegistries();
-        const fakeHTTPService = {
-            start() {
-                return {
-                    get: (route) => {
-                        return Promise.resolve([
-                            {
-                                "name": "Odoo",
-                                "domain": "odoo.com",
-                            },
-                            {
-                                "name": "MyCompany",
-                                "domain": "mycompany.com",
-                            },
-                            {
-                                "name": "YourCompany",
-                                "domain": "yourcompany.com",
-                            },
-                        ]);
-                    },
-                };
-            },
-        };
-        serviceRegistry.add("http", fakeHTTPService);
     },
 }, function () {
 
@@ -183,6 +157,22 @@ QUnit.module('partner_autocomplete', {
                         'display_name': "California (US)",
                     },
                 });
+            }
+            else if (route.startsWith("https://autocomplete.clearbit.com/v1/companies/suggest")) {
+                return Promise.resolve([
+                    {
+                        "name": "Odoo",
+                        "domain": "odoo.com",
+                    },
+                    {
+                        "name": "MyCompany",
+                        "domain": "mycompany.com",
+                    },
+                    {
+                        "name": "YourCompany",
+                        "domain": "yourcompany.com",
+                    },
+                ])
             }
         }
     }


### PR DESCRIPTION
The Partner Autocomplete service was unreliable when used on a database hosted under a subdomain of odoo.com (i.e. from *.odoo.com).

This was caused by a combination of the CORS policy of the Autocomplete API of Clearbit and the caching of the browser.

If the user performed a first request with search query "Odoo" from https://a.odoo.com, the browser would cache the results, including the `Access-Control-Allow-Origin` header set to `https://a.odoo.com`.

The same request performed from https://b.odoo.com would lead to a CORS policy error as the browser would use the cached response from earlier request.

This commit addresses the issue by disabling the caching of the requests made to the Clearbit Autocomplete API.
