### PR TITLE
[IMP] html_editor: add custom font size input in toolbar using iframe

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -20,6 +20,7 @@ import { FontSelector } from "./font_selector";
 import { getBaseContainerSelector } from "@html_editor/utils/base_container";
 import { withSequence } from "@html_editor/utils/resource";
 import { reactive } from "@odoo/owl";
+import { FontSizeSelector } from "./font_size_selector";
 
 export const fontItems = [
     {
@@ -179,7 +180,7 @@ export class FontPlugin extends Plugin {
                             tagName: item.tagName,
                             extraClass: item.extraClass,
                         });
-                        this.updateFontParams();
+                        this.updateFontSelectorParams();
                     },
                 },
             },
@@ -187,16 +188,23 @@ export class FontPlugin extends Plugin {
                 id: "font-size",
                 groupId: "font-size",
                 title: _t("Font size"),
-                Component: FontSelector,
+                Component: FontSizeSelector,
                 props: {
                     getItems: () => this.fontSizeItems,
                     getDisplay: () => this.fontSize,
+                    onFontSizeInput: (size) => {
+                        this.dependencies.format.formatSelection("fontSize", {
+                            formatProps: { size },
+                            applyStyle: true,
+                        });
+                        this.updateFontSizeSelectorParams();
+                    },
                     onSelected: (item) => {
                         this.dependencies.format.formatSelection("setFontSizeClassName", {
                             formatProps: { className: item.className },
                             applyStyle: true,
                         });
-                        this.updateFontParams();
+                        this.updateFontSizeSelectorParams();
                     },
                 },
             },
