### PR TITLE
[FIX] hr_recruitment: Reset referral state when restoring applicant.

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -692,7 +692,8 @@ class Applicant(models.Model):
         for applicant in self:
             applicant.write(
                 {'stage_id': applicant.job_id.id and default_stage[applicant.job_id.id],
-                 'refuse_reason_id': False})
+                 'refuse_reason_id': False,
+                 'referral_state': 'progress'}})
 
     def toggle_active(self):
         self = self.with_context(just_unarchived=True)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The `reset_applicant` method previously did not reset the `referral_state` to `'progress'`, causing the referral page to incorrectly display the applicant as "not hired" even when their actual state was ongoing.

This commit explicitly sets `referral_state` to `'progress'` to ensure proper state management when an applicant is restored.

opw-4523156

Related commit: f48ae97c2cadcdc085d32be25be365fdbb5605ef

Current behavior before PR:

Refuse an applicant and restore it, go to the referral app, the state will be displayed as not hired instead of ongoing

Desired behavior after PR is merged:

It should display as ongoing


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
