### PR TITLE
[FIX] the bug that can not apply half day off

### DIFF
--- a/doc/cla/individual/bennfocus.md
+++ b/doc/cla/individual/bennfocus.md
@@ -1,0 +1,11 @@
+Germany, 2025-02-07
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Benn Ma bennmsg@gmail.com https://github.com/bennfocus


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
It allows employees to apply half day off.

Current behavior before PR:
When I apply half day off, it always take 1 day from my available holidays.

Desired behavior after PR is merged:
Be able to apply half day off, and only deduct 0.5 days from the pool.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
