### PR TITLE
[IMP] purchase_stock: monthy demand

### DIFF
--- a/addons/account/static/src/components/product_catalog/kanban_controller.js
+++ b/addons/account/static/src/components/product_catalog/kanban_controller.js
@@ -3,19 +3,17 @@ import { patch } from "@web/core/utils/patch";
 import { _t } from "@web/core/l10n/translation";
 
 patch(ProductCatalogKanbanController.prototype, {
-    async _defineButtonContent() {
-        const fields = this.orderResModel === "account.move" ? ["state", "move_type"] : ["state"];
-        const orderStateInfo = await this.orm.searchRead(
-            this.orderResModel,
-            [["id", "=", this.orderId]],
-            fields,
-        );
-        if (orderStateInfo[0]?.move_type === "out_invoice") {
+    get stateFiels() {
+        return this.orderResModel === "account.move" ? ["state", "move_type"] : super.stateFiels;
+    },
+
+    _defineButtonContent() {
+        if (this.orderStateInfo.move_type === "out_invoice") {
             this.buttonString = _t("Back to Invoice");
-        } else if (orderStateInfo[0]?.move_type === "in_invoice") {
+        } else if (this.orderStateInfo.move_type === "in_invoice") {
             this.buttonString = _t("Back to Bill");
         } else {
-            this.buttonString = super._defineButtonContent();
+            super._defineButtonContent();
         }
     },
 });

--- a/addons/mrp/static/src/components/product_catalog/kanban_controller.js
+++ b/addons/mrp/static/src/components/product_catalog/kanban_controller.js
@@ -3,7 +3,14 @@ import { patch } from "@web/core/utils/patch";
 import { _t } from "@web/core/l10n/translation";
 
 patch(ProductCatalogKanbanController.prototype, {
-    async _defineButtonContent() {
+    setOrderStateInfo() {
+        if (["mrp.bom", "mrp.production"].includes(this.orderResModel)) {
+            return {};
+        }
+        return super.setOrderStateInfo();
+    },
+
+    _defineButtonContent() {
         if (this.orderResModel === "mrp.bom") {
             this.buttonString = _t("Back to BoM");
         } else if (this.orderResModel === "mrp.production") {

--- a/addons/mrp_subcontracting_purchase/models/__init__.py
+++ b/addons/mrp_subcontracting_purchase/models/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_move_line
+from . import product_product
 from . import purchase_order
 from . import stock_move
 from . import stock_picking

--- a/addons/mrp_subcontracting_purchase/models/product_product.py
+++ b/addons/mrp_subcontracting_purchase/models/product_product.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+from odoo.fields import Domain
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    @api.model
+    def _get_monthly_demand_moves_location_domain(self):
+        domain = Domain.AND([
+            Domain.OR([
+                super()._get_monthly_demand_moves_location_domain(),
+                [('location_dest_id.is_subcontracting_location', '=', True)],
+            ]),
+            [('location_id.is_subcontracting_location', '!=', True)],
+        ])
+        return domain

--- a/addons/product/static/src/product_catalog/kanban_controller.js
+++ b/addons/product/static/src/product_catalog/kanban_controller.js
@@ -9,7 +9,6 @@ export class ProductCatalogKanbanController extends KanbanController {
 
     setup() {
         super.setup();
-        this.action = useService("action");
         this.orm = useService("orm");
         this.orderId = this.props.context.order_id;
         this.orderResModel = this.props.context.product_catalog_order_model;
@@ -41,9 +40,9 @@ export class ProductCatalogKanbanController extends KanbanController {
         // If, for some weird reason, the user reloads the page then the breadcrumbs are
         // lost, and we fall back to the form view ourselves.
         if (this.env.config.breadcrumbs.length > 1) {
-            await this.action.restore();
+            await this.actionService.restore();
         } else {
-            await this.action.doAction({
+            await this.actionService.doAction({
                 type: "ir.actions.act_window",
                 res_model: this.orderResModel,
                 views: [[false, "form"]],

--- a/addons/product/static/src/product_catalog/kanban_controller.xml
+++ b/addons/product/static/src/product_catalog/kanban_controller.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="ProductCatalogKanbanController" t-inherit="web.KanbanView" t-inherit-mode="primary">
         <xpath expr="//button[hasclass('o-kanban-button-new')]" position="replace">
-            <button t-out="this.buttonString" type="button" class="btn btn-secondary o-kanban-button-back" t-on-click="this.backToQuotationDebounced"/>
+            <button t-out="this.buttonString" type="button" class="btn btn-primary o-kanban-button-back" t-on-click="this.backToQuotationDebounced"/>
         </xpath>
     </t>
 </templates>

--- a/addons/product/static/src/product_catalog/kanban_model.js
+++ b/addons/product/static/src/product_catalog/kanban_model.js
@@ -52,8 +52,9 @@ export class ProductCatalogKanbanModel extends RelationalModel {
                 quantity: Math.floor(Math.random() * 10),
                 min_qty: 0,
                 price: Math.floor(Math.random() * 500) + 100,
+                productType: "consu",
                 readOnly: false,
-                uom: { display_name: "Units", id: 1 }
+                uom: { display_name: "Units", id: 1 },
             };
         }
         return sampleOrderLineInfo;

--- a/addons/product/static/src/product_catalog/kanban_model.js
+++ b/addons/product/static/src/product_catalog/kanban_model.js
@@ -49,6 +49,7 @@ export class ProductCatalogKanbanModel extends RelationalModel {
         const numRecords = 10; // Number of records to generate
         for (let i = 1; i <= numRecords; i++) {
             sampleOrderLineInfo[i] = {
+                isSample: true,
                 quantity: Math.floor(Math.random() * 10),
                 min_qty: 0,
                 price: Math.floor(Math.random() * 500) + 100,

--- a/addons/product/static/src/product_catalog/order_line/order_line.js
+++ b/addons/product/static/src/product_catalog/order_line/order_line.js
@@ -4,6 +4,7 @@ import { formatFloat, formatMonetary } from "@web/views/fields/formatters";
 export class ProductCatalogOrderLine extends Component {
     static template = "product.ProductCatalogOrderLine";
     static props = {
+        isSample: { type: Boolean, optional: true},
         productId: Number,
         quantity: Number,
         price: Number,

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -184,7 +184,7 @@
                 </xpath>
                 <xpath expr="//filter[@name='goods']" position="after">
                     <filter string="In the Order"
-                            name="products_in_order"
+                            name="products_in_purchase_order"
                             domain="[('is_in_purchase_order', '=', True)]"/>
                 </xpath>
             </field>

--- a/addons/purchase_stock/__manifest__.py
+++ b/addons/purchase_stock/__manifest__.py
@@ -27,6 +27,7 @@
         'report/report_stock_rule.xml',
         'wizard/stock_replenishment_info.xml',
         'wizard/product_replenish_views.xml',
+        'wizard/purchase_order_suggest_views.xml',
     ],
     'demo': [
         'data/purchase_stock_demo.xml',
@@ -36,7 +37,10 @@
     'post_init_hook': '_create_buy_rules',
     'assets': {
         'web.assets_backend': [
-            'purchase_stock/static/**/*',
+            'purchase_stock/static/src/**/*',
+        ],
+        'web.assets_unit_tests': [
+            'purchase_stock/static/tests/**/*',
         ],
     },
     'author': 'Odoo S.A.',

--- a/addons/purchase_stock/data/purchase_stock_demo.xml
+++ b/addons/purchase_stock/data/purchase_stock_demo.xml
@@ -66,6 +66,313 @@
 
         <function model="purchase.order" name="button_confirm" eval="[[ref('purchase_order_8')]]"/>
 
+        <!-- PURCHASE ORDER SUGGEST DEMO DATA -->
+        <!-- Generate needed stock. -->
+        <record id="stock_inventory_product_product_8" model="stock.quant">
+            <field name="product_id" ref="product.product_product_8"/>
+            <field name="inventory_quantity">8.0</field>
+            <field name="location_id" model="stock.location" eval="obj().env.ref('stock.warehouse0').lot_stock_id.id"/>
+        </record>
+
+        <record id="stock_inventory_product_delivery_01" model="stock.quant">
+            <field name="product_id" ref="product.product_delivery_01"/>
+            <field name="inventory_quantity">23.0</field>
+            <field name="location_id" model="stock.location" eval="obj().env.ref('stock.warehouse0').lot_stock_id.id"/>
+        </record>
+
+        <function model="stock.quant" name="action_apply_inventory">
+            <function model="stock.quant" name="search"
+                eval="[[('id', 'in', (ref('stock_inventory_product_product_8'), ref('stock_inventory_product_delivery_01'),))]]"
+            />
+        </function>
+
+        <!-- Generate deliveries in the past for purchase suggest testing purpose. -->
+        <record id="picking_delivery_1" model="stock.picking">
+            <field name="location_id" ref="stock.stock_location_stock"/>
+            <field name="location_dest_id" ref="stock.stock_location_customers"/>
+            <field name="picking_type_id" ref="stock.picking_type_out"/>
+            <field name="scheduled_date" eval="datetime.now() - timedelta(days=335)"/>
+            <field name="state">draft</field>
+            <field name="move_ids" model="stock.move" eval="[
+                (0, 0, {
+                    'name': obj().env.ref('product.product_product_8').name,
+                    'product_id': ref('product.product_product_8'),
+                    'product_uom': ref('uom.product_uom_unit'),
+                    'product_uom_qty': 3.0,
+                    'picking_type_id': ref('stock.picking_type_out'),
+                    'location_id': ref('stock.stock_location_stock'),
+                    'location_dest_id': ref('stock.stock_location_customers'),
+                }),
+                (0, 0, {
+                    'name': obj().env.ref('product.product_delivery_01').name,
+                    'product_id': ref('product.product_delivery_01'),
+                    'product_uom': ref('uom.product_uom_unit'),
+                    'product_uom_qty': 6.0,
+                    'picking_type_id': ref('stock.picking_type_out'),
+                    'location_id': ref('stock.stock_location_stock'),
+                    'location_dest_id': ref('stock.stock_location_customers'),
+                }),
+            ]"/>
+        </record>
+
+        <record id="picking_delivery_2" model="stock.picking">
+            <field name="location_id" ref="stock.stock_location_stock"/>
+            <field name="location_dest_id" ref="stock.stock_location_customers"/>
+            <field name="picking_type_id" ref="stock.picking_type_out"/>
+            <field name="scheduled_date" eval="datetime.now() - timedelta(days=80)"/>
+            <field name="state">draft</field>
+            <field name="move_ids" model="stock.move" eval="[
+                (0, 0, {
+                    'name': obj().env.ref('product.product_product_9').name,
+                    'product_id': ref('product.product_product_9'),
+                    'product_uom': ref('uom.product_uom_unit'),
+                    'product_uom_qty': 10.0,
+                    'picking_type_id': ref('stock.picking_type_out'),
+                    'location_id': ref('stock.stock_location_stock'),
+                    'location_dest_id': ref('stock.stock_location_customers'),
+                }),
+            ]"/>
+        </record>
+
+        <record id="picking_delivery_3" model="stock.picking">
+            <field name="location_id" ref="stock.stock_location_stock"/>
+            <field name="location_dest_id" ref="stock.stock_location_customers"/>
+            <field name="picking_type_id" ref="stock.picking_type_out"/>
+            <field name="scheduled_date" eval="datetime.now() - timedelta(days=60)"/>
+            <field name="state">draft</field>
+            <field name="move_ids" model="stock.move" eval="[
+                (0, 0, {
+                    'name': obj().env.ref('product.product_product_8').name,
+                    'product_id': ref('product.product_product_8'),
+                    'product_uom': ref('uom.product_uom_unit'),
+                    'product_uom_qty': 3.0,
+                    'picking_type_id': ref('stock.picking_type_out'),
+                    'location_id': ref('stock.stock_location_stock'),
+                    'location_dest_id': ref('stock.stock_location_customers'),
+                }),
+                (0, 0, {
+                    'name': obj().env.ref('product.product_delivery_01').name,
+                    'product_id': ref('product.product_delivery_01'),
+                    'product_uom': ref('uom.product_uom_unit'),
+                    'product_uom_qty': 12.0,
+                    'picking_type_id': ref('stock.picking_type_out'),
+                    'location_id': ref('stock.stock_location_stock'),
+                    'location_dest_id': ref('stock.stock_location_customers'),
+                }),
+                (0, 0, {
+                    'name': obj().env.ref('product.product_product_9').name,
+                    'product_id': ref('product.product_product_9'),
+                    'product_uom': ref('uom.product_uom_unit'),
+                    'product_uom_qty': 8.0,
+                    'picking_type_id': ref('stock.picking_type_out'),
+                    'location_id': ref('stock.stock_location_stock'),
+                    'location_dest_id': ref('stock.stock_location_customers'),
+                }),
+            ]"/>
+        </record>
+
+        <record id="picking_delivery_4" model="stock.picking">
+            <field name="location_id" ref="stock.stock_location_stock"/>
+            <field name="location_dest_id" ref="stock.stock_location_customers"/>
+            <field name="picking_type_id" ref="stock.picking_type_out"/>
+            <field name="scheduled_date" eval="datetime.now() - timedelta(days=23)"/>
+            <field name="state">draft</field>
+            <field name="move_ids" model="stock.move" eval="[
+                (0, 0, {
+                    'name': obj().env.ref('product.product_product_8').name,
+                    'product_id': ref('product.product_product_8'),
+                    'product_uom': ref('uom.product_uom_unit'),
+                    'product_uom_qty': 2.0,
+                    'picking_type_id': ref('stock.picking_type_out'),
+                    'location_id': ref('stock.stock_location_stock'),
+                    'location_dest_id': ref('stock.stock_location_customers'),
+                }),
+                (0, 0, {
+                    'name': obj().env.ref('product.product_delivery_01').name,
+                    'product_id': ref('product.product_delivery_01'),
+                    'product_uom': ref('uom.product_uom_unit'),
+                    'product_uom_qty': 5.0,
+                    'picking_type_id': ref('stock.picking_type_out'),
+                    'location_id': ref('stock.stock_location_stock'),
+                    'location_dest_id': ref('stock.stock_location_customers'),
+                }),
+            ]"/>
+        </record>
+
+        <record id="picking_delivery_5" model="stock.picking">
+            <field name="location_id" ref="stock.stock_location_stock"/>
+            <field name="location_dest_id" ref="stock.stock_location_customers"/>
+            <field name="picking_type_id" ref="stock.picking_type_out"/>
+            <field name="scheduled_date" eval="datetime.now() - timedelta(days=10)"/>
+            <field name="state">draft</field>
+            <field name="move_ids" model="stock.move" eval="[
+                (0, 0, {
+                    'name': obj().env.ref('product.product_product_9').name,
+                    'product_id': ref('product.product_product_9'),
+                    'product_uom': ref('uom.product_uom_unit'),
+                    'product_uom_qty': 4.0,
+                    'picking_type_id': ref('stock.picking_type_out'),
+                    'location_id': ref('stock.stock_location_stock'),
+                    'location_dest_id': ref('stock.stock_location_customers'),
+                }),
+            ]"/>
+        </record>
+
+        <function model="stock.picking" name="button_validate">
+            <value model="stock.picking" eval="[
+                obj().env.ref('purchase_stock.picking_delivery_1').id,
+                obj().env.ref('purchase_stock.picking_delivery_2').id,
+                obj().env.ref('purchase_stock.picking_delivery_3').id,
+                obj().env.ref('purchase_stock.picking_delivery_4').id,
+                obj().env.ref('purchase_stock.picking_delivery_5').id,
+            ]"/>
+        </function>
+
+        <!-- Rewrite deliveries' effective date. -->
+        <function model="stock.picking" name="write">
+            <value model="stock.picking" eval="[obj().env.ref('purchase_stock.picking_delivery_1').id]"/>
+            <value eval="{'date_done': datetime.now() - timedelta(days=333)}"/>
+        </function>
+        <function model="stock.move" name="write">
+            <value model="stock.move" search="[
+                ('product_id', '=', ref('product.product_product_8')),
+                ('picking_id', '=', ref('purchase_stock.picking_delivery_1')),
+            ]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=333)}"/>
+        </function>
+        <function model="stock.move" name="write">
+            <value model="stock.move" search="[
+                ('product_id', '=', ref('product.product_delivery_01')),
+                ('picking_id', '=', ref('purchase_stock.picking_delivery_1')),
+            ]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=333)}"/>
+        </function>
+        <function model="stock.move.line" name="write">
+            <value model="stock.move.line" search="[
+                ('product_id', '=', ref('product.product_product_8')),
+                ('picking_id', '=', ref('purchase_stock.picking_delivery_1')),
+            ]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=333)}"/>
+        </function>
+        <function model="stock.move.line" name="write">
+            <value model="stock.move.line" search="[
+                ('product_id', '=', ref('product.product_delivery_01')),
+                ('picking_id', '=', ref('purchase_stock.picking_delivery_1')),
+            ]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=333)}"/>
+        </function>
+
+        <function model="stock.picking" name="write">
+            <value model="stock.picking" eval="[obj().env.ref('purchase_stock.picking_delivery_2').id]"/>
+            <value eval="{'date_done': datetime.now() - timedelta(days=75)}"/>
+        </function>
+        <function model="stock.move" name="write">
+            <value model="stock.move" search="[('picking_id', '=', ref('purchase_stock.picking_delivery_2'))]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=75)}"/>
+        </function>
+        <function model="stock.move.line" name="write">
+            <value model="stock.move.line" search="[('picking_id', '=', ref('purchase_stock.picking_delivery_2'))]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=75)}"/>
+        </function>
+
+        <function model="stock.picking" name="write">
+            <value model="stock.picking" eval="[obj().env.ref('purchase_stock.picking_delivery_3').id]"/>
+            <value eval="{'date_done': datetime.now() - timedelta(days=50)}"/>
+        </function>
+        <function model="stock.move" name="write">
+            <value model="stock.move" search="[
+                ('product_id', '=', ref('product.product_product_8')),
+                ('picking_id', '=', ref('purchase_stock.picking_delivery_3')),
+            ]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=50)}"/>
+        </function>
+        <function model="stock.move" name="write">
+            <value model="stock.move" search="[
+                ('product_id', '=', ref('product.product_product_9')),
+                ('picking_id', '=', ref('purchase_stock.picking_delivery_3')),
+            ]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=50)}"/>
+        </function>
+        <function model="stock.move" name="write">
+            <value model="stock.move" search="[
+                ('product_id', '=', ref('product.product_delivery_01')),
+                ('picking_id', '=', ref('purchase_stock.picking_delivery_3')),
+            ]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=50)}"/>
+        </function>
+        <function model="stock.move.line" name="write">
+            <value model="stock.move.line" search="[
+                ('product_id', '=', ref('product.product_product_8')),
+                ('picking_id', '=', ref('purchase_stock.picking_delivery_3')),
+            ]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=50)}"/>
+        </function>
+        <function model="stock.move.line" name="write">
+            <value model="stock.move.line" search="[
+                ('product_id', '=', ref('product.product_product_9')),
+                ('picking_id', '=', ref('purchase_stock.picking_delivery_3')),
+            ]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=50)}"/>
+        </function>
+        <function model="stock.move.line" name="write">
+            <value model="stock.move.line" search="[
+                ('product_id', '=', ref('product.product_delivery_01')),
+                ('picking_id', '=', ref('purchase_stock.picking_delivery_3')),
+            ]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=50)}"/>
+        </function>
+
+        <function model="stock.picking" name="write">
+            <value model="stock.picking" eval="[obj().env.ref('purchase_stock.picking_delivery_4').id]"/>
+            <value eval="{'date_done': datetime.now() - timedelta(days=21)}"/>
+        </function>
+        <function model="stock.move" name="write">
+            <value model="stock.move" search="[
+                ('product_id', '=', ref('product.product_product_8')),
+                ('picking_id', '=', ref('purchase_stock.picking_delivery_4')),
+            ]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=21)}"/>
+        </function>
+        <function model="stock.move" name="write">
+            <value model="stock.move" search="[
+                ('product_id', '=', ref('product.product_delivery_01')),
+                ('picking_id', '=', ref('purchase_stock.picking_delivery_4')),
+            ]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=21)}"/>
+        </function>
+        <function model="stock.move.line" name="write">
+            <value model="stock.move.line" search="[
+                ('product_id', '=', ref('product.product_product_8')),
+                ('picking_id', '=', ref('purchase_stock.picking_delivery_4')),
+            ]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=21)}"/>
+        </function>
+        <function model="stock.move.line" name="write">
+            <value model="stock.move.line" search="[
+                ('product_id', '=', ref('product.product_delivery_01')),
+                ('picking_id', '=', ref('purchase_stock.picking_delivery_4')),
+            ]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=21)}"/>
+        </function>
+
+        <function model="stock.picking" name="write">
+            <value model="stock.picking" eval="[obj().env.ref('purchase_stock.picking_delivery_5').id]"/>
+            <value eval="{'date_done': datetime.now() - timedelta(days=7)}"/>
+        </function>
+        <function model="stock.move" name="write">
+            <value model="stock.move" search="[
+                ('product_id', '=', ref('product.product_product_9')),
+                ('picking_id', '=', ref('purchase_stock.picking_delivery_5')),
+            ]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=7)}"/>
+        </function>
+        <function model="stock.move.line" name="write">
+            <value model="stock.move.line" search="[
+                ('product_id', '=', ref('product.product_product_9')),
+                ('picking_id', '=', ref('purchase_stock.picking_delivery_5')),
+            ]"/>
+            <value eval="{'date': datetime.now() - timedelta(days=7)}"/>
+        </function>
     </data>
 
     <data noupdate="0">

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -227,6 +227,29 @@ class PurchaseOrder(models.Model):
         invoice_vals['invoice_incoterm_id'] = self.incoterm_id.id
         return invoice_vals
 
