### PR TITLE
[FIX] html_editor: properly check formatted nodes

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -5,9 +5,11 @@ import { cleanTextNode, splitTextNode, unwrapContents } from "../utils/dom";
 import {
     areSimilarElements,
     isContentEditable,
+    isEmptyTextNode,
     isSelfClosingElement,
     isTextNode,
     isVisibleTextNode,
+    isZwnbsp,
     isZWS,
 } from "../utils/dom_info";
 import { childNodes, closestElement, descendants, selectElements } from "../utils/dom_traversal";
@@ -180,7 +182,13 @@ export class FormatPlugin extends Plugin {
     isSelectionFormat(format, traversedNodes = this.dependencies.selection.getTraversedNodes()) {
         const selectedNodes = traversedNodes.filter(isTextNode);
         const isFormatted = formatsSpecs[format].isFormatted;
-        return selectedNodes.length && selectedNodes.every((n) => isFormatted(n, this.editable));
+        return (
+            selectedNodes.length &&
+            selectedNodes.every(
+                (node) =>
+                    isZwnbsp(node) || isEmptyTextNode(node) || isFormatted(node, this.editable)
+            )
+        );
     }
 
     // @todo: issues:

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -14,6 +14,10 @@ export function isEmpty(el) {
     return false;
 }
 
+export function isEmptyTextNode(node) {
+    return node.nodeType === Node.TEXT_NODE && node.nodeValue.length === 0;
+}
+
 /**
  * Return true if the given node appears bold. The node is considered to appear
  * bold if its font weight is bigger than 500 (eg.: Heading 1), or if its font

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -200,6 +200,17 @@ test("toolbar link buttons react to selection change", async () => {
     expect(".btn[name='unlink']").toHaveCount(1);
 });
 
+test("toolbar format buttons should react to format change", async () => {
+    await setupEditor(
+        `<div class="o-paragraph">[\ufeff<a href="http://test.com">\ufefftest.com\ufeff</a>\ufeff&nbsp;]</div>`
+    );
+    await waitFor(".o-we-toolbar");
+    expect(".btn[name='bold']").not.toHaveClass("active");
+    await contains(".btn[name='bold']").click();
+    await animationFrame();
+    expect(".btn[name='bold']").toHaveClass("active");
+});
+
 test("toolbar works: can select font", async () => {
     const { el } = await setupEditor("<p>test</p>");
     expect(getContent(el)).toBe("<p>test</p>");


### PR DESCRIPTION
**Problem**:
When applying formatting (e.g., Bold) to a selection that includes
a link, isZwnbsp characters inside the DOM cause
incorrect formatting state detection. isZwnbsp nodes are not formatted,
but they are still considered when checking the selection state.

**Solution**:
Modify `isSelectionFormat` to check only visible text nodes.
isZwnbsp characters should be ignored as they do not get formatted.
Also when split we remove `FEFF` chars from text node which in
case the node has only one `FEFF` will become an empty node
We should exludes those nodes from the check too.

**Steps to Reproduce**:
1. Type a link followed by a space.
2. Select all the text.
3. Apply "Bold."
4. The "Bold" button in the toolbar remains inactive incorrectly.

opw-4555595

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
