### PR TITLE
[FIX] account: hide drag & drop on mobile

### DIFF
--- a/addons/account/static/src/components/bill_guide/bill_guide.js
+++ b/addons/account/static/src/components/bill_guide/bill_guide.js
@@ -1,3 +1,4 @@
+import { isMobileOS } from "@web/core/browser/feature_detection";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { DocumentFileUploader } from "../document_file_uploader/document_file_uploader";
@@ -16,6 +17,7 @@ export class BillGuide extends Component {
         this.action = useService("action");
         this.context = null;
         this.alias = null;
+        this.isMobile = isMobileOS();
         onWillStart(this.onWillStart);
     }
 

--- a/addons/account/static/src/components/bill_guide/bill_guide.xml
+++ b/addons/account/static/src/components/bill_guide/bill_guide.xml
@@ -7,9 +7,9 @@
                     <img class="img-fluid" src="/web/static/img/folder.svg"/>
                 </div>
                 <div class="text-center mt-2">
-                    <span class="btn account_drag_drop_btn pe-none">Drag &amp; drop</span>
+                    <span t-if="!isMobile" class="btn account_drag_drop_btn pe-none">Drag &amp; drop</span>
                     <div>
-                        <span class="btn pe-none px-1 fw-normal">or</span>
+                        <span t-if="!isMobile" class="btn pe-none px-1 fw-normal">or</span>
                         <a class="btn btn-link px-0 fw-normal"
                             href="#"
                             type="object"


### PR DESCRIPTION
Hide the 'Drag & Drop' button on mobile devices in
the accounting dashboard journals.

Linked:https://github.com/odoo/enterprise/pull/78707

task-4497104