### PR TITLE
[FIX] point_of_sale: change phone_mobile_search in partner list to phone

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PartnerListScreen/PartnerListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PartnerListScreen/PartnerListScreen.js
@@ -204,7 +204,8 @@ odoo.define('point_of_sale.PartnerListScreen', function(require) {
                 const search_fields = [
                     "name",
                     "parent_name",
-                    "phone_mobile_search",
+                    "phone",
+                    "mobile",
                     "email",
                     "vat",
                 ];


### PR DESCRIPTION
Steps to reproduce the bug:
 - Install POS, then uninstall the sms gateway
 - Open a shop and then click on customers button
 - write anything in the input field then click on `Search More`

Problem:
Error is raised in the request because the `partner_list.js` screen is passing the field `phone_mobile_search` in the search_fields. The `phone_mobile_search` field is only introduced to the res.partner model in the a PhoneMixin and the inheritence is only applied in the `sms gateway module` so the field will only be available if the `sms gateway is installed`.

Possible Approaches:
- [18.0 fix] added a function in the partner_list.js that tells if the PhoneMixin is applied and it returns false in the pos, and overriden the same function in the pos_sms bridge module that implies that both pos and sms are installed and it returns true there meaning the mixin is applied.
- [16.0, 17.0 fix] changed the search filter to use phone, mobile attributes. this will lose the phone_mixin searching features. we don't have a pos_sms bridge module in these versions so the workaround in 18.0 can't be applied
- [Non Stable, master fix] add the inheritence of the mixin in the pos module, but that will require module upgrade
- [Non Stable] add a whole direct dependency between the pos and the sms gateway

opw-4455381

Description of the issue/feature this PR addresses:

Current behavior before PR: Search More button in the partner list in POS is not working if the sms module is uninstalled

Desired behavior after PR is merged: `Search More` button in partner list in POS is working whatever sms is installed or not




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
