### PR TITLE
[FIX] rating: Remove extra border line on rating image

### DIFF
--- a/addons/rating/static/src/scss/rating_templates.scss
+++ b/addons/rating/static/src/scss/rating_templates.scss
@@ -11,6 +11,7 @@
     }
     .o_rating_label {
         opacity: 0.5;
+        border: none !important;
         &:hover {
             transform: scale(1.1);
         }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The o_rating_label css is not properly configured, which caused an unintended extra border line to appear on the rating image

This commit removes the border explicitly in the CSS file to correct the visual issue.

opw-4482430
Related Commit: https://github.com/odoo/odoo/commit/9e8a709f80e3e4620bfa92decb383781b04d64c8#diff-b7f943d7f11d281f92f78810d7da31d5ab33d4e5952d66ce973d0bc24278ebcd

Current behavior before PR:

![image](https://github.com/user-attachments/assets/4cf52f5f-b6e3-4d6d-bf04-db576804fd00)


Desired behavior after PR is merged:

The border will be invisible and everything else still functional without any influence


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
