### PR TITLE
[FIX] sale_pdf_quote_builder: provide company_id to quotation documents

### DIFF
--- a/addons/sale_pdf_quote_builder/controllers/quotation_document.py
+++ b/addons/sale_pdf_quote_builder/controllers/quotation_document.py
@@ -21,9 +21,13 @@ class QuotationDocumentController(Controller):
         auth='user',
     )
     def upload_document(self, ufile, sale_order_template_id=False):
-        sale_order_template_id = request.env['sale.order.template'].browse(
+        # TODO: add `allowed_company_ids` as method param in master
+        if allowed_company_ids := request.params.get('allowed_company_ids'):
+            request.update_context(allowed_company_ids=json.loads(allowed_company_ids))
+        sale_order_template = request.env['sale.order.template'].browse(
             int(sale_order_template_id)
         )
+        company = sale_order_template.company_id if sale_order_template else request.env.company
         files = request.httprequest.files.getlist('ufile')
         result = {'success': _("All files uploaded")}
         for ufile in files:
@@ -33,7 +37,8 @@ class QuotationDocumentController(Controller):
                     'name': ufile.filename,
                     'mimetype': mimetype,
                     'raw': ufile.read(),
-                    'quotation_template_ids': sale_order_template_id,
+                    'quotation_template_ids': sale_order_template.ids,
+                    'company_id': company.id,
                 })
                 # pypdf will also catch malformed document
                 utils._ensure_document_not_encrypted(base64.b64decode(doc.datas))

--- a/addons/sale_pdf_quote_builder/static/src/js/quotation_document_kanban/quotation_document_kanban_controller.js
+++ b/addons/sale_pdf_quote_builder/static/src/js/quotation_document_kanban/quotation_document_kanban_controller.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { onWillRender } from "@odoo/owl";
 import { UploadButton } from '@product/js/product_document_kanban/upload_button/upload_button';
 import { KanbanController } from '@web/views/kanban/kanban_controller';
 
@@ -10,5 +11,10 @@ export class QuotationDocumentKanbanController extends KanbanController {
         super.setup();
         this.uploadRoute = '/sale_pdf_quote_builder/quotation_document/upload';
         this.allowedMIMETypes='application/pdf';
+        onWillRender(() => {
+            this.formData = {
+                'allowed_company_ids': JSON.stringify(this.props.context.allowed_company_ids),
+            };
+        });
     }
 }

--- a/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
+++ b/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
@@ -1,23 +1,32 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import json
 from base64 import b64encode
 from functools import partial
+from unittest.mock import patch
+
+from werkzeug.datastructures import FileStorage
 
 from odoo import Command
 from odoo.tests import tagged
 from odoo.tools.misc import file_open
 
 from odoo.addons.base.tests.common import BaseUsersCommon
-from odoo.addons.sale.tests.common import SaleCommon
+from odoo.addons.sale_management.tests.common import SaleManagementCommon
+from odoo.addons.sale_pdf_quote_builder.controllers.quotation_document import (
+    QuotationDocumentController
+)
 from .files import forms_pdf, plain_pdf
 
 
 @tagged('-at_install', 'post_install')
-class TestPDFQuoteBuilder(BaseUsersCommon, SaleCommon):
+class TestPDFQuoteBuilder(BaseUsersCommon, SaleManagementCommon):
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        cls.QuotationDocumentController = QuotationDocumentController()
 
         cls.sale_order.validity_date = '2020-11-04'
         cls.sale_order.partner_id.tz = 'Europe/Brussels'
@@ -56,6 +65,8 @@ class TestPDFQuoteBuilder(BaseUsersCommon, SaleCommon):
             'res_model': 'product.product',
             'res_id': cls.product.id,
         })
+
+        cls.alt_company = cls.env['res.company'].create({'name': "Backup Company"})
 
     def test_compute_customizable_pdf_form_fields_when_no_file(self):
         self.env['quotation.document'].search([]).action_archive()
@@ -153,6 +164,67 @@ class TestPDFQuoteBuilder(BaseUsersCommon, SaleCommon):
         # should return all document data regardless of access
         self.assertEqual('Header', dialog_param['headers']['files'][0]['name'])
         self.assertEqual('Product > Test Product', dialog_param['lines'][0]['name'])
