### PR TITLE
[FIX] point_of_sale: adjust config name size on preparation ticket

### DIFF
--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -11,7 +11,7 @@
                 <div class="pos-receipt-title" t-if="data.preset_name">
                     <t t-esc="data.preset_name"/>
                 </div>
-                <div class="font-size: 78%;">
+                <div style="font-size: 78%;">
                     <span><t t-esc="data.config_name"/> : <t t-esc="data.time"/></span><br/>
                     <span>By: <t t-esc="data.employee_name"/></span>
                 </div>


### PR DESCRIPTION
This commit ensures that the config name is printed with the correct size on the preparation ticket.

