### PR TITLE
[IMP] orm, account: remove ignore_duplicates from _load_records

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -494,7 +494,7 @@ class AccountChartTemplate(models.AbstractModel):
 
         return data
 
-    def _load_data(self, data, ignore_duplicates=False):
+    def _load_data(self, data):
         """Load all the data linked to the template into the database.
 
         The data can contain translation values (i.e. `name@fr_FR` to translate the name in French)
@@ -504,8 +504,6 @@ class AccountChartTemplate(models.AbstractModel):
         :param data: Basically all the final data of records to create/update for the chart
                      of accounts. It is a mapping {model: {xml_id: values}}.
         :type data: dict[str, dict[(str, int), dict]]
-
-        :param ignore_duplicates: if true, inputs that match records already in the DB will be ignored
         """
         def deref_values(values, model):
             """Replace xml_id references by database ids in all provided values.
@@ -628,7 +626,7 @@ class AccountChartTemplate(models.AbstractModel):
                     'values': deref_values(record_vals, self.env[model]),
                     'noupdate': True,
                 })
-            created_records[model] = self.with_context(lang='en_US').env[model]._load_records(all_records_vals, ignore_duplicates=ignore_duplicates)
+            created_records[model] = self.with_context(lang='en_US').env[model]._load_records(all_records_vals)
         return created_records
 
     def _post_load_data(self, template_code, company, template_data):

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -4668,13 +4668,12 @@ class BaseModel(metaclass=MetaModel):
             records._clean_properties()
         return records
 
-    def _load_records(self, data_list, update=False, ignore_duplicates=False):
+    def _load_records(self, data_list, update=False):
         """ Create or update records of this model, and assign XMLIDs.
 
             :param data_list: list of dicts with keys `xml_id` (XMLID to
                 assign), `noupdate` (flag on XMLID), `values` (field values)
             :param update: should be ``True`` when upgrading a module
-            :param ignore_duplicates: if true, inputs that match records already in the DB will be ignored
 
             :return: the records corresponding to ``data_list``
         """
@@ -4708,6 +4707,8 @@ class BaseModel(metaclass=MetaModel):
                     to_update.append(data)
                 elif not update:
                     to_create.append(data)
+                else:
+                    raise ValidationError(_("Cannot update a record without specifying its id or xml_id"))
                 continue
             row = existing.get(xml_id)
             if not row:
@@ -4731,11 +4732,8 @@ class BaseModel(metaclass=MetaModel):
                 to_create.append(data)
 
         # update existing records
-        if ignore_duplicates:
-            data_list = [data for data in data_list if data not in to_update]
-        else:
-            for data in to_update:
-                data['record']._load_records_write(data['values'])
+        for data in to_update:
+            data['record']._load_records_write(data['values'])
 
         # check for records to create with an XMLID from another module
         module = self.env.context.get('install_module')


### PR DESCRIPTION
the return value of _load_records is defined as

    :return: the records corresponding to ``data_list``

which implies the guarantee:

    ``len(_load_records(data_list, ..)) == len(data_list)``

However, ``ignore_duplicates`` introduced in https://github.com/odoo/odoo/pull/160203 violated this rule.
Specifically, ``_load_records(data_list, update=False, ignore_duplicates=True)``
only returns newly created records.
And ``_load_records(data_list, update=True, ignore_duplicates=True)``, returns
newly created records and pre-existing noupdate records.
It is hard to define the method's feature.

The logic of ignoring duplicates was kept exclusive to l10n_fr_fec_import module, since it was only used there.
And the commit https://github.com/odoo/odoo/commit/613fbb33de82b748f09bc3c15ecf186aec3c8605 responsible for adding the logic in account and ORM was reverted.

task-4556286




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
