### PR TITLE
[FIX] hr_holidays: accrual plans access rights

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -602,7 +602,7 @@ class HolidaysType(models.Model):
             carryover_policy = accrual_plan_level.action_with_unused_accruals if accrual_plan_level else False
             carryover_date = False
             if carryover_policy in ['maximum', 'lost']:
-                carryover_date = allocation._get_carryover_date(target_date)
+                carryover_date = allocation.sudo()._get_carryover_date(target_date)
                 # If carry over date == target date, then add 1 year to carry over date.
                 # Rational: for example if carry over date = 01/01 this year and target date = 01/01 this year,
                 # then any accrued days on 01/01 this year will have their carry over date 01/01 next year


### PR DESCRIPTION
Accrual plans are not readable for regular users, so once a user has an accrual plan set on one of their allocations, they cannot open their time off dashboard. Access rights error gets thrown.

The bug was supposedly fixed in commit: https://github.com/odoo/odoo/commit/30f7fe62ef2579ed0a0c3ad9dbec5edf2ca60b18 but it did not consider adding the sudo() for the condition based on the carryover_policy.

Steps to Reproduce on Runbot:
As Mitchell Admin:
1. Install Time Off app
2. Create a time off type (show in dashboard,requires allocation)
3. Create an accrual plan (accrued_gain_time: end, carryover_date: year_start)
4. Create a rule for the accrual plan (Accumulate 0.5 days, month at the 1st of the month, carryover policy is either none or maximum)
5. Create an allocation for Marc Demo,who has no time off rights, for the time off type. Set to accrual allocation and link to the accrual plan.Then, set the start date to the 1st of the month and run until some future date.

As Marc Demo:
1. Attempt to click into the Time Off app
2. Observe Access Right error

opw-4551392

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
