### PR TITLE
[FIX] web: fix formatted_read_group fill_temporal

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -556,16 +556,19 @@ class Base(models.AbstractModel):
         else:
             existing = sorted(set().union(existing, required_dates))
 
-        groups_mapped = {values[0]: values for values in groups}
+        groups_mapped = defaultdict(list)
+        for group in groups:
+            groups_mapped[group[0]].append(group)
+
         result = []
         for dt in existing:
             if dt in groups_mapped:
-                result.append(groups_mapped[dt])
+                result.extend(groups_mapped[dt])
             else:
                 result.append((dt, *empty_item))
 
         if False in groups_mapped:
-            result.append(groups_mapped[False])
+            result.extend(groups_mapped[False])
 
         return result
 


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/163300, the fill_temporal feature doesn't work properly when we group by multiple fields.
The `_web_read_group_fill_temporal` implementation discards some groups for no reason because it doesn't consider other levels of grouping to recreate the result.

It happens because the line `groups_mapped = {values[0]: values for values in groups}` only takes in account the last group for each date found. The value of the dict should be able to contains several groups.

Fix it