### PR TITLE
[FIX] l10n_sa_edi: xpath change

### DIFF
--- a/addons/l10n_sa_edi/views/res_partner_views.xml
+++ b/addons/l10n_sa_edi/views/res_partner_views.xml
@@ -7,10 +7,10 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form"/>
             <field name="arch" type="xml">
-                <field name="vat" position="before">
+                <xpath expr="//div[hasclass('o_address_format')]"  position="after">
                     <field name="l10n_sa_additional_identification_scheme" invisible="country_code != 'SA'"/>
                     <field name="l10n_sa_additional_identification_number" invisible="country_code != 'SA' or l10n_sa_additional_identification_scheme == 'TIN'"/>
-                </field>
+                </xpath>
             </field>
         </record>
 


### PR DESCRIPTION
The module base_vat add a div around the vat field and so the xpath place the field in the div which is not what we want. By putting it after the address we are sure that those field are rightly placed

task: 4543204



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
