### PR TITLE
[FIX] pos_loyalty: prevent deletion of mail template if in use

### DIFF
--- a/addons/pos_loyalty/i18n/pos_loyalty.pot
+++ b/addons/pos_loyalty/i18n/pos_loyalty.pot
@@ -762,6 +762,14 @@ msgid "Yes"
 msgstr ""
 
 #. module: pos_loyalty
+#. odoo-python
+#: code:addons/pos_loyalty/models/mail_template.py:0
+#, python-format
+msgid ""
+"You cannot delete this mail template as it is being use by another model."
+msgstr ""
+
+#. module: pos_loyalty
 #. odoo-javascript
 #: code:addons/pos_loyalty/static/src/overrides/models/pos_store.js:0
 #, python-format

--- a/addons/pos_loyalty/models/__init__.py
+++ b/addons/pos_loyalty/models/__init__.py
@@ -7,6 +7,7 @@ from . import loyalty_mail
 from . import loyalty_program
 from . import loyalty_reward
 from . import loyalty_rule
+from . import mail_template
 from . import pos_config
 from . import pos_order_line
 from . import pos_order

--- a/addons/pos_loyalty/models/mail_template.py
+++ b/addons/pos_loyalty/models/mail_template.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models, _
+from odoo.exceptions import ValidationError
+
+class MailTemplate(models.Model):
+    _inherit = 'mail.template'
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_mail_template(self):
+        linked_templates = {
+            template.name for template in self.env['loyalty.program'].search([]).mapped('mail_template_id')
+        }
+
+        if any(record.name in linked_templates for record in self):
+            raise ValidationError(_(
+                "You cannot delete this mail template as it is being use by another model."
+            ))


### PR DESCRIPTION
Currently a `ParseError` is arising when the user upgrades the `pos_loyalty` module after deleting the `Gift Card: Gift Card Information` template in the mail template.

Steps to reproduce:
---
- Install the `pos_loyalty` module
- Delete `Gift Card: Gift Card Information` from `Email Templates`
- Now upgrade `pos_loyalty` module

Traceback:
---
```
UserError: You must set 'Email template' before setting 'Print Report'.

ParseError: while parsing /home/odoo/src/odoo/saas-18.1/addons/pos_loyalty/data/gift_card_data.xml:12, somewhere inside <record id="loyalty.gift_card_program" model="loyalty.program">
        <field name="pos_report_print_id" ref="loyalty.report_gift_card"/>
    </record>
```

This commit resolves the issue by preventing the deletion of mail template if it is used by `Gift Cards`

sentry-6267881886

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
