### PR TITLE
[FIX] sale_timesheet: check if analytic account exists before use

### DIFF
--- a/addons/sale_timesheet/models/hr_timesheet.py
+++ b/addons/sale_timesheet/models/hr_timesheet.py
@@ -219,7 +219,10 @@ class AccountAnalyticLine(models.Model):
         company = self.env['res.company'].browse(vals.get('company_id'))
         accounts = self.env['account.analytic.account'].browse([
             int(account_id) for account_id in next(iter(distribution)).split(',')
-        ])
+        ]).exists()
+
+        if not accounts:
+            return super()._timesheet_preprocess_get_accounts(vals)
 
         plan_column_names = {account.root_plan_id._column_name() for account in accounts}
         mandatory_plans = [plan for plan in self._get_mandatory_plans(company, business_domain='timesheet') if plan['column_name'] != 'account_id']


### PR DESCRIPTION
## Issue:
When duplicating a sale order with a service product that creates tasks, adding a timesheet entry to the task from the duplicate sale order fails if the original task and project were deleted before duplication.

## Steps to reproduce:
- disable Analytic Accounting.
- Create a service product that create a test, keep project empty.
- create a project.
- create a sale order with the service product and the project.
- confirm the sale order.
- remove the task that was created by the service product and delete the project.
- duplicate the sale order.
- confirm the duplicate sale order.
- open the task created by the sale order.
- try adding a timesheet to the task.
- an error is raised saying that the analytic account doesn't exist.

## Root cause:
- When we delete a project, it's linked analytic account is removed automatically by the `project_project` override of the `unlink` method, but it might be still referred in the analytic distribution of sale order line, so when we try fetching it in `_timesheet_preprocess_get_accounts` it gives the "Missing Record" error.

## Fix:
- make sure the analytic account exists when browsing to them in `_timesheet_preprocess_get_accounts`.
- fallback to super when there are no analytic accounts

OPW-4474903

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
