### PR TITLE
[IMP] base, web: add invisible field to menus

### DIFF
--- a/addons/point_of_sale/views/pos_assets_index.xml
+++ b/addons/point_of_sale/views/pos_assets_index.xml
@@ -29,7 +29,7 @@
             })"/>;
             // Prevent the menu_service to load anything. In an ideal world, POS assets would only contain
             // what is genuinely necessary, and not the whole backend.
-            odoo.loadMenusPromise = Promise.resolve();
+            odoo.loadMenusPromise = Promise.resolve({});
         </script>
 
         <t t-call="web.conditional_assets_tests">

--- a/addons/project/views/project_sharing_project_task_templates.xml
+++ b/addons/project/views/project_sharing_project_task_templates.xml
@@ -7,7 +7,7 @@
                     odoo.__session_info__ = <t t-out="json.dumps(session_info)"/>;
                     // Prevent the menu_service to load anything. In an ideal world, Project Sharing assets would only contain
                     // what is genuinely necessary, and not the whole backend.
-                    odoo.loadMenusPromise = Promise.resolve();
+                    odoo.loadMenusPromise = Promise.resolve({});
                 </script>
                 <base target="_parent"/>
                 <t t-call-assets="project.webclient"/>

--- a/addons/web/models/ir_ui_menu.py
+++ b/addons/web/models/ir_ui_menu.py
@@ -36,6 +36,7 @@ class IrUiMenu(models.Model):
                     "webIcon": None,
                     "webIconData": None,
                     "webIconDataMimetype": None,
+                    "webInvisible": False,
                     "backgroundImage": menu.get('backgroundImage'),
                 }
             else:
@@ -82,6 +83,7 @@ class IrUiMenu(models.Model):
                     "webIcon": web_icon,
                     "webIconData": web_icon_data,
                     "webIconDataMimetype": menu['web_icon_data_mimetype'],
+                    "webInvisible": menu['web_invisible'],
                 }
 
         return web_menus

--- a/addons/web/static/src/webclient/menus/menu_service.js
+++ b/addons/web/static/src/webclient/menus/menu_service.js
@@ -1,6 +1,8 @@
+import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { browser } from "../../core/browser/browser";
 import { registry } from "../../core/registry";
 import { session } from "@web/session";
+import { user } from "@web/core/user";
 
 const loadMenusUrl = `/web/webclient/load_menus`;
 