+    def action_display_suggest(self, product_domain=False):
+        self.ensure_one()
+        product_ids = self.order_line.product_id.ids
+        if product_domain:
+            product_ids = self.env['product.product'].with_context(order_id=self.id).search(product_domain).ids
+        context = {
+            'dialog_size': 'medium',
+            'default_purchase_order_id': self.id,
+            'default_warehouse_id': self.picking_type_id.warehouse_id.id,
+            'default_product_ids': product_ids,
+        }
+        return {
+            'type': 'ir.actions.act_window',
+            'name': _("Suggest Quantities based on Sales & Demands"),
+            'target': 'new',
+            'view_mode': 'form',
+            'views': [[False, 'form']],
+            'res_id': False,
+            'view_id': self.env.ref('purchase_stock.purchase_order_suggest_view_form').id,
+            'res_model': 'purchase.order.suggest',
+            'context': context,
+        }
+
     # --------------------------------------------------
     # Business methods
     # --------------------------------------------------

--- a/addons/purchase_stock/security/ir.model.access.csv
+++ b/addons/purchase_stock/security/ir.model.access.csv
@@ -1,6 +1,7 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_purchase_order_stock_worker,purchase.order,model_purchase_order,stock.group_stock_user,1,0,0,0
 access_purchase_order_line_stock_worker,purchase.order.line,model_purchase_order_line,stock.group_stock_user,1,0,0,0
