### PR TITLE
[IMP] micro-optimizations on model

### DIFF
--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1353,15 +1353,16 @@ class Field(typing.Generic[T]):
         if record is None:
             return self         # the field is accessed through the owner class
 
-        if not record._ids:
+        record_len = len(record._ids)
+        if not record_len:
             # null record -> return the null value for this field
             value = self.convert_to_cache(False, record, validate=False)
             return self.convert_to_record(value, record)
+        if record_len != 1:
+            # let ensure_one() raise the proper exception
+            record.ensure_one()
 
         env = record.env
-
-        # only a single record may be accessed
-        record.ensure_one()
 
         if self.compute and self.store:
             # process pending computations

--- a/odoo/orm/identifiers.py
+++ b/odoo/orm/identifiers.py
@@ -5,11 +5,12 @@ class NewId:
     """ Pseudo-ids for new records, encapsulating an optional origin id (actual
         record id) and an optional reference (any value).
     """
-    __slots__ = ['origin', 'ref']
+    __slots__ = ('origin', 'ref', '__hash')  # noqa: RUF023
 
     def __init__(self, origin=None, ref=None):
         self.origin = origin
         self.ref = ref
+        self.__hash = hash(origin or ref or id(self))
 
     def __bool__(self):
         return False
@@ -21,7 +22,7 @@ class NewId:
         )
 
     def __hash__(self):
-        return hash(self.origin or self.ref or id(self))
+        return self.__hash
 
     def __repr__(self):
         return (

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1911,7 +1911,7 @@ class BaseModel(metaclass=MetaModel):
 
         if field.relational:
             # groups is a recordset; determine order on groups's model
-            groups = self.env[field.comodel_name].browse([value.id for value in values])
+            groups = self.env[field.comodel_name].browse(value.id for value in values)
             values = group_expand(self, groups, domain).sudo()
             if read_group_order == groupby + ' desc':
                 values.browse(reversed(values._ids))
@@ -1953,7 +1953,7 @@ class BaseModel(metaclass=MetaModel):
         # add folding information if present
         if field.relational and groups._fold_name in groups._fields:
             fold = {group.id: group[groups._fold_name]
-                    for group in groups.browse([key for key in result if key])}
+                    for group in groups.browse(key for key in result if key)}
             for key, line in result.items():
                 line['__fold'] = fold.get(key, False)
 
@@ -6203,7 +6203,7 @@ class BaseModel(metaclass=MetaModel):
             if self._name != other._name:
                 raise TypeError(f"inconsistent models in: {self} - {other}")
             other_ids = set(other._ids)
-            return self.browse([id for id in self._ids if id not in other_ids])
+            return self.browse(id_ for id_ in self._ids if id_ not in other_ids)
         except AttributeError:
             raise TypeError(f"unsupported operand types in: {self} - {other!r}")
 
@@ -6215,7 +6215,7 @@ class BaseModel(metaclass=MetaModel):
             if self._name != other._name:
                 raise TypeError(f"inconsistent models in: {self} & {other}")
             other_ids = set(other._ids)
-            return self.browse(OrderedSet(id for id in self._ids if id in other_ids))
+            return self.browse(OrderedSet(id_ for id_ in self._ids if id_ in other_ids))
         except AttributeError:
             raise TypeError(f"unsupported operand types in: {self} & {other!r}")
 


### PR DESCRIPTION
Small optimizations of core functions.

## iteration
We can prevent allocation when iterating over a single element (common case) and resolve variables only once.
```python
def test(n):
  model = self.browse(range(n))
  %timeit list(model)

# BEFORE and AFTER times
In [5]: test(0)
148 ns ± 0.266 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
143 ns ± 1.78 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
In [4]: test(1)
282 ns ± 2.93 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
161 ns ± 2.96 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
In [6]: test(5)
761 ns ± 3.29 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
714 ns ± 1.96 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
In [7]: test(50)
6.19 μs ± 17.7 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
5.66 μs ± 22.7 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
In [9]: test(5500)
719 μs ± 1.59 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
664 μs ± 6.36 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

## browse
Don't allocate a list if not needed.

## with_context
Simplify the signature of the function and make the first positional parameter explicit.
```python
%timeit self.with_context()
%timeit self.with_context(a='test')
%timeit self.with_context({"a": "ok"})
%timeit self.with_context({"a": "ok"}, b=1, a=5)
1.85 μs ± 5.93 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
2.36 μs ± 22.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
2.16 μs ± 19.8 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
2.31 μs ± 66.3 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
AFTER
1.86 μs ± 21.6 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
2.28 μs ± 27.1 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
2.08 μs ± 18.3 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
2.17 μs ± 23.9 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

## field get ensure one
Strip 10ns of ~400 just by removing a function call.
```python
In [2]: %timeit self.name
392 ns ± 3.16 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
In [7]: %timeit len(self._ids) == 1
16.9 ns ± 0.0621 ns per loop (mean ± std. dev. of 7 runs, 100,000,000 loops each)
In [8]: %timeit self.ensure_one()
24.9 ns ± 0.255 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

## NewId.hash
Computes the hash with an overhead of 20ns in the first run, then we gain 54ns at each call. Since we lookup often, we gain some time.
```python
In [3]: %timeit hash(n)
94.5 ns ± 0.941 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
In [4]: %timeit {NewId(ref=i) for i in range(1000)}
173 μs ± 1.55 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
AFTER
In [4]: %timeit hash(n)
43.7 ns ± 0.181 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
In [5]: %timeit {NewId() for i in range(1000)}
166 μs ± 2.07 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
