### PR TITLE
[IMP] pos: presets config, better UX

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -1329,7 +1329,6 @@ msgstr ""
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_preset__slots_per_interval
-#: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_preset_form
 msgid "Capacity"
 msgstr ""
 
@@ -1924,6 +1923,11 @@ msgstr ""
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
 msgid "Configurations &gt; Settings"
+msgstr ""
+
+#. module: point_of_sale
+#: model_terms:ir.ui.view,arch_db:point_of_sale.res_config_settings_view_form
+msgid "Configure Presets"
 msgstr ""
 
 #. module: point_of_sale
@@ -2873,6 +2877,11 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js:0
 msgid "Empty Order"
+msgstr ""
+
+#. module: point_of_sale
+#: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_preset_form
+msgid "Enable Time Slots"
 msgstr ""
 
 #. module: point_of_sale
@@ -4788,6 +4797,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__sequence_id
 #: model:ir.model.fields,field_description:point_of_sale.field_res_config_settings__pos_sequence_id
 msgid "Order IDs Sequence"
+msgstr ""
+
+#. module: point_of_sale
+#: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_preset_form
+msgid "Order Limit"
 msgstr ""
 
 #. module: point_of_sale
@@ -6742,6 +6756,11 @@ msgstr ""
 #: code:addons/point_of_sale/static/src/app/components/navbar/proxy_status/proxy_status.js:0
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
 msgid "Scanner"
+msgstr ""
+
+#. module: point_of_sale
+#: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_preset_form
+msgid "Schedule"
 msgstr ""
 
 #. module: point_of_sale
@@ -8914,6 +8933,12 @@ msgstr ""
 #: code:addons/point_of_sale/models/pos_category.py:0
 msgid ""
 "You cannot delete a point of sale category while a session is still opened."
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-python
+#: code:addons/point_of_sale/models/pos_preset.py:0
+msgid "You cannot delete a preset that is linked to a POS configuration."
 msgstr ""
 
 #. module: point_of_sale

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -500,6 +500,9 @@ class PosConfig(models.Model):
 
         result = super(PosConfig, self).write(vals)
 
+        if self.use_presets and self.default_preset_id.id not in self.available_preset_ids.ids:
+            self.available_preset_ids |= self.default_preset_id
+
         self.sudo()._set_fiscal_position()
         self.sudo()._check_modules_to_install()
         self.sudo()._check_groups_implied()

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -563,7 +563,7 @@ export class TicketScreen extends Component {
                 }
             }
         }
