### PR TITLE
[FIX] stock: correct empty screen message in physical adjustments

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -429,10 +429,9 @@ class StockQuant(models.Model):
                 <p class="o_view_nocontent_smiling_face">
                     {}
                 </p><p>
-                    {} <span class="fa fa-long-arrow-right"/> {}</p>
+                    {} <span class="fa fa-cog"/> </p>
                 """.format(_('Your stock is currently empty'),
-                           _('Press the CREATE button to define quantity for each product in your stock or import them from a spreadsheet throughout Favorites'),
-                           _('Import')),
+                           _('Press the CREATE button to define quantity for each product in your stock or import them from a spreadsheet throughout the action menu')),
         }
         return action
 


### PR DESCRIPTION
Before:
------------------------------------
When there are no records in Physical Inventory Adjustments, the empty screen incorrectly suggests import data via "Favorites → Import." However, from version 17.0 onwards, the import option is now available through the action menu instead , causing confusion for users.

After:
------------------------------------
Replaced "Favorites → Import" with the correct message: "import them from a spreadsheet throughout the action menu," and changed the icon from the long right arrow to the configuration icon for clarity.

Task - 4550935