### PR TITLE
[IMP] website_sale: clarify product snippet filter

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -423,7 +423,7 @@ class Website(Home):
                 ['|', ('filter_id.model_id', '=', model_name), ('action_server_id.model_id.model', '=', model_name)]
             ])
         dynamic_filter = request.env['website.snippet.filter'].sudo().search_read(
-            domain, ['id', 'name', 'limit', 'model_name'], order='id asc'
+            domain, ['id', 'name', 'limit', 'model_name', 'help'], order='id asc'
         )
         return dynamic_filter
 

--- a/addons/website/models/website_snippet_filter.py
+++ b/addons/website/models/website_snippet_filter.py
@@ -24,6 +24,11 @@ class WebsiteSnippetFilter(models.Model):
     limit = fields.Integer(help='The limit is the maximum number of records retrieved', required=True)
     website_id = fields.Many2one('website', string='Website', ondelete='cascade')
     model_name = fields.Char(string='Model name', compute='_compute_model_name')
+    help = fields.Text(
+        string="Description",
+        help="Optional help text describing the filter usage and/or purpose.",
+        translate=True,
+    )
 
     @api.depends('filter_id', 'action_server_id')
     def _compute_model_name(self):

--- a/addons/website/static/src/snippets/s_dynamic_snippet/options.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/options.js
@@ -241,6 +241,9 @@ const dynamicSnippetOptions = options.Class.extend({
             } else {
                 button.innerText = data[id].name;
             }
+            if (data[id].help) {
+                button.title = data[id].help;
+            }
             selectUserValueWidgetElement.appendChild(button);
         }
     },

--- a/addons/website_sale/data/data.xml
+++ b/addons/website_sale/data/data.xml
@@ -87,7 +87,7 @@ response = DynamicFilter._get_products('latest_sold')
             </field>
         </record>
         <record id="dynamic_snippet_latest_viewed_products_action" model="ir.actions.server">
-            <field name="name">Recently Viewed Products</field>
+            <field name="name">Recently Viewed Products (per user)</field>
             <field name="model_id" ref="model_product_product"/>
             <field name="state">code</field>
             <field name="code">
@@ -142,7 +142,8 @@ response = DynamicFilter._get_products('alternative_products', product_template_
             <field name="action_server_id" ref="website_sale.dynamic_snippet_latest_viewed_products_action"/>
             <field name="field_names">display_name,description_sale,image_512</field>
             <field name="limit" eval="16"/>
-            <field name="name">Recently Viewed Products</field>
+            <field name="name">Recently Viewed Products (per user)</field>
+            <field name="help">The building block will remain empty until the user visits a product page.</field>
         </record>
         <record id="dynamic_filter_cross_selling_accessories" model="website.snippet.filter">
             <field name="action_server_id" ref="website_sale.dynamic_snippet_accessories_action"/>


### PR DESCRIPTION
The "Recently Viewed Products" filter was previously unclear, confusing users as it didn't distinguish between a "per user" and global basis. To address this, it's been renamed to "Recently Viewed Products (per user)" to clarify its functionality.

When using the "Recently Viewed Products (per user)" filter, users must remain on a product page for a few seconds before the product appears in the filter block. This could lead to confusion about how the block functions. To improve user comprehension, a tooltip is added to provide an explanation of the criteria for products to be shown in this filter block.


task-3916458

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
