### PR TITLE
[FIX] pos_self_order: load products included in combos

### DIFF
--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -71,6 +71,15 @@ class ProductProduct(models.Model):
             order='sequence,default_code,name',
             load=False
         )
+        combo_products = self.browse((p['id'] for p in products if p["type"]=="combo"))
+        combo_products_choice = self.with_context(display_default_code=False).search_read(
+            [("id", 'in', combo_products.combo_ids.combo_item_ids.product_id.ids), ("id", "not in", [p['id'] for p in products])],
+            fields,
+            limit=config.get_limited_product_count(),
+            order='sequence,default_code,name',
+            load=False
+        )
+        products.extend(combo_products_choice)
         for product in products:
             product['image_128'] = bool(product['image_128'])
 

--- a/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
@@ -51,3 +51,20 @@ registry.category("web_tour.tours").add("self_combo_selector", {
         Utils.checkIsNoBtn("Order Now"),
     ],
 });
+
+registry.category("web_tour.tours").add("self_combo_selector_category", {
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Test Combo"),
+        ...ProductPage.setupCombo([
+            {
+                product: "Combo Product 5",
+                attributes: [],
+            },
+        ]),
+        Utils.clickBtn("Order"),
+        Utils.clickBtn("Pay"),
+        Utils.clickBtn("Ok"),
+        Utils.checkIsNoBtn("Order Now"),
+    ],
+});

--- a/addons/pos_self_order/tests/test_self_order_combo.py
+++ b/addons/pos_self_order/tests/test_self_order_combo.py
@@ -3,6 +3,7 @@
 import odoo.tests
 from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
 from odoo.addons.point_of_sale.tests.common_setup_methods import setup_product_combo_items
+from odoo.fields import Command
 
 
 @odoo.tests.tagged("post_install", "-at_install")
@@ -37,3 +38,30 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
         self.assertEqual(parent_line_id.combo_line_ids, combo_line_ids, "The combo parent should have 3 combo lines")
         self.assertEqual(parent_line_id.qty, 2, "There should be 2 combo products")
         self.assertEqual(parent_line_id.qty, combo_line_ids[0].qty, "The quantities should match with the parent")
+
+    def test_self_order_combo_categories(self):
+        setup_product_combo_items(self)
+        category = self.env['pos.category'].create({'name': 'Test Category'})
+        self.env["product.product"].create(
+            {
+                "available_in_pos": True,
+                "list_price": 10,
+                "name": "Test Combo",
+                "type": "combo",
+                'pos_categ_ids': category.ids,
+                "combo_ids": self.desks_combo,
+            }
+        )
+
+        self.pos_config.write({
+            'self_ordering_default_user_id': self.pos_admin.id,
+            'self_ordering_takeaway': False,
+            'self_ordering_mode': 'mobile',
+            'limit_categories': True,
+            'iface_available_categ_ids': category.ids,
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+
+        self.start_tour(self_route, "self_combo_selector_category")


### PR DESCRIPTION
Currently, if the products included in a combo don't have a pos category included in the pos config, they will not load. Selecting the combo product could result in crashing the page or just no selection showing.

Steps to reproduce:
-------------------
* Change restaurant to **QR menu + Ordering**
* Go to products, select the Burger combo
* Delete Drinks choice
* For the burger choice, delete one of the product and modify the other by removing the pos category.
* Open mobile menu
* Select the burger combo
> Observation: Page crashes

Why the fix:
------------

https://github.com/odoo/odoo/blob/2ab0b63b7042293f8229b29bcea478d37d4c3df5/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js#L141-L148

The page would crash because `c.product_id` is undefined so you cannot access `attribute_line_ids`. `product_id` is undefined because the products were not loaded.

Currently only the products that have a pos category defined in `iface_available_categ_ids` are loaded. We now load all the products included in the loaded combo. Similarly as done in the shop: https://github.com/odoo/odoo/blob/2ab0b63b7042293f8229b29bcea478d37d4c3df5/addons/point_of_sale/models/pos_config.py#L797-L798

opw-4516061