### PR TITLE
[FIX] pos_restaurant:fix empty preparation receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1653,7 +1653,6 @@ export class PosStore extends Reactive {
 
     async printChanges(order, orderChange) {
         const unsuccedPrints = [];
-        const lastChangedLines = order.last_order_preparation_change.lines;
         orderChange.new.sort((a, b) => {
             const sequenceA = a.pos_categ_sequence;
             const sequenceB = b.pos_categ_sequence;
@@ -1669,8 +1668,9 @@ export class PosStore extends Reactive {
                 printer.config.product_categories_ids,
                 orderChange
             );
+            const anyChangesToPrint = Object.values(changes).some((change) => change.length);
             const diningModeUpdate = orderChange.modeUpdate;
-            if (diningModeUpdate || !Object.keys(lastChangedLines).length) {
+            if (diningModeUpdate || anyChangesToPrint) {
                 const printed = await this.printReceipts(
                     order,
                     printer,

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -393,3 +393,16 @@ registry.category("web_tour.tours").add("PreparationPrinterContent", {
             },
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("MultiPreparationPrinter", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Product 1"),
+            ProductScreen.clickOrderButton(),
+            Dialog.bodyIs("Failed in printing Detailed Receipt changes of the order"),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -399,3 +399,42 @@ class TestFrontend(TestFrontendCommon):
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PreparationPrinterContent', login="pos_user")
+
+    def test_multiple_preparation_printer(self):
+        """This test make sure that no empty receipt are sent when using multiple printer with different categories
+           The tour will check that we tried did not try to print two receipt. We can achieve that by checking the content
+           of the error message. Because we do not have real printer an error message will be displayed, this will contain
+           all the receipt that failed to print. If it contains more than 1 it means that we tried to print a second receipt
+           and it should not be the case here. The only one we should see is 'Detailed Receipt'
+        """
+        pos_category_1 = self.env['pos.category'].create({'name': 'Category 1'})
+        pos_category_2 = self.env['pos.category'].create({'name': 'Category 2'})
+        printer_1 = self.env['pos.printer'].create({
+            'name': 'Printer',
+            'printer_type': 'epson_epos',
+            'epson_printer_ip': '0.0.0.0',
+            'product_categories_ids': [Command.set(pos_category_2.ids)],
+        })
+        printer_2 = self.env['pos.printer'].create({
+            'name': 'Printer',
+            'printer_type': 'epson_epos',
+            'epson_printer_ip': '0.0.0.0',
+            'product_categories_ids': [Command.set(pos_category_1.ids)],
+        })
+
+
+        self.main_pos_config.write({
+            'is_order_printer' : True,
+            'printer_ids': [Command.set([printer_1.id, printer_2.id])],
+        })
+
+        self.product_1 = self.env['product.product'].create({
+            'name': 'Product 1',
+            'available_in_pos': True,
+            'list_price': 10,
+            'pos_categ_ids': [(6, 0, [pos_category_1.id])],
+            'taxes_id': False,
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'MultiPreparationPrinter', login="pos_user")


### PR DESCRIPTION
When creating multiple preparation printers for different pos categories you could have a case where an empty receipt is printed.

Steps to reproduce:
-------------------
* Create 2 PoS categories CAT 1 and CAT 2
* Create a first preparation printer for CAT 2
* Create a second preparation printer for CAT 1
* Create a product P1 for CAT 1
* Assign the two printers to a PoS
* Open PoS and add the P1 to your order
* Send the order in preparation
> Observation: Two receipts are printed and one of them is empty

Why the fix:
------------
When going over each printer to print the relevant changes, if the first printer in the list has no changes it would always print an empty receipt because `last_preparation_change` would always be empty. To fix this we rely on `changes` to check if there are any changes to print on this printer

opw-4462586