### PR TITLE
[IMP] hr_leave: Skip date constraint check for 'Other' leave type

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -195,6 +195,7 @@ class HolidaysRequest(models.Model):
         inverse='_inverse_supported_attachment_ids')
     supported_attachment_ids_count = fields.Integer(compute='_compute_supported_attachment_ids')
     # UX fields
+    leave_type_time_type = fields.Selection(related="holiday_status_id.time_type", readonly=True)
     leave_type_request_unit = fields.Selection(related='holiday_status_id.request_unit', readonly=True)
     leave_type_support_document = fields.Boolean(related="holiday_status_id.support_document")
     # Interface fields used when not using hour-based computation
@@ -553,6 +554,8 @@ class HolidaysRequest(models.Model):
             ('state', 'not in', ['cancel', 'refuse']),
         ])
         for holiday in self:
+            if holiday.leave_type_time_type == "other":
+                continue
             domain = [
                 ('employee_id', '=', holiday.employee_id.id),
                 ('date_from', '<', holiday.date_to),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This commit modifies the `_check_date` method in the `HrLeave` model to skip the date constraint check when the leave type is set to 'Other'.

- Updated `_check_date` method to bypass the standard date validation if `leave_type_time_type` is 'other'.

- This allows for more flexible date configurations for specific leave types.

Current behavior before PR:

The _check_date method always enforces date constraints, regardless of the leave type. This prevents the use of "leave" types that do not require strict date validation as they are worked time.

Desired behavior after PR is merged:

The _check_date method will skip date validation when the leave_type_time_type is set to 'other', allowing for more flexible leave configurations.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
