### PR TITLE
[FIX] point_of_sale: customer popup display

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.scss
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.scss
@@ -43,7 +43,6 @@
     }
     &.selected {
         background-color: $o-component-active-bg;
-        border: $border-width solid $o-component-active-border;
         color: $o-action;
     }
 

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.xml
@@ -45,7 +45,7 @@
         <t t-else="">
             <tr class="partner-line partner-info" t-att-class="{'selected': props.isSelected}" t-att-data-id="props.partner.id"
                 t-on-click="() => this.props.onClickPartner(props.partner)">
-                <td>
+                <td class="text-break w-25">
                     <b t-esc="props.partner.name or ''" />
                     <div class="company-field text-bg-muted" t-esc="props.partner.parent_name or ''" />
                 </td>

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
@@ -20,7 +20,7 @@
                     debounceMillis="100" />
             </t>
             <div class="fixed-head h-100 pt-0 overflow-hidden">
-                <div class="overflow-y-auto overflow-x-hidden h-100" t-ref="partner-list">
+                <div class="overflow-y-auto h-100" t-ref="partner-list">
                     <t t-set="initialPartners" t-value="getPartners(this.state.initialPartners)"/>
                     <t t-set="loadedPartners" t-value="getPartners(this.state.loadedPartners)"/>
                     <t t-set="nbrPartners" t-value="initialPartners.length + loadedPartners.length"/>


### PR DESCRIPTION
Handle case where customer name is too long causing the customer action buttons inaccessible.

- Put `width` and `text-break` on partner name column.
- Enable overflow-x on the partner modal (so that if the partner infos are too long, its buttons are still accessible).
- Remove weird left/right border on partner line inside customer popup.

task-id: 4547853

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
