### PR TITLE
[FIX] mrp: add MO lines for kit variant components when BoM update

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2406,14 +2406,14 @@ class MrpProduction(models.Model):
         def operation_key_values(record):
             return tuple(record[key] for key in ('company_id', 'name', 'workcenter_id'))
 
-        def filter_by_attributes(record):
-            product_attribute_ids = self.product_id.product_template_attribute_value_ids.ids
+        def filter_by_attributes(record, target_product=self.product_id):
+            product_attribute_ids = target_product.product_template_attribute_value_ids.ids
             return not record.bom_product_template_attribute_value_ids or\
                    any(att_val.id in product_attribute_ids for att_val in record.bom_product_template_attribute_value_ids)
 
         ratio = self._get_ratio_between_mo_and_bom_quantities(bom)
         _dummy, bom_lines = bom.explode(self.product_id, bom.product_qty)
-        bom_lines_by_id = {(line.id, line.product_id.id): line for line, _dummy in bom_lines if filter_by_attributes(line)}
+        bom_lines_by_id = {(line.id, line.product_id.id): line for line, context in bom_lines if filter_by_attributes(line, context['product'])}
         bom_byproducts_by_id = {byproduct.id: byproduct for byproduct in bom.byproduct_ids.filtered(filter_by_attributes)}
         operations_by_id = {operation.id: operation for operation in bom.operation_ids.filtered(filter_by_attributes)}
 


### PR DESCRIPTION
Issue
-----
When using the "Update BOM" button for a confirmed manufacturing order, components used to produce a specific variant of a kit product are not added to the MO consumables.

Steps to reproduce
-----
- Install Manufacturing app
- Create a BoM for the "T-Shirt" product
    - Add a "Logo" product as a consumable
- Create a "Fabric" product, with "Material" Attribute with values "P" & "C"
- Create a BoM for the "Fabric" product
    - Set Bom Type to "Kit"
    - Add a "Thread" product as a consumable
    - Add a "Polyester" product as a consumable for variant "P"
    - Add a "Coton" product as a consumable for variant "C"
- Create a Manufacturing Order for "T-Shirt"
- Confirm the MO
- Open the BoM (click the link in the form)
- Add "Fabric (C)" as a component to the BoM
- Go back to the MO and click "Udate BoM"

-> There is no line for the consumption of "Coton" from the "Fabric" BoM

Cause
-----
The _link_bom method filters the bom_lines to keep based on the attributes of the final product only, instead of the bom_line's intermediate product.

-----
Ticket:
opw-4480039
