### PR TITLE
[FIX] payment: prevent outdated link from being copied in payment wizard

### DIFF
--- a/addons/payment/__manifest__.py
+++ b/addons/payment/__manifest__.py
@@ -38,9 +38,14 @@
         'web.assets_frontend': [
             'payment/static/lib/jquery.payment/jquery.payment.js',
             'payment/static/src/**/*',
+            ('remove', 'payment/static/src/js/payment_wizard_copy_clipboard_field.js'),
         ],
         'web.assets_backend': [
             'payment/static/src/scss/payment_provider.scss',
+            'payment/static/src/js/payment_wizard_copy_clipboard_field.js',
+        ],
+        'web.qunit_suite_tests': [
+            'payment/static/tests/payment_wizard_copy_clipboard_field_tests.js',
         ],
     },
     'license': 'LGPL-3',

--- a/addons/payment/static/src/js/payment_wizard_copy_clipboard_field.js
+++ b/addons/payment/static/src/js/payment_wizard_copy_clipboard_field.js
@@ -1,0 +1,29 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import {
+    copyClipboardButtonField,
+    CopyClipboardButtonField,
+} from "@web/views/fields/copy_clipboard/copy_clipboard_field";
+
+import { CopyButton } from "@web/views/fields/copy_clipboard/copy_button";
+
+class PaymentWizardCopyButton extends CopyButton {
+    async onClick() {
+        await this.env.model.mutex.getUnlockedDef();
+        return super.onClick();
+    }
+}
+
+class PaymentWizardCopyClipboardButtonField extends CopyClipboardButtonField {
+    static components = { CopyButton: PaymentWizardCopyButton };
+}
+
+const paymentWizardCopyClipboardButtonField = {
+    ...copyClipboardButtonField,
+    component: PaymentWizardCopyClipboardButtonField,
+};
+
+registry
+    .category("fields")
+    .add("PaymentWizardCopyClipboardButtonField", paymentWizardCopyClipboardButtonField);

--- a/addons/payment/static/tests/payment_wizard_copy_clipboard_field_tests.js
+++ b/addons/payment/static/tests/payment_wizard_copy_clipboard_field_tests.js
@@ -1,0 +1,73 @@
+/** @odoo-module **/
+
+import { browser } from "@web/core/browser/browser";
+import { click, getFixture, patchWithCleanup, editInput } from "@web/../tests/helpers/utils";
+import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
+
+let serverData;
+let target;
+
+QUnit.module("Payment", {
+    beforeEach() {
+        target = getFixture();
+        serverData = {
+            models: {
+                "payment.link.wizard": {
+                    fields: {
+                        amount: { string: "Amount", type: "float" },
+                        link: { string: "Payment Link", type: "char" },
+                    },
+                    onchanges: {
+                        amount(record) {
+                            record.link = `/payment/pay?amount=${record.amount}`;
+                        },
+                    },
+                    records: [{ id: 1, amount: 15, link: "/payment/pay?amount=15" }],
+                },
+            },
+        };
+
+        setupViewRegistries();
+    },
+});
+
+QUnit.test("copy link immediatly after entering the amount", async (assert) => {
+    assert.expect(2);
+
+    await makeView({
+        serverData,
+        type: "form",
+        resModel: "payment.link.wizard",
+        arch: `<form>
+            <group>
+                <group>
+                    <field name="amount"/>
+                     <field
+                        string="Generate and Copy Payment Link"
+                        name="link"
+                        widget="PaymentWizardCopyClipboardButtonField"
+                    />
+                </group>
+            </group>
+        </form>`,
+        resId: 1,
+        async mockRPC(route, { method, model }) {},
+    });
+
+    patchWithCleanup(browser, {
+        navigator: {
+            clipboard: {
+                writeText: (text) => {
+                    assert.step(`copied "${text}"`);
+                    return Promise.resolve();
+                },
+            },
+        },
+    });
+
+    // not awaiting the events
+    editInput(target, ".o_field_widget[name=amount] input", "13");
+
+    await click(target, ".o_clipboard_button");
+    assert.verifySteps(['copied "/payment/pay?amount=13"']);
+});

--- a/addons/payment/wizards/payment_link_wizard_views.xml
+++ b/addons/payment/wizards/payment_link_wizard_views.xml
@@ -35,7 +35,7 @@
                            string="Generate and Copy Payment Link"
                            readonly="1"
                            disabled="bool(warning_message)"
-                           widget="CopyClipboardButton"
+                           widget="PaymentWizardCopyClipboardButtonField"
                            data-hotkey="q"/>
                     <button string="Close"
                             class="btn btn-secondary rounded-2"


### PR DESCRIPTION
Steps to reproduce
==================

- Install account
- Open an invoice
- Click on the cog
- Click on "Generate a Payment Link"
- Open the browser devtools and add a delay in the network tab to simulate a slow network
- Edit the amount
- Click on the Copy button

=> The copied URL is not up to date and contains the previous amount

Cause of the issue
==================

The copy button is actually a field named `link`
Changing the `amount` causes an onchange that updates the `link` value. When the button is clicked, the amount field is blurred, and this starts the onchange. The link is then immediately copied without waiting for the new value.

Solution
========

There is no mechanism in the framework made for this purpose, but what we can do, is wait for the model mutex to be unlocked. The lock is held during the onchange, so it is guaranteed that the up to date link is copied.

opw-4358629