### PR TITLE
[FIX] l10n_es_edi_facturae: add missing certificate dields

### DIFF
--- a/addons/l10n_es_edi_facturae/models/l10n_es_edi_facturae_certificate.py
+++ b/addons/l10n_es_edi_facturae/models/l10n_es_edi_facturae_certificate.py
@@ -76,10 +76,13 @@ class Certificate(models.Model):
         rfc4514_attr = dict(element.rfc4514_string().split("=", 1) for element in cert_public.issuer.rdns)
 
         # The 'Organizational Unit' field is optional
+        issuer = f"CN={rfc4514_attr.pop('CN')}, "
         if 'OU' in rfc4514_attr:
-            issuer = f"CN={rfc4514_attr['CN']}, OU={rfc4514_attr['OU']}, O={rfc4514_attr['O']}, C={rfc4514_attr['C']}"
-        else:
-            issuer = f"CN={rfc4514_attr['CN']}, O={rfc4514_attr['O']}, C={rfc4514_attr['C']}"
+            issuer += f"OU={rfc4514_attr.pop('OU')}, "
+        issuer += f"O={rfc4514_attr.pop('O')}, C={rfc4514_attr.pop('C')}"
+
+        # Add remaining certificate fields (not all certificates have other fields)
+        issuer += "".join([f", {key}={value}" for key, value in rfc4514_attr.items()])
 
         # Identifiers
         document_id = f"Document-{sha1(etree.tostring(edi_data)).hexdigest()}"

--- a/addons/l10n_es_edi_facturae/tests/data/expected_signed_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_signed_document.xml
@@ -277,18 +277,18 @@
     </ds:Reference>
     <ds:Reference Type="http://uri.etsi.org/01903#SignedProperties" URI="#SignatureProperties-Document-da39a3ee5e6b4b0d3255bfef95601890afd80709">
       <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-      <ds:DigestValue>YXyvKAVjnGxvHZabPY9gmDt0YQgcpBcEq5Hv7ioXR1E=</ds:DigestValue>
+      <ds:DigestValue>PwdgUVaQn3/meV+vxkpYZbSu5q4S8Nyu5ccl2d+J7f0=</ds:DigestValue>
     </ds:Reference>
     <ds:Reference URI="#KeyInfo-Document-da39a3ee5e6b4b0d3255bfef95601890afd80709">
       <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
       <ds:DigestValue>ARCif8tQIKagVfeHX4Fit5ZfK3mXQCPclQISywh7h44=</ds:DigestValue>
     </ds:Reference>
   </ds:SignedInfo>
-  <ds:SignatureValue>Cj2/PhdPDOyj4wl5NAD029AUJmqDBT6AizdhBbHgRUI0Lnkd5I66qbhy0Mq2oD5XCE8dDGR7TFRI
-yWPlrSr33Boulu/isYWCfFXROjwMj20lipK3TwBuvD52SnuOiXd+dfWY+IutNyC1hSP8Sk7O1qiE
-C1abUoq2kOTYgn+US6lsS7+9bZcp/3j2KeF3zMDD/kaaVtPl4lU79wZyAyUA/GvSxcDr+7J3yxVQ
-K86e4v4S7l2FTdXGdcgauhKJ9BGbUhxVv59ceF5vGRrBoMvW61OcrLaUVyaQS9QNZH7vWOh1RyrI
-GotRRlx0kZP7HgLLv8F0DZPEUmqxzGFc8+7few==
+  <ds:SignatureValue>jEfah4l5JQHNK39X9Vytkn2mGLNWLpEnGHeh5mSZL0dqSBcWcL93SOkiMbNeSMl1r1hKrNlsTirj
+X2WdTNRY19u3YhOc/ZEa1hmi5vKdq5QvsQvGNhu72GIybnh4LpYwfK/MwOBr9gAMGnJYAiOjG7YZ
+bHzi8Nn3ViUApPmaYPAtkhWYHmTQBLChCMkGTHRy+i99NDSlL7SYcgztA6OQHlwNv4WyT4fXtZoa
+gmmRAFR4B3ccUYv28XtHMmz50HE1RxOn+AH4Z8AAdgQmCnbY0tyGOJPNTsShV4nisALqcmx8Tdqb
+4MhISi8x4ehjACvNSGNo9gMgsRdVZVQc7U7Qaw==
 </ds:SignatureValue>
   <ds:KeyInfo Id="KeyInfo-Document-da39a3ee5e6b4b0d3255bfef95601890afd80709">
     <ds:X509Data>
@@ -337,7 +337,7 @@ aWAYAMCL4KhvISclysD+5juDLpGCLHPtKxBXTQ==
                 <ds:DigestValue>FHf2lN+5FALNa7JXV2+pByL92/dr8LeCVhpItYic5oA=</ds:DigestValue>
               </xades:CertDigest>
               <xades:IssuerSerial>
-                <ds:X509IssuerName>CN=runbot.odoo.com, OU=R&amp;D, O=Odoo, C=BE</ds:X509IssuerName>
+                <ds:X509IssuerName>CN=runbot.odoo.com, OU=R&amp;D, O=Odoo, C=BE, ST=Wallonnia, L=Ramillies, 1.2.840.113549.1.9.1=info@odoo.com</ds:X509IssuerName>
                 <ds:X509SerialNumber>548631688851000697209704649636588277530075594025</ds:X509SerialNumber>
               </xades:IssuerSerial>
             </xades:Cert>


### PR DESCRIPTION
Certain certificates contain additional fields beyond those currently included (CN, OU, O, C), such as "2.5.4.97" and "L".

Since these additional fields are not incorporated into the issuer name, attempts to validate the signed document on the following sites will result in errors:
- https://face.gob.es/es/facturas/validar-visualizar-facturas
- https://valide.redsara.es/valide/validarFirma/ejecutar.html

These errors typically indicate that the signature is either invalid and that the certificate does not match the values within `<KeyInfo>`. This discrepancy occurs because all certificate fields are included in the signature, but some are missing from the `<X509IssuerName>` field.

This fix adds the missing certificate fields to ensure consistency between the signature and the issuer name. Based on my tests, the order of these fields does not affect the validation process.

opw-4484906
opw-4482626