@@ -23,6 +25,13 @@ function makeFetchLoadMenus() {
 
 function makeMenus(env, menusData, fetchLoadMenus) {
     let currentAppId;
+    function evaluateInvisible() {
+        Object.values(menusData).forEach((menu) => {
+            menu.invisible = evaluateBooleanExpr(menu.webInvisible, user.evalContext);
+            delete menu.webInvisible;
+        });
+    }
+    evaluateInvisible();
     function _getMenu(menuId) {
         return menusData[menuId];
     }
@@ -39,7 +48,9 @@ function makeMenus(env, menusData, fetchLoadMenus) {
             return Object.values(menusData);
         },
         getApps() {
-            return this.getMenu("root").children.map((mid) => this.getMenu(mid));
+            return this.getMenu("root")
+                .children.filter((mID) => !menusData[mID].invisible)
+                .map((mid) => this.getMenu(mid));
         },
         getMenu: _getMenu,
         getCurrentApp() {
@@ -51,7 +62,9 @@ function makeMenus(env, menusData, fetchLoadMenus) {
         getMenuAsTree(menuID) {
             const menu = this.getMenu(menuID);
             if (!menu.childrenTree) {
-                menu.childrenTree = menu.children.map((mid) => this.getMenuAsTree(mid));
+                menu.childrenTree = menu.children
+                    .filter((mID) => !menusData[mID].invisible)
+                    .map((mid) => this.getMenuAsTree(mid));
             }
             return menu;
         },
@@ -71,6 +84,7 @@ function makeMenus(env, menusData, fetchLoadMenus) {
         async reload() {
             if (fetchLoadMenus) {
                 menusData = await fetchLoadMenus(true);
+                evaluateInvisible();
                 env.bus.trigger("MENUS:APP-CHANGED");
             }
         },

--- a/addons/web/static/tests/webclient/navbar.test.js
+++ b/addons/web/static/tests/webclient/navbar.test.js
@@ -665,3 +665,90 @@ test("Do not execute adapt when navbar is destroyed", async () => {
     await runAllTimers();
     expect.verifySteps([]);
 });
+
+test.tags("desktop");
+test("root children are not render if invisibles", async () => {
+    defineMenus([
+        {
+            id: "root",
+            children: [
+                { id: 1, children: [], name: "My app 1", appID: 1, webInvisible: "True" },
+                { id: 2, children: [], name: "My app 2", appID: 2 },
+                { id: 3, children: [], name: "My app 3", appID: 3 },
+                { id: 4, children: [], name: "My app 4", appID: 4 },
+                {
+                    id: 5,
+                    children: [],
+                    name: "My app 5",
+                    appID: 5,
+                    webInvisible: "companies.active_id == 2",
+                },
+                {
+                    id: 6,
+                    children: [],
+                    name: "My app 6",
+                    appID: 6,
+                    webInvisible: "companies.active_id == 1",
+                },
+                { id: 7, children: [], name: "My app 7", appID: 7 },
+            ],
+            name: "root",
+            appID: "root",
+        },
+    ]);
+    await mountWithCleanup(NavBar);
+    await contains(".o_navbar_apps_menu button.dropdown-toggle").click();
+    expect(".dropdown-item").toHaveCount(5, {
+        message: "5 apps present",
+    });
+});
+
+test.tags("desktop");
+test("menu children are not render if invisibles", async () => {
+    defineMenus([
+        {
+            id: "root",
+            children: [
+                {
+                    id: 1,
+                    children: [
+                        { id: 2, children: [], name: "Section 2", appID: 1 },
+                        {
+                            id: 3,
+                            children: [
+                                { id: 6, children: [], name: "Sub-Section 6", appID: 1 },
+                                { id: 7, children: [], name: "Sub-Section 7", appID: 1 },
+                            ],
+                            name: "Section 3",
+                            appID: 1,
+                            webInvisible: "companies.active_id == 2",
+                        },
+                        {
+                            id: 4,
+                            children: [
+                                { id: 8, children: [], name: "Sub-Section 8", appID: 1 },
+                                { id: 9, children: [], name: "Sub-Section 9", appID: 1 },
+                            ],
+                            name: "Section 4",
+                            appID: 1,
+                            webInvisible: "companies.active_id == 1",
+                        },
+                        { id: 5, children: [], name: "Section 5", appID: 1 },
+                    ],
+                    name: "My app 1",
+                    appID: 1,
+                },
+            ],
+            name: "root",
+            appID: "root",
+        },
+    ]);
+    await makeMockEnv();
+    // Set menu and mount
+    getService("menu").setCurrentMenu(1);
+    await mountWithCleanup(NavBar);
+
+    expect(".o_menu_sections > *:not(.o_menu_sections_more):visible").toHaveCount(3, {
+        message: "should have 3 menu sections displayed",
+    });
+});

--- a/addons/web/tests/test_load_menus.py
+++ b/addons/web/tests/test_load_menus.py
@@ -46,6 +46,7 @@ class LoadMenusTests(HttpCase):
                 'webIcon': False,
                 'webIconData': '/web/static/img/default_icon_app.png',
                 'webIconDataMimetype': False,
+                'webInvisible': False,
                 'xmlid': '',
             },
             str(self.menu_child.id): {
@@ -59,6 +60,7 @@ class LoadMenusTests(HttpCase):
                 'webIcon': False,
                 'webIconData': False,
                 'webIconDataMimetype': False,
+                'webInvisible': False,
                 'xmlid': '',
             },
             'root': {
@@ -73,6 +75,7 @@ class LoadMenusTests(HttpCase):
                 'webIcon': None,
                 'webIconData': None,
                 'webIconDataMimetype': None,
+                'webInvisible': False,
                 'xmlid': '',
             },
         }

--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -18,7 +18,7 @@ class TestPerfSessionInfo(common.HttpCase):
         self.authenticate(user.login, "info")
 
         self.env.registry.clear_all_caches()
-        # cold ormcache (only web: 42, all module: 117)
+        # cold ormcache (only web: 37, all module: 117)
         with self.assertQueryCount(117):
             self.url_open(
                 "/web/session/get_session_info",
@@ -26,7 +26,7 @@ class TestPerfSessionInfo(common.HttpCase):
                 headers={"Content-Type": "application/json"},
             )
 
-        # cold fields cache - warm ormcache (only web: 6, all module: 25)
+        # cold fields cache - warm ormcache (only web: 5, all module: 25)
         with self.assertQueryCount(25):
             self.url_open(
                 "/web/session/get_session_info",

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -42,6 +42,7 @@ class IrUiMenu(models.Model):
                                          ('ir.actions.client', 'ir.actions.client')])
 
     web_icon_data = fields.Binary(string='Web Icon Image', attachment=True)
+    web_invisible = fields.Char(string="Invisible", help="Python expression, when evaluated as true, the menu isn't shown.")
 
     @api.depends('name', 'parent_id.complete_name')
     def _compute_complete_name(self):
@@ -236,7 +237,7 @@ class IrUiMenu(models.Model):
         blacklisted_menu_ids = self._load_menus_blacklist()
         visible_menus = self.search_fetch(
             [('id', 'not in', blacklisted_menu_ids)],
-            ['name', 'parent_id', 'action', 'web_icon'],
+            ['name', 'parent_id', 'action', 'web_icon', 'web_invisible'],
         )._filter_visible_menus()
 
         children_dict = defaultdict(list)  # {parent_id: []} / parent_id == False for root menus
@@ -289,6 +290,7 @@ class IrUiMenu(models.Model):
                 'web_icon': menu.web_icon,
                 'web_icon_data': attachment['datas'].decode() if attachment else False,
                 'web_icon_data_mimetype': attachment['mimetype'] if attachment else False,
+                'web_invisible': menu.web_invisible,
                 'xmlid': xmlids.get(menu_id, ""),
             }
 

--- a/odoo/addons/base/views/ir_ui_menu_views.xml
+++ b/odoo/addons/base/views/ir_ui_menu_views.xml
@@ -10,6 +10,7 @@
                                 <field name="name"/>
                                 <field name="parent_id" groups="base.group_no_one"/>
                                 <field name="sequence" groups="base.group_no_one"/>
+                                <field name="web_invisible"/>
                             </group>
                             <group groups="base.group_no_one">
                                 <field name="complete_name"/>


### PR DESCRIPTION
This commit adds the ability to conditionally render menus.

This is done by adding a new field: `web_invisible`. Note that, this field accepts Python expressions.

task-id: 4250356
