### PR TITLE
[FIX] pos_restaurant: set tab floating order

### DIFF
--- a/addons/pos_restaurant/static/src/app/popup/edit_order_name_popup/edit_order_name_popup.js
+++ b/addons/pos_restaurant/static/src/app/popup/edit_order_name_popup/edit_order_name_popup.js
@@ -13,6 +13,7 @@ export class EditOrderNamePopup extends TextInputPopup {
     }
     transferOrder(order) {
         this.pos.transferOrder(this.currentOrder.uuid, null, order);
+        this.pos.setOrder(order);
         this.dialog.closeAll();
     }
     get currentOrder() {

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -98,7 +98,7 @@ patch(PosStore.prototype, {
             }
 
             destOrder.uiState.unmerge[uuid] = {
-                table_id: sourceOrder.table_id.id,
+                table_id: sourceOrder.table_id?.id,
                 quantity: orphanLine.qty,
             };
 


### PR DESCRIPTION
Fix issue generating traceback where when merging floating orders together. As `mergeOrders` can be used with floating orders, it doesn't necessarily contain a table. A check has been added to handle this case properly. After selecting an order to merge with, we now also redirect to this order.

Steps to reproduce:
- Create new floating order
- Add items to the cart
- Click "Set Tab"
- Select existing floating orders

task-id: 4551788

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