+
+    def test_quotation_document_upload_no_template(self):
+        """Check that uploading quotation documents get assigned the active company."""
+        if 'website' not in self.env:
+            self.skipTest("Module `website` not found")
+        else:
+            from odoo.addons.website.tools import MockRequest  # noqa: PLC0415
+
+        allowed_company_ids = [self.alt_company.id, self.env.company.id]
+
+        # Upload document without Sale Order Template
+        with (
+            MockRequest(self.env) as request,
+            file_open(plain_pdf, 'rb') as file,
+            patch.object(request.httprequest.files, 'getlist', lambda _key: [FileStorage(file)]),
+        ):
+            request.params['allowed_company_ids'] = json.dumps(allowed_company_ids)
+            res = self.QuotationDocumentController.upload_document(ufile=FileStorage(file))
+            self.assertEqual(res.status_code, 200, "Upload should be successful")
+
+        quotation_document = self.env['quotation.document'].search([
+            ('name', '=', plain_pdf),
+        ], limit=1)
+        self.assertTrue(quotation_document, "A new quotation document should be created")
+        self.assertEqual(
+            quotation_document.company_id,
+            self.alt_company,
+            "Quotation document company should be the currently active company",
+        )
+
+    def test_quotation_document_upload_for_template(self):
+        """Check that uploading quotation documents get assigned the the quotation company."""
+        if 'website' not in self.env:
+            self.skipTest("Module `website` not found")
+        else:
+            from odoo.addons.website.tools import MockRequest  # noqa: PLC0415
+
+        allowed_company_ids = [self.alt_company.id, self.env.company.id]
+
+        # Upload a document for a Sale Order Template without company id
+        self.empty_order_template.company_id = False
+        with (
+            MockRequest(self.env) as request,
+            file_open(forms_pdf, 'rb') as file,
+            patch.object(request.httprequest.files, 'getlist', lambda _key: [FileStorage(file)]),
+        ):
+            request.params['allowed_company_ids'] = json.dumps(allowed_company_ids)
+            res = self.QuotationDocumentController.upload_document(
+                ufile=FileStorage(file),
+                sale_order_template_id=str(self.empty_order_template.id),
+            )
+            self.assertEqual(res.status_code, 200, "Upload should be successful")
+
+        quotation_document = self.env['quotation.document'].search([
+            ('name', '=', forms_pdf),
+        ], limit=1)
+        self.assertTrue(quotation_document, "A new quotation document should be created")
+        self.assertFalse(
+            quotation_document.company_id,
+            "Quotation document shouldn't have a company id",
+        )
 
     def _test_custom_content_kanban_like(self):
         # TODO VCR finish tour and uncomment


### PR DESCRIPTION
Versions:
---------
18.0+

Issue:
------
When uploading a document using the `Upload` button, the document is always assigned to the user's main company, regardless of the selected company.

Steps to Reproduce:
-------------------
1. Create a secondary company that the current user can access.
2. Navigate to Sales / Configuration / Sales Orders / Headers/Footers.
3. Switch the user's current company to the secondary company.
4. Click the `Upload` button and select any document.
    - Notice that no document is added to the secondary company's scope.
5. Switch back to the primary company.
    - The uploaded document is available under the primary company instead of the secondary one.

Cause:
------
During the upload process, no company-specific information is provided to associate the document with the selected company.

Due to the inheritance of the `ir.attachment` model, it uses `self.env.company` as the default company value for the document[^1]. Because the upload happens via the `HttpDispatcher`, no `allowed_company_ids` context value is provided to the request. Without this context value present, `request.env.company` defaults to the main company of the current user[^2].

Fix:
----
Use the `company_id` associated with the relevant `sale.order.template` (`False` when uploading documents not linked to a template).

opw-4472602

[^1]: https://github.com/odoo/odoo/blob/d99e44f22634ac589a940d85fab84ca2b2e85332/odoo/addons/base/models/ir_attachment.py#L408-L409
[^2]: https://github.com/odoo/odoo/blob/d99e44f22634ac589a940d85fab84ca2b2e85332/odoo/api.py#L680-L681