### PR TITLE
[FIX] html_editor: prevent the generation of ghost mutations

### DIFF
--- a/addons/html_editor/static/src/others/embedded_component_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_component_plugin.js
@@ -183,6 +183,9 @@ export class EmbeddedComponentPlugin extends Plugin {
     }
 
     destroyRemovedComponents(infos) {
+        // Avoid registering mutations if removed hosts are handled in
+        // the same microtask as when they were removed.
+        this.dependencies.history.disableObserver();
         for (const info of infos) {
             if (!this.editable.contains(info.host)) {
                 const host = info.host;
@@ -206,6 +209,7 @@ export class EmbeddedComponentPlugin extends Plugin {
                 }
             }
         }
+        this.dependencies.history.enableObserver();
     }
 
     deepDestroyComponent({ host }) {

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -159,9 +159,11 @@ export function setTagName(el, newTagName) {
  * @param {...string} classNames - The class names to be removed.
  */
 export function removeClass(element, ...classNames) {
-    element.classList.remove(...classNames);
-    if (!element.classList.length) {
+    const classNamesSet = new Set(classNames);
+    if ([...element.classList].every((className) => classNamesSet.has(className))) {
         element.removeAttribute("class");
+    } else {
+        element.classList.remove(...classNames);
     }
 }
 

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -65,7 +65,7 @@ test("should not display hint in paragraph with media content", async () => {
 });
 
 test("should not lose track of temporary hints on split block", async () => {
-    const { el, editor } = await setupEditor("<p>[]</p>", {});
+    const { el, editor, plugins } = await setupEditor("<p>[]</p>", {});
     expect(getContent(el)).toBe(`<p placeholder='Type "/" for commands' class="o-we-hint">[]</p>`);
     editor.shared.split.splitBlock();
     editor.shared.history.addStep();
@@ -93,6 +93,8 @@ test("should not lose track of temporary hints on split block", async () => {
             <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
         `)
     );
+    // Changing the selection should not generate mutations for the next step
+    expect(plugins.get("history").currentStep.mutations.length).toBe(0);
 });
 
 test("hint should only Be display for focused empty block element", async () => {

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -549,9 +549,10 @@ describe("shortcut", () => {
         expect.verifySteps([]);
         await insertText(editor, "a");
         expect.verifySteps([
+            // mutations for "a" insertion register new records for the current step
             "handleNewRecords",
             "contentUpdated",
-            "handleNewRecords",
+            // mutations for the hint removal are filtered out (no registered record)
             "contentUpdated",
             "onchange",
         ]);


### PR DESCRIPTION
This PR handles 2 cases of ghost mutations generation:

When switching the selection, the hint plugin generated mutations
that were not part of a step. They should be ignored.

When undoing the insertion of nested embedded components,
the post-processing allowing for OWL Component destruction
was generating ghost mutations. They should also be ignored.

See commits for further details

task-4561045