### PR TITLE
[FIX] purchase_stock: respect manual valuation

### DIFF
--- a/addons/purchase_stock/models/account_move_line.py
+++ b/addons/purchase_stock/models/account_move_line.py
@@ -327,7 +327,10 @@ class AccountMoveLine(models.Model):
             unit_valuation_difference_curr = unit_valuation_difference * self.currency_rate
             unit_valuation_difference_curr = product_uom._compute_price(unit_valuation_difference_curr, self.product_uom_id)
             out_qty_to_invoice = product_uom._compute_quantity(out_qty_to_invoice, self.product_uom_id)
-            if not float_is_zero(unit_valuation_difference_curr * out_qty_to_invoice, precision_rounding=self.currency_id.rounding):
+            if (
+                not self.currency_id.is_zero(unit_valuation_difference_curr * out_qty_to_invoice) and
+                self.product_id.valuation == 'real_time'
+            ):
                 aml_vals_list += self._prepare_pdiff_aml_vals(out_qty_to_invoice, unit_valuation_difference_curr)
 
             # Generate the SVL values for the on hand quantities (and impact the parent layer)

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -3559,3 +3559,49 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         move_line.qty_done = 2.
         delivery.button_validate()
         self.assertEqual(delivery.state, 'done')
+
+    def test_manual_non_standard_cost_bill_post(self):
+        """ With manual valuation (+ continental accounting), receiving some product with a
+        non-standard cost method, consuming the available qty, and then invoicing that product at
+        different `price_unit` than the receipt should not create pdiff AccountMoveLines.
+        """
+        self.env.company.anglo_saxon_accounting = False
+        self.product1.categ_id.write({
+            'property_valuation': 'manual_periodic',
+            'property_cost_method': 'average',
+        })
+        product = self.product1
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': product.id,
+                'product_qty': 10,
+                'price_unit': 100,
+            })],
+        })
+        purchase_order.button_confirm()
+        purchase_order.picking_ids.move_ids.quantity_done = 10
+        purchase_order.picking_ids.button_validate()
+        with Form(self.env['stock.scrap']) as scrap_form:
+            scrap_form.product_id = product
+            scrap_form.scrap_qty = 10
+            scrap = scrap_form.save()
+        scrap.action_validate()
+        purchase_order.action_create_invoice()
+        bill = purchase_order.invoice_ids
+        bill.line_ids.price_unit = 120
+        bill.invoice_date = fields.Date.today()
+        bill.action_post()
+        expense_account, tax_paid_account, account_payable_account = (
+            self.company_data['default_account_expense'],
+            self.company_data['default_account_tax_purchase'],
+            self.company_data['default_account_payable'],
+        )
+        self.assertRecordValues(
+            bill.line_ids,
+            [
+                {'account_id': expense_account.id,           'debit': 1200.0,   'credit': 0.0},
+                {'account_id': tax_paid_account.id,          'debit': 180.0,    'credit': 0.0},
+                {'account_id': account_payable_account.id,   'debit': 0.0,      'credit': 1380.0},
+            ]
+        )


### PR DESCRIPTION
**Current behavior:**
Invoicing some product at a price unit different from that at reception (with the product having manual valuation and non-standard costing) will create pdiff account move lines on the invoice.

**Expected behavior:**
With manual valuation, there should not be pdiff AMLs.

**Steps to reproduce:**
1. Create a product with average costing and manual valuation

2. Receive 10 units @ $100 to establish some std price

3. Consume the 10 product qty (scrap, sale, ...)

4. Create the invoice on the purchase order

5. Change the price unit on the bill to $120 per product -> post

6. In the journal items tab on the invoice, see the pdiff AMLs

**Cause of the issue:**
No consideration for valuation when creating the AMLs for pdiff.

**Fix:**
Check that valuation is not manual prior to creating the AMLs.

opw-4492217