### PR TITLE
[IMP] point_of_sale: format report date based on user’s language preference

### DIFF
--- a/addons/point_of_sale/views/pos_session_sales_details.xml
+++ b/addons/point_of_sale/views/pos_session_sales_details.xml
@@ -27,7 +27,8 @@
                 <div class="row">
                     <div class="col-12 text-end mt-2">
                         <span class="badge bg-light text-dark border border-dark p-2">
-                            <strong>    As of <span t-esc="context_timestamp(datetime.datetime.now()).strftime('%m/%d/%Y')"/>
+                            <t t-set="date_format" t-value="env['res.lang']._get_data(code=env.user.lang).date_format"/>
+                            <strong>    As of <span t-esc="context_timestamp(datetime.datetime.now()).strftime(date_format)"/>
                             </strong>
                         </span>
                     </div>


### PR DESCRIPTION
Before this commit:
==========
- The Point of Sale report date was always formatted as "%m/%d/%Y," ignoring the date format specified by the user's language settings.

After this commit:
==========
- The report date will now be formatted according to the date format defined by the user's language, ensuring consistency and better localization.

task-4523330