### PR TITLE
[FIX] hr_recruitment_survey: Show recruitment-type surveys in Participations section

### DIFF
--- a/addons/hr_recruitment_survey/models/survey_survey.py
+++ b/addons/hr_recruitment_survey/models/survey_survey.py
@@ -23,3 +23,11 @@ class SurveySurvey(models.Model):
                 if view := self.env.ref('hr_recruitment_survey.survey_survey_view_form', raise_if_not_found=False):
                     return view.id
         return super().get_formview_id(access_uid=access_uid)
+    
+    def action_survey_user_input_completed(self):
+        action = super().action_survey_user_input_completed()
+        if self.survey_type == 'recruitment':
+            action.update({
+                'domain': [('survey_id.survey_type', '=', 'recruitment')]
+            }) 
+        return action


### PR DESCRIPTION
**Issue**
Recruitment-type surveys do not appear in the Participations section, even when participants have completed the survey.

Steps to Reproduce:
1. Install hr_recruitment_survey module 
2. Open the Surveys app.
3. Create a new survey or open an existing one.
4. Set the survey type to Recruitment.
5. Click on the Participations smart button.

Expected behavior: Participants who completed the survey should be listed.
Actual behavior: No participants are shown.

**Root Cause**

https://github.com/odoo/odoo/blob/de935a1b3ad96e24b5fd1bd317c73c12e9b3a08f/addons/survey/models/survey_survey.py#L1090-L1096

Once the smart button is clicked, the action variable is populated through the following record

https://github.com/odoo/odoo/blob/de935a1b3ad96e24b5fd1bd317c73c12e9b3a08f/addons/survey/views/survey_user_views.xml#L153-L168

The record includes a domain filter that restricts the displayed results to specific survey types. Since "recruitment" is not listed among the accepted survey types, it fails the check and is excluded from the results.

**Fix**
Overriding the action_survey_user_input action template in XML to extend the domain was impractical because it replaced the existing domain rather than extending it. This prevented seamless integration with other modules, limiting flexibility. Instead, we opted to extend the domain within the action's returned values, ensuring better modularity and maintainability.

opw-4516112

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
