### PR TITLE
[FIX] web_editor: fix non-deterministic test timeouts

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/link.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/link.test.js
@@ -737,7 +737,7 @@ describe('Link', () => {
                 contentAfter: '<p><a href="#/">[]abc</a></p>',
             });
         });
-        it('should zwnbsp-pad simple text link', async () => {
+        describe('should zwnbsp-pad simple text link', () => {
             const removeZwnbsp = editor => {
                 for (const descendant of descendants(editor.editable)) {
                     if (descendant.nodeType === Node.TEXT_NODE && descendant.textContent === '\ufeff') {
@@ -745,68 +745,78 @@ describe('Link', () => {
                     }
                 }
             }
-            await testEditor(BasicEditor, {
-                contentBefore: '<p>a[]<a href="#/">bc</a>d</p>',
-                contentBeforeEdit: '<p>a[]\ufeff<a href="#/">\ufeffbc\ufeff</a>\ufeffd</p>',
-                stepFunction: async editor => {
-                    removeZwnbsp(editor);
-                    const p = editor.editable.querySelector('p');
-                    setSelection(p, 1, p, 1, false); // set the selection via the parent
-                    editor.sanitize(); // insert the zwnbsp again
-                },
-                contentAfterEdit: '<p>a[]\ufeff<a href="#/">\ufeffbc\ufeff</a>\ufeffd</p>',
+            it('should zwnbsp-pad simple text link (1)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a[]<a href="#/">bc</a>d</p>',
+                    contentBeforeEdit: '<p>a[]\ufeff<a href="#/">\ufeffbc\ufeff</a>\ufeffd</p>',
+                    stepFunction: async editor => {
+                        removeZwnbsp(editor);
+                        const p = editor.editable.querySelector('p');
+                        setSelection(p, 1, p, 1, false); // set the selection via the parent
+                        editor.sanitize(); // insert the zwnbsp again
+                    },
+                    contentAfterEdit: '<p>a[]\ufeff<a href="#/">\ufeffbc\ufeff</a>\ufeffd</p>',
+                });
             });
-            await testEditor(BasicEditor, {
-                contentBefore: '<p>a<a href="#/">[]bc</a>d</p>',
-                contentBeforeEdit: '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]bc\ufeff</a>\ufeffd</p>',
-                stepFunction: async editor => {
-                    removeZwnbsp(editor);
-                    const a = editor.editable.querySelector('a');
-                    setSelection(a, 0, a, 0, false); // set the selection via the parent
-                    await nextTick();
-                    editor.sanitize(); // insert the zwnbsp again
-                },
-                contentAfterEdit: '<p>a\ufeff<a href="#/" class="o_link_in_selection">[]\ufeffbc\ufeff</a>\ufeffd</p>',
+            it('should zwnbsp-pad simple text link (2)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="#/">[]bc</a>d</p>',
+                    contentBeforeEdit: '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]bc\ufeff</a>\ufeffd</p>',
+                    stepFunction: async editor => {
+                        removeZwnbsp(editor);
+                        const a = editor.editable.querySelector('a');
+                        setSelection(a, 0, a, 0, false); // set the selection via the parent
+                        await nextTick();
+                        editor.sanitize(); // insert the zwnbsp again
+                    },
+                    contentAfterEdit: '<p>a\ufeff<a href="#/" class="o_link_in_selection">[]\ufeffbc\ufeff</a>\ufeffd</p>',
+                });
             });
-            await testEditor(BasicEditor, {
-                contentBefore: '<p>a<a href="#/">b[]</a>d</p>',
-                contentBeforeEdit: '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffb[]\ufeff</a>\ufeffd</p>',
-                stepFunction: async editor => {
-                    const a = editor.editable.querySelector('a');
-                    // Insert an extra character as a text node so we can set
-                    // the selection between the characters while still
-                    // targetting their parent.
-                    a.appendChild(document.createTextNode('c'));
-                    removeZwnbsp(editor);
-                    setSelection(a, 1, a, 1, false); // set the selection via the parent
-                    await nextTick();
-                    editor.sanitize(); // insert the zwnbsp again
-                },
-                contentAfterEdit: '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffb[]c\ufeff</a>\ufeffd</p>',
+            it('should zwnbsp-pad simple text link (3)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="#/">b[]</a>d</p>',
+                    contentBeforeEdit: '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffb[]\ufeff</a>\ufeffd</p>',
+                    stepFunction: async editor => {
+                        const a = editor.editable.querySelector('a');
+                        // Insert an extra character as a text node so we can set
+                        // the selection between the characters while still
+                        // targetting their parent.
+                        a.appendChild(document.createTextNode('c'));
+                        removeZwnbsp(editor);
+                        setSelection(a, 1, a, 1, false); // set the selection via the parent
+                        await nextTick();
+                        editor.sanitize(); // insert the zwnbsp again
+                    },
+                    contentAfterEdit: '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffb[]c\ufeff</a>\ufeffd</p>',
+                });
             });
-            await testEditor(BasicEditor, {
-                contentBefore: '<p>a<a href="#/">bc[]</a>d</p>',
-                contentBeforeEdit: '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffbc[]\ufeff</a>\ufeffd</p>',
-                stepFunction: async editor => {
-                    removeZwnbsp(editor);
-                    const a = editor.editable.querySelector('a');
-                    setSelection(a, 1, a, 1, false); // set the selection via the parent
-                    await nextTick();
-                    editor.sanitize(); // insert the zwnbsp again
-                },
-                contentAfterEdit: '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffbc\ufeff[]</a>\ufeffd</p>',
+            it('should zwnbsp-pad simple text link (4)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="#/">bc[]</a>d</p>',
+                    contentBeforeEdit: '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffbc[]\ufeff</a>\ufeffd</p>',
+                    stepFunction: async editor => {
+                        removeZwnbsp(editor);
+                        const a = editor.editable.querySelector('a');
+                        setSelection(a, 1, a, 1, false); // set the selection via the parent
+                        await nextTick();
+                        editor.sanitize(); // insert the zwnbsp again
+                    },
+                    contentAfterEdit: '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffbc\ufeff[]</a>\ufeffd</p>',
+                });
             });
-            await testEditor(BasicEditor, {
-                contentBefore: '<p>a<a href="#/">bc</a>[]d</p>',
-                contentBeforeEdit: '<p>a\ufeff<a href="#/">\ufeffbc\ufeff</a>\ufeff[]d</p>',
-                stepFunction: async editor => {
-                    descendants(editor.editable).forEach(c => c.nodeType === Node.TEXT_NODE && c.textContent === '\ufeff' && c.remove()); // remove the zwnbsp
-                    const p = editor.editable.querySelector('p');
-                    setSelection(p, 2, p, 2, false); // set the selection via the parent
-                    await nextTick();
-                    editor.sanitize(); // insert the zwnbsp again
-                },
-                contentAfterEdit: '<p>a\ufeff<a href="#/">\ufeffbc\ufeff</a>\ufeff[]d</p>',
+            it('should zwnbsp-pad simple text link (5)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="#/">bc</a>[]d</p>',
+                    contentBeforeEdit: '<p>a\ufeff<a href="#/">\ufeffbc\ufeff</a>\ufeff[]d</p>',
+                    stepFunction: async editor => {
+                        descendants(editor.editable).forEach(c => c.nodeType === Node.TEXT_NODE && c.textContent === '\ufeff' && c.remove()); // remove the zwnbsp
+                        const p = editor.editable.querySelector('p');
+                        setSelection(p, 2, p, 2, false); // set the selection via the parent
+                        await nextTick();
+                        editor.sanitize(); // insert the zwnbsp again
+                    },
+                    contentAfterEdit: '<p>a\ufeff<a href="#/">\ufeffbc\ufeff</a>\ufeff[]d</p>',
+                });
             });
         });
         it('should not zwnbsp-pad nav-link', async () => {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/list.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/list.test.js
@@ -3425,68 +3425,84 @@ describe('List', () => {
                         });
                     });
                     describe('Checklist to unordered', () => {
-                        it('should delete across an checklist list and an unordered list', async () => {
+                        describe('should delete across an checklist list and an unordered list', () => {
                             // Forward selection
-                            await testEditor(BasicEditor, {
-                                removeCheckIds: true,
-                                contentBefore:
-                                    '<ul class="o_checklist"><li class="o_checked">ab[cd</li></ul><ul><li class="o_checked">ef]gh</li></ul>',
-                                stepFunction: deleteForward,
-                                contentAfter:
-                                    '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                            it('should delete across an checklist list and an unordered list (1)', async () => {
+                                await testEditor(BasicEditor, {
+                                    removeCheckIds: true,
+                                    contentBefore:
+                                        '<ul class="o_checklist"><li class="o_checked">ab[cd</li></ul><ul><li class="o_checked">ef]gh</li></ul>',
+                                    stepFunction: deleteForward,
+                                    contentAfter:
+                                        '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                                });
                             });
-                            await testEditor(BasicEditor, {
-                                removeCheckIds: true,
-                                contentBefore:
-                                    '<ul class="o_checklist"><li>ab[cd</li></ul><ul><li class="o_checked">ef]gh</li></ul>',
-                                stepFunction: deleteForward,
-                                contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
+                            it('should delete across an checklist list and an unordered list (2)', async () => {
+                                await testEditor(BasicEditor, {
+                                    removeCheckIds: true,
+                                    contentBefore:
+                                        '<ul class="o_checklist"><li>ab[cd</li></ul><ul><li class="o_checked">ef]gh</li></ul>',
+                                    stepFunction: deleteForward,
+                                    contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
+                                });
                             });
-                            await testEditor(BasicEditor, {
-                                removeCheckIds: true,
-                                contentBefore:
-                                    '<ul class="o_checklist"><li class="o_checked">ab[cd</li></ul><ul><li>ef]gh</li></ul>',
-                                stepFunction: deleteForward,
-                                contentAfter:
-                                    '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                            it('should delete across an checklist list and an unordered list (3)', async () => {
+                                await testEditor(BasicEditor, {
+                                    removeCheckIds: true,
+                                    contentBefore:
+                                        '<ul class="o_checklist"><li class="o_checked">ab[cd</li></ul><ul><li>ef]gh</li></ul>',
+                                    stepFunction: deleteForward,
+                                    contentAfter:
+                                        '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                                });
                             });
-                            await testEditor(BasicEditor, {
-                                removeCheckIds: true,
-                                contentBefore:
-                                    '<ul class="o_checklist"><li>ab[cd</li></ul><ul><li>ef]gh</li></ul>',
-                                stepFunction: deleteForward,
-                                contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
+                            it('should delete across an checklist list and an unordered list (4)', async () => {
+                                await testEditor(BasicEditor, {
+                                    removeCheckIds: true,
+                                    contentBefore:
+                                        '<ul class="o_checklist"><li>ab[cd</li></ul><ul><li>ef]gh</li></ul>',
+                                    stepFunction: deleteForward,
+                                    contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
+                                });
                             });
+                            it('should delete across an checklist list and an unordered list (5)', async () => {
                             // Backward selection
-                            await testEditor(BasicEditor, {
-                                removeCheckIds: true,
-                                contentBefore:
-                                    '<ul class="o_checklist"><li class="o_checked">ab]cd</li></ul><ul><li class="o_checked">ef[gh</li></ul>',
-                                stepFunction: deleteForward,
-                                contentAfter:
-                                    '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                                await testEditor(BasicEditor, {
+                                    removeCheckIds: true,
+                                    contentBefore:
+                                        '<ul class="o_checklist"><li class="o_checked">ab]cd</li></ul><ul><li class="o_checked">ef[gh</li></ul>',
+                                    stepFunction: deleteForward,
+                                    contentAfter:
+                                        '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                                });
                             });
-                            await testEditor(BasicEditor, {
-                                removeCheckIds: true,
-                                contentBefore:
-                                    '<ul class="o_checklist"><li>ab]cd</li></ul><ul><li class="o_checked">ef[gh</li></ul>',
-                                stepFunction: deleteForward,
-                                contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
+                            it('should delete across an checklist list and an unordered list (6)', async () => {
+                                await testEditor(BasicEditor, {
+                                    removeCheckIds: true,
+                                    contentBefore:
+                                        '<ul class="o_checklist"><li>ab]cd</li></ul><ul><li class="o_checked">ef[gh</li></ul>',
+                                    stepFunction: deleteForward,
+                                    contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
+                                });
                             });
-                            await testEditor(BasicEditor, {
-                                removeCheckIds: true,
-                                contentBefore:
-                                    '<ul class="o_checklist"><li class="o_checked">ab]cd</li></ul><ul><li>ef[gh</li></ul>',
-                                stepFunction: deleteForward,
-                                contentAfter:
-                                    '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                            it('should delete across an checklist list and an unordered list (7)', async () => {
+                                await testEditor(BasicEditor, {
+                                    removeCheckIds: true,
+                                    contentBefore:
+                                        '<ul class="o_checklist"><li class="o_checked">ab]cd</li></ul><ul><li>ef[gh</li></ul>',
+                                    stepFunction: deleteForward,
+                                    contentAfter:
+                                        '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                                });
                             });
-                            await testEditor(BasicEditor, {
-                                removeCheckIds: true,
-                                contentBefore:
-                                    '<ul class="o_checklist"><li>ab]cd</li></ul><ul><li>ef[gh</li></ul>',
-                                stepFunction: deleteForward,
-                                contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
+                            it('should delete across an checklist list and an unordered list (8)', async () => {
+                                await testEditor(BasicEditor, {
+                                    removeCheckIds: true,
+                                    contentBefore:
+                                        '<ul class="o_checklist"><li>ab]cd</li></ul><ul><li>ef[gh</li></ul>',
+                                    stepFunction: deleteForward,
+                                    contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
+                                });
                             });
                         });
                         it('should delete across an checklist list item and an unordered list item within an checklist list', async () => {
@@ -4417,64 +4433,78 @@ describe('List', () => {
                                     '<ul class="o_checklist"><li class="o_checked">[]<br></li></ul>',
                             });
                         });
-                        it('should merge a list item with its previous list item', async () => {
-                            await testEditor(BasicEditor, {
-                                removeCheckIds: true,
-                                contentBefore:
-                                    '<ul class="o_checklist"><li class="o_checked">abc</li><li class="o_checked">[]def</li></ul>',
-                                stepFunction: deleteBackward,
-                                contentAfter:
-                                    '<ul class="o_checklist"><li class="o_checked">abc</li></ul><p>[]def</p>',
+                        describe('should merge a list item with its previous list item', () => {
+                            it('should merge a list item with its previous list item (1)', async () => {
+                                await testEditor(BasicEditor, {
+                                    removeCheckIds: true,
+                                    contentBefore:
+                                        '<ul class="o_checklist"><li class="o_checked">abc</li><li class="o_checked">[]def</li></ul>',
+                                    stepFunction: deleteBackward,
+                                    contentAfter:
+                                        '<ul class="o_checklist"><li class="o_checked">abc</li></ul><p>[]def</p>',
+                                });
                             });
-                            await testEditor(BasicEditor, {
-                                removeCheckIds: true,
-                                contentBefore:
-                                    '<ul class="o_checklist"><li class="o_checked">abc</li><li>[]def</li></ul>',
-                                stepFunction: deleteBackward,
-                                contentAfter:
-                                    '<ul class="o_checklist"><li class="o_checked">abc</li></ul><p>[]def</p>',
+                            it('should merge a list item with its previous list item (2)', async () => {
+                                await testEditor(BasicEditor, {
+                                    removeCheckIds: true,
+                                    contentBefore:
+                                        '<ul class="o_checklist"><li class="o_checked">abc</li><li>[]def</li></ul>',
+                                    stepFunction: deleteBackward,
+                                    contentAfter:
+                                        '<ul class="o_checklist"><li class="o_checked">abc</li></ul><p>[]def</p>',
+                                });
                             });
-                            await testEditor(BasicEditor, {
-                                removeCheckIds: true,
-                                contentBefore:
-                                    '<ul class="o_checklist"><li>abc</li><li class="o_checked">[]def</li></ul>',
-                                stepFunction: deleteBackward,
-                                contentAfter: '<ul class="o_checklist"><li>abc</li></ul><p>[]def</p>',
+                            it('should merge a list item with its previous list item (3)', async () => {
+                                await testEditor(BasicEditor, {
+                                    removeCheckIds: true,
+                                    contentBefore:
+                                        '<ul class="o_checklist"><li>abc</li><li class="o_checked">[]def</li></ul>',
+                                    stepFunction: deleteBackward,
+                                    contentAfter: '<ul class="o_checklist"><li>abc</li></ul><p>[]def</p>',
+                                });
                             });
-                            // With another list item after.
-                            await testEditor(BasicEditor, {
-                                removeCheckIds: true,
-                                contentBefore:
-                                    '<ul class="o_checklist"><li class="o_checked">abc</li><li class="o_checked">[]def</li><li class="o_checked">ghi</li></ul>',
-                                stepFunction: deleteBackward,
-                                contentAfter:
-                                    '<ul class="o_checklist"><li class="o_checked">abc</li></ul><p>[]def</p><ul class="o_checklist"><li class="o_checked">ghi</li></ul>',
+                            it('should merge a list item with its previous list item (4)', async () => {
+                                // With another list item after.
+                                await testEditor(BasicEditor, {
+                                    removeCheckIds: true,
+                                    contentBefore:
+                                        '<ul class="o_checklist"><li class="o_checked">abc</li><li class="o_checked">[]def</li><li class="o_checked">ghi</li></ul>',
+                                    stepFunction: deleteBackward,
+                                    contentAfter:
+                                        '<ul class="o_checklist"><li class="o_checked">abc</li></ul><p>[]def</p><ul class="o_checklist"><li class="o_checked">ghi</li></ul>',
+                                });
                             });
-                            await testEditor(BasicEditor, {
-                                removeCheckIds: true,
-                                contentBefore:
-                                    '<ul class="o_checklist"><li class="o_checked">abc</li><li>[]def</li><li>ghi</li></ul>',
-                                stepFunction: deleteBackward,
-                                contentAfter:
-                                    '<ul class="o_checklist"><li class="o_checked">abc</li></ul><p>[]def</p><ul class="o_checklist"><li>ghi</li></ul>',
+                            it('should merge a list item with its previous list item (5)', async () => {
+                                await testEditor(BasicEditor, {
+                                    removeCheckIds: true,
+                                    contentBefore:
+                                        '<ul class="o_checklist"><li class="o_checked">abc</li><li>[]def</li><li>ghi</li></ul>',
+                                    stepFunction: deleteBackward,
+                                    contentAfter:
+                                        '<ul class="o_checklist"><li class="o_checked">abc</li></ul><p>[]def</p><ul class="o_checklist"><li>ghi</li></ul>',
+                                });
                             });
-                            await testEditor(BasicEditor, {
-                                removeCheckIds: true,
-                                contentBefore:
-                                    '<ul class="o_checklist"><li class="o_checked">abc</li><li>[]def</li><li class="o_checked">ghi</li></ul>',
-                                stepFunction: deleteBackward,
-                                contentAfter:
-                                    '<ul class="o_checklist"><li class="o_checked">abc</li></ul><p>[]def</p><ul class="o_checklist"><li class="o_checked">ghi</li></ul>',
+                            it('should merge a list item with its previous list item (6)', async () => {
+                                await testEditor(BasicEditor, {
+                                    removeCheckIds: true,
+                                    contentBefore:
+                                        '<ul class="o_checklist"><li class="o_checked">abc</li><li>[]def</li><li class="o_checked">ghi</li></ul>',
+                                    stepFunction: deleteBackward,
+                                    contentAfter:
+                                        '<ul class="o_checklist"><li class="o_checked">abc</li></ul><p>[]def</p><ul class="o_checklist"><li class="o_checked">ghi</li></ul>',
+                                });
                             });
-                            // Where the list item to merge into is empty, with an
-                            // empty list item before.
-                            await testEditor(BasicEditor, {
-                                removeCheckIds: true,
-                                contentBefore:
-                                    '<ul class="o_checklist"><li><br></li><li><br></li><li class="o_checked">[]abc</li></ul>',
-                                stepFunction: deleteBackward,
-                                contentAfter:
-                                    '<ul class="o_checklist"><li><br></li><li><br></li></ul><p>[]abc</p>',
+                            it('should merge a list item with its previous list item (7)', async () => {
+                                // Where the list item to merge into is empty, with an
+                                // empty list item before.
+                                await testEditor(BasicEditor, {
+                                    removeCheckIds: true,
+                                    contentBefore:
+                                        '<ul class="o_checklist"><li><br></li><li><br></li><li class="o_checked">[]abc</li></ul>',
+                                    stepFunction: deleteBackward,
+                                    contentAfter:
+                                        '<ul class="o_checklist"><li><br></li><li><br></li></ul><p>[]abc</p>',
+                                });
                             });
                         });
                         it('should rejoin sibling lists', async () => {
@@ -8499,134 +8529,146 @@ describe('List', () => {
                     `),
                 });
             });
-            it('should outdent a list inside a nav-item list', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: unformat(`
-                        <ul>
-                            <li class="nav-item">
-                                <ul>
-                                    <li>a[]b</li>
-                                </ul>
-                            </li>
-                        </ul>
-                    `),
-                    stepFunction: outdentList,
-                    contentAfter: unformat(`
-                        <ul>
-                            <li class="nav-item">
-                                <p>a[]b</p>
-                            </li>
-                        </ul>
-                    `),
-                });
-                await testEditor(BasicEditor, {
-                    contentBefore: unformat(`
-                        <ul>
-                            <li class="nav-item">
-                                <ol>
-                                    <li>a[]b</li>
-                                </ol>
-                            </li>
-                        </ul>
-                    `),
-                    stepFunction: outdentList,
-                    contentAfter: unformat(`
-                        <ul>
-                            <li class="nav-item">
-                                <p>a[]b</p>
-                            </li>
-                        </ul>
-                    `),
-                });
-                await testEditor(BasicEditor, {
-                    contentBefore: unformat(`
-                        <ul>
-                            <li class="nav-item">
-                                <ul class="o_checklist">
-                                    <li>a[]b</li>
-                                </ul>
-                            </li>
-                        </ul>
-                    `),
-                    stepFunction: outdentList,
-                    contentAfter: unformat(`
-                        <ul>
-                            <li class="nav-item">
-                                <p>a[]b</p>
-                            </li>
-                        </ul>
-                    `),
-                });
-                await testEditor(BasicEditor, {
-                    contentBefore: unformat(`
-                        <ul>
-                            <li class="nav-item">
-                                <div>
+            describe('should outdent a list inside a nav-item list', () => {
+                it('should outdent a list inside a nav-item list (1)', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: unformat(`
+                            <ul>
+                                <li class="nav-item">
                                     <ul>
                                         <li>a[]b</li>
                                     </ul>
-                                </div>
-                            </li>
-                        </ul>
-                    `),
-                    stepFunction: outdentList,
-                    contentAfter: unformat(`
-                        <ul>
-                            <li class="nav-item">
-                                <div>
+                                </li>
+                            </ul>
+                        `),
+                        stepFunction: outdentList,
+                        contentAfter: unformat(`
+                            <ul>
+                                <li class="nav-item">
                                     <p>a[]b</p>
-                                </div>
-                            </li>
-                        </ul>
-                    `),
+                                </li>
+                            </ul>
+                        `),
+                    });
                 });
-                await testEditor(BasicEditor, {
-                    contentBefore: unformat(`
-                        <ul>
-                            <li class="nav-item">
-                                <div>
+                it('should outdent a list inside a nav-item list (2)', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: unformat(`
+                            <ul>
+                                <li class="nav-item">
                                     <ol>
-                                        <li>
-                                            <h1>a[]b</h1>
-                                        </li>
+                                        <li>a[]b</li>
                                     </ol>
-                                </div>
-                            </li>
-                        </ul>
-                    `),
-                    stepFunction: outdentList,
-                    contentAfter: unformat(`
-                        <ul>
-                            <li class="nav-item">
-                                <div>
-                                    <h1>a[]b</h1>
-                                </div>
-                            </li>
-                        </ul>
-                    `),
+                                </li>
+                            </ul>
+                        `),
+                        stepFunction: outdentList,
+                        contentAfter: unformat(`
+                            <ul>
+                                <li class="nav-item">
+                                    <p>a[]b</p>
+                                </li>
+                            </ul>
+                        `),
+                    });
                 });
-                await testEditor(BasicEditor, {
-                    contentBefore: unformat(`
-                        <ul>
-                            <li class="nav-item">
-                                <div>
+                it('should outdent a list inside a nav-item list (3)', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: unformat(`
+                            <ul>
+                                <li class="nav-item">
                                     <ul class="o_checklist">
                                         <li>a[]b</li>
                                     </ul>
-                                </div>
-                            </li>
-                        </ul>
-                    `),
-                    stepFunction: outdentList,
-                    contentAfter: unformat(`
-                        <ul>
-                            <li class="nav-item">
-                                <div>
+                                </li>
+                            </ul>
+                        `),
+                        stepFunction: outdentList,
+                        contentAfter: unformat(`
+                            <ul>
+                                <li class="nav-item">
                                     <p>a[]b</p>
-                                </div>
-                            </li>
-                        </ul>
-                    `),
+                                </li>
+                            </ul>
+                        `),
+                    });
+                });
+                it('should outdent a list inside a nav-item list (4)', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: unformat(`
+                            <ul>
+                                <li class="nav-item">
+                                    <div>
+                                        <ul>
+                                            <li>a[]b</li>
+                                        </ul>
+                                    </div>
+                                </li>
+                            </ul>
+                        `),
+                        stepFunction: outdentList,
+                        contentAfter: unformat(`
+                            <ul>
+                                <li class="nav-item">
+                                    <div>
+                                        <p>a[]b</p>
+                                    </div>
+                                </li>
+                            </ul>
+                        `),
+                    });
+                });
+                it('should outdent a list inside a nav-item list (5)', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: unformat(`
+                            <ul>
+                                <li class="nav-item">
+                                    <div>
+                                        <ol>
+                                            <li>
+                                                <h1>a[]b</h1>
+                                            </li>
+                                        </ol>
+                                    </div>
+                                </li>
+                            </ul>
+                        `),
+                        stepFunction: outdentList,
+                        contentAfter: unformat(`
+                            <ul>
+                                <li class="nav-item">
+                                    <div>
+                                        <h1>a[]b</h1>
+                                    </div>
+                                </li>
+                            </ul>
+                        `),
+                    });
+                });
+                it('should outdent a list inside a nav-item list (6)', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: unformat(`
+                            <ul>
+                                <li class="nav-item">
+                                    <div>
+                                        <ul class="o_checklist">
+                                            <li>a[]b</li>
+                                        </ul>
+                                    </div>
+                                </li>
+                            </ul>
+                        `),
+                        stepFunction: outdentList,
+                        contentAfter: unformat(`
+                            <ul>
+                                <li class="nav-item">
+                                    <div>
+                                        <p>a[]b</p>
+                                    </div>
+                                </li>
+                            </ul>
+                        `),
+                    });
                 });
             });
         });


### PR DESCRIPTION
Those tests were too long and sometimes triggered a timeout when the runbot happened to be too slow.

This commit separates each test into its own async function so that the timeout is applied on each test separately, thus significantly decreasing the likelihood of a timeout to occur in any of them.

runbot-112694
runbot-112819
