### PR TITLE
 [IMP] auth_totp: make totp_secret unreachable

### DIFF
--- a/addons/auth_totp/tests/test_totp.py
+++ b/addons/auth_totp/tests/test_totp.py
@@ -124,3 +124,17 @@ class TestTOTP(TestTOTPCommon, HttpCaseWithUserDemo):
         response = self.url_open("/web/session/authenticate", data=json.dumps(payload), headers=headers)
         data = response.json()
         self.assertEqual(data['result']['uid'], None)
+
+
+    def test_totp_field_access(self):
+        """
+        Ensure that the field of the totp secret cannot be accessed even by the admin
+        """
+        users = self.env.user.create([
+            {'name': 'test_totp_user', 'login': 'test', 'password': 'passwordtest', 'totp_secret': '111111'},
+            {'name': 'test_totp_user2', 'login': 'test2', 'password': 'passwordtest'}])
+        self.env.cache.invalidate()
+        self.assertFalse(users[0].sudo().totp_secret)
+        users._compute_totp_enabled()  # make sure the compute works for batch operation
+        self.assertFalse(users[1].totp_enabled)
+        self.assertTrue(users[0].totp_enabled)


### PR DESCRIPTION
This commit changes the compute of the totp_token in order to make
it unreachable via the attribute of the record for all user.

Instead, the fetching of the value from the database is inlined
in the check function. There shouldn't be any other scope where
this value should be directly used.