### PR TITLE
[FIX] sale: Fix wrapping issue

### DIFF
--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -106,7 +106,7 @@
                         >
                             <t t-if="not line.display_type and line.product_type != 'combo'">
                                 <td name="td_name"><span t-field="line.name">Bacon Burger</span></td>
-                                <td name="td_quantity" class="text-end text-nowrap">
+                                <td name="td_quantity" t-attf-class="text-end {{ 'text-nowrap' if (not line.product_packaging_id or len(line.product_packaging_id.name) &lt; 10) else '' }}">
                                     <span t-field="line.product_uom_qty">3</span>
                                     <span t-field="line.product_uom">units</span>
                                     <span t-if="line.product_packaging_id">


### PR DESCRIPTION
step to reporduce:
1. createdb with sale and inventory in 18.0 and activate product packaging
2. Create product or demo product can be used add the product packaging in inventory tab.
3. if packaging name is have more text then it description data will auto wrap in small portion which don't look good.

before fix:
![image](https://github.com/user-attachments/assets/df55f4c3-c293-463b-a68f-c701ce880b62)

after fix:
![image](https://github.com/user-attachments/assets/6606dcc7-f9e4-4f24-874c-d0255c2dffdc)


upg-2452360
opw-4527424

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
