### PR TITLE
[FIX] server: notifies is on _cnx

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1243,12 +1243,13 @@ class WorkerCron(Worker):
         if not self.db_queue:
             # list databases
             db_names = OrderedSet(cron_database_list())
+            pg_conn = self.dbcursor._cnx
             notified = OrderedSet(
                 notif.payload
-                for notif in self.dbcursor.notifies
+                for notif in pg_conn.notifies
                 if notif.channel == 'cron_trigger'
             )
-            self.dbcursor.notifies.clear()  # free resources
+            pg_conn.notifies.clear()  # free resources
             # add notified databases (in order) first in the queue
             self.db_queue.extend(db for db in notified if db in db_names)
             self.db_queue.extend(db for db in db_names if db not in notified)


### PR DESCRIPTION
`notifies` is the attribute of the raw connection, not the cursor. Fix in multi-process, multi-threaded version is ok.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
