### PR TITLE
[IMP] web,hr_holidays: calendar: add show_date_picker option

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_controller.xml
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_controller.xml
@@ -13,7 +13,6 @@
                 </span>
             </t>
         </xpath>
-        <DatePicker position="replace"/>
     </t>
 
 </templates>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -360,6 +360,7 @@
                     date_start="date_from"
                     date_stop="date_to"
                     quick_create="0"
+                    show_date_picker="0"
                     show_unusual_days="True"
                     color="color"
                     hide_time="True"
@@ -386,6 +387,7 @@
                     date_stop="date_to"
                     mode="year"
                     quick_create="0"
+                    show_date_picker="0"
                     show_unusual_days="True"
                     color="color"
                     hide_time="True">

--- a/addons/web/static/src/views/calendar/calendar_arch_parser.js
+++ b/addons/web/static/src/views/calendar/calendar_arch_parser.js
@@ -37,6 +37,7 @@ export class CalendarArchParser {
         let isDateHidden = false;
         let isTimeHidden = false;
         let formViewId = false;
+        let showDatePicker = true;
         const popoverFieldNodes = {};
         const filtersInfo = {};
 
@@ -111,6 +112,9 @@ export class CalendarArchParser {
                     }
                     if (node.hasAttribute("form_view_id")) {
                         formViewId = parseInt(node.getAttribute("form_view_id"), 10);
+                    }
+                    if (node.hasAttribute("show_date_picker")) {
+                        showDatePicker = exprToBoolean(node.getAttribute("show_date_picker"));
                     }
 
                     break;
@@ -203,6 +207,7 @@ export class CalendarArchParser {
             scale,
             scales,
             showUnusualDays,
+            showDatePicker,
         };
     }
 }

--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -236,6 +236,14 @@ export class CalendarController extends Component {
         return !this.env.isSmall || !this.state.showSideBar;
     }
 
+    get showDatePicker() {
+        return this.model.showDatePicker && !this.env.isSmall;
+    }
+
+    get hasSideBar() {
+        return this.showDatePicker || this.model.filterSections.length > 0;
+    }
+
     get showSideBar() {
         return this.state.showSideBar;
     }

--- a/addons/web/static/src/views/calendar/calendar_controller.xml
+++ b/addons/web/static/src/views/calendar/calendar_controller.xml
@@ -55,15 +55,15 @@
                             </t>
                         </h5>
                     </div>
-                    <div class="o_sidebar_toggler d-none d-md-flex d-print-none align-items-center border-bottom pe-3">
+                    <div t-if="hasSideBar" class="o_sidebar_toggler d-none d-md-flex d-print-none align-items-center border-bottom pe-3">
                         <button class="btn btn-light oi oi-panel-right collapsed ms-2 lh-base" t-on-click="toggleSideBar"/>
                     </div>
-                    <MobileFilterPanel t-if="env.isSmall" t-props="mobileFilterPanelProps" />
+                    <MobileFilterPanel t-if="env.isSmall and hasSideBar" t-props="mobileFilterPanelProps" />
                     <div class="o_calendar_wrapper d-flex overflow-hidden">
                         <t t-if="showCalendar" t-component="props.Renderer" t-props="rendererProps"/>
-                        <div t-if="showSideBar" class="o_calendar_sidebar_container d-print-none position-relative w-100 w-md-auto bg-view overflow-x-hidden overflow-y-auto">
+                        <div t-if="hasSideBar and showSideBar" class="o_calendar_sidebar_container d-print-none position-relative w-100 w-md-auto bg-view overflow-x-hidden overflow-y-auto">
                             <div class="o_calendar_sidebar">
