### PR TITLE
[FIX] sms: don't send SMS during module installation

### DIFF
--- a/addons/sms/models/sms_api.py
+++ b/addons/sms/models/sms_api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, models
+from odoo import _, api, exceptions, models
 from odoo.addons.iap.tools import iap_tools
 
 DEFAULT_ENDPOINT = 'https://iap-sms.odoo.com'
@@ -13,6 +13,9 @@ class SmsApi(models.AbstractModel):
 
     @api.model
     def _contact_iap(self, local_endpoint, params):
+        if not self.env.registry.ready:  # Don't reach IAP servers during module installation
+            raise exceptions.AccessError("Unavailable during module installation.")
+
         account = self.env['iap.account'].get('sms')
         params['account_token'] = account.account_token
         endpoint = self.env['ir.config_parameter'].sudo().get_param('sms.endpoint', DEFAULT_ENDPOINT)


### PR DESCRIPTION
The installation of the demo data of module `industry_fsm_sale` module triggered the sending of an SMS.
Now, the SMS API is unavailable during module installation.
