### PR TITLE
[FIX] im_livechat,*: composer inactive when chatbot expects inputs

### DIFF
--- a/addons/im_livechat/static/src/core/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/core/common/chat_window_patch.xml
@@ -9,7 +9,7 @@
         </xpath>
         <xpath expr="//Composer" position="replace">
             <t t-if="thread?.composerDisabled and !thread?.isTransient and store.self.notEq(thread?.livechatVisitorMember?.persona)">$0</t>
-            <div t-if="thread?.composerDisabled" class="bg-200 py-1 text-center d-flex fst-italic fw-bold text-muted" t-ref="composerDisabledContainer">
+            <div t-if="thread?.composerHidden" class="bg-200 py-1 text-center d-flex fst-italic fw-bold text-muted" t-ref="composerDisabledContainer">
                 <span t-if="!showGiveFeedbackBtn" class="flex-grow-1"/>
                 <span t-esc="thread.composerDisabledText"/>
                 <span class="flex-grow-1"/>

--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -59,6 +59,10 @@ patch(Thread.prototype, {
         return this.channel_type === "livechat" || super.isChatChannel;
     },
 
+    get composerHidden() {
+        return this.channel_type === "livechat" && this.livechat_active === false;
+    },
+
     get composerDisabled() {
         return this.channel_type === "livechat" && this.livechat_active === false;
     },

--- a/addons/im_livechat/static/src/embed/common/composer_patch.js
+++ b/addons/im_livechat/static/src/embed/common/composer_patch.js
@@ -1,10 +1,25 @@
 import { Composer } from "@mail/core/common/composer";
 
+import { useEffect } from "@odoo/owl";
+
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 import { session } from "@web/session";
 
 patch(Composer.prototype, {
+    setup() {
+        super.setup();
+        useEffect(
+            () => {
+                if (this.thread?.composerDisabled) {
+                    this.ref.el.blur();
+                } else {
+                    this.ref.el.focus();
+                }
+            },
+            () => [this.thread?.composerDisabled]
+        );
+    },
     get placeholder() {
         if (this.thread?.channel_type !== "livechat") {
             return super.placeholder;

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -145,6 +145,13 @@ patch(Thread.prototype, {
         return super.showUnreadBanner;
     },
 
+    get composerHidden() {
+        if (this.chatbot?.forwarded && this.livechat_active) {
+            return false;
+        }
+        return super.composerHidden || this.chatbot?.completed;
+    },
+
     get composerDisabled() {
         const step = this.chatbot?.currentStep;
         if (this.chatbot?.forwarded && this.livechat_active) {
@@ -166,12 +173,6 @@ patch(Thread.prototype, {
         }
         if (this.chatbot.completed) {
             return _t("This livechat conversation has ended");
-        }
-        if (
-            this.chatbot.currentStep?.type === "question_selection" &&
-            !this.chatbot.currentStep.selectedAnswer
-        ) {
-            return _t("Select an option above");
         }
         return _t("Say something");
     },

--- a/addons/website/static/tests/tours/website_form_editor_frontend.js
+++ b/addons/website/static/tests/tours/website_form_editor_frontend.js
@@ -218,7 +218,7 @@ registry.category("web_tour.tours").add('website_form_contactus_submit', {
     // the email
     {
         isActive: ["body:has(.o-livechat-root)"],
-        trigger: ":shadow span:contains(select an option above)",
+        trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
     },
     {
         content: "Fill in the subject",

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -76,11 +76,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 trigger: messagesContain("Can you give us your email please?"),
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input ",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "edit No, you won't get my email!",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "press Enter",
             },
             {
@@ -90,11 +90,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 ),
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "edit okfine@fakeemail.com",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "press Enter",
             },
             {
@@ -106,11 +106,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 trigger: messagesContain("Would you mind providing your website address?"),
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "edit https://www.fakeaddress.com",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "press Enter",
             },
             {
@@ -120,11 +120,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 // should ask for feedback now
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "edit Yes, actually, I'm glad you asked!",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "press Enter",
             },
             {
@@ -132,24 +132,24 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 run: "edit I think it's outrageous that you ask for all my personal information!",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "press Enter",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "edit I will be sure to take this to your manager!",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "press Enter",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "edit I want to say...",
             },
             {
                 // Simulate that the user is typing, so the chatbot shouldn't go to the next step
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run() {
                     const counter = window.debounceAnswerCount;
                     const target = new TourHelpers(this.anchor);
@@ -221,11 +221,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 trigger: messagesContain("Would you mind providing your website address?"),
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "edit no",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "press Enter",
             },
             {
@@ -235,11 +235,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 ),
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "edit no, nothing so say",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "press Enter",
             },
             {

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_fw_operator_matching_lang.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_fw_operator_matching_lang.js
@@ -12,7 +12,7 @@ registry.category("web_tour.tours").add("chatbot_fw_operator_matching_lang", {
             run: "click",
         },
         {
-            trigger: ".o-livechat-root:shadow .o-mail-Composer-input:enabled",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
         },
     ],
 });


### PR DESCRIPTION
*=website, website_livechat

Before this commit:
When the chatbot required processing, the composer became inactive. Upon re-enabling for user input, the composer lost focus, forcing users to click on it each time to provide input.

This commit ensures that the composer retains focus, allowing users to immediately start typing without needing to click.

task-4509416
