### PR TITLE
[FIX] account: hide print button when move type is entry

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -725,7 +725,7 @@
                         <button name="action_print_pdf"
                                 type="object"
                                 class="oe_highlight"
-                                invisible="state != 'posted' or is_being_sent or invoice_pdf_report_id"
+                                invisible="state != 'posted' or is_being_sent or invoice_pdf_report_id or move_type == 'entry'"
                                 string="Print"/>
                         <button name="action_print_pdf"
                                 type="object"


### PR DESCRIPTION
This error occurs when `o.tax_totals` returns `False`, causing an AttributeError when accessed in the QWeb template.

Steps to Reproduce :

- Install the module `accountant.`
- Go to Reporting and open Tax Return.
- Open Closing Entry and Print.

`AttributeError: 'bool' object has no attribute 'get'`

The error occurs when printing the tax report for the first time. The system first attempts to display the document configuration popup for the user based on the account move. However, since `o.tax_totals is not available` in the tax report 
`(as it is a journal entry)`, and when the user`Configure Document Layout`, it raises a validation error.

At [1] we cannot print pdf when `move_type == entry` so it is better to hide `Print` button in this condition.

This error is resolved by hiding the `Print` button in the `Tax Return` `Journal Entries`, as it only contains journal items.

Link [1] : 

https://github.com/odoo/odoo/blob/63fc0d1cefaf8f59acd0743a225d1002425ff156/addons/account/models/ir_actions_report.py#L72

sentry-6115648026

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