-                                <DatePicker t-if="!env.isSmall" t-props="datePickerProps" />
+                                <DatePicker t-if="showDatePicker" t-props="datePickerProps" />
                                 <FilterPanel t-props="filterPanelProps" />
                             </div>
                         </div>

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -73,7 +73,11 @@ export class CalendarModel extends Model {
         return this.meta.canDelete;
     }
     get canEdit() {
-        return this.meta.canEdit && this.data.hasEditRight && !this.meta.fields[this.meta.fieldMapping.date_start].readonly;
+        return (
+            this.meta.canEdit &&
+            this.data.hasEditRight &&
+            !this.meta.fields[this.meta.fieldMapping.date_start].readonly
+        );
     }
     get eventLimit() {
         return this.meta.eventLimit;
@@ -137,6 +141,9 @@ export class CalendarModel extends Model {
     }
     get scales() {
         return this.meta.scales;
+    }
+    get showDatePicker() {
+        return this.meta.showDatePicker;
     }
     get storageKey() {
         return `scaleOf-viewId-${this.env.config.viewId}`;
@@ -488,9 +495,12 @@ export class CalendarModel extends Model {
      */
     fetchRecords(data) {
         const { context, fieldNames, resModel } = this.meta;
-        return this.orm.searchRead(resModel, this.computeDomain(data), [
-            ...new Set([...fieldNames, ...Object.keys(this.meta.activeFields)]),
-        ], { context });
+        return this.orm.searchRead(
+            resModel,
+            this.computeDomain(data),
+            [...new Set([...fieldNames, ...Object.keys(this.meta.activeFields)])],
+            { context }
+        );
     }
     /**
      * @protected

--- a/addons/web/static/tests/views/calendar/calendar_arch_parser.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_arch_parser.test.js
@@ -26,6 +26,7 @@ const DEFAULT_ARCH_RESULTS = {
     scale: "week",
     scales: ["day", "week", "month", "year"],
     showUnusualDays: false,
+    showDatePicker: true,
 };
 
 function parseArch(arch) {

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -3741,14 +3741,14 @@ test(`form_view_id attribute works (for creating events)`, async () => {
         },
     });
 
-    onRpc("create", () => {
+    onRpc("create", () =>
         // we simulate here the case where a create call with just
         // the field name fails.  This is a normal flow, the server
         // reject the create rpc (quick create), then the web client
         // fall back to a form view. This happens typically when a
         // model has required fields
-        return Promise.reject("None shall pass!");
-    });
+        Promise.reject("None shall pass!")
+    );
 
     await mountView({
         resModel: "event",
@@ -3805,14 +3805,14 @@ test(`calendar fallback to form view id in action if necessary`, async () => {
         },
     });
 
-    onRpc("create", () => {
+    onRpc("create", () =>
         // we simulate here the case where a create call with just
         // the field name fails.  This is a normal flow, the server
         // reject the create rpc (quick create), then the web client
         // fall back to a form view. This happens typically when a
         // model has required fields
-        return Promise.reject("None shall pass!");
-    });
+        Promise.reject("None shall pass!")
+    );
     await mountView({
         resModel: "event",
         type: "calendar",
@@ -4640,6 +4640,39 @@ test(`popover ignores readonly field modifier`, async () => {
 });
 
 test.tags("desktop");
+test(`calendar with option show_date_picker set to false and no filter`, async () => {
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `
+            <calendar date_start="start" date_stop="stop" show_date_picker="0">
+                <field name="name"/>
+            </calendar>
+        `,
+    });
+    expect(`.o_datetime_picker`).toHaveCount(0);
+    expect(`.o_calendar_sidebar`).toHaveCount(0);
+    expect(`.o_sidebar_toggler`).toHaveCount(0);
+});
+
+test.tags("desktop");
+test(`calendar with option show_date_picker set to false and filters`, async () => {
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `
+            <calendar date_start="start" date_stop="stop" show_date_picker="0">
+                <field name="name"/>
+                <field name="partner_id" filters="1"/>
+            </calendar>
+        `,
+    });
+    expect(`.o_datetime_picker`).toHaveCount(0);
+    expect(`.o_calendar_sidebar`).toHaveCount(1);
+    expect(`.o_sidebar_toggler`).toHaveCount(1);
+});
+
+test.tags("desktop");
 test(`can not select invalid scale from datepicker`, async () => {
     await mountView({
         resModel: "event",
@@ -5215,7 +5248,6 @@ test("simple calendar rendering in mobile", async () => {
 
     expect(".o_calendar_button_prev").toHaveCount(0, { message: "prev button should be hidden" });
     expect(".o_calendar_button_next").toHaveCount(0, { message: "next button should be hidden" });
-    await displayCalendarPanel();
     expect(".o_calendar_container .o_calendar_header button.o_calendar_button_today").toBeVisible({
         message: "today button should be visible",
     });
@@ -5281,9 +5313,7 @@ test("calendar: today button", async () => {
 
     expect(queryFirst(".fc-col-header-cell[data-date]").dataset.date).toBe("2016-12-11");
 
-    await contains(".o_other_calendar_panel").click();
     await contains(".o_calendar_button_today").click();
-    await contains(".o_other_calendar_panel").click();
     expect(queryFirst(".fc-col-header-cell[data-date]").dataset.date).toBe("2016-12-12");
 });
 
@@ -5481,7 +5511,7 @@ test("calendar: check context is correclty sent to fetch data", async () => {
 });
 
 test(`disable editing without write access rights`, async () => {
-    onRpc("has_access", ({ args }) => args[1] != 'write');
+    onRpc("has_access", ({ args }) => args[1] != "write");
     await mountView({
         resModel: "event",
         type: "calendar",
@@ -5491,5 +5521,7 @@ test(`disable editing without write access rights`, async () => {
             </calendar>
         `,
     });
-    expect(`.fc-event-draggable`).toHaveCount(0, { message: "Record should not be draggable/editable" });
+    expect(`.fc-event-draggable`).toHaveCount(0, {
+        message: "Record should not be draggable/editable",
+    });
 });

--- a/odoo/addons/base/rng/calendar_view.rng
+++ b/odoo/addons/base/rng/calendar_view.rng
@@ -28,6 +28,7 @@
             <rng:optional><rng:attribute name="delete"/></rng:optional>
             <rng:optional><rng:attribute name="edit"/></rng:optional>
             <rng:optional><rng:attribute name="scales"/></rng:optional>
+            <rng:optional><rng:attribute name="show_date_picker"/></rng:optional>
             <rng:optional>
                 <rng:attribute name="mode">
                     <rng:choice>


### PR DESCRIPTION
This new option allows, by setting it to a falsy value, to get rid of the mini calendar displayed on the right sidepanel of calendar views.

We use this option in hr_holidays views, which allows to remove a customization.

Part of task-4510549

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
