### PR TITLE
[FIX] website_hr_recruitment_livechat: fix typo

### DIFF
--- a/addons/website_hr_recruitment_livechat/data/website_hr_recruitment_livechat_chatbot_demo.xml
+++ b/addons/website_hr_recruitment_livechat/data/website_hr_recruitment_livechat_chatbot_demo.xml
@@ -15,7 +15,7 @@
         </record>
 
         <record id="chatbot_script_website_hr_recruitment_welcome" model="chatbot.script.step">
-            <field name="message">Hello, can I help you find the pefect job?</field>
+            <field name="message">Hello, can I help you find the perfect job?</field>
             <field name="sequence">1</field>
             <field name="step_type">free_input_single</field>
             <field name="chatbot_script_id" ref="chatbot_script_website_hr_recruitment"/>


### PR DESCRIPTION
This PR aims to fix a typo introduced in Commit[^1]. With this commit, the front-end recruitment page now features a chatbot to help visitors. However, the first message sent by the bot has a typo in it.

task-4552457


[^1]: https://github.com/odoo/odoo/commit/94c65c489e88608a2bda301724567c7db480c9d4
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
