### PR TITLE
[FIX] website: fix display options of searchbar

### DIFF
--- a/addons/website/static/src/snippets/s_searchbar/search_bar.js
+++ b/addons/website/static/src/snippets/s_searchbar/search_bar.js
@@ -127,7 +127,7 @@ export class SearchBar extends Interaction {
                 hasMoreResults: results.length < res["results_count"],
                 search: this.inputEl.value,
                 fuzzySearch: res["fuzzy_search"],
-                widget: this,
+                widget: this.options,
             }, this.el)[0];
         }
         this.hasDropdown = !!res;


### PR DESCRIPTION
Since [1] when the searchbar was converted from public widgets to interactions, the display options are only stored inside the `options` field of the interaction, while they were also available in the public widget itself.
Because of this, the icons did not appear anymore when displaying the search results.

This commit fixes this by providing the options to the QWeb context instead of the interaction instance.

Steps to reproduce:
- Install website.
- Click on the search icon.
- Type 'a'.

=> Icons were not displayed in front of the results anymore.

[1]: https://github.com/odoo/odoo/commit/b9b3a605e0f4c5da3a258c980107d6162da7f44f#diff-c4ffbfa5c52a0766010068916597a5e8cb2ea25a7e3b9bf73ef8601108ccb221L43-L46

task-4367641
