### PR TITLE
[FIX] l10n_de: allow deleting attachments for non DE companies

### DIFF
--- a/addons/l10n_de/i18n/de.po
+++ b/addons/l10n_de/i18n/de.po
@@ -776,6 +776,13 @@ msgstr "Sie können den Code eines Kontos nicht ändern."
 
 #. module: l10n_de
 #. odoo-python
+#: code:addons/l10n_de/models/res_company.py:0
+#, python-format
+msgid "You cannot change the fiscal country."
+msgstr "Sie können das Steuerland nicht ändern."
+
+#. module: l10n_de
+#. odoo-python
 #: code:addons/l10n_de/models/ir_attachment.py:0
 #, python-format
 msgid "You cannot remove parts of the audit trail."

--- a/addons/l10n_de/i18n/l10n_de.pot
+++ b/addons/l10n_de/i18n/l10n_de.pot
@@ -832,6 +832,13 @@ msgstr ""
 
 #. module: l10n_de
 #. odoo-python
+#: code:addons/l10n_de/models/res_company.py:0
+#, python-format
+msgid "You cannot change the fiscal country."
+msgstr ""
+
+#. module: l10n_de
+#. odoo-python
 #: code:addons/l10n_de/models/ir_attachment.py:0
 #, python-format
 msgid "You cannot remove parts of the audit trail."

--- a/addons/l10n_de/models/ir_attachment.py
+++ b/addons/l10n_de/models/ir_attachment.py
@@ -32,7 +32,7 @@ class IrAttachment(models.Model):
                 raise ue
 
     def write(self, vals):
-        if vals.keys() & {'res_id', 'res_model', 'raw', 'datas', 'store_fname', 'db_datas'}:
+        if vals.keys() & {'res_id', 'res_model', 'raw', 'datas', 'store_fname', 'db_datas', 'company_id'}:
             try:
                 self._except_audit_trail()
             except UserError as e:
@@ -51,6 +51,7 @@ class IrAttachment(models.Model):
             attachment.res_model == 'account.move'
             and attachment.res_id
             and attachment.res_field in ('invoice_pdf_report_file', 'ubl_cii_xml_file')
+            and attachment.company_id.account_fiscal_country_id.code == 'DE'
         )
         if invoice_pdf_attachments:
             # only detach the document from the field, but keep it in the database for the audit trail

--- a/addons/l10n_de/models/res_company.py
+++ b/addons/l10n_de/models/res_company.py
@@ -17,6 +17,15 @@ class ResCompany(models.Model):
     )
     l10n_de_widnr = fields.Char(string="W-IdNr.", help="Business identification number.", tracking=True)
 
+    def write(self, vals):
+        if (
+            'account_fiscal_country_id' in vals
+            and (german_companies := self.filtered(lambda c: c.account_fiscal_country_id.code == 'DE'))
+            and self.env['account.move'].search_count([('company_id', 'in', german_companies.ids)], limit=1)
+        ):
+            raise ValidationError(_("You cannot change the fiscal country."))
+        return super().write(vals)
+
     @api.depends('country_code')
     @api.constrains('state_id', 'l10n_de_stnr')
     def _validate_l10n_de_stnr(self):


### PR DESCRIPTION
In 50c62eab72678d51fb88c88fbeb81da2decca6f2, an override was done to attachments to disable deleting them, detaching them instead. As this is only required for German companies, a check can be added in the override to allow non-German companies to be able to delete their attachments. Also, another restriction was added for changing the fiscal country to make sure the flow for deleting German attachments cannot be bypassed.

task-4500319
