### PR TITLE
[FIX] web: remove extra white background from image in dark mode

### DIFF
--- a/addons/web/static/src/views/fields/image/image_field.scss
+++ b/addons/web/static/src/views/fields/image/image_field.scss
@@ -1,9 +1,12 @@
 .o_field_image {
-    background-color: var(--ImageField-background-color, transparent);
 
     > div {
         height: 100%;
         width: 100%;
+
+        > img {
+            background-color: var(--ImageField-background-color, transparent);
+        }
     }
 
     button {


### PR DESCRIPTION
Steps to reproduce:
- Turn on dark mode
- Open the Field Service app.
- Click on "Add Product" to navigate to the product catalog.

Issue:
- An extra white background appears below the product image.

Solution:
- Updated the CSS to apply `--ImageField-background-color` directly to the `<img>`
  tag instead of the `.o_field_image` parent div. This prevents unwanted white 
  spaces below the parent container

The change has been applied globally to all `.o_field_image` elements, as the 
`.o_field_image` class is always on the parent `<div>`, not on the `<img>` tag.

task-4302221

