### PR TITLE
[FIX] website: include archived snippet views to avoid duplication error

### DIFF
--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -601,7 +601,7 @@ class IrModuleModule(models.Model):
             create_values = [values for values in create_values if values]
 
             keys = [values['key'] for values in create_values]
-            existing_primary_template_keys = self.env['ir.ui.view'].search_fetch([
+            existing_primary_template_keys = self.env['ir.ui.view'].with_context(active_test=False).search_fetch([
                 ('mode', '=', 'primary'), ('key', 'in', keys),
             ], ['key']).mapped('key')
             missing_create_values = [values for values in create_values if values['key'] not in existing_primary_template_keys]


### PR DESCRIPTION
- While calling `_generate_primary_snippet_templates`, `create_missing_views` fetches the existing snippet views. However, archived snippet is ignored, causing `create_missing_views` to attempt to create the snippet again, mistakenly considering it as a missing view. This leads to a traceback:

```py
  File "/data/build/odoo/odoo/sql_db.py", line 332, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "ir_model_data_module_name_uniq_index"
DETAIL:  Key (module, name)=(website, new_page_template_services_0_s_website_form) already exists.
```

- To prevent such errors, it's better to fetch inactive views as well during creation.

opw-4510585
upg-2452055



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
