### PR TITLE
[FIX] hr_recruitment : Allow Interviewer to search with applicant name

### DIFF
--- a/addons/hr_recruitment/security/ir.model.access.csv
+++ b/addons/hr_recruitment/security/ir.model.access.csv
@@ -3,7 +3,7 @@ access_hr_job_interviewer,hr.job.interviewer,hr.model_hr_job,group_hr_recruitmen
 access_hr_job_user,hr.job user,model_hr_job,group_hr_recruitment_user,1,1,1,1
 hr.access_hr_job_user,hr.job user,model_hr_job,hr.group_hr_user,1,0,0,0
 access_hr_applicant_interviewer,hr.applicant.interviewer,model_hr_applicant,group_hr_recruitment_interviewer,1,1,0,0
-access_hr_candidate_interviewer,hr.candidate.interviewer,model_hr_candidate,group_hr_recruitment_interviewer,0,1,0,0
+access_hr_candidate_interviewer,hr.candidate.interviewer,model_hr_candidate,group_hr_recruitment_interviewer,1,1,0,0
 access_hr_applicant_user,hr.applicant.user,model_hr_applicant,group_hr_recruitment_user,1,1,1,1
 access_hr_candidate_user,hr.candidate.user,model_hr_candidate,group_hr_recruitment_user,1,1,1,1
 access_hr_recruitment_stage_interviewer,hr.recruitment.stage.interviewer,model_hr_recruitment_stage,group_hr_recruitment_interviewer,1,0,0,0


### PR DESCRIPTION
### Steps to reproduce:
	- Create a user with 'Interviewer' group
	- Assign that user as interviewer to few applications
	- Log in as this user
	- Go to All applications list view in Recruitment module
	- Search on 'Applicant'

### Cause:
In https://github.com/odoo-dev/odoo/commit/de79f671150ba29737ffc92d22687463b561524d#diff-3a7fc7935e58656320cc3e13fe8311415c847ae6a4273d87ef606ed520f83754 after introducing the hr_candidate we added an access rule for interviewer group to access this class but he can only write on it and can't search on it.

### Fix:
We updated the access rule of the interviewer group so hec an be able to search on Applicant name.

opw-4501932