### PR TITLE
[IMP] web: add context props to Record component

### DIFF
--- a/addons/web/static/src/model/record.js
+++ b/addons/web/static/src/model/record.js
@@ -34,6 +34,7 @@ class _Record extends Component {
                 activeFields,
                 resId: this.props.info.resId,
                 mode: this.props.info.mode,
+                context: this.props.info.context,
             },
             hooks: {
                 onRecordSaved: this.props.info.onRecordSaved || (() => {}),
@@ -42,9 +43,7 @@ class _Record extends Component {
             },
         };
         const modelServices = Object.fromEntries(
-            StandaloneRelationalModel.services.map((servName) => {
-                return [servName, useService(servName)];
-            })
+            StandaloneRelationalModel.services.map((servName) => [servName, useService(servName)])
         );
         modelServices.orm = this.orm;
         this.model = useState(new StandaloneRelationalModel(this.env, modelParams, modelServices));
@@ -162,14 +161,20 @@ export class Record extends Component {
         "resId?",
         "mode?",
         "values?",
+        "context?",
         "onRecordChanged?",
         "onRecordSaved?",
         "onWillSaveRecord?",
     ];
+    static defaultProps = {
+        context: {},
+    };
     setup() {
         const { activeFields, fieldNames, fields, resModel } = this.props;
         if (!activeFields && !fieldNames) {
-            throw Error(`Record props should have either a "activeFields" key or a "fieldNames" key`);
+            throw Error(
+                `Record props should have either a "activeFields" key or a "fieldNames" key`
+            );
         }
         if (!fields && (!fieldNames || !resModel)) {
             throw Error(

--- a/addons/web/static/tests/model/record.test.js
+++ b/addons/web/static/tests/model/record.test.js
@@ -96,6 +96,33 @@ test(`can be updated with different resId`, async () => {
     expect.verifySteps(["/web/dataset/call_kw/foo/web_read"]);
 });
 
+test(`can be receive a context as props`, async () => {
+    class Parent extends Component {
+        static props = ["*"];
+        static components = { Record, Field };
+        static template = xml`
+            <div class="root">
+                <Record resModel="'foo'" fieldNames="['foo']" context="{ test: 4 }" t-slot-scope="data">
+                    <Field name="'foo'" record="data.record"/>
+                </Record>
+            </div>
+        `;
+    }
+
+    onRpc("onchange", ({ kwargs }) => {
+        expect.step(`onchange`);
+        expect(kwargs.context).toEqual({
+            allowed_company_ids: [1],
+            lang: "en",
+            test: 4,
+            tz: "taht",
+            uid: 7,
+        });
+    });
+    await mountWithCleanup(Parent);
+    expect.verifySteps(["onchange"]);
+});
+
 test(`predefined fields and values`, async () => {
     class Parent extends Component {
         static props = ["*"];


### PR DESCRIPTION
Before this commit, it was not possible to specify a custom context when using the Record component. Now it is. It is especially useful to set `default_*` keys, s.t. some fields get the proper default value.

Part of task-4510549

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
