### PR TITLE
[FIX] purchase_stock: prevent error when opening replenish wizard

### DIFF
--- a/addons/purchase_stock/tests/test_replenish_wizard.py
+++ b/addons/purchase_stock/tests/test_replenish_wizard.py
@@ -492,3 +492,14 @@ class TestReplenishWizard(TestStockCommon):
             ('partner_id', '=', partner_b.id)
         ])
         self.assertEqual(po.amount_untaxed, 10, "best price is 10$")
+
+    def test_delete_buy_route_and_replenish(self):
+        """ Test that the replenish wizard does not crash when the 'buy' route is deleted """
+        self.env.ref('purchase_stock.route_warehouse0_buy', raise_if_not_found=False).unlink()
+        self.product1.product_tmpl_id.seller_ids.unlink()
+        replenish_wizard = self.env['product.replenish'].create({
+            'product_id': self.product1.id,
+            'product_tmpl_id': self.product1.product_tmpl_id.id,
+            'product_uom_id': self.uom_unit.id,
+        })
+        self.assertTrue(replenish_wizard._get_route_domain(self.product1.product_tmpl_id))

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -104,6 +104,7 @@ class ProductReplenish(models.TransientModel):
 
     def _get_route_domain(self, product_tmpl_id):
         domain = super()._get_route_domain(product_tmpl_id)
-        if not product_tmpl_id.seller_ids:
-            domain = AND([domain, [('id', '!=', self.env.ref('purchase_stock.route_warehouse0_buy', raise_if_not_found=False).id)]])
+        buy_route = self.env.ref('purchase_stock.route_warehouse0_buy', raise_if_not_found=False)
+        if buy_route and not product_tmpl_id.seller_ids:
+            domain = AND([domain, [('id', '!=', buy_route.id)]])
         return domain


### PR DESCRIPTION
Currently, an error occurs when the replenish wizard is unable to find the default 'Buy' route, which the user may have deleted.

Steps to produce:
- Install the `purchase_stock` module.
- Activate `Multi-Step Routes` from Settings.
- Navigate to `Inventory > Configuration > Warehouse Management > Routes (list)`.
- Delete the `Buy` route record.
- Create a new product without adding vendors or defining routes.
- Click on the `Replenish` button.
- Observe the error.

`AttributeError: 'NoneType' object has no attribute 'id'`

The issue occurs when attempting to access the `id` of the 'Buy' route `purchase_stock.route_warehouse0_buy` - [1], without verifying if it exists. If this route is missing, `self.env.ref(...)` returns `None` which leads to an `AttributeError`.

This commit resolves the issue by checking whether the `purchase_stock.route_warehouse0_buy` route exists before attempting to access its `id`. This prevents errors when the route is missing.

[1] - https://github.com/odoo/odoo/blob/58f4b01dda6ba2e67c21663399aab1c189f4a312/addons/purchase_stock/wizard/product_replenish.py#L108

Sentry-6275025957

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