@@ -241,9 +249,18 @@ export class FontPlugin extends Plugin {
 
         /** Handlers */
         input_handlers: this.onInput.bind(this),
-        selectionchange_handlers: this.updateFontParams.bind(this),
-        post_undo_handlers: this.updateFontParams.bind(this),
-        post_redo_handlers: this.updateFontParams.bind(this),
+        selectionchange_handlers: [
+            this.updateFontSelectorParams.bind(this),
+            this.updateFontSizeSelectorParams.bind(this),
+        ],
+        post_undo_handlers: [
+            this.updateFontSelectorParams.bind(this),
+            this.updateFontSizeSelectorParams.bind(this),
+        ],
+        post_redo_handlers: [
+            this.updateFontSelectorParams.bind(this),
+            this.updateFontSizeSelectorParams.bind(this),
+        ],
 
         /** Overrides */
         split_element_block_overrides: [
@@ -485,8 +502,12 @@ export class FontPlugin extends Plugin {
             this.dependencies.dom.setTag({ tagName: headingToBe });
         }
     }
-    updateFontParams() {
+
+    updateFontSelectorParams() {
         this.font.displayName = this.fontName;
+    }
+
+    updateFontSizeSelectorParams() {
         this.fontSize.displayName = this.fontSizeName;
     }
 }

--- a/addons/html_editor/static/src/main/font/font_size_selector.js
+++ b/addons/html_editor/static/src/main/font/font_size_selector.js
@@ -1,0 +1,106 @@
+import { Component, onMounted, useEffect, useRef, useState } from "@odoo/owl";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { toolbarButtonProps } from "@html_editor/main/toolbar/toolbar";
+import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
+import { useDebounced } from "@web/core/utils/timing";
+
+const MAX_FONT_SIZE = 144;
+
+export class FontSizeSelector extends Component {
+    static template = "html_editor.FontSizeSelector";
+    static props = {
+        getItems: Function,
+        getDisplay: Function,
+        onFontSizeInput: Function,
+        onSelected: Function,
+        ...toolbarButtonProps,
+    };
+    static components = { Dropdown, DropdownItem };
+
+    setup() {
+        this.items = this.props.getItems();
+        this.state = useState(this.props.getDisplay());
+        this.dropdown = useDropdownState();
+        this.iframeContentRef = useRef("iframeContent");
+        this.debouncedCustomFontSizeInput = useDebounced(this.onCustomFontSizeInput, 200);
+
+        onMounted(() => {
+            const iframeEl = this.iframeContentRef.el;
+            const iframeDoc = iframeEl.contentWindow.document;
+            this.fontSizeInput = iframeDoc.createElement("input");
+            Object.assign(iframeDoc.body.style, {
+                padding: "0",
+                margin: "0",
+            });
+            Object.assign(this.fontSizeInput.style, {
+                width: "100%",
+                height: "100%",
+                border: "none",
+                outline: "none",
+                textAlign: "center",
+            });
+            this.fontSizeInput.type = "text";
+            this.fontSizeInput.name = "font-size-input";
+            this.fontSizeInput.autocomplete = "off";
+            iframeDoc.body.appendChild(this.fontSizeInput);
+            this.fontSizeInput.addEventListener("click", () => {
+                if (!this.dropdown.isOpen) {
+                    this.dropdown.open();
+                }
+            });
+            this.fontSizeInput.addEventListener("input", this.debouncedCustomFontSizeInput);
+            this.fontSizeInput.addEventListener("keydown", this.onKeyDownFontSizeInput.bind(this));
+        });
+        useEffect(
+            () => {
+                // Update `fontSizeInputValue` whenever the font size changes.
+                this.fontSizeInput.value = this.state.displayName;
+            },
+            () => [this.state.displayName]
+        );
+        useEffect(
+            () => {
+                // Focus input on dropdown open, blur on close.
+                this.dropdown.isOpen ? this.fontSizeInput.select() : this.fontSizeInput.blur();
+            },
+            () => [this.dropdown.isOpen]
+        );
+    }
+
+    onCustomFontSizeInput(ev) {
+        let fontSize = parseInt(ev.target.value, 10);
+        if (fontSize > 0) {
+            fontSize = Math.min(fontSize, MAX_FONT_SIZE);
+            if (this.state.displayName !== fontSize) {
+                this.props.onFontSizeInput(`${fontSize}px`);
+            } else {
+                // Reset input if state.displayName does not change.
+                this.fontSizeInput.value = this.state.displayName;
+            }
+        }
+    }
+
+    onKeyDownFontSizeInput(ev) {
+        if (["Enter", "Tab"].includes(ev.key) && this.dropdown.isOpen) {
+            this.dropdown.close();
+        } else if (["ArrowUp", "ArrowDown"].includes(ev.key)) {
+            const fontSizeSelectorMenu = document.querySelector(".o_font_size_selector_menu");
+            if (!fontSizeSelectorMenu) {
+                return;
+            }
+            ev.target.blur();
+            const fontSizeMenuItemToFocus =
+                ev.key === "ArrowUp"
+                    ? fontSizeSelectorMenu.lastElementChild
+                    : fontSizeSelectorMenu.firstElementChild;
+            if (fontSizeMenuItemToFocus) {
+                fontSizeMenuItemToFocus.focus();
+            }
+        }
+    }
+
+    onSelected(item) {
+        this.props.onSelected(item);
+    }
+}

--- a/addons/html_editor/static/src/main/font/font_size_selector.scss
+++ b/addons/html_editor/static/src/main/font/font_size_selector.scss
@@ -1,0 +1,3 @@
+.o_font_size_selector_menu {
+    --dropdown-min-width: none;
+}

--- a/addons/html_editor/static/src/main/font/font_size_selector.xml
+++ b/addons/html_editor/static/src/main/font/font_size_selector.xml
@@ -1,0 +1,16 @@
+<templates xml:space="preserve">
+    <t t-name="html_editor.FontSizeSelector">
+        <Dropdown state="dropdown" menuClass="'o_font_size_selector_menu'">
+            <button class="btn btn-light" t-att-title="props.title">
+                <iframe t-ref="iframeContent" style="width: 4ch; height:100%;"/>
+            </button>
+            <t t-set-slot="content">
+                <t t-foreach="items" t-as="item" t-key="item_index">
+                    <DropdownItem onSelected="() => this.onSelected(item)" t-on-pointerdown.prevent="() => {}">
+                        <t t-esc="item.name"/>
+                    </DropdownItem>
+                </t>
+            </t>
+        </Dropdown>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -94,7 +94,10 @@ export const formatsSpecs = {
         isFormatted: (node) =>
             FONT_SIZE_CLASSES.find((cls) => closestElement(node)?.classList?.contains(cls)),
         hasStyle: (node, props) => FONT_SIZE_CLASSES.find((cls) => node.classList.contains(cls)),
-        addStyle: (node, props) => node.classList.add(props.className),
+        addStyle: (node, props) => {
+            node.style.removeProperty("font-size");
+            node.classList.add(props.className);
+        },
         removeStyle: (node) => removeClass(node, ...FONT_SIZE_CLASSES, ...TEXT_STYLE_CLASSES),
     },
     switchDirection: {

--- a/addons/html_editor/static/tests/_helpers/editor.js
+++ b/addons/html_editor/static/tests/_helpers/editor.js
@@ -153,6 +153,8 @@ export async function testEditor(config) {
             });
         };
     }
