### PR TITLE
[FIX] point_of_sale: ensure `pos-receipt-order-data` xpath always exists

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -87,6 +87,9 @@
 
             <div class="before-footer" />
 
+            <!-- This prevents missing receipt elements in modules like `l10n_fr_pos_cert`, `l10n_co_pos`, etc. -->
+            <div class="pos-receipt-order-data" />
+
             <div t-if="props.data.pos_qr_code">
                 <br /><br />
                 <div class="pos-receipt-order-data mb-2">


### PR DESCRIPTION
Before this commit:
===
- The `pos-receipt-order-data` class was used as an XPath reference in multiple
modules (l10n_fr_pos_cert, l10n_co_pos, pos_mercury, and pos_restaurant).
- In point_of_sale, first of this class was used to add a QR code (pos_qr_code)
to the receipt, but it was wrapped in a t-if="pos_qr_code" condition.
- Due to this, the XPath content from other modules was only visible when
pos_qr_code was present.

After this commit:
===
- Added an empty `<div class="pos-receipt-order-data" />` outside the conditional
block.
- This ensures that the XPath reference is always available.


task-4552477