### PR TITLE
[IMP] l10n_sa_edi: remove company_id from the xml when partner is not SA

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -111,6 +111,15 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
             ),
         }]
 
+    def _get_partner_party_legal_entity_vals_list(self, partner):
+        # EXTEND 'account.edi.xml.ubl_20'
+        partners_party_legal = super()._get_partner_party_legal_entity_vals_list(partner)
+        for partner_party_legal in partners_party_legal:
+            if partner_party_legal['commercial_partner'].country_code != 'SA':
+                partner_party_legal['company_id'] = False
+
+        return partners_party_legal
+
     def _l10n_sa_get_payment_means_code(self, invoice):
         """ Return payment means code to be used to set the value on the XML file """
         return 'unknown'

--- a/addons/l10n_sa_edi/tests/compliance/standard/invoice.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/invoice.xml
@@ -115,7 +115,6 @@
             </cac:PostalAddress>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName>Chichi Lboukla</cbc:RegistrationName>
-                <cbc:CompanyID>US12345677</cbc:CompanyID>
                 <cac:RegistrationAddress>
                     <cbc:StreetName>4557 De Silva St</cbc:StreetName>
                     <cbc:BuildingNumber>12300</cbc:BuildingNumber>

--- a/addons/l10n_sa_edi/tests/test_files/downpayment_invoice.xml
+++ b/addons/l10n_sa_edi/tests/test_files/downpayment_invoice.xml
@@ -115,7 +115,6 @@
       </cac:PostalAddress>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Chichi Lboukla</cbc:RegistrationName>
-        <cbc:CompanyID>US12345677</cbc:CompanyID>
         <cac:RegistrationAddress>
           <cbc:StreetName>4557 De Silva St</cbc:StreetName>
           <cbc:BuildingNumber>12300</cbc:BuildingNumber>

--- a/addons/l10n_sa_edi/tests/test_files/final_invoice.xml
+++ b/addons/l10n_sa_edi/tests/test_files/final_invoice.xml
@@ -115,7 +115,6 @@
       </cac:PostalAddress>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Chichi Lboukla</cbc:RegistrationName>
-        <cbc:CompanyID>US12345677</cbc:CompanyID>
         <cac:RegistrationAddress>
           <cbc:StreetName>4557 De Silva St</cbc:StreetName>
           <cbc:BuildingNumber>12300</cbc:BuildingNumber>


### PR DESCRIPTION
This commit will set the company_id from partner party legal entity when the partner is not from SA

task: 4531706




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
