### PR TITLE
[FIX] web: detect googlebot to avoid redirects

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -33,7 +33,7 @@ ALLOWED_DEBUG_MODES = ['', '1', 'assets', 'tests', 'disable-t-cache']
 class Http(models.AbstractModel):
     _inherit = 'ir.http'
 
-    bots = ["bot", "crawl", "slurp", "spider", "curl", "wget", "facebookexternalhit", "whatsapp", "trendsmapresolver", "pinterest", "instagram", "google-pagerenderer", "preview"]
+    bots = ["bot", "crawl", "slurp", "spider", "curl", "wget", "facebookexternalhit", "whatsapp", "trendsmapresolver", "pinterest", "instagram", "google-pagerenderer", "preview", "googlebot", "googlebot-image"]
 
     @classmethod
     def is_a_bot(cls):


### PR DESCRIPTION
Those redirects can kill how the site is fetched. If a website has its default language different to english and english is available as a secondary one, the crawler bot will be always redirected to the english version. For example: mysite.info/en_US.

The effect of that is that crawlers like the Googlebot-image aren't able to validate the site icon, as they don't use any site subfolder.

This is the relevant part where the redirection should be avoided

https://github.com/odoo/odoo/blob/cce0b490090580be51fdf5a40fad2ec2b9a49401/addons/http_routing/models/ir_http.py#L452-L455

cc @Tecnativa TT48630


Set to draft for the moment to test on customer


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
