### PR TITLE
[FIX] website_sale: fix add_to_cart_snippet_tour

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -71,7 +71,7 @@ wTourUtils.registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         wTourUtils.clickOnElement('add to cart button', ':iframe .s_add_to_cart_btn'),
         {
             content: "Wait for the redirection to the payment page",
-            trigger: "iframe h3:contains('Confirm order')",
+            trigger: ":iframe h3:contains('Confirm order')",
             timeout: 20000,
             run: () => null,
         },


### PR DESCRIPTION
Correct trigger which was wrong, causing JS test to timeout

runbot-task-98520
