### PR TITLE
[FIX] loyalty: preventing errors when  product category is missing

### DIFF
--- a/addons/loyalty/data/loyalty_data.xml
+++ b/addons/loyalty/data/loyalty_data.xml
@@ -6,7 +6,7 @@
         <field name="list_price">50</field>
         <field name="type">service</field>
         <field name="purchase_ok" eval="False"/>
-        <field name="categ_id" ref="product.product_category_services"/>
+        <field name="categ_id" eval="ref('product.product_category_services', raise_if_not_found=False)"/>
         <field name="image_1920" type="base64" file="loyalty/static/img/gift_card.png"/>
     </record>
     <!-- Basic product for eWallet programs -->
@@ -15,7 +15,7 @@
         <field name="list_price">50</field>
         <field name="type">service</field>
         <field name="purchase_ok" eval="False"/>
-        <field name="categ_id" ref="product.product_category_services"/>
+        <field name="categ_id" eval="ref('product.product_category_services', raise_if_not_found=False)"/>
     </record>
 
     <data noupdate="1">


### PR DESCRIPTION
Currently, an exception is generated when a user tries to find the 'Services' product category after it has been deleted.

Steps to reproduce:

1. Install the sale_management module.
2. Navigate to Sales -> Configuration -> Product Categories.
3. Delete the 'Services' category.
4. Go to Sales Settings.
5. Enable 'Promotions, Loyalty & Gift Cards'.
6. Click Save -> An error occurs.

Error:
```ParseError
while parsing /home/odoo/src/odoo/saas-18.1/addons/loyalty/data/loyalty
_data.xml:4, somewhere inside
```

This issue[1] occurs because when the system tries to reference the missing
'Services' product category, it results in a ParseError due to a missing
required record.

[1] -
https://github.com/odoo/odoo/blob/4d9984d0b5f5a856104d11261fecd27ddc2e5466/addons/loyalty/data/loyalty_data.xml#L4-L11

This fix resolves the issue by providing a False value when the 'Services'
product category is missing.

sentry-6243406444

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
