### PR TITLE
[FIX] account: improve audit trail deletion error message

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -17319,7 +17319,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account/models/mail_message.py:0
 msgid ""
-"You cannot remove parts of the audit trail. Archive the record instead."
+"You cannot remove parts of the audit trail. If possible, archive it instead."
 msgstr ""
 
 #. module: account

--- a/addons/account/models/mail_message.py
+++ b/addons/account/models/mail_message.py
@@ -166,7 +166,7 @@ class Message(models.Model):
                 message.account_audit_log_move_id
                 and not message.account_audit_log_move_id.posted_before
             ):
-                raise UserError(self.env._("You cannot remove parts of the audit trail. Archive the record instead."))
+                raise UserError(self.env._("You cannot remove parts of the audit trail. If possible, archive it instead."))
 
     def write(self, vals):
         # We allow any whitespace modifications in the subject


### PR DESCRIPTION
**issue:**
When "Audit Trail" is activated and a user creates an incorrect payment, deleting the payment is not possible. 
The error message suggests archiving the payment; however, there is no option to archive it.

A more flexible error message should be used instead.

opw-4494820