+    const isMobileTest = config.props?.mobile;
+    delete config.props?.mobile;
     const { el, editor } = await setupEditor(contentBefore, config);
     // The stageSelection should have been triggered by the click on
     // the editable. As we set the selection programmatically, we dispatch the
@@ -163,7 +165,20 @@ export async function testEditor(config) {
     editor.shared.history.stageSelection();
 
     if (config.props?.iframe) {
-        expect("iframe").toHaveCount(1);
+        const selection = editor.document.getSelection();
+        // If there is no selection, iframe count remains 1 on both mobile
+        // and desktop since the toolbar is not open.
+        // When a selection exists:
+        //   - On mobile: The toolbar remains open regardless of whether
+        //     selection is collapsed or not, so the iframe count is 2.
+        //   - On desktop: The toolbar opens only when selection is not
+        //     collapsed, resulting in 2 iframes; otherwise, it remains 1.
+        // 2 iframes because the font size input is inside its own iframe.
+        let iframeCount = 1;
+        if (selection.anchorNode) {
+            iframeCount = isMobileTest || !selection.isCollapsed ? 2 : 1;
+        }
+        expect("iframe").toHaveCount(iframeCount);
     }
 
     if (contentBeforeEdit) {

--- a/addons/html_editor/static/tests/misc.test.js
+++ b/addons/html_editor/static/tests/misc.test.js
@@ -33,7 +33,7 @@ test("cannot reattach a destroyed editor", async () => {
 test.tags("iframe");
 test("can instantiate a Editor in an iframe", async () => {
     const { el, editor } = await setupEditor("<p>hel[lo] world</p>", { props: { iframe: true } });
-    expect("iframe").toHaveCount(1);
+    expect("iframe").toHaveCount(2);
     expect(el.innerHTML).toBe(`<p>hello world</p>`);
     expect(getContent(el)).toBe(`<p>hel[lo] world</p>`);
     setContent(el, "<div>a[dddb]</div>");

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -40,10 +40,21 @@ test("should open the Powerbox on type `/`", async () => {
     expect(".o-we-powerbox").toHaveCount(1);
 });
 
-test.tags("iframe");
-test("in iframe: should open the Powerbox on type `/`", async () => {
+test.tags("iframe", "desktop");
+test("in iframe, desktop: should open the Powerbox on type `/`", async () => {
     const { el, editor } = await setupEditor("<p>ab[]</p>", { props: { iframe: true } });
     expect("iframe").toHaveCount(1);
+    expect(".o-we-powerbox").toHaveCount(0);
+    expect(getContent(el)).toBe("<p>ab[]</p>");
+    await insertText(editor, "/");
+    await animationFrame();
+    expect(".o-we-powerbox").toHaveCount(1);
+});
+
+test.tags("iframe", "mobile");
+test("in iframe, mobile: should open the Powerbox on type `/`", async () => {
+    const { el, editor } = await setupEditor("<p>ab[]</p>", { props: { iframe: true } });
+    expect("iframe").toHaveCount(2);
     expect(".o-we-powerbox").toHaveCount(0);
     expect(getContent(el)).toBe("<p>ab[]</p>");
     await insertText(editor, "/");

--- a/addons/html_editor/static/tests/table/tabulation.test.js
+++ b/addons/html_editor/static/tests/table/tabulation.test.js
@@ -32,10 +32,39 @@ describe("move selection with tab/shift+tab", () => {
                 `),
             });
         });
-        test.tags("iframe");
-        test("should move cursor to the end of next cell in an iframe", async () => {
+        test.tags("iframe", "desktop");
+        test("in iframe, desktop: should move cursor to the end of next cell in an iframe", async () => {
             await testEditor({
                 props: { iframe: true },
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>[]ab</td>
+                                <td>cd</td>
+                                <td>ef</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: async () => press("Tab"),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab</td>
+                                <td>cd[]</td>
+                                <td>ef</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+        test.tags("iframe", "mobile");
+        test("in iframe, mobile: should move cursor to the end of next cell in an iframe", async () => {
+            await testEditor({
+                props: { iframe: true, mobile: true },
                 contentBefore: unformat(`
                     <table>
                         <tbody>

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -2,6 +2,7 @@ import { withSequence } from "@html_editor/utils/resource";
 import { describe, expect, test } from "@odoo/hoot";
 import {
     click,
+    getActiveElement,
     keyDown,
     keyUp,
     manuallyDispatchProgrammaticEvent,
@@ -10,6 +11,7 @@ import {
     press,
     queryAll,
     queryAllTexts,
+    queryOne,
     waitFor,
     waitForNone,
 } from "@odoo/hoot-dom";
@@ -298,26 +300,24 @@ test("toolbar works: can select font size", async () => {
     expect(".o-we-toolbar").toHaveCount(0);
     setContent(el, "<p>[test]</p>");
     await waitFor(".o-we-toolbar");
-    expect(".o-we-toolbar [name='font-size']").toHaveText(
-        getFontSizeFromVar("body-font-size").toString()
-    );
+    const iframeEl = queryOne(".o-we-toolbar [name='font-size'] iframe");
+    const inputEl = iframeEl.contentWindow.document?.querySelector("input");
+    expect(inputEl).toHaveValue(getFontSizeFromVar("body-font-size").toString());
 
     await contains(".o-we-toolbar [name='font-size'] .dropdown-toggle").click();
     const sizes = new Set(
-        fontSizeItems.map((item) => {
-            return getFontSizeFromVar(item.variableName).toString();
-        })
+        fontSizeItems.map((item) => getFontSizeFromVar(item.variableName).toString())
     );
-    expect(queryAllTexts(".o_font_selector_menu .dropdown-item")).toEqual([...sizes]);
+    expect(queryAllTexts(".o_font_size_selector_menu .dropdown-item")).toEqual([...sizes]);
     const h1Size = getFontSizeFromVar("h1-font-size").toString();
-    await contains(`.o_font_selector_menu .dropdown-item:contains('${h1Size}')`).click();
+    await contains(`.o_font_size_selector_menu .dropdown-item:contains('${h1Size}')`).click();
     expect(getContent(el)).toBe(`<p><span class="h1-fs">[test]</span></p>`);
-    expect(".o-we-toolbar [name='font-size']").toHaveText(h1Size);
+    expect(inputEl).toHaveValue(h1Size);
     await contains(".o-we-toolbar [name='font-size'] .dropdown-toggle").click();
     const oSmallSize = getFontSizeFromVar("small-font-size").toString();
-    await contains(`.o_font_selector_menu .dropdown-item:contains('${oSmallSize}')`).click();
+    await contains(`.o_font_size_selector_menu .dropdown-item:contains('${oSmallSize}')`).click();
     expect(getContent(el)).toBe(`<p><span class="o_small-fs">[test]</span></p>`);
-    expect(".o-we-toolbar [name='font-size']").toHaveText(oSmallSize);
+    expect(inputEl).toHaveValue(oSmallSize);
 });
 
 test.tags("desktop");
@@ -336,16 +336,87 @@ test("toolbar works: display correct font size on select all", async () => {
         return Math.round(pxValue);
     };
     await waitFor(".o-we-toolbar");
+    const iframeEl = queryOne(".o-we-toolbar [name='font-size'] iframe");
+    const inputEl = iframeEl.contentWindow.document?.querySelector("input");
     await contains(".o-we-toolbar [name='font-size'] .dropdown-toggle").click();
     await animationFrame();
     const h1Size = getFontSizeFromVar("h1-font-size").toString();
-    await contains(`.o_font_selector_menu .dropdown-item:contains('${h1Size}')`).click();
+    await contains(`.o_font_size_selector_menu .dropdown-item:contains('${h1Size}')`).click();
     expect(getContent(el)).toBe(`<p><span class="h1-fs">[test]</span></p>`);
     setContent(el, `<p><span class="h1-fs">te[]st</span></p>`);
     await waitForNone(".o-we-toolbar");
     await press(["ctrl", "a"]); // Select all
     await waitFor(".o-we-toolbar");
-    expect(".o-we-toolbar [name='font-size']").toHaveText(`${h1Size}`);
+    expect(inputEl).toHaveValue(`${h1Size}`);
+});
+
+test("toolbar works: displays correct font size on input", async () => {
+    const { el } = await setupEditor("<p>[test]</p>");
+    await waitFor(".o-we-toolbar");
+
+    const iframeEl = queryOne(".o-we-toolbar [name='font-size'] iframe");
+    expect(iframeEl).toHaveCount(1);
+    const inputEl = iframeEl.contentWindow.document?.querySelector("input");
+    await contains(inputEl).click();
+    // Ensure that the input has the default font size value.
+    expect(inputEl).toHaveValue("14");
+    expect(".o_font_size_selector_menu").toHaveCount(1);
+    // Ensure that the selection is still present in the editable.
+    expect(getContent(el)).toBe(`<p>[test]</p>`);
+    expect(getActiveElement()).toBe(inputEl);
+
+    await press("8");
+    expect(inputEl).toHaveValue("8");
+    await advanceTime(200);
+    expect(".o_font_size_selector_menu").toHaveCount(1);
+    expect(getContent(el)).toBe(`<p><span style="font-size: 8px;">[test]</span></p>`);
+    expect(".o-we-toolbar").toHaveCount(1);
+});
+
+test("toolbar works: font size dropdown closes on Enter and Tab key press", async () => {
+    await setupEditor("<p>[test]</p>");
+    await waitFor(".o-we-toolbar");
+
+    const iframeEl = queryOne(".o-we-toolbar [name='font-size'] iframe");
+    expect(iframeEl).toHaveCount(1);
+    const inputEl = iframeEl.contentWindow.document?.querySelector("input");
+    await contains(inputEl).click();
+    expect(".o_font_size_selector_menu").toHaveCount(1);
+
+    await press("Enter");
+    await animationFrame();
+    expect(".o_font_size_selector_menu").toHaveCount(0);
+
+    await contains(inputEl).click();
+    expect(".o_font_size_selector_menu").toHaveCount(1);
+    await press("Tab");
+    await animationFrame();
+    expect(".o_font_size_selector_menu").toHaveCount(0);
+});
+
+test("toolbar works: ArrowUp/Down moves focus to font size dropdown", async () => {
+    await setupEditor("<p>[test]</p>");
+    await waitFor(".o-we-toolbar");
+
+    const iframeEl = queryOne(".o-we-toolbar [name='font-size'] iframe");
+    expect(iframeEl).toHaveCount(1);
+    const inputEl = iframeEl.contentWindow.document?.querySelector("input");
+    await contains(inputEl).click();
+    expect(".o_font_size_selector_menu").toHaveCount(1);
+    expect(getActiveElement()).toBe(inputEl);
+
+    const fontSizeSelectorMenu = queryOne(".o_font_size_selector_menu");
+    await press("ArrowDown");
+    await animationFrame();
+    expect(".o_font_size_selector_menu").toHaveCount(1);
+    expect(getActiveElement()).toBe(fontSizeSelectorMenu.firstElementChild);
+
+    await contains(inputEl).click();
+    expect(".o_font_size_selector_menu").toHaveCount(1);
+    await press("ArrowUp");
+    await animationFrame();
+    expect(".o_font_size_selector_menu").toHaveCount(1);
+    expect(getActiveElement()).toBe(fontSizeSelectorMenu.lastElementChild);
 });
 
 test.tags("desktop");


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- The editor only provided a font size dropdown with predefined options, preventing the selection of a custom font size.

### Desired behavior after PR is merged:

- A font size input field is added to toolbar using an _`iframe`_, ensuring the selection remains intact in editable area.
- Clicking the font size input selects the text and displays the predefined font size dropdown.  
- The entered value in the font size input is applied to the selected content after a _`200ms`_ debounce.
- The font size can also be selected from the dropdown.
- Font size dropdown closes on Enter and Tab key press.
- ArrowUp/Down moves focus to font size dropdown.

task-4488396

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
