### PR TITLE
[FIX] website_sale: display fiscal information in the correct group

### DIFF
--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -170,20 +170,35 @@
                 <field name="description_ecommerce" invisible="1" />         <!-- Adding this field as we needed in product_barcodelookup module to store value in this field -->
             </group>
             <xpath expr="//page[@name='sales']/group[@name='sale']" position="inside">
-                <group colspan="2" name="product_template_images" string="eCommerce Media" invisible="not sale_ok">
-                    <field
-                        colspan="2"
-                        name="product_template_image_ids"
-                        class="o_website_sale_image_list"
-                        context="{'default_name': name}"
-                        mode="kanban"
-                        add-label="Add Media"
-                        nolabel="1"
-                        widget="x2_many_media_viewer"
-                        options="{'convert_to_webp': True}"
-                    />
-                </group>
-            </xpath>
+                    <group name="e-shop" string="Ecommerce Shop">
+                        <field name="is_published"/>
+                        <field 
+                            name="website_id"
+                            options="{'no_create': True}"
+                            groups="website.group_multi_website"
+                            placeholder="All"
+                        />
+                        <field name="website_sequence" groups="base.group_no_one"/>
+                        <field name="public_categ_ids" widget="many2many_tags" string="Categories"/>
+                        <field 
+                            name="website_ribbon_id"
+                            groups="base.group_no_one"
+                            options="{'no_quick_create': True}"
+                        />
+                    </group>
+                    <group name="product_template_images" string="eCommerce Media" invisible="not sale_ok">
+                        <field
+                            name="product_template_image_ids"
+                            class="o_website_sale_image_list"
+                            context="{'default_name': name}"
+                            mode="kanban"
+                            add-label="Add Media"
+                            nolabel="1"
+                            widget="x2_many_media_viewer"
+                            options="{'convert_to_webp': True}"
+                        />
+                    </group>
+                </xpath>
             <xpath expr="//page[@name='sales']//group[@name='description']" position="after">
                 <group string="Ecommerce Description" name="ecom_description">
                    <field
@@ -195,25 +210,6 @@
                     />
                 </group>
             </xpath>
-            <group name="extra_info" position="inside">
-                <field name="is_published"/>
-                <field
-                    name="website_id"
-                    options="{'no_create': True}"
-                    groups="website.group_multi_website"
-                    placeholder="All"
-                />
-                <field name="website_sequence" groups="base.group_no_one"/>
-                <field name="public_categ_ids" widget="many2many_tags" string="Categories"/>
-                <field
-                    name="website_ribbon_id"
-                    groups="base.group_no_one"
-                    options="{'no_quick_create': True}"
-                />
-            </group>
-            <group name="extra_info" position="attributes">
-                <attribute name="string">Ecommerce Shop</attribute>
-            </group>
         </field>
     </record>
 


### PR DESCRIPTION
**Issue**
BR fiscal product fields are displayed inside Ecommerce Shop group instead of Extra Info group

Steps to Reproduce:

1. Install Accounting, Sales, eCommerce, and l10n_br_avatax modules. 
2. Switch company settings from YourCompany to BR Company. 
3. Navigate to Products > Sales Tab.
4. Observe that the fiscal information fields appear under the Ecommerce Shop group instead of Extra Info. 

Expected Behavior: BR fiscal product fields should be displayed inside the Extra Info group. 
Actual Behavior: BR fiscal product fields are incorrectly placed in the Ecommerce Shop group.

**Root Cause**

The issue occurs because the code mistakenly modifies the Extra Info group, adds eCommerce-related fields inside it, and then renames it to Ecommerce Shop. This causes the Extra Info group to disappear, leading to fiscal information being displayed incorrectly.

**Fix**
Instead of modifying the existing Extra Info group, a new separate group is created specifically for eCommerce-related fields. This ensures that fiscal information remains inside the Extra Info group and that eCommerce fields are properly placed next to Ecommerce Media, maintaining UI consistency.

opw-4533760


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
