### PR TITLE
[IMP] l10n_vn_edi_viettel: Optional customer info

### DIFF
--- a/addons/l10n_vn_edi_viettel/wizard/account_move_send.py
+++ b/addons/l10n_vn_edi_viettel/wizard/account_move_send.py
@@ -51,7 +51,7 @@ class AccountMoveSend(models.TransientModel):
 
     def _l10n_vn_edi_needed(self, invoice):
         """ Return true if the invoice state is ready to send, and there are credentials setup on the company. """
-        return invoice.l10n_vn_edi_invoice_state == 'ready_to_send' and invoice._l10n_vn_edi_get_credentials_company()
+        return bool(invoice.l10n_vn_edi_invoice_state == 'ready_to_send' and invoice._l10n_vn_edi_get_credentials_company())
 
     # -------------------------------------------------------------------------
     # ATTACHMENTS


### PR DESCRIPTION
When sending an invoice to Viettel, we currently
raise an error in Odoo if the address information
of the customer is not set.
If the VAT is not set, it is the api raising an
error.

In both case, the information is optional, and
we should be able to invoice.
For the address information the validation in
Odoo is removed, and for the VAT the json will
now contain '' if it is not set instead of False

Also make sure that the json file is attached
to the chatter if it has been generated for audit
purpose

task-4405507

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
