### PR TITLE
[FIX] website_sale_stock: Don't cache user_email

### DIFF
--- a/addons/website_sale_stock/views/website_sale_stock_templates.xml
+++ b/addons/website_sale_stock/views/website_sale_stock_templates.xml
@@ -15,7 +15,7 @@
       <div class="availability_messages o_not_editable"/>
     </xpath>
       <xpath expr="//div[@id='product_details']" position="inside">
-          <input id="wsale_user_email" type="hidden" t-att-value="user_email"/>
+          <input id="wsale_user_email" type="hidden" t-att-value="user_email" t-nocache="user_email changes between users"/>
       </xpath>
   </template>
 


### PR DESCRIPTION
`#wsale_user_email` is used to prefill the email when the product is out of stock and the user wants to receive restock notifications. When different users access the same product, the email ends up being reused which is not desirable.

Task ID: [#4471810](https://www.odoo.com/odoo/my-tasks/4471810) (vdin)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
