### PR TITLE
[FIX] point_of_sale: method delete_ called with undefined record

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -658,6 +658,9 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
     }
 
     function delete_(model, record, opts = {}) {
+        if (!record){
+            return;
+        }
         const id = record.id;
         const fields = getFields(model);
         const handleCommand = (inverse, field, record, backend = false) => {


### PR DESCRIPTION
In certain case when adding a pos.order.lien then removing it and spliting the order the syncronazation try to delete on the other device already deleted pos.order.line resulting in a traceback

Description of the issue/feature this PR addresses:

Fix a traceback when spliting an order

Current behavior before PR:

Traceback

Desired behavior after PR is merged:

No more traceback

Ticket : #4562134
