### PR TITLE
[FIX] point_of_sale: fix traceback on userlabel

### DIFF
--- a/addons/point_of_sale/views/report_userlabel.xml
+++ b/addons/point_of_sale/views/report_userlabel.xml
@@ -14,7 +14,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                <td><div t-if="user.barcode" t-field="user.barcode" t-options="{'widget': 'barcode', 'symbology': 'EAN13', 'width': 300, 'height': 50, 'img_style': 'width:100%;height:35%;'}"/></td>
+                                <td><div t-if="user.sudo().barcode" t-field="user.sudo().barcode" t-options="{'widget': 'barcode', 'symbology': 'EAN13', 'width': 300, 'height': 50, 'img_style': 'width:100%;height:35%;'}"/></td>
                                 <td><strong t-field="user.name"/></td>
                             </tr>
                         </tbody>


### PR DESCRIPTION
Steps to Reproduce:
- Log in with a user having no special access right in Employees.
- Install point_of_sale and hr modules.
- Try to download the "User Labels" from the "My Profile" section.

Cause:
- In the report barcode field has been used which is accessible only to users having "group_hr_user" group.

Fix:
- Added a check before accessing the barcode field, to ensure the user has the appropriate access right.

task-4497441

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
