### PR TITLE
[IMP] analytic,web: Record: support all model hooks

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -309,7 +309,9 @@ export class AnalyticDistribution extends Component {
             fields: recordFields,
             values: values,
             activeFields: recordFields,
-            onRecordChanged: async (record, changes) => await this.lineChanged(record, changes, line),
+            hooks: {
+                onRecordChanged: async (record, changes) => await this.lineChanged(record, changes, line),
+            }
         }
     }
 

--- a/addons/web/static/src/model/record.js
+++ b/addons/web/static/src/model/record.js
@@ -36,11 +36,7 @@ class _Record extends Component {
                 mode: this.props.info.mode,
                 context: this.props.info.context,
             },
-            hooks: {
-                onRecordSaved: this.props.info.onRecordSaved || (() => {}),
-                onWillSaveRecord: this.props.info.onWillSaveRecord || (() => {}),
-                onRecordChanged: this.props.info.onRecordChanged || (() => {}),
-            },
+            hooks: this.props.info.hooks,
         };
         const modelServices = Object.fromEntries(
             StandaloneRelationalModel.services.map((servName) => [servName, useService(servName)])
@@ -162,9 +158,7 @@ export class Record extends Component {
         "mode?",
         "values?",
         "context?",
-        "onRecordChanged?",
-        "onRecordSaved?",
-        "onWillSaveRecord?",
+        "hooks?",
     ];
     static defaultProps = {
         context: {},

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -203,6 +203,10 @@ export class Record extends DataPoint {
         });
     }
 
+    getChanges({ withReadonly } = {}) {
+        return this._getChanges(this._changes, { withReadonly });
+    }
+
     async isDirty() {
         await this.model._askChanges();
         return this.dirty;

--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -172,7 +172,7 @@ export class RelationalModel extends Model {
         const data = await this.keepLast.add(this._loadData(config));
         this.root = this._createRoot(config, data);
         this.config = config;
-        return this.hooks.onRootLoaded();
+        return this.hooks.onRootLoaded(this.root);
     }
 
     // -------------------------------------------------------------------------
@@ -638,7 +638,7 @@ export class RelationalModel extends Model {
             commit(data);
         }
         if (reload && config.isRoot) {
-            return this.hooks.onRootLoaded();
+            return this.hooks.onRootLoaded(this.root);
         }
     }
 
@@ -680,10 +680,12 @@ export class RelationalModel extends Model {
         const groupBy = config.groupBy[0];
         const aggregates = [
             "__count",
-            ...getAggregateSpecifications(pick(
-                config.fields,
-                ...Object.keys(config.activeFields).filter(fname => fname != groupBy)
-            )),
+            ...getAggregateSpecifications(
+                pick(
+                    config.fields,
+                    ...Object.keys(config.activeFields).filter((fname) => fname != groupBy)
+                )
+            ),
         ];
         const orderBy = [];
         let groupByInsideOrder = false;

--- a/addons/web/static/src/views/kanban/progress_bar_hook.js
+++ b/addons/web/static/src/views/kanban/progress_bar_hook.js
@@ -345,8 +345,8 @@ export function useProgressBar(progressAttributes, model, aggregateFields, activ
         });
     };
     const onRootLoaded = model.hooks.onRootLoaded;
-    model.hooks.onRootLoaded = async () => {
-        await onRootLoaded();
+    model.hooks.onRootLoaded = async (root) => {
+        await onRootLoaded(root);
         return prom;
     };
 

--- a/addons/web/static/src/webclient/res_user_group_ids_field/res_user_group_ids_field.js
+++ b/addons/web/static/src/webclient/res_user_group_ids_field/res_user_group_ids_field.js
@@ -46,6 +46,9 @@ export class ResUserGroupIdsField extends Component {
                 </group>
             </t>`;
         this.archInfo = new FormArchParser().parse(parseXML(arch), models, "main");
+        this.hooks = {
+            onRecordChanged: this.onRecordChanged.bind(this),
+        };
     }
 
     get values() {

--- a/addons/web/static/src/webclient/res_user_group_ids_field/res_user_group_ids_field.xml
+++ b/addons/web/static/src/webclient/res_user_group_ids_field/res_user_group_ids_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="web.ResUserGroupIdsField">
-    <Record fields="fields" fieldNames="Object.keys(fields)" values="values" onRecordChanged.bind="onRecordChanged" t-slot-scope="data">
+    <Record fields="fields" fieldNames="Object.keys(fields)" values="values" hooks="hooks" t-slot-scope="data">
         <FormRenderer record="data.record" archInfo="archInfo"/>
     </Record>
 </t>


### PR DESCRIPTION
This commit is two-fold.

First, it alters the props of the Record component: it now takes
a `hooks` props, which is an object of callbacks. That way, all
hooks supported by the RelationalModel are supported by the Record
component (instead of the few that were hardcoded before).

Second, a `getChanges` function has been introduced on the Record
datapoint. It offers a public API for code outside of the model to
access the changes of a record.

Combined, those changes allow business code using the Record
component to 1) retrieve the root datapoint (with the onRootLoaded
hook), and 2) to access the changes on the record. This was
necessary for task-4510549.
