### PR TITLE
[FIX] account_audit_trail: improve audit trail deletion error message

### DIFF
--- a/addons/account_audit_trail/i18n/account_audit_trail.pot
+++ b/addons/account_audit_trail/i18n/account_audit_trail.pot
@@ -214,5 +214,5 @@ msgstr ""
 #: code:addons/account_audit_trail/models/mail_message.py:0
 #, python-format
 msgid ""
-"You cannot remove parts of the audit trail. Archive the record instead."
+"You cannot remove parts of the audit trail."
 msgstr ""

--- a/addons/account_audit_trail/models/mail_message.py
+++ b/addons/account_audit_trail/models/mail_message.py
@@ -192,7 +192,7 @@ class Message(models.Model):
                 message.account_audit_log_move_id
                 and not message.account_audit_log_move_id.posted_before
             ):
-                raise UserError(_("You cannot remove parts of the audit trail. Archive the record instead."))
+                raise UserError(_("You cannot remove parts of the audit trail."))
 
     def write(self, vals):
         # We allow any whitespace modifications in the subject


### PR DESCRIPTION
**issue:**

When "Audit Trail" is activated and a user creates an incorrect payment, deleting the payment is not possible.
The error message suggests archiving the payment; however, there is no option to archive it.

A more flexible error message should be used instead.

opw-4494820
