### PR TITLE
[IMP] core: introduce website_image helper for cleaner XML definitions

### DIFF
--- a/addons/website/data/image_library.xml
+++ b/addons/website/data/image_library.xml
@@ -1,1073 +1,177 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <odoo>
 
 <!-- Pre loaded images -->
-<record id="website.business_conference" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">business_conference.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/business_conference.jpg</field>
-</record>
-<record id="website.library_image_team" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">team.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/team.jpg</field>
-</record>
-<record id="website.library_image_01" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">bridge.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/bridge.jpg</field>
-</record>
-<record id="website.library_image_02" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">library_image_02.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/library_image_02.jpg</field>
-</record>
-<record id="website.library_image_03" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">library_image_03.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/library_image_03.jpg</field>
-</record>
-<record id="website.library_image_04" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">manufacturing.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/manufacturing.jpg</field>
-</record>
-<record id="website.library_image_05" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">library_image_05.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/library_image_05.jpg</field>
-</record>
-<record id="website.library_image_06" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">gift.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/gift.jpg</field>
-</record>
-<record id="website.library_image_07" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">library_image_07.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/library_image_07.jpg</field>
-</record>
-<record id="website.library_image_08" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">library_image_08.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/library_image_08.jpg</field>
-</record>
-<record id="website.library_image_09" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">office.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/office.jpg</field>
-</record>
-<record id="website.library_image_10" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">library_image_10.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/library_image_10.jpg</field>
-</record>
-<record id="website.library_image_11" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">library_image_11.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/library_image_11.jpg</field>
-</record>
-<record id="website.library_image_12" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">sell.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/sell.jpg</field>
-</record>
-<record id="website.library_image_13" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">library_image_13.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/library_image_13.jpg</field>
-</record>
-<record id="website.library_image_14" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">library_image_14.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/library_image_14.jpg</field>
-</record>
-<record id="website.library_image_15" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">sweet.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/sweet.jpg</field>
-</record>
-<record id="website.library_image_16" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">library_image_16.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/library_image_16.jpg</field>
-</record>
-<record id="website.library_image_17" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">marketing.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/marketing.jpg</field>
-</record>
-<record id="website.library_image_18" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">firework.jpg</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/library/firework.jpg</field>
-</record>
-
-<!-- Website Builder Background Images -->
-<record id="website.s_background_image_01" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_background_image_01.jpg</field>
-    <field name="type">url</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="url">/website/static/src/img/backgrounds/peak.jpg</field>
-</record>
-<record id="website.s_background_image_02" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_background_image_02.jpg</field>
-    <field name="type">url</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="url">/website/static/src/img/backgrounds/la.jpg</field>
-</record>
-<record id="website.s_background_image_03" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_background_image_03.jpg</field>
-    <field name="type">url</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="url">/website/static/src/img/backgrounds/panama-sky.jpg</field>
-</record>
-<record id="website.s_background_image_04" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_background_image_04.jpg</field>
-    <field name="type">url</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="url">/website/static/src/img/backgrounds/cubes.jpg</field>
-</record>
-<record id="website.s_background_image_05" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_background_image_05.jpg</field>
-    <field name="type">url</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="url">/website/static/src/img/backgrounds/building-profile.jpg</field>
-</record>
-<record id="website.s_background_image_06" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_background_image_06.jpg</field>
-    <field name="type">url</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="url">/website/static/src/img/backgrounds/type.jpg</field>
-</record>
-<record id="website.s_background_image_07" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_background_image_07.jpg</field>
-    <field name="type">url</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="url">/website/static/src/img/backgrounds/people.jpg</field>
-</record>
-<record id="website.s_background_image_08" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_background_image_08.jpg</field>
-    <field name="type">url</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="url">/website/static/src/img/backgrounds/city.jpg</field>
-</record>
-<record id="website.s_background_image_09" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_background_image_09.jpg</field>
-    <field name="type">url</field>
-    <field name="res_model">ir.ui.view</field>
-    <field name="url">/website/static/src/img/backgrounds/sails.jpg</field>
-</record>
-
-<!-- Header default images (to be replaced by themes) -->
-<record id="website.header_image_1_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">header_image_1_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/header_image_1_default_image.jpg</field>
-</record>
-
-<!-- Snippets' Default Images (to be replaced by themes) -->
-<record id="website.s_cover_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_cover_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_cover.jpg</field>
-</record>
-<record id="website.s_text_cover_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_text_cover_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_text_cover.jpg</field>
-</record>
-<record id="website.s_masonry_block_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_masonry_block_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_masonry_block_1.jpg</field>
-</record>
-<record id="website.s_masonry_block_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_masonry_block_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_picture.jpg</field>
-</record>
-<record id="website.s_image_punchy_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_image_punchy_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_image_punchy.jpg</field>
-</record>
-<record id="website.s_sidegrid_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_sidegrid_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_sidegrid_default_image_1.jpg</field>
-</record>
-<record id="website.s_sidegrid_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_sidegrid_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_sidegrid_default_image_2.jpg</field>
-</record>
-<record id="website.s_sidegrid_default_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_sidegrid_default_image_3.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_sidegrid_default_image_3.jpg</field>
-</record>
-<record id="website.s_sidegrid_default_image_4" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_sidegrid_default_image_4.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_sidegrid_default_image_4.jpg</field>
-</record>
-<record id="website.s_media_list_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_media_list_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_media_list_1.jpg</field>
-</record>
-<record id="website.s_media_list_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_media_list_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_media_list_2.jpg</field>
-</record>
-<record id="website.s_media_list_default_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_media_list_default_image_3.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_media_list_3.jpg</field>
-</record>
-<record id="website.s_product_list_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_product_list_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_product_list_1.jpg</field>
-</record>
-<record id="website.s_product_list_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_product_list_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_product_list_2.jpg</field>
-</record>
-<record id="website.s_product_list_default_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_product_list_default_image_3.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_product_list_3.jpg</field>
-</record>
-<record id="website.s_product_list_default_image_4" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_product_list_default_image_4.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_product_list_4.jpg</field>
-</record>
-<record id="website.s_product_list_default_image_5" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_product_list_default_image_5.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_product_list_5.jpg</field>
-</record>
-<record id="website.s_product_list_default_image_6" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_product_list_default_image_6.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_product_list_6.jpg</field>
-</record>
-<record id="website.s_quotes_carousel_demo_image_0" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_quotes_carousel_image_0.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_quotes_carousel_0.jpg</field>
-</record>
-<record id="website.s_quotes_carousel_demo_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_quotes_carousel_image_01.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_quotes_carousel_1.jpg</field>
-</record>
-<record id="website.s_quotes_carousel_demo_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_quotes_carousel_image_02.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_quotes_carousel_2.jpg</field>
-</record>
-<record id="website.s_quotes_carousel_demo_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_quotes_carousel_image_3.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_team_member_3.jpg</field>
-</record>
-<record id="website.s_quotes_carousel_demo_image_4" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_quotes_carousel_image_4.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_team_member_2.jpg</field>
-</record>
-<record id="website.s_quotes_carousel_demo_image_5" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_quotes_carousel_image_5.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_team_member_4.jpg</field>
-</record>
-<record id="website.s_showcase_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_showcase_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_showcase.jpg</field>
-</record>
-<record id="website.s_mockup_image_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mockup_image_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mockup_image.jpg</field>
-</record>
-<record id="website.s_image_text_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_image_text_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_image_text.jpg</field>
-</record>
-<record id="website.s_text_image_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_text_image_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_text_image.jpg</field>
-</record>
-<record id="website.s_image_hexagonal_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_image_hexagonal_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_image_hexagonal.jpg</field>
-</record>
-<record id="website.s_image_hexagonal_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_image_hexagonal_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_image_hexagonal_1.jpg</field>
-</record>
-<record id="website.s_three_columns_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_three_columns_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/web/image/website.library_image_11</field>
-</record>
-<record id="website.s_three_columns_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_three_columns_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/web/image/website.library_image_13</field>
-</record>
-<record id="website.s_three_columns_default_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_three_columns_default_image_3.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/web/image/website.library_image_07</field>
-</record>
-<record id="website.s_card_offset_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_card_offset_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_card_offset.jpg</field>
-</record>
-<record id="website.s_card_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_card_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_card_1.jpg</field>
-</record>
-<record id="website.s_carousel_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_carousel_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_carousel_1.jpg</field>
-</record>
-<record id="website.s_carousel_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_carousel_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_carousel_2.jpg</field>
-</record>
-<record id="website.s_carousel_default_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_carousel_default_image_3.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_carousel_3.jpg</field>
-</record>
-<record id="website.s_framed_intro_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_framed_intro_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_framed_intro.jpg</field>
-</record>
-<record id="website.s_carousel_intro_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_carousel_intro_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_text_cover.jpg</field>
-</record>
-<record id="website.s_carousel_intro_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_carousel_intro_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_image_title_default_image.jpg</field>
-</record>
-<record id="website.s_carousel_intro_default_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_carousel_intro_default_image_3.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_banner_3.jpg</field>
-</record>
-<record id="website.s_picture_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_picture_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_picture.jpg</field>
-</record>
-<record id="website.s_striped_top_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_striped_top_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_striped_top.jpg</field>
-</record>
-<record id="website.s_banner_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_banner_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_banner.jpg</field>
-</record>
-<record id="website.s_banner_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_banner_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_banner_2.jpg</field>
-</record>
-<record id="website.s_banner_default_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_banner_default_image_3.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_banner_3.jpg</field>
-</record>
-<record id="website.s_closer_look_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_closer_look_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_closer_look.jpg</field>
-</record>
-<record id="website.s_faq_horizontal_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_faq_horizontal_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_faq_horizontal_1.jpg</field>
-</record>
-<record id="website.s_images_constellation_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_images_constellation_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_images_constellation_default_image.jpg</field>
-</record>
-<record id="website.s_images_constellation_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_images_constellation_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_images_constellation_default_image_1.jpg</field>
-</record>
-<record id="website.s_images_constellation_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_images_constellation_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_images_constellation_default_image_2.jpg</field>
-</record>
-<record id="website.s_parallax_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_parallax_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_parallax.jpg</field>
-</record>
-<record id="website.s_reference_demo_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_reference_demo_image_1.png</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_references_1.png</field>
-</record>
-<record id="website.s_reference_demo_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_reference_demo_image_2.png</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_references_2.png</field>
-</record>
-<record id="website.s_reference_demo_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_reference_demo_image_3.png</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_references_3.png</field>
-</record>
-<record id="website.s_reference_demo_image_4" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_reference_demo_image_4.png</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_references_4.png</field>
-</record>
-<record id="website.s_reference_demo_image_5" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_reference_demo_image_5.png</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_references_5.png</field>
-</record>
-<record id="website.s_reference_default_image_6" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_reference_default_image_6.png</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_references_6.png</field>
-</record>
-<record id="website.s_cta_mockups_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_cta_mockups_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_cta_mockups.jpg</field>
-</record>
-<record id="website.s_cta_mockups_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_cta_mockups_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_cta_mockups_1.jpg</field>
-</record>
-<record id="website.s_company_team_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_company_team_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_team_member_1.jpg</field>
-</record>
-<record id="website.s_company_team_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_company_team_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_team_member_2.jpg</field>
-</record>
-<record id="website.s_company_team_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_company_team_image_3.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_team_member_3.jpg</field>
-</record>
-<record id="website.s_company_team_image_4" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_company_team_image_4.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_team_member_4.jpg</field>
-</record>
-<record id="website.s_company_team_image_5" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_company_team_image_5.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_team_member_5.jpg</field>
-</record>
-<record id="website.s_company_team_image_6" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_company_team_image_6.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_team_member_6.jpg</field>
-</record>
-<record id="website.s_mega_menu_menu_image_menu_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_menu_image_menu_default_image.png</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_references_5.png</field>
-</record>
-<record id="website.s_mega_menu_thumbnails_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_thumbnails_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_1.jpg</field>
-</record>
-<record id="website.s_mega_menu_thumbnails_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_thumbnails_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_2.jpg</field>
-</record>
-<record id="website.s_mega_menu_thumbnails_default_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_thumbnails_default_image_3.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_3.jpg</field>
-</record>
-<record id="website.s_mega_menu_thumbnails_default_image_4" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_thumbnails_default_image_4.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_4.jpg</field>
-</record>
-<record id="website.s_mega_menu_thumbnails_default_image_5" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_thumbnails_default_image_5.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_5.jpg</field>
-</record>
-<record id="website.s_mega_menu_thumbnails_default_image_6" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_thumbnails_default_image_6.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_6.jpg</field>
-</record>
-<record id="website.s_mega_menu_thumbnails_default_image_7" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_thumbnails_default_image_7.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_7.jpg</field>
-</record>
-<record id="website.s_mega_menu_thumbnails_default_image_8" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_thumbnails_default_image_8.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_8.jpg</field>
-</record>
-<record id="website.s_mega_menu_thumbnails_default_image_9" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_thumbnails_default_image_9.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_9.jpg</field>
-</record>
-<record id="website.s_mega_menu_thumbnails_default_image_10" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_thumbnails_default_image_10.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_10.jpg</field>
-</record>
-<record id="website.s_mega_menu_thumbnails_default_image_11" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_thumbnails_default_image_11.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_11.jpg</field>
-</record>
-<record id="website.s_mega_menu_images_subtitles_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_images_subtitles_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_images_subtitles_default_image_1.jpg</field>
-</record>
-<record id="website.s_mega_menu_images_subtitles_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_images_subtitles_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_images_subtitles_default_image_2.jpg</field>
-</record>
-<record id="website.s_mega_menu_images_subtitles_default_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_images_subtitles_default_image_3.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_images_subtitles_default_image_3.jpg</field>
-</record>
-<record id="website.s_mega_menu_images_subtitles_default_image_4" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_images_subtitles_default_image_4.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_images_subtitles_default_image_4.jpg</field>
-</record>
-<record id="website.s_mega_menu_images_subtitles_default_image_5" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_images_subtitles_default_image_5.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_images_subtitles_default_image_5.jpg</field>
-</record>
-<record id="website.s_mega_menu_images_subtitles_default_image_6" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_images_subtitles_default_image_6.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_images_subtitles_default_image_6.jpg</field>
-</record>
-<record id="website.s_mega_menu_images_subtitles_default_image_7" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_images_subtitles_default_image_7.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_images_subtitles_default_image_7.jpg</field>
-</record>
-<record id="website.s_mega_menu_menus_logos_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_menus_logos_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_menus_logos_default_image.jpg</field>
-</record>
-<record id="website.s_mega_menu_menus_logos_default_logo_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_menus_logos_default_logo_1.png</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_menus_logos_default_logo_1.png</field>
-</record>
-<record id="website.s_mega_menu_menus_logos_default_logo_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_menus_logos_default_logo_2.png</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_menus_logos_default_logo_2.png</field>
-</record>
-<record id="website.s_mega_menu_menus_logos_default_logo_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_menus_logos_default_logo_3.png</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_menus_logos_default_logo_3.png</field>
-</record>
-<record id="website.s_mega_menu_menus_logos_default_logo_4" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_menus_logos_default_logo_4.png</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_menus_logos_default_logo_4.png</field>
-</record>
-<record id="website.s_mega_menu_menus_logos_default_logo_5" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_menus_logos_default_logo_5.png</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_menus_logos_default_logo_5.png</field>
-</record>
-<record id="website.s_mega_menu_menus_logos_default_logo_6" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_menus_logos_default_logo_6.png</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_menus_logos_default_logo_6.png</field>
-</record>
-<record id="website.s_mega_menu_cards_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_cards_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_cards_default_image_1.jpg</field>
-</record>
-<record id="website.s_mega_menu_cards_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_cards_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_cards_default_image_2.jpg</field>
-</record>
-<record id="website.s_mega_menu_cards_default_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_cards_default_image_3.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_cards_default_image_3.jpg</field>
-</record>
-<record id="website.s_mega_menu_cards_default_image_4" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_cards_default_image_4.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_cards_default_image_4.jpg</field>
-</record>
-<record id="website.s_mega_menu_cards_default_image_5" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_cards_default_image_5.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_cards_default_image_5.jpg</field>
-</record>
-<record id="website.s_mega_menu_cards_default_image_6" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_cards_default_image_6.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_cards_default_image_6.jpg</field>
-</record>
-<record id="website.s_mega_menu_cards_default_image_7" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_cards_default_image_7.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_cards_default_image_7.jpg</field>
-</record>
-<record id="website.s_mega_menu_cards_default_image_8" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_mega_menu_cards_default_image_8.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_mega_menu_cards_default_image_8.jpg</field>
-</record>
-<record id="website.s_product_catalog_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_product_catalog_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_product_catalog.jpg</field>
-</record>
-<record id="website.s_pricelist_cafe_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_pricelist_cafe_default_image.png</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_pricelist_cafe_default_image.png</field>
-</record>
-<record id="website.s_blockquote_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_blockquote_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_team_member_2.jpg</field>
-</record>
-<record id="website.s_blockquote_cover_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_blockquote_cover_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_blockquote_cover.jpg</field>
-</record>
-<record id="website.s_quadrant_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_quadrant_default_image_1</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_quadrant_default_image_1.jpg</field>
-</record>
-<record id="website.s_quadrant_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_quadrant_default_image_2</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_quadrant_default_image_2.jpg</field>
-</record>
-<record id="website.s_quadrant_default_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_quadrant_default_image_3</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_quadrant_default_image_3.jpg</field>
-</record>
-<record id="website.s_quadrant_default_image_4" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_quadrant_default_image_4</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_quadrant_default_image_4.jpg</field>
-</record>
-<record id="website.s_popup_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_popup_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_popup.jpg</field>
-</record>
-<record id="website.s_cta_box_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_cta_box_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_cta_box_default_image.jpg</field>
-</record>
-<record id="website.s_accordion_image_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_accordion_image_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_accordion_image_default_image.jpg</field>
-</record>
-<record id="website.s_pricelist_boxed_default_background" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_pricelist_boxed_default_background.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_pricelist_boxed_default_background.jpg</field>
-</record>
-<record id="website.s_adventure_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_adventure_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_adventure_default_image.jpg</field>
-</record>
-<record id="website.s_image_title_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_image_title_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_image_title_default_image.jpg</field>
-</record>
-<record id="website.s_key_images_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_key_images_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_key_images_default_image_1.jpg</field>
-</record>
-<record id="website.s_key_images_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_key_images_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_key_images_default_image_2.jpg</field>
-</record>
-<record id="website.s_key_images_default_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_key_images_default_image_3.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_key_images_default_image_3.jpg</field>
-</record>
-<record id="website.s_key_images_default_image_4" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_key_images_default_image_4.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_key_images_default_image_4.jpg</field>
-</record>
-<record id="website.s_kickoff_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_kickoff_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_kickoff_default_image.jpg</field>
-</record>
-<record id="website.s_intro_pill_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_connections_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_intro_pill_default_image.jpg</field>
-</record>
-<record id="website.s_intro_pill_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_connections_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_intro_pill_default_image_2.jpg</field>
-</record>
-<record id="website.s_image_frame_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_image_frame_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_image_frame.jpg</field>
-</record>
-<record id="website.s_wavy_grid_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_wavy_grid_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_wavy_grid_default_image_1.jpg</field>
-</record>
-<record id="website.s_wavy_grid_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_wavy_grid_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_wavy_grid_default_image_2.jpg</field>
-</record>
-<record id="website.s_wavy_grid_default_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_wavy_grid_default_image_3.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_wavy_grid_default_image_3.jpg</field>
-</record>
-<record id="website.s_wavy_grid_default_image_4" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_wavy_grid_default_image_4.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_wavy_grid_default_image_4.jpg</field>
-</record>
-<record id="website.s_images_mosaic_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_images_mosaic_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_images_mosaic_default_image_1.jpg</field>
-</record>
-<record id="website.s_images_mosaic_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_images_mosaic_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_images_mosaic_default_image_2.jpg</field>
-</record>
-<record id="website.s_images_mosaic_default_image_3" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_images_mosaic_default_image_3.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_images_mosaic_default_image_3.jpg</field>
-</record>
-<record id="website.s_images_mosaic_default_image_4" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_images_mosaic_default_image_4.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_images_mosaic_default_image_4.jpg</field>
-</record>
-<record id="website.s_images_mosaic_default_image_5" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_images_mosaic_default_image_5.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_images_mosaic_default_image_5.jpg</field>
-</record>
-<record id="website.s_shape_image_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_shape_image_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_shape_image_default_image.jpg</field>
-</record>
-<record id="website.s_empowerment_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_empowerment_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_empowerment_default_image.jpg</field>
-</record>
-<record id="website.s_website_form_overlay_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_website_form_overlay_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_cover.jpg</field>
-</record>
-<record id="website.app_store_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">app_store_image.svg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/app_store.svg</field>
-</record>
-<record id="website.google_play_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">google_play_image.svg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/google_play.svg</field>
-</record>
-<record id="website.s_opening_hours_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_opening_hours_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_opening_hours.jpg</field>
-</record>
-<record id="website.s_newsletter_grid_default_image_1" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_newsletter_grid_default_image_1.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/web/image/website.s_images_mosaic_default_image_5</field>
-</record>
-<record id="website.s_newsletter_grid_default_image_2" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_newsletter_grid_default_image_2.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/web/image/website.s_banner_default_image_2</field>
-</record>
-<record id="website.s_website_form_info_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_website_form_info_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/website/static/src/img/snippets_demo/s_website_form_info.jpg</field>
-</record>
-<record id="website.s_website_form_cover_default_image" model="ir.attachment">
-    <field name="public" eval="True"/>
-    <field name="name">s_website_form_cover_default_image.jpg</field>
-    <field name="type">url</field>
-    <field name="url">/web/image/website.s_cover_default_image</field>
-</record>
-
+<website_image id="website.business_conference" url="/website/static/src/img/library/business_conference.jpg"/>
+<website_image id="website.library_image_team" name="team.jpg" url="/website/static/src/img/library/team.jpg"/>
+<website_image id="website.library_image_01" name="bridge.jpg" url="/website/static/src/img/library/bridge.jpg"/>
+<website_image id="website.library_image_02" url="/website/static/src/img/library/library_image_02.jpg"/>
+<website_image id="website.library_image_03" url="/website/static/src/img/library/library_image_03.jpg"/>
+<website_image id="website.library_image_04" name="manufacturing.jpg" url="/website/static/src/img/library/manufacturing.jpg"/>
+<website_image id="website.library_image_05" url="/website/static/src/img/library/library_image_05.jpg"/>
+<website_image id="website.library_image_06" name="gift.jpg" url="/website/static/src/img/library/gift.jpg"/>
+<website_image id="website.library_image_07" url="/website/static/src/img/library/library_image_07.jpg"/>
+<website_image id="website.library_image_08" url="/website/static/src/img/library/library_image_08.jpg"/>
+<website_image id="website.library_image_09" name="office.jpg" url="/website/static/src/img/library/office.jpg"/>
+<website_image id="website.library_image_10" url="/website/static/src/img/library/library_image_10.jpg"/>
+<website_image id="website.library_image_11" url="/website/static/src/img/library/library_image_11.jpg"/>
+<website_image id="website.library_image_12" name="sell.jpg" url="/website/static/src/img/library/sell.jpg"/>
+<website_image id="website.library_image_13" url="/website/static/src/img/library/library_image_13.jpg"/>
+<website_image id="website.library_image_14" url="/website/static/src/img/library/library_image_14.jpg"/>
+<website_image id="website.library_image_15" name="sweet.jpg" url="/website/static/src/img/library/sweet.jpg"/>
+<website_image id="website.library_image_16" url="/website/static/src/img/library/library_image_16.jpg"/>
+<website_image id="website.library_image_17" name="marketing.jpg" url="/website/static/src/img/library/marketing.jpg"/>
+<website_image id="website.library_image_18" name="firework.jpg" url="/website/static/src/img/library/firework.jpg"/>
+<website_image id="website.s_background_image_01" url="/website/static/src/img/backgrounds/peak.jpg"/>
+<website_image id="website.s_background_image_02" url="/website/static/src/img/backgrounds/la.jpg"/>
+<website_image id="website.s_background_image_03" url="/website/static/src/img/backgrounds/panama-sky.jpg"/>
+<website_image id="website.s_background_image_04" url="/website/static/src/img/backgrounds/cubes.jpg"/>
+<website_image id="website.s_background_image_05" url="/website/static/src/img/backgrounds/building-profile.jpg"/>
+<website_image id="website.s_background_image_06" url="/website/static/src/img/backgrounds/type.jpg"/>
+<website_image id="website.s_background_image_07" url="/website/static/src/img/backgrounds/people.jpg"/>
+<website_image id="website.s_background_image_08" url="/website/static/src/img/backgrounds/city.jpg"/>
+<website_image id="website.s_background_image_09" url="/website/static/src/img/backgrounds/sails.jpg"/>
+<website_image id="website.header_image_1_default_image" url="/website/static/src/img/snippets_demo/header_image_1_default_image.jpg"/>
+<website_image id="website.s_cover_default_image" url="/website/static/src/img/snippets_demo/s_cover.jpg"/>
+<website_image id="website.s_text_cover_default_image" url="/website/static/src/img/snippets_demo/s_text_cover.jpg"/>
+<website_image id="website.s_masonry_block_default_image_1" url="/website/static/src/img/snippets_demo/s_masonry_block_1.jpg"/>
+<website_image id="website.s_masonry_block_default_image_2" url="/website/static/src/img/snippets_demo/s_picture.jpg"/>
+<website_image id="website.s_image_punchy_default_image" url="/website/static/src/img/snippets_demo/s_image_punchy.jpg"/>
+<website_image id="website.s_sidegrid_default_image_1" url="/website/static/src/img/snippets_demo/s_sidegrid_default_image_1.jpg"/>
+<website_image id="website.s_sidegrid_default_image_2" url="/website/static/src/img/snippets_demo/s_sidegrid_default_image_2.jpg"/>
+<website_image id="website.s_sidegrid_default_image_3" url="/website/static/src/img/snippets_demo/s_sidegrid_default_image_3.jpg"/>
+<website_image id="website.s_sidegrid_default_image_4" url="/website/static/src/img/snippets_demo/s_sidegrid_default_image_4.jpg"/>
+<website_image id="website.s_media_list_default_image_1" url="/website/static/src/img/snippets_demo/s_media_list_1.jpg"/>
+<website_image id="website.s_media_list_default_image_2" url="/website/static/src/img/snippets_demo/s_media_list_2.jpg"/>
+<website_image id="website.s_media_list_default_image_3" url="/website/static/src/img/snippets_demo/s_media_list_3.jpg"/>
+<website_image id="website.s_product_list_default_image_1" url="/website/static/src/img/snippets_demo/s_product_list_1.jpg"/>
+<website_image id="website.s_product_list_default_image_2" url="/website/static/src/img/snippets_demo/s_product_list_2.jpg"/>
+<website_image id="website.s_product_list_default_image_3" url="/website/static/src/img/snippets_demo/s_product_list_3.jpg"/>
+<website_image id="website.s_product_list_default_image_4" url="/website/static/src/img/snippets_demo/s_product_list_4.jpg"/>
+<website_image id="website.s_product_list_default_image_5" url="/website/static/src/img/snippets_demo/s_product_list_5.jpg"/>
+<website_image id="website.s_product_list_default_image_6" url="/website/static/src/img/snippets_demo/s_product_list_6.jpg"/>
+<website_image id="website.s_quotes_carousel_demo_image_0" name="s_quotes_carousel_image_0.jpg" url="/website/static/src/img/snippets_demo/s_quotes_carousel_0.jpg"/>
+<website_image id="website.s_quotes_carousel_demo_image_1" name="s_quotes_carousel_image_01.jpg" url="/website/static/src/img/snippets_demo/s_quotes_carousel_1.jpg"/>
+<website_image id="website.s_quotes_carousel_demo_image_2" name="s_quotes_carousel_image_02.jpg" url="/website/static/src/img/snippets_demo/s_quotes_carousel_2.jpg"/>
+<website_image id="website.s_quotes_carousel_demo_image_3" name="s_quotes_carousel_image_3.jpg" url="/website/static/src/img/snippets_demo/s_team_member_3.jpg"/>
+<website_image id="website.s_quotes_carousel_demo_image_4" name="s_quotes_carousel_image_4.jpg" url="/website/static/src/img/snippets_demo/s_team_member_2.jpg"/>
+<website_image id="website.s_quotes_carousel_demo_image_5" name="s_quotes_carousel_image_5.jpg" url="/website/static/src/img/snippets_demo/s_team_member_4.jpg"/>
+<website_image id="website.s_showcase_default_image" url="/website/static/src/img/snippets_demo/s_showcase.jpg"/>
+<website_image id="website.s_mockup_image_default_image" url="/website/static/src/img/snippets_demo/s_mockup_image.jpg"/>
+<website_image id="website.s_image_text_default_image" url="/website/static/src/img/snippets_demo/s_image_text.jpg"/>
+<website_image id="website.s_text_image_default_image" url="/website/static/src/img/snippets_demo/s_text_image.jpg"/>
+<website_image id="website.s_image_hexagonal_default_image" url="/website/static/src/img/snippets_demo/s_image_hexagonal.jpg"/>
+<website_image id="website.s_image_hexagonal_default_image_1" url="/website/static/src/img/snippets_demo/s_image_hexagonal_1.jpg"/>
+<website_image id="website.s_three_columns_default_image_1" name="s_three_columns_default_image_1.jpg" url="/web/image/website.library_image_11"/>
+<website_image id="website.s_three_columns_default_image_2" name="s_three_columns_default_image_2.jpg" url="/web/image/website.library_image_13"/>
+<website_image id="website.s_three_columns_default_image_3" name="s_three_columns_default_image_3.jpg" url="/web/image/website.library_image_07"/>
+<website_image id="website.s_card_offset_default_image" url="/website/static/src/img/snippets_demo/s_card_offset.jpg"/>
+<website_image id="website.s_card_default_image_1" url="/website/static/src/img/snippets_demo/s_card_1.jpg"/>
+<website_image id="website.s_carousel_default_image_1" url="/website/static/src/img/snippets_demo/s_carousel_1.jpg"/>
+<website_image id="website.s_carousel_default_image_2" url="/website/static/src/img/snippets_demo/s_carousel_2.jpg"/>
+<website_image id="website.s_carousel_default_image_3" url="/website/static/src/img/snippets_demo/s_carousel_3.jpg"/>
+<website_image id="website.s_framed_intro_default_image" url="/website/static/src/img/snippets_demo/s_framed_intro.jpg"/>
+<website_image id="website.s_carousel_intro_default_image_1" url="/website/static/src/img/snippets_demo/s_text_cover.jpg"/>
+<website_image id="website.s_carousel_intro_default_image_2" url="/website/static/src/img/snippets_demo/s_image_title_default_image.jpg"/>
+<website_image id="website.s_carousel_intro_default_image_3" url="/website/static/src/img/snippets_demo/s_banner_3.jpg"/>
+<website_image id="website.s_picture_default_image" url="/website/static/src/img/snippets_demo/s_picture.jpg"/>
+<website_image id="website.s_striped_top_default_image" name="s_striped_top_image.jpg" url="/website/static/src/img/snippets_demo/s_striped_top.jpg"/>
+<website_image id="website.s_banner_default_image" url="/website/static/src/img/snippets_demo/s_banner.jpg"/>
+<website_image id="website.s_banner_default_image_2" url="/website/static/src/img/snippets_demo/s_banner_2.jpg"/>
+<website_image id="website.s_banner_default_image_3" url="/website/static/src/img/snippets_demo/s_banner_3.jpg"/>
+<website_image id="website.s_closer_look_default_image" url="/website/static/src/img/snippets_demo/s_closer_look.jpg"/>
+<website_image id="website.s_faq_horizontal_default_image_1" name="s_faq_horizontal_1.jpg" url="/website/static/src/img/snippets_demo/s_faq_horizontal_1.jpg"/>
+<website_image id="website.s_images_constellation_default_image" url="/website/static/src/img/snippets_demo/s_images_constellation_default_image.jpg"/>
+<website_image id="website.s_images_constellation_default_image_1" url="/website/static/src/img/snippets_demo/s_images_constellation_default_image_1.jpg"/>
+<website_image id="website.s_images_constellation_default_image_2" url="/website/static/src/img/snippets_demo/s_images_constellation_default_image_2.jpg"/>
+<website_image id="website.s_parallax_default_image" url="/website/static/src/img/snippets_demo/s_parallax.jpg"/>
+<website_image id="website.s_reference_demo_image_1" url="/website/static/src/img/snippets_demo/s_references_1.png"/>
+<website_image id="website.s_reference_demo_image_2" url="/website/static/src/img/snippets_demo/s_references_2.png"/>
+<website_image id="website.s_reference_demo_image_3" url="/website/static/src/img/snippets_demo/s_references_3.png"/>
+<website_image id="website.s_reference_demo_image_4" url="/website/static/src/img/snippets_demo/s_references_4.png"/>
+<website_image id="website.s_reference_demo_image_5" url="/website/static/src/img/snippets_demo/s_references_5.png"/>
+<website_image id="website.s_reference_default_image_6" url="/website/static/src/img/snippets_demo/s_references_6.png"/>
+<website_image id="website.s_cta_mockups_default_image" url="/website/static/src/img/snippets_demo/s_cta_mockups.jpg"/>
+<website_image id="website.s_cta_mockups_default_image_1" url="/website/static/src/img/snippets_demo/s_cta_mockups_1.jpg"/>
+<website_image id="website.s_company_team_image_1" url="/website/static/src/img/snippets_demo/s_team_member_1.jpg"/>
+<website_image id="website.s_company_team_image_2" url="/website/static/src/img/snippets_demo/s_team_member_2.jpg"/>
+<website_image id="website.s_company_team_image_3" url="/website/static/src/img/snippets_demo/s_team_member_3.jpg"/>
+<website_image id="website.s_company_team_image_4" url="/website/static/src/img/snippets_demo/s_team_member_4.jpg"/>
+<website_image id="website.s_company_team_image_5" url="/website/static/src/img/snippets_demo/s_team_member_5.jpg"/>
+<website_image id="website.s_company_team_image_6" url="/website/static/src/img/snippets_demo/s_team_member_6.jpg"/>
+<website_image id="website.s_mega_menu_menu_image_menu_default_image" url="/website/static/src/img/snippets_demo/s_references_5.png"/>
+<website_image id="website.s_mega_menu_thumbnails_default_image_1" url="/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_1.jpg"/>
+<website_image id="website.s_mega_menu_thumbnails_default_image_2" url="/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_2.jpg"/>
+<website_image id="website.s_mega_menu_thumbnails_default_image_3" url="/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_3.jpg"/>
+<website_image id="website.s_mega_menu_thumbnails_default_image_4" url="/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_4.jpg"/>
+<website_image id="website.s_mega_menu_thumbnails_default_image_5" url="/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_5.jpg"/>
+<website_image id="website.s_mega_menu_thumbnails_default_image_6" url="/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_6.jpg"/>
+<website_image id="website.s_mega_menu_thumbnails_default_image_7" url="/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_7.jpg"/>
+<website_image id="website.s_mega_menu_thumbnails_default_image_8" url="/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_8.jpg"/>
+<website_image id="website.s_mega_menu_thumbnails_default_image_9" url="/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_9.jpg"/>
+<website_image id="website.s_mega_menu_thumbnails_default_image_10" url="/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_10.jpg"/>
+<website_image id="website.s_mega_menu_thumbnails_default_image_11" url="/website/static/src/img/snippets_demo/s_mega_menu_thumbnails_default_image_11.jpg"/>
+<website_image id="website.s_mega_menu_images_subtitles_default_image_1" url="/website/static/src/img/snippets_demo/s_mega_menu_images_subtitles_default_image_1.jpg"/>
+<website_image id="website.s_mega_menu_images_subtitles_default_image_2" url="/website/static/src/img/snippets_demo/s_mega_menu_images_subtitles_default_image_2.jpg"/>
+<website_image id="website.s_mega_menu_images_subtitles_default_image_3" url="/website/static/src/img/snippets_demo/s_mega_menu_images_subtitles_default_image_3.jpg"/>
+<website_image id="website.s_mega_menu_images_subtitles_default_image_4" url="/website/static/src/img/snippets_demo/s_mega_menu_images_subtitles_default_image_4.jpg"/>
+<website_image id="website.s_mega_menu_images_subtitles_default_image_5" url="/website/static/src/img/snippets_demo/s_mega_menu_images_subtitles_default_image_5.jpg"/>
+<website_image id="website.s_mega_menu_images_subtitles_default_image_6" url="/website/static/src/img/snippets_demo/s_mega_menu_images_subtitles_default_image_6.jpg"/>
+<website_image id="website.s_mega_menu_images_subtitles_default_image_7" url="/website/static/src/img/snippets_demo/s_mega_menu_images_subtitles_default_image_7.jpg"/>
+<website_image id="website.s_mega_menu_menus_logos_default_image" url="/website/static/src/img/snippets_demo/s_mega_menu_menus_logos_default_image.jpg"/>
+<website_image id="website.s_mega_menu_menus_logos_default_logo_1" url="/website/static/src/img/snippets_demo/s_mega_menu_menus_logos_default_logo_1.png"/>
+<website_image id="website.s_mega_menu_menus_logos_default_logo_2" url="/website/static/src/img/snippets_demo/s_mega_menu_menus_logos_default_logo_2.png"/>
+<website_image id="website.s_mega_menu_menus_logos_default_logo_3" url="/website/static/src/img/snippets_demo/s_mega_menu_menus_logos_default_logo_3.png"/>
+<website_image id="website.s_mega_menu_menus_logos_default_logo_4" url="/website/static/src/img/snippets_demo/s_mega_menu_menus_logos_default_logo_4.png"/>
+<website_image id="website.s_mega_menu_menus_logos_default_logo_5" url="/website/static/src/img/snippets_demo/s_mega_menu_menus_logos_default_logo_5.png"/>
+<website_image id="website.s_mega_menu_menus_logos_default_logo_6" url="/website/static/src/img/snippets_demo/s_mega_menu_menus_logos_default_logo_6.png"/>
+<website_image id="website.s_mega_menu_cards_default_image_1" url="/website/static/src/img/snippets_demo/s_mega_menu_cards_default_image_1.jpg"/>
+<website_image id="website.s_mega_menu_cards_default_image_2" url="/website/static/src/img/snippets_demo/s_mega_menu_cards_default_image_2.jpg"/>
+<website_image id="website.s_mega_menu_cards_default_image_3" url="/website/static/src/img/snippets_demo/s_mega_menu_cards_default_image_3.jpg"/>
+<website_image id="website.s_mega_menu_cards_default_image_4" url="/website/static/src/img/snippets_demo/s_mega_menu_cards_default_image_4.jpg"/>
+<website_image id="website.s_mega_menu_cards_default_image_5" url="/website/static/src/img/snippets_demo/s_mega_menu_cards_default_image_5.jpg"/>
+<website_image id="website.s_mega_menu_cards_default_image_6" url="/website/static/src/img/snippets_demo/s_mega_menu_cards_default_image_6.jpg"/>
+<website_image id="website.s_mega_menu_cards_default_image_7" url="/website/static/src/img/snippets_demo/s_mega_menu_cards_default_image_7.jpg"/>
+<website_image id="website.s_mega_menu_cards_default_image_8" url="/website/static/src/img/snippets_demo/s_mega_menu_cards_default_image_8.jpg"/>
+<website_image id="website.s_product_catalog_default_image" url="/website/static/src/img/snippets_demo/s_product_catalog.jpg"/>
+<website_image id="website.s_pricelist_cafe_default_image" url="/website/static/src/img/snippets_demo/s_pricelist_cafe_default_image.png"/>
+<website_image id="website.s_blockquote_default_image" url="/website/static/src/img/snippets_demo/s_team_member_2.jpg"/>
+<website_image id="website.s_blockquote_cover_default_image" url="/website/static/src/img/snippets_demo/s_blockquote_cover.jpg"/>
+<website_image id="website.s_quadrant_default_image_1" name="s_quadrant_default_image_1" url="/website/static/src/img/snippets_demo/s_quadrant_default_image_1.jpg"/>
+<website_image id="website.s_quadrant_default_image_2" name="s_quadrant_default_image_2" url="/website/static/src/img/snippets_demo/s_quadrant_default_image_2.jpg"/>
+<website_image id="website.s_quadrant_default_image_3" name="s_quadrant_default_image_3" url="/website/static/src/img/snippets_demo/s_quadrant_default_image_3.jpg"/>
+<website_image id="website.s_quadrant_default_image_4" name="s_quadrant_default_image_4" url="/website/static/src/img/snippets_demo/s_quadrant_default_image_4.jpg"/>
+<website_image id="website.s_popup_default_image" url="/website/static/src/img/snippets_demo/s_popup.jpg"/>
+<website_image id="website.s_cta_box_default_image" url="/website/static/src/img/snippets_demo/s_cta_box_default_image.jpg"/>
+<website_image id="website.s_accordion_image_default_image" url="/website/static/src/img/snippets_demo/s_accordion_image_default_image.jpg"/>
+<website_image id="website.s_pricelist_boxed_default_background" url="/website/static/src/img/snippets_demo/s_pricelist_boxed_default_background.jpg"/>
+<website_image id="website.s_adventure_default_image" url="/website/static/src/img/snippets_demo/s_adventure_default_image.jpg"/>
+<website_image id="website.s_image_title_default_image" url="/website/static/src/img/snippets_demo/s_image_title_default_image.jpg"/>
+<website_image id="website.s_key_images_default_image_1" url="/website/static/src/img/snippets_demo/s_key_images_default_image_1.jpg"/>
+<website_image id="website.s_key_images_default_image_2" url="/website/static/src/img/snippets_demo/s_key_images_default_image_2.jpg"/>
+<website_image id="website.s_key_images_default_image_3" url="/website/static/src/img/snippets_demo/s_key_images_default_image_3.jpg"/>
+<website_image id="website.s_key_images_default_image_4" url="/website/static/src/img/snippets_demo/s_key_images_default_image_4.jpg"/>
+<website_image id="website.s_kickoff_default_image" url="/website/static/src/img/snippets_demo/s_kickoff_default_image.jpg"/>
+<website_image id="website.s_intro_pill_default_image" name="s_connections_default_image.jpg" url="/website/static/src/img/snippets_demo/s_intro_pill_default_image.jpg"/>
+<website_image id="website.s_intro_pill_default_image_2" name="s_connections_default_image_2.jpg" url="/website/static/src/img/snippets_demo/s_intro_pill_default_image_2.jpg"/>
+<website_image id="website.s_image_frame_default_image" url="/website/static/src/img/snippets_demo/s_image_frame.jpg"/>
+<website_image id="website.s_wavy_grid_default_image_1" url="/website/static/src/img/snippets_demo/s_wavy_grid_default_image_1.jpg"/>
+<website_image id="website.s_wavy_grid_default_image_2" url="/website/static/src/img/snippets_demo/s_wavy_grid_default_image_2.jpg"/>
+<website_image id="website.s_wavy_grid_default_image_3" url="/website/static/src/img/snippets_demo/s_wavy_grid_default_image_3.jpg"/>
+<website_image id="website.s_wavy_grid_default_image_4" url="/website/static/src/img/snippets_demo/s_wavy_grid_default_image_4.jpg"/>
+<website_image id="website.s_images_mosaic_default_image_1" url="/website/static/src/img/snippets_demo/s_images_mosaic_default_image_1.jpg"/>
+<website_image id="website.s_images_mosaic_default_image_2" url="/website/static/src/img/snippets_demo/s_images_mosaic_default_image_2.jpg"/>
+<website_image id="website.s_images_mosaic_default_image_3" url="/website/static/src/img/snippets_demo/s_images_mosaic_default_image_3.jpg"/>
+<website_image id="website.s_images_mosaic_default_image_4" url="/website/static/src/img/snippets_demo/s_images_mosaic_default_image_4.jpg"/>
+<website_image id="website.s_images_mosaic_default_image_5" url="/website/static/src/img/snippets_demo/s_images_mosaic_default_image_5.jpg"/>
+<website_image id="website.s_shape_image_default_image" url="/website/static/src/img/snippets_demo/s_shape_image_default_image.jpg"/>
+<website_image id="website.s_empowerment_default_image" url="/website/static/src/img/snippets_demo/s_empowerment_default_image.jpg"/>
+<website_image id="website.s_website_form_overlay_default_image" url="/website/static/src/img/snippets_demo/s_cover.jpg"/>
+<website_image id="website.app_store_image" url="/website/static/src/img/snippets_demo/app_store.svg"/>
+<website_image id="website.google_play_image" url="/website/static/src/img/snippets_demo/google_play.svg"/>
+<website_image id="website.s_opening_hours_default_image" url="/website/static/src/img/snippets_demo/s_opening_hours.jpg"/>
+<website_image id="website.s_newsletter_grid_default_image_1" name="s_newsletter_grid_default_image_1.jpg" url="/web/image/website.s_images_mosaic_default_image_5"/>
+<website_image id="website.s_newsletter_grid_default_image_2" name="s_newsletter_grid_default_image_2.jpg" url="/web/image/website.s_banner_default_image_2"/>
+<website_image id="website.s_website_form_info_default_image" url="/website/static/src/img/snippets_demo/s_website_form_info.jpg"/>
+<website_image id="website.s_website_form_cover_default_image" name="s_website_form_cover_default_image.jpg" url="/web/image/website.s_cover_default_image"/>
 </odoo>

