### PR TITLE
[FIX] stock_account: added read access right to the stock valuation layer to inv/user group

### DIFF
--- a/addons/stock_account/views/stock_lot_views.xml
+++ b/addons/stock_account/views/stock_lot_views.xml
@@ -7,10 +7,9 @@
         <field name="inherit_id" ref="stock.view_production_lot_form"/>
         <field name="arch" type="xml">
         <xpath expr="//div[@name='button_box']" position="inside">
-            <field name="stock_valuation_layer_ids" invisible="1"/>
             <button type="object"
                 name="action_view_stock_valuation_layers"
-                class="oe_stat_button" icon="fa-dollar" groups="account.group_account_invoice"
+                class="oe_stat_button" icon="fa-dollar" groups="stock.group_stock_manager"
                 invisible="not stock_valuation_layer_ids">
                 <div class="o_stat_info">
                     <span class="o_stat_text">Valuation</span>


### PR DESCRIPTION

steps to reproduce the bug:
 - install inventory and invoicing app
 - change the user access right of the inventory app to `User`
 - access any of the serial number you have in any of the apps having it

Problem:
Error is raised because no access right for the `stock.valuation.layer` model to the user group. new attribute `stock_valuation_layer_ids` was added to the `stock.lot`model on the stock_account module, and hence no access right for that model for the user group so now anyone with user access to inventory app won't be able to access the serial numbers or edit them

opw-4466042
opw-4551745

Description of the issue/feature this PR addresses:

Current behavior before PR: users with `user access right to inventory app` can't access the serial numbers

Desired behavior after PR is merged: users with `user access right to inventory app` can access the serial numbers


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
