### PR TITLE
[IMP] l10n_in_hr_holiday: added exceptional days

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
+++ b/addons/hr_holidays/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
@@ -11,7 +11,7 @@
                     <span class="align-middle"><img class="o_calendar_filter_line" src="/hr/static/src/img/icons/line.svg"/> Refused</span>
                 </div>
 
-                <div class="d-flex flex-column mt-4" t-if="leaveState.mandatoryDays.length">
+                <div class="d-flex flex-column mt-4 mandatory_day" t-if="leaveState.mandatoryDays.length">
                     <h5>Mandatory Days</h5>
                     <ul class="ps-0">
                         <li t-foreach="leaveState.mandatoryDays" t-as="mandatoryDay" t-key="mandatoryDay.id" class="mt-2 list-unstyled">

--- a/addons/hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
+++ b/addons/hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
@@ -54,11 +54,7 @@ export class TimeOffCalendarYearRenderer extends CalendarYearRenderer {
             this.popover.close();
             const date = luxon.DateTime.fromISO(info.dateStr);
             const target = info.dayEl;
-            const mandatory_days_data = await this.orm.call(
-                "hr.employee",
-                "get_mandatory_days_data",
-                [date, date]
-            );
+            const mandatory_days_data = await this.getMandatoryData(info, date);
             mandatory_days_data.forEach((mandatory_day_data) => {
                 mandatory_day_data["start"] = luxon.DateTime.fromISO(mandatory_day_data["start"]);
                 mandatory_day_data["end"] = luxon.DateTime.fromISO(mandatory_day_data["end"]);
@@ -74,6 +70,10 @@ export class TimeOffCalendarYearRenderer extends CalendarYearRenderer {
         } else {
             super.onDateClick(info);
         }
+    }
+
+    async getMandatoryData(info, date) {
+        return await this.orm.call("hr.employee", "get_exceptional_days_data", [date, date]);
     }
 
     getDayCellClassNames(info) {

--- a/addons/l10n_in_hr_holidays/__manifest__.py
+++ b/addons/l10n_in_hr_holidays/__manifest__.py
@@ -10,8 +10,15 @@
     'depends': ['hr_holidays'],
     'auto_install': ['hr_holidays'],
     'data': [
+        'security/ir.model.access.csv',
         'views/hr_leave_views.xml',
         'views/hr_leave_type_views.xml',
+        'views/hr_leave_exceptional_day_views.xml',
     ],
     'license': 'LGPL-3',
+    'assets': {
+        'web.assets_backend': [
+            'l10n_in_hr_holidays/static/src/**/*',
+        ],
+    },
 }

--- a/addons/l10n_in_hr_holidays/models/__init__.py
+++ b/addons/l10n_in_hr_holidays/models/__init__.py
@@ -1,4 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import hr_leave
+from . import hr_employee
 from . import hr_leave_type
+from . import hr_leave_exceptional_day

--- a/addons/l10n_in_hr_holidays/models/hr_employee.py
+++ b/addons/l10n_in_hr_holidays/models/hr_employee.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+from odoo import models, api
+
+
+class HrEmployees(models.Model):
+    _inherit = 'hr.employee'
+
+    @api.model
+    def get_exceptional_days_data(self, date_start, date_end):
+        self = self._get_contextual_employee()
+        exceptional_days = self._get_exceptional_days(date_start, date_end).sorted('start_date')
+        return list(map(lambda ed: {
+            'id': -ed.id,
+            'colorIndex': ed.color,
+            'end': datetime.combine(ed.end_date, datetime.max.time()).isoformat(),
+            'endType': "datetime",
+            'isAllDay': True,
+            'start': datetime.combine(ed.start_date, datetime.min.time()).isoformat(),
+            'startType': "datetime",
+            'title': ed.name,
+        }, exceptional_days))
+
+    def get_exceptional_days(self, start_date, end_date):
+        all_days = {}
+
+        self = self or self.env.user.employee_id
+
+        exceptional_days = self._get_exceptional_days(start_date, end_date)
+        for exceptional_day in exceptional_days:
+            num_days = (exceptional_day.end_date - exceptional_day.start_date).days
+            for d in range(num_days + 1):
+                all_days[str(exceptional_day.start_date + relativedelta(days=d))] = exceptional_day.color
+
+        return all_days
+
+    def _get_exceptional_days(self, start_date, end_date):
+        domain = [
+            ('start_date', '<=', end_date),
+            ('end_date', '>=', start_date),
+            ('company_id', 'in', self.env.companies.ids),
+            '|',
+                ('resource_calendar_id', '=', False),
+                ('resource_calendar_id', '=', self.resource_calendar_id.id),
+        ]
+
+        if self.department_id:
+            domain += [
+                '|',
+                ('department_ids', '=', False),
+                ('department_ids', 'parent_of', self.department_id.id),
+            ]
+        else:
+            domain += [('department_ids', '=', False)]
+
+        return self.env['l10n.in.hr.holiday.exceptional.day'].search(domain)

--- a/addons/l10n_in_hr_holidays/models/hr_leave_exceptional_day.py
+++ b/addons/l10n_in_hr_holidays/models/hr_leave_exceptional_day.py
@@ -1,0 +1,39 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from random import randint
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+
+class HrHolidayExceptionalDay(models.Model):
+    _name = 'l10n.in.hr.holiday.exceptional.day'
+    _description = 'Exceptional Day'
+    _order = 'start_date desc, end_date desc'
+
+    name = fields.Char(required=True)
+    company_id = fields.Many2one('res.company', default=lambda self: self.env.company, required=True)
+    start_date = fields.Date(required=True)
+    end_date = fields.Date(required=True)
+    color = fields.Integer(default=lambda dummy: randint(1, 11))
+    department_ids = fields.Many2many('hr.department', string="Departments")
+    resource_calendar_id = fields.Many2one(
+        'resource.calendar', 'Working Hours',
+        domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
+
+    _date_from_after_day_to = models.Constraint(
+        'CHECK(start_date <= end_date)',
+        'The start date must be anterior than the end date.',
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            public_leave = self.env['resource.calendar.leaves'].search([
+                ('time_type', '=', 'leave'),
+                ('date_from', '<=', fields.Datetime.to_datetime(vals['end_date'])),
+                ('date_to', '>=', fields.Datetime.to_datetime(vals['start_date'])),
+                ('company_id', '=', vals.get('company_id'))
+            ])
+            if public_leave:
+                raise UserError(_('You cannot create an exceptional day that overlaps with a public leave.'))
+            return super().create(vals_list)

--- a/addons/l10n_in_hr_holidays/security/ir.model.access.csv
+++ b/addons/l10n_in_hr_holidays/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_hr_leave_exceptional_day_user,access_hr_holidays_exceptional_day_user,l10n_in_hr_holidays.model_l10n_in_hr_holiday_exceptional_day,base.group_user,1,0,0,0
+access_hr_leave_exceptional_day_manager,access_hr_holidays_exceptional_day_manager,l10n_in_hr_holidays.model_l10n_in_hr_holiday_exceptional_day,base.group_user,1,1,1,1

--- a/addons/l10n_in_hr_holidays/static/src/views/calendar/calendar_model.js
+++ b/addons/l10n_in_hr_holidays/static/src/views/calendar/calendar_model.js
@@ -1,0 +1,27 @@
+import { patch } from "@web/core/utils/patch";
+import { serializeDate } from "@web/core/l10n/dates";
+import { TimeOffCalendarModel } from "@hr_holidays/views/calendar/calendar_model";
+
+patch(TimeOffCalendarModel.prototype, {
+    setup(params, services) {
+        super.setup(params, services);
+        this.data.exceptionalDays = {};
+    },
+
+    async updateData(data) {
+        await super.updateData(data);
+        data.exceptionalDays = await this.fetchExceptionalDays(data);
+    },
+
+    async fetchExceptionalDays(data) {
+        return this.orm.call("hr.employee", "get_exceptional_days", [
+            this.employeeId,
+            serializeDate(data.range.start, "datetime"),
+            serializeDate(data.range.end, "datetime"),
+        ]);
+    },
+
+    get exceptionalDays() {
+        return this.data.exceptionalDays;
+    },
+});

--- a/addons/l10n_in_hr_holidays/static/src/views/calendar/common/calendar_common_renderer.js
+++ b/addons/l10n_in_hr_holidays/static/src/views/calendar/common/calendar_common_renderer.js
@@ -1,0 +1,14 @@
+import { patch } from "@web/core/utils/patch";
+import { useExceptionalDays } from "../../hooks";
+import { TimeOffCalendarCommonRenderer } from "@hr_holidays/views/calendar/common/calendar_common_renderer";
+
+patch(TimeOffCalendarCommonRenderer.prototype, {
+    setup() {
+        super.setup();
+        this.exceptionalDays = useExceptionalDays(this.props);
+    },
+
+    getDayCellClassNames(info) {
+        return [...super.getDayCellClassNames(info), ...this.exceptionalDays(info)];
+    },
+});

--- a/addons/l10n_in_hr_holidays/static/src/views/calendar/filter_panel/calendar_filter_panel.js
+++ b/addons/l10n_in_hr_holidays/static/src/views/calendar/filter_panel/calendar_filter_panel.js
@@ -1,0 +1,32 @@
+import { patch } from "@web/core/utils/patch";
+import { serializeDate } from "@web/core/l10n/dates";
+import { TimeOffCalendarFilterPanel } from "@hr_holidays/views/calendar/filter_panel/calendar_filter_panel";
+
+patch(TimeOffCalendarFilterPanel.prototype, {
+    setup() {
+        super.setup();
+        this.leaveState = {
+            ...this.leaveState,
+            exceptionalHoliday: [],
+        };
+    },
+    async updateSpecialDays() {
+        await super.updateSpecialDays();
+        const exceptionDays = await this.orm.call(
+            "hr.employee",
+            "get_exceptional_days_data",
+            [
+                serializeDate(this.props.model.rangeStart, "datetime"),
+                serializeDate(this.props.model.rangeEnd, "datetime"),
+            ],
+            {
+                context: { employee_id: this.props.employee_id },
+            }
+        );
+        exceptionDays.forEach((mandatoryDay) => {
+            mandatoryDay.start = luxon.DateTime.fromISO(mandatoryDay.start);
+            mandatoryDay.end = luxon.DateTime.fromISO(mandatoryDay.end);
+        });
+        this.leaveState.exceptionalHoliday = exceptionDays;
+    },
+});

--- a/addons/l10n_in_hr_holidays/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
+++ b/addons/l10n_in_hr_holidays/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="hr_holidays.CalendarFilterPanel" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('mandatory_day')]" position="after">
+            <div class="d-flex flex-column mt-4" t-if="leaveState.exceptionalHoliday.length">
+                <h5>Exceptional Days</h5>
+                <ul class="ps-0">
+                    <li t-foreach="leaveState.exceptionalHoliday" t-as="exceptional" t-key="exceptional.id" class="mt-2 list-unstyled">
+                        <strong
+                            t-esc="getFormattedDateSpan(exceptional.start, exceptional.end)"
+                            t-att-class="'hr_mandatory_day_'+exceptional.colorIndex"/>
+                        : <t t-esc="exceptional.title"/>
+                    </li>
+                </ul>
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/l10n_in_hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
+++ b/addons/l10n_in_hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
@@ -1,0 +1,22 @@
+import { patch } from "@web/core/utils/patch";
+import { useExceptionalDays } from "../../hooks";
+import { TimeOffCalendarYearRenderer } from "@hr_holidays/views/calendar/year/calendar_year_renderer";
+
+patch(TimeOffCalendarYearRenderer.prototype, {
+    setup() {
+        super.setup();
+        this.exceptionalDays = useExceptionalDays(this.props);
+    },
+
+    async getMandatoryData(info, date) {
+        if (info.dayEl.classList.contains("hr_exceptional_days")) {
+            return await this.orm.call("hr.employee", "get_exceptional_days_data", [date, date]);
+        } else {
+            return super.getMandatoryData(info, date);
+        }
+    },
+
+    getDayCellClassNames(info) {
+        return [...super.getDayCellClassNames(info), ...this.exceptionalDays(info)];
+    },
+});

--- a/addons/l10n_in_hr_holidays/static/src/views/hooks.js
+++ b/addons/l10n_in_hr_holidays/static/src/views/hooks.js
@@ -1,0 +1,10 @@
+export function useExceptionalDays(props) {
+    return (info) => {
+        const date = luxon.DateTime.fromJSDate(info.date).toISODate();
+        const exceptionalDays = props.model.exceptionalDays[date];
+        if (exceptionalDays) {
+            return [`hr_exceptional_day hr_mandatory_day hr_mandatory_day_${exceptionalDays}`];
+        }
+        return [];
+    };
+}

--- a/addons/l10n_in_hr_holidays/tests/__init__.py
+++ b/addons/l10n_in_hr_holidays/tests/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_sandwich_leave
+from . import test_exceptional_day_leave

--- a/addons/l10n_in_hr_holidays/tests/test_exceptional_day_leave.py
+++ b/addons/l10n_in_hr_holidays/tests/test_exceptional_day_leave.py
@@ -1,0 +1,109 @@
+from odoo.tests import tagged, TransactionCase
+from odoo.exceptions import UserError
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestExceptionalDayLeave(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company_india = cls.env['res.company'].create({
+            'name': "Indian Company",
+            'country_id': cls.env.ref('base.in').id,
+        })
+        cls.env = cls.env(context=dict(cls.env.context, allowed_company_ids=cls.company_india.ids))
+        cls.Leave = cls.env['hr.leave']
+        cls.employee = cls.env['hr.employee'].create({'name': 'Test Employee'})
+
+        cls.exceptional_day_1 = cls.env['l10n.in.hr.holiday.exceptional.day'].create({
+            'name': 'Exceptional Day',
+            'start_date': '2025-02-08',
+            'end_date': '2025-02-09',
+            'company_id': cls.company_india.id,
+        })
+
+        cls.exceptional_day_2 = cls.env['l10n.in.hr.holiday.exceptional.day'].create({
+            'name': 'Test Exceptional Day',
+            'start_date': '2025-02-15',
+            'end_date': '2025-02-15',
+            'company_id': cls.company_india.id,
+        })
+
+        cls.wednesday_public_holiday = cls.env['resource.calendar.leaves'].create({
+            'name': 'Test public holiday',
+            'date_from': '2025-02-14 00:00:00',
+            'date_to': '2025-02-14 23:59:59',
+            'resource_id': False,
+        })
+
+    def test_leave_on_one_exceptional_day(self):
+        leave = self.Leave.create({
+            'employee_id': self.employee.id,
+            'request_date_from': '2025-02-08',
+            'request_date_to': '2025-02-08',
+            'holiday_status_id': self.env.ref('hr_holidays.holiday_status_cl').id
+        })
+        self.assertEqual(leave.number_of_days, 1, "Leave duration should be 1 day")
+
+    def test_leave_on_exceptional_day(self):
+        leave = self.Leave.create({
+            'employee_id': self.employee.id,
+            'request_date_from': '2025-02-08',
+            'request_date_to': '2025-02-09',
+            'holiday_status_id': self.env.ref('hr_holidays.holiday_status_cl').id
+        })
+        self.assertEqual(leave.number_of_days, 2, "Leave duration should be 2 days")
+
+    def test_leave_stops_with_exceptional_day(self):
+        leave = self.Leave.create({
+            'employee_id': self.employee.id,
+            'request_date_from': '2025-02-07',
+            'request_date_to': '2025-02-08',
+            'holiday_status_id': self.env.ref('hr_holidays.holiday_status_cl').id
+        })
+        self.assertEqual(leave.number_of_days, 2, "Leave duration should be 2 days")
+
+    def test_leave_starts_with_exceptional_day(self):
+        leave = self.Leave.create({
+            'employee_id': self.employee.id,
+            'request_date_from': '2025-02-08',
+            'request_date_to': '2025-02-10',
+            'holiday_status_id': self.env.ref('hr_holidays.holiday_status_cl').id
+        })
+        self.assertEqual(leave.number_of_days, 3, "Leave duration should be 3 days")
+
+    def test_leave_covering_exceptional_days(self):
+        leave = self.Leave.create({
+            'employee_id': self.employee.id,
+            'request_date_from': '2025-02-07',
+            'request_date_to': '2025-02-10',
+            'holiday_status_id': self.env.ref('hr_holidays.holiday_status_cl').id
+        })
+        self.assertEqual(leave.number_of_days, 4, "Leave duration should be 2 days")
+
+    def test_leave_public_holiday_exceptional_day(self):
+        leave = self.Leave.create({
+            'employee_id': self.employee.id,
+            'request_date_from': '2025-02-14',
+            'request_date_to': '2025-02-15',
+            'holiday_status_id': self.env.ref('hr_holidays.holiday_status_cl').id
+        })
+        self.assertEqual(leave.number_of_days, 1, "Leave duration should be 1 day")
+
+    def test_leave_covering_public_holiday_exceptional_day(self):
+        leave = self.Leave.create({
+            'employee_id': self.employee.id,
+            'request_date_from': '2025-02-13',
+            'request_date_to': '2025-02-15',
+            'holiday_status_id': self.env.ref('hr_holidays.holiday_status_cl').id
+        })
+        self.assertEqual(leave.number_of_days, 2, "Leave duration should be 2 days")
+
+    def test_exceptional_day_on_public_holiday(self):
+        with self.assertRaises(UserError):
+            self.env['l10n.in.hr.holiday.exceptional.day'].create({
+                'name': 'Exceptional Day on Public Holiday',
+                'start_date': '2025-02-14',
+                'end_date': '2025-02-14',
+                'company_id': self.company_india.id,
+            })

--- a/addons/l10n_in_hr_holidays/views/hr_leave_exceptional_day_views.xml
+++ b/addons/l10n_in_hr_holidays/views/hr_leave_exceptional_day_views.xml
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<odoo>
+    <record id="hr_leave_exceptional_day_view_form" model="ir.ui.view">
+        <field name="model">l10n.in.hr.holiday.exceptional.day</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="start_date" string="Dates" widget="daterange" options="{'end_date_field': 'end_date'}" />
+                            <field name="end_date" invisible="1" />
+                        </group>
+                        <group>
+                            <field name="color" widget="color_picker"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="hr_leave_exceptional_day_view_list" model="ir.ui.view">
+        <field name="model">l10n.in.hr.holiday.exceptional.day</field>
+        <field name="arch" type="xml">
+            <list editable="bottom">
+                <field name="company_id" column_invisible="True"/>
+                <field name="name"/>
+                <field name="company_id" groups="base.group_multi_company"/>
+                <field name="department_ids" widget="many2many_tags" optional="hide"/>
+                <field name="start_date"/>
+                <field name="end_date"/>
+                <field name="resource_calendar_id"/>
+                <field name="color" widget="color_picker"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="hr_leave_exceptional_day_view_search" model="ir.ui.view">
+        <field name="model">l10n.in.hr.holiday.exceptional.day</field>
+        <field name="arch" type="xml">
+            <search string="Exceptional Day">
+                <field name="name"/>
+                <field name="start_date"/>
+                <field name="end_date"/>
+                <field name="company_id" groups="base.group_multi_company"/>
+                <separator />
+                <filter name="filter_date" date="start_date" default_period="year" string="Period"/>
+                <group expand="0" string="Group By">
+                    <filter name="department" string="Department" context="{'group_by': 'department_ids'}"/>
+                    <filter name="company" string="Company" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="hr_leave_exceptional_day_action" model="ir.actions.act_window">
+        <field name="name">Exceptional Days</field>
+        <field name="res_model">l10n.in.hr.holiday.exceptional.day</field>
+        <field name="view_mode">list,form</field>
+        <field name="search_view_id" ref="hr_leave_exceptional_day_view_search"/>
+        <field name="context">{'search_default_filter_date': True}</field>
+    </record>
+
+    <menuitem
+        id="hr_holidays_exceptional_day_menu_configuration"
+        action="hr_leave_exceptional_day_action"
+        name="Exceptional Days"
+        parent="hr_holidays.menu_hr_holidays_configuration"
+        groups="hr_holidays.group_hr_holidays_manager"
+        sequence="6"/>
+</odoo>


### PR DESCRIPTION
In this commit,

we are introducing a feature for managing exceptional working days for employees If an employee is required to work on a non-working day, we will utilize this newly created exceptional day

- This model includes a calendar field, allowing you to set exceptional days for specific calendars. If not specified, it will apply to all employees.
- The model also has a company field to ensure it only applies to the selected company.
- Additionally, a color field indicates how the calendar will display these exceptional days.
- In the calendar's filter area, you will find a section for exceptional days, which lists all the defined exceptional days.
- Exceptional days should be created on non-working days, as this is their intended purpose.
- Do not create an exceptional day on a public holiday, as this will trigger a user error.
- If an employee takes leave on an exceptional day, it will be treated as a normal leave day, similar to a working day,
and it will be deducted from their leave allocation

Task - 4222822

