### PR TITLE
[FIX] l10n_in_ewaybill: fix traceback while unlinking attchments

### DIFF
--- a/addons/l10n_in_ewaybill/models/ir_attachment.py
+++ b/addons/l10n_in_ewaybill/models/ir_attachment.py
@@ -6,7 +6,7 @@ class IrAttachment(models.Model):
     _inherit = 'ir.attachment'
 
     @api.ondelete(at_uninstall=False)
-    def _unlink_except_government_document(self):
+    def _unlink_except_ewaybill_government_document(self):
         """
         Prevents the deletion of attachments related to government-issued documents.
         """
@@ -17,4 +17,3 @@ class IrAttachment(models.Model):
             for attachment in self
         ):
             raise UserError(_("You can't unlink an attachment that you received from the government"))
-        return super()._unlink_except_government_document()


### PR DESCRIPTION
Currently, a traceback is occurring when the user tries to unlink an attachment.

To reproduce this issue:

1) Install `l10n_in_ewaybill`
2) Try to unlink any attachments from `settings/technical/attachments`

Error:-
```
AttributeError: 'super' object has no attribute '_unlink_except_government_document'
```

This error was occurring because of the latest changes from the below commit.

https://github.com/odoo/odoo/pull/195701/commits/f2a5024f6fb43110e1f0672db89df7c67f54412d

Here the method `_unlink_except_government_document` is actually defined in the `account_edi` module.

https://github.com/odoo/odoo/blob/dea5b91e6917fc52bd39bf77fcc59fd648635158/addons/account_edi/models/ir_attachment.py#L11

But in the above commit, a super call was used in `l10n_in_ewaybill`. 
Here the `l10n_in_ewaybill` module is not dependent on `account_edi` directly or indirectly.

https://github.com/odoo/odoo/blob/dea5b91e6917fc52bd39bf77fcc59fd648635158/addons/l10n_in_ewaybill/models/ir_attachment.py#L20

This will lead to the above traceback.

sentry-6272499414

