### PR TITLE
[FIX] im_livechat: fix fw operator step with message

### DIFF
--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -70,7 +70,7 @@ class LivechatChatbotScriptController(http.Controller):
         store.add(
             "ChatbotStep",
             {
-                "id": (next_step.id, discuss_channel.id),
+                "id": (next_step.id, posted_message.id),
                 "isLast": next_step._is_last_step(discuss_channel),
                 "message": Store.one(posted_message, only_id=True),
                 "operatorFound": next_step.step_type == "forward_operator"

--- a/addons/im_livechat/models/mail_message.py
+++ b/addons/im_livechat/models/mail_message.py
@@ -43,7 +43,7 @@ class MailMessage(models.Model):
                 )
                 if step := chatbot_message.script_step_id:
                     step_data = {
-                        "id": (step.id, channel.id),
+                        "id": (step.id, message.id),
                         "message": Store.one(message, only_id=True),
                         "scriptStep": Store.one(step, only_id=True),
                         "operatorFound": step.step_type == "forward_operator"

--- a/addons/im_livechat/static/tests/embed/livechat_button.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_button.test.js
@@ -1,4 +1,3 @@
-import { waitNotifications } from "@bus/../tests/bus_test_helpers";
 import { LivechatButton } from "@im_livechat/embed/common/livechat_button";
 import {
     defineLivechatModels,
@@ -15,7 +14,7 @@ import {
     step,
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
-import { mountWithCleanup, onRpc } from "@web/../tests/web_test_helpers";
+import { asyncStep, mountWithCleanup, onRpc } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineLivechatModels();
@@ -45,13 +44,16 @@ test("open/close persisted channel", async () => {
         }
     });
     const env = await start({ authenticateAs: false });
+    env.services.bus_service.subscribe("discuss.channel/new_message", () =>
+        asyncStep("discuss.channel/new_message")
+    );
     await mountWithCleanup(LivechatButton);
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "How can I help?");
     await triggerHotkey("Enter");
     await assertSteps(["persisted"]);
     await contains(".o-mail-Message-content", { text: "How can I help?" });
-    await waitNotifications([env, "discuss.channel/new_message"]);
+    await assertSteps(["discuss.channel/new_message"]);
     await click("[title*='Close Chat Window']");
     await click(".o-livechat-CloseConfirmation-leave");
     await contains(".o-mail-ChatWindow", { text: "Did we correctly answer your question?" });

--- a/addons/im_livechat/static/tests/embed/message_actions.test.js
+++ b/addons/im_livechat/static/tests/embed/message_actions.test.js
@@ -1,5 +1,3 @@
-import { waitNotifications } from "@bus/../tests/bus_test_helpers";
-
 import { LivechatButton } from "@im_livechat/embed/common/livechat_button";
 import {
     defineLivechatModels,
@@ -14,7 +12,7 @@ import {
     startServer,
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
-import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { asyncStep, mountWithCleanup, waitForSteps } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineLivechatModels();
@@ -25,13 +23,16 @@ test("Only two quick actions are shown", async () => {
     await startServer();
     await loadDefaultEmbedConfig();
     const env = await start({ authenticateAs: false });
+    env.services.bus_service.subscribe("discuss.channel/new_message", () =>
+        asyncStep("discuss.channel/new_message")
+    );
     await mountWithCleanup(LivechatButton);
     await click(".o-livechat-LivechatButton");
     await contains(".o-mail-ChatWindow");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
     // message data from post contains no reaction, wait now to avoid overriding newer value later
-    await waitNotifications([env, "discuss.channel/new_message"]);
+    await waitForSteps(["discuss.channel/new_message"]);
     await click("[title='Add a Reaction']");
     await click(".o-Emoji", { text: "😅" });
     await contains(".o-mail-MessageReaction", { text: "😅" });

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -43,9 +43,13 @@ export class DiscussCoreCommon {
             });
             this._handleNotificationChannelDelete(thread, metadata);
         });
-        this.busService.subscribe("discuss.channel/new_message", (payload, metadata) =>
-            this._handleNotificationNewMessage(payload, metadata)
-        );
+        this.busService.subscribe("discuss.channel/new_message", (payload, metadata) => {
+            // Insert should always be done before any async operation. Indeed,
+            // awaiting before the insertion could lead to overwritting newer
+            // state coming from more recent `mail.record/insert` notifications.
+            this.store.insert(payload.data, { html: true });
+            this._handleNotificationNewMessage(payload, metadata);
+        });
         this.busService.subscribe("discuss.channel/transient_message", (payload) => {
             const { body, thread } = payload;
             const lastMessageId = this.store.getLastMessageId();
@@ -149,8 +153,10 @@ export class DiscussCoreCommon {
         if (!channel) {
             return;
         }
-        const { Message: messages = [] } = this.store.insert(data, { html: true });
-        const message = messages[0];
+        const message = this.store.Message.get(data["mail.message"][0]);
+        if (!message) {
+            return;
+        }
         if (message.notIn(channel.messages)) {
             if (!channel.loadNewer) {
                 channel.addOrReplaceMessage(message, this.store.Message.get(temporary_id));

--- a/addons/mail/static/tests/discuss/core/web/sidebar.test.js
+++ b/addons/mail/static/tests/discuss/core/web/sidebar.test.js
@@ -1,4 +1,4 @@
-import { waitForChannels, waitNotifications } from "@bus/../tests/bus_test_helpers";
+import { waitForChannels } from "@bus/../tests/bus_test_helpers";
 import {
     click,
     contains,
@@ -9,7 +9,7 @@ import {
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
-import { Command, serverState } from "@web/../tests/web_test_helpers";
+import { asyncStep, Command, serverState, waitForSteps } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -67,6 +67,9 @@ test("unknown channel can be displayed and interacted with", async () => {
         name: "Not So Secret",
     });
     const env = await start();
+    env.services.bus_service.subscribe("discuss.channel/new_message", () =>
+        asyncStep("discuss.channel/new_message")
+    );
     await openDiscuss();
     await contains("button.o-active", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
@@ -76,7 +79,7 @@ test("unknown channel can be displayed and interacted with", async () => {
     await insertText(".o-mail-Composer-input", "Hello", { replace: true });
     await click(".o-mail-Composer-send:enabled");
     await contains(".o-mail-Message", { text: "Hello" });
-    await waitNotifications([env, "discuss.channel/new_message"]);
+    await waitForSteps(["discuss.channel/new_message"]);
     await click("button", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarChannel:not(.o-active)", { text: "Not So Secret" });
     await click("[title='Leave Channel']", {


### PR DESCRIPTION
Before this PR, the chat bot would continue even after forwarding
an operator to the visitor when the step contained a message.

Steps to reproduce:
- Create a chat bot script with three steps: "text",
"free_input_single", "fw_operator" with a message set.
- Start the bot as a visitor, the operator is correctly added
to the channel but the input is not available, the conversation
is considered as ended.

This is due to a race conditions when processing the notifications
coming on the bus. When the message is posted, the operator is not
yet added, this information is sent on the bus. When the operator is
added, another payload is sent on the bus informing an operator was
found.

However, the processing of the message notification is delayed and
comes after the processing of the newest information, leading to an
incorrect state.

To solve this issue, ensure insertions are made immediately in the
new message handler and send updated data on the bus to ensure the
state is correct.

This PR also fixes identifying fields issue wiht chat bot steps (step
is identified by script step and message not channel.

opw-4514479