### PR TITLE
[FIX] account: invoice report average price

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -133,6 +133,30 @@ class AccountInvoiceReport(models.Model):
                 AND line.display_type = 'product'
         '''
 
+    @api.model
+    def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
+        """
+        This is a hack to allow us to correctly calculate the average price.
+        """
+        set_fields = set(fields)
+
+        if 'price_average:avg' in fields:
+            set_fields.add('quantity')
+            set_fields.add('price_subtotal')
+
+        res = super().read_group(domain, list(set_fields), groupby, offset, limit, orderby, lazy)
+
+        if 'price_average:avg' in fields:
+            for data in res:
+                data['price_average'] = data['price_subtotal'] / data['quantity'] if data['quantity'] else 0
+
+                if 'quantity' not in fields:
+                    del data['quantity']
+                if 'price_subtotal' not in fields:
+                    del data['price_subtotal']
+
+        return res
+
 
 class ReportInvoiceWithoutPayment(models.AbstractModel):
     _name = 'report.account.report_invoice'

--- a/addons/account/tests/test_account_invoice_report.py
+++ b/addons/account/tests/test_account_invoice_report.py
@@ -117,3 +117,57 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
             [20, -20, -1],
             [600, -600, -1],
         ])
+
+    def test_avg_price_calculation(self):
+        """
+        Check that the average is correctly calculated based on the total price and quantity:
+            3 lines:
+                - 10 units * 10$
+                -  5 units *  5$
+                - 20 units *  2$
+            Total quantity: 35
+            Total price: 165$
+            Average: 165 / 35 = 4.71
+        """
+        product = self.product_a.copy()
+        invoice = self.env["account.move"].create({
+            'move_type': 'out_invoice',
+                'partner_id': self.partner_a.id,
+                'invoice_date': fields.Date.from_string('2016-01-01'),
+                'currency_id': self.env.company.currency_id.id,
+                'invoice_line_ids': [
+                    (0, None, {
+                        'product_id': product.id,
+                        'quantity': 10,
+                        'price_unit': 10,
+                    }),
+                    (0, None, {
+                        'product_id': product.id,
+                        'quantity': 5,
+                        'price_unit': 5,
+                    }),
+                    (0, None, {
+                        'product_id': product.id,
+                        'quantity': 20,
+                        'price_unit': 2,
+                    }),
+                ]
+        })
+        invoice.action_post()
+
+        report = self.env['account.invoice.report'].read_group(
+            [('product_id', '=', product.id)],
+            ['price_subtotal', 'quantity', 'price_average:avg'],
+            [],
+        )
+        self.assertEqual(report[0]['quantity'], 35)
+        self.assertEqual(report[0]['price_subtotal'], 165)
+        self.assertEqual(round(report[0]['price_average'], 2), 4.71)
+
+        # ensure that it works with only 'price_average:avg' in fields
+        report = self.env['account.invoice.report'].read_group(
+            [('product_id', '=', product.id)],
+            ['price_average:avg'],
+            [],
+        )
+        self.assertEqual(round(report[0]['price_average'], 2), 4.71)


### PR DESCRIPTION
Steps:

- Create and confirm an invoice with 3 lines for the same product P:
    1 - 10 quantity, 10$
    2 -  5 quantity,  5$
    3 - 20 quantity,  2$
- Go to invoice analysis, pivot view
- Filter to see only product P
- Measure Untaxed Amount, Product Quantity and Average Price
-> The average price is 5.67 instead of 4.71

This is because the SQL query calculates the average of each line before
calculating the average of the 3 lines instead of calculating the global
average.

With this commit, we override the `read_group` method to make the
correct calcultaion of the average price.

opw-4503562
