### PR TITLE
[FIX] account: prevent generation of new pdf when existing

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -617,7 +617,7 @@ class AccountMoveSend(models.AbstractModel):
             self._prepare_invoice_pdf_report(batch)
 
         for invoice, invoice_data in invoices_data_pdf.items():
-            if not invoice_data.get('error'):
+            if not invoice_data.get('error') and not invoice.invoice_pdf_report_id:
                 self._hook_invoice_document_after_pdf_report_render(invoice, invoice_data)
 
         # Cleanup the error if we don't want to block the regular pdf generation.

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -574,7 +574,9 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
 
         # Send it again. The PDF must not be created again.
         wizard = self.create_send_and_print(invoice, sending_methods=['email', 'manual'])
-        results = wizard.action_send_and_print()
+        with patch('odoo.addons.account.models.account_move_send.AccountMoveSend._hook_invoice_document_after_pdf_report_render') as mocked_method:
+            results = wizard.action_send_and_print()
+            mocked_method.assert_not_called()
         self.assertEqual(results['type'], 'ir.actions.act_url')
         self.assertFalse(invoice.sending_data)
         self.assertRecordValues(invoice, [{'invoice_pdf_report_id': pdf_report.id}])


### PR DESCRIPTION
Steps to reproduce:
[l10n_de]
- create an invoice
- confirm the invoice
- send the invoice
- send the invoice again

Issue:
You will get an error "You cannot remove parts of the audit trail. Archive the record instead."

Cause:
We don't prevent entering the hook if there is already a generated pdf. During the hook, we want to "generate a Factur-X and embed it inside the PDF for inter-portability" https://github.com/odoo/odoo/blob/84a0b81a258262e3bb9dbaa9c9f37796303a9dad/addons/account_edi_ubl_cii/models/account_move_send.py#L124-L128

In the German loca, while trying to write on the attachment, we'll check that the move has not been already posted. In which case it will raise the error https://github.com/odoo/odoo/blob/5215428114842c606202e7b1c69f5f597a977f92/addons/l10n_de/models/ir_attachment.py#L13-L34

solution:
Prevent entering the hook if there is already a pdf as it is done a few lines before https://github.com/odoo/odoo/blob/9f65f1a3b0b6b893f230729c56f287f5aff6af35/addons/account/models/account_move_send.py#L607

opw-4471377