-        return emptyOrderForPartner || emptyOrder || this.pos.addNewOrder();
+        return emptyOrderForPartner || emptyOrder || this.pos.addNewOrder({ partner_id: partner });
     }
     _doesOrderHaveSoleItem(order) {
         const orderlines = order.getOrderlines();

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1858,14 +1858,15 @@ export class PosStore extends WithLazyGetterTrap {
         }
 
         if (preset) {
+            order.setPreset(preset);
+
             if (preset.identification === "address" && !order.partner_id) {
-                const partner = await this.selectPartner();
+                const partner = await this.selectPartner(order);
                 if (!partner) {
                     return;
                 }
             }
 
-            order.setPreset(preset);
             if (preset.identification === "name" && !order.floating_order_name && !order.table_id) {
                 order.floating_order_name = order.getPartner()?.name;
                 if (!order.floating_order_name) {
@@ -1893,9 +1894,8 @@ export class PosStore extends WithLazyGetterTrap {
             preset.computeAvailabilities();
         }
     }
-    async selectPartner() {
+    async selectPartner(currentOrder = this.getOrder()) {
         // FIXME, find order to refund when we are in the ticketscreen.
-        const currentOrder = this.getOrder();
         if (!currentOrder) {
             return false;
         }

--- a/addons/point_of_sale/views/pos_preset_view.xml
+++ b/addons/point_of_sale/views/pos_preset_view.xml
@@ -31,9 +31,9 @@
                         <group>
                             <field name="pricelist_id"/>
                             <field name="fiscal_position_id"/>
-                            <field name="use_timing" />
-                            <field name="resource_calendar_id" invisible="not use_timing" />
-                            <label for="slot_params" string="Capacity" invisible="not use_timing" />
+                            <field name="use_timing" string="Enable Time Slots" />
+                            <field name="resource_calendar_id" string="Schedule" invisible="not use_timing" />
+                            <label for="slot_params" string="Order Limit" invisible="not use_timing" />
                             <div invisible="not use_timing">
                                 <field id="slot_params" name="slots_per_interval" class="oe_inline border-bottom text-center" />
                                 <label for="interval_time" string="orders per" style="font-weight:bold;" />

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -52,16 +52,19 @@
                                 <field name="pos_use_presets" readonly="pos_has_active_session"/>
                                 <div class="content-group" invisible="not pos_use_presets">
                                     <div class="row">
+                                        <label for="pos_available_preset_ids" class="col-lg-3" string="Available"/>
+                                        <field name="pos_available_preset_ids" widget="many2many_tags" options="{'no_quick_create': True, 'color_field': 'color'}" readonly="pos_has_active_session" />
+                                    </div>
+                                    <div class="row">
                                         <label for="pos_default_preset_id" class="col-lg-3" string="Default"/>
                                         <field name="pos_default_preset_id"
                                             options="{'no_create': True}"
+                                            domain="[('id', 'in', pos_available_preset_ids)]"
                                             required="pos_use_presets"
-                                            readonly="pos_has_active_session"
-                                            domain="[('identification', '=', 'none')]" />
+                                            readonly="pos_has_active_session"/>
                                     </div>
-                                    <div class="row">
-                                        <label for="pos_available_preset_ids" class="col-lg-3" string="Others"/>
-                                        <field name="pos_available_preset_ids" widget="many2many_tags" options="{'no_quick_create': True, 'color_field': 'color'}" readonly="pos_has_active_session" />
+                                    <div>
+                                        <button name="%(action_pos_preset_form)d" icon="oi-arrow-right" type="action" string="Configure Presets" class="btn-link"/>
                                     </div>
                                 </div>
                             </setting>

--- a/addons/pos_restaurant/i18n/pos_restaurant.pot
+++ b/addons/pos_restaurant/i18n/pos_restaurant.pot
@@ -1445,6 +1445,12 @@ msgstr ""
 
 #. module: pos_restaurant
 #. odoo-python
+#: code:addons/pos_restaurant/models/pos_preset.py:0
+msgid "You cannot delete the master preset(s)."
+msgstr ""
+
+#. module: pos_restaurant
+#. odoo-python
 #: code:addons/pos_restaurant/models/pos_restaurant.py:0
 msgid ""
 "You cannot remove a floor that is used in a PoS session, close the "

--- a/addons/pos_restaurant/models/__init__.py
+++ b/addons/pos_restaurant/models/__init__.py
@@ -7,3 +7,4 @@ from . import pos_payment
 from . import pos_restaurant
 from . import pos_session
 from . import res_config_settings
+from . import pos_preset

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -112,11 +112,11 @@ class PosConfig(models.Model):
             'pos_restaurant.food',
             'pos_restaurant.drinks',
         ])
-        default_preset = self.env.ref('pos_restaurant.pos_takein_preset', False) or self.env['pos.preset'].search([('identification', '=', 'none')], limit=1)
         presets = self.get_record_by_ref([
+            'pos_restaurant.pos_takein_preset',
             'pos_restaurant.pos_takeout_preset',
             'pos_restaurant.pos_delivery_preset',
-        ])
+        ]) + self.env['pos.preset'].search([]).ids
         config = self.env['pos.config'].create({
             'name': _('Restaurant'),
             'company_id': self.env.company.id,
@@ -126,9 +126,9 @@ class PosConfig(models.Model):
             'iface_available_categ_ids': restaurant_categories,
             'iface_splitbill': True,
             'module_pos_restaurant': True,
-            'use_presets': True if default_preset else False,
-            'default_preset_id': default_preset.id if default_preset else False,
-            'available_preset_ids': [(6, 0, ([default_preset.id] + presets) if default_preset else presets)],
+            'use_presets': True if presets else False,
+            'default_preset_id': presets[0] if presets else False,
+            'available_preset_ids': [(6, 0, presets)],
         })
         self.env['ir.model.data']._update_xmlids([{
             'xml_id': self._get_suffixed_ref_name(ref_name),

--- a/addons/pos_restaurant/models/pos_preset.py
+++ b/addons/pos_restaurant/models/pos_preset.py
@@ -1,0 +1,16 @@
+from odoo import api, models, _
+from odoo.exceptions import UserError
+
+
+class PosPreset(models.Model):
+    _inherit = "pos.preset"
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_master_presets(self):
+        master_presets = self.env["pos.config"].get_record_by_ref([
+            'pos_restaurant.pos_takein_preset',
+            'pos_restaurant.pos_takeout_preset',
+            'pos_restaurant.pos_delivery_preset',
+        ])
+        if any(preset.id in master_presets for preset in self):
+            raise UserError(_('You cannot delete the master preset(s).'))


### PR DESCRIPTION
After this commit:
===
- Allowed all presets to be set as default.  
- Added a shortcut to edit presets from settings.  
- Renamed `Others` to `Available` for clarity. 
- Users can select a `default` preset only from `available presets`. 
- Enabled users to change preset identification, even if set as default.  
- Improved field names for better usability.  
- Restricted deletion of master and in-use presets.  

Task: 4523232
Related PR: odoo/odoo#202640