### PR TITLE
[FIX] base: embedded action default domain

### DIFF
--- a/odoo/addons/base/models/ir_embedded_actions.py
+++ b/odoo/addons/base/models/ir_embedded_actions.py
@@ -77,7 +77,7 @@ class IrEmbeddedActions(models.Model):
             for record in records:
                 action_groups = record.groups_ids
                 if not action_groups or (action_groups & self.env.user.groups_id):
-                    domain_model = literal_eval(record.domain)
+                    domain_model = literal_eval(record.domain or '[]')
                     record.is_visible = (
                         record.parent_res_id in (False, self.env.context.get('active_id', False))
                         and record.user_id.id in (False, self.env.uid)


### PR DESCRIPTION
Steps:
- Set domain of an embedded action to false
    - this override the default value
- Try to use the embedded action

Actual result:
- Error due to invalid domain

Expected result:
- Embedded action work and use empty domain as default

opw-4529210
opw-4563505