### PR TITLE
[FIX] sale_project: prevent access error when duplicating a project

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -42,7 +42,7 @@ class ProjectProject(models.Model):
     partner_id = fields.Many2one(compute="_compute_partner_id", store=True, readonly=False)
     display_sales_stat_buttons = fields.Boolean(compute='_compute_display_sales_stat_buttons', export_string_translation=False)
     sale_order_state = fields.Selection(related='sale_order_id.state', export_string_translation=False)
-    reinvoiced_sale_order_id = fields.Many2one('sale.order', string='Sales Order', groups='sales_team.group_sale_salesman', domain="[('partner_id', '=', partner_id)]",
+    reinvoiced_sale_order_id = fields.Many2one('sale.order', string='Sales Order', groups='sales_team.group_sale_salesman', copy=False, domain="[('partner_id', '=', partner_id)]",
         help="Products added to stock pickings, whose operation type is configured to generate analytic costs, will be re-invoiced in this sales order if they are set up for it.",
     )
 


### PR DESCRIPTION
**issue:**

If a user lacks Sales module rights, they are not allowed to duplicate a project.

**steps to reproduce:**

- Settings / Users & Companies / Users
- Remove sales rights from the user while retaining rights in projects
- In the project module, try duplicating a project

An access error is raised because the ```reinvoiced_sale_order_id``` field is attempted to be read during the copy operation

opw-4466519