### PR TITLE
[FIX] point_of_sale: Unecessary this when updating customer display

### DIFF
--- a/addons/point_of_sale/static/src/customer_display/customer_display_adapter.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display_adapter.js
@@ -23,9 +23,9 @@ export class CustomerDisplayPosAdapter {
 
         if (pos.config.customer_display_type === "remote") {
             pos.data.call("pos.config", "update_customer_display", [
-                [this.pos.config.id],
+                [pos.config.id],
                 this.data,
-                this.pos.config.access_token,
+                pos.config.access_token,
             ]);
         }
 


### PR DESCRIPTION
This will prevent having a traceback when loading an order on mobile devices

Description of the issue/feature this PR addresses:

When opening a order on a mobile devices when customer display is set to remote we get a traceback

Current behavior before PR:

When opening a order on a mobile devices when customer display is set to remote we get a traceback

Desired behavior after PR is merged:

No more traceback
