### PR TITLE
[REF] html_editor: remove unused parameter in `pasteText`

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -258,14 +258,13 @@ export class ClipboardPlugin extends Plugin {
         if (this.delegateTo("paste_text_overrides", selection, text)) {
             return;
         } else {
-            this.pasteText(selection, text);
+            this.pasteText(text);
         }
     }
     /**
-     * @param {EditorSelection} selection
      * @param {string} text
      */
-    pasteText(selection, text) {
+    pasteText(text) {
         const textFragments = text.split(/\r?\n/);
         let textIndex = 1;
         for (const textFragment of textFragments) {
@@ -279,10 +278,8 @@ export class ClipboardPlugin extends Plugin {
                 });
             });
             this.dependencies.dom.insert(modifiedTextFragment);
-            // The selection must be updated after calling insert, as the insertion
-            // process modifies the selection.
-            selection = this.dependencies.selection.getEditableSelection();
             if (textIndex < textFragments.length) {
+                const selection = this.dependencies.selection.getEditableSelection();
                 // Break line by inserting new paragraph and
                 // remove current paragraph's bottom margin.
                 const block = closestBlock(selection.anchorNode);
@@ -308,7 +305,6 @@ export class ClipboardPlugin extends Plugin {
                         blockBefore.remove();
                         cursors.remapNode(blockBefore, div).restore();
                     }
-                    selection = this.dependencies.selection.getEditableSelection();
                 }
             }
             textIndex++;

--- a/addons/html_editor/static/src/main/link/link_paste_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_paste_plugin.js
@@ -90,7 +90,7 @@ export class LinkPastePlugin extends Plugin {
                     this.dependencies.link.createLink(url, splitAroundUrl[i])
                 );
             } else if (splitAroundUrl[i] !== "") {
-                this.dependencies.clipboard.pasteText(selection, splitAroundUrl[i]);
+                this.dependencies.clipboard.pasteText(splitAroundUrl[i]);
             }
         }
     }


### PR DESCRIPTION
**Reason**:
After PR https://github.com/odoo/odoo/pull/196130, we discovered that the `selection` parameter of `pasteText` was unnecessary. It was not used before calling `insert`, and after that, the selection is outdated. The current selection should instead be retrieved from the selection plugin.

**Change**:
Remove the unused `selection` parameter from `pasteText`.

opw-4558222

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
