### PR TITLE
[FIX] web: Ensure dropdown auto-closes in nested DOM environments

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -232,6 +232,10 @@ export class Dropdown extends Component {
     }
 
     popoverCloseOnClickAway(target, activeEl) {
+        const rootNode = target.getRootNode();
+        if (rootNode instanceof ShadowRoot) {
+            target = rootNode.host;
+        }
         return this.uiService.getActiveElementOf(target) === activeEl;
     }
 


### PR DESCRIPTION
When opening a dropdown inside an `IFrame` or `Shadow DOM`, clicking inside the nested DOM does not trigger auto-close. This happens because the event handler checks whether the clicked element is inside the main document, which is not the case for elements inside an IFrame or Shadow DOM.

This commit fixes the issue by ensuring that, in such scenarios, the correct document context (nested DOM) is used for the click detection instead of the clicked element itself.

Task-4525603

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
