### PR TITLE
[FIX] point_of_sale: ensuring the correct removal from self.syncingOrders

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1035,7 +1035,7 @@ class PosGlobalState extends PosModel {
                 self.set_synch('connected');
                 return server_ids;
             }).catch(function (error){
-                ordersToSync.forEach(order_id => self.syncingOrders.delete(order_id));
+                ordersToSync.forEach(order => self.syncingOrders.delete(order.id));
                 console.warn('Failed to send orders:', ordersToSync);
                 if(error.code === 200 ){    // Business Logic Error, not a connection problem
                     // Hide error if already shown before ...


### PR DESCRIPTION
Previously, the code attempted to delete an element using order_id, but ordersToSync is an array of order objects, not order IDs.
The fix updates the loop to use order.id instead of order_id, ensuring the correct removal from self.syncingOrders.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
