### PR TITLE
[FIX] mail, portal: toggle star in the portal

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -822,6 +822,7 @@ class Message(models.Model):
         """ Toggle messages as (un)starred. Technically, the notifications related
             to uid are set to (un)starred.
         """
+        self.ensure_one()
         # a user should always be able to star a message they can read
         self.check_access('read')
         starred = not self.starred
@@ -833,6 +834,7 @@ class Message(models.Model):
         self.env.user._bus_send(
             "mail.message/toggle_star", {"message_ids": [self.id], "starred": starred}
         )
+        return Store(self, {"starred": self.starred}).get_result()
 
     def _message_reaction(self, content, action, partner, guest, store: Store = None):
         self.ensure_one()

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -492,9 +492,13 @@ export class Message extends Record {
     }
 
     async toggleStar() {
-        await this.store.env.services.orm.silent.call("mail.message", "toggle_message_starred", [
-            [this.id],
-        ]);
+        this.store.insert(
+            await this.store.env.services.orm.silent.call(
+                "mail.message",
+                "toggle_message_starred",
+                [[this.id]]
+            )
+        );
     }
 
     async unfollow() {

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -310,6 +310,7 @@ export class MailMessage extends models.ServerModel {
         const ResPartner = this.env["res.partner"];
 
         const messages = this.browse(ids);
+        const store = new mailDataHelpers.Store();
         for (const message of messages) {
             const wasStarred = message.starred_partner_ids.includes(this.env.user.partner_id);
             this.write([message.id], {
@@ -324,7 +325,9 @@ export class MailMessage extends models.ServerModel {
                 message_ids: [message.id],
                 starred: !wasStarred,
             });
+            store.add(this.browse(message.id), { starred: !wasStarred });
         }
+        return store.get_result();
     }
 
     unstar_all() {

--- a/addons/portal/models/mail_message.py
+++ b/addons/portal/models/mail_message.py
@@ -51,6 +51,7 @@ class MailMessage(models.Model):
             'model',
             'published_date_str',
             'res_id',
+            'starred',
             'subtype_id',
         }
 

--- a/addons/test_mail_full/__manifest__.py
+++ b/addons/test_mail_full/__manifest__.py
@@ -28,10 +28,15 @@ real applications. """,
         'data/mail_message_subtype_data.xml',
         'security/ir.model.access.csv',
         'security/ir_rule_data.xml',
+        'views/test_portal_template.xml',
     ],
     'assets': {
         'web.assets_unit_tests': [
             'test_mail_full/static/tests/**/*',
+            ('remove', 'test_mail_full/static/tests/tours/**/*'),
+        ],
+        'web.assets_tests': [
+            'test_mail_full/static/tests/tours/**/*',
         ],
     },
     'installable': True,

--- a/addons/test_mail_full/controllers/portal.py
+++ b/addons/test_mail_full/controllers/portal.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 
 from odoo import http
 from odoo.http import request
@@ -12,3 +10,14 @@ class PortalTest(http.Controller):
     @http.route('/my/test_portal/<int:res_id>', type='http', auth='public', methods=['GET'])
     def test_portal_record_view(self, res_id, access_token=None, **kwargs):
         return request.make_response(f'Record view of test_portal {res_id} ({access_token}, {kwargs})')
+
+    @http.route("/my/test_portal_records/<int:res_id>", type="http", auth="public", website=True)
+    def test_portal_record_page(self, res_id, **kwargs):
+        record = request.env["mail.test.portal"]._get_thread_with_access(res_id, **kwargs)
+        values = {
+            "object": record,
+            "token": kwargs.get("access_token", None),
+            "hash": kwargs.get("hash", None),
+            "pid": kwargs.get("pid", None),
+        }
+        return request.render("test_mail_full.test_portal_template", values)

--- a/addons/test_mail_full/static/tests/tours/message_actions_tour.js
+++ b/addons/test_mail_full/static/tests/tours/message_actions_tour.js
@@ -1,0 +1,14 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("star_message_tour", {
+    steps: () => [
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message:contains(Test Message)",
+            run: "hover && click #chatterRoot:shadow .o-mail-Message [title='Mark as Todo'] i.fa-star-o",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message:contains(Test Message)",
+            run: "hover #chatterRoot:shadow .o-mail-Message [title='Mark as Todo'] i.fa-star.o-mail-Message-starred",
+        },
+    ],
+});

--- a/addons/test_mail_full/tests/__init__.py
+++ b/addons/test_mail_full/tests/__init__.py
@@ -11,3 +11,4 @@ from . import test_portal_message_update_controller
 from . import test_portal_thread_controller
 from . import test_rating
 from . import test_res_users
+from . import test_ui

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -239,7 +239,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
     def test_portal_message_format_norating(self):
         messages_all = self.messages_all.with_user(self.env.user)
 
-        with self.assertQueryCount(employee=13):
+        with self.assertQueryCount(employee=15):
             # res = messages_all.portal_message_format(options=None)
             res = messages_all.portal_message_format(options={'rating_include': False})
 
@@ -291,7 +291,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
     def test_portal_message_format_rating(self):
         messages_all = self.messages_all.with_user(self.env.user)
 
-        with self.assertQueryCount(employee=27):
+        with self.assertQueryCount(employee=29):
             res = messages_all.portal_message_format(options={'rating_include': True})
 
         self.assertEqual(len(res), len(messages_all))
@@ -313,7 +313,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
     def test_portal_message_format_monorecord(self):
         message = self.messages_all[0].with_user(self.env.user)
 
-        with self.assertQueryCount(employee=19):
+        with self.assertQueryCount(employee=20):
             res = message.portal_message_format(options={'rating_include': True})
 
         self.assertEqual(len(res), 1)

--- a/addons/test_mail_full/tests/test_ui.py
+++ b/addons/test_mail_full/tests/test_ui.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import tests
+from odoo.addons.test_mail_full.tests.test_portal import TestPortal
+
+
+@tests.common.tagged("post_install", "-at_install")
+class TestUIPortal(TestPortal):
+    def test_star_message(self):
+        self.env["mail.message"].create(
+            {
+                "author_id": self.user_employee.partner_id.id,
+                "body": "Test Message",
+                "model": self.record_portal._name,
+                "res_id": self.record_portal.id,
+                "subtype_id": self.ref("mail.mt_comment"),
+            }
+        )
+        self.start_tour(
+            f"/my/test_portal_records/{self.record_portal.id}",
+            "star_message_tour",
+            login=self.user_employee.login,
+        )

--- a/addons/test_mail_full/views/test_portal_template.xml
+++ b/addons/test_mail_full/views/test_portal_template.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="test_portal_template" name="Test Portal" inherit_id="portal.portal_sidebar">
+        <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
+            <!-- chatter -->
+            <div>
+                <h3>Communication history</h3>
+                <t t-call="portal.message_thread"/>
+            </div>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
Before this PR, toggling the star on a message (`Mark as Todo`) didn't work for internal users, even though the feature is available to them in the portal environment. This happens because:
- The `starred` value is not sent with the message data when fetching the messages in the portal.
- Sending over the bus is not available in the portal. 

This PR fixes the issue by returning the proper data either when fetching the messages or when toggling the star.

There is an extra query when calling `portal_message_format` because of `mail_message_res_partner_starred_rel`. Also, there is `sometimes` another extra query when calling `portal_message_format` on multiple messages depending on
which partner is already in the cache. This is what happens:

Without extra query:
- Query on res_partner by `_read_format` for `5 partners`
- Computing starred starts (_compute_starred)
- Query for mail_message_res_partner_starred_rel
- Computing starred ends 

With extra query:
- Computing starred starts (_compute_starred)
- Query for mail_message_res_partner_starred_rel
- Query on res_partner by `_read_format` for `4 partners`
- Computing starred ends
- Query on res_partner by `_read_format` for `1 partner`

Although it doesn't happen all the time, this PR considers an extra query count for this process to avoid unwanted crashes on related tests.

task-4526370

