### PR TITLE
[FIX] mrp: fix traceback when clicking overview of a MO

### DIFF
--- a/addons/mrp/report/mrp_report_mo_overview.py
+++ b/addons/mrp/report/mrp_report_mo_overview.py
@@ -606,7 +606,7 @@ class ReportMrpReport_Mo_Overview(models.AbstractModel):
             return self._format_receipt_date('available')
 
         replenishments_with_date = list(filter(lambda r: r.get('summary', {}).get('receipt', {}).get('date'), replenishments))
-        max_date = max([get(rep, 'date', True) for rep in replenishments_with_date], default=fields.Date.today())
+        max_date = max([get(rep, 'date', True) for rep in replenishments_with_date], default=fields.Datetime.today())
         if has_to_order_line or any(get(rep, 'type', True) == 'estimated' for rep in replenishments):
             return self._format_receipt_date('estimated', max_date)
         else:


### PR DESCRIPTION
Currently, a traceback appears when the user opens 'Overview' of a canceled 'Manufacturing Order'.

To reproduce this issue:

1) Install MRP
2) Create a new Manufacturing Order record
3) Give a `product` with a `Quantity` more than the `On hand` quantity of that product 
4) Add a product in the Component with the `To consume` value more than
   the On Hand quantity of that product
5) Click on the `Cancel` button then Click the `Overview` button

Error:-
```
TypeError: can't compare datetime.datetime to datetime.date
```

This error is occurring because of the recent changes from the below.

https://github.com/odoo/odoo/pull/184928/files#diff-a889e57d7462d595b2a3e056dc37237c9ab73d43c42458b52288733ae84aca73L609-R609

Initially, it was `datetime.datetime`, But recently it was changed to the `datetime.date`.
This leads to the above traceback when a comparison is made between 
`datetime.datetime` and `datetime.date` from the below lines

https://github.com/odoo/odoo/blob/cb96e9133590e07880f0e98b21486d578caecd3a/addons/mrp/report/mrp_report_mo_overview.py#L583

sentry-6250719075

