### PR TITLE
[FIX] website_sale_loyalty: Cart Update Inheritance

### DIFF
--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -156,16 +156,17 @@ class SaleOrder(models.Model):
             request.session.pop('successful_code')
         return code
 
-    def _cart_update(self, *args, **kwargs):
-        product_id, set_qty = kwargs['product_id'], kwargs.get('set_qty')
+    def _cart_update(self, product_id, line_id=None, add_qty=0, set_qty=0, **kwargs):
 
         line = self.order_line.filtered(lambda sol: sol.product_id.id == product_id)[:1]
         reward_id = line.reward_id
         if set_qty == 0 and line.coupon_id and reward_id and reward_id.reward_type == 'discount':
             # Force the deletion of the line even if it's a temporary record created by new()
-            kwargs['line_id'] = line.id
+            line_id = line.id
 
-        res = super(SaleOrder, self)._cart_update(*args, **kwargs)
+        res = super()._cart_update(
+            product_id, line_id=line_id, add_qty=add_qty, set_qty=set_qty, **kwargs
+        )
         self._update_programs_and_rewards()
         self._auto_apply_rewards()
         return res

--- a/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
+++ b/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
@@ -337,10 +337,7 @@ class TestWebsiteSaleCoupon(TransactionCase):
             lambda l: l.coupon_id and l.coupon_id.id == self.coupon.id
         )
 
-        kwargs = {
-            'line_id': None, 'product_id': coupon_line.product_id.id, 'add_qty': None, 'set_qty': 0
-        }
-        order._cart_update(**kwargs)
+        order._cart_update(coupon_line.product_id.id, add_qty=None)
 
         msg = "The coupon should've been removed from the order"
         self.assertEqual(len(order.applied_coupon_ids), 0, msg=msg)
@@ -420,8 +417,8 @@ class TestWebsiteSaleCoupon(TransactionCase):
             lambda line: line.coupon_id and line.coupon_id.id == self.coupon.id
         )
         order._cart_update(
-            line_id=None,
             product_id=coupon_line.product_id.id,
+            line_id=None,
             add_qty=None,
             set_qty=0,
         )


### PR DESCRIPTION
When having other modules that depend on the module, if they make an inheritance of the method `_cart_update` like it is on the original method from module `website_sale` (with parameters and then `kwargs`) the inheritance of this module fails, because neither `product_id` nor `set_qty` came on the `kwargs` values instead they came in the `args`.

![Website Loyalty error](https://github.com/user-attachments/assets/ebe7a8dc-7b7c-4f11-8064-bcc7c24218bf)

![Website Loyalty error with PDB](https://github.com/user-attachments/assets/2bf85807-f230-4e65-9090-b6c1e390682e)


By inheriting the way the original method is set, it will avoid having to check on the `args` or `kwargs` for the `product_id` and `set_qty` values and use the parameters instead.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
