### PR TITLE
[FIX] html_editor: apply font-size on highest non-block ancestor

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -519,12 +519,22 @@ export class FormatPlugin extends Plugin {
 function getOrCreateSpan(node, ancestors) {
     const document = node.ownerDocument;
     const span = ancestors.find((element) => element.tagName === "SPAN" && element.isConnected);
+    const lastInlineAncestor = ancestors.findLast(
+        (element) => !isBlock(element) && element.isConnected
+    );
     if (span) {
         return span;
     } else {
         const span = document.createElement("span");
-        node.after(span);
-        span.append(node);
+        // Apply font span above current inline top ancestor so that
+        // the font style applies to the other style tags as well.
+        if (lastInlineAncestor) {
+            lastInlineAncestor.after(span);
+            span.append(lastInlineAncestor);
+        } else {
+            node.after(span);
+            span.append(node);
+        }
         return span;
     }
 }

--- a/addons/html_editor/static/tests/format/font_size.test.js
+++ b/addons/html_editor/static/tests/format/font_size.test.js
@@ -179,3 +179,19 @@ test("should add style to a span parent of an inline", async () => {
         )}</span>d</p>`,
     });
 });
+
+test("should apply font size on top of `u` and `s` tags", async () => {
+    await testEditor({
+        contentBefore: `<p>a<u>[b]</u>c</p>`,
+        stepFunction: setFontSize("18px"),
+        contentAfter: `<p>a<span style="font-size: 18px;"><u>[b]</u></span>c</p>`,
+    });
+});
+
+test("should apply font size on topmost `u` or `s` tags if multiple applied", async () => {
+    await testEditor({
+        contentBefore: `<p>a<s><u>[b]</u></s>c</p>`,
+        stepFunction: setFontSize("18px"),
+        contentAfter: `<p>a<span style="font-size: 18px;"><s><u>[b]</u></s></span>c</p>`,
+    });
+});


### PR DESCRIPTION
**Problem**:
When `u` or `s` tags are applied, changing the `font-size` wraps the text inside these tags instead of applying it to the tags themselves. For example,
`a<u>b</u>c` → `a<u><font>b</font></u>c`,
which results in an inconsistent appearance.

**Solution**:
Ensure that the `span` for font size is applied to the highest non-block ancestor to maintain proper styling.

**Steps to Reproduce**:
1. Add text.
2. Apply underline.
3. Increase font size.
4. Observe that the underline remains the original size instead of scaling with the text.

opw-3086072

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
