### PR TITLE
[FIX] point_of_sale: fix view field attribute invisible

### DIFF
--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -66,7 +66,7 @@
                 <page string="Point of Sale" name="pos" invisible="not available_in_pos">
                     <group>
                         <group name="pos" string="Point of Sale">
-                            <field name="color" invisible="true"/>
+                            <field name="color" invisible="True"/>
                             <field name="to_weight"/>
                             <field name="pos_categ_ids"
                                    widget="many2many_tags"


### PR DESCRIPTION
Steps to reproduce :

-open settings/technical/views
-search "product.template.form.inherit"
-select the view with external id "point_of_sale.product_template_form_inherit"
-A Yellow Warning Message should appear indicating an Access Rights Inconsistency

Problem:
In the product_view.xml file of the point_of_sale module, in the view named product.template.form.inherit for the field "color", the invisible condition was invisible="true". This caused an accessed right inconsistency because the python code did not recognize true as a Boolean but looked for a field named "true" in the product.template model and didn't find any.

https://github.com/odoo/odoo/blob/abf0b5f102a0bad3ed0feb8b8e967f5e3c8d2288/addons/point_of_sale/views/product_view.xml#L69

opw-4520474
