### PR TITLE
[FIX] point_of_sale: search product by variant internal reference

### DIFF
--- a/addons/point_of_sale/models/product_product.py
+++ b/addons/point_of_sale/models/product_product.py
@@ -13,7 +13,7 @@ class ProductProduct(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['id', 'lst_price', 'display_name', 'product_tmpl_id', 'product_template_variant_value_ids', 'barcode', 'product_tag_ids']
+        return ['id', 'lst_price', 'display_name', 'product_tmpl_id', 'product_template_variant_value_ids', 'barcode', 'product_tag_ids', 'default_code']
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_active_pos_session(self):

--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -253,8 +253,16 @@ export class ProductTemplate extends Base {
 
     exactMatch(searchWord) {
         const fields = ["barcode", "default_code"];
-        return fields.some(
-            (field) => this[field] && this[field].toLowerCase().includes(searchWord)
+        const variantMatch = this.product_variant_ids.some(
+            (variant) =>
+                (variant.default_code && variant.default_code.toLowerCase().includes(searchWord)) ||
+                variant.product_template_variant_value_ids.some((vv) =>
+                    vv.name.toLowerCase().includes(searchWord)
+                )
+        );
+        return (
+            variantMatch ||
+            fields.some((field) => this[field] && this[field].toLowerCase().includes(searchWord))
         );
     }
 

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -129,7 +129,6 @@ export class PosStore extends WithLazyGetterTrap {
         this.selectedPartner = null;
         this.selectedCategory = null;
         this.searchProductWord = "";
-        this.mainProductVariant = {};
         this.ready = new Promise((resolve) => {
             this.markReady = resolve;
         });
@@ -421,7 +420,6 @@ export class PosStore extends WithLazyGetterTrap {
 
             for (let i = 0; i < nbrProduct - 1; i++) {
                 products[i].available_in_pos = false;
-                this.mainProductVariant[products[i].id] = products[nbrProduct - 1];
             }
         }
     }
@@ -2119,28 +2117,13 @@ export class PosStore extends WithLazyGetterTrap {
         return this.config.proxy_ip;
     }
 
-    addMainProductsToDisplay(products) {
-        const uniqueProductsMap = new Map();
-        for (const product of products) {
-            if (product.id in this.mainProductVariant) {
-                const mainProduct = this.mainProductVariant[product.id];
-                uniqueProductsMap.set(mainProduct.id, mainProduct);
-            } else {
-                uniqueProductsMap.set(product.id, product);
-            }
-        }
-        return Array.from(uniqueProductsMap.values());
-    }
-
     get productsToDisplay() {
         const searchWord = this.searchProductWord.trim();
         const allProducts = this.models["product.template"].getAll();
         let list = [];
 
         if (searchWord !== "") {
-            list = this.addMainProductsToDisplay(
-                this.getProductsBySearchWord(searchWord, allProducts)
-            );
+            list = this.getProductsBySearchWord(searchWord, allProducts);
         } else if (this.selectedCategory?.id) {
             list = this.selectedCategory.associatedProducts;
         } else {


### PR DESCRIPTION
Fix issue where product variants could not be searched in POS using their internal reference (default_code) or name (value).

Steps to Reproduce:
- Create a product with a POS category.
- Create variants and assign internal references.
- Open POS and try searching for a variant using its internal reference.
- No results were found.

Fix:
- Added `default_code` to `_load_pos_data_fields` to ensure it’s available in POS data.
- Updated `exactMatch` function to check variants `default_code` & `name` when searching.
- Remove function `addMainProductsToDisplay` and variable `mainProductVariant` as they were previously used when we were searching into `product.product`. Now that we use `product.template` we don't need this anymore.

task-id: 4552450

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
