### PR TITLE
[FIX] web_editor: prevent deleting content before buttons

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/deleteBackward.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/deleteBackward.js
@@ -30,6 +30,7 @@ import {
     closestBlock,
     getOffsetAndCharSize,
     ZERO_WIDTH_CHARS,
+    isButton,
 } from '../utils/utils.js';
 
 Text.prototype.oDeleteBackward = function (offset, alreadyMoved = false) {
@@ -126,7 +127,7 @@ HTMLElement.prototype.oDeleteBackward = function (offset, alreadyMoved = false, 
             const parentOffset = childNodeIndex(this);
 
             if (!nodeSize(this) || contentIsZWS) {
-                const visible = isVisible(this) && !contentIsZWS;
+                const visible = (isVisible(this) && !contentIsZWS) || isButton(this);
                 const restore = prepareUpdate(...boundariesOut(this));
                 this.remove();
                 restore();

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1888,6 +1888,19 @@ export function isVisible(node, areBlocksAlwaysVisible = true) {
     return [...node.childNodes].some(n => isVisible(n));
 }
 
+/**
+ * Returns whether an element is a button
+ *
+ * @param {Node} node
+ * @returns {boolean}
+ */
+export function isButton(node) {
+    if (!node || node.nodeType !== Node.ELEMENT_NODE) {
+        return false;
+    }
+    return node.nodeName === "BUTTON" || node.classList.contains("btn");
+}
+
 export function isVisibleTextNode(testedNode) {
     if (!testedNode.length) {
         return false;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -2086,6 +2086,13 @@ X[]
                         contentAfter: `<p contenteditable="false">ab[]cdef</p>`,
                     });
                 });
+                it('should delete only the button', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: `<p>a<a class="btn">[]</a></p>`,
+                        stepFunction: deleteBackward,
+                        contentAfter: `<p>a[]</p>`,
+                    });
+                });
             });
             describe('Line breaks', () => {
                 describe('Single', () => {


### PR DESCRIPTION
**Problem**:
When focusing on an empty button (`<a>` tag with `btn` class) and pressing backspace, any visible content before it gets deleted. This happens because buttons are not considered as visible content when handling deletions.

**Solution**:
Modify `oDeleteBackward` to detect elements with the `btn` class. When deleting such an element, update the selection to avoid deleting preceding content.

**Steps to Reproduce**:
1. Open the website builder.
2. Add some content with a button.
3. Insert a form just before the button.
4. Press backspace while focusing on the button.
5. The form gets deleted along with the button.

opw-4280705

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
