### PR TITLE
[FIX] account: handle multiple sequence reset periods in cut-off entries

### DIFF
--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -292,12 +292,15 @@ class AutomaticEntryWizard(models.TransientModel):
             }),
         ]
 
+    def _get_lock_safe_date(self, date):
+        # Use a reference move in the correct journal because _get_accounting_date depends on the journal sequence.
+        reference_move = self.env['account.move'].new({'journal_id': self.journal_id.id, 'move_type': 'entry', 'invoice_date': date})
+        return reference_move._get_accounting_date(date, False)
+
     def _get_move_dict_vals_change_period(self):
-        reference_move = self.env['account.move'].new({'journal_id': self.journal_id.id, 'move_type': 'entry'})
 
         def get_lock_safe_date(aml):
-            # Use a reference move in the correct journal because _get_accounting_date depends on the journal sequence.
-            return reference_move._get_accounting_date(aml.date, False)
+            return self._get_lock_safe_date(aml.date)
 
         # set the change_period account on the selected journal items
 
@@ -388,7 +391,7 @@ class AutomaticEntryWizard(models.TransientModel):
         accrual_move_offsets = defaultdict(int)
         for move in self.move_line_ids.move_id:
             amount = sum((self.move_line_ids._origin & move.line_ids).mapped('balance'))
-            accrual_move = created_moves[1:].filtered(lambda m: m.date == m._get_accounting_date(move.date, False))
+            accrual_move = created_moves[1:].filtered(lambda m: m.date == self._get_lock_safe_date(move.date))
 
             if accrual_account.reconcile and accrual_move.state == 'posted' and destination_move.state == 'posted':
                 destination_move_lines = destination_move.mapped('line_ids').filtered(lambda line: line.account_id == accrual_account)[destination_move_offset:destination_move_offset+2]


### PR DESCRIPTION
Current behavior before commit:

creating cut-off journal entries for a vendor bill in a previous year using a new
sequence reset period in current year will raise an error due to the accrual move
date mismatch with the destination move fetched from the move in _get_accounting_date

Reason:
due to the accrual move
date mismatch with the destination move fetched from the move in _get_accounting_date

Fix:
Added a function to compute a reference move for each get_lock_safe_date call
and compare approrpiate dates for accrual moves.

Steps to reproduce on runbot:

1. ensure the sequence for the Miscellaneous
Operations journal
(l10n_fr for example) resets yearly for the
previous year (ex 2024)

2. create a new journal entry in the
Miscellaneous Operations journal in current year and rename it
to "Name 3000"

3. Create a vendor bill and set the date field to be 12/12/2024 for example
and post it

4. Create cut-off journal entries with a recognition date set as today and the same journal
"Miscellaneous Operations" and observe the traceback.

opw-4507925