### PR TITLE
[FIX] account: basic user report rights

### DIFF
--- a/addons/account/security/ir.model.access.csv
+++ b/addons/account/security/ir.model.access.csv
@@ -62,6 +62,7 @@ access_account_journal_group_invoice,account.journal.group invoice,model_account
 access_account_journal_group_readonly,account.journal.group readonly,model_account_journal_group,account.group_account_readonly,1,0,0,0
 access_account_journal_group_manager,account.journal.group manager,model_account_journal_group,account.group_account_manager,1,1,1,1
 
+access_account_group_basic,account.group.basic,model_account_group,account.group_account_basic,1,0,0,0
 access_account_group_manager,account.group,model_account_group,account.group_account_manager,1,1,1,1
 access_account_group,account.group,model_account_group,account.group_account_readonly,1,0,0,0
 access_account_root_manager,account.root,model_account_root,account.group_account_manager,1,0,0,0
@@ -132,12 +133,16 @@ access_account_move_send_batch_wizard,access.account.move.send.batch.wizard,mode
 
 access_account_accrued_orders_wizard,account.account.accrued.orders.wizard,account.model_account_accrued_orders_wizard,group_account_user,1,1,1,0
 
+access_account_report_basic,account.report.basic,model_account_report,account.group_account_basic,1,0,0,0
 access_account_report_readonly,account.report.readonly,model_account_report,account.group_account_readonly,1,0,0,0
 access_account_report_ac_user,account.report.ac.user,model_account_report,account.group_account_manager,1,1,1,1
+access_account_report_line_basic,account.report.line.basic,model_account_report_line,account.group_account_basic,1,0,0,0
 access_account_report_line_readonly,account.report.line.readonly,model_account_report_line,account.group_account_readonly,1,0,0,0
 access_account_report_line_ac_user,account.report.line.ac.user,model_account_report_line,account.group_account_manager,1,1,1,1
+access_account_report_expression_basic,account.report.expression.basic,model_account_report_expression,account.group_account_basic,1,0,0,0
 access_account_report_expression_readonly,account.report.expression.readonly,model_account_report_expression,account.group_account_readonly,1,0,0,0
 access_account_report_expression_ac_user,account.report.expression.ac.user,model_account_report_expression,account.group_account_manager,1,1,1,1
+access_account_report_column_basic,account.report.column.basic,model_account_report_column,account.group_account_basic,1,0,0,0
 access_account_report_column_readonly,account.report.column.readonly,model_account_report_column,account.group_account_readonly,1,0,0,0
 access_account_report_column_ac_user,account.report.column.ac.user,model_account_report_column,account.group_account_manager,1,1,1,1
 


### PR DESCRIPTION
With the introduction of Invoicing Enterprise (access to bank recon etc) a new user group was created "Invoicing & Banks" (`group_account_basic`) This group should also be able to access the customer statement / partner ledger (from the partner smart button)

Task-4465208