+access_purchase_order_suggest,purchase.order.suggest,model_purchase_order_suggest,purchase.group_purchase_user,1,1,1,0
 access_stock_location_purchase_user,stock.location,stock.model_stock_location,purchase.group_purchase_user,1,0,0,0
 access_stock_warehouse_purchase_user,stock.warehouse,stock.model_stock_warehouse,purchase.group_purchase_user,1,0,0,0
 access_stock_picking_purchase_user,stock.picking,stock.model_stock_picking,purchase.group_purchase_user,1,1,1,1

--- a/addons/purchase_stock/static/src/css/purchase_stock.scss
+++ b/addons/purchase_stock/static/src/css/purchase_stock.scss
@@ -1,0 +1,7 @@
+.o_purchase_order_suggest .o_field_widget.o_small {
+    display: inline;
+
+    input {
+        width: 40px;
+    }
+}

--- a/addons/purchase_stock/static/src/js/time_period_selection_fields.js
+++ b/addons/purchase_stock/static/src/js/time_period_selection_fields.js
@@ -1,0 +1,46 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { selectionField, SelectionField } from "@web/views/fields/selection/selection_field";
+
+const { DateTime } = luxon;
+
+export class TimePeriodSelectionField extends SelectionField {
+    get options() {
+        // This field widget replaces three last options of `based_on` field by
+        // the current month, the next month and the after next month for the
+        // last year. For instance, if the current date is 12 January 2025,
+        // the options will be "January 2024", "February 2024" and "March 2024".
+        const date1 = DateTime.now().set({ day: 1 }).minus({ years: 1 });
+        const date2 = date1.plus({ months: 1 });
+        const date3 = date1.plus({ months: 2 });
+        const options = [];
+        for (const option of this.props.record.fields[this.props.name].selection) {
+            if (option[0] === "last_year") {
+                options.push([option[0], `${date1.monthLong} ${date1.year}`]);
+            } else if (option[0] === "last_year_2") {
+                options.push([option[0], `${date2.monthLong} ${date2.year}`]);
+            } else if (option[0] === "last_year_3") {
+                options.push([option[0], `${date3.monthLong} ${date3.year}`]);
+            } else if (option[0] === "last_year_quarter") {
+                let beginDate = date1.monthShort;
+                const endDate = `${date3.monthShort} ${date3.year}`;
+                if (date1.year !== date3.year) {
+                    beginDate += ` ${date1.year}`;
+                }
+                options.push([option[0], `${beginDate}-${endDate}`]);
+            } else if (option[0] !== false && option[1] !== "") {
+                options.push(option);
+            }
+        }
+        return options;
+    }
+}
+
+export const timePeriodSelectionField = {
+    ...selectionField,
+    component: TimePeriodSelectionField,
+    displayName: _t("Time Perdiod Selection"),
+    supportedTypes: ["selection"],
+};
+
+registry.category("fields").add("time_period_selection", timePeriodSelectionField);

