### PR TITLE
[FIX] point_of_sale: combo preparation receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1658,7 +1658,11 @@ export class PosStore extends Reactive {
 
     async printChanges(order, orderChange) {
         const unsuccedPrints = [];
-        orderChange.new.sort((a, b) => {
+        const isPartOfCombo = (line) =>
+            line.isCombo || this.models["product.product"].get(line.product_id).type == "combo";
+        const comboChanges = orderChange.new.filter(isPartOfCombo);
+        const normalChanges = orderChange.new.filter((line) => !isPartOfCombo(line));
+        normalChanges.sort((a, b) => {
             const sequenceA = a.pos_categ_sequence;
             const sequenceB = b.pos_categ_sequence;
             if (sequenceA === 0 && sequenceB === 0) {
@@ -1667,6 +1671,7 @@ export class PosStore extends Reactive {
 
             return sequenceA - sequenceB;
         });
+        orderChange.new = [...comboChanges, ...normalChanges];
 
         for (const printer of this.unwatched.printers) {
             const changes = this._getPrintingCategoriesChanges(

--- a/addons/point_of_sale/tests/common_setup_methods.py
+++ b/addons/point_of_sale/tests/common_setup_methods.py
@@ -29,6 +29,16 @@ def setup_product_combo_items(self):
         }
     )
 
+    pos_category_1 = self.env["pos.category"].create({
+        "name": "Category 1",
+    })
+    pos_category_2 = self.env["pos.category"].create({ 
+        "name": "Category 2",
+    })
+    pos_category_3 = self.env["pos.category"].create({
+        "name": "Category 3",
+    })
+
     combo_product_1 = self.env["product.product"].create(
         {
             "name": "Combo Product 1",
@@ -36,6 +46,7 @@ def setup_product_combo_items(self):
             "available_in_pos": True,
             "list_price": 10,
             "taxes_id": [(6, 0, [tax10.id])],
+            "pos_categ_ids": [(6, 0, [pos_category_1.id])],
         }
     )
 
@@ -46,6 +57,7 @@ def setup_product_combo_items(self):
             "available_in_pos": True,
             "list_price": 11,
             "taxes_id": [(6, 0, [tax20in.id])],
+            "pos_categ_ids": [(6, 0, [pos_category_1.id])],
         }
     )
 
@@ -56,6 +68,7 @@ def setup_product_combo_items(self):
             "available_in_pos": True,
             "list_price": 16,
             "taxes_id": [(6, 0, [tax30.id])],
+            "pos_categ_ids": [(6, 0, [pos_category_1.id])],
         }
     )
 
@@ -86,6 +99,7 @@ def setup_product_combo_items(self):
             "available_in_pos": True,
             "list_price": 20,
             "taxes_id": [(6, 0, [tax10.id])],
+            "pos_categ_ids": [(6, 0, [pos_category_2.id])],
         }
     )
 
@@ -96,6 +110,7 @@ def setup_product_combo_items(self):
             "available_in_pos": True,
             "list_price": 25,
             "taxes_id": [(6, 0, [tax20in.id])],
+            "pos_categ_ids": [(6, 0, [pos_category_2.id])],
         }
     )
 
@@ -122,6 +137,7 @@ def setup_product_combo_items(self):
             "available_in_pos": True,
             "list_price": 30,
             "taxes_id": [(6, 0, [tax30.id])],
+            "pos_categ_ids": [(6, 0, [pos_category_3.id])],
         }
     )
 
@@ -132,6 +148,7 @@ def setup_product_combo_items(self):
             "available_in_pos": True,
             "list_price": 32,
             "taxes_id": [(6, 0, [tax10.id])],
+            "pos_categ_ids": [(6, 0, [pos_category_3.id])],
         }
     )
 
@@ -142,6 +159,7 @@ def setup_product_combo_items(self):
             "available_in_pos": True,
             "list_price": 40,
             "taxes_id": [(6, 0, [tax20in.id])],
+            "pos_categ_ids": [(6, 0, [pos_category_3.id])],
         }
     )
 
@@ -152,6 +170,7 @@ def setup_product_combo_items(self):
             "available_in_pos": True,
             "list_price": 50,
             "taxes_id": [(6, 0, [tax20in.id])],
+            "pos_categ_ids": [(6, 0, [pos_category_3.id])],
         }
     )
 
