### PR TITLE
[FIX] html_editor: ensure text visibility when setting background color

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -714,6 +714,11 @@ export class TablePlugin extends Plugin {
             }
             for (const td of selectedTds) {
                 this.dependencies.color.colorElement(td, color, mode);
+                if (color) {
+                    td.style["color"] = getComputedStyle(td).color;
+                } else {
+                    td.style["color"] = "";
+                }
             }
         }
     }

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -111,7 +111,46 @@ test("should not apply color on an uneditable element", async () => {
     });
 });
 
+test("should apply color with default text color on block when applying background color", async () => {
+    const defaultTextColor = "color: rgb(55, 65, 81);";
+    await testEditor({
+        contentBefore: unformat(`
+                <table><tbody>
+                    <tr><td class="o_selected_td">[ab</td></tr>
+                    <tr><td class="o_selected_td">cd]</td></tr>
+                </tbody></table>
+            `),
+        stepFunction: setColor("rgb(255, 0, 0)", "backgroundColor"),
+        contentAfter: unformat(`
+                <table><tbody>
+                    <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}">[ab</td></tr>
+                    <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}">cd]</td></tr>
+                </tbody></table>
+            `),
+    });
+});
+
+test("should remove color from block when removing background color", async () => {
+    const defaultTextColor = "color: rgb(55, 65, 81);";
+    await testEditor({
+        contentBefore: unformat(`
+            <table><tbody>
+                <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}">[ab</td></tr>
+                <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}">cd]</td></tr>
+            </tbody></table>
+        `),
+        stepFunction: setColor("", "backgroundColor"),
+        contentAfter: unformat(`
+            <table><tbody>
+                <tr><td>[ab</td></tr>
+                <tr><td>cd]</td></tr>
+            </tbody></table>
+        `),
+    });
+});
+
 test("should not apply background color on an uneditable selected cell in a table", async () => {
+    const defaultTextColor = "color: rgb(55, 65, 81);";
     await testEditor({
         contentBefore: unformat(`
                 <table><tbody>
@@ -123,9 +162,9 @@ test("should not apply background color on an uneditable selected cell in a tabl
         stepFunction: setColor("rgb(255, 0, 0)", "backgroundColor"),
         contentAfter: unformat(`
                 <table><tbody>
-                    <tr><td style="background-color: rgb(255, 0, 0);">[ab</td></tr>
+                    <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}">[ab</td></tr>
                     <tr><td contenteditable="false">cd</td></tr>
-                    <tr><td style="background-color: rgb(255, 0, 0);">ef]</td></tr>
+                    <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}">ef]</td></tr>
                 </tbody></table>
             `),
     });
@@ -143,9 +182,8 @@ test("should not apply font tag to t nodes (protects if else nodes separation)",
                 </t>
             </p>
         ]`),
-        stepFunction: setColor('red', 'color'),
-        contentAfter:
-        unformat(`[
+        stepFunction: setColor("red", "color"),
+        contentAfter: unformat(`[
             <p>
                 <t t-if="object.partner_id.parent_id">
                     <t t-out="object.partner_id.parent_id.name or ''" style="color: red;">

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -508,6 +508,7 @@ describe("color preview", () => {
     });
 
     test("should preview color in table on hover in solid tab", async () => {
+        const defaultTextColor = "color: rgb(55, 65, 81);";
         const { el } = await setupEditor(`
             <table class="table table-bordered o_table">
                 <tbody>
@@ -534,12 +535,12 @@ describe("color preview", () => {
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
-                        <td class="" style="background-color: rgb(206, 0, 0);">
+                        <td class="" style="background-color: rgb(206, 0, 0); ${defaultTextColor}">
                             <p>[<br></p>
                         </td>
                     </tr>
                     <tr>
-                        <td class="" style="background-color: rgb(206, 0, 0);">
+                        <td class="" style="background-color: rgb(206, 0, 0); ${defaultTextColor}">
                             <p>]<br></p>
                         </td>
                     </tr>
@@ -569,6 +570,7 @@ describe("color preview", () => {
     });
 
     test("should preview color in table on hover in custom tab", async () => {
+        const defaultTextColor = "color: rgb(55, 65, 81);";
         const { el } = await setupEditor(`
             <table class="table table-bordered o_table">
                 <tbody>
@@ -597,12 +599,12 @@ describe("color preview", () => {
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
-                        <td class="bg-black">
+                        <td class="bg-black" style="${defaultTextColor}">
                             <p>[<br></p>
                         </td>
                     </tr>
                     <tr>
-                        <td class="bg-black">
+                        <td class="bg-black" style="${defaultTextColor}">
                             <p>]<br></p>
                         </td>
                     </tr>


### PR DESCRIPTION
**Problem**:
When applying a light background color to a table cell, switching to dark mode changes the text color to white, making it invisible.

**Solution**:
When setting a background color on a block element, also apply the default text color. This ensures text remains visible in both light and dark modes.

**Steps to Reproduce**:
1. Add a table.
2. Change the background color of cells to white.
3. Switch to dark mode.
4. Observe that the text inside the cells is not visible.

opw-4546663

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
