### PR TITLE
[FIX] mail, im_livechat: Hide live chat commands to visitors

### DIFF
--- a/addons/crm_livechat/static/src/core/channel_commands.js
+++ b/addons/crm_livechat/static/src/core/channel_commands.js
@@ -2,6 +2,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("discuss.channel_commands").add("lead", {
+    condition: ({ store, thread }) => store.self.type === "partner" && store.self.isInternalUser,
     help: _t("Create a new lead (/lead lead title)"),
     methodName: "execute_command_lead",
 });

--- a/addons/im_livechat/static/src/core/web/channel_commands_patch.js
+++ b/addons/im_livechat/static/src/core/web/channel_commands_patch.js
@@ -2,6 +2,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("discuss.channel_commands").add("history", {
+    condition: ({ store, thread }) => store.self.type === "partner" && store.self.isInternalUser,
     channel_types: ["livechat"],
     help: _t("See 15 last visited pages"),
     methodName: "execute_command_history",

--- a/addons/mail/static/src/discuss/core/common/channel_commands.js
+++ b/addons/mail/static/src/discuss/core/common/channel_commands.js
@@ -5,14 +5,20 @@ const commandRegistry = registry.category("discuss.channel_commands");
 
 commandRegistry
     .add("help", {
+        condition: ({ store, thread }) =>
+            store.self.type === "partner" && store.self.isInternalUser,
         help: _t("Show a helper message"),
         methodName: "execute_command_help",
     })
     .add("leave", {
+        condition: ({ store, thread }) =>
+            store.self.type === "partner" && store.self.isInternalUser,
         help: _t("Leave this channel"),
         methodName: "execute_command_leave",
     })
     .add("who", {
+        condition: ({ store, thread }) =>
+            store.self.type === "partner" && store.self.isInternalUser,
         channel_types: ["channel", "chat", "group"],
         help: _t("List users in the current channel"),
         methodName: "execute_command_who",

--- a/addons/mail/static/src/discuss/core/common/suggestion_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/suggestion_service_patch.js
@@ -8,6 +8,26 @@ const commandRegistry = registry.category("discuss.channel_commands");
 
 /** @type {SuggestionService} */
 const suggestionServicePatch = {
+    getChannelCommands(thread) {
+        if (!thread || thread.model !== "discuss.channel") {
+            return [];
+        }
+        return commandRegistry
+            .getEntries()
+            .map(([name, command]) => ({
+                channel_types: command.channel_types,
+                condition: command.condition,
+                help: command.help,
+                id: command.id,
+                name,
+            }))
+            .filter(({ condition, channel_types }) => {
+                const passesCondition = !condition || condition({ store: this.store, thread });
+                const passesChannelType =
+                    !channel_types || channel_types.includes(thread.channel_type);
+                return passesCondition && passesChannelType;
+            });
+    },
     getSupportedDelimiters(thread, env) {
         const res = super.getSupportedDelimiters(...arguments);
         return thread?.model === "discuss.channel" ? [...res, ["/", 0]] : res;
@@ -26,25 +46,9 @@ const suggestionServicePatch = {
             // channel commands are channel specific
             return;
         }
-        const commands = commandRegistry
-            .getEntries()
-            .filter(([name, command]) => {
-                if (!cleanTerm(name).includes(cleanedSearchTerm)) {
-                    return false;
-                }
-                if (command.channel_types) {
-                    return command.channel_types.includes(thread.channel_type);
-                }
-                return true;
-            })
-            .map(([name, command]) => {
-                return {
-                    channel_types: command.channel_types,
-                    help: command.help,
-                    id: command.id,
-                    name,
-                };
-            });
+        const commands = this.getChannelCommands(thread).filter(({ name }) =>
+            cleanTerm(name).includes(cleanedSearchTerm)
+        );
         const sortFunc = (c1, c2) => {
             if (c1.channel_types && !c2.channel_types) {
                 return -1;

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -387,6 +387,7 @@ const threadPatch = {
             const command = commandRegistry.get(firstWord, false);
             if (
                 command &&
+                (!command.condition || command.condition({ store: this.store, thread: this })) &&
                 (!command.channel_types || command.channel_types.includes(this.channel_type))
             ) {
                 await this.executeCommand(command, body);

--- a/addons/mail/static/src/discuss/typing/common/composer_patch.js
+++ b/addons/mail/static/src/discuss/typing/common/composer_patch.js
@@ -60,6 +60,8 @@ patch(Composer.prototype, {
                 value === "/" || // suggestions not yet started
                 this.hasSuggestions ||
                 (command &&
+                    (!command.condition ||
+                        command.condition({ store: this.store, thread: this.thread })) &&
                     (!command.channel_types ||
                         command.channel_types.includes(this.thread.channel_type)))
             ) {


### PR DESCRIPTION
**Current behavior before PR:**

channel commands like `/help ` or `/leave` are visible to visitors even it is not functional for them.

**Desired behavior after PR is merged:**

commands are now hidden from visitors.

task-4552209

related: [PR](https://github.com/odoo/enterprise/pull/82963)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
