### PR TITLE
[IMP] account - imported line shouldn't change tax

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -859,7 +859,7 @@ class AccountMoveLine(models.Model):
     @api.depends('product_id', 'product_uom_id')
     def _compute_tax_ids(self):
         for line in self:
-            if line.display_type in ('line_section', 'line_note', 'payment_term'):
+            if line.display_type in ('line_section', 'line_note', 'payment_term') or line.is_imported:
                 continue
             # /!\ Don't remove existing taxes if there is no explicit taxes set on the account.
             if line.product_id or (line.display_type != 'discount' and (line.account_id.tax_ids or not line.tax_ids)):


### PR DESCRIPTION
[IMP] account - imported line shouldn't change tax

Foward-port https://github.com/odoo/odoo/pull/193483 messed up and
removed important code of https://github.com/odoo/odoo/pull/172787.

This commit adds it back.

task-4547597

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
