### PR TITLE
[IMP] orm: check decorators in overrides

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -357,6 +357,7 @@ class AccountBankStatementLine(models.Model):
                 defaults.setdefault('date', last_line.date)
         return defaults
 
+    @api.model
     def new(self, values=None, origin=None, ref=None):
         return super(AccountBankStatementLine, self.with_context(is_statement_line=True)).new(values, origin, ref)
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3082,6 +3082,7 @@ class AccountMove(models.Model):
     # LOW-LEVEL METHODS
     # -------------------------------------------------------------------------
 
+    @api.model
     def check_field_access_rights(self, operation, field_names):
         result = super().check_field_access_rights(operation, field_names)
         if not field_names:

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1308,6 +1308,8 @@ class AccountMoveLine(models.Model):
     # -------------------------------------------------------------------------
     # CRUD/ORM
     # -------------------------------------------------------------------------
+
+    @api.model
     def check_field_access_rights(self, operation, field_names):
         result = super().check_field_access_rights(operation, field_names)
         if not field_names:

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -327,6 +327,7 @@ class HrEmployee(models.Model):
         for employee_private, employee_public in zip(self, self.env['hr.employee.public'].browse(self.ids)):
             employee_private.display_name = employee_public.display_name
 
+    @api.model
     def search_fetch(self, domain, field_names, offset=0, limit=None, order=None):
         if self.browse().has_access('read'):
             return super().search_fetch(domain, field_names, offset, limit, order)

--- a/addons/test_base_automation/models/test_base_automation.py
+++ b/addons/test_base_automation/models/test_base_automation.py
@@ -152,6 +152,7 @@ class BaseAutomationModelWithRecnameM2o(models.Model):
     _rec_name = "user_id"
     user_id = fields.Many2one("base.automation.model.with.recname.char", string='Responsible')
 
+    @api.model
     def name_create(self, name):
         name = name.strip()
         user = self.env["base.automation.model.with.recname.char"].search([('description', '=ilike', name)], limit=1)

--- a/addons/web/tests/test_load_menus.py
+++ b/addons/web/tests/test_load_menus.py
@@ -1,5 +1,6 @@
-from odoo import Command
+from odoo import api, Command
 from odoo.tests.common import HttpCase
+
 
 class LoadMenusTests(HttpCase):
 
@@ -26,6 +27,8 @@ class LoadMenusTests(HttpCase):
 
         # Patch search to only return these menus
         origin_search_fetch = self.env.registry["ir.ui.menu"].search_fetch
+
+        @api.model
         def search_fetch(self, domain, *args, **kwargs):
             return origin_search_fetch(self, domain + [('id', 'in', menus.ids)], *args, **kwargs)
 

--- a/odoo/addons/test_lint/tests/test_override_signatures.py
+++ b/odoo/addons/test_lint/tests/test_override_signatures.py
@@ -110,6 +110,13 @@ def assert_valid_override(parent_signature, child_signature):
         assert child_has_varkwargs and parent_has_varkwargs, "wrong keyword parameters"
 
 
+def assert_attribute_override(parent_method, child_method):
+    for attribute in ('_autovacuum', '_api_model'):
+        parent_attr = getattr(parent_method, attribute, None)
+        child_attr = getattr(child_method, attribute, None)
+        assert parent_attr == child_attr, f"attribute {attribute!r} does not match"
+
+
 @tagged('-at_install', 'post_install')
 class TestLintOverrideSignatures(LintCase):
     def test_lint_override_signature(self):
@@ -142,6 +149,7 @@ class TestLintOverrideSignatures(LintCase):
                     with self.subTest(module=child_module, model=model_name, method=method_name):
                         try:
                             assert_valid_override(original_signature, override_signature)
+                            assert_attribute_override(method, override)
                             counter[method_name].hit += 1
                         except AssertionError as exc:
                             counter[method_name].miss += 1

--- a/odoo/addons/test_rpc/models.py
+++ b/odoo/addons/test_rpc/models.py
@@ -11,6 +11,7 @@ class Test_RpcModel_A(models.Model):
     field_b1 = fields.Many2one("test_rpc.model_b", string="required field", required=True)
     field_b2 = fields.Many2one("test_rpc.model_b", string="restricted field", ondelete="restrict")
 
+    @api.model
     @api.private
     def read_group(self, *a, **kw):
         return super().read_group(*a, **kw)

--- a/odoo/orm/decorators.py
+++ b/odoo/orm/decorators.py
@@ -45,17 +45,6 @@ def attrsetter(attr, value) -> Decorator:
     return setter
 
 
-def propagate(method1: T | None, method2: T) -> T:
-    """ Propagate decorators from ``method1`` to ``method2``, and return the
-        resulting method.
-    """
-    if method1:
-        for attr in ('_returns',):
-            if hasattr(method1, attr) and not hasattr(method2, attr):
-                setattr(method2, attr, getattr(method1, attr))
-    return method2
-
-
 @typing.overload
 def constrains(func: Callable[[BaseModel], Collection[str]], /) -> Decorator:
     ...


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When overwriting methods, most decorators are not automatically propagated. Most of the time this is on purpose, but sometimes we should have the same attribute set.

The main example is @api.model: it is a kind of classmethod and an override should be as well.
This prevents forgetting to add @api.model and break RPC calls.

Current behavior before PR:
If you forget to add @api.model on the overwrite, the RPC calls will fail at it will try to set the ids for the recordset.

Desired behavior after PR is merged:
Keep behaviour when overriding. Avoids issues like #195268


odoo/enterprise#78798

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
