### PR TITLE
[FIX] point_of_sale: lot-serial dialog in small ui

### DIFF
--- a/addons/point_of_sale/static/src/app/store/select_lot_popup/edit_list_input/edit_list_input.scss
+++ b/addons/point_of_sale/static/src/app/store/select_lot_popup/edit_list_input/edit_list_input.scss
@@ -35,3 +35,9 @@
 .pos .edit-list-inputs .options-dropdown .option:hover {
     background-color: $gray-200;
 }
+
+@media (max-width: 575px) {
+    .pos .edit-list-inputs .options-dropdown {
+        position: static;
+    }
+}


### PR DESCRIPTION
Before this commit:
==
- Lot-serial dropdown not visible in the small UI.

After this commit:
==
- Displayed the lot-serial dropdown in the small UI.

opw-4551161


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
