### PR TITLE
[FIX] orm: fix _load_records

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -605,7 +605,7 @@ class AccountChartTemplate(models.AbstractModel):
                 created_models.add(model)
 
         created_records = {}
-        for model, model_data in delay(list(deepcopy(data).items())):
+        for model_name, model_data in delay(list(deepcopy(data).items())):
             all_records_vals = []
             for xml_id, record_vals in model_data.items():
                 # Extract the translations from the values
@@ -622,10 +622,12 @@ class AccountChartTemplate(models.AbstractModel):
 
                 all_records_vals.append({
                     'xml_id': xml_id,
-                    'values': deref_values(record_vals, self.env[model]),
+                    'values': deref_values(record_vals, self.env[model_name]),
                     'noupdate': True,
                 })
-            created_records[model] = self.with_context(lang='en_US').env[model]._load_records(all_records_vals, ignore_duplicates=ignore_duplicates)
+            model = self.with_context(lang='en_US').env[model_name]
+            model._load_records(all_records_vals, ignore_duplicates=ignore_duplicates)
+            created_records[model_name] = model.concat(*(vals['record'] for vals in all_records_vals if vals.get('state') == 'created'))
         return created_records
 
     def _post_load_data(self, template_code, company, template_data):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5173,13 +5173,12 @@ class BaseModel(metaclass=MetaModel):
     def _load_records_create(self, values):
         return self.create(values)
 
-    def _load_records(self, data_list, update=False, ignore_duplicates=False):
+    def _load_records(self, data_list, update=False):
         """ Create or update records of this model, and assign XMLIDs.
 
             :param data_list: list of dicts with keys `xml_id` (XMLID to
                 assign), `noupdate` (flag on XMLID), `values` (field values)
             :param update: should be ``True`` when upgrading a module
-            :param ignore_duplicates: if true, inputs that match records already in the DB will be ignored
 
             :return: the records corresponding to ``data_list``
         """
@@ -5239,11 +5238,8 @@ class BaseModel(metaclass=MetaModel):
                 to_create.append(data)
 
         # update existing records
-        if ignore_duplicates:
-            to_update = []
         for data in to_update:
             data['record']._load_records_write(data['values'])
-            data['state'] = 'updated'
 
         # check for records to create with an XMLID from another module
         module = self.env.context.get('install_module')
@@ -5268,7 +5264,6 @@ class BaseModel(metaclass=MetaModel):
         if to_create:
             records = self._load_records_create([data['values'] for data in to_create])
             for data, record in zip(to_create, records):
-                data['state'] = 'created'
                 data['record'] = record
                 if data.get('xml_id'):
                     # add XML ids for parent records that have just been created


### PR DESCRIPTION
the return value of _load_records is defined as

:return: the records corresponding to ``data_list``

which means the

len(_load_records(data_list, ..)) == len(data_list)

while in some corner cases it is not satisfied

=========================================================

This 1st commit is the first approach to fix the problem (check diff for the first commit)

since during `_load_records`, each `data` in `data_list` is modified with key 'records' (fixed: in some corner cases, data['records'] won't be assigned and may case KeyError when return). I think it is OK to add one more key 'state'/'modified' in the data as a hack to identify data for new created records.

I personaly think the name `ignore_duplicates` is quite confusing. My gut feeling is either during or after `_load_records` there will be duplicated records or xml_Ids and they are acceptable for sake of `ignore`. But I haven't found a better name.

=========================================================

The 2nd commit is the second approach to fix the problem (check diff for the whole PR)

This approach uses one extra query per model in `_load_data` for account
to filter out data for existing records before `_load_records` to avoid
modifying `base`.

NOTE: previously `ignore_duplicate` won't update existing records but can update
their xml_ids, not sure if it is a side-effect or designed feature.


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
