### PR TITLE
[FIX] stock_picking_batch: Display UoM in Batch Transfer Report

### DIFF
--- a/addons/stock_picking_batch/report/report_picking_batch.xml
+++ b/addons/stock_picking_batch/report/report_picking_batch.xml
@@ -92,7 +92,7 @@
                                                     <span t-if="has_package or move_operation.state == 'done'"
                                                           t-esc="sum(move_operation.mapped('qty_done'))"/>
                                                     <span t-else="" t-esc="sum(move_operation.mapped('reserved_uom_qty'))"/>
-                                                    <span t-field="move_operation.uom_id" groups="move_operation.group_uom"/>
+                                                    <span t-field="move_operation.product_uom_id" groups="uom.group_uom"/>
                                                 </td>
                                                 <td>
                                                     <span t-esc="move_operation.picking_id.display_name"/>


### PR DESCRIPTION
Steps to Reproduce:

- Create a batch transfer.
- Print the batch transfer report.

Problem:
The unit of measure is not displayed next to the quantity.

Solution:
Access the unit of measure from group_uom in uom instead of move_operation.

OPW-4476534

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
