### PR TITLE
[FIX] hw_drivers: no pairing code on boot

### DIFF
--- a/addons/hw_drivers/connection_manager.py
+++ b/addons/hw_drivers/connection_manager.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime, timedelta
 import logging
 import platform
 import requests
@@ -12,6 +11,8 @@ from odoo.addons.hw_drivers.main import manager
 from odoo.addons.hw_drivers.tools import helpers, wifi
 
 _logger = logging.getLogger(__name__)
+
+PAIRING_CODE_TIMEOUT_SECONDS = 300
 
 
 class ConnectionManager(Thread):
@@ -25,8 +26,8 @@ class ConnectionManager(Thread):
             return
 
         if not helpers.get_odoo_server_url():
-            end_time = datetime.now() + timedelta(minutes=5)
-            while datetime.now() < end_time:
+            end_time = time.monotonic() + PAIRING_CODE_TIMEOUT_SECONDS
+            while time.monotonic() < end_time:
                 self._connect_box()
                 time.sleep(10)
             self.pairing_code = False

--- a/addons/hw_drivers/tools/wifi.py
+++ b/addons/hw_drivers/tools/wifi.py
@@ -269,9 +269,7 @@ def is_access_point():
     :return: True if the device is in access point mode
     :rtype: bool
     """
-    # We only get the first line as `lo` can still be active when `wlan0` is up
-    device = _nmcli(['-g', 'device', 'connection', 'show', '--active'], sudo=True).splitlines()[0]
-    return device == 'lo'
+    return subprocess.run(['systemctl', 'is-active', 'hostapd']).returncode == 0
 
 @cache
 def generate_qr_code_image(qr_code_data):


### PR DESCRIPTION
This PR contains 2 commits:

- [FIX] hw_drivers: pairing code cleared on time change

  Before this commit, if the system time was changed
  while the connection manager was running, it could
  immediately finish waiting and clear the pairing
  code. This happens quite easily due to the
  system time being set via NTP just after boot.

  After this commit, the 5 minute wait uses
  `time.monotonic()`, which is not affected by
  system clock changes. This ensures the pairing
  code can stay visible for the full 5 minutes.


- [FIX] hw_drivers: is_access_point false positive

  Before this commit, `is_access_point` was using
  the loopback interface `lo` to determine if the
  access point was up. If it was the only interface
  present, it returned true. However, what this
  actually represented was whether no network
  connection was present. At boot, while waiting for
  an IP, the access point is not up but
  `is_access_point` was returning true. A
  side-effect of this was the `ConnectionManager`
  never starting, and therefore no pairing code
  appearing for the user.

  After this commit, `is_access_point` uses the
  status of the `hostapd` service to check if the
  access point is up. This in turn fixes the pairing
  code issue.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
