### PR TITLE
[FIX] pos_restaurant: show correct time in receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1717,16 +1717,12 @@ export class PosStore extends Reactive {
     }
 
     async getRenderedReceipt(order, title, lines, fullReceipt = false, diningModeUpdate) {
-        let time;
-        if (order.write_date) {
-            time = order.write_date?.split(" ")[1].split(":");
-            time = time[0] + "h" + time[1];
-        }
+        const time = DateTime.now().toFormat("HH:mm");
 
         const printingChanges = {
             table_name: order.table_id ? order.table_id.table_number : "",
             config_name: order.config.name,
-            time: order.write_date ? time : "",
+            time: time,
             tracking_number: order.tracking_number,
             takeaway: order.config.takeaway && order.takeaway,
             employee_name: order.employee_id?.name || order.user_id?.name,

--- a/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
@@ -1,5 +1,6 @@
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import { negate } from "@point_of_sale/../tests/tours/utils/common";
+const { DateTime } = luxon;
 
 export function confirmPopup() {
     return [Dialog.confirm()];
@@ -82,6 +83,19 @@ export function waitRequest() {
         {
             content: "Wait for request to finish",
             trigger: "body:not(:has(.fa-circle-o-notch))",
+        },
+    ];
+}
+
+export function freezeDateTime(millis) {
+    return [
+        {
+            trigger: "body",
+            run: () => {
+                DateTime.now = () => {
+                    return DateTime.fromMillis(millis);
+                };
+            },
         },
     ];
 }

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -383,6 +383,7 @@ registry.category("web_tour.tours").add("PreparationPrinterContent", {
             Dialog.confirm("Open Register"),
             FloorScreen.clickTable("5"),
             ProductScreen.clickDisplayedProduct("Product Test"),
+            Chrome.freezeDateTime(1739370000000),
             Dialog.confirm("Add"),
             ProductScreen.totalAmountIs("10"),
             {
@@ -398,6 +399,9 @@ registry.category("web_tour.tours").add("PreparationPrinterContent", {
                         throw new Error("Product Test (Value 1) not found in printed receipt");
                     }
                 },
+            },
+            {
+                trigger: ".pos-receipt .receipt-header:contains('14:20')",
             },
         ].flat(),
 });


### PR DESCRIPTION
When printing a preparation receipt the correct time was not shown (It was always UTC time). Also when the order was not sent to the server the time was not shown at all.

Steps to reproduce:
-------------------
* Setup a kitchen printer for a PoS
* Open PoS go on a table and add some products
* Click on the Order button
> Observation: The time is not shown in the receipt
* Leave the table and come back to it to make sure order is sent to the server
* Add another product and send the order to the kitchen
> Observation: The time is in UTC

Why the fix:
------------
Instead of relying on the write date of the order we now rely on the current time of the client to show the time in the receipt. This time will always correspond to the time the order was sent to the kitchen.

opw-4454102