--- a/odoo/import_xml.rng
+++ b/odoo/import_xml.rng
@@ -184,6 +184,14 @@
         </rng:element>
     </rng:define>
 
+    <rng:define name="website_image">
+        <rng:element name="website_image">
+            <rng:attribute name="id"/>
+            <rng:attribute name="url"/>
+            <rng:optional><rng:attribute name="name"/></rng:optional>
+        </rng:element>
+    </rng:define>
+
     <rng:define name="template">
         <rng:element name="template">
             <rng:optional><rng:attribute name="id"/></rng:optional>
@@ -322,6 +330,7 @@
                     <rng:ref name="odoo_openerp_data"/>
                     <rng:ref name="menuitem" />
                     <rng:ref name="record" />
+                    <rng:ref name="website_image" />
                     <rng:ref name="template" />
                     <rng:ref name="delete" />
                     <rng:ref name="act_window" />

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -460,6 +460,35 @@ form: module.record_id""" % (xml_id,)
             self._tag_record(child_rec, extra_vals={inverse_name: record.id})
         return rec_model, record.id
 
+    def _tag_website_image(self, el):
+        image_id = el.get("id")
+        image_url = el.get("url")
+
+        extension = image_url.rsplit(".", 1)[-1] if "." in image_url else "webp"
+
+        if "." in image_id:
+            name = image_id.rsplit(".", 1)[1]
+        else:
+            name = image_id
+
+        name += f".{extension}"
+
+        record = etree.Element("record", id=image_id, model="ir.attachment")
+
+        def create_field(name, value, **kwargs):
+            field = etree.Element("field", name=name, **kwargs)
+            if value is not None:
+                field.text = value
+            return field
+
+        record.append(create_field("public", "True", eval="True"))
+        record.append(create_field("name", el.get("name") or name))
+        record.append(create_field("type", "url"))
+        record.append(create_field("res_model", "ir.ui.view"))
+        record.append(create_field("url", image_url))
+
+        return self._tag_record(record)
+
     def _tag_template(self, el):
         # This helper transforms a <template> element into a <record> and forwards it
         tpl_id = el.get('id', el.get('t-name'))
@@ -598,6 +627,7 @@ form: module.record_id""" % (xml_id,)
         self.xml_filename = xml_filename
         self._tags = {
             'record': self._tag_record,
+            'website_image': self._tag_website_image,
             'delete': self._tag_delete,
             'function': self._tag_function,
             'menuitem': self._tag_menuitem,


### PR DESCRIPTION
This commit introduces a new `<website_image/>` helper, simplifying XML
syntax for preloaded images.

- Added support for `<website_image/>`
- Updated RelaxNG schema to validate `<website_image/>`.
- if the name attribute is not provided, the name will be constructed
  from the id.

This improves readability and maintainability of image records in
website modules.

Ex:
```xml
<record id="website.s_text_image_default_image" model="ir.attachment">
    <field name="public" eval="True"/>
    <field name="name">s_text_image_default_image.jpg</field>
    <field name="res_model">ir.ui.view</field>
    <field name="type">url</field>
    <field name="url">/website/static/src/img/snippets_demo/s_text_image.jpg</field>
</record>
````
is equivalent to:
```xml
<website_image id="website.s_text_image_default_image"
 url="/website/static/src/img/snippets_demo/s_text_image.jpg"/>
```

and

```xml
<record id="website.library_image_team" model="ir.attachment">
    <field name="public" eval="True"/>
    <field name="name">team.jpg</field>
    <field name="res_model">ir.ui.view</field>
    <field name="type">url</field>
    <field name="url">/website/static/src/img/library/team.jpg</field>
</record>
```

is equivalent to

```xml
<website_image id="website.library_image_team" name="team.jpg"
 url="/website/static/src/img/library/team.jpg"/>
```

task-4552191