### PR TITLE
[FIX] l10n_sa{_edi}: fix QR code without ZATCA

### DIFF
--- a/addons/l10n_sa/models/account_move.py
+++ b/addons/l10n_sa/models/account_move.py
@@ -40,8 +40,9 @@ class AccountMove(models.Model):
                 company_vat_enc = get_qr_encoding(2, record.company_id.vat)
                 time_sa = fields.Datetime.context_timestamp(self.with_context(tz='Asia/Riyadh'), record.l10n_sa_confirmation_datetime)
                 timestamp_enc = get_qr_encoding(3, time_sa.isoformat())
-                invoice_total_enc = get_qr_encoding(4, float_repr(abs(record.amount_total_signed), 2))
-                total_vat_enc = get_qr_encoding(5, float_repr(abs(record.amount_tax_signed), 2))
+                totals = record._get_l10n_sa_totals()
+                invoice_total_enc = get_qr_encoding(4, float_repr(abs(totals['total_amount']), 2))
+                total_vat_enc = get_qr_encoding(5, float_repr(abs(totals['total_tax']), 2))
 
                 str_to_encode = seller_name_enc + company_vat_enc + timestamp_enc + invoice_total_enc + total_vat_enc
                 qr_code_str = base64.b64encode(str_to_encode).decode()
@@ -57,3 +58,10 @@ class AccountMove(models.Model):
                     'l10n_sa_confirmation_datetime': fields.Datetime.now()
                 })
         return res
+
+    def _get_l10n_sa_totals(self):
+        self.ensure_one()
+        return {
+            'total_amount': self.amount_total_signed,
+            'total_tax': self.amount_tax_signed,
+        }

--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -219,6 +219,14 @@ class AccountMove(models.Model):
             return self.env['account.move.line']
         return super()._get_tax_lines_to_aggregate()
 
+    def _get_l10n_sa_totals(self):
+        self.ensure_one()
+        invoice_vals = self.env['account.edi.xml.ubl_21.zatca']._export_invoice_vals(self)
+        return {
+            'total_amount': invoice_vals['vals']['legal_monetary_total_vals']['tax_inclusive_amount'],
+            'total_tax': invoice_vals['vals']['tax_total_vals'][-1]['tax_amount'],
+        }
+
 
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and l10n_sa_edi
- Switch to a Saudi Arabian company (e.g. SA Company)
- Duplicate "Customer Invoices" journal:
  * Default Income Account: 500001 Sales Account
  * Electronic invoicing: [disabled]
- Create a retention tax:
  * Name: Retention 10%
  * Amount: -10.00000%
  * Is Retention: [checked]

- Create an invoice:
  * Customer: [a Saudi Arabian contact] (e.g. ARAMCO Medinah Branch)
  * Journal: Customer Invoices
  * Invoice Lines:
    - Price: 100.00
    - Taxes: "Sales Tax 15%" + "Retention 10%"
- Confirm the invoice
- Print the invoice
- Scan the QR code on the invoice with an app like "E-invoice QR Reader"

=> In the QR code, the total amount of the invoice with VAT included is 115.00 and the total amount of the VAT is 15.00.
The amount of the retention tax is excluded from the total and the VAT amounts, which is the expected behavior.

- Create the exact same invoice with the duplicated journal without electronic invoicing
- Confirm the invoice
- Print the invoice
- Scan the QR code on the invoice

**Issue:**
In the QR code, the amount of the retention (-10.00) is taken into account.
The total amount of the invoice with VAT included is 105.00 and the total amount of the VAT is 5.00.
The QR code should provide the same amounts either the used journal has "Electronic invoicing" enabled or not.

**Cause:**
Depending on the presence of an electronic invoice document or not, the QR code is generated by the overriding compute method from "l10_sa_edi" or the original one in "l10n_sa".
However, the "Is Retention" field of the "account.tax" model is introduced by "l10n_sa_edi" module and when the QR code is computed by the original method, this field is not taken into account and the corresponding retention tax is wrongly handled like any other tax.

**Solution:**
Use the same total amounts than the ones computed in "l10n_sa_edi" (where retention tax are excluded) in the original compute method if "l10n_sa_edi" is installed.

opw-4525519



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