--- a/addons/purchase_stock/static/src/product_catalog/kanban_controller.js
+++ b/addons/purchase_stock/static/src/product_catalog/kanban_controller.js
@@ -1,0 +1,45 @@
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { ProductCatalogKanbanController } from "@product/product_catalog/kanban_controller";
+import { patch } from "@web/core/utils/patch";
+import { _t } from "@web/core/l10n/translation";
+
+patch(ProductCatalogKanbanController.prototype, {
+    _defineButtonContent() {
+        super._defineButtonContent(...arguments);
+        this.displaySuggestButton = (
+            this.orderResModel === "purchase.order" && this.orderStateInfo.state === "draft"
+        );
+    },
+
+    async openSuggestWizard() {
+        // Display a warning if there is no product.
+        const records = this.model.root.records.filter((rec) => !rec.productCatalogData.isSample);
+        if (records.length === 0) {
+            return this.dialog.add(ConfirmationDialog, {
+                title: _t("No product to buy found"),
+                body: _t("Change the applied filters to receive suggestions about quantities to replenish for desired products."),
+            });
+        }
+        const args = [[this.orderId], this.model.config.domain];
+        const action = await this.model.orm.call("purchase.order", "action_display_suggest", args);
+        const onClose = (args) => {
+            return args?.refresh && this._adaptSearchFilter();
+        };
+        this.actionService.doAction(action, { onClose });
+    },
+
+    _adaptSearchFilter() {
+        // Add "In the Order" filter in the search bar if it wasn't already there.
+        const { searchModel } = this.env.model.env;
+        const inTheOrderFilter = Object.values(searchModel.searchItems).find(
+            (searchItem) => searchItem.name === "products_in_purchase_order"
+        );
+        if (inTheOrderFilter &&
+            searchModel.query.findIndex((queryEl) => queryEl.searchItemId === inTheOrderFilter.id) === -1
+        ) {
+            searchModel.toggleSearchItem(inTheOrderFilter.id);
+        } else {
+            this.model.load();
+        }
+    }
+});

--- a/addons/purchase_stock/static/src/product_catalog/kanban_controller.xml
+++ b/addons/purchase_stock/static/src/product_catalog/kanban_controller.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="purchase_stock.ProductCatalogKanbanController" t-inherit="ProductCatalogKanbanController" t-inherit-mode="extension">
+        <xpath expr="//button[hasclass('o-kanban-button-back')]" position="after">
+            <button t-if="displaySuggestButton"
+                    t-out="'Suggest'" type="button"
+                    class="btn btn-secondary o-kanban-button-suggest"
+                    t-on-click="this.openSuggestWizard"/>
+        </xpath>
+    </t>
+</templates>

--- a/addons/purchase_stock/static/tests/purchase_stock.test.js
+++ b/addons/purchase_stock/static/tests/purchase_stock.test.js
@@ -1,0 +1,63 @@
+import { defineMailModels } from "@mail/../tests/mail_test_helpers";
+import { describe, destroy, expect, test } from "@odoo/hoot";
+import { mockDate } from "@odoo/hoot-mock";
+import {
+    defineModels,
+    fields,
+    models,
+    mountView,
+} from "@web/../tests/web_test_helpers";
+
+class PurchaseOrderSuggest extends models.Model {
+    _name = "purchase.order.suggest";
+    based_on = fields.Selection({
+        selection: [
+            ["one_week", "Last 7 days"],
+            ["one_month", "Last 30 days"],
+            ["three_months", "Last 3 months"],
+            ["one_year", "Last 12 months"],
+            ["last_year", "Same month last year"],
+            ["last_year_2", "Next month last year"],
+            ["last_year_3", "After next month last year"],
+            ["last_year_quarter", "Last year quarter"],
+        ],
+        default: "one_month",
+        string: "Based on",
+    });
+    _views = {
+        form: `
+            <form>
+                <sheet>
+                    <field name="based_on" widget="time_period_selection"/>
+                </sheet>
+            </form>
+        `,
+    };
+}
+defineModels([PurchaseOrderSuggest]);
+defineMailModels();
+
+describe("time_period_selection field", () => {
+    test("relative selection options", async () => {
+        mockDate("2025-11-15 07:00:00");
+        const view = await mountView({
+            type: "form",
+            resModel: "purchase.order.suggest",
+        });
+        expect("select option:nth-last-child(4)").toHaveText("November 2024");
+        expect("select option:nth-last-child(3)").toHaveText("December 2024");
+        expect("select option:nth-last-child(2)").toHaveText("January 2025");
+        expect("select option:last-child").toHaveText("Nov 2024-Jan 2025");
+        destroy(view);
+        // Check for a different date.
+        mockDate("2020-03-20 07:00:00");
+        await mountView({
+            type: "form",
+            resModel: "purchase.order.suggest",
+        });
+        expect("select option:nth-last-child(4)").toHaveText("March 2019");
+        expect("select option:nth-last-child(3)").toHaveText("April 2019");
+        expect("select option:nth-last-child(2)").toHaveText("May 2019");
+        expect("select option:last-child").toHaveText("Mar-May 2019");
+    });
+});

--- a/addons/purchase_stock/tests/__init__.py
+++ b/addons/purchase_stock/tests/__init__.py
@@ -12,6 +12,7 @@ from . import test_purchase_delete_order
 from . import test_purchase_lead_time
 from . import test_purchase_order
 from . import test_purchase_order_process
+from . import test_purchase_order_suggest
 from . import test_purchase_stock_report
 from . import test_stockvaluation
 from . import test_replenish_wizard

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import re
 from datetime import datetime, timedelta

