### PR TITLE
[FIX] survey: make "Votes" translatable

### DIFF
--- a/addons/survey/i18n/survey.pot
+++ b/addons/survey/i18n/survey.pot
@@ -69,6 +69,13 @@ msgstr ""
 
 #. module: survey
 #. odoo-python
+#: code:addons/survey/models/survey_question.py:0
+#, python-format
+msgid "%s Votes"
+msgstr ""
+
+#. module: survey
+#. odoo-python
 #: code:addons/survey/models/survey_survey.py:0
 #, python-format
 msgid "%s certification passed"
@@ -3347,6 +3354,11 @@ msgid "Products"
 msgstr ""
 
 #. module: survey
+#: model_terms:ir.ui.view,arch_db:survey.survey_invite_view_form
+msgid "Public share URL"
+msgstr ""
+
+#. module: survey
 #: model:ir.model.fields,field_description:survey.field_survey_question_answer__question_id
 #: model:ir.model.fields,field_description:survey.field_survey_user_input_line__question_id
 #: model_terms:ir.ui.view,arch_db:survey.survey_question_answer_view_search
@@ -4646,6 +4658,11 @@ msgstr ""
 #: code:addons/survey/models/survey_survey_template.py:0
 #, python-format
 msgid "Use humor and make jokes"
+msgstr ""
+
+#. module: survey
+#: model_terms:ir.ui.view,arch_db:survey.survey_invite_view_form
+msgid "Use template"
 msgstr ""
 
 #. module: survey

--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -506,7 +506,8 @@ class SurveyQuestion(models.Model):
         table_data = [{
             'value': _('Other (see comments)') if not sug_answer else sug_answer.value,
             'suggested_answer': sug_answer,
-            'count': count_data[sug_answer]
+            'count': count_data[sug_answer],
+            'count_text': _("%s Votes", count_data[sug_answer]),
             }
             for sug_answer in suggested_answers]
         graph_data = [{

--- a/addons/survey/views/survey_templates_statistics.xml
+++ b/addons/survey/views/survey_templates_statistics.xml
@@ -388,7 +388,7 @@
                             </td>
                             <td class="o_survey_answer">
                                 <span t-esc="round(choice_data['count'] * 100.0/ (len(question_data['answer_line_done_ids']) or 1), 2)"></span> %
-                                <span t-esc="'%s Votes' % choice_data['count']" class="badge text-bg-primary"/>
+                                <span t-out="choice_data['count_text']" class="badge text-bg-primary"/>
                                 <i t-if="choice_data['suggested_answer'].id and choice_data['count']"
                                     class="fa fa-filter text-primary filter-add-answer"
                                     t-att-data-question-id="question.id"


### PR DESCRIPTION
In the survey stats, the number of votes for a multiple choice answer displayed the label "Votes" without it being translatable.

This commit makes it translatable.

[task-4421055](https://www.odoo.com/odoo/project.task/4421055)