### PR TITLE
[FIX] event_crm: allow syncing of multi-event leads

### DIFF
--- a/addons/event_crm/models/event_registration.py
+++ b/addons/event_crm/models/event_registration.py
@@ -148,7 +148,7 @@ class EventRegistration(models.Model):
                 if not lead.partner_id:
                     lead_values['description'] = lead.registration_ids._get_lead_description(_("Participants"), line_counter=True)
                 elif new_vals['partner_id'] != lead.partner_id.id:
-                    lead_values['description'] = lead.description + "<br/>" + lead.registration_ids._get_lead_description(_("Updated registrations"), line_counter=True, line_suffix=_("(updated)"))
+                    lead_values['description'] = (lead.description or '') + "<br/>" + lead.registration_ids._get_lead_description(_("Updated registrations"), line_counter=True, line_suffix=_("(updated)"))
             if lead_values:
                 lead.write(lead_values)
 
@@ -236,8 +236,9 @@ class EventRegistration(models.Model):
                 'phone': self._find_first_notnull('phone'),
                 'lang_id': False,
             }
+        contact_name = valid_partner.name or self._find_first_notnull('name') or self._find_first_notnull('email')
         contact_vals.update({
-            'name': "%s - %s" % (self.event_id.name, valid_partner.name or self._find_first_notnull('name') or self._find_first_notnull('email')),
+            'name': f'{self.event_id[:1].name} - {contact_name}',
             'partner_id': valid_partner.id,
             'mobile': valid_partner.mobile or self._find_first_notnull('mobile'),
         })

--- a/addons/event_crm/tests/test_crm_lead_merge.py
+++ b/addons/event_crm/tests/test_crm_lead_merge.py
@@ -10,6 +10,52 @@ from odoo.tests.common import tagged, users
 class TestLeadCrmMerge(TestLeadMergeCommon, TestEventCrmCommon):
 
     @users('user_sales_manager')
+    def test_merge_different_events_and_update(self):
+        """Check that merging leads related to different events works and keeps the sync working.
+
+        If leads are merged after being linked to registrations on different events, sync should
+        still be able to pick values to set on the lead.
+        """
+        other_event = self.env['event.event'].sudo().create({
+            'name': 'TestOtherEvent',
+            'date_tz': 'Europe/Brussels',
+        })
+        self.test_rule_order_done.event_registration_filter = repr(
+            [('name', 'like', 'test-send-email-on-leads-with-multiple-events-_')]
+        )
+
+        # create registrations and check rule generated leads
+        registrations = self.env['event.registration'].sudo().create([{
+            'email': self.event_customer.email,
+            'event_id': self.event_0.id,
+            'name': 'test-send-email-on-leads-with-multiple-events-1',
+            'partner_id': False,
+            'state': 'done',
+        }, {
+            'email': self.event_customer.email,
+            'event_id': other_event.id,
+            'name': 'test-send-email-on-leads-with-multiple-events-2',
+            'partner_id': False,
+            'state': 'done',
+        }])
+        self.assertTrue(registrations[0].lead_ids, "Order rule should have created leads for both registrations")
+        self.assertTrue(registrations[1].lead_ids, "Order rule should have created leads for both registrations")
+        self.assertFalse(
+            registrations[0].lead_ids & registrations[1].lead_ids,
+            "Different events should create different leads"
+        )
+        self.assertFalse(
+            registrations.lead_ids.partner_id,
+            "Leads are expected to have no partner, like the original registration"
+        )
+        # merge into one lead with multiple registrations
+        final_lead = registrations.lead_ids._merge_opportunity(auto_unlink=False, max_length=None)
+        self.assertEqual(final_lead.registration_ids, registrations)
+        # update customer to trigger sync
+        registrations[0].partner_id = self.event_customer
+        self.assertEqual(registrations.lead_ids.partner_id, registrations[0].partner_id)
+
+    @users('user_sales_manager')
     def test_merge_method_dependencies(self):
         """ Test if dependences for leads are not lost while merging leads. In
         this test leads are ordered as


### PR DESCRIPTION
It is possible to have a lead linked to registration from different events by using the merge method on the leads.

Currently once they are merged it becomes impossible to update any field that is synced as syncing expects we will only encounter one event.

We just default to the first event for the name.

Additionally the test revealed that if the lead doesn't have a description and a partner is added, the update mechanism crashes.

task-4531433