### PR TITLE
[IMP] point_of_sale: display free_qty instead of qty_available

### DIFF
--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -185,7 +185,7 @@ class ProductTemplate(models.Model):
         self.ensure_one()
         config = self.env['pos.config'].browse(pos_config_id)
         product_variant = self.env['product.product'].browse(product_variant_id) if product_variant_id else False
-        template_or_variant = product_variant or self
+        template_or_variant = product_variant or self.product_variant_id
 
         # Tax related
         taxes = self.taxes_id.compute_all(price, config.currency_id, quantity, template_or_variant)
@@ -218,6 +218,7 @@ class ProductTemplate(models.Model):
             {'id': w.id,
             'name': w.name,
             'available_quantity': template_or_variant.with_context({'warehouse_id': w.id}).qty_available,
+            'free_qty': template_or_variant.with_context({'warehouse_id': w.id}).free_qty,
             'forecasted_quantity': template_or_variant.with_context({'warehouse_id': w.id}).virtual_available,
             'uom': template_or_variant.uom_name}
             for w in self.env['stock.warehouse'].search([('company_id', '=', config.company_id.id)])]

--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
@@ -21,7 +21,7 @@
                                 :
                             </div>
                             <div>
-                                <span class="me-1 fw-bolder"><t t-esc="warehouse.available_quantity" class="table-name"/></span>
+                                <span class="me-1 fw-bolder"><t t-esc="warehouse.free_qty" class="table-name"/></span>
                                 <t t-esc="warehouse.uom"/> available,
                             </div>
                             <div>

--- a/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.js
+++ b/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.js
@@ -25,6 +25,8 @@ export class ProductInfoBanner extends Component {
         this.state = useState({
             other_warehouses: [],
             available_quantity: 0,
+            free_qty: 0,
+            uom: "",
             price_with_tax: 0,
             price_without_tax: 0,
             tax_name: "",
@@ -47,6 +49,8 @@ export class ProductInfoBanner extends Component {
                 const productInfo = result.productInfo;
                 this.state.other_warehouses = productInfo.warehouses.slice(1);
                 this.state.available_quantity = productInfo.warehouses[0]?.available_quantity;
+                this.state.free_qty = productInfo.warehouses[0]?.free_qty;
+                this.state.uom = productInfo.warehouses[0]?.uom;
                 this.state.price_with_tax = productInfo.all_prices.price_with_tax;
                 this.state.price_without_tax = productInfo.all_prices.price_without_tax;
                 this.state.tax_name = productInfo.all_prices.tax_details[0]?.name || "";
@@ -66,11 +70,11 @@ export class ProductInfoBanner extends Component {
     }
 
     get bannerBackground() {
-        if (!this.props.productTemplate.is_storable || this.state.available_quantity > 10) {
+        if (!this.props.productTemplate.is_storable || this.state.free_qty > 10) {
             return "bg-info";
         }
 
-        return this.state.available_quantity < 5 ? "bg-danger" : "bg-warning";
+        return this.state.free_qty < 5 ? "bg-danger" : "bg-warning";
     }
 
     get bannerClass() {

--- a/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml
+++ b/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml
@@ -6,8 +6,8 @@
             <div>
                 <div class="h4" t-esc="props.product?.display_name || props.productTemplate.display_name"/>
                 <div t-if="this.props.productTemplate.is_storable" class="h4">
-                    <span>On hand: </span>
-                    <span t-if="this.fetchStock.status === 'success' || this.props.info"><t t-esc="this.state.available_quantity"/> Units</span>
+                    <span>Free To Use: </span>
+                    <span t-if="this.fetchStock.status === 'success' || this.props.info"><t t-esc="this.state.free_qty"/> <t t-esc="this.state.uom"/></span>
                     <span t-elif="this.fetchStock.status === 'error'">N/A</span>
                     <i t-else="" class="fa fa-fw fa-spin fa-circle-o-notch" aria-hidden="true" />
                 </div>


### PR DESCRIPTION
This commit changes the product information display in POS to show the free quantity (qty_available - reserved_qty) instead of just qty_available. This gives a more accurate representation of the actual stock that can be sold, as it accounts for reserved quantities.

Task ID: 4556306



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
