### PR TITLE
[FIX] l10n_in_sale: fix FPOS when invoice created from sale order

### DIFF
--- a/addons/l10n_in_sale/models/sale_order.py
+++ b/addons/l10n_in_sale/models/sale_order.py
@@ -38,4 +38,7 @@ class SaleOrder(models.Model):
         if self.country_code == 'IN':
             invoice_vals['l10n_in_reseller_partner_id'] = self.l10n_in_reseller_partner_id.id
             invoice_vals['l10n_in_gst_treatment'] = self.l10n_in_gst_treatment
+            # Removing FPOS from `invoice_vals` to let `l10n_in` handle it per the Indian context,
+            # computing it directly on the move.
+            invoice_vals.pop('fiscal_position_id')
         return invoice_vals


### PR DESCRIPTION
- Before this commit: The fiscal position was computed on the sales order, which did not comply with Indian regulations. When the invoice was created, it used the precomputed fiscal position from the sales order.

- After this commit: The fiscal position is recomputed on account.move at the time of invoice creation, ensuring compliance with Indian regulations.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
