### PR TITLE
[FIX] core: validate company-dependent many2one fields to prevent MissingError

### DIFF
--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -1655,6 +1655,21 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
             self.assertEqual(record_company.count, 0)
             self.assertEqual(record_company.phi, 0.0)
 
+    def test_27_company_dependent_missing_many2one(self):
+        """ test assign missing records to company dependent many2one """
+        Model = self.env['test_new_api.company']
+        record = Model.create({})
+
+        tag = self.env['test_new_api.multi.tag'].create({'name': 'Foo'})
+        record.tag_id = tag
+        tag.unlink()
+
+        with self.assertRaises(MissingError):
+            record.tag_id = 1000
+
+        with self.assertRaises(MissingError):
+            record = Model.create({'tag_id': 1000})
+
     def test_28_company_dependent_search(self):
         """ Test the search on company-dependent fields in all corner cases.
             This assumes that filtered_domain() correctly filters records when
@@ -1811,7 +1826,7 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
             'child_of': (company0.id, company1.id, company2.id),
             'parent_of': (company0.id, company1.id, company2.id),
         })
-        test_field('partner_id', [company1.id, company2.id], {
+        test_field('partner_id', [company1.partner_id.id, company2.partner_id.id], {
             'child_of': (company0.partner_id.id, company1.partner_id.id, company2.partner_id.id),
             'parent_of': (company0.partner_id.id, company1.partner_id.id, company2.partner_id.id),
         })

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -1513,6 +1513,19 @@ class Cache:
             for context_key, field_cache in field_caches.items()
         }
         return GroupedCompanyDependentFieldCache(company_field_cache)
+    
+    def _get_company_dependent_many2one_ids(self, field, records):
+        """
+        return all company dependent many2one ids cached by the records
+        """
+        assert field.company_dependent and field.type == 'many2one'
+        field_caches = self._data.get(field, EMPTY_DICT)
+        return  {
+            value
+            for field_cache in field_caches.values()
+            for id_ in records._ids
+            if (value := field_cache.get(id_))
+        }
 
 
 class GroupedCompanyDependentFieldCache:


### PR DESCRIPTION
Added existence checks for company-dependent many2one fields to ensure assigned ids are valid and to handle cases where records are deleted concurrently. This prevents potential MissingError issues in the future.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
