### PR TITLE
[IMP] web: list: force column widths computation on dblclick

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -317,9 +317,15 @@
             // 'initial' as it will force them to 'inline', not 'table-cell'.
             display: table-cell !important;
         }
-
-        &.o_resizing tr > :not(.o_column_resizing) {
-            opacity: 0.5;
+        
+        tbody .o_column_resizing {
+            position: relative;
+            &:after {
+                @include o-position-absolute($top: 0, $bottom: 0, $right: 0);
+                background-color: #{$border-color};
+                width: 4px;
+                content: '';
+            }
         }
 
         &.o_empty_list {

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -38,7 +38,8 @@
                                     </div>
                                     <span
                                           class="o_resize position-absolute top-0 end-0 bottom-0 ps-1 bg-black-25 opacity-0 opacity-50-hover z-1"
-                                          t-on-pointerdown.stop.prevent="this.columnWidths.onStartResize"/>
+                                          t-on-pointerdown.stop.prevent="this.columnWidths.onStartResize"
+                                          t-on-dblclick="this.columnWidths.resetWidths"/>
                                 </t>
                             </th>
                             <th t-else="" t-on-keydown="(ev) => this.onCellKeydown(ev)" t-att-class="{'o_list_button w-print-0 p-print-0': column.type === 'button_group'}"/>

--- a/addons/web/static/tests/views/list/column_widths.test.js
+++ b/addons/web/static/tests/views/list/column_widths.test.js
@@ -1536,3 +1536,24 @@ test(`resize: unnamed columns cannot be resized`, async () => {
         message: "Columns without name should not have a resize handle",
     });
 });
+
+test(`dblclick on resize handle to force a recomputation of all widths`, async () => {
+    await mountView({
+        type: "list",
+        resModel: "foo",
+        arch: `
+            <list>
+                <field name="foo"/>
+                <field name="int_field"/>
+            </list>`,
+    });
+
+    const originalWidths = getColumnWidths();
+    await contains(`th:eq(1) .o_resize`, { visible: false }).dragAndDrop(`th:eq(2)`);
+    const widthsAfterResize = getColumnWidths();
+    expect(widthsAfterResize[0]).toBe(originalWidths[0]);
+    expect(widthsAfterResize[1]).toBeGreaterThan(originalWidths[1]);
+
+    await contains(".o_list_table th .o_resize", { visible: false }).dblclick();
+    expect(getColumnWidths()).toEqual(originalWidths);
+});


### PR DESCRIPTION
This commit allows to force the a column widths recomputation by dblclicking on the resize handle, in the list view header. This helps for x2many lists, when the user just created a record which doesn't fit well with default widths initially computed, or when browsing to the next page.

Task-4555667

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
