### PR TITLE
[FIX] im_livechat: ensure 'question selection' step has answers

### DIFF
--- a/addons/im_livechat/models/chatbot_script.py
+++ b/addons/im_livechat/models/chatbot_script.py
@@ -4,6 +4,7 @@
 from odoo import api, models, fields
 from odoo.http import request
 from odoo.tools import email_normalize, get_lang, html2plaintext, is_html_empty, plaintext2html
+from odoo.exceptions import ValidationError
 
 
 class ChatbotScript(models.Model):
@@ -27,6 +28,12 @@ class ChatbotScript(models.Model):
         ('first_step_operator', 'First Step Operator'),
         ('first_step_invalid', 'First Step Invalid'),
     ], compute="_compute_first_step_warning")
+
+    @api.constrains("script_step_ids")
+    def _check_question_selection(self):
+        for step in self.script_step_ids:
+            if step.step_type == "question_selection" and not step.answer_ids:
+                raise ValidationError(self.env._("Step of type 'Question' must have answers."))
 
     def _compute_livechat_channel_count(self):
         channels_data = self.env['im_livechat.channel.rule']._read_group(


### PR DESCRIPTION
**Current behavior before PR:**

It was possible to save a step with step_type "question selection" without any answers. However, this would cause an error when the bot was executed.


**Desired behavior after PR is merged:**

A constraint has been added to ensure that a "question selection" step cannot be saved without at least one answer.

task-id:[4522835](https://www.odoo.com/odoo/my-tasks/4522835)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
