### PR TITLE
[FIX] l10n_ar: fix Qweb overrides between AR and AE

### DIFF
--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -159,14 +159,15 @@
         </t>
 
         <!-- use column vat instead of taxes and only if vat discriminated -->
-        <xpath expr="//th[@name='th_taxes']/span" position="replace">
-            <span>% VAT</span>
+        <xpath expr="//th[@name='th_taxes']" position="replace">
+            <th name="th_taxes"
+                t-attf-class="text-start {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"
+                t-if="not o._l10n_ar_include_vat()">
+                <span t-if="o.company_id.country_id.code == 'AR'">% VAT</span>
+                <span t-else="">Taxes</span>
+            </th>
         </xpath>
 
-        <!-- use column vat instead of taxes and only list vat taxes-->
-        <xpath expr="//th[@name='th_taxes']" position="attributes">
-            <attribute name="t-if">not o._l10n_ar_include_vat()</attribute>
-        </xpath>
         <xpath expr="//span[@id='line_tax_ids']/.." position="attributes">
             <attribute name="t-if">not o._l10n_ar_include_vat()</attribute>
         </xpath>


### PR DESCRIPTION
When AE localization extends the default invoice report, they replace the `<th name="th_taxes"><span>Taxes</span></th>` with `<th name="th_taxes"><span t-if="...">VAT</span><span t-else="">Taxes</span></th>`. Then when AR localization is installed, it will replace the first div with the t-if. We end up in a situation with a `<span/>` followed by a `<span t-else=""/>` which raise an error because it is expecting a `t-if`.

task-no
