### PR TITLE
[FIX] account: prevent error when applying sorting on assets list

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -147,29 +147,35 @@ class AccountAccount(models.Model):
         if fname == 'code':
             return self.with_company(self.env.company.root_id).sudo()._field_to_sql(alias, 'code_store', query, flush)
         if fname == 'placeholder_code':
-            # The placeholder_code is defined as the account's code in the first active company to
-            # which the account belongs.
-            query.add_join(
-                'LEFT JOIN',
-                'account_first_company',
-                SQL(
-                    """(
-                        SELECT DISTINCT ON (rel.account_account_id)
-                               rel.account_account_id AS account_id,
-                               rel.res_company_id AS company_id,
-                               SPLIT_PART(res_company.parent_path, '/', 1) AS root_company_id,
-                               res_company.name AS company_name
-                          FROM account_account_res_company_rel rel
-                          JOIN res_company
-                            ON res_company.id = rel.res_company_id
-                         WHERE rel.res_company_id IN %(authorized_company_ids)s
-                      ORDER BY rel.account_account_id, company_id
-                    )""",
-                    authorized_company_ids=self.env.user._get_company_ids(),
-                    to_flush=self._fields['company_ids'],
-                ),
-                SQL('account_first_company.account_id = %(account_id)s', account_id=SQL.identifier(alias, 'id')),
-            )
+            if 'account_first_company' not in query._joins:
+                # When multiple accounts are selected, ``placeholder_code`` is used for all of them
+                # as it is in the default ``_order`` (e.g., for ``account_asset_id`` and
+                # ``account_depreciation_id`` in ``account_assets``).
+
+                # As ``placeholder_code`` represents the account's code in the first active company
+                # to which the account belongs in the hierarchy, we must ensure that we do not introduce
+                # a second ``JOIN`` to the account-company relation to avoid redundancy in joins.
+                query.add_join(
+                    'LEFT JOIN',
+                    'account_first_company',
+                    SQL(
+                        """(
+                            SELECT DISTINCT ON (rel.account_account_id)
+                                rel.account_account_id AS account_id,
+                                rel.res_company_id AS company_id,
+                                SPLIT_PART(res_company.parent_path, '/', 1) AS root_company_id,
+                                res_company.name AS company_name
+                            FROM account_account_res_company_rel rel
+                            JOIN res_company
+                                ON res_company.id = rel.res_company_id
+                            WHERE rel.res_company_id IN %(authorized_company_ids)s
+                        ORDER BY rel.account_account_id, company_id
+                        )""",
+                        authorized_company_ids=self.env.user._get_company_ids(),
+                        to_flush=self._fields['company_ids'],
+                    ),
+                    SQL('account_first_company.account_id = %(account_id)s', account_id=SQL.identifier(alias, 'id')),
+                )
 
             return SQL(
                 """


### PR DESCRIPTION
Currently, an error occurs when sorting is applied again on a different related field after sorting another related field first.

Steps to reproduce:
- Install `accountant` module
- Navigate `Accounting > Accounting > Assets (list view)`
- Apply Sorting on column `Fixed Asset Account`
- Try to sort the column `Depreciation Account`
- Observe the error

Error: `AssertionError`

The issue occurs when attempting to add a JOIN on an SQL query without verifying whether it has already been included.  - [1]

This commit resolves the issue by adding a conditional check before adding a join in the query, ensuring that duplicate joins are not added.

[1] - https://github.com/odoo/odoo/blob/b2e564f07f6883111da4581bccfb0f45c7588063/addons/account/models/account_account.py#L150-L152

Sentry-6039417751