### PR TITLE
[FIX] point_of_sale: missing related fields after synchronization

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -977,8 +977,9 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
             const fields = getFields(model);
 
             for (const rawRec of rawRecords) {
+                let keepCurrentConnection = false;
                 if (ignoreConnection[model].includes(rawRec.id)) {
-                    continue;
+                    keepCurrentConnection = true;
                 }
 
                 const recorded = records[model][rawRec.id];
@@ -995,6 +996,9 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
 
                 for (const name in fields) {
                     const field = fields[name];
+                    if (keepCurrentConnection && typeof recorded[field.name] === "object") {
+                        continue;
+                    }
                     alreadyLinkedSet.add(field);
 
                     if (X2MANY_TYPES.has(field.type)) {


### PR DESCRIPTION
When we sync PoS models after write to a record we don't want to overwrite local connections.
However this means we don't create new connections when we receive related record data from the backend, possibly breaking flows relying on account move data, like the following:

User in Chile needs to print on the POS receipt the SII Fiscal barcode This is currently not being printed and this makes the ticket not a validal legal invoice or electronic ticket.

Step to reproduce:
- With a Chilean company setup
- Open POS session
- Make an order to customer "Consumidor Final Anónimo"
- Pay and check generated receipt

Issue: On the receipt no barcode is shown, a broken image placeholder can be observed.
This occurs because the related record (account_move) is not loaded

opw-4489277

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
