### PR TITLE
[FIX] pos_restaurant: prevent error when archiving floor plan

### DIFF
--- a/addons/pos_restaurant/models/pos_restaurant.py
+++ b/addons/pos_restaurant/models/pos_restaurant.py
@@ -55,8 +55,8 @@ class RestaurantFloor(models.Model):
                     )
             for table in floor.table_ids:
                 # Verify if table number begin by old prefix if it is not 0
-                if (self.floor_prefix == 0 or (table.table_number and str(table.table_number).startswith(str(self.floor_prefix)))) and vals.get('floor_prefix') is not None:
-                    table_number_wo_prefix = str(table.table_number)[len(str(self.floor_prefix)):] if self.floor_prefix != 0 else str(table.table_number).zfill(2)
+                if (floor.floor_prefix == 0 or (table.table_number and str(table.table_number).startswith(str(floor.floor_prefix)))) and vals.get('floor_prefix') is not None:
+                    table_number_wo_prefix = str(table.table_number)[len(str(floor.floor_prefix)):] if floor.floor_prefix != 0 else str(table.table_number).zfill(2)
                     table.table_number = str(vals.get('floor_prefix')) + table_number_wo_prefix
 
         return super().write(vals)

--- a/addons/pos_restaurant/tests/__init__.py
+++ b/addons/pos_restaurant/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_frontend
+from . import test_pos_restaurant_flow

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -62,12 +62,12 @@ class TestFrontendCommon(TestPointOfSaleHttpCommon):
 
         cls.pos_config.floor_ids.unlink()
 
-        main_floor = cls.env['restaurant.floor'].create({
+        cls.main_floor = cls.env['restaurant.floor'].create({
             'name': 'Main Floor',
             'pos_config_ids': [(4, cls.pos_config.id)],
             'floor_prefix': 1,
         })
-        second_floor = cls.env['restaurant.floor'].create({
+        cls.second_floor = cls.env['restaurant.floor'].create({
             'name': 'Second Floor',
             'pos_config_ids': [(4, cls.pos_config.id)],
             'floor_prefix': 2,
@@ -75,14 +75,14 @@ class TestFrontendCommon(TestPointOfSaleHttpCommon):
 
         cls.main_floor_table_5 = cls.env['restaurant.table'].create([{
             'table_number': 105,
-            'floor_id': main_floor.id,
+            'floor_id': cls.main_floor.id,
             'seats': 4,
             'position_h': 100,
             'position_v': 100,
         }])
         cls.env['restaurant.table'].create([{
             'table_number': 104,
-            'floor_id': main_floor.id,
+            'floor_id': cls.main_floor.id,
             'seats': 4,
             'shape': 'square',
             'position_h': 350,
@@ -90,7 +90,7 @@ class TestFrontendCommon(TestPointOfSaleHttpCommon):
         },
         {
             'table_number': 102,
-            'floor_id': main_floor.id,
+            'floor_id': cls.main_floor.id,
             'seats': 4,
             'position_h': 250,
             'position_v': 100,
@@ -98,7 +98,7 @@ class TestFrontendCommon(TestPointOfSaleHttpCommon):
         {
 
             'table_number': 201,
-            'floor_id': second_floor.id,
+            'floor_id': cls.second_floor.id,
             'seats': 4,
             'shape': 'square',
             'position_h': 100,
@@ -106,7 +106,7 @@ class TestFrontendCommon(TestPointOfSaleHttpCommon):
         },
         {
             'table_number': 203,
-            'floor_id': second_floor.id,
+            'floor_id': cls.second_floor.id,
             'seats': 4,
             'position_h': 100,
             'position_v': 250,

--- a/addons/pos_restaurant/tests/test_pos_restaurant_flow.py
+++ b/addons/pos_restaurant/tests/test_pos_restaurant_flow.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+from odoo.addons.pos_restaurant.tests.test_frontend import TestFrontendCommon
+
+@tagged('post_install', '-at_install')
+class TestPosRestaurantFlow(TestFrontendCommon):
+
+    def test_floor_plans_archive(self):
+        floors = self.main_floor + self.second_floor
+        floors.action_archive()
+        # All floors should be archived successfully
+        self.assertTrue(all(floor.active is False for floor in floors), "All floors should be archived")


### PR DESCRIPTION
This error occurs when we attempt to archive the floor plans.

Steps to reproduce:
---
- Install the ``pos_restaurant`` module
- POS > Configuration > Floor Plans
- Select two plans > Archive

Traceback : 
---
``ValueError: Expected singleton: restaurant.floor(2, 3, 4, 5)``

At [1], this error occurs because we are retrieving the ``floor_prefix`` data from self, which returns all records instead of a single record.

This commit will resolve the above error by using ``floor`` in place of ``self`` in the for loop.

[1]- https://github.com/odoo/odoo/blob/4d9984d0b5f5a856104d11261fecd27ddc2e5466/addons/pos_restaurant/models/pos_restaurant.py#L58-L60

sentry-6275463514

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
