### PR TITLE
[FIX] account: invoice product name in both languages

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -172,12 +172,7 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
 
     get label() {
         let label = this.props.record.data.name;
-        if (label.includes(this.productName)) {
-            label = label.replace(this.productName, "");
-            if (label.includes("\n")) {
-                label = label.replace("\n", "");
-            }
-        }
+        label = label.split('\n').slice(1).join('\n');
         return label;
     }
 


### PR DESCRIPTION
When an invoice is created, the system will automatically translate the strings into the customer language. In the printed pdf the customer will see just the translated terms. However, in the backend the user will see the original product name and the translated name + description.

Steps to reproduce:
- Have a user using a language [LANG1]
- Have a customer using a language [LANG2]
- Make an invoice to the customer, add a product with both name and description with translation available

Issue: The name of the product is duplicated, it appears in user language and customer language

opw-4444773

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
