### PR TITLE
[REM] base_import_module: clean module_uninstall method for assets

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -330,12 +330,6 @@ class IrModuleModule(models.Model):
         res = super().module_uninstall()
         if modules_to_delete:
             deleted_modules_names = modules_to_delete.mapped('name')
-            assets_data = self.env['ir.model.data'].search([
-                ('model', '=', 'ir.asset'),
-                ('module', 'in', deleted_modules_names),
-            ])
-            assets = self.env['ir.asset'].search([('id', 'in', assets_data.mapped('res_id'))])
-            assets.unlink()
             _logger.info("deleting imported modules upon uninstallation: %s",
                          ", ".join(deleted_modules_names))
             modules_to_delete.unlink()

--- a/addons/base_import_module/tests/test_cloc.py
+++ b/addons/base_import_module/tests/test_cloc.py
@@ -269,6 +269,15 @@ class TestClocFields(test_cloc.TestClocCustomization):
         attachments = self.env['ir.attachment'].search([('url', 'ilike', 'test_imported_module/static/src/js/test_js')])
         self.assertFalse(attachments, "No more attachment from assets should remain in the db")
 
+        assets_data = self.env['ir.model.data'].search([
+            ('model', '=', 'ir.asset'),
+            ('module', '=', 'test_imported_module'),
+        ])
+        self.assertFalse(
+            self.env['ir.asset'].search([('id', 'in', assets_data.mapped('res_id'))]),
+            "No more assets should remain in the db",
+        )
+
         irmodeldata = self.env['ir.model.data'].search([('module', '=', '__cloc_exclude__')])
         self.assertTrue(
             len(irmodeldata) == 1 and irmodeldata.res_id == self.env.ref('base.view_company_form').id,


### PR DESCRIPTION
The module_uninstall method was removing `ir.asset` related to the module being uninstalled, but it is already done by the parent method. This commit therefore removes these useless lines.
