### PR TITLE
[FIX] base: remove all cloc excluded records

### DIFF
--- a/addons/base_import_module/tests/test_cloc.py
+++ b/addons/base_import_module/tests/test_cloc.py
@@ -261,3 +261,16 @@ class TestClocFields(test_cloc.TestClocCustomization):
         cl = cloc.Cloc()
         cl.count_customization(self.env)
         self.assertEqual(cl.code.get('test_imported_module', 0), 0)
+
+        # Uninstall data module
+        self.env['ir.module.module'].search([('name', '=', 'test_imported_module')]).module_uninstall()
+
+        # Check that the database is cleaned after uninstallation
+        attachments = self.env['ir.attachment'].search([('url', 'ilike', 'test_imported_module/static/src/js/test_js')])
+        self.assertFalse(attachments, "No more attachment from assets should remain in the db")
+
+        irmodeldata = self.env['ir.model.data'].search([('module', '=', '__cloc_exclude__')])
+        self.assertTrue(
+            len(irmodeldata) == 1 and irmodeldata.res_id == self.env.ref('base.view_company_form').id,
+            "Only base form view should remain excluded",
+        )

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2479,6 +2479,8 @@ class IrModelData(models.Model):
                 ('model', '=', records._name),
                 ('res_id', 'in', records.ids),
             ])
+            cloc_exclude_data = ref_data.filtered(lambda imd: imd.module == '__cloc_exclude__')
+            ref_data -= cloc_exclude_data
             records -= records.browse((ref_data - module_data).mapped('res_id'))
             if not records:
                 return
@@ -2507,6 +2509,7 @@ class IrModelData(models.Model):
             _logger.info('Deleting %s', records)
             try:
                 with self._cr.savepoint():
+                    cloc_exclude_data.unlink()
                     records.unlink()
             except Exception:
                 if len(records) <= 1:


### PR DESCRIPTION
Steps to reproduce:
- Install any industry module;
- Uninstall the module;

Current behaviour:
Some records from the industry module (like a knowledge article) which have a second xmlid from `__cloc_exclude__` remain in the database after the uninstallation.

Expected behaviour:
After this commit, all records from the industry and their related `__cloc_exclude__` ir_model_data entries are removed.

task-4501067
