### PR TITLE
[FIX] account: prevent payment reference override in wizard

### DIFF
--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -1312,3 +1312,12 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
                 'reconciled': False,
             },
         ])
+
+    def test_communication_wizard(self):
+        """
+        Tests that changing the payment reference updates the payment wizard's communication accordingly.
+        """
+        self.out_invoice_1.payment_reference = "test"
+        ctx = {'active_model': 'account.move', 'active_ids': self.out_invoice_1.ids}
+        wizard = self.env['account.payment.register'].with_context(**ctx).create({})
+        self.assertEqual(wizard.communication, "test")

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -133,7 +133,7 @@ class AccountPaymentRegister(models.TransientModel):
         :param batch_result:    A batch returned by '_get_batches'.
         :return:                A string representing a communication to be set on payment.
         '''
-        labels = set(line.name or line.move_id.ref or line.move_id.name for line in batch_result['lines'])
+        labels = set(line.move_id.payment_reference or line.name or line.move_id.ref or line.move_id.name for line in batch_result['lines'])
         return ' '.join(sorted(labels))
 
     @api.model


### PR DESCRIPTION
Steps to reproduce:
- add a payment reference on a vendor bill
- confirm
- register a payment
- see the memo takes the payment reference value
- update the payment reference on the invoice, register (no matter if you reset the invoice into draft or not)
- register a payment

Issue:
see the memo takes the same vale as the initial payment reference

Cause:
We use the `line.name` which is not wrong as when we update the payment reference the it will be updated. But whenever we update the payment reference again, the `line.name` will not be updated https://github.com/odoo/odoo/blob/0bec22df0a34c6bc201d2627cf1123509d272a6d/addons/account/models/account_move_line.py#L482-L483

Solution:
We prioritize the payment reference for the communication as it is the case in 18.0

opw-4405999