### PR TITLE
[FIX] website_sale: remove GeoIP restriction on partner prop pricelist

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -181,7 +181,6 @@ class Website(models.Model):
                 lambda pl:
                     pl._is_available_on_website(self)
                     and check_pricelist(pl)
-                    and pl._is_available_in_country(country_code)
             )
             pricelists |= partner_pricelist
 

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -545,7 +545,11 @@ class TestWebsitePriceListAvailableGeoIP(TestWebsitePriceListAvailable):
         self.env.user.partner_id.property_product_pricelist = self.w1_pl_code_select
         with patch('odoo.addons.website_sale.models.website.Website._get_geoip_country_code', return_value=self.BE.code):
             pls = self.website.get_pricelist_available()
-        self.assertEqual(pls, self.website1_be_pl, "Only pricelists for BE and accessible on website should be returned, but not the partner pricelist as it is website compliant but not GeoIP compliant.")
+        self.assertEqual(
+            pls,
+            self.website1_be_pl + self.w1_pl_code_select,
+            "Website-compliant BE pricelists & non-BE partner pricelist should be available",
+        )
 
     def test_get_pricelist_available_geoip4(self):
         # Test get all available with geoip and visible pricelists + promo pl


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Enable/patch GeoIP functionality;
2. create a pricelist for a country group;
3. make it available on eCommerce;
4. have a portal user located in the country group;
5. assign the pricelist to the portal user;
6. log into eCommerce as portal user outside the country group.

Issue
-----
The pricelist assigned to the partner isn't being used.

Cause
-----
Even when assigned specifically to the user, if they logged in from elsewhere, pricelists restricted to certain country groups wouldn't get applied.

Solution
--------
Remove the restriction.

opw-4359711