### PR TITLE
[IMP] hr_fleet: enable Driver assignment logs delete

### DIFF
--- a/addons/hr_fleet/views/fleet_vehicle_views.xml
+++ b/addons/hr_fleet/views/fleet_vehicle_views.xml
@@ -114,6 +114,9 @@
            <xpath expr="//kanban" position="attributes">
                 <attribute name="js_class">hr_fleet_kanban_view</attribute>
             </xpath>
+            <t t-name="menu">
+                <a role="menuitem" type="delete" class="dropdown-item">Delete</a>
+            </t>
        </field>
    </record>
 </odoo>


### PR DESCRIPTION
- add the delete menuitem to the attachment kanban view inside the driver assignment logs

Task: 4559047



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