--- a/addons/purchase_stock/tests/test_purchase_order_suggest.py
+++ b/addons/purchase_stock/tests/test_purchase_order_suggest.py
@@ -1,0 +1,443 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import datetime, timedelta
+from dateutil.relativedelta import relativedelta
+
+from odoo import Command, fields
+from odoo.addons.purchase_stock.tests.common import PurchaseTestCommon
+from odoo.tests import tagged, freeze_time
+
+
+@freeze_time("2021-01-14 09:12:15")
+@tagged('post_install', '-at_install')
+class TestPurchaseOrderSuggest(PurchaseTestCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.delivery_type = cls.env['stock.picking.type'].browse(cls.picking_type_out)
+        cls.stock_location = cls.delivery_type.default_location_src_id
+        cls.customer_location = cls.delivery_type.default_location_dest_id
+        # Create a product and a supplier info.
+        cls.product_1 = cls.env['product.product'].create({
+            'name': 'Product 1',
+            'standard_price': 115,
+            'is_storable': True,
+        })
+        cls.env['product.supplierinfo'].create([{
+            'partner_id': cls.partner_1.id,
+            'price': 100,
+            'product_id': cls.product_1.id,
+        }])
+
+    def assertEstimatedPrice(self, po_suggest, price, based_on='one_month', days=30, factor=100, warehouse=False):
+        """ This helper method does an assert for the `purchase.order.suggest` wizard
+        estimated price for the given parameters (use the default values if not set).
+        Note that the wizard fields are updated each time this method is called."""
+        po_suggest.based_on = based_on
+        po_suggest.number_of_days = days
+        po_suggest.percent_factor = factor
+        po_suggest.warehouse_id = warehouse
+        self.assertEqual(po_suggest.estimated_price, price)
+
+    def _create_and_process_delivery_at_date(self, products_and_quantities, date=False, warehouse=False):
+        date = date or datetime.now()
+        delivery_type = warehouse.out_type_id if warehouse else self.delivery_type
+        with freeze_time(date):
+            delivery = self.env['stock.picking'].create({
+                'picking_type_id': self.delivery_type.id,
+                'location_id': delivery_type.default_location_src_id.id,
+                'location_dest_id': delivery_type.default_location_dest_id.id,
+                'move_ids': [Command.create({
+                    'name': f'Delivery move test for {product.name}',
+                    'location_id': delivery_type.default_location_src_id.id,
+                    'location_dest_id': delivery_type.default_location_dest_id.id,
+                    'product_id': product.id,
+                    'product_uom': self.uom_unit.id,
+                    'product_uom_qty': qty,
+                }) for (product, qty) in products_and_quantities],
+            })
+            delivery.action_confirm()
+            delivery.action_assign()
+            delivery.button_validate()
+            return delivery
+
+    def test_purchase_order_suggest_quantities(self):
+        """ Checks the suggest wizard adds right products with right quantities.
+        Also checks some values, like the products' quantity demand or the
+        suggest expected price, are rigthly computed too."""
+        today = fields.Datetime.now()
+        # Create some products.
+        product_2, product_3 = self.env['product.product'].create([{
+            'name': f'Product {i + 1}',
+            'standard_price': price,
+            'is_storable': True,
+        } for (i, price) in enumerate([25, 50])])
+        self.env['stock.quant']._update_available_quantity(self.product_1, self.stock_location, 42)
+        self.env['stock.quant']._update_available_quantity(product_2, self.stock_location, 15)
+        self.env['stock.quant']._update_available_quantity(product_3, self.stock_location, 20)
+
+        # Create supplier info.
+        self.env['product.supplierinfo'].create([{
+            'partner_id': self.partner_1.id,
+            'price': 20,
+            'product_id': product_2.id,
+        }, {
+            'partner_id': self.partner_1.id,
+            'price': 50,
+            'product_id': product_3.id,
+        }])
+
+        # Create some delivery in the past.
+        self._create_and_process_delivery_at_date(
+            [(self.product_1, 12)], today - relativedelta(years=1)
+        )
+        self._create_and_process_delivery_at_date(
+            [(self.product_1, 5), (product_2, 5)], today - relativedelta(months=10, days=3)
+        )
+        self._create_and_process_delivery_at_date(
+            [(self.product_1, 5), (product_3, 10)], today - relativedelta(months=2, days=5)
+        )
+        self._create_and_process_delivery_at_date(
+            [(self.product_1, 10), (product_3, 10)], today - relativedelta(months=1)
+        )
+        self._create_and_process_delivery_at_date(
+            [(self.product_1, 10), (product_2, 5)], today - relativedelta(days=15)
+        )
+        self._create_and_process_delivery_at_date(
+            [(product_2, 5)], today - relativedelta(days=3)
+        )
+
+        # Check product demand quantity.
+        # With no dates given in the context, the monthly demand should take only last month.
+        self.assertEqual(self.product_1.monthly_demand, 20)
+        self.assertEqual(product_2.monthly_demand, 10)
+        self.assertEqual(product_3.monthly_demand, 10)
+        # Check for last week.
+        one_week_ago = today - relativedelta(weeks=1)
+        context = {
+            'monthly_demand_start_date': one_week_ago,
+            'monthly_demand_limit_date': today,
+        }
+        self.assertEqual(self.product_1.with_context(context).monthly_demand, 0)
+        self.assertEqual(product_2.with_context(context).monthly_demand, 5)
+        self.assertEqual(product_3.with_context(context).monthly_demand, 0)
+        # Check for last three months.
+        three_months_ago = today - relativedelta(months=3)
+        context = {
+            'monthly_demand_start_date': three_months_ago,
+            'monthly_demand_limit_date': today,
+        }
+        self.assertEqual(self.product_1.with_context(context).monthly_demand, 25)
+        self.assertEqual(product_2.with_context(context).monthly_demand, 10)
+        self.assertEqual(product_3.with_context(context).monthly_demand, 20)
+        # Check for last year months.
+        one_year_ago = today - relativedelta(years=1)
+        context = {
+            'monthly_demand_start_date': one_year_ago,
+            'monthly_demand_limit_date': today,
+        }
+        self.assertEqual(self.product_1.with_context(context).monthly_demand, 42)
+        self.assertEqual(product_2.with_context(context).monthly_demand, 15)
+        self.assertEqual(product_3.with_context(context).monthly_demand, 20)
+        # Check for January 2020.
+        last_january = datetime(year=today.year - 1, month=today.month, day=1)
+        context = {
+            'monthly_demand_start_date': last_january,
+            'monthly_demand_limit_date': last_january + relativedelta(months=1),
+        }
+        self.assertEqual(self.product_1.with_context(context).monthly_demand, 12)
+        self.assertEqual(product_2.with_context(context).monthly_demand, 0)
+        self.assertEqual(product_3.with_context(context).monthly_demand, 0)
+        # Check for February 2020.
+        last_february = datetime(year=today.year - 1, month=today.month, day=1) + relativedelta(months=1)
+        context = {
+            'monthly_demand_start_date': last_february,
+            'monthly_demand_limit_date': last_february + relativedelta(months=1),
+        }
+        self.assertEqual(self.product_1.with_context(context).monthly_demand, 0)
+        self.assertEqual(product_2.with_context(context).monthly_demand, 0)
+        self.assertEqual(product_3.with_context(context).monthly_demand, 0)
+        # Check for March 2020.
+        last_march = datetime(year=today.year - 1, month=today.month, day=1) + relativedelta(months=2)
+        context = {
+            'monthly_demand_start_date': last_march,
+            'monthly_demand_limit_date': last_march + relativedelta(months=1),
+        }
+        self.assertEqual(self.product_1.with_context(context).monthly_demand, 5)
+        self.assertEqual(product_2.with_context(context).monthly_demand, 5)
+        self.assertEqual(product_3.with_context(context).monthly_demand, 0)
+
+        # Create a new PO for the vendor then check suggest wizard estimed price.
+        po = self.env['purchase.order'].create({'partner_id': self.partner_1.id})
+        action = po.action_display_suggest()
+        context = {
+            **action['context'],
+            'default_product_ids': (self.product_1 | product_2 | product_3).ids,
+            }
+        po_suggest = self.env['purchase.order.suggest'].with_context(context).create({
+            'number_of_days': 30,
+        })
+        # Check estimed price for default values (30 days, based on last month, with 100% factor.)
+        self.assertEstimatedPrice(po_suggest, 2700)
+        self.assertEstimatedPrice(po_suggest, 1350, days=15)
+        self.assertEstimatedPrice(po_suggest, 3410, factor=125)
+        # Check estimed price for 3 months.
+        self.assertEstimatedPrice(po_suggest, 1330, based_on='three_months')
+        self.assertEstimatedPrice(po_suggest, 3700, based_on='three_months', days=90)
+        # Check estimed price for current year.
+        self.assertEstimatedPrice(po_suggest, 540, based_on='one_year')
+        self.assertEstimatedPrice(po_suggest, 5500, based_on='one_year', days=365)
+
+        # Use suggest wizard to generate PO lines and check their values.
+        po_suggest.based_on = 'one_month'
+        po_suggest.number_of_days = 30
+        po_suggest.percent_factor = 100
+        po_suggest.action_purchase_order_suggest()
+        self.assertRecordValues(po.order_line, [
+            {'product_id': self.product_1.id, 'product_qty': 20},
+            {'product_id': product_2.id, 'product_qty': 10},
+            {'product_id': product_3.id, 'product_qty': 10},
+        ])
+        # Regenerate PO lines for 3 months (existing lines qty must be updated.)
+        po_suggest.based_on = 'three_months'
+        po_suggest.number_of_days = 30
+        po_suggest.percent_factor = 100
+        po_suggest.action_purchase_order_suggest()
+        self.assertRecordValues(po.order_line, [
+            {'product_id': self.product_1.id, 'product_qty': 9},
+            {'product_id': product_2.id, 'product_qty': 4},
+            {'product_id': product_3.id, 'product_qty': 7},
+        ])
+        po_suggest.number_of_days = 90
+        po_suggest.action_purchase_order_suggest()
+        self.assertRecordValues(po.order_line, [
+            {'product_id': self.product_1.id, 'product_qty': 25},
+            {'product_id': product_2.id, 'product_qty': 10},
+            {'product_id': product_3.id, 'product_qty': 20},
+        ])
+
+    def test_purchase_order_suggest_quantities_for_consu(self):
+        """ Checks the suggest wizard works also with consumable products."""
+        today = fields.Datetime.now()
+        # Create a consumable product.
+        consu = self.env['product.product'].create({
+            'name': 'Product Consu',
+            'standard_price': 23,
+        })
+
+        # Create supplier info.
+        self.env['product.supplierinfo'].create({
+            'partner_id': self.partner_1.id,
+            'price': 20,
+            'product_id': consu.id,
+        })
+
+        # Create some delivery in the past.
+        self._create_and_process_delivery_at_date([(consu, 55)], today - relativedelta(years=1, months=3))
+        self._create_and_process_delivery_at_date([(consu, 12)], today - relativedelta(years=1))
+        self._create_and_process_delivery_at_date([(consu, 5)], today - relativedelta(months=10, days=3))
+        self._create_and_process_delivery_at_date([(consu, 5)], today - relativedelta(months=2, days=5))
+        self._create_and_process_delivery_at_date([(consu, 10)], today - relativedelta(months=1))
+        self._create_and_process_delivery_at_date([(consu, 10)], today - relativedelta(days=15))
+
+        # Check product demand quantity.
+        # With no dates given in the context, the monthly demand should take only last month.
+        self.assertEqual(consu.monthly_demand, 20)
+        # Check for last week.
+        one_week_ago = today - relativedelta(weeks=1)
+        context = {
+            'monthly_demand_start_date': one_week_ago,
+            'monthly_demand_limit_date': today,
+        }
+        self.assertEqual(consu.with_context(context).monthly_demand, 0)
+        # Check for last three months.
+        three_months_ago = today - relativedelta(months=3)
+        context = {
+            'monthly_demand_start_date': three_months_ago,
+            'monthly_demand_limit_date': today,
+        }
+        self.assertEqual(consu.with_context(context).monthly_demand, 25)
+        # Check for last year months.
+        one_year_ago = today - relativedelta(years=1)
+        context = {
+            'monthly_demand_start_date': one_year_ago,
+            'monthly_demand_limit_date': today,
+        }
+        self.assertEqual(consu.with_context(context).monthly_demand, 42)
+        # Check for January 2020.
+        last_january = datetime(year=today.year - 1, month=today.month, day=1)
+        context = {
+            'monthly_demand_start_date': last_january,
+            'monthly_demand_limit_date': last_january + relativedelta(months=1),
+        }
+        self.assertEqual(consu.with_context(context).monthly_demand, 12)
+        # Check for February 2020.
+        last_february = datetime(year=today.year - 1, month=today.month, day=1) + relativedelta(months=1)
+        context = {
+            'monthly_demand_start_date': last_february,
+            'monthly_demand_limit_date': last_february + relativedelta(months=1),
+        }
+        self.assertEqual(consu.with_context(context).monthly_demand, 0)
+        # Check for March 2020.
+        last_march = datetime(year=today.year - 1, month=today.month, day=1) + relativedelta(months=2)
+        context = {
+            'monthly_demand_start_date': last_march,
+            'monthly_demand_limit_date': last_march + relativedelta(months=1),
+        }
+        self.assertEqual(consu.with_context(context).monthly_demand, 5)
+
+        # Create a new PO for the vendor then check suggest wizard estimed price.
+        po = self.env['purchase.order'].create({'partner_id': self.partner_1.id})
+        action = po.action_display_suggest()
+        context = {
+            **action['context'],
+            'default_product_ids': consu.ids,
+            }
+        po_suggest = self.env['purchase.order.suggest'].with_context(context).create({
+            'number_of_days': 30,
+        })
+        # Check estimed price for default values (30 days, based on last month, with 100% factor.)
+        self.assertEstimatedPrice(po_suggest, 400)
+        self.assertEstimatedPrice(po_suggest, 200, days=15)
+        self.assertEstimatedPrice(po_suggest, 500, factor=125)
+        # Check estimed price for 3 months.
+        self.assertEstimatedPrice(po_suggest, 180, based_on='three_months')
+        self.assertEstimatedPrice(po_suggest, 500, based_on='three_months', days=90)
+        # Check estimed price for current year.
+        self.assertEstimatedPrice(po_suggest, 80, based_on='one_year')
+        self.assertEstimatedPrice(po_suggest, 840, based_on='one_year', days=365)
+
+        # Use suggest wizard to generate PO lines and check their values.
+        po_suggest.based_on = 'one_month'
+        po_suggest.number_of_days = 30
+        po_suggest.percent_factor = 100
+        po_suggest.action_purchase_order_suggest()
+        self.assertRecordValues(po.order_line, [
+            {'product_id': consu.id, 'product_qty': 20},
+        ])
+        # Regenerate PO lines for 3 months (existing lines qty must be updated.)
+        po_suggest.based_on = 'three_months'
+        po_suggest.number_of_days = 30
+        po_suggest.percent_factor = 100
+        po_suggest.action_purchase_order_suggest()
+        self.assertRecordValues(po.order_line, [
+            {'product_id': consu.id, 'product_qty': 9},
+        ])
+        po_suggest.number_of_days = 90
+        po_suggest.action_purchase_order_suggest()
+        self.assertRecordValues(po.order_line, [
+            {'product_id': consu.id, 'product_qty': 25},
+        ])
+
+    def test_purchase_order_suggest_quantities_deduce_forecast_quantity(self):
+        """ Ensures that when the forecast quantity is deduced from the suggested quantity"""
+        today = fields.Datetime.now()
+        self.env['stock.quant']._update_available_quantity(self.product_1, self.stock_location, 12)
+        # Do a delivery in the past.
+        self._create_and_process_delivery_at_date([(self.product_1, 12)], date=today - timedelta(days=10))
+
+        # Create a new PO for the vendor then check suggest wizard estimed price.
+        po = self.env['purchase.order'].create({'partner_id': self.partner_1.id})
+        action = po.action_display_suggest()
+        context = {
+            **action['context'],
+            'default_product_ids': self.product_1.ids,
+            }
+        po_suggest = self.env['purchase.order.suggest'].with_context(context).create({
+            'number_of_days': 30,
+        })
+        # Check estimed price no forecast quantity.
+        self.assertEstimatedPrice(po_suggest, 1200)
+        po_suggest.action_purchase_order_suggest()
+        self.assertRecordValues(po.order_line, [
+            {'product_id': self.product_1.id, 'product_qty': 12},
+        ])
+
+        # Prepare a receipt for this product and confirm it.
+        receipt = self.env['stock.picking'].create({
+            'picking_type_id': self.picking_type_in,
+            'location_id': self.supplier_location,
+            'location_dest_id': self.stock_location.id,
+            'move_ids': [Command.create({
+                'name': f'Receipt move test for {self.product_1.name}',
+                'location_id': self.supplier_location,
+                'location_dest_id': self.stock_location.id,
+                'product_id': self.product_1.id,
+                'product_uom': self.uom_unit.id,
+                'product_uom_qty': 6,
+            })],
+        })
+        receipt.action_confirm()
+        receipt.action_assign()
+        # Check estimed price deduce the forecast quantity.
+        self.assertEstimatedPrice(po_suggest, 600)
+        po_suggest.action_purchase_order_suggest()
+        self.assertRecordValues(po.order_line, [
+            {'product_id': self.product_1.id, 'product_qty': 6},
+        ])
+
+    def test_purchase_order_suggest_quantities_multiwarehouse(self):
+        """ Ensure the product's qty demand is correctly computed for the right warehouse."""
+        warehouse = self.delivery_type.warehouse_id
+        date = fields.Datetime.now() - relativedelta(days=15)
+        self.env['stock.quant']._update_available_quantity(self.product_1, self.stock_location, 5)
+        self.env['stock.quant']._update_available_quantity(self.product_1, self.warehouse_1.lot_stock_id, 10)
+        # Make a delivery in each warehouse.
+        self._create_and_process_delivery_at_date([(self.product_1, 5)], date)
+        self._create_and_process_delivery_at_date([(self.product_1, 10)], date, warehouse=self.warehouse_1)
+        self.assertEqual(self.product_1.monthly_demand, 15)
+        self.assertEqual(self.product_1.with_context(warehouse_id=warehouse.id).monthly_demand, 5)
+        self.assertEqual(self.product_1.with_context(warehouse_id=self.warehouse_1.id).monthly_demand, 10)
+
+        # Create a PO for each warehouse and check the right quantity is added to the PO line.
+        po_1 = self.env['purchase.order'].create({
+            'partner_id': self.partner_1.id,
+            'picking_type_id': warehouse.in_type_id.id,
+        })
+        action = po_1.action_display_suggest()
+        context = {
+            **action['context'],
+            'default_product_ids': self.product_1.ids,
+        }
+        po_1_suggest = self.env['purchase.order.suggest'].with_context(context).create({
+            'number_of_days': 30,
+        })
+        self.assertEqual(po_1_suggest.warehouse_id, po_1.picking_type_id.warehouse_id, "Should use PO warehouse by default")
+        self.assertEstimatedPrice(po_1_suggest, 1500, warehouse=False)
+        self.assertEstimatedPrice(po_1_suggest, 500, warehouse=warehouse)
+        self.assertEstimatedPrice(po_1_suggest, 1000, warehouse=self.warehouse_1)
+        # Generate PO line for qty demand based on one specific warehouse.
+        po_1_suggest.warehouse_id = warehouse
+        po_1_suggest.action_purchase_order_suggest()
+        self.assertRecordValues(po_1.order_line, [
+            {'product_id': self.product_1.id, 'product_qty': 5},
+        ])
+        # Generate PO line for qty demand not based on any warehouse.
+        po_1_suggest.warehouse_id = False
+        po_1_suggest.action_purchase_order_suggest()
+        self.assertRecordValues(po_1.order_line, [
+            {'product_id': self.product_1.id, 'product_qty': 15},
+        ])
+
+        po_2 = self.env['purchase.order'].create({
+            'partner_id': self.partner_1.id,
+            'picking_type_id': self.warehouse_1.in_type_id.id,
+        })
+        action = po_2.action_display_suggest()
+        context = {
+            **action['context'],
+            'default_product_ids': self.product_1.ids,
+        }
+        po_2_suggest = self.env['purchase.order.suggest'].with_context(context).create({
+            'number_of_days': 30,
+        })
+        self.assertEqual(po_2_suggest.warehouse_id, po_2.picking_type_id.warehouse_id, "Should use PO warehouse by default")
+        self.assertEstimatedPrice(po_2_suggest, 1500, warehouse=False)
+        self.assertEstimatedPrice(po_2_suggest, 500, warehouse=warehouse)
+        self.assertEstimatedPrice(po_2_suggest, 1000, warehouse=self.warehouse_1)
+        # Generate PO line for qty demand based on one specific warehouse.
+        po_2_suggest.warehouse_id = self.warehouse_1
+        po_2_suggest.action_purchase_order_suggest()
+        self.assertRecordValues(po_2.order_line, [
+            {'product_id': self.product_1.id, 'product_qty': 10},
+        ])

--- a/addons/purchase_stock/views/product_views.xml
+++ b/addons/purchase_stock/views/product_views.xml
@@ -32,14 +32,22 @@
         <field name="arch" type="xml">
             <xpath expr="//kanban" position="attributes">
                     <attribute name="js_class">purchase_product_kanban_catalog</attribute>
-                    <attribute name="sample">1</attribute> 
+                    <attribute name="sample">1</attribute>
             </xpath>
+            <field name="id" position="after">
+                <field name="type"/>
+            </field>
             <div name="o_kanban_qty_available" position="after">
                 <div t-if="record.is_storable.raw_value"
                      name="o_kanban_qty_forecasted">
                     <span>Forecasted: </span>
                     <field name="virtual_available"/>
                     <field name="uom_id" widget="many2one_uom" class="ms-1" groups="uom.group_uom"/>
+                </div>
+                <div t-if="record.type.raw_value === 'consu'" name="o_kanban_monthly_demand">
+                    <span>Monthly Demand:</span>
+                    <field name="monthly_demand" class="ms-1"/>
+                    <field name="uom_id" class="ms-1" groups="uom.group_uom"/>
                 </div>
             </div>
         </field>

--- a/addons/purchase_stock/wizard/__init__.py
+++ b/addons/purchase_stock/wizard/__init__.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import stock_replenishment_info
 from . import product_replenish
+from . import purchase_order_suggest

--- a/addons/purchase_stock/wizard/purchase_order_suggest.py
+++ b/addons/purchase_stock/wizard/purchase_order_suggest.py
@@ -1,0 +1,204 @@
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+from math import ceil
+
+from odoo import api, Command, fields, models
+
+
+class PurchaseOrderSuggest(models.TransientModel):
+    _name = 'purchase.order.suggest'
+    _description = 'Purchase Order Suggest'
+
+    purchase_order_id = fields.Many2one('purchase.order', required=True)
+    currency_id = fields.Many2one('res.currency', related='purchase_order_id.currency_id')
+    partner_id = fields.Many2one('res.partner', related='purchase_order_id.partner_id', change_default=True)
+    product_ids = fields.Many2many('product.product')
+    warehouse_id = fields.Many2one('stock.warehouse', string="Warehouse")
+
+    based_on = fields.Selection(
+        selection=[
+            ('one_week', "Last 7 days"),
+            ('one_month', "Last 30 days"),
+            ('three_months', "Last 3 months"),
+            ('one_year', "Last 12 months"),
+            ('last_year', "Same month last year"),
+            ('last_year_2', "Next month last year"),
+            ('last_year_3', "After next month last year"),
+            ('last_year_quarter', "Last year quarter"),
+        ],
+        default='one_month',
+        string='Based on',
+        required=True
+    )
+    number_of_days = fields.Integer(
+        string="Replenish for", required=True,
+        default=7,
+        help="Suggested quantities to replenish will be computed for all filtered products\
+              in this catalog in order to cover this amount of days of average demand.")
+    percent_factor = fields.Integer(default=100, required=True)
+    estimated_price = fields.Float(
+        string="Expected",
+        compute='_compute_estimated_price',
+        digits='Product Price')
+    product_count = fields.Integer(compute='_compute_estimated_price')
+    hide_warehouse = fields.Boolean(compute='_compute_hide_warehouse')
+    multiplier = fields.Float(compute='_compute_multiplier')
+
+    def _compute_hide_warehouse(self):
+        if not self.env.user.has_group('stock.group_stock_multi_warehouses'):
+            self.hide_warehouse = True
+        else:
+            company_warehouses_count = self.env['stock.warehouse'].search_count([('company_id', '=', self.env.company.id)])
+            self.hide_warehouse = company_warehouses_count < 2
+
+    @api.depends('based_on', 'number_of_days', 'percent_factor', 'product_ids', 'warehouse_id')
+    def _compute_estimated_price(self):
+        for suggest in self:
+            estimated_price, product_count = 0, 0
+            seller_params = {'order_id': suggest.purchase_order_id}
+
+            # Explicitly fetch existing records to avoid "NewId origin" shenanigans
+            # and add context's values needed by the monthly demand's compute.
+            products = self.env['product.product'].browse(self.product_ids.ids).with_context(
+                suggest._get_montlhy_demand_context()
+            )
+            for product in products:
+                # First, compute the product's quantity.
+                quantity = ceil(product.monthly_demand * suggest.multiplier)
+                qty_to_deduce = max(product.qty_available, 0) + max(product.incoming_qty, 0)
+                quantity -= qty_to_deduce
+                if quantity <= 0:
+                    continue
+                product_count += 1
+                # Then, compute the price.
+                price = product.standard_price
+                seller = product._select_seller(
+                    partner_id=suggest.partner_id,
+                    quantity=quantity,
+                    ordered_by='min_qty',
+                    params=seller_params
+                )
+                if seller:
+                    price = seller.price_discounted
+                estimated_price += price * quantity
+            suggest.product_count = product_count
+            suggest.estimated_price = estimated_price
+
+    @api.depends('number_of_days', 'percent_factor')
+    def _compute_multiplier(self):
+        for suggest in self:
+            match suggest.based_on:
+                case 'one_week':
+                    period_in_days = 7
+                case 'three_months' | 'last_year_quarter':
+                    period_in_days = 90
+                case 'one_year':
+                    period_in_days = 365
+                case _:
+                    period_in_days = 30
+            suggest.multiplier = (suggest.number_of_days / period_in_days) * (suggest.percent_factor / 100)
+
+    def action_purchase_order_suggest(self):
+        """ Auto-fill the Purchase Order with vendor's product regarding the
+        past demand (real consumtion for a given period of time.)"""
+        self.ensure_one()
+        order = self.purchase_order_id
+        # Products are either the given products, either the supplier's products.
+        supplierinfos = self.env['product.supplierinfo'].search([
+            ('partner_id', '=', order.partner_id.id),
+        ])
+        products = self.product_ids or supplierinfos.product_id
+        # Add context's values needed by the monthly demand's compute.
+        products = products.with_context(self._get_montlhy_demand_context())
+        # Create new PO lines for each product with a monthy demand.
+        po_lines_commands = []
+        for product in products:
+            existing_po_lines = order.order_line.filtered(lambda pol: pol.product_id == product)
+            existing_po_line = existing_po_lines[:1]
+            # If there is multiple lines for the same product, we delete all the
+            # lines except the first one (who will be updated.)
+            for po_line in existing_po_lines[1:]:
+                po_lines_commands.append(Command.unlink(po_line.id))
+            quantity = ceil(product.monthly_demand * self.multiplier)
+            qty_to_deduce = max(product.qty_available, 0) + max(product.incoming_qty, 0)
+            quantity -= qty_to_deduce
+            if quantity <= 0:
+                # If there is no quantity for a filtered product and there is an
+                # existing PO line for this product, we delete it.
+                if existing_po_line:
+                    po_lines_commands.append(Command.unlink(existing_po_line.id))
+                continue
+            supplierinfo = supplierinfos.filtered(lambda supinfo: supinfo.product_id == product)[:1]
+            if existing_po_line:
+                # If a PO line already exists for this product, we simply update its quantity.
+                vals = self.env['purchase.order.line']._prepare_purchase_order_line(
+                    product,
+                    quantity,
+                    product.uom_id,
+                    order.company_id,
+                    supplierinfo,
+                    order
+                )
+                po_lines_commands.append(Command.update(existing_po_line.id, vals))
+            else:
+                # If not, we create a new PO line.
+                vals = self.env['purchase.order.line']._prepare_purchase_order_line(
+                    product,
+                    quantity,
+                    product.uom_id,
+                    order.company_id,
+                    supplierinfo,
+                    order
+                )
+                po_lines_commands.append(Command.create(vals))
+        order.order_line = po_lines_commands
+        self._save_values_for_vendor()
+        return {
+            'type': 'ir.actions.act_window_close',
+            'infos': {'refresh': True},
+        }
+
+    def _get_montlhy_demand_context(self):
+        self.ensure_one()
+        start_date, limit_date = self._get_period_of_time()
+        context = {
+            'monthly_demand_start_date': start_date,
+            'monthly_demand_limit_date': limit_date,
+        }
+        if self.warehouse_id and not self.hide_warehouse:
+            context['warehouse_id'] = self.warehouse_id.id
+        return context
+
+    def _get_period_of_time(self):
+        self.ensure_one()
+        start_date = fields.Datetime.now()
+        limit_date = fields.Datetime.now()
+        if self.based_on == 'one_week':
+            start_date = start_date - relativedelta(weeks=1)
+        elif self.based_on == 'one_month':
+            start_date = start_date - relativedelta(months=1)
+        elif self.based_on == 'three_months':
+            start_date = start_date - relativedelta(months=3)
+        elif self.based_on == 'one_year':
+            start_date = start_date - relativedelta(years=1)
+        else:  # Relative period of time.
+            today = fields.Datetime.now()
+            start_date = datetime(year=today.year - 1, month=today.month, day=1)
+
+            if self.based_on == 'last_year_2':
+                start_date += relativedelta(months=1)
+            elif self.based_on == 'last_year_3':
+                start_date += relativedelta(months=2)
+
+            if self.based_on == 'last_year_quarter':
+                limit_date = start_date + relativedelta(months=3)
+            else:
+                limit_date = start_date + relativedelta(months=1)
+        return start_date, limit_date
+
+    def _save_values_for_vendor(self):
+        """ Save fields' value as default values for the PO vendor."""
+        cid = self.env.company.id
+        condition = f'partner_id={self.partner_id.id}'
+        for field in ['based_on', 'number_of_days', 'percent_factor']:
+            self.env['ir.default'].set('purchase.order.suggest', field, self[field], company_id=cid, condition=condition)

--- a/addons/purchase_stock/wizard/purchase_order_suggest_views.xml
+++ b/addons/purchase_stock/wizard/purchase_order_suggest_views.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="purchase_order_suggest_view_form" model="ir.ui.view">
+        <field name="name">purchase.order.suggest.view.form</field>
+        <field name="model">purchase.order.suggest</field>
+        <field name="arch" type="xml">
+            <form class="o_purchase_order_suggest">
+                <field name="purchase_order_id" invisible="1"/> <!-- Needed for `currency_id` related field. -->
+                <field name="currency_id" invisible="1"/> <!-- Needed for `estimated_price` `currency_field` option. -->
+                <field name="product_ids" invisible="1"/> <!-- Needed for `_compute_product_count`. -->
+                <group>
+                    <div class="text-muted">
+                        <p>Get recommendations of products to purchase at <field name="partner_id" class="oe_inline fw-bold" options="{'no_open': True}"/> based on stock on hand, and expected sales volumes.</p>
+                        <p>Set a reference period to estimate sales, and use the percentage to take into account seasonability and the increase/decrease of business.</p>
+                    </div>
+                </group>
+                <group>
+                    <label for="number_of_days"/>
+                    <div>
+                        <field name="number_of_days" class="o_small"/> days
+                    </div>
+                    <field name="warehouse_id" string="In" placeholder="All Warehouses" invisible="hide_warehouse"/>
+                    <label for="based_on"/>
+                    <div>
+                        <field name="based_on" class="oe_inline me-2" widget="time_period_selection"/> x
+                        <field name="percent_factor" class="o_small"/> %
+                    </div>
+                </group>
+                <footer>
+                    <button invisible="estimated_price"
+                            class="btn-secondary disabled"
+                            name="action_purchase_order_suggest"
+                            string="Compute" type="object"/>
+                    <button invisible="not estimated_price"
+                            class="btn-primary"
+                            name="action_purchase_order_suggest"
+                            string="Compute" type="object"
+                            data-hotkey="q"/>
+                    <button string="Discard" class="btn btn-secondary" special="cancel" data-hotkey="x"/>
+                    <div class="position-absolute end-0 pe-3 text-end text-info fw-bold">
+                        <!-- <label class="d-block" for="estimated_price"/> -->
+                        <div><field name="product_count" class="oe_inline"/> Products</div>
+                        <field name="estimated_price" widget="monetary" options="{'currency_field': 'currency_id'}"/>
+                    </div>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/repair/static/src/components/product_catalog/kanban_controller.js
+++ b/addons/repair/static/src/components/product_catalog/kanban_controller.js
@@ -3,7 +3,7 @@ import { patch } from "@web/core/utils/patch";
 import { _t } from "@web/core/l10n/translation";
 
 patch(ProductCatalogKanbanController.prototype, {
-    async _defineButtonContent() {
+    _defineButtonContent() {
         if (this.orderResModel === "repair.order") {
             this.buttonString = _t("Back to Repair");
         } else {

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -131,7 +131,7 @@
             <filter name="goods" position="after">
                 <filter string="In the Order"
                         invisible="context.get('active_model', '') != 'sale.order.line'"
-                        name="products_in_order"
+                        name="products_in_sale_order"
                         domain="[('product_catalog_product_is_in_sale_order', '=', True)]"/>
             </filter>
         </field>


### PR DESCRIPTION
This commit adds an action to automatically populate a Purchase Order from the Product Catalog. This action displays a wizard to let the user selects the period of time, the warehouse to take in consideration, for how much time the replenish is needed and a percentage to manually adapt the quantity.
Once the wizard is set, the total price for all the product's need is displayed and the user can confirm and a PO line will be created for every product.

The products displayed in the catalog are the ones who will be replenished. Their done outgoing moves are used to compute the "monthly demand".

task-4536728

Enterprise PR: odoo/enterprise#79704