### PR TITLE
[FIX] point_of_sale: add to context without override

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -934,7 +934,7 @@ class PosSession(models.Model):
             # revert the accounts because account.payment doesn't accept negative amount.
             outstanding_account, destination_account = destination_account, outstanding_account
 
-        account_payment = self.env['account.payment'].with_context({"pos_payment": True}).create({
+        account_payment = self.env['account.payment'].with_context(pos_payment=True).create({
             'amount': abs(amounts['amount']),
             'journal_id': payment_method.journal_id.id,
             'force_outstanding_account_id': outstanding_account.id,


### PR DESCRIPTION
Fixup for this commit https://github.com/odoo/odoo/commit/c9cefd88bb6f38f8fd504b7c4a8abf263aa1aa4b

A test in 17.4 highlighted a issue with the use of with_context which was overriding it completely instead of adding to it.

opw-4310781