### PR TITLE
[IMP] account: Secured group usability

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -678,9 +678,6 @@ class AccountJournal(models.Model):
             for journal in self.filtered(lambda r: r.type == 'bank' and not r.bank_account_id):
                 journal.set_bank_account(vals.get('bank_acc_number'), vals.get('bank_id'))
 
-        if vals.get('restrict_mode_hash_table'):
-            self.env['res.groups']._activate_group_account_secured()
-
         return result
 
     def _alias_get_creation_values(self):
@@ -879,9 +876,6 @@ class AccountJournal(models.Model):
             # Create the bank_account_id if necessary
             if journal.type == 'bank' and not journal.bank_account_id and vals.get('bank_acc_number'):
                 journal.set_bank_account(vals.get('bank_acc_number'), vals.get('bank_id'))
-
-        if any(journals.mapped('restrict_mode_hash_table')):
-            self.env['res.groups']._activate_group_account_secured()
 
         return journals
 

--- a/addons/account/wizard/account_secure_entries_wizard.py
+++ b/addons/account/wizard/account_secure_entries_wizard.py
@@ -259,8 +259,6 @@ class AccountSecureEntries(models.TransientModel):
         if not self.hash_date:
             raise UserError(_("Set a date. The moves will be secured up to including this date."))
 
-        self.env['res.groups']._activate_group_account_secured()
-
         if not self.move_to_hash_ids:
             return
 


### PR DESCRIPTION
**Current behavior:**
As of now, whenever a journal is set to "Hash on Post", the user is granted the secured group rights. This allows the user to see the lock icon in the status bar, the extra default filters in the list views of Journal Entries and Journal Items, and access to the Secure Entries wizard.

However, if only entries from journals with "Hash on Post" are secured, these features are not necessary. The user trusts Odoo to hash any and all entries that are posted in that specific journal.

**Expected behavior:**
When "Hash on Post" is active, the user does not need any additional user group. However, if even one entry is secured and does not belong to a journal with the "hash on post" feature, the user will then need access to the new features, such as the lock icon, default filters, and the Secure Entries wizard.

**Approach:**
This commit removes the calls to _activate_group_account_secured() when setting a journal to "Hash on Post". It also removes it from the Secure Entries wizard. Instead, we add the key 'journal_restrict_mode' to the chains_to_hash, which indicates the value of the journal's restrict_mode_hash_table field. If at least one chain with moves does not have 'journal_restrict_mode', only then we call _activate_group_account_secured()  from _hash_moves(). This will only happen when the Secure Entries wizard is used, hashing entries from all journals.

task-4348380

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