@@ -248,5 +267,6 @@ def setup_product_combo_items(self):
             "combo_ids": [
                 (6, 0, [self.desks_combo.id, self.chairs_combo.id, self.desk_accessories_combo.id])
             ],
+            "pos_categ_ids": [(6, 0, [pos_category_2.id])],
         }
     )

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -15,6 +15,7 @@ import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen
 import { inLeftSide, negateStep } from "@point_of_sale/../tests/tours/utils/common";
 import { registry } from "@web/core/registry";
 import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
+import * as combo from "@point_of_sale/../tests/tours/utils/combo_popup_util";
 
 const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
 
@@ -402,6 +403,55 @@ registry.category("web_tour.tours").add("PreparationPrinterContent", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("ComboSortedPreparationReceiptTour", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Office Combo"),
+            combo.select("Combo Product 2"),
+            combo.select("Combo Product 4"),
+            combo.select("Combo Product 6"),
+            Dialog.confirm(),
+            ProductScreen.clickDisplayedProduct("Office Combo"),
+            combo.select("Combo Product 1"),
+            combo.select("Combo Product 5"),
+            combo.select("Combo Product 8"),
+            Dialog.confirm(),
+            {
+                content: "Check if order preparation has product correctly ordered",
+                trigger: "body",
+                run: async () => {
+                    const order = posmodel.get_order();
+                    const data = posmodel.getOrderChanges();
+                    const changes = Object.values(data.orderlines);
+                    const printed = await posmodel.getRenderedReceipt(order, "New", changes);
+                    const orderLines = [...printed.querySelectorAll(".orderline")];
+                    const orderLinesInnerText = orderLines.map((orderLine) => orderLine.innerText);
+                    const expectedOrderLines = [
+                        "Office Combo",
+                        "Combo Product 2",
+                        "Combo Product 4",
+                        "Combo Product 6",
+                        "Office Combo",
+                        "Combo Product 1",
+                        "Combo Product 5",
+                        "Combo Product 8",
+                    ];
+                    for (let i = 0; i < orderLinesInnerText.length; i++) {
+                        if (!orderLinesInnerText[i].includes(expectedOrderLines[i])) {
+                            throw new Error("Order line mismatch");
+                        }
+                    }
+                },
+            },
+            ProductScreen.totalAmountIs("95.00"),
+            ProductScreen.clickPayButton(),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("MultiPreparationPrinter", {
     checkDelay: 50,
     steps: () =>
@@ -412,5 +462,6 @@ registry.category("web_tour.tours").add("MultiPreparationPrinter", {
             ProductScreen.clickDisplayedProduct("Product 1"),
             ProductScreen.clickOrderButton(),
             Dialog.bodyIs("Failed in printing Detailed Receipt changes of the order"),
+            Dialog.confirm(),
         ].flat(),
 });

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -400,6 +400,21 @@ class TestFrontend(TestFrontendCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PreparationPrinterContent', login="pos_user")
 
+    def test_combo_preparation_receipt(self):
+        setup_product_combo_items(self)
+        pos_printer = self.env['pos.printer'].create({
+            'name': 'Printer',
+            'printer_type': 'epson_epos',
+            'epson_printer_ip': '0.0.0.0',
+            'product_categories_ids': [Command.set(self.env['pos.category'].search([]).ids)],
+        })
+        self.pos_config.write({
+            'is_order_printer' : True,
+            'printer_ids': [Command.set(pos_printer.ids)],
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('ComboSortedPreparationReceiptTour')
+
     def test_multiple_preparation_printer(self):
         """This test make sure that no empty receipt are sent when using multiple printer with different categories
            The tour will check that we tried did not try to print two receipt. We can achieve that by checking the content


### PR DESCRIPTION
When sending combo products that contains different products with different pos categories, the receipt was not showing the products grouped by combo.

Steps to reproduce:
-------------------
* Create a combo product with different products with different pos categories
* Setup a preparation printer that will print all categories
* Open PoS and add at least 2 combo products with different selection
* Send the order to the kitchen
> Observation: The product on the receipt are grouped by product
  category instead of being grouped by combo.

Why the fix:
------------
Instead of sorting all product based on their category, we filter out the combo products first and sort the other products based on their category.

opw-4459211