### PR TITLE
[FIX] account_payment: Link Payment Transaction with Invoice for Electronic Payments

### DIFF
--- a/addons/account_payment/models/account_payment.py
+++ b/addons/account_payment/models/account_payment.py
@@ -199,6 +199,12 @@ class AccountPayment(models.Model):
 
     def _prepare_payment_transaction_vals(self, **extra_create_values):
         self.ensure_one()
+        if self._context.get('active_model', '') == 'account.move':
+            invoice_ids = self._context.get('active_ids', [])
+        elif self._context.get('active_model', '') == 'account.move.line':
+            invoice_ids = self.env['account.move'].search([('line_ids', '=', self._context.get('active_ids'))]).ids
+        else:
+            invoice_ids = []
         return {
             'provider_id': self.payment_token_id.provider_id.id,
             'payment_method_id': self.payment_token_id.payment_method_id.id,
@@ -211,9 +217,7 @@ class AccountPayment(models.Model):
             'token_id': self.payment_token_id.id,
             'operation': 'offline',
             'payment_id': self.id,
-            **({'invoice_ids': [Command.set(self._context.get('active_ids', []))]}
-                if self._context.get('active_model') == 'account.move'
-                else {}),
+            'invoice_ids': [Command.set(invoice_ids)],
             **extra_create_values,
         }
 


### PR DESCRIPTION
Steps to reproduce:

- Create an invoice through Accounting app
- Post the invoice
- Register the payment using the "Register Payment" wizard with an electronic payment method.

Description of the issue/feature this PR addresses:
**The payment transaction was not being linked to the invoice for electronic payments.**

To resolve this, I passed the current invoice IDs as context through action_register_payment in the account.move.line model. Then, I retrieved this context value in _prepare_payment_transaction_vals of the account.payment model to set the invoice_ids Many2many field.


Current behavior before PR:
The payment transaction is not linked to the invoice for electronic payments.

Desired behavior after PR is merged:
The payment transaction will be correctly linked to the invoice for electronic payments.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
