### PR TITLE
[FIX] hr_attendance: kiosk mode lang

### DIFF
--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import datetime
+
 from odoo.service.common import exp_version
 from odoo import http, _
 from odoo.http import request
@@ -7,7 +9,6 @@ from odoo.osv import expression
 from odoo.tools import float_round, py_to_js_locale, SQL
 from odoo.tools.image import image_data_uri
 
-import datetime
 
 class HrAttendance(http.Controller):
     @staticmethod
@@ -111,7 +112,7 @@ class HrAttendance(http.Controller):
                         'kiosk_mode': kiosk_mode,
                         'from_trial_mode': from_trial_mode,
                         'barcode_source': company.attendance_barcode_source,
-                        'lang': py_to_js_locale(company.partner_id.lang),
+                        'lang': py_to_js_locale(company.partner_id.lang or self.env.lang),
                         'server_version_info': version_info.get('server_version_info'),
                     },
                 }


### PR DESCRIPTION
Issue: When you try to acssess the kiosk mode for a company which has no lang set on its partner, a blocking error is raised

solve: add the env.lang as a default lang if the partner lang return false

Task: 4465594


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
