### PR TITLE
[IMP] l10n_jo_edi: partner identification

### DIFF
--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -103,8 +103,8 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
 
     def _get_partner_party_identification_vals_list(self, partner):
         return [{
-            'id_attrs': {'schemeID': 'TN'},
-            'id': partner.vat,
+            'id_attrs': {'schemeID': 'TN' if not partner.country_code or partner.country_code == 'JO' else 'PN'},
+            'id': partner.vat if partner.vat and partner.vat != '/' else '',
         }]
 
     def _get_partner_address_vals(self, partner):


### PR DESCRIPTION
Before this commit we had a schemeID equals to TN every time. But it should be equals to TN only if the partner is from 'JO' otherwise 'PN'

task: 4547131




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
