### PR TITLE
[FIX] *sale: fix visibility of quantity buttons in product configurator

### DIFF
--- a/addons/sale/static/src/js/product/product.xml
+++ b/addons/sale/static/src/js/product/product.xml
@@ -29,7 +29,7 @@
             </t>
         </td>
         <td class="o_sale_product_configurator_qty py-3 px-0 text-end">
-            <t t-if="!this.props.optional">
+            <t t-if="!this.props.optional &amp;&amp; env.showQuantity">
                 <div
                     name="sale_product_configurator_quantity_buttons"
                     class="input-group justify-content-center">
@@ -56,7 +56,7 @@
                     </button>
                 </div>
             </t>
-            <t t-else="">
+            <t t-elif="this.props.optional">
                 <t t-call="sale.product_price" name="sale_product_configurator_optional_price"/>
             </t>
             <a

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -27,6 +27,13 @@ export class ProductConfiguratorDialog extends Component {
         currencyId: { type: Number, optional: true },
         soDate: String,
         edit: { type: Boolean, optional: true },
+        options: {
+            type: Object,
+            optional: true,
+            shape: {
+                showQuantity : { type: Boolean, optional: true },
+            },
+        },
         save: Function,
         discard: Function,
         close: Function, // This is the close from the env of the Dialog Component
@@ -52,6 +59,7 @@ export class ProductConfiguratorDialog extends Component {
         useSubEnv({
             mainProductTmplId: this.props.productTemplateId,
             currency: this.currency,
+            showQuantity: this.props.options?.showQuantity ?? true,
             addProduct: this._addProduct.bind(this),
             removeProduct: this._removeProduct.bind(this),
             setQuantity: this._setQuantity.bind(this),

--- a/addons/sale/static/src/js/product_list/product_list.xml
+++ b/addons/sale/static/src/js/product_list/product_list.xml
@@ -12,8 +12,15 @@
             <thead t-if="!this.props.areProductsOptional">
                 <tr>
                     <th class="px-0 border-bottom-0" colspan="2">Product</th>
-                    <th class="px-0 text-center border-bottom-0">Quantity</th>
-                    <th class="px-0 text-end border-bottom-0">Price</th>
+                    <th t-if="env.showQuantity" class="px-0 text-center border-bottom-0">
+                        Quantity
+                    </th>
+                    <th
+                        class="px-0 text-end border-bottom-0"
+                        t-att-colspan="env.showQuantity ? 1 : 2"
+                    >
+                        Price
+                    </th>
                 </tr>
             </thead>
             <tbody class="border-top-0">

--- a/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -10,9 +10,9 @@ patch(ProductConfiguratorDialog, {
         ...ProductConfiguratorDialog.props,
         isFrontend: { type: Boolean, optional: true },
         options: {
-            type: Object,
-            optional: true,
+            ...ProductConfiguratorDialog.props.options,
             shape: {
+                ...ProductConfiguratorDialog.props.options.shape,
                 isMainProductConfigurable: { type: Boolean, optional: true },
             },
         },

--- a/addons/website_sale/static/src/js/website_sale_product_configurator.js
+++ b/addons/website_sale/static/src/js/website_sale_product_configurator.js
@@ -41,7 +41,10 @@ WebsiteSale.include({
             soDate: serializeDateTime(DateTime.now()),
             edit: false,
             isFrontend: true,
-            options: { isMainProductConfigurable: !isOnProductPage },
+            options: {
+                isMainProductConfigurable: !isOnProductPage,
+                showQuantity: Boolean(document.querySelector('.js_add_cart_json')),
+            },
             save: async (mainProduct, optionalProducts, options) => {
                 this._trackProducts([mainProduct, ...optionalProducts]);
 


### PR DESCRIPTION
Before this fix, the quantity buttons were always visible in eCommerce, even if the website didn't allow changing the quantity.