### PR TITLE
[IMP] base,web: calendar add multi_create in month view

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -203,8 +203,9 @@ export class Record extends DataPoint {
         });
     }
 
-    getChanges({ withReadonly } = {}) {
-        return this._getChanges(this._changes, { withReadonly });
+    async getChanges({ withReadonly } = {}) {
+        await this.model._askChanges();
+        return this.model.mutex.exec(() => this._getChanges(this._changes, { withReadonly }));
     }
 
     async isDirty() {

--- a/addons/web/static/src/views/calendar/calendar_arch_parser.js
+++ b/addons/web/static/src/views/calendar/calendar_arch_parser.js
@@ -17,14 +17,14 @@ const SCALES = ["day", "week", "month", "year"];
 export class CalendarParseArchError extends Error {}
 
 export class CalendarArchParser {
-    parse(arch, models, modelName) {
+    parse(xmlDoc, models, modelName) {
         const fields = models[modelName].fields;
         const fieldNames = new Set(fields.display_name ? ["display_name"] : []);
         const fieldMapping = { date_start: "date_start" };
         let jsClass = null;
         let eventLimit = 5;
         let scales = [...SCALES];
-        const sessionScale = browser.sessionStorage.getItem("calendar-scale");
+        const sessionScale = browser.sessionStorage.getItem("calendar-scale"); // FIXME: move
         let scale = sessionScale || "week";
         let canCreate = true;
         let canDelete = true;
@@ -32,6 +32,7 @@ export class CalendarArchParser {
         let aggregate;
         let quickCreate = true;
         let quickCreateViewId = null;
+        const multiCreateView = xmlDoc.getAttribute("multi_create_view");
         let hasEditDialog = false;
         let showUnusualDays = false;
         let isDateHidden = false;
@@ -42,7 +43,7 @@ export class CalendarArchParser {
         const popoverFieldNodes = {};
         const filtersInfo = {};
 
-        visitXML(arch, (node) => {
+        visitXML(xmlDoc, (node) => {
             switch (node.tagName) {
                 case "calendar": {
                     if (!node.hasAttribute("date_start")) {
@@ -196,6 +197,7 @@ export class CalendarArchParser {
             filtersInfo,
             formViewId,
             hasEditDialog,
+            multiCreateView,
             quickCreate,
             quickCreateViewId,
             isDateHidden,

--- a/addons/web/static/src/views/calendar/calendar_arch_parser.js
+++ b/addons/web/static/src/views/calendar/calendar_arch_parser.js
@@ -9,7 +9,6 @@ const FIELD_ATTRIBUTE_NAMES = [
     "date_delay",
     "date_stop",
     "all_day",
-    "recurrence_update",
     "create_name_field",
     "color",
 ];
@@ -30,6 +29,7 @@ export class CalendarArchParser {
         let canCreate = true;
         let canDelete = true;
         let canEdit = true;
+        let aggregate;
         let quickCreate = true;
         let quickCreateViewId = null;
         let hasEditDialog = false;
@@ -59,6 +59,10 @@ export class CalendarArchParser {
                             fieldNames.add(fieldName);
                             fieldMapping[fieldAttrName] = fieldName;
                         }
+                    }
+                    if (node.hasAttribute("aggregate")) {
+                        aggregate = node.getAttribute("aggregate");
+                        fieldNames.add(aggregate.split(":")[0]);
                     }
 
                     if (node.hasAttribute("event_limit")) {
@@ -182,6 +186,7 @@ export class CalendarArchParser {
         });
 
         return {
+            aggregate,
             canCreate,
             canDelete,
             canEdit,

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -9,6 +9,8 @@ import { makeWeekColumn } from "./calendar_common_week_column";
 
 import { Component } from "@odoo/owl";
 import { useBus } from "@web/core/utils/hooks";
+import { useSquareSelection } from "@web/views/calendar/square_selection_hook";
+import { CALENDAR_MODES } from "@web/views/calendar/calendar_modes";
 
 const SCALE_TO_FC_VIEW = {
     day: "timeGridDay",
@@ -56,15 +58,25 @@ export class CalendarCommonRenderer extends Component {
         editRecord: Function,
         deleteRecord: Function,
         setDate: { type: Function, optional: true },
+        calendarMode: { type: String, optional: true },
+        multiCreateRecord: { type: Function, optional: true },
+        multiDeleteRecords: { type: Function, optional: true },
+    };
+
+    static defaultProps = {
+        calendarMode: CALENDAR_MODES.filter,
     };
 
     setup() {
         this.fc = useFullCalendar("fullCalendar", this.options);
         this.click = useClickHandler(this.onClick, this.onDblClick);
         this.popover = useCalendarPopover(this.constructor.components.Popover);
+
         useBus(this.props.model.bus, "SCROLL_TO_CURRENT_HOUR", () =>
             this.fc.api.scrollToTime(`${luxon.DateTime.local().hour - 2}:00:00`)
         );
+
+        useSquareSelection();
     }
 
     get options() {

--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -8,10 +8,10 @@ import { Layout } from "@web/search/layout";
 import { useModelWithSampleData } from "@web/model/model";
 import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
 import { useSetupAction } from "@web/search/action_hook";
-import { DateTimePicker } from "@web/core/datetime/datetime_picker";
-import { CalendarFilterPanel } from "./filter_panel/calendar_filter_panel";
 import { CalendarMobileFilterPanel } from "./mobile_filter_panel/calendar_mobile_filter_panel";
 import { CalendarQuickCreate } from "./quick_create/calendar_quick_create";
+import { CalendarSidePanel } from "@web/views/calendar/calendar_side_panel/calendar_side_panel";
+import { CALENDAR_MODES } from "@web/views/calendar/calendar_modes";
 import { SearchBar } from "@web/search/search_bar/search_bar";
 import { useSearchBarToggler } from "@web/search/search_bar/search_bar_toggler";
 import { ViewScaleSelector } from "@web/views/view_components/view_scale_selector";
@@ -44,8 +44,6 @@ function useUniqueDialog() {
 
 export class CalendarController extends Component {
     static components = {
-        DatePicker: DateTimePicker,
-        FilterPanel: CalendarFilterPanel,
         MobileFilterPanel: CalendarMobileFilterPanel,
         QuickCreate: CalendarQuickCreate,
         QuickCreateFormView: FormViewDialog,
@@ -53,6 +51,7 @@ export class CalendarController extends Component {
         SearchBar,
         ViewScaleSelector,
         CogMenu,
+        CalendarSidePanel,
     };
     static template = "web.CalendarController";
     static props = {
@@ -97,6 +96,7 @@ export class CalendarController extends Component {
             showSideBar:
                 !this.env.isSmall &&
                 Boolean(sessionShowSidebar != null ? JSON.parse(sessionShowSidebar) : true),
+            mode: this.model.hasMultiCreate ? CALENDAR_MODES.add : CALENDAR_MODES.filter,
         });
 
         this.searchBarToggler = useSearchBarToggler();
@@ -106,6 +106,8 @@ export class CalendarController extends Component {
             deleteRecord: this.deleteRecord.bind(this),
             editRecord: this.editRecord.bind(this),
             setDate: this.setDate.bind(this),
+            multiCreateRecord: this.multiCreateRecord.bind(this),
+            multiDeleteRecords: this.multiDeleteRecords.bind(this),
         };
     }
 
@@ -175,57 +177,29 @@ export class CalendarController extends Component {
             ...this._baseRendererProps,
             model: this.model,
             isWeekendVisible: this.model.scale === "day" || this.state.isWeekendVisible,
+            calendarMode: this.state.mode,
         };
     }
-    get containerProps() {
-        return {
-            model: this.model,
-        };
-    }
-    get datePickerProps() {
-        return {
-            type: "date",
-            showWeekNumbers: false,
-            maxPrecision: "days",
-            daysOfWeekFormat: "narrow",
-            onSelect: (date) => {
-                let scale = "week";
 
-                if (this.model.date.hasSame(date, "day")) {
-                    const scales = ["month", "week", "day"];
-                    scale = scales[(scales.indexOf(this.model.scale) + 1) % scales.length];
-                } else {
-                    // Check if dates are on the same week
-                    // As a.hasSame(b, "week") does not depend on locale and week always starts on Monday,
-                    // we are comparing derivated dates instead to take this into account.
-                    const currentDate =
-                        this.model.date.weekday === 7
-                            ? this.model.date.plus({ day: 1 })
-                            : this.model.date;
-                    const pickedDate = date.weekday === 7 ? date.plus({ day: 1 }) : date;
-
-                    // a.hasSame(b, "week") does not depend on locale and week alway starts on Monday
-                    if (currentDate.hasSame(pickedDate, "week")) {
-                        scale = "day";
-                    }
-                }
-
-                this.model.load({ scale, date });
-            },
-            value: this.model.date,
-        };
-    }
-    get filterPanelProps() {
-        return {
-            model: this.model,
-        };
-    }
     get mobileFilterPanelProps() {
         return {
             model: this.model,
             sideBarShown: this.state.showSideBar,
             toggleSideBar: () => {
                 this.state.showSideBar = !this.state.showSideBar;
+            },
+        };
+    }
+
+    get sidePanelProps() {
+        return {
+            model: this.model,
+            context: this.props.context,
+            mode: this.state.mode,
+            setMode: (mode) => {
+                if (Object.values(CALENDAR_MODES).includes(mode)) {
+                    this.state.mode = mode;
+                }
             },
         };
     }
@@ -239,12 +213,8 @@ export class CalendarController extends Component {
         return !this.env.isSmall || !this.state.showSideBar;
     }
 
-    get showDatePicker() {
-        return this.model.showDatePicker && !this.env.isSmall;
-    }
-
     get hasSideBar() {
-        return this.showDatePicker || this.model.filterSections.length > 0;
+        return this.model.showDatePicker || this.model.filterSections.length > 0;
     }
 
     get showSideBar() {
@@ -411,5 +381,14 @@ export class CalendarController extends Component {
     toggleWeekendVisibility() {
         this.state.isWeekendVisible = !this.state.isWeekendVisible;
         browser.localStorage.setItem("calendar.isWeekendVisible", this.state.isWeekendVisible);
+    }
+
+    async multiCreateRecord(dates) {
+        const values = await this.model.data.multiCreateRecord.getChanges();
+        await this.model.multiCreateRecords(dates, values);
+    }
+
+    async multiDeleteRecords(ids) {
+        await this.model.unlinkRecords(ids);
     }
 }

--- a/addons/web/static/src/views/calendar/calendar_controller.xml
+++ b/addons/web/static/src/views/calendar/calendar_controller.xml
@@ -55,18 +55,13 @@
                             </t>
                         </h5>
                     </div>
-                    <div t-if="hasSideBar" class="o_sidebar_toggler d-none d-md-flex d-print-none align-items-center border-bottom pe-3">
+                    <div t-if="hasSideBar and !model.hasMultiCreate and !env.isSmall" class="o_sidebar_toggler d-flex d-print-none align-items-center border-bottom pe-3">
                         <button class="btn btn-light oi oi-panel-right collapsed ms-2 lh-base" t-on-click="toggleSideBar"/>
                     </div>
-                    <MobileFilterPanel t-if="env.isSmall and hasSideBar" t-props="mobileFilterPanelProps" />
+                    <MobileFilterPanel t-if="env.isSmall and (hasSideBar or model.hasMultiCreate)" t-props="mobileFilterPanelProps" />
                     <div class="o_calendar_wrapper d-flex overflow-hidden">
                         <t t-if="showCalendar" t-component="props.Renderer" t-props="rendererProps"/>
-                        <div t-if="hasSideBar and showSideBar" class="o_calendar_sidebar_container d-print-none position-relative w-100 w-md-auto bg-view overflow-x-hidden overflow-y-auto">
-                            <div class="o_calendar_sidebar">
-                                <DatePicker t-if="showDatePicker" t-props="datePickerProps" />
-                                <FilterPanel t-props="filterPanelProps" />
-                            </div>
-                        </div>
+                        <CalendarSidePanel t-if="(hasSideBar or model.hasMultiCreate) and showSideBar" t-props="sidePanelProps"/>
                     </div>
                 </div>
             </Layout>
@@ -74,5 +69,4 @@
     </t>
 
     <t t-name="web.CalendarController.controlButtons"/>
-
 </templates>

--- a/addons/web/static/src/views/calendar/calendar_modes.js
+++ b/addons/web/static/src/views/calendar/calendar_modes.js
@@ -1,0 +1,5 @@
+export const CALENDAR_MODES = {
+    filter: "FILTER",
+    add: "ADD",
+    delete: "DELETE",
+};

--- a/addons/web/static/src/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_renderer.js
@@ -20,6 +20,9 @@ export class CalendarRenderer extends Component {
         editRecord: Function,
         deleteRecord: Function,
         setDate: Function,
+        calendarMode: String,
+        multiCreateRecord: Function,
+        multiDeleteRecords: Function,
     };
     get calendarComponent() {
         return this.constructor.components[this.props.model.scale];

--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -729,3 +729,10 @@
         }
     }
 }
+
+.fc-day.o-highlight {
+    background-color: var(--fc-highlight-color) !important;
+    &.fc-day-disabled {
+        background-image: repeating-linear-gradient(-45deg, transparent, var(--fc-neutral-bg-color) 25px, transparent 50px);
+    }
+}

--- a/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.js
+++ b/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.js
@@ -1,0 +1,113 @@
+import { Component, onWillStart, useState } from "@odoo/owl";
+import { FormRenderer } from "@web/views/form/form_renderer";
+import { DateTimePicker } from "@web/core/datetime/datetime_picker";
+import { CalendarFilterPanel } from "@web/views/calendar/filter_panel/calendar_filter_panel";
+import { Record } from "@web/model/record";
+import { useService } from "@web/core/utils/hooks";
+import { FormArchParser } from "@web/views/form/form_arch_parser";
+import { parseXML } from "@web/core/utils/xml";
+import { extractFieldsFromArchInfo } from "@web/model/relational_model/utils";
+import { CALENDAR_MODES } from "@web/views/calendar/calendar_modes";
+
+export class CalendarSidePanel extends Component {
+    static components = {
+        FormRenderer,
+        DatePicker: DateTimePicker,
+        FilterPanel: CalendarFilterPanel,
+        Record,
+    };
+    static template = "web.CalendarSidePanel";
+    static props = ["model", "mode", "setMode", "context?"];
+    static defaultProps = {
+        context: {},
+    };
+
+    setup() {
+        this.viewService = useService("view");
+
+        this.CALENDAR_MODES = CALENDAR_MODES;
+        this.state = useState({
+            isReady: !this.props.model.hasMultiCreate,
+        });
+
+        if (this.props.model.hasMultiCreate) {
+            onWillStart(() => {
+                this.loadMultiCreateView().then(() => {
+                    this.state.isReady = true;
+                });
+            });
+        }
+    }
+
+    get datePickerProps() {
+        return {
+            type: "date",
+            showWeekNumbers: false,
+            maxPrecision: "days",
+            daysOfWeekFormat: "narrow",
+            onSelect: (date) => {
+                let scale = "week";
+
+                if (this.props.model.date.hasSame(date, "day")) {
+                    const scales = ["month", "week", "day"];
+                    scale = scales[(scales.indexOf(this.props.model.scale) + 1) % scales.length];
+                } else {
+                    // Check if dates are on the same week
+                    // As a.hasSame(b, "week") does not depend on locale and week always starts on Monday,
+                    // we are comparing derivated dates instead to take this into account.
+                    const currentDate =
+                        this.props.model.date.weekday === 7
+                            ? this.props.model.date.plus({ day: 1 })
+                            : this.props.model.date;
+                    const pickedDate = date.weekday === 7 ? date.plus({ day: 1 }) : date;
+
+                    // a.hasSame(b, "week") does not depend on locale and week alway starts on Monday
+                    if (currentDate.hasSame(pickedDate, "week")) {
+                        scale = "day";
+                    }
+                }
+
+                this.props.model.load({ scale, date });
+            },
+            value: this.props.model.date,
+        };
+    }
+    get filterPanelProps() {
+        return {
+            model: this.props.model,
+        };
+    }
+
+    get showDatePicker() {
+        return this.props.model.showDatePicker && !this.env.isSmall;
+    }
+
+    async loadMultiCreateView() {
+        const { fields, relatedModels, views } = await this.viewService.loadViews({
+            context: {
+                ...this.props.context,
+                form_view_ref: this.props.model.meta.multiCreateView,
+            },
+            resModel: this.props.model.resModel,
+            views: [[false, "form"]],
+        });
+        const parser = new FormArchParser();
+        const arch = views.form.arch;
+        const resModel = this.props.model.resModel;
+        this.multiCreateArchInfo = parser.parse(parseXML(arch), relatedModels, resModel);
+        const { activeFields } = extractFieldsFromArchInfo(this.multiCreateArchInfo, fields);
+        this.multiCreateRecordProps = {
+            resModel,
+            fields,
+            activeFields,
+            context: this.props.context,
+            hooks: {
+                onRootLoaded: this.onMultiCreateRootLoaded.bind(this),
+            },
+        };
+    }
+
+    onMultiCreateRootLoaded(record) {
+        this.props.model.data.multiCreateRecord = record;
+    }
+}

--- a/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
+++ b/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="web.CalendarSidePanel">
+        <div class="o_calendar_sidebar_container d-print-none position-relative w-100 w-md-auto bg-view overflow-x-hidden overflow-y-auto">
+            <div class="o_calendar_sidebar">
+                <div t-if="props.model.hasMultiCreate" class="d-flex flex-column gap-1">
+                    <div class="btn-group">
+                        <button class="btn btn-secondary" t-att-class="{'active': props.mode === CALENDAR_MODES.filter}" data-tooltip="Filter"  t-on-click.stop="() => this.props.setMode(CALENDAR_MODES.filter)"><i class="fa fa-filter"/></button>
+                        <button class="btn btn-secondary" t-att-class="{'active': props.mode === CALENDAR_MODES.add}" data-tooltip="New" t-on-click="() => this.props.setMode(CALENDAR_MODES.add)"><i class="fa fa-plus"/></button>
+                        <button class="btn btn-secondary" t-att-class="{'active': props.mode === CALENDAR_MODES.delete}" data-tooltip="Clicking on a day or selecting an area will irrevocably delete its content" t-on-click="() => this.props.setMode(CALENDAR_MODES.delete)">
+                            <i class="fa fa-trash" t-att-class="{'text-danger': props.mode === CALENDAR_MODES.delete}"/>
+                        </button>
+                    </div>
+                    <div t-if="state.isReady and props.mode === CALENDAR_MODES.add" class="o_form_view o_xxs_form_view mt-2">
+                        <Record t-props="multiCreateRecordProps" t-slot-scope="data">
+                            <FormRenderer record="data.record" archInfo="multiCreateArchInfo" class="'p-0'"/>
+                        </Record>
+                    </div>
+                </div>
+                <DatePicker t-if="props.mode === CALENDAR_MODES.filter and showDatePicker" t-props="datePickerProps" />
+                <FilterPanel t-props="filterPanelProps" />
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/web/static/src/views/calendar/calendar_year/calendar_year_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_year/calendar_year_renderer.js
@@ -21,6 +21,9 @@ export class CalendarYearRenderer extends Component {
         editRecord: Function,
         deleteRecord: Function,
         setDate: { type: Function, optional: true },
+        calendarMode: { type: String, optional: true },
+        multiCreateRecord: { type: Function, optional: true },
+        multiDeleteRecords: { type: Function, optional: true },
     };
 
     setup() {

--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
@@ -5,7 +5,7 @@
         <t t-foreach="props.model.filterSections" t-as="section" t-key="section.fieldName">
             <t t-if="section.filters.length gt 0 or section.canAddFilter">
                 <div
-                    class="o_calendar_filter d-flex flex-column gap-1 mt-4 mb-2"
+                    class="o_calendar_filter d-flex flex-column gap-1 mt-3 mb-2"
                     t-att-data-name="section.fieldName"
                 >
                     <t t-if="section.label">

--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
@@ -87,6 +87,7 @@
                     class="o_cw_filter_title flex-grow-1 text-truncate lh-base"
                     t-esc="filter.label"
                 />
+                <span t-if="filter.aggregatedValue" t-esc="filter.aggregatedValue"/>
             </label>
             <t t-if="filter.canRemove">
                 <button

--- a/addons/web/static/src/views/calendar/square_selection_hook.js
+++ b/addons/web/static/src/views/calendar/square_selection_hook.js
@@ -1,0 +1,152 @@
+import { useComponent, useEffect, useRef } from "@odoo/owl";
+import { CALENDAR_MODES } from "@web/views/calendar/calendar_modes";
+
+/**
+ * Add a square selection into FullCalendar
+ */
+export function useSquareSelection() {
+    const component = useComponent();
+    const calendarRef = useRef("fullCalendar");
+    const state = {};
+
+    useEffect(
+        (el, mode) => {
+            if (mode !== CALENDAR_MODES.filter) {
+                component.fc.api.setOption("editable", false);
+                component.fc.api.setOption("selectable", false);
+                component.fc.api.setOption("dateClick", () => {});
+            } else {
+                const options = component.options;
+                component.fc.api.setOption("editable", options.editable);
+                component.fc.api.setOption("selectable", options.selectable);
+                component.fc.api.setOption("dateClick", options.dateClick.bind(component));
+            }
+
+            clearState();
+
+            if (mode !== CALENDAR_MODES.filter) {
+                window.addEventListener("pointerdown", pointerDown);
+                window.addEventListener("pointermove", pointerMove);
+                window.addEventListener("pointerup", pointerUp);
+                window.addEventListener("pointercancel", pointerCancel);
+                return () => {
+                    window.removeEventListener("pointerdown", pointerDown);
+                    window.removeEventListener("pointermove", pointerMove);
+                    window.removeEventListener("pointerup", pointerUp);
+                    window.removeEventListener("pointercancel", pointerCancel);
+                };
+            }
+        },
+        () => [calendarRef.el, component.props.calendarMode]
+    );
+
+    function getElementIndex(element) {
+        return [].indexOf.call(element?.parentNode.children || [], element);
+    }
+
+    function clearState() {
+        state.startCol = -1;
+        state.endCol = -1;
+        state.startRow = -1;
+        state.endRow = -1;
+
+        state.currentSelectionElement = [];
+    }
+
+    function getSelectedElement() {
+        const elementsToSelect = [];
+        const [startX, endX] = [state.startCol, state.endCol].sort();
+        const [startY, endY] = [state.startRow, state.endRow].sort();
+
+        for (let x = startX; x <= endX; x++) {
+            for (let y = startY; y <= endY; y++) {
+                elementsToSelect.push(
+                    `tbody tr[role="row"]:nth-child(${y + 1}) > .fc-day:nth-child(${x + 1})`
+                );
+            }
+        }
+
+        if (elementsToSelect.length) {
+            return calendarRef.el.querySelectorAll(elementsToSelect.join(","));
+        } else {
+            return [];
+        }
+    }
+
+    function drawHighlight() {
+        const highlight = "o-highlight";
+
+        calendarRef.el.querySelectorAll(`.${highlight}`).forEach((node) => {
+            node.classList.remove(highlight);
+        });
+
+        state.currentSelectionElement.forEach((node) => {
+            node.classList.add(highlight);
+        });
+    }
+
+    function pointerDown(ev) {
+        if (ev.target.closest(".fc-event")) {
+            return;
+        }
+        const targetElement = ev.target.closest(".fc-day:not(.fc-col-header-cell)");
+        if (!targetElement) {
+            return;
+        }
+        const rowSelector = 'tr[role="row"]';
+        state.startCol = state.endCol = getElementIndex(targetElement);
+        state.startRow = state.endRow = getElementIndex(targetElement.closest(rowSelector));
+        state.currentSelectionElement = [targetElement];
+        drawHighlight();
+    }
+
+    function pointerMove(ev) {
+        const targetElement = ev.target.closest(".fc-day:not(.fc-col-header-cell)");
+        if (!targetElement || state.startCol < 0 || state.startRow < 0) {
+            return;
+        }
+        const rowSelector = 'tr[role="row"]';
+        state.endCol = getElementIndex(targetElement);
+        state.endRow = getElementIndex(targetElement.closest(rowSelector));
+        state.currentSelectionElement = getSelectedElement();
+        drawHighlight();
+    }
+
+    async function pointerUp(ev) {
+        const targetElement = ev.target.closest(".fc-day:not(.fc-col-header-cell)");
+        if (!targetElement) {
+            clearState();
+            drawHighlight();
+            return;
+        }
+        await onSquareSelection(state.currentSelectionElement);
+        clearState();
+        drawHighlight();
+    }
+
+    function pointerCancel(ev) {
+        clearState();
+        drawHighlight();
+    }
+
+    async function onSquareSelection(currentSelectionElement) {
+        if (component.props.calendarMode === CALENDAR_MODES.add) {
+            const dates = [];
+            for (const element of currentSelectionElement) {
+                const date = luxon.DateTime.fromISO(element.dataset.date);
+                if (!date.invalid) {
+                    dates.push(date);
+                }
+            }
+            await component.props.multiCreateRecord(dates);
+        } else if (component.props.calendarMode === CALENDAR_MODES.delete) {
+            const ids = [];
+            for (const element of currentSelectionElement) {
+                for (const event of [...element.querySelectorAll(".fc-event")]) {
+                    ids.push(parseInt(event.dataset.eventId, 10));
+                }
+            }
+            await component.props.multiDeleteRecords(ids);
+        }
+    }
+}

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -11,12 +11,15 @@ import { useSortable } from "@web/core/utils/sortable_owl";
 import { getTabableElements } from "@web/core/utils/ui";
 import { Field, getPropertyFieldInfo } from "@web/views/fields/field";
 import { getTooltipInfo } from "@web/views/fields/field_tooltip";
-import { getClassNameFromDecoration } from "@web/views/utils";
+import {
+    computeAggregatedValue,
+    getClassNameFromDecoration,
+    getFormattedValue,
+} from "@web/views/utils";
 import { combineModifiers } from "@web/model/relational_model/utils";
 import { ViewButton } from "@web/views/view_button/view_button";
 import { useBounceButton } from "@web/views/view_hook";
 import { Widget } from "@web/views/widgets/widget";
-import { getFormattedValue } from "../utils";
 import { localization } from "@web/core/l10n/localization";
 import { useMagicColumnWidths } from "./column_width_hook";
 
@@ -614,18 +617,7 @@ export class ListRenderer extends Component {
                 }
             }
             if (func) {
-                let aggregateValue = 0;
-                if (func === "max") {
-                    aggregateValue = Math.max(-Infinity, ...fieldValues);
-                } else if (func === "min") {
-                    aggregateValue = Math.min(Infinity, ...fieldValues);
-                } else if (func === "avg") {
-                    aggregateValue =
-                        fieldValues.reduce((acc, val) => acc + val) / fieldValues.length;
-                } else if (func === "sum") {
-                    aggregateValue = fieldValues.reduce((acc, val) => acc + val);
-                }
-
+                const aggregatedValue = computeAggregatedValue(fieldValues, func);
                 const formatter = formatters.get(widget, false) || formatters.get(type, false);
                 const formatOptions = {
                     digits: attrs.digits ? JSON.parse(attrs.digits) : undefined,
@@ -636,7 +628,7 @@ export class ListRenderer extends Component {
                 }
                 aggregates[fieldName] = {
                     help: attrs[func],
-                    value: formatter ? formatter(aggregateValue, formatOptions) : aggregateValue,
+                    value: formatter ? formatter(aggregatedValue, formatOptions) : aggregatedValue,
                 };
             }
         }

--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -1,5 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { unique } from "@web/core/utils/arrays";
 import { exprToBoolean } from "@web/core/utils/strings";
 import { combineModifiers } from "@web/model/relational_model/utils";
 
@@ -294,4 +295,30 @@ export function uuid() {
     window.crypto.getRandomValues(array);
     // Uint8Array to hex
     return [...array].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Given an array of values and an aggregator function, returns the aggregated
+ * value.
+ *
+ * @param {number[]} values
+ * @param {'sum'|'avg'|'min'|'max'|'count'|'count_distinct'} aggregator
+ * @returns number
+ * @throws {Error} if the aggregator function given isn't supported
+ */
+export function computeAggregatedValue(values, aggregator) {
+    if (aggregator === "sum") {
+        return values.reduce((acc, v) => v + acc, 0);
+    } else if (aggregator === "avg") {
+        return values.reduce((acc, v) => v + acc, 0) / values.length;
+    } else if (aggregator === "min") {
+        return Math.min(Infinity, ...values);
+    } else if (aggregator === "max") {
+        return Math.max(-Infinity, ...values);
+    } else if (aggregator === "count") {
+        return values.length;
+    } else if (aggregator === "count_distinct") {
+        return unique(values).length;
+    }
+    throw new Error(`Invalid aggregator '${aggregator}'`);
 }

--- a/addons/web/static/tests/model/record.test.js
+++ b/addons/web/static/tests/model/record.test.js
@@ -289,8 +289,8 @@ test(`can access record changes`, async () => {
             </Record>
         `;
 
-        doSomething(record) {
-            expect.step(`do something with ${JSON.stringify(record.getChanges())}`);
+        async doSomething(record) {
+            expect.step(`do something with ${JSON.stringify(await record.getChanges())}`);
         }
     }
 
@@ -521,7 +521,7 @@ test(`supports passing dynamic values -- full control to the user of Record`, as
             });
             this.hooks = {
                 onRecordChanged: this.onRecordChanged.bind(this),
-            }
+            };
         }
 
         onRecordChanged(record, changes) {

--- a/addons/web/static/tests/views/calendar/calendar_arch_parser.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_arch_parser.test.js
@@ -7,6 +7,7 @@ describe.current.tags("headless");
 
 const parser = new CalendarArchParser();
 const DEFAULT_ARCH_RESULTS = {
+    aggregate: undefined,
     canCreate: true,
     canDelete: true,
     canEdit: true,

--- a/addons/web/static/tests/views/calendar/calendar_arch_parser.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_arch_parser.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { FAKE_FIELDS } from "./calendar_test_helpers";
 
+import { parseXML } from "@web/core/utils/xml";
 import { CalendarArchParser } from "@web/views/calendar/calendar_arch_parser";
 
 describe.current.tags("headless");
@@ -24,6 +25,7 @@ const DEFAULT_ARCH_RESULTS = {
     isDateHidden: false,
     isTimeHidden: false,
     monthOverflow: true,
+    multiCreateView: null,
     popoverFieldNodes: {},
     scale: "week",
     scales: ["day", "week", "month", "year"],
@@ -32,7 +34,7 @@ const DEFAULT_ARCH_RESULTS = {
 };
 
 function parseArch(arch) {
-    return parser.parse(arch, { fake: { fields: FAKE_FIELDS } }, "fake");
+    return parser.parse(parseXML(arch), { fake: { fields: FAKE_FIELDS } }, "fake");
 }
 
 function parseWith(attrs) {

--- a/addons/web/static/tests/views/calendar/calendar_multi_create.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_multi_create.test.js
@@ -1,0 +1,316 @@
+import { beforeEach, expect, test } from "@odoo/hoot";
+import { click, edit } from "@odoo/hoot-dom";
+import { advanceTime, animationFrame, mockTimeZone, runAllTimers } from "@odoo/hoot-mock";
+import {
+    contains,
+    defineModels,
+    fields,
+    models,
+    mountView,
+    onRpc,
+    preloadBundle,
+    serverState,
+} from "@web/../tests/web_test_helpers";
+
+import { CalendarModel } from "@web/views/calendar/calendar_model";
+
+class Event extends models.Model {
+    name = fields.Char();
+    date_start = fields.Date();
+    type = fields.Many2one({ relation: "event.type" });
+    user_id = fields.Many2one({ relation: "calendar.user" });
+
+    // FIXME: needed for the filter to work
+    filter_user_id = fields.Many2one({ relation: "calendar.user" });
+
+    _records = [
+        {
+            id: 1,
+            name: "event 1",
+            date_start: "2019-02-11",
+            type: 1,
+            user_id: 1,
+        },
+        {
+            id: 2,
+            name: "event 2",
+            date_start: "2019-03-12",
+            type: 1,
+            user_id: 1,
+        },
+        {
+            id: 3,
+            name: "event 3",
+            date_start: "2019-03-12",
+            type: 1,
+            user_id: 1,
+        },
+        {
+            id: 4,
+            name: "event 4",
+            date_start: "2019-03-14",
+            type: 1,
+            user_id: 2,
+        },
+        {
+            id: 5,
+            name: "event 5",
+            date_start: "2019-03-13",
+            type: 1,
+            user_id: 3,
+        },
+        {
+            id: 6,
+            name: "event 6",
+            date_start: "2019-03-18",
+            type: 1,
+            user_id: 3,
+        },
+        {
+            id: 7,
+            name: "event 7",
+            date_start: "2019-04-14",
+            type: 1,
+            user_id: 1,
+        },
+    ];
+
+    _views = {
+        calendar: `
+            <calendar date_start="date_start" scales="month" multi_create_view="multi_create_form" aggregate="id:count">
+                <!-- Popover -->
+                <field name="name"/>
+                <field name="type"/>
+                
+                <!-- Filter -->
+                <field name="user_id" write_model="filter.user" write_field="filter_user_id" filter_field="is_checked"/>
+            
+                <!-- For filter to work -->
+                <field name="date_start" invisible="1"/>
+                <field name="filter_user_id" invisible="1"/>
+            </calendar>
+        `,
+        "form,multi_create_form": `
+            <form>
+                <group>
+                    <field name="name"/>
+                    <field name="type"/>
+                </group>
+            </form>
+        `,
+    };
+}
+
+class EventType extends models.Model {
+    name = fields.Char();
+
+    _records = [
+        { id: 1, name: "Event Type 1" },
+        { id: 2, name: "Event Type 2" },
+        { id: 3, name: "Event Type 3" },
+    ];
+}
+
+class CalendarUser extends models.Model {
+    name = fields.Char();
+
+    _records = [
+        { id: 1, name: "user 1" },
+        { id: 2, name: "user 2" },
+        { id: 3, name: "user 3" },
+        { id: 7, name: "user 7" },
+    ];
+}
+
+class FilterUser extends models.Model {
+    filter_user_id = fields.Many2one({ relation: "calendar.user" });
+    user_id = fields.Many2one({ relation: "calendar.user" });
+    is_checked = fields.Boolean();
+
+    _records = [
+        { id: 1, filter_user_id: 1, user_id: serverState.userId, is_checked: true },
+        { id: 2, filter_user_id: 3, user_id: serverState.userId, is_checked: true },
+    ];
+}
+
+defineModels([Event, EventType, CalendarUser, FilterUser]);
+
+preloadBundle("web.fullcalendar_lib");
+
+beforeEach(() => {
+    mockTimeZone("Europe/Brussels");
+});
+
+test.tags("desktop");
+test("multi_create: render and basic functionalities", async () => {
+    onRpc("event", "create", ({ args: [records] }) => {
+        for (const record of records) {
+            if (record.name !== "Time off" || record.type !== 3) {
+                expect.step("error");
+            }
+            expect.step(`${record.user_id}_${record.date_start}`);
+        }
+    });
+
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        context: { default_name: "Sick" },
+    });
+
+    expect(".fc .fc-event").toHaveCount(4, { message: "events should be filter" });
+    expect(".o_calendar_sidebar .btn-group .btn").toHaveCount(3, {
+        message: "multi create should be enabled",
+    });
+
+    expect(".o_calendar_sidebar .btn-group .btn.active").toHaveAttribute("data-tooltip", "New", {
+        message: "multi create mode should be the default",
+    });
+    expect(".o_calendar_sidebar_container .o_form_view").toBeVisible();
+    expect(".o_calendar_sidebar_container .o_form_view [name='name'] input").toHaveValue("Sick", {
+        message: "should have a default value from the context",
+    });
+    await click(".o_calendar_sidebar_container .o_form_view [name='name'] input");
+    await edit("Time off");
+    await contains(".o_calendar_sidebar_container .o_form_view [name='type'] input").click();
+    await contains(".o-autocomplete--dropdown-item:contains('Event Type 3')").click();
+
+    const { drop, moveTo } = await contains(".fc-day[data-date='2019-03-04']").drag();
+    await moveTo(".fc-day[data-date='2019-03-14']");
+    await animationFrame();
+    expect(".fc-day.o-highlight").toHaveCount(8);
+    await drop();
+    await animationFrame();
+    expect.verifySteps([
+        "1_2019-03-04",
+        "3_2019-03-04",
+        "1_2019-03-05",
+        "3_2019-03-05",
+        "1_2019-03-06",
+        "3_2019-03-06",
+        "1_2019-03-07",
+        "3_2019-03-07",
+        "1_2019-03-11",
+        "3_2019-03-11",
+        "1_2019-03-12",
+        "3_2019-03-12",
+        "1_2019-03-13",
+        "3_2019-03-13",
+        "1_2019-03-14",
+        "3_2019-03-14",
+    ]);
+    expect(".fc .fc-event").toHaveCount(20, {
+        message: "events should be added for the two users selected",
+    });
+
+    await click(".fc-event[data-event-id='8']");
+    await runAllTimers();
+    await animationFrame();
+    await expect(".o_popover").toHaveCount(1);
+    await expect(".o_popover .o_field_widget[name='name']").toHaveText("Time off");
+    await expect(".o_popover .o_field_widget[name='type']").toHaveText("Event Type 3");
+    await expect(".o_popover .o_field_widget[name='user_id']").toHaveText("user 1");
+
+    await click(".fc-event[data-event-id='9']");
+    await runAllTimers();
+    await animationFrame();
+    await expect(".o_popover").toHaveCount(1);
+    await expect(".o_popover .o_field_widget[name='user_id']").toHaveText("user 3");
+
+    await click(".o_calendar_filter_item[data-value='3'] input");
+    await animationFrame();
+    await advanceTime(CalendarModel.DEBOUNCED_LOAD_DELAY);
+    expect(".fc .fc-event").toHaveCount(10, { message: "events should be filter" });
+});
+
+test.tags("desktop");
+test("multi_create: filter mode (normal calendar)", async () => {
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        context: { default_name: "Sick" },
+    });
+
+    await click(".o_calendar_sidebar .btn-group .btn[data-tooltip='Filter']");
+    await animationFrame();
+    expect(".o_calendar_sidebar .btn-group .btn.active").toHaveAttribute("data-tooltip", "Filter", {
+        message: "filter mode (normal) should be active",
+    });
+
+    await click(".fc-event[data-event-id='2']");
+    await runAllTimers();
+    await animationFrame();
+    await expect(".o_popover").toHaveCount(1);
+
+    await click(".o_calendar_header"); // Hide the popover
+    await animationFrame();
+
+    const drag3 = await contains(".fc-day[data-date='2019-02-26']").drag();
+    await drag3.drop(".fc-day[data-date='2019-04-03']");
+    await animationFrame();
+    expect(".modal").toHaveCount(1);
+    expect(".modal input[name='title']").toHaveValue("Sick");
+});
+
+test.tags("desktop");
+test("multi_create: delete", async () => {
+    onRpc("event", "unlink", ({ args: [ids] }) => {
+        expect.step(ids);
+    });
+
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        context: { default_name: "Sick" },
+    });
+
+    await click(".o_calendar_sidebar .btn-group .btn .fa-trash");
+    await animationFrame();
+    expect(".o_calendar_sidebar .btn-group .btn.active i").toHaveClass(
+        ["fa-trash", "text-danger"],
+        {
+            message: "multi delete mode should be active and have red icon",
+        }
+    );
+    expect(".o_calendar_sidebar_container .o_form_view").toHaveCount(0);
+
+    await click(".fc-event[data-event-id='2']");
+    await runAllTimers();
+    await animationFrame();
+    await expect(".o_popover").toHaveCount(1);
+
+    await click(".o_calendar_header"); // Hide the popover
+    await animationFrame();
+
+    const { drop } = await contains(".fc-day[data-date='2019-02-26']").drag();
+    await drop(".fc-day[data-date='2019-04-03']");
+    await animationFrame();
+    expect.verifySteps([[2, 3, 5]]);
+    expect(".fc .fc-event").toHaveCount(1, { message: "selected events should be deleted" });
+
+    await click(".o_calendar_filter_item[data-value='3'] input");
+    await animationFrame();
+    await advanceTime(CalendarModel.DEBOUNCED_LOAD_DELAY);
+    expect(".fc .fc-event").toHaveCount(0, { message: "events should be filter" });
+});
+
+test.tags("desktop");
+test("multi_create: test onChange on form with no blur (input text)", async () => {
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        context: { default_name: "Sick" },
+    });
+
+    await click(".o_calendar_sidebar_container .o_form_view [name='name'] input");
+    await edit("Test onChange");
+
+    await click(".fc-day[data-date='2019-03-04']");
+    await animationFrame();
+
+    await click(".fc-event[data-event-id='8']");
+    await runAllTimers();
+    await animationFrame();
+    await expect(".o_popover").toHaveCount(1);
+    await expect(".o_popover .o_field_widget[name='name']").toHaveText("Test onChange");
+});

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -5603,3 +5603,44 @@ test(`calendar renderer is rendered once after search refresh`, async () => {
     await validateSearch();
     expect.verifySteps(["rendered"]);
 });
+
+test.tags("desktop");
+test(`calendar with filters and count aggregate`, async () => {
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `
+            <calendar date_start="start" date_stop="stop" aggregate="id:count">
+                <field name="attendee_ids" write_model="filter.partner" write_field="partner_id" filter_field="is_checked"/>
+            </calendar>
+        `,
+    });
+
+    expect(queryAllTexts(".o_calendar_filter_item span")).toEqual(["partner 1", "2", "partner 2"]);
+});
+
+test.tags("desktop");
+test(`calendar with dynamic filters and sum aggregate`, async () => {
+    Event._fields.revenue = fields.Float();
+    Event._records[0].revenue = 1200;
+    Event._records[1].revenue = 350;
+    Event._records[2].revenue = 800;
+    Event._records[3].revenue = 3000;
+    Event._records[4].revenue = 1900;
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `
+            <calendar date_start="start" date_stop="stop" aggregate="revenue:sum">
+                <field name="partner_id" filters="1"/>
+            </calendar>
+        `,
+    });
+
+    expect(queryAllTexts(".o_calendar_filter_item span")).toEqual([
+        "partner 1",
+        "4,550",
+        "partner 4",
+        "2,700",
+    ]);
+});

--- a/addons/web/static/tests/views/view_utils.test.js
+++ b/addons/web/static/tests/views/view_utils.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "@odoo/hoot";
+
+import { computeAggregatedValue } from "@web/views/utils";
+
+describe.current.tags("headless");
+
+describe("computeAggregatedValue", () => {
+    test("sum", () => {
+        expect(computeAggregatedValue([], "sum")).toBe(0);
+        expect(computeAggregatedValue([7], "sum")).toBe(7);
+        expect(computeAggregatedValue([7, 3], "sum")).toBe(10);
+        expect(computeAggregatedValue([7.23, 3.1], "sum")).toBe(10.33);
+        expect(computeAggregatedValue([10, 2, -3, 2, -5, 27, 2], "sum")).toBe(35);
+    });
+
+    test("min", () => {
+        expect(computeAggregatedValue([], "min")).toBe(Infinity);
+        expect(computeAggregatedValue([7], "min")).toBe(7);
+        expect(computeAggregatedValue([7, 3], "min")).toBe(3);
+        expect(computeAggregatedValue([7.23, 3.1], "min")).toBe(3.1);
+        expect(computeAggregatedValue([10, 2, -3, 2, -5, 27, 2], "min")).toBe(-5);
+    });
+
+    test("max", () => {
+        expect(computeAggregatedValue([], "max")).toBe(-Infinity);
+        expect(computeAggregatedValue([7], "max")).toBe(7);
+        expect(computeAggregatedValue([7, 3], "max")).toBe(7);
+        expect(computeAggregatedValue([7.23, 3.1], "max")).toBe(7.23);
+        expect(computeAggregatedValue([10, 2, -3, 2, -5, 27, 2], "max")).toBe(27);
+    });
+
+    test("avg", () => {
+        expect(computeAggregatedValue([], "avg")).toBe(NaN);
+        expect(computeAggregatedValue([7], "avg")).toBe(7);
+        expect(computeAggregatedValue([7, 3], "avg")).toBe(5);
+        expect(computeAggregatedValue([7.23, 3.1], "avg")).toBe(5.165);
+        expect(computeAggregatedValue([10, 2, -3, 2, -5, 27, 2], "avg")).toBe(5);
+    });
+
+    test("count", () => {
+        expect(computeAggregatedValue([], "count")).toBe(0);
+        expect(computeAggregatedValue([7], "count")).toBe(1);
+        expect(computeAggregatedValue([7, 3], "count")).toBe(2);
+        expect(computeAggregatedValue([7.23, 3.1], "count")).toBe(2);
+        expect(computeAggregatedValue([10, 2, -3, 2, -5, 27, 2], "count")).toBe(7);
+    });
+
+    test("count_distinct", () => {
+        expect(computeAggregatedValue([], "count_distinct")).toBe(0);
+        expect(computeAggregatedValue([7], "count_distinct")).toBe(1);
+        expect(computeAggregatedValue([7, 3], "count_distinct")).toBe(2);
+        expect(computeAggregatedValue([7.23, 3.1], "count_distinct")).toBe(2);
+        expect(computeAggregatedValue([10, 2, -3, 2, -5, 27, 2], "count_distinct")).toBe(5);
+    });
+
+    test("invalid aggregator", () => {
+        expect(() => computeAggregatedValue([])).toThrow("Invalid aggregator 'undefined'");
+        expect(() => computeAggregatedValue([], "oups")).toThrow("Invalid aggregator 'oups'");
+    });
+});

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1334,8 +1334,10 @@ actual arch.
     #------------------------------------------------------
     def _postprocess_tag_calendar(self, node, name_manager, node_info):
         for additional_field in ('date_start', 'date_delay', 'date_stop', 'color', 'all_day'):
-            if fnames := node.get(additional_field):
-                name_manager.has_field(node, fnames.split('.', 1)[0], node_info)
+            if fname := node.get(additional_field):
+                name_manager.has_field(node, fname, node_info)
+        if fname := node.get('aggregate'):
+            name_manager.has_field(node, fname.split(':')[0], node_info)
         for f in node:
             if f.tag == 'filter':
                 name_manager.has_field(node, f.get('name'), node_info)

--- a/odoo/addons/base/rng/calendar_view.rng
+++ b/odoo/addons/base/rng/calendar_view.rng
@@ -13,6 +13,7 @@
             <rng:optional><rng:attribute name="date_stop" /></rng:optional>
             <rng:optional><rng:attribute name="date_delay" /></rng:optional>
             <rng:optional><rng:attribute name="all_day" /></rng:optional>
+            <rng:optional><rng:attribute name="aggregate" /></rng:optional>
             <rng:optional><rng:attribute name="form_view_id" /></rng:optional>
             <rng:optional><rng:attribute name="event_limit" /></rng:optional>
             <rng:optional><rng:attribute name="create_name_field" /></rng:optional>

--- a/odoo/addons/base/rng/calendar_view.rng
+++ b/odoo/addons/base/rng/calendar_view.rng
@@ -19,6 +19,7 @@
             <rng:optional><rng:attribute name="create_name_field" /></rng:optional>
             <rng:optional><rng:attribute name="quick_create" /></rng:optional>
             <rng:optional><rng:attribute name="quick_create_view_id" /></rng:optional>
+            <rng:optional><rng:attribute name="multi_create_view" /></rng:optional>
             <rng:optional><rng:attribute name="color" /></rng:optional>
             <rng:optional><rng:attribute name="event_open_popup" /></rng:optional>
             <rng:optional><rng:attribute name="show_unusual_days" /></rng:optional>


### PR DESCRIPTION
This commit adds new functionalities in the calendar view, in particular
the month one.

These functionalities are:
* multi create: adds multi record at once using values set in a custom
form view, this feature is enabled using the new attribute
`multi_create_view` on the `calendar` node in the arch.
* multi delete: delete multi record at once

task-4510549

Co-authored-by: Aaron Bohy <aab@odoo.com>

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
