### PR TITLE
[FIX] base: try/exc attachment b64encode from binascii

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -11475,6 +11475,13 @@ msgid "Bypass HTML Field Sanitize"
 msgstr ""
 
 #. module: base
+#. odoo-python
+#: code:addons/base/models/ir_attachment.py:0
+#, python-format
+msgid "Byte-string in %s in is too large to encode."
+msgstr ""
+
+#. module: base
 #: model:res.partner.industry,full_name:base.res_partner_industry_C
 msgid "C - MANUFACTURING"
 msgstr ""

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -225,7 +225,10 @@ class IrAttachment(models.Model):
             return
 
         for attach in self:
-            attach.datas = base64.b64encode(attach.raw or b'')
+            try:
+                attach.datas = base64.b64encode(attach.raw or b'')
+            except MemoryError:
+                raise MemoryError(_('Byte-string in %s in is too large to encode.', attach.res_name))
 
     @api.depends('store_fname', 'db_datas')
     def _compute_raw(self):


### PR DESCRIPTION
**Current behavior:**
When exporting Binary field types, the underlying `b2a_base64()` implementation in binascii.py/c can return NULL when the input length exceeds https://github.com/python/cpython/blob/63f0406d5ad25a55e49c3903b29407c50a17cfd5/Modules/binascii.c#L102 I.e., when there is not enough memory available.

The resulting error propagated to the User is not clear.

**Expected behavior:**
A clear error/exception message.

**Steps to reproduce:**
1. Make 10,000 products with values for their `image_1920` field

2. Try to export ALL the products in 1 go (with `image_1920` as one of the export fields)

3. Traceback

**Cause of the issue:**
...

**Fix:**
Commit header

opw-4346901