### PR TITLE
[FIX] web: disable autocomplete for many2x field input

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -24,6 +24,7 @@ export class AutoComplete extends Component {
             },
         },
         placeholder: { type: String, optional: true },
+        autocomplete: { type: String, optional: true},
         autoSelect: { type: Boolean, optional: true },
         resetOnSelect: { type: Boolean, optional: true },
         onInput: { type: Function, optional: true },
@@ -41,6 +42,7 @@ export class AutoComplete extends Component {
     static defaultProps = {
         value: "",
         placeholder: "",
+        autocomplete: "new-password",
         autoSelect: false,
         dropdown: true,
         onInput: () => {},

--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -7,7 +7,7 @@
                 type="text"
                 t-att-id="props.id"
                 class="o-autocomplete--input o_input pe-3"
-                autocomplete="new-password"
+                t-att-autocomplete="props.autocomplete"
                 t-att-placeholder="props.placeholder"
                 role="combobox"
                 t-att-aria-activedescendant="activeSourceOptionId"

--- a/addons/web/static/src/views/fields/relational_utils.xml
+++ b/addons/web/static/src/views/fields/relational_utils.xml
@@ -36,6 +36,7 @@
             value="props.value"
             id="props.id"
             placeholder="props.placeholder"
+            autocomplete="'off'"
             sources="sources"
             autoSelect="props.autoSelect"
             onSelect.bind="onSelect"


### PR DESCRIPTION
Steps:
- Open a task
- Click on "Tags" field input

Actual result:
- Autocomplete is there and can hide dropdown (partially or fully)
![image](https://github.com/user-attachments/assets/b72252e5-f276-4571-8c37-970dde7d91b3)

Expected result:
- Autocomplete is really off by default for many2x field
- No autocompletion like before 18.1, we already have one as it's a dropdown

opw-4551051

Caused by: https://github.com/odoo/odoo/commit/9c0f5612e9fab514116e2385338d8fc1ce42b821