### PR TITLE
[IMP] web: remove href="#"

### DIFF
--- a/addons/account/static/src/components/account_file_uploader/account_file_uploader.xml
+++ b/addons/account/static/src/components/account_file_uploader/account_file_uploader.xml
@@ -19,7 +19,7 @@
 
     <t t-name="account.JournalUploadLink">
         <t groups="account.group_account_invoice">
-            <a t-att-class="props.btnClass" href="#" t-out="props.linkText"/>
+            <button t-att-class="props.btnClass" t-out="props.linkText"/>
         </t>
     </t>
 

--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -15,14 +15,13 @@
                     <tr>
                     <t t-if="info.outstanding">
                         <td>
-                            <a title="assign to invoice"
+                            <button title="assign to invoice"
                                role="button"
                                class="oe_form_field btn btn-secondary outstanding_credit_assign"
                                t-att-data-id="line.id"
                                style="margin-right: 0px; padding-left: 5px; padding-right: 5px;"
-                               href="#"
                                data-bs-toggle="tooltip"
-                               t-on-click.prevent="() => this.assignOutstandingCredit(info.moveId, line.id)">Add</a>
+                               t-on-click.prevent="() => this.assignOutstandingCredit(info.moveId, line.id)">Add</button>
                         </td>
                         <td style="max-width: 11em;">
                             <a t-att-title="line.formattedDate"

--- a/addons/account/static/src/components/actionable_errors/actionable_errors.xml
+++ b/addons/account/static/src/components/actionable_errors/actionable_errors.xml
@@ -8,15 +8,14 @@
                     <div t-att-class="`alert alert-${level} m-0 p-1 ps-3`" role="alert">
                         <div t-att-name="error" style="white-space: pre-wrap;">
                             <t t-out="error_value.message"/>
-                            <a class="fw-bold"
+                            <button class="fw-bold btn btn-link p-0"
                                t-if="error_value.action"
-                               href="#"
                                t-on-click.prevent="() => this.handleOnClick(error_value)"
                             >
                                 <i class="oi oi-arrow-right ms-1"/>
                                 <span class="ms-1" t-out="error_value.action_text"/>
                                 <i t-if="level === 'danger'" class="fa fa-warning ms-1"/>
-                            </a>
+                            </button>
                         </div>
                     </div>
                 </t>

--- a/addons/account/static/src/components/bill_guide/bill_guide.xml
+++ b/addons/account/static/src/components/bill_guide/bill_guide.xml
@@ -11,7 +11,6 @@
                     <div>
                         <span class="btn pe-none px-1 fw-normal">or</span>
                         <a class="btn btn-link px-0 fw-normal"
-                            href="#"
                             type="object"
                             name="action_create_vendor_bill"
                             journal_type="purchase"
@@ -44,14 +43,14 @@
                         </div>
                         <div>
                             <span class="btn pe-none px-1 fw-normal">or</span>
-                            <a href="#"
+                            <button
                                 type="object"
                                 class="btn btn-link px-0 fw-normal"
                                 t-on-click="() => this.handleButtonClick('action_create_new')"
                                 groups="account.group_account_invoice"
                             >
                                 Create manually
-                            </a>
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -63,14 +62,14 @@
                     </div>
                     <div class="text-center mt-2">
                         <div class="">
-                            <a href="#"
+                            <button
                                 type="object"
-                                class="o_invoice_new"
+                                class="o_invoice_new btn btn-link p-0 fw-normal"
                                 t-on-click="() => this.handleButtonClick('action_create_new')"
                                 groups="account.group_account_invoice"
                             >
                                 Create a bill manually
-                            </a>
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/addons/account/static/src/components/onboarding/onboarding.xml
+++ b/addons/account/static/src/components/onboarding/onboarding.xml
@@ -8,7 +8,8 @@
                     'fa-circle text-secondary': step.state == 'not_done',
                     'fa-check-circle text-success': step.state != 'not_done',
                 }"/>
-                <a href="#"
+                <button
+                   t-att-class="'btn btn-link p-0 fw-normal'"
                    t-att-data-method="step.action"
                    data-model="onboarding.onboarding.step"
                    t-out="step.title"

--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -240,7 +240,7 @@
     <template id="portal_invoice_error" name="Invoice error/warning display">
         <div class="row mr16">
             <div t-attf-class="'col-lg-12 mr16 ml16 alert alert-dismissable' #{'alert-danger' if error else 'alert-warning'}" role="alert">
-                <a href="#" class="close" data-bs-dismiss="alert" aria-label="close" title="close">×</a>
+                <button class="close btn btn-link p-0" data-bs-dismiss="alert" aria-label="close" title="close">×</button>
                 <t t-if="error == 'generic'" name="generic">
                     There was an error processing this page.
                 </t>
@@ -251,7 +251,7 @@
     <template id="portal_invoice_success" name="Invoice success display">
         <div class="row mr16">
             <div class="col-lg-12 mr16 ml16 alert alert-dismissable alert-success" role="status">
-                <a href="#" class="close" data-bs-dismiss="alert" aria-label="close" title="close">×</a>
+                <button class="close btn btn-link p-0" data-bs-dismiss="alert" aria-label="close" title="close">×</button>
             </div>
         </div>
     </template>

--- a/addons/account_payment/static/tests/interactions/portal_invoice_page_payment.test.js
+++ b/addons/account_payment/static/tests/interactions/portal_invoice_page_payment.test.js
@@ -65,7 +65,7 @@ test("portal_invoice_page_payment is started with #portal_pay", async () => {
                                     </div>
                                     <div class="d-flex flex-column gap-4 mt-3">
                                         <div class="d-flex flex-column gap-2">
-                                            <a href="#" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#pay_with" data-oe-id="868" data-oe-xpath="/data/xpath[2]/a" data-oe-model="ir.ui.view" data-oe-field="arch">
+                                            <a href="#test" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#pay_with" data-oe-id="868" data-oe-xpath="/data/xpath[2]/a" data-oe-model="ir.ui.view" data-oe-field="arch">
                                             <i class="fa fa-fw fa-arrow-circle-right"></i> Pay Now
                                             </a>
                                             <div class="o_download_pdf d-flex flex-lg-column flex-xl-row flex-wrap gap-2">

--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -298,13 +298,12 @@
             </div>
         </xpath>
         <xpath expr="//t[@t-call='portal.portal_record_sidebar']//div[hasclass('o_download_pdf')]" position="before">
-            <a t-if="invoice._has_to_be_paid()"
-                href="#"
+            <button t-if="invoice._has_to_be_paid()"
                 class="btn btn-primary"
                 data-bs-toggle="modal"
                 data-bs-target="#pay_with">
                 <i class="fa fa-fw fa-arrow-circle-right"/> Pay Now
-            </a>
+            </button>
         </xpath>
         <xpath expr="//div[@id='invoice_content']//div[hasclass('o_portal_html_view')]" position="before">
             <t t-set="tx" t-value="invoice.get_portal_last_transaction()"/>
@@ -346,7 +345,7 @@
 
     <template id="portal_invoice_success" name="Invoice success display: payment success"
             inherit_id="account.portal_invoice_success">
-        <xpath expr="//a[hasclass('close')]" position="after">
+        <xpath expr="//button[hasclass('close')]" position="after">
             <t t-if="success == 'pay_invoice'">
                 <t t-set="tx_sudo" t-value="invoice.get_portal_last_transaction()"/>
                 <span t-if="tx_sudo.provider_id.sudo().done_msg" t-out="tx_sudo.provider_id.sudo().done_msg"/>

--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.xml
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.xml
@@ -58,7 +58,7 @@
                         </tr>
                         <tr>
                             <td t-on-click.stop.prevent="addLine" class="o_field_x2many_list_row_add" t-att-colspan="allPlans.length + 2 + valueColumnEnabled">
-                                <a href="#" t-ref="addLineButton" tabindex="0">Add a Line</a>
+                                <button class="btn btn-link p-0 fw-normal" t-ref="addLineButton" tabindex="0">Add a Line</button>
                             </td>
                         </tr>
                     </tbody>

--- a/addons/base_import/static/src/import_data_column_error/import_data_column_error.xml
+++ b/addons/base_import/static/src/import_data_column_error/import_data_column_error.xml
@@ -10,9 +10,9 @@
                 </p>
                 <ul>
                     <t t-foreach="props.errors" t-as="error" t-key="error_index">
-                        <a t-if="error_index === 3" href="#" class="o_import_report_count" t-on-click="() => this.state.isExpanded = !this.state.isExpanded">
+                        <button t-if="error_index === 3" class="o_import_report_count btn btn-link p-0" t-on-click="() => this.state.isExpanded = !this.state.isExpanded">
                             <i t-attf-class="fa fa-chevron-{{state.isExpanded ? 'up' : 'down'}}"></i> <t t-esc="props.errors.length - error_index"/> more
-                        </a>
+                        </button>
                         <li t-if="isErrorVisible(error_index)" t-attf-class="o_import_report_more p-0 text-{{error.priority}} {{error_index > 2 ? 'list-unstyled' : ''}}">
                             <t t-if="error.rows.from === error.rows.to">
                                 <b t-esc="error.value"/> at row <t t-esc="error.rows.from + 1"/>
@@ -29,9 +29,9 @@
             <t t-if="moreInfo">
                 <t t-if="typeof moreInfo === 'string'" t-esc="moreInfo"/>
                 <div t-else="" class="o_import_moreinfo" t-on-click="onMoreInfoClicked">
-                    <a href="#" class="o_import_see_all">
+                    <button class="o_import_see_all btn btn-link p-0">
                         <i class="oi oi-arrow-right"></i> See possible values
-                    </a>
+                    </button>
                 </div>
                 <ul t-if="state.moreInfoContent" class="o_import_report_more">
                     <li t-foreach="state.moreInfoContent" t-as="msg" t-key="msg_index"><t t-esc="msg"/></li>

--- a/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_popover.xml
+++ b/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_popover.xml
@@ -9,16 +9,16 @@
         </xpath>
         <xpath expr="//div[hasclass('flex-grow-1')]" position="after">
             <t t-if="fieldInfo.options.shouldOpenRecord">
-                <a href="#" t-on-click="onClickOpenRecord">
+                <button class="btn btn-link p-0 fw-normal" t-on-click="onClickOpenRecord">
                     <t t-out="props.record.rawRecord.res_model_name"/>
-                </a>
+                </button>
         </t>
         </xpath>
     </t>
 
     <t t-name="calendar.AttendeeCalendarCommonPopover.footer" t-inherit="web.CalendarCommonPopover.footer" t-inherit-mode="primary">
         <xpath expr="//t[@t-if='isEventDeletable']" position="after">
-            <a t-if="isEventArchivable and isEventDetailsVisible" href="#" class="btn btn-secondary o_cw_popover_archive_g" t-on-click="onClickArchive">Delete</a>
+            <button t-if="isEventArchivable and isEventDetailsVisible" class="btn btn-secondary o_cw_popover_archive_g" t-on-click="onClickArchive">Delete</button>
             <t t-if="displayAttendeeAnswerChoice">
                 <div class="btn-group w-100 w-lg-auto ms-lg-auto order-first order-lg-0 px-2 px-lg-0">
                     <button class="btn"

--- a/addons/calendar/static/tests/attendee_calendar_views.test.js
+++ b/addons/calendar/static/tests/attendee_calendar_views.test.js
@@ -122,7 +122,7 @@ test("Linked record rendering", async () => {
     await changeScale("week");
     await clickEvent(eventId);
     expect(".fa-link").toHaveCount(1, { message: "A link icon should be present" });
-    expect("li a[href='#']").toHaveText(display_name);
+    expect("li button").toHaveText(display_name);
 });
 
 test("Default duration rendering", async () => {

--- a/addons/crm/views/utm_campaign_views.xml
+++ b/addons/crm/views/utm_campaign_views.xml
@@ -15,14 +15,14 @@
                 <t t-else="">
                     <t t-set="crm_lead_count_label">Opportunities</t>
                 </t>
-                <a t-if="record.crm_lead_count" href="#" t-att-title="crm_lead_count_label" role="button"
+                <button t-if="record.crm_lead_count" t-att-title="crm_lead_count_label" role="button"
                     groups="sales_team.group_sale_salesman" type="object" name="action_redirect_to_leads_opportunities"
-                    class="btn-outline-primary rounded-pill me-1 order-3">
+                    class="rounded-pill me-1 order-3 p-0">
                     <span class="badge">
                         <i class="fa fa-fw fa-star" t-att-aria-label="crm_lead_count_label" role="img"/>
                         <field name="crm_lead_count"/>
                     </span>
-                </a>
+                </button>
             </xpath>
         </field>
     </record>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -311,8 +311,8 @@
                             <field name="vehicle_properties" widget="properties"/>
                             <footer class="pt-0 mt-0" t-if="!selection_mode">
                                 <div class="d-flex fs-6">
-                                    <a t-if="record.contract_count.raw_value>0" type="object"
-                                        name="return_action_to_open" href="#" data-context='{"xml_id":"fleet_vehicle_log_contract_action"}'>
+                                    <button t-if="record.contract_count.raw_value>0" type="object"
+                                        name="return_action_to_open" data-context='{"xml_id":"fleet_vehicle_log_contract_action"}' class="btn btn-link fw-normal p-0">
                                         <field name="contract_count"/>
                                         Contract(s)
                                         <span t-if="record.contract_renewal_due_soon.raw_value and !record.contract_renewal_overdue.raw_value"
@@ -321,7 +321,7 @@
                                         <span t-if="record.contract_renewal_overdue.raw_value"
                                             class="fa fa-exclamation-triangle text-danger" role="img" aria-label="Attention: renewal overdue" title="Attention: renewal overdue">
                                         </span>
-                                    </a>
+                                    </button>
                                     <field name="activity_ids" widget="kanban_activity" class="ms-2"/>
                                 </div>
                             </footer>

--- a/addons/hr/static/src/components/employee_chat/employee_chat.xml
+++ b/addons/hr/static/src/components/employee_chat/employee_chat.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="hr.OpenChat">
-        <a t-if="props.record.data.user_id and props.record.resId"
+        <button t-if="props.record.data.user_id and props.record.resId"
             title="Chat"
             icon="fa-comments"
             t-on-click.prevent="() => openChat(props.record.resId)"
-            href="#"
-            class="ml8 o_employee_chat_btn"
+            class="ml8 o_employee_chat_btn btn btn-link p-0"
             role="button">
             <i class="fa fa-comments align-middle fs-6"/>
-        </a>
+        </button>
     </t>
 </templates>

--- a/addons/hr_attendance/static/src/components/pin_code/pin_code.xml
+++ b/addons/hr_attendance/static/src/components/pin_code/pin_code.xml
@@ -24,9 +24,9 @@
                                 </div>
                                 <div class="row g-2">
                                     <div class="col-4" t-foreach="padButtons" t-as="btn" t-key="btn[0]">
-                                        <a href="#" t-on-click="() => this.onClickPadButton(btn[0])" t-attf-class="o_hr_attendance_PINbox_button btn {{btn[1]? btn[1] : 'btn-secondary'}} d-flex align-items-center justify-content-center py-2 py-xl-3 rounded-1">
+                                        <button t-on-click="() => this.onClickPadButton(btn[0])" t-attf-class="o_hr_attendance_PINbox_button btn {{btn[1]? btn[1] : 'btn-secondary'}} d-flex align-items-center justify-content-center py-2 py-xl-3 rounded-1 w-100">
                                             <t t-esc="btn[0]"/>
-                                        </a>
+                                        </button>
                                     </div>
                                 </div>
                             </div>

--- a/addons/hr_org_chart/static/src/fields/hr_org_chart.xml
+++ b/addons/hr_org_chart/static/src/fields/hr_org_chart.xml
@@ -54,7 +54,7 @@
                 data-bs-trigger="focus"
                 data-bs-toggle="popover"
                 t-on-click="(event) => this._onOpenPopover(event, employee)">
-            <a href="#"
+            <button
                 t-attf-class="badge rounded-pill bg-300 border {{employee.indirect_sub_count &lt; 10 ? 'px-2' : 'px-1' }}"
                 t-esc="employee.indirect_sub_count"
                 />
@@ -73,9 +73,9 @@
     <t t-set="emp_count" t-value="0"/>
     <div t-if='managers.length &gt; 0' class="o_org_chart_group_up position-relative">
         <div t-if='managers_more' class="o_org_chart_more pe-3">
-            <a href="#" t-att-data-employee-id="managers[0].id" class="o_employee_more_managers d-block bg-100 px-3" t-on-click.prevent="() => this._onEmployeeMoreManager(managers[0].id)">
+            <button t-att-data-employee-id="managers[0].id" class="o_employee_more_managers d-block bg-100 px-3 btn btn-link text-start w-100" t-on-click.prevent="() => this._onEmployeeMoreManager(managers[0].id)">
                 <i class="fa fa-angle-double-up" role="img" aria-label="More managers" title="More managers"/>
-            </a>
+            </button>
         </div>
 
         <t t-foreach="managers" t-as="employee" t-key="employee_index">
@@ -111,11 +111,11 @@
         <t t-if="(children.length + managers.length) &gt; 19">
             <div class="o_org_chart_entry o_org_chart_more d-flex overflow-visible">
                 <div class="o_media_left position-relative">
-                    <a href="#"
+                    <button
                         t-att-data-employee-id="self.id"
                         t-att-data-employee-name="self.name"
                         class="o_org_chart_show_more o_employee_sub_redirect btn btn-link ps-2"
-                        t-on-click.prevent="_onEmployeeSubRedirect">See All</a>
+                        t-on-click.prevent="_onEmployeeSubRedirect">See All</button>
                 </div>
             </div>
         </t>
@@ -131,7 +131,7 @@
             <div class="d-flex align-items-center">
                 <span class="flex-shrink-0" t-att-style='"background-image:url(\"/web/image/hr.employee.public/" + props.employee.id + "/avatar_1024/\")"'/>
                 <b class="flew-grow-1"><t t-esc="props.employee.name"/></b>
-                <a href="#" class="ms-auto o_employee_redirect" t-att-data-employee-id="props.employee.id" t-on-click.prevent="() => this._onEmployeeRedirect(props.employee.id)"><i class="fa fa-external-link" role="img" aria-label='Redirect' title="Redirect"></i></a>
+                <button class="ms-auto o_employee_redirect btn btn-link p-0" t-att-data-employee-id="props.employee.id" t-on-click.prevent="() => this._onEmployeeRedirect(props.employee.id)"><i class="fa fa-external-link" role="img" aria-label='Redirect' title="Redirect"></i></button>
             </div>
         </h3>
         <div class="popover-body">
@@ -140,10 +140,10 @@
                     <tr>
                         <td class="text-end"><b t-esc="props.employee.direct_sub_count"/></td>
                         <td>
-                            <a href="#" class="o_employee_sub_redirect" data-type='direct'
+                            <button class="o_employee_sub_redirect btn btn-link p-0" data-type='direct'
                                     t-att-data-employee-name="props.employee.name" t-att-data-employee-id="props.employee.id"
                                     t-on-click.prevent="_onEmployeeSubRedirect">
-                                <b>Direct subordinates</b></a>
+                                <b>Direct subordinates</b></button>
                         </td>
                     </tr>
                     <tr>
@@ -151,19 +151,19 @@
                             <b t-esc="props.employee.indirect_sub_count - props.employee.direct_sub_count"/>
                         </td>
                         <td>
-                            <a href="#" class="o_employee_sub_redirect" data-type='indirect'
+                            <button class="o_employee_sub_redirect btn btn-link fw-normal p-0" data-type='indirect'
                                     t-att-data-employee-name="props.employee.name" t-att-data-employee-id="props.employee.id"
                                     t-on-click.prevent="_onEmployeeSubRedirect">
-                                Indirect subordinates</a>
+                                Indirect subordinates</button>
                         </td>
                     </tr>
                     <tr>
                         <td class="text-end"><b t-esc="props.employee.indirect_sub_count"/></td>
                         <td>
-                            <a href="#" class="o_employee_sub_redirect" data-type='total'
+                            <button class="o_employee_sub_redirect btn btn-link fw-normal p-0" data-type='total'
                                     t-att-data-employee-name="props.employee.name" t-att-data-employee-id="props.employee.id"
                                     t-on-click.prevent="_onEmployeeSubRedirect">
-                                Total</a>
+                                Total</button>
                         </td>
                     </tr>
                 </tbody>

--- a/addons/hr_timesheet/views/project_task_portal_templates.xml
+++ b/addons/hr_timesheet/views/project_task_portal_templates.xml
@@ -7,7 +7,7 @@
         </xpath>
         <xpath expr="//div[@id='task-nav']" position="before">
             <div t-if="timesheets and allow_timesheets and show_portal_timesheets" class="d-grid flex-grow-1" id='nav-report'>
-                <a class="btn btn-light o_print_btn o_project_timesheet_print d-block" t-att-href="task.get_portal_url(report_type='pdf')" href="#" title="View Details" role="button" target="_blank"><i class="fa fa-print"/> View Details</a>
+                <a class="btn btn-light o_print_btn o_project_timesheet_print d-block" t-att-href="task.get_portal_url(report_type='pdf')" title="View Details" role="button" target="_blank"><i class="fa fa-print"/> View Details</a>
             </div>
         </xpath>
         <xpath expr="//li[@id='nav-header']" position="after">

--- a/addons/html_editor/static/src/components/history_dialog/history_dialog.xml
+++ b/addons/html_editor/static/src/components/history_dialog/history_dialog.xml
@@ -10,13 +10,13 @@
 
                     <t t-foreach="state.revisionsData" t-as="rev"
                        t-key="rev.revision_id">
-                        <a type="object" href="#" role="button"
+                        <button type="object" role="button"
                            t-attf-class="btn btn-outline-primary #{state.revisionId === rev.revision_id ? 'active' : ''}"
                            t-on-click="() => this.updateCurrentRevision(rev.revision_id )">
                             <strong><t t-esc="this.getRevisionDate(rev)" /></strong>
                             <br/>
                             <small><t t-esc="rev.create_user_name" /></small>
-                        </a>
+                        </button>
                     </t>
                 </div>
                 <div class="history-container">

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -107,27 +107,27 @@
                         </span>
                         <div class="ms-1 w-100">
                             <div class="d-flex">
-                                <a href="#" target="_blank" t-on-click="onClickForceEditMode" t-attf-href="{{state.url}}" class="o_we_url_link fw-bold flex-grow-1 text-truncate" style="max-width: 160px;" t-attf-title="{{state.urlTitle}}">
+                                <a target="_blank" t-on-click="onClickForceEditMode" t-attf-href="{{state.url}}" class="o_we_url_link fw-bold flex-grow-1 text-truncate" style="max-width: 160px;" t-attf-title="{{state.urlTitle}}">
                                     <t t-esc="state.urlTitle"/>
                                 </a>
                                 <div class="flex-grow-1 d-flex justify-content-end">
-                                    <a href="#" class="mx-1 o_we_replace_title_btn text-dark"
+                                    <button class="mx-1 o_we_replace_title_btn text-dark bg-transparent border-0 p-0"
                                         t-if="!state.isImage and state.urlTitle and state.label === '' and !state.showReplaceTitleBanner"
                                         t-on-click="onClickReplaceTitle"
                                         title="Replace URL with its title"
                                     >
                                         <i class="fa fa-magic"></i>
-                                    </a>
-                                    <a href="#" class="mx-1 o_we_copy_link text-dark" t-on-click="onClickCopy" title="Copy Link">
+                                    </button>
+                                    <button class="mx-1 o_we_copy_link text-dark bg-transparent border-0 p-0" t-on-click="onClickCopy" title="Copy Link">
                                         <i class="fa fa-clipboard"></i>
-                                    </a>
+                                    </button>
                                     <t t-if="props.canEdit">
-                                        <a href="#" class="mx-1 o_we_edit_link text-dark" t-on-click="onClickEdit" title="Edit Link">
+                                        <button class="mx-1 o_we_edit_link text-dark bg-transparent border-0 p-0" t-on-click="onClickEdit" title="Edit Link">
                                             <i class="fa fa-edit"></i>
-                                        </a>
-                                        <a href="#" class="ms-1 o_we_remove_link text-dark" t-on-click="onClickRemove" title="Remove Link">
+                                        </button>
+                                        <button class="ms-1 o_we_remove_link text-dark bg-transparent border-0 p-0" t-on-click="onClickRemove" title="Remove Link">
                                             <i class="fa fa-chain-broken"></i>
-                                        </a>
+                                        </button>
                                     </t>
                                 </div>
                             </div>
@@ -140,7 +140,7 @@
                         </div>
                     </div>
                     <div t-if="state.imgSrc" class="o_extra_info_card" style="align-self: center; max-width: 235px">
-                            <a href="#" target="_blank" t-attf-href="{{state.url}}" title="Open in a new tab">
+                            <a target="_blank" t-attf-href="{{state.url}}" title="Open in a new tab">
                                 <img t-att-src="state.imgSrc" class="img-fluid mb-1" style="max-width: 230; max-height: 100%;"/>
                             </a>
                     </div>

--- a/addons/html_editor/static/src/main/link/navbar_link_popover.xml
+++ b/addons/html_editor/static/src/main/link/navbar_link_popover.xml
@@ -2,10 +2,10 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="html_editor.navbarLinkPopover" t-inherit="html_editor.linkPopover">
-        <xpath expr="//a[@title='Remove Link']" position="replace">
-            <a href="#" class="ms-2 js_edit_menu text-dark" t-on-click="onClickEditMenu" title="Edit Menu">
+        <xpath expr="//button[@title='Remove Link']" position="replace">
+            <button class="ms-2 js_edit_menu text-dark border-0 bg-transparent p-0" t-on-click="onClickEditMenu" title="Edit Menu">
                 <i class="fa fa-sitemap"></i>
-            </a>
+            </button>
         </xpath>
     </t>
 

--- a/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.scss
+++ b/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.scss
@@ -12,7 +12,7 @@ $embedded-toc-bg--active: #1ba1e4;
     & .o_embedded_toc_content {
         background-color: $o-view-background-color;
 
-        a[class*="o_embedded_toc_link_depth_"] {
+        button[class*="o_embedded_toc_link_depth_"] {
             font-family: $font-family-base !important;
             border-radius: 5px;
             min-height: $line-height-base * $font-size-base;
@@ -25,13 +25,13 @@ $embedded-toc-bg--active: #1ba1e4;
 
         }
 
-        a.o_embedded_toc_link_depth_0 {
+        button.o_embedded_toc_link_depth_0 {
             // initial 5px padding to give some space to first level
             padding-left: 5px;
         }
 
         @for $depth from 1 through 5 {
-            a.o_embedded_toc_link_depth_#{$depth} {
+            button.o_embedded_toc_link_depth_#{$depth} {
                 padding-left: calc(5px + Min(30px, 10%) * #{$depth});
             }
         }

--- a/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.xml
+++ b/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.xml
@@ -10,10 +10,10 @@
         </div>
         <div t-if="!state.folded" class="o_embedded_toc_content">
             <t t-foreach="this.state.toc.headings" t-as="heading" t-key="heading_index">
-                <a href="#" contenteditable="false"
+                <button contenteditable="false"
                     t-out="heading.name"
                     t-on-click.prevent="() => this.onTocLinkClick(heading)"
-                    t-attf-class="o_no_link_popover py-1 pe-1 d-block text-reset o_embedded_toc_link #{'o_embedded_toc_link_depth_' + heading.depth}"/>
+                    t-attf-class="o_no_link_popover py-1 pe-1 d-block text-reset w-100 btn btn-link text-start fw-normal o_embedded_toc_link #{'o_embedded_toc_link_depth_' + heading.depth}"/>
             </t>
         </div>
     </div>

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -318,17 +318,17 @@ test("should apply background color to a list of 3 links", async () => {
         contentBefore:
             "<ul>" +
             "<li>" +
-            '<a href="#">' +
+            '<a href="#test">' +
             "[abc" +
             "</a>" +
             "</li>" +
             "<li>" +
-            '<a href="#">' +
+            '<a href="#test">' +
             "bcd" +
             "</a>" +
             "</li>" +
             "<li>" +
-            '<a href="#">' +
+            '<a href="#test">' +
             "cde]" +
             "</a>" +
             "</li>" +
@@ -337,21 +337,21 @@ test("should apply background color to a list of 3 links", async () => {
         contentAfter:
             "<ul>" +
             "<li>" +
-            '<a href="#">' +
+            '<a href="#test">' +
             '<font style="background-color: rgb(255, 0, 0);">' +
             "[abc" +
             "</font>" +
             "</a>" +
             "</li>" +
             "<li>" +
-            '<a href="#">' +
+            '<a href="#test">' +
             '<font style="background-color: rgb(255, 0, 0);">' +
             "bcd" +
             "</font>" +
             "</a>" +
             "</li>" +
             "<li>" +
-            '<a href="#">' +
+            '<a href="#test">' +
             '<font style="background-color: rgb(255, 0, 0);">' +
             "cde]" +
             "</font>" +
@@ -363,11 +363,11 @@ test("should apply background color to a list of 3 links", async () => {
 
 test("should distribute color to texts and to button separately", async () => {
     await testEditor({
-        contentBefore: '<p>a[b<a href="#" class="btn">c</a>d]e</p>',
+        contentBefore: '<p>a[b<a href="#test" class="btn">c</a>d]e</p>',
         stepFunction: setColor("rgb(255, 0, 0)", "color"),
         contentAfter:
             '<p>a<font style="color: rgb(255, 0, 0);">[b</font>' +
-            '<a href="#" class="btn"><font style="color: rgb(255, 0, 0);">c</font></a>' +
+            '<a href="#test" class="btn"><font style="color: rgb(255, 0, 0);">c</font></a>' +
             '<font style="color: rgb(255, 0, 0);">d]</font>e</p>',
     });
 });

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -458,7 +458,7 @@ describe("Selection collapsed", () => {
 
         test("should remove a link to uploaded document", async () => {
             await testEditor({
-                contentBefore: `<p>abc<a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a>[]</p>`,
+                contentBefore: `<p>abc<a href="#test" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a>[]</p>`,
                 stepFunction: deleteBackward,
                 contentAfter: `<p>abc[]</p>`,
             });
@@ -466,7 +466,7 @@ describe("Selection collapsed", () => {
 
         test("should remove a link to uploaded document at the beginning of the editable", async () => {
             await testEditor({
-                contentBefore: `<p><a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a>[]</p>`,
+                contentBefore: `<p><a href="#test" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a>[]</p>`,
                 stepFunction: deleteBackward,
                 contentAfter: `<p>[]<br></p>`,
             });
@@ -497,7 +497,7 @@ describe("Selection collapsed", () => {
         });
         test("should delete only the button", async () => {
             await testEditor({
-                contentBefore: `<p>a<a class="btn" href="#">[]</a></p>`,
+                contentBefore: `<p>a<a class="btn" href="#test">[]</a></p>`,
                 stepFunction: deleteBackward,
                 contentAfter: `<p>a[]</p>`,
             });

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -334,7 +334,7 @@ describe("Selection collapsed", () => {
 
         test("should remove a link to uploaded document", async () => {
             await testEditor({
-                contentBefore: `<p>[]<a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a>abc</p>`,
+                contentBefore: `<p>[]<a href="test#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a>abc</p>`,
                 stepFunction: deleteForward,
                 contentAfter: `<p>[]abc</p>`,
             });
@@ -342,7 +342,7 @@ describe("Selection collapsed", () => {
 
         test("should remove a link to uploaded document at the end of the editable", async () => {
             await testEditor({
-                contentBefore: `<p>[]<a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a></p>`,
+                contentBefore: `<p>[]<a href="#test" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a></p>`,
                 stepFunction: deleteForward,
                 contentAfter: `<p>[]<br></p>`,
             });
@@ -350,7 +350,7 @@ describe("Selection collapsed", () => {
 
         test("should delete only the button", async () => {
             await testEditor({
-                contentBefore: `<p><a class="btn" href="#">[]</a>a</p>`,
+                contentBefore: `<p><a class="btn" href="#test">[]</a>a</p>`,
                 stepFunction: deleteForward,
                 contentAfter: `<p>[]a</p>`,
             });

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -58,7 +58,7 @@ test("placeholder must not be visible if there is content in the editor", async 
 
 test("placeholder must not be visible if there is content in the editor (2)", async () => {
     const content =
-        '<p><a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a></p>';
+        '<p><span title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></span></p>';
     const { el } = await setupEditor(content, { config: { placeholder: "test" } });
     // Unchanged, no placeholder hint.
     expect(getContent(el)).toBe(content);
@@ -66,7 +66,7 @@ test("placeholder must not be visible if there is content in the editor (2)", as
 
 test("should not display hint in paragraph with media content", async () => {
     const content =
-        '<p><a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a>[]</p>';
+        '<p><span title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></span>[]</p>';
     const { el } = await setupEditor(content);
     // Unchanged, no empty paragraph hint.
     expect(getContent(el)).toBe(content);

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -343,7 +343,7 @@ test("XML-like self-closing elements are fixed in readonly mode", async () => {
     Partner._records = [
         {
             id: 1,
-            txt: `<a href="#"/>outside<a href="#">inside</a>`,
+            txt: `<a href="#test"/>outside<a href="#test">inside</a>`,
         },
     ];
     await mountView({
@@ -359,7 +359,7 @@ test("XML-like self-closing elements are fixed in readonly mode", async () => {
     expect(".odoo-editor-editable").toHaveCount(0);
     expect(`[name="txt"] .o_readonly`).toHaveCount(1);
     expect(`[name="txt"] .o_readonly`).toHaveInnerHTML(
-        `<a href="#" target="_blank" rel="noreferrer"></a>outside<a href="#" target="_blank" rel="noreferrer">inside</a>`
+        `<a href="#test" target="_blank" rel="noreferrer"></a>outside<a href="#test" target="_blank" rel="noreferrer">inside</a>`
     );
 });
 
@@ -367,7 +367,7 @@ test("XML-like self-closing elements are fixed in editable mode", async () => {
     Partner._records = [
         {
             id: 1,
-            txt: `<a href="#"/>outside<a href="#">inside</a>`,
+            txt: `<a href="#test"/>outside<a href="#test">inside</a>`,
         },
     ];
     await mountView({
@@ -383,7 +383,7 @@ test("XML-like self-closing elements are fixed in editable mode", async () => {
     expect(".odoo-editor-editable").toHaveCount(1);
     expect(`[name="txt"] .o_readonly`).toHaveCount(0);
     expect(`[name="txt"] .odoo-editor-editable`).toHaveInnerHTML(
-        `<div class="o-paragraph">outside<a href="#">inside</a></div>`
+        `<div class="o-paragraph">outside<a href="#test">inside</a></div>`
     );
 });
 
@@ -954,7 +954,7 @@ test("link preview in Link Popover", async () => {
     setSelectionInHtmlField(".test_target a");
     await animationFrame();
     // Click on the edit link icon
-    await contains("a.o_we_edit_link").click();
+    await contains("button.o_we_edit_link").click();
     expect(".o-we-linkpopover input.o_we_label_link").toHaveValue("This website", {
         message: "The label input field should match the link's content",
     });
@@ -965,11 +965,11 @@ test("link preview in Link Popover", async () => {
     });
     // Click on Discard button to undo changes.
     await contains(".o-we-linkpopover .o_we_discard_link").click();
-    await waitFor("a.o_we_edit_link");
+    await waitFor("button.o_we_edit_link");
     expect(".test_target a").toHaveText("This website");
 
     // Click on the edit link icon
-    await contains("a.o_we_edit_link").click();
+    await contains("button.o_we_edit_link").click();
     expect(".o-we-linkpopover input.o_we_label_link").toHaveValue("This website", {
         message: "The label input field should match the link's content",
     });
@@ -984,7 +984,7 @@ test("link preview in Link Popover", async () => {
     });
 
     // Click on the edit link icon
-    await contains("a.o_we_edit_link").click();
+    await contains("button.o_we_edit_link").click();
     expect(".o-we-linkpopover input.o_we_label_link").toHaveValue("New label", {
         message: "The label input field should match the link's content",
     });

--- a/addons/html_editor/static/tests/html_viewer.test.js
+++ b/addons/html_editor/static/tests/html_viewer.test.js
@@ -13,12 +13,12 @@ test(`XML-like self-closing elements are fixed in a standalone HtmlViewer`, asyn
         Component: HtmlViewer,
         props: {
             config: {
-                value: markup(`<a href="#"/>outside<a href="#">inside</a>`),
+                value: markup(`<a href="#test"/>outside<a href="#test">inside</a>`),
             },
         },
     });
     await animationFrame();
     expect(".o_readonly").toHaveInnerHTML(
-        `<a href="#" target="_blank" rel="noreferrer"></a>outside<a href="#" target="_blank" rel="noreferrer">inside</a>`
+        `<a href="#test" target="_blank" rel="noreferrer"></a>outside<a href="#test" target="_blank" rel="noreferrer">inside</a>`
     );
 });

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -497,7 +497,7 @@ test("can undo adding link to image", async () => {
 
 test("can remove the link of an image", async () => {
     await setupEditor(`
-        <a href="#"><img src="${base64Img}"></a>
+        <a href="#test"><img src="${base64Img}"></a>
     `);
     const img = queryOne("img");
     await click("img");
@@ -511,7 +511,7 @@ test("can remove the link of an image", async () => {
 
 test("can undo link removing of an image", async () => {
     const { editor } = await setupEditor(`
-        <a href="#"><img src="${base64Img}"></a>
+        <a href="#test"><img src="${base64Img}"></a>
     `);
     const img = queryOne("img");
     await click("img");

--- a/addons/html_editor/static/tests/initialization.test.js
+++ b/addons/html_editor/static/tests/initialization.test.js
@@ -167,26 +167,27 @@ describe("list normalization", () => {
 describe("link normalization", () => {
     test("should move inline color from anchor to font", async () => {
         await testEditor({
-            contentBefore: '<p><a href="#" style="color: #008f8c">test</a></p>',
+            contentBefore: '<p><a href="#test" style="color: #008f8c">test</a></p>',
             contentAfter:
-                '<p><a href="#"><font style="color: rgb(0, 143, 140);">test</font></a></p>',
+                '<p><a href="#test"><font style="color: rgb(0, 143, 140);">test</font></a></p>',
         });
     });
 
     test("should remove anchor color and retain font color", async () => {
         await testEditor({
             contentBefore:
-                '<p><a href="#" style="color: #008f8c"><font style="color: rgb(255, 0, 0);">test</font></a></p>',
-            contentAfter: '<p><a href="#"><font style="color: rgb(255, 0, 0);">test</font></a></p>',
+                '<p><a href="#test" style="color: #008f8c"><font style="color: rgb(255, 0, 0);">test</font></a></p>',
+            contentAfter:
+                '<p><a href="#test"><font style="color: rgb(255, 0, 0);">test</font></a></p>',
         });
     });
 
     test("should handle inline color styles in multiple anchor elements", async () => {
         await testEditor({
             contentBefore:
-                '<p><a href="#" style="color: #008f8c"><font style="color: rgb(255, 0, 0);">test</font></a></p><p><a href="#" style="color: #008f8c">test</a></p>',
+                '<p><a href="#test" style="color: #008f8c"><font style="color: rgb(255, 0, 0);">test</font></a></p><p><a href="#test" style="color: #008f8c">test</a></p>',
             contentAfter:
-                '<p><a href="#"><font style="color: rgb(255, 0, 0);">test</font></a></p><p><a href="#"><font style="color: rgb(0, 143, 140);">test</font></a></p>',
+                '<p><a href="#test"><font style="color: rgb(255, 0, 0);">test</font></a></p><p><a href="#test"><font style="color: rgb(0, 143, 140);">test</font></a></p>',
         });
     });
 });

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -615,12 +615,12 @@ describe("not collapsed selection", () => {
                 editor.shared.dom.insert(
                     parseHTML(
                         editor.document,
-                        '<p>\uFEFF<a href="#">\uFEFFlink\uFEFF</a>\uFEFF</p><p>\uFEFF<a href="#">\uFEFFlink\uFEFF</a>\uFEFF</p>'
+                        '<p>\uFEFF<a href="#test">\uFEFFlink\uFEFF</a>\uFEFF</p><p>\uFEFF<a href="#test">\uFEFFlink\uFEFF</a>\uFEFF</p>'
                     )
                 );
                 editor.shared.history.addStep();
             },
-            contentAfter: '<p><a href="#">link</a></p><p><a href="#">link</a>[]</p>',
+            contentAfter: '<p><a href="#test">link</a></p><p><a href="#test">link</a>[]</p>',
         });
     });
 });

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -81,16 +81,16 @@ describe("Selection collapsed", () => {
         });
         test("should split block without afecting the uploaded document link", async () => {
             await testEditor({
-                contentBefore: `<p>abc<a href="#" title="document" data-mimetype="application/pdf" class="o_image"></a>[]def</p>`,
+                contentBefore: `<p>abc<a href="#test" title="document" data-mimetype="application/pdf" class="o_image"></a>[]def</p>`,
                 stepFunction: splitBlock,
-                contentAfter: `<p>abc<a href="#" title="document" data-mimetype="application/pdf" class="o_image"></a></p><p>[]def</p>`,
+                contentAfter: `<p>abc<a href="#test" title="document" data-mimetype="application/pdf" class="o_image"></a></p><p>[]def</p>`,
             });
         });
         test("should split block without afecting the uploaded document link (2)", async () => {
             await testEditor({
-                contentBefore: `<p>abc<a href="#" title="document" data-mimetype="application/pdf" class="o_image"></a>[]</p>`,
+                contentBefore: `<p>abc<a href="#test" title="document" data-mimetype="application/pdf" class="o_image"></a>[]</p>`,
                 stepFunction: splitBlock,
-                contentAfter: `<p>abc<a href="#" title="document" data-mimetype="application/pdf" class="o_image"></a></p><p>[]<br></p>`,
+                contentAfter: `<p>abc<a href="#test" title="document" data-mimetype="application/pdf" class="o_image"></a></p><p>[]<br></p>`,
             });
         });
         test("should not split block with conditional template", async () => {
@@ -476,73 +476,74 @@ describe("Selection collapsed", () => {
         // see `anchor.nodeName === "A" && brEls.includes(anchor.firstChild)` in line_break_plugin.js
         test("should insert line breaks outside the edges of an anchor in unbreakable", async () => {
             await testEditor({
-                contentBefore: `<div class="oe_unbreakable">ab<a href="#">[]cd</a></div>`,
+                contentBefore: `<div class="oe_unbreakable">ab<a href="#test">[]cd</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable">ab<br><a href="#">[]cd</a></div>`,
+                contentAfter: `<div class="oe_unbreakable">ab<br><a href="#test">[]cd</a></div>`,
             });
             await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="#">a[]b</a></div>`,
+                contentBefore: `<div class="oe_unbreakable"><a href="#test">a[]b</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="#">a<br>[]b</a></div>`,
+                contentAfter: `<div class="oe_unbreakable"><a href="#test">a<br>[]b</a></div>`,
             });
             await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="#">ab[]</a></div>`,
+                contentBefore: `<div class="oe_unbreakable"><a href="#test">ab[]</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="#">ab</a><br><br>[]</div>`,
+                contentAfter: `<div class="oe_unbreakable"><a href="#test">ab</a><br><br>[]</div>`,
             });
             await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="#">ab[]</a>cd</div>`,
+                contentBefore: `<div class="oe_unbreakable"><a href="#test">ab[]</a>cd</div>`,
                 stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="#">ab</a><br>[]cd</div>`,
+                contentAfter: `<div class="oe_unbreakable"><a href="#test">ab</a><br>[]cd</div>`,
             });
             await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="#" style="display: block;">ab[]</a></div>`,
+                contentBefore: `<div class="oe_unbreakable"><a href="#test" style="display: block;">ab[]</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="#" style="display: block;">ab</a>[]<br></div>`,
+                contentAfter: `<div class="oe_unbreakable"><a href="#test" style="display: block;">ab</a>[]<br></div>`,
             });
         });
 
         test("should insert a paragraph break outside the starting edge of an anchor at start of block", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">[]ab</a></p>',
+                contentBefore: '<p><a href="#test">[]ab</a></p>',
                 stepFunction: splitBlockA,
                 contentAfterEdit:
-                    '<p><br></p><p>\ufeff<a href="#" class="o_link_in_selection">\ufeff[]ab\ufeff</a>\ufeff</p>',
-                contentAfter: '<p><br></p><p><a href="#">[]ab</a></p>',
+                    '<p><br></p><p>\ufeff<a href="#test" class="o_link_in_selection">\ufeff[]ab\ufeff</a>\ufeff</p>',
+                contentAfter: '<p><br></p><p><a href="#test">[]ab</a></p>',
             });
         });
         test("should insert a paragraph break outside the starting edge of an anchor after some text", async () => {
             await testEditor({
-                contentBefore: '<p>ab<a href="#">[]cd</a></p>',
+                contentBefore: '<p>ab<a href="#test">[]cd</a></p>',
                 stepFunction: splitBlockA,
                 contentAfterEdit:
-                    '<p>ab</p><p>\ufeff<a href="#" class="o_link_in_selection">\ufeff[]cd\ufeff</a>\ufeff</p>',
-                contentAfter: '<p>ab</p><p><a href="#">[]cd</a></p>',
+                    '<p>ab</p><p>\ufeff<a href="#test" class="o_link_in_selection">\ufeff[]cd\ufeff</a>\ufeff</p>',
+                contentAfter: '<p>ab</p><p><a href="#test">[]cd</a></p>',
             });
         });
         test("should insert a paragraph break in the middle of an anchor", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">a[]b</a></p>',
+                contentBefore: '<p><a href="#test">a[]b</a></p>',
                 stepFunction: splitBlockA,
                 contentAfterEdit:
-                    '<p>\ufeff<a href="#">\ufeffa\ufeff</a>\ufeff</p><p>\ufeff<a href="#" class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeff</p>',
-                contentAfter: '<p><a href="#">a</a></p><p><a href="#">[]b</a></p>',
+                    '<p>\ufeff<a href="#test">\ufeffa\ufeff</a>\ufeff</p><p>\ufeff<a href="#test" class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeff</p>',
+                contentAfter: '<p><a href="#test">a</a></p><p><a href="#test">[]b</a></p>',
             });
         });
         test("should insert a paragraph break outside the ending edge of an anchor", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">ab[]</a></p>',
+                contentBefore: '<p><a href="#test">ab[]</a></p>',
                 stepFunction: splitBlockA,
-                contentAfterEdit: `<p>\ufeff<a href="#">\ufeffab\ufeff</a>\ufeff</p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
-                contentAfter: `<p><a href="#">ab</a></p><p>[]<br></p>`,
+                contentAfterEdit: `<p>\ufeff<a href="#test">\ufeffab\ufeff</a>\ufeff</p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
+                contentAfter: `<p><a href="#test">ab</a></p><p>[]<br></p>`,
             });
         });
         test("should insert a paragraph break outside the ending edge of an anchor (2)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">ab[]</a>cd</p>',
+                contentBefore: '<p><a href="#test">ab[]</a>cd</p>',
                 stepFunction: splitBlockA,
-                contentAfterEdit: '<p>\ufeff<a href="#">\ufeffab\ufeff</a>\ufeff</p><p>[]cd</p>',
-                contentAfter: '<p><a href="#">ab</a></p><p>[]cd</p>',
+                contentAfterEdit:
+                    '<p>\ufeff<a href="#test">\ufeffab\ufeff</a>\ufeff</p><p>[]cd</p>',
+                contentAfter: '<p><a href="#test">ab</a></p><p>[]cd</p>',
             });
         });
     });

--- a/addons/html_editor/static/tests/keyboard/arrow.test.js
+++ b/addons/html_editor/static/tests/keyboard/arrow.test.js
@@ -242,11 +242,11 @@ describe("Around ZWS", () => {
 describe("Around links", () => {
     test("should move into a link (ArrowRight)", async () => {
         await testEditor({
-            contentBefore: '<p>ab[]<a href="#">cd</a>ef</p>',
+            contentBefore: '<p>ab[]<a href="#test">cd</a>ef</p>',
             contentBeforeEdit:
                 "<p>ab[]" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#">' +
+                '<a href="#test">' +
                 "\ufeff" + // start zwnbsp
                 "cd" + // content
                 "\ufeff" + // end zwnbsp
@@ -257,24 +257,24 @@ describe("Around links", () => {
             contentAfterEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#" class="o_link_in_selection">' +
+                '<a href="#test" class="o_link_in_selection">' +
                 "\ufeff" + // start zwnbsp
                 "[]cd" + // content
                 "\ufeff" + // end zwnbsp
                 "</a>" +
                 "\ufeff" + // after zwnbsp
                 "ef</p>",
-            contentAfter: '<p>ab<a href="#">[]cd</a>ef</p>',
+            contentAfter: '<p>ab<a href="#test">[]cd</a>ef</p>',
         });
     });
 
     test("should move into a link (ArrowLeft)", async () => {
         await testEditor({
-            contentBefore: '<p>ab<a href="#">cd</a>[]ef</p>',
+            contentBefore: '<p>ab<a href="#test">cd</a>[]ef</p>',
             contentBeforeEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#">' +
+                '<a href="#test">' +
                 "\ufeff" + // start zwnbsp
                 "cd" + // content
                 "\ufeff" + // end zwnbsp
@@ -285,24 +285,24 @@ describe("Around links", () => {
             contentAfterEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#" class="o_link_in_selection">' +
+                '<a href="#test" class="o_link_in_selection">' +
                 "\ufeff" + // start zwnbsp
                 "cd[]" + // content
                 "\ufeff" + // end zwnbsp
                 "</a>" +
                 "\ufeff" + // after zwnbsp
                 "ef</p>",
-            contentAfter: '<p>ab<a href="#">cd[]</a>ef</p>',
+            contentAfter: '<p>ab<a href="#test">cd[]</a>ef</p>',
         });
     });
 
     test("should move out of a link (ArrowRight)", async () => {
         await testEditor({
-            contentBefore: '<p>ab<a href="#">cd[]</a>ef</p>',
+            contentBefore: '<p>ab<a href="#test">cd[]</a>ef</p>',
             contentBeforeEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#" class="o_link_in_selection">' +
+                '<a href="#test" class="o_link_in_selection">' +
                 "\ufeff" + // start zwnbsp
                 "cd[]" + // content
                 "\ufeff" + // end zwnbsp
@@ -313,24 +313,24 @@ describe("Around links", () => {
             contentAfterEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#">' +
+                '<a href="#test">' +
                 "\ufeff" + // start zwnbsp
                 "cd" + // content
                 "\ufeff" + // end zwnbsp
                 "</a>" +
                 "\ufeff" + // after zwnbsp
                 "[]ef</p>",
-            contentAfter: '<p>ab<a href="#">cd</a>[]ef</p>',
+            contentAfter: '<p>ab<a href="#test">cd</a>[]ef</p>',
         });
     });
 
     test("should move out of a link (ArrowLeft)", async () => {
         await testEditor({
-            contentBefore: '<p>ab<a href="#">[]cd</a>ef</p>',
+            contentBefore: '<p>ab<a href="#test">[]cd</a>ef</p>',
             contentBeforeEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#" class="o_link_in_selection">' +
+                '<a href="#test" class="o_link_in_selection">' +
                 "\ufeff" + // start zwnbsp
                 "[]cd" + // content
                 "\ufeff" + // end zwnbsp
@@ -341,14 +341,14 @@ describe("Around links", () => {
             contentAfterEdit:
                 "<p>ab[]" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#">' +
+                '<a href="#test">' +
                 "\ufeff" + // start zwnbsp
                 "cd" + // content
                 "\ufeff" + // end zwnbsp
                 "</a>" +
                 "\ufeff" + // after zwnbsp
                 "ef</p>",
-            contentAfter: '<p>ab[]<a href="#">cd</a>ef</p>',
+            contentAfter: '<p>ab[]<a href="#test">cd</a>ef</p>',
         });
     });
 });
@@ -555,7 +555,7 @@ describe("Around invisible chars in RTL languages", () => {
     });
 
     describe("ZWNBSP", () => {
-        const content = "<p>" + "الرجال" + '<a href="#">اءيتجنب</a>' + "هؤلاء" + "</p>";
+        const content = "<p>" + "الرجال" + '<a href="#test">اءيتجنب</a>' + "هؤلاء" + "</p>";
         // Displayed as "هؤلاء<a href="#">اءيتجنب</a>الرجال" in the editor:
         //                third +         link      + first
         test("should move into a link (ArrowLeft)", async () => {
@@ -574,7 +574,7 @@ describe("Around invisible chars in RTL languages", () => {
             expect(selection.anchorOffset).toBe(1);
             // Displayed as هؤلاء\uFEFF<a href="#">\uFEFFاءيتجنب[]\uFEFF</a>\uFEFFالرجال
             expect(getContent(el)).toBe(
-                '<p>الرجال\uFEFF<a href="#" class="o_link_in_selection">\uFEFF[]اءيتجنب\uFEFF</a>\uFEFFهؤلاء</p>'
+                '<p>الرجال\uFEFF<a href="#test" class="o_link_in_selection">\uFEFF[]اءيتجنب\uFEFF</a>\uFEFFهؤلاء</p>'
             );
         });
         test("should move into a link (ArrowRight)", async () => {
@@ -594,7 +594,7 @@ describe("Around invisible chars in RTL languages", () => {
             expect(selection.anchorOffset).toBe(link2ndChild.length);
             // Displayed as هؤلاء\uFEFF<a href="#">\uFEFF[]اءيتجنب\uFEFF</a>\uFEFFالرجال
             expect(getContent(el)).toBe(
-                '<p>الرجال\uFEFF<a href="#" class="o_link_in_selection">\uFEFFاءيتجنب[]\uFEFF</a>\uFEFFهؤلاء</p>'
+                '<p>الرجال\uFEFF<a href="#test" class="o_link_in_selection">\uFEFFاءيتجنب[]\uFEFF</a>\uFEFFهؤلاء</p>'
             );
         });
         test("should move out of a link (ArrowLeft)", async () => {
@@ -613,7 +613,7 @@ describe("Around invisible chars in RTL languages", () => {
             expect(selection.anchorOffset).toBe(1);
             // Displayed as هؤلاء[]\uFEFF<a href="#">\uFEFFاءيتجنب\uFEFF</a>\uFEFFالرجال
             expect(getContent(el)).toBe(
-                '<p>الرجال\uFEFF<a href="#">\uFEFFاءيتجنب\uFEFF</a>\uFEFF[]هؤلاء</p>'
+                '<p>الرجال\uFEFF<a href="#test">\uFEFFاءيتجنب\uFEFF</a>\uFEFF[]هؤلاء</p>'
             );
         });
         test("should move out of a link (ArrowRight)", async () => {
@@ -633,7 +633,7 @@ describe("Around invisible chars in RTL languages", () => {
             expect(selection.anchorOffset).toBe(pFirstChild.length);
             // Displayed as هؤلاء\uFEFF<a href="#">\uFEFFاءيتجنب\uFEFF</a>\uFEFF[]الرجال
             expect(getContent(el)).toBe(
-                '<p>الرجال[]\uFEFF<a href="#">\uFEFFاءيتجنب\uFEFF</a>\uFEFFهؤلاء</p>'
+                '<p>الرجال[]\uFEFF<a href="#test">\uFEFFاءيتجنب\uFEFF</a>\uFEFFهؤلاء</p>'
             );
         });
     });

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -9,7 +9,7 @@ import { getContent } from "../_helpers/selection";
 describe("button style", () => {
     test("editable button should have cursor text", async () => {
         const { el } = await setupEditor(
-            '<p><a href="#" class="btn btn-fill-primary">Link styled as button</a></p>'
+            '<p><a href="#test" class="btn btn-fill-primary">Link styled as button</a></p>'
         );
 
         const button = el.querySelector("a");
@@ -110,7 +110,7 @@ describe("Custom button style", () => {
         const { el } = await setupEditor("<p>[Hello]</p>", allowCustomOpt);
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-link");
-        await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#", {
+        await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#test", {
             confirm: false,
         });
         await click('select[name="link_type"]');
@@ -141,14 +141,14 @@ describe("Custom button style", () => {
         await animationFrame();
 
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="#" class="btn btn-fill-custom" style="color: #FF0000; background-color: #00FF00; border-width: 6px; border-color: #0000FF; border-style: dotted; ">Hello</a></p>'
+            '<p><a href="#test" class="btn btn-fill-custom" style="color: #FF0000; background-color: #00FF00; border-width: 6px; border-color: #0000FF; border-style: dotted; ">Hello</a></p>'
         );
 
         await click(".o_we_apply_link");
         await animationFrame();
 
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="#" class="btn btn-fill-custom" style="color: #FF0000; background-color: #00FF00; border-width: 6px; border-color: #0000FF; border-style: dotted; ">Hello[]</a></p>'
+            '<p><a href="#test" class="btn btn-fill-custom" style="color: #FF0000; background-color: #00FF00; border-width: 6px; border-color: #0000FF; border-style: dotted; ">Hello[]</a></p>'
         );
     });
 
@@ -156,7 +156,7 @@ describe("Custom button style", () => {
         const { el } = await setupEditor("<p>[Hello]</p>", allowTargetBlankOpt);
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-link");
-        await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#", {
+        await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#test", {
             confirm: false,
         });
 
@@ -166,7 +166,7 @@ describe("Custom button style", () => {
         await animationFrame();
 
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="#" target="_blank">Hello[]</a></p>'
+            '<p><a href="#test" target="_blank">Hello[]</a></p>'
         );
     });
 });

--- a/addons/html_editor/static/tests/link/delete.test.js
+++ b/addons/html_editor/static/tests/link/delete.test.js
@@ -5,8 +5,8 @@ import { testEditor } from "../_helpers/editor";
 describe("delete selection involving links", () => {
     test("should remove link", async () => {
         await testEditor({
-            contentBefore: '<p><a href="#">[abc</a>d]ef</p>',
-            contentBeforeEdit: '<p>\ufeff<a href="#">\ufeff[abc\ufeff</a>\ufeffd]ef</p>',
+            contentBefore: '<p><a href="#test">[abc</a>d]ef</p>',
+            contentBeforeEdit: '<p>\ufeff<a href="#test">\ufeff[abc\ufeff</a>\ufeffd]ef</p>',
             stepFunction: deleteBackward,
             contentAfterEdit: "<p>[]ef</p>",
             contentAfter: "<p>[]ef</p>",
@@ -14,8 +14,8 @@ describe("delete selection involving links", () => {
     });
     test("should remove link (2)", async () => {
         await testEditor({
-            contentBefore: '<p>ab[c<a href="#">def]</a></p>',
-            contentBeforeEdit: '<p>ab[c\ufeff<a href="#">\ufeffdef]\ufeff</a>\ufeff</p>',
+            contentBefore: '<p>ab[c<a href="#test">def]</a></p>',
+            contentBeforeEdit: '<p>ab[c\ufeff<a href="#test">\ufeffdef]\ufeff</a>\ufeff</p>',
             stepFunction: deleteBackward,
             contentAfterEdit: "<p>ab[]</p>",
             contentAfter: "<p>ab[]</p>",
@@ -23,12 +23,12 @@ describe("delete selection involving links", () => {
     });
     test("should not remove link (only after clean)", async () => {
         await testEditor({
-            contentBefore: '<p><a href="#">[abc]</a>def</p>',
+            contentBefore: '<p><a href="#test">[abc]</a>def</p>',
             contentBeforeEdit:
-                '<p>\ufeff<a href="#" class="o_link_in_selection">\ufeff[abc]\ufeff</a>\ufeffdef</p>',
+                '<p>\ufeff<a href="#test" class="o_link_in_selection">\ufeff[abc]\ufeff</a>\ufeffdef</p>',
             stepFunction: deleteBackward,
             contentAfterEdit:
-                '<p>\ufeff<a href="#" class="o_link_in_selection">\ufeff[]\ufeff</a>\ufeffdef</p>',
+                '<p>\ufeff<a href="#test" class="o_link_in_selection">\ufeff[]\ufeff</a>\ufeffdef</p>',
             contentAfter: "<p>[]def</p>",
         });
     });
@@ -43,29 +43,29 @@ describe("empty list items, starting and ending with links", () => {
     // result.
     const tests = [
         // (1) <a>[...</a>...<a>...]</a>
-        '<ul><li>ab</li><li><a href="#">[cd</a></li><li>ef</li><li><a href="#a">gh]</a></li><li>ij</li></ul>',
-        '<ul><li>ab</li><li><a href="#">[\ufeffcd</a></li><li>ef</li><li><a href="#a">gh\ufeff]</a></li><li>ij</li></ul>',
-        '<ul><li>ab</li><li><a href="#">\ufeff[cd</a></li><li>ef</li><li><a href="#a">gh\ufeff]</a></li><li>ij</li></ul>',
-        '<ul><li>ab</li><li><a href="#">[\ufeffcd</a></li><li>ef</li><li><a href="#a">gh]\ufeff</a></li><li>ij</li></ul>',
-        '<ul><li>ab</li><li><a href="#">\ufeff[cd</a></li><li>ef</li><li><a href="#a">gh]\ufeff</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#test">[cd</a></li><li>ef</li><li><a href="#a">gh]</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#test">[\ufeffcd</a></li><li>ef</li><li><a href="#a">gh\ufeff]</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#test">\ufeff[cd</a></li><li>ef</li><li><a href="#a">gh\ufeff]</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#test">[\ufeffcd</a></li><li>ef</li><li><a href="#a">gh]\ufeff</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#test">\ufeff[cd</a></li><li>ef</li><li><a href="#a">gh]\ufeff</a></li><li>ij</li></ul>',
         // (2) [<a>...</a>...<a>...]</a>
-        '<ul><li>ab</li><li>[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh]</a></li><li>ij</li></ul>',
-        '<ul><li>ab</li><li>[\ufeff<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh\ufeff]</a></li><li>ij</li></ul>',
-        '<ul><li>ab</li><li>\ufeff[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh\ufeff]</a></li><li>ij</li></ul>',
-        '<ul><li>ab</li><li>[\ufeff<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh]\ufeff</a></li><li>ij</li></ul>',
-        '<ul><li>ab</li><li>\ufeff[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh]\ufeff</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>[<a href="#test">cd</a></li><li>ef</li><li><a href="#a">gh]</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>[\ufeff<a href="#test">cd</a></li><li>ef</li><li><a href="#a">gh\ufeff]</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>\ufeff[<a href="#test">cd</a></li><li>ef</li><li><a href="#a">gh\ufeff]</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>[\ufeff<a href="#test">cd</a></li><li>ef</li><li><a href="#a">gh]\ufeff</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>\ufeff[<a href="#test">cd</a></li><li>ef</li><li><a href="#a">gh]\ufeff</a></li><li>ij</li></ul>',
         // (3) <a>[...</a>...<a>...</a>]
-        '<ul><li>ab</li><li><a href="#">[cd</a></li><li>ef</li><li><a href="#a">gh</a>]</li><li>ij</li></ul>',
-        '<ul><li>ab</li><li><a href="#">[\ufeffcd</a></li><li>ef</li><li><a href="#a">gh</a>\ufeff]</li><li>ij</li></ul>',
-        '<ul><li>ab</li><li><a href="#">\ufeff[cd</a></li><li>ef</li><li><a href="#a">gh</a>\ufeff]</li><li>ij</li></ul>',
-        '<ul><li>ab</li><li><a href="#">[\ufeffcd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
-        '<ul><li>ab</li><li><a href="#">\ufeff[cd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#test">[cd</a></li><li>ef</li><li><a href="#a">gh</a>]</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#test">[\ufeffcd</a></li><li>ef</li><li><a href="#a">gh</a>\ufeff]</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#test">\ufeff[cd</a></li><li>ef</li><li><a href="#a">gh</a>\ufeff]</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#test">[\ufeffcd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#test">\ufeff[cd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
         // (4) [<a>...</a>...<a>...</a>]
-        '<ul><li>ab</li><li>[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>]</li><li>ij</li></ul>',
-        '<ul><li>ab</li><li>[\ufeff<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>\ufeff]</li><li>ij</li></ul>',
-        '<ul><li>ab</li><li>\ufeff[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>\ufeff]</li><li>ij</li></ul>',
-        '<ul><li>ab</li><li>[\ufeff<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
-        '<ul><li>ab</li><li>\ufeff[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>[<a href="#test">cd</a></li><li>ef</li><li><a href="#a">gh</a>]</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>[\ufeff<a href="#test">cd</a></li><li>ef</li><li><a href="#a">gh</a>\ufeff]</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>\ufeff[<a href="#test">cd</a></li><li>ef</li><li><a href="#a">gh</a>\ufeff]</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>[\ufeff<a href="#test">cd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>\ufeff[<a href="#test">cd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
     ];
     let testIndex = 1;
     for (const contentBefore of tests) {

--- a/addons/html_editor/static/tests/link/isolated.test.js
+++ b/addons/html_editor/static/tests/link/isolated.test.js
@@ -369,14 +369,15 @@ test("should remove zwnbsp from middle of the link (2)", async () => {
 
 test("should zwnbps-pad links with .btn class", async () => {
     await testEditor({
-        contentBefore: '<p><a href="#" class="btn">content</a></p>',
-        contentBeforeEdit: '<p>\ufeff<a href="#" class="btn">\ufeffcontent\ufeff</a>\ufeff</p>',
+        contentBefore: '<p><a href="#test" class="btn">content</a></p>',
+        contentBeforeEdit: '<p>\ufeff<a href="#test" class="btn">\ufeffcontent\ufeff</a>\ufeff</p>',
     });
 });
 
 test("should not add visual indication to a button", async () => {
     await testEditor({
-        contentBefore: '<p><a href="#" class="btn">[]content</a></p>',
-        contentBeforeEdit: '<p>\ufeff<a href="#" class="btn">\ufeff[]content\ufeff</a>\ufeff</p>',
+        contentBefore: '<p><a href="#test" class="btn">[]content</a></p>',
+        contentBeforeEdit:
+            '<p>\ufeff<a href="#test" class="btn">\ufeff[]content\ufeff</a>\ufeff</p>',
     });
 });

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -335,8 +335,8 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
 
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="#">#[]</a></p>');
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#test");
+            expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="#test">#test[]</a></p>');
         });
         test("Should be able to insert button on empty p", async () => {
             const { editor, el } = await setupEditor("<p>[]</p>");
@@ -368,9 +368,9 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
             await contains(".o-we-linkpopover input.o_we_label_link").fill("link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#test");
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>a <a href="#">link[]</a>&nbsp;&nbsp;b</p>'
+                '<p>a <a href="#test">link[]</a>&nbsp;&nbsp;b</p>'
             );
         });
         test("should insert a link then create a new <p>", async () => {
@@ -379,11 +379,11 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
             await contains(".o-we-linkpopover input.o_we_label_link").fill("link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#test");
             // press("Enter");
             splitBlock(editor);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                `<p>ab<a href="#">link</a></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
+                `<p>ab<a href="#test">link</a></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
             );
         });
         test("should insert a link then create a new <p>, and another character", async () => {
@@ -392,12 +392,12 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
             await contains(".o-we-linkpopover input.o_we_label_link").fill("link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#test");
             // press("Enter");
             splitBlock(editor);
             await insertText(editor, "D");
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>a<a href="#">link</a></p><p>D[]b</p>'
+                '<p>a<a href="#test">link</a></p><p>D[]b</p>'
             );
         });
         test("should insert a link then insert a <br>", async () => {
@@ -406,10 +406,12 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
             await contains(".o-we-linkpopover input.o_we_label_link").fill("link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#test");
             // press("Enter");
             insertLineBreak(editor);
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p>a<a href="#">link</a><br>[]b</p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p>a<a href="#test">link</a><br>[]b</p>'
+            );
         });
         test("should insert a link then insert a <br> and another character", async () => {
             const { editor, el } = await setupEditor("<p>a[]b</p>");
@@ -417,11 +419,13 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
             await contains(".o-we-linkpopover input.o_we_label_link").fill("link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#test");
             // press("Enter");
             insertLineBreak(editor);
             await insertText(editor, "D");
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p>a<a href="#">link</a><br>D[]b</p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p>a<a href="#test">link</a><br>D[]b</p>'
+            );
         });
     });
     describe("Creation by toolbar", () => {
@@ -430,9 +434,9 @@ describe("Link creation", () => {
             await waitFor(".o-we-toolbar");
             await click(".o-we-toolbar .fa-link");
             await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
-                "#"
+                "#test"
             );
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="#">Hello[]</a></p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="#test">Hello[]</a></p>');
         });
         test("should convert valid url to https link", async () => {
             const { el } = await setupEditor("<p>[Hello]</p>");
@@ -462,9 +466,9 @@ describe("Link creation", () => {
             );
             await waitFor(".o-we-toolbar");
             click(".o-we-toolbar .fa-link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#test");
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>Hello this is <a href="#">a <b>new</b> <u>link</u> keeping style[]</a>!</p>'
+                '<p>Hello this is <a href="#test">a <b>new</b> <u>link</u> keeping style[]</a>!</p>'
             );
         });
         test("should convert all selected text to link and keep style except bgclor", async () => {
@@ -473,9 +477,9 @@ describe("Link creation", () => {
             );
             await waitFor(".o-we-toolbar");
             click(".o-we-toolbar .fa-link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#test");
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>Hello this is <a href="#">a <b>new</b> <u>link</u> keeping style[]</a>!</p>'
+                '<p>Hello this is <a href="#test">a <b>new</b> <u>link</u> keeping style[]</a>!</p>'
             );
         });
         test("should convert all selected text to link and keep style except color (2)", async () => {
@@ -484,9 +488,9 @@ describe("Link creation", () => {
             );
             await waitFor(".o-we-toolbar");
             click(".o-we-toolbar .fa-link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#test");
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>Hello this is a <b>ne</b><a href="#"><b>w</b> <u>link</u> keep[]</a><span style="color:red">ing</span> style!</p>'
+                '<p>Hello this is a <b>ne</b><a href="#test"><b>w</b> <u>link</u> keep[]</a><span style="color:red">ing</span> style!</p>'
             );
         });
         test("should set the link on two existing characters", async () => {
@@ -497,9 +501,9 @@ describe("Link creation", () => {
             expect('.o-we-toolbar button[name="link"]').not.toHaveAttribute("disabled");
             await click(".o-we-toolbar .fa-link");
             await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
-                "#"
+                "#test"
             );
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p>H<a href="#">el[]</a>lo</p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe('<p>H<a href="#test">el[]</a>lo</p>');
         });
         test("should not allow to create a link if selection span multiple block", async () => {
             const { el } = await setupEditor("<p>H[ello</p><p>wor]ld</p>");
@@ -554,9 +558,11 @@ describe("Link creation", () => {
             await waitFor(".o-we-toolbar");
             await click(".o-we-toolbar .fa-link");
             await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
-                "#"
+                "#test"
             );
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p>aaa<a href="#">ab[]</a>cdef</p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p>aaa<a href="#test">ab[]</a>cdef</p>'
+            );
         });
         test("should remove link when click away without inputting url", async () => {
             const { el } = await setupEditor("<p>H[el]lo</p>");
@@ -613,9 +619,9 @@ describe("Link creation", () => {
             // not validated link shouldn't affect the DOM yet
             expect(cleanLinkArtifacts(getContent(el))).toBe("<p>[Hello]</p>");
             await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
-                "#"
+                "#test"
             );
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="#">Hello[]</a></p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="#test">Hello[]</a></p>');
 
             undo(editor);
             expect(cleanLinkArtifacts(getContent(el))).toBe("<p>[Hello]</p>");
@@ -626,9 +632,9 @@ describe("Link creation", () => {
             await click(".o-we-toolbar .fa-link");
             // not validated link shouldn't affect the DOM yet
             expect(cleanLinkArtifacts(getContent(el))).toBe("<p><b>[Hello]</b></p>");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#test");
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p><b><a href="#">Hello[]</a></b></p>'
+                '<p><b><a href="#test">Hello[]</a></b></p>'
             );
             undo(editor);
             expect(cleanLinkArtifacts(getContent(el))).toBe("<p><b>[Hello]</b></p>");
@@ -764,14 +770,14 @@ describe("Link formatting in the popover", () => {
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-link");
 
-        await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#", {
+        await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#test", {
             confirm: false,
         });
 
         await click('select[name="link_type"]');
         await select("secondary");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="#" class="btn btn-fill-secondary">link1</a></p>'
+            '<p><a href="#test" class="btn btn-fill-secondary">link1</a></p>'
         );
         await click(".o_we_discard_link");
         expect(cleanLinkArtifacts(getContent(el))).toBe("<p>[link1]</p>");
@@ -1050,7 +1056,7 @@ describe("link preview", () => {
         await contains(".o-we-linkpopover input.o_we_href_input_link").fill("http://odoo.com/");
         await animationFrame();
         expect("button.o_we_replace_title_btn").toHaveCount(1);
-        expect("a.o_we_replace_title_btn").toHaveCount(0);
+        expect("button.o_we_replace_title_btn").toHaveCount(0);
         const pNode = document.querySelector("p");
         setSelection({
             anchorNode: pNode,
@@ -1065,7 +1071,7 @@ describe("link preview", () => {
         });
         await waitFor(".o_we_replace_title_btn");
         expect(".o-we-linkpopover").toHaveCount(1);
-        expect("a.o_we_replace_title_btn").toHaveCount(1);
+        expect("button.o_we_replace_title_btn").toHaveCount(1);
         expect("button.o_we_replace_title_btn").toHaveCount(0);
     });
 });
@@ -1112,90 +1118,96 @@ describe("links with inline image", () => {
         const { el } = await setupEditor(`<p>ab[cd<img src="${base64Img}">ef]g</p>`);
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-link");
-        await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit("#");
+        await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
+            "#test"
+        );
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">cd<img src="${base64Img}">ef[]</a>g</p>`
+            `<p>ab<a href="#test">cd<img src="${base64Img}">ef[]</a>g</p>`
         );
     });
     test("can undo add link to inline image + text", async () => {
         const { editor, el } = await setupEditor(`<p>ab[cd<img src="${base64Img}">ef]g</p>`);
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-link");
-        await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit("#");
+        await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
+            "#test"
+        );
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">cd<img src="${base64Img}">ef[]</a>g</p>`
+            `<p>ab<a href="#test">cd<img src="${base64Img}">ef[]</a>g</p>`
         );
         undo(editor);
         await animationFrame();
         expect(cleanLinkArtifacts(getContent(el))).toBe(`<p>ab[cd<img src="${base64Img}">ef]g</p>`);
     });
     test("can remove link from an inline image", async () => {
-        const { el } = await setupEditor(`<p>ab<a href="#">cd<img src="${base64Img}">ef</a>g</p>`);
+        const { el } = await setupEditor(
+            `<p>ab<a href="#test">cd<img src="${base64Img}">ef</a>g</p>`
+        );
         await click("img");
         await waitFor(".o-we-toolbar");
         expect("button[name='unlink']").toHaveCount(1);
         await click("button[name='unlink']");
         await animationFrame();
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">cd[</a><img src="${base64Img}"><a href="#">]ef</a>g</p>`
+            `<p>ab<a href="#test">cd[</a><img src="${base64Img}"><a href="#test">]ef</a>g</p>`
         );
         expect(".o-we-linkpopover").toHaveCount(0);
     });
     test("can remove link from a selection of an inline image + text", async () => {
         const { el } = await setupEditor(
-            `<p>ab<a href="#">c[d<img src="${base64Img}">e]f</a>g</p>`
+            `<p>ab<a href="#test">c[d<img src="${base64Img}">e]f</a>g</p>`
         );
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-unlink");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">c</a>[d<img src="${base64Img}">e]<a href="#">f</a>g</p>`
+            `<p>ab<a href="#test">c</a>[d<img src="${base64Img}">e]<a href="#test">f</a>g</p>`
         );
     });
     test("can remove link from a selection (ltr) with multiple inline images", async () => {
         const { el } = await setupEditor(
-            `<p>ab<a href="#">c[d<img src="${base64Img}">e<img src="${base64Img}">f]g</a>h</p>`
+            `<p>ab<a href="#test">c[d<img src="${base64Img}">e<img src="${base64Img}">f]g</a>h</p>`
         );
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-unlink");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">c</a>[d<img src="${base64Img}">e<img src="${base64Img}">f]<a href="#">g</a>h</p>`
+            `<p>ab<a href="#test">c</a>[d<img src="${base64Img}">e<img src="${base64Img}">f]<a href="#test">g</a>h</p>`
         );
     });
     test("can remove link from a selection (rtl) with multiple inline images", async () => {
         const { el } = await setupEditor(
-            `<p>ab<a href="#">c]d<img src="${base64Img}">e<img src="${base64Img}">f[g</a>h</p>`
+            `<p>ab<a href="#test">c]d<img src="${base64Img}">e<img src="${base64Img}">f[g</a>h</p>`
         );
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-unlink");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">c</a>]d<img src="${base64Img}">e<img src="${base64Img}">f[<a href="#">g</a>h</p>`
+            `<p>ab<a href="#test">c</a>]d<img src="${base64Img}">e<img src="${base64Img}">f[<a href="#test">g</a>h</p>`
         );
     });
     test("can remove link from a selection (ltr) with multiple inline images acrossing different links", async () => {
         const { el } = await setupEditor(
-            `<p>ab<a href="#">c[d<img src="${base64Img}">e</a>xx<a href="#">f<img src="${base64Img}">g]h</a>i</p>`
+            `<p>ab<a href="#test">c[d<img src="${base64Img}">e</a>xx<a href="#test">f<img src="${base64Img}">g]h</a>i</p>`
         );
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-unlink");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">c</a>[d<img src="${base64Img}">exxf<img src="${base64Img}">g]<a href="#">h</a>i</p>`
+            `<p>ab<a href="#test">c</a>[d<img src="${base64Img}">exxf<img src="${base64Img}">g]<a href="#test">h</a>i</p>`
         );
     });
     test("can remove link from a selection (rtl) with multiple inline images acrossing different links", async () => {
         const { el } = await setupEditor(
-            `<p>ab<a href="#">c]d<img src="${base64Img}">e</a>xx<a href="#">f<img src="${base64Img}">g[h</a>i</p>`
+            `<p>ab<a href="#test">c]d<img src="${base64Img}">e</a>xx<a href="#test">f<img src="${base64Img}">g[h</a>i</p>`
         );
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-unlink");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">c</a>]d<img src="${base64Img}">exxf<img src="${base64Img}">g[<a href="#">h</a>i</p>`
+            `<p>ab<a href="#test">c</a>]d<img src="${base64Img}">exxf<img src="${base64Img}">g[<a href="#test">h</a>i</p>`
         );
     });
 });
 
 describe("readonly mode", () => {
     test("popover should not display edit buttons in readonly mode", async () => {
-        await setupEditor('<p><a class="o_link_readonly" href="#">link[]</a></p>');
+        await setupEditor('<p><a class="o_link_readonly" href="#test">link[]</a></p>');
         await waitFor(".o-we-linkpopover");
         // Copy link button should be available
         expect(".o-we-linkpopover .o_we_copy_link").toHaveCount(1);
@@ -1205,7 +1217,7 @@ describe("readonly mode", () => {
     });
     // TODO: need to check with AGE
     test.todo("popover should not open for not editable image", async () => {
-        await setupEditor(`<a href="#"><img src="${base64Img}" contenteditable="false"></a>`);
+        await setupEditor(`<a href="#test"><img src="${base64Img}" contenteditable="false"></a>`);
         await click("img");
         await animationFrame();
         expect(".o-we-linkpopover").toHaveCount(0);

--- a/addons/html_editor/static/tests/list/delete_backward.test.js
+++ b/addons/html_editor/static/tests/list/delete_backward.test.js
@@ -2547,7 +2547,7 @@ describe("Selection not collapsed", () => {
         test("should remove the o_checked class on delete range", async () => {
             await testEditor({
                 contentBefore:
-                    '<ul class="o_checklist"><li>ab</li><li class="o_checked"><a href="#">[cd</a></li><li>ef]</li><li>gh</li></ul>',
+                    '<ul class="o_checklist"><li>ab</li><li class="o_checked"><a href="#test">[cd</a></li><li>ef]</li><li>gh</li></ul>',
                 stepFunction: deleteBackward,
                 contentAfterEdit:
                     '<ul class="o_checklist"><li>ab</li><li o-we-hint-text="List" class="o-we-hint">[]<br></li><li>gh</li></ul>',

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -2493,7 +2493,7 @@ describe("link", () => {
 
         test("should replace link for new content when pasting in an empty link (collapsed)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#" oe-zws-empty-inline="">[]\u200B</a></p>',
+                contentBefore: '<p><a href="#test" oe-zws-empty-inline="">[]\u200B</a></p>',
                 stepFunction: async (editor) => {
                     pasteText(editor, "abc");
                 },
@@ -2502,7 +2502,7 @@ describe("link", () => {
         });
         test("should replace link for new content when pasting in an empty link (collapsed)(2)", async () => {
             await testEditor({
-                contentBefore: '<p>xy<a href="#" oe-zws-empty-inline="">\u200B[]</a>z</p>',
+                contentBefore: '<p>xy<a href="#test" oe-zws-empty-inline="">\u200B[]</a>z</p>',
                 stepFunction: async (editor) => {
                     pasteText(editor, "abc");
                 },
@@ -2512,7 +2512,7 @@ describe("link", () => {
 
         test("should replace link for new content (url) when pasting in an empty link (collapsed)", async () => {
             const { el, editor } = await setupEditor(
-                `<p>xy<a href="#" oe-zws-empty-inline="">\u200B[]</a>z</p>`
+                `<p>xy<a href="#test" oe-zws-empty-inline="">\u200B[]</a>z</p>`
             );
             pasteText(editor, "http://odoo.com");
             await animationFrame();
@@ -2523,9 +2523,9 @@ describe("link", () => {
         });
 
         test("should replace link for new content (imgUrl) when pasting in an empty link (collapsed) (1)", async () => {
-            const { el, editor } = await setupEditor(`<p>xy<a href="#">[]</a>z</p>`);
+            const { el, editor } = await setupEditor(`<p>xy<a href="#test">[]</a>z</p>`);
             expect(getContent(el)).toBe(
-                `<p>xy\ufeff<a href="#" class="o_link_in_selection">\ufeff[]</a>\ufeffz</p>`
+                `<p>xy\ufeff<a href="#test" class="o_link_in_selection">\ufeff[]</a>\ufeffz</p>`
             );
             pasteText(editor, imgUrl);
             await animationFrame();
@@ -2538,7 +2538,7 @@ describe("link", () => {
 
         test("should replace link for new content (url) when pasting in an empty link (collapsed) (2)", async () => {
             const { el, editor } = await setupEditor(
-                `<p>xy<a href="#" oe-zws-empty-inline="">\u200B[]</a>z</p>`
+                `<p>xy<a href="#test" oe-zws-empty-inline="">\u200B[]</a>z</p>`
             );
             pasteText(editor, imgUrl);
             await animationFrame();
@@ -2556,14 +2556,14 @@ describe("link", () => {
 
         test("should paste and transform plain text content over an empty link (collapsed)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">[]\u200B</a></p>',
+                contentBefore: '<p><a href="#test">[]\u200B</a></p>',
                 stepFunction: async (editor) => {
                     pasteText(editor, "abc www.odoo.com xyz");
                 },
                 contentAfter: '<p>abc <a href="http://www.odoo.com">www.odoo.com</a> xyz[]</p>',
             });
             await testEditor({
-                contentBefore: '<p><a href="#">[]\u200B</a></p>',
+                contentBefore: '<p><a href="#test">[]\u200B</a></p>',
                 stepFunction: async (editor) => {
                     pasteText(editor, "odoo.com\ngoogle.com");
                 },
@@ -2575,7 +2575,7 @@ describe("link", () => {
 
         test("should paste html content over an empty link (collapsed)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">[]\u200B</a></p>',
+                contentBefore: '<p><a href="#test">[]\u200B</a></p>',
                 stepFunction: async (editor) => {
                     pasteHtml(
                         editor,
@@ -2588,7 +2588,7 @@ describe("link", () => {
         });
         test("should paste html content over an empty link (collapsed) (2)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">[]\u200B</a></p>',
+                contentBefore: '<p><a href="#test">[]\u200B</a></p>',
                 stepFunction: async (editor) => {
                     pasteHtml(
                         editor,
@@ -2664,11 +2664,11 @@ describe("link", () => {
 
         test("should paste plain text inside non empty link (collapsed)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">a[]b</a></p>',
+                contentBefore: '<p><a href="#test">a[]b</a></p>',
                 stepFunction: async (editor) => {
                     pasteHtml(editor, "<span>123</span>");
                 },
-                contentAfter: '<p><a href="#">a123[]b</a></p>',
+                contentAfter: '<p><a href="#test">a123[]b</a></p>',
             });
         });
 
@@ -2825,7 +2825,7 @@ describe("link", () => {
 
         test("should paste plain text content over a link if all of its contents is selected (not collapsed)", async () => {
             await testEditor({
-                contentBefore: '<p>a<a href="#">[xyz]</a>d</p>',
+                contentBefore: '<p>a<a href="#test">[xyz]</a>d</p>',
                 stepFunction: async (editor) => {
                     pasteText(editor, "bc");
                 },
@@ -2835,14 +2835,14 @@ describe("link", () => {
 
         test("should paste and transform plain text content over a link if all of its contents is selected (not collapsed)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">[xyz]</a></p>',
+                contentBefore: '<p><a href="#test">[xyz]</a></p>',
                 stepFunction: async (editor) => {
                     pasteText(editor, "www.odoo.com");
                 },
                 contentAfter: '<p><a href="http://www.odoo.com">www.odoo.com</a>[]</p>',
             });
             await testEditor({
-                contentBefore: '<p><a href="#">[xyz]</a></p>',
+                contentBefore: '<p><a href="#test">[xyz]</a></p>',
                 stepFunction: async (editor) => {
                     pasteText(editor, "abc www.odoo.com xyz");
                 },
@@ -2883,7 +2883,7 @@ describe("link", () => {
 
         test("should paste html content over a link if all of its contents is selected (not collapsed)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">[xyz]</a></p>',
+                contentBefore: '<p><a href="#test">[xyz]</a></p>',
                 stepFunction: async (editor) => {
                     pasteHtml(
                         editor,
@@ -2896,7 +2896,7 @@ describe("link", () => {
         });
         test("should paste html content over a link if all of its contents is selected (not collapsed) (2)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">[xyz]</a></p>',
+                contentBefore: '<p><a href="#test">[xyz]</a></p>',
                 stepFunction: async (editor) => {
                     pasteHtml(
                         editor,

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -937,7 +937,7 @@ test("toolbar should close on open link popover (iframe)", async () => {
 
 test.tags("desktop");
 test("toolbar should close on edit link from preview", async () => {
-    await setupEditor(`<p><a href="#">[a]</a></p>`);
+    await setupEditor(`<p><a href="#test">[a]</a></p>`);
     expect(".o-we-toolbar").toHaveCount(1);
     await click(".o-we-toolbar .fa-link");
     await waitFor(".o-we-linkpopover");

--- a/addons/html_editor/static/tests/utils/dom_info.test.js
+++ b/addons/html_editor/static/tests/utils/dom_info.test.js
@@ -357,7 +357,7 @@ describe("getDeepestPosition", () => {
         expect([node, offset]).toEqual([a, 1]);
     });
     test("should not skip zwnbsp", () => {
-        const [a] = insertTestHtml('\ufeff<a href="#">abc</a>');
+        const [a] = insertTestHtml('\ufeff<a href="#test">abc</a>');
         const editable = a.parentElement;
         const zwnbsp = editable.firstChild;
         const [node, offset] = getDeepestPosition(editable, 0);
@@ -413,14 +413,14 @@ describe("isEmptyBlock", () => {
     });
 
     test("should identify a tag with text as non-empty", () => {
-        const [a] = insertTestHtml('<a href="#">Link text</a>');
+        const [a] = insertTestHtml('<a href="#test">Link text</a>');
         const result = isEmptyBlock(a);
         expect(result).toBe(false);
     });
 
     test("should return false for a p containing media element", () => {
         const [p] = insertTestHtml(
-            '<p><a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a></p>'
+            '<p><a href="#test" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a></p>'
         );
         const result = isEmptyBlock(p);
         expect(result).toBe(false);

--- a/addons/link_tracker/views/utm_campaign_views.xml
+++ b/addons/link_tracker/views/utm_campaign_views.xml
@@ -20,14 +20,14 @@
         <field name="inherit_id" ref="utm.utm_campaign_view_kanban"/>
         <field name="arch" type="xml">
             <xpath expr="//footer/div" position="inside">
-                <a t-if="record.click_count" href="#" title="Clicks" role="button"
+                <button t-if="record.click_count" title="Clicks" role="button"
                     type="action" name="%(link_tracker_action_campaign)d"
-                    class="btn-outline-primary rounded-pill me-1 order-4">
+                    class="rounded-pill me-1 order-4 p-0">
                     <span class="badge">
                         <i class="fa fa-fw fa-mouse-pointer" aria-label="Clicks" role="img"/>
                         <field name="click_count"/>
                     </span>
-                </a>
+                </button>
             </xpath>
         </field>
     </record>

--- a/addons/mail_group/views/portal_templates.xml
+++ b/addons/mail_group/views/portal_templates.xml
@@ -180,12 +180,12 @@
                         <t t-set="group_message_child_ids" t-value="message.group_message_child_ids.filtered(lambda m: m.moderation_status == 'accepted')"/>
                         <div class="o_mg_link_parent" t-if="group_message_child_ids and (not mode or mode == 'thread')">
                             <p class="mt8">
-                                <a href="#" class="o_mg_link_hide">
+                                <button class="o_mg_link_hide btn btn-link p-0">
                                     <i class="oi oi-chevron-right" role="img" aria-label="Hide replies" title="Hide replies"/> <t t-esc="len(group_message_child_ids)"/> replies
-                                </a>
-                                <a href="#" class="o_mg_link_show d-none">
+                                </button>
+                                <button class="o_mg_link_show d-none btn btn-link p-0">
                                     <i class="oi oi-chevron-down" role="img" aria-label="Show replies" title="Show replies"/> <t t-esc="len(group_message_child_ids)"/> replies
-                                </a>
+                                </button>
                             </p>
                             <div class="o_mg_link_content o_mg_replies ms-5 d-none">
                                 <t t-call="mail_group.messages_short">
@@ -219,12 +219,12 @@
         <div class="o_mg_link_parent">
             <t t-set="attachments" t-value="message.attachment_ids"/>
             <p t-if="attachments" class="mt8">
-                <a href="#" class="o_mg_link_hide">
+                <button class="o_mg_link_hide btn btn-link p-0">
                     <i class="oi oi-chevron-right" role="img" aria-label="Hide attachments" title="Hide attachments"/> <t t-esc="len(attachments)"/> attachments
-                </a>
-                <a href="#" class="o_mg_link_show d-none">
+                </button>
+                <button class="o_mg_link_show d-none btn btn-link p-0">
                     <i class="oi oi-chevron-down" role="img" aria-label="Show attachments" title="Show attachments"/> <t t-esc="len(attachments)"/> attachments
-                </a>
+                </button>
             </p>
             <div class="o_mg_link_content d-none row justify-content-center">
                 <div class="mx-4 my-3 text-center o_mg_attachment" t-foreach="attachments" t-as="attachment">

--- a/addons/marketing_card/static/src/scss/card_campaign.scss
+++ b/addons/marketing_card/static/src/scss/card_campaign.scss
@@ -1,5 +1,5 @@
 .o_kanban_view .o_marketing_card_campaign_kanban {
-    a:hover > .badge {
+    button:hover > .badge {
         background-color: $o-brand-primary;
         color: white;
     }

--- a/addons/marketing_card/views/card_campaign_views.xml
+++ b/addons/marketing_card/views/card_campaign_views.xml
@@ -160,18 +160,18 @@
                         <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" class="mt-2"/>
                         <footer class="pt-0">
                             <div>
-                                <a type="object" name="action_view_cards_shared" href="#" class="me-1">
+                                <button type="object" name="action_view_cards_shared" class="me-1 p-0">
                                     <span class="badge rounded-pill">
                                         <i class="fa fa-fw fa-share" aria-label="Shares" role="img" title="Shares"/>
                                         <field name="card_share_count"/>
                                     </span>
-                                </a>
-                                <a type="object" name="action_view_cards_clicked" href="#" class="me-1">
+                                </button>
+                                <button type="object" name="action_view_cards_clicked" class="me-1 p-0">
                                     <span class="badge rounded-pill">
                                         <i class="fa fa-fw fa-mouse-pointer" aria-label="Clicks" role="img" title="Clicks"/>
                                         <field name="target_url_click_count"/>
                                     </span>
-                                </a>
+                                </button>
                             </div>
                             <field name="user_id" class="ms-auto" widget="many2one_avatar_user"/>
                         </footer>

--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -543,6 +543,7 @@ class MassMailController(http.Controller):
         return True
 
     def _format_bl_request(self, mailing, document_id):
+        # TODO
         mailing_model_name = request.env['ir.model']._get(mailing.mailing_model_real).display_name
         return {
             'mailing_link': Markup(f'<a href="#" data-oe-model="mailing.mailing" data-oe-id="{mailing.id}">{escape(mailing.subject)}</a>'),

--- a/addons/mass_mailing/static/src/scss/themes/theme_default.scss
+++ b/addons/mass_mailing/static/src/scss/themes/theme_default.scss
@@ -210,6 +210,11 @@ div.col[class*="mb"], div.col[class*="mt"] {
         background-color: #685563;
         border-color: #685563;
     }
+    button.btn-primary, button.btn-outline-primary, button.btn-fill-primary {
+        color: #FFFFFF;
+        background-color: #35979c;
+        border-color: #35979c;
+    }
     hr {
         border-top-color: #212529;
         width: 100%;

--- a/addons/mass_mailing/static/src/xml/mass_mailing.xml
+++ b/addons/mass_mailing/static/src/xml/mass_mailing.xml
@@ -23,12 +23,12 @@
             </div>
         </div>
         <div class="d-inline-block w-100">
-            <a t-foreach="themes" t-as="theme" t-key="theme_index"
-                t-att-id="theme.name" role="menuitem" href="#" class="dropdown-item px-4">
+            <button t-foreach="themes" t-as="theme" t-key="theme_index"
+                t-att-id="theme.name" role="menuitem" class="dropdown-item px-4">
                 <div class="o_thumb small mb-2"  t-attf-style="background-image: url(#{theme.img}_small.png)"/>
                 <div class="o_thumb large mb-2" t-attf-style="background-image: url(#{theme.img}_large.png)"/>
                 <h5 class="text-white text-capitalize text-truncate" t-esc="theme.title"/>
-            </a>
+            </button>
         </div>
     </div>
 </templates>

--- a/addons/mass_mailing/views/snippets/s_call_to_action.xml
+++ b/addons/mass_mailing/views/snippets/s_call_to_action.xml
@@ -10,7 +10,7 @@
                     <p>Join us and make your company a better place.</p>
                 </div>
                 <div class="col-lg-3" style="text-align: center;">
-                    <a href="#" class="btn btn-primary btn-lg">Contact us</a>
+                    <button class="btn btn-primary btn-lg">Contact us</button>
                 </div>
             </div>
         </div>

--- a/addons/mass_mailing/views/snippets/s_color_blocks_2.xml
+++ b/addons/mass_mailing/views/snippets/s_color_blocks_2.xml
@@ -8,13 +8,13 @@
                         <i class="fa fa-shield fa-5x m-3 mx-auto d-block"/>
                         <h2 style="text-align: center;">A color block</h2>
                         <p style="text-align: center;">Color blocks are a simple and effective way to <b>present and highlight your content</b>. Choose an image or a color for the background. You can even resize and duplicate the blocks to create your own layout. Add images or icons to customize the blocks.</p>
-                        <p style="text-align: center;"><a href="#" class="btn btn-primary">More Details</a></p>
+                        <p style="text-align: center;"><button class="btn btn-primary">More Details</button></p>
                     </div>
                     <div class="col-lg-6 o_cc o_cc5 pt32 pb32">
                         <i class="fa fa-cube fa-5x m-3 mx-auto d-block"/>
                         <h2 style="text-align: center;">Another color block</h2>
                         <p style="text-align: center;">Color blocks are a simple and effective way to <b>present and highlight your content</b>. Choose an image or a color for the background. You can even resize and duplicate the blocks to create your own layout. Add images or icons to customize the blocks.</p>
-                        <p style="text-align: center;"><a href="#" class="btn btn-primary">More Details</a></p>
+                        <p style="text-align: center;"><button class="btn btn-primary">More Details</button></p>
                     </div>
                 </div>
             </div>

--- a/addons/mass_mailing/views/snippets/s_comparisons.xml
+++ b/addons/mass_mailing/views/snippets/s_comparisons.xml
@@ -21,7 +21,7 @@
                             </ul>
                         </div>
                         <div class="card-footer" style="text-align: center;">
-                            <a href="#" class="btn btn-primary">More</a>
+                            <button class="btn btn-primary">More</button>
                         </div>
                     </div>
                 </div>
@@ -51,7 +51,7 @@
                             </ul>
                         </div>
                         <div class="card-footer" style="text-align: center;">
-                            <a href="#" class="btn btn-primary">More</a>
+                            <button class="btn btn-primary">More</button>
                         </div>
                     </div>
                 </div>

--- a/addons/mass_mailing/views/snippets/s_coupon_code.xml
+++ b/addons/mass_mailing/views/snippets/s_coupon_code.xml
@@ -14,7 +14,7 @@
             </table>
             <br/>
             <p style="text-align:center;">
-                <a role="button" href="#" class="btn btn-primary">Use now</a>
+                <button role="button" class="btn btn-primary">Use now</button>
             </p>
         </div>
     </template>

--- a/addons/mass_mailing/views/snippets/s_event.xml
+++ b/addons/mass_mailing/views/snippets/s_event.xml
@@ -14,7 +14,7 @@
                                 <p><font class="text-o-color-1">25 September 2022 - 4:30 PM</font></p>
                                 <p>London, United Kingdom</p>
                                 <p>
-                                    <a href="#" target="_blank" class="btn btn-primary">Register Now</a>
+                                    <button target="_blank" class="btn btn-primary">Register Now</button>
                                 </p>
                             </div>
                         </div>
@@ -29,7 +29,7 @@
                                 <p><font class="text-o-color-1">26 September 2022 - 1:30 PM</font></p>
                                 <p>London, United Kingdom</p>
                                 <p>
-                                    <a href="#" target="_blank" class="btn btn-primary">Register Now</a>
+                                    <button target="_blank" class="btn btn-primary">Register Now</button>
                                 </p>
                             </div>
                         </div>

--- a/addons/mass_mailing/views/snippets/s_image_text.xml
+++ b/addons/mass_mailing/views/snippets/s_image_text.xml
@@ -12,7 +12,7 @@
                     <h3>Omnichannel sales</h3>
                     <p style="text-align: justify;">Get your inside sales (CRM) fully integrated with online sales (eCommerce), in-store sales (Point of Sale) and marketplaces like Amazon.</p>
                     <div style="text-align: left;">
-                        <a href="#" class="btn btn-link">Read More</a>
+                        <button class="btn btn-link">Read More</button>
                     </div>
                 </div>
             </div>

--- a/addons/mass_mailing/views/snippets/s_media_list.xml
+++ b/addons/mass_mailing/views/snippets/s_media_list.xml
@@ -13,7 +13,7 @@
                         <div class="col-lg-8 s_media_list_body">
                             <h3>Media heading</h3>
                             <p>Use this snippet to build various types of components that feature a left- or right-aligned image alongside textual content. Duplicate the element to create a list that fits your needs.</p>
-                            <a href="#" class="btn btn-primary">Discover</a>
+                            <button class="btn btn-primary">Discover</button>
                         </div>
                     </div>
                 </div>
@@ -36,7 +36,7 @@
                         <div class="col-lg-8 s_media_list_body">
                             <h3>Post heading</h3>
                             <p>Use this component for creating a list of featured elements to which you want to bring attention.</p>
-                            <a href="#">Continue reading <i class="fa fa-long-arrow-right align-middle ms-1"/></a>
+                            <button class="btn-link border-0 bg-transparent p-0">Continue reading <i class="fa fa-long-arrow-right align-middle ms-1"/></button>
                         </div>
                     </div>
                 </div>

--- a/addons/mass_mailing/views/snippets/s_product_list.xml
+++ b/addons/mass_mailing/views/snippets/s_product_list.xml
@@ -10,21 +10,21 @@
                         <img src="/web/image/mass_mailing.s_product_list_default_image_1" alt="" class="img img-fluid" style="padding: 15px 0px"/>
                     </a>
                     <p style="text-align: center;">Check out all our furniture</p>
-                    <p style="text-align: center;"><a class="btn btn-primary" href="#">Furniture</a></p>
+                    <p style="text-align: center;"><button class="btn btn-primary">Furniture</button></p>
                 </div>
                 <div class="col-lg-4 o_cc pt16 pb16">
                     <a href="">
                         <img src="/web/image/mass_mailing.s_product_list_default_image_2" alt="" class="img img-fluid" style="padding: 15px 0px"/>
                     </a>
                     <p style="text-align: center;">Check out all our clothes</p>
-                    <p style="text-align: center;"><a class="btn btn-primary" href="#">Clothes</a></p>
+                    <p style="text-align: center;"><button class="btn btn-primary">Clothes</button></p>
                 </div>
                 <div class="col-lg-4 o_cc pt16 pb16">
                     <a href="">
                         <img src="/web/image/mass_mailing.s_product_list_default_image_3" alt="" class="img img-fluid" style="padding: 15px 0px"/>
                     </a>
                     <p style="text-align: center;">Check out all our books</p>
-                    <p style="text-align: center;"><a class="btn btn-primary" href="#">Books</a></p>
+                    <p style="text-align: center;"><button class="btn btn-primary">Books</button></p>
                 </div>
             </div>
         </div>

--- a/addons/mass_mailing/views/snippets/s_showcase.xml
+++ b/addons/mass_mailing/views/snippets/s_showcase.xml
@@ -49,7 +49,7 @@
             </div>
         </div>
         <div class="container pt32" style="text-align: center;" align="center">
-            <a href="#" class="btn btn-primary">Discover all the features</a>
+            <button class="btn btn-primary">Discover all the features</button>
         </div>
     </div>
 </template>

--- a/addons/mass_mailing/views/snippets/s_text_image.xml
+++ b/addons/mass_mailing/views/snippets/s_text_image.xml
@@ -9,7 +9,7 @@
                     <h3>A unique value</h3>
                     <p style="text-align: justify;">The open source model of Odoo has allowed us to leverage thousands of developers and business experts to build hundreds of apps in just a few years.</p>
                     <div style="text-align: left;">
-                        <a href="#" class="btn btn-link">Read More</a>
+                        <button class="btn btn-link">Read More</button>
                     </div>
                 </div>
                 <div class="col-lg-6 px-0">

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -149,7 +149,7 @@
                     <h3 style="text-align: center;"><font class="text-o-color-2"><span style="font-weight:bolder;">-20%</span></font></h3>
                     <p style="text-align: center;">ON YOUR NEXT ORDER!</p>
                     <div style="text-align: center;">
-                        <a role="button" href="#" class="btn btn-primary">Redeem Discount!</a>
+                        <button role="button" class="btn btn-primary">Redeem Discount!</button>
                     </div>
                 </div>
                 <div class="col-lg-6 pt16">

--- a/addons/mass_mailing/views/themes_templates.xml
+++ b/addons/mass_mailing/views/themes_templates.xml
@@ -54,7 +54,7 @@
                    <span style="font-size: 12px; font-weight: bolder;">Customer Service</span>
                 </p>
                 <p style="text-align: center;">
-                    <a role="button" href="#" class="btn btn-primary">LOGIN</a>
+                    <button role="button" class="btn btn-primary">LOGIN</button>
                 </p>
             </div>
         </div>

--- a/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
+++ b/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
@@ -192,8 +192,12 @@
             p, p > *, li, li > * {
                 color: #adadad;
             }
-            a:not(.btn), a.btn.btn-link {
+            a:not(.btn), a.btn.btn-link, button.btn.btn-link, button.btn-link {
                 color: #36a6d2;
+            }
+            button.btn.btn-primary, button.btn.btn-outline-primary, button.btn.btn-fill-primary {
+                background-color: #36a6d2;
+                border-color: #36a6d2;
             }
             a.btn.btn-primary, a.btn.btn-outline-primary, a.btn.btn-fill-primary {
                 background-color: #36a6d2;
@@ -248,7 +252,7 @@
                         <h1>Breaking IT news
                             <br/>and Analysis</h1>
                         <p style="text-align: left;">Our roundup of the most popular and latest tech related videos from last week.<br/></p>
-                        <p style="text-align:left;"><a class="btn btn-primary" href="#">VISIT OUR WEBSITE</a></p>
+                        <p style="text-align:left;"><button class="btn btn-primary">VISIT OUR WEBSITE</button></p>
                     </div>
                     <div class="col-lg-5 px-0">
                         <img class="img-fluid o_we_custom_image" src="/web_editor/image_shape/mass_mailing_themes.s_tech_default_image/web_editor/geometric/geo_cornered_triangle.svg" data-shape="web_editor/geometric/geo_cornered_triangle" data-file-name="text_image-cornered_triangle.svg" data-shape-colors=";;;;" data-original-mimetype="image/jpeg"/>
@@ -272,7 +276,7 @@
                                 <p>Modern smartphones have all the built-in tech equal to a majority of the current professional cameras.</p>
                                 <a class="btn btn-primary" t-att-href="website_url_or_none"><span class="fa fa-play" />&amp;nbsp;&amp;nbsp;WATCH VIDEO</a>
                                 &amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;
-                                <a class="btn btn-link" href="#">READ MORE</a>
+                                <button class="btn btn-link">READ MORE</button>
                             </div>
                         </div>
                     </div>
@@ -361,8 +365,12 @@
             p, p > *, li, li > * {
                 font-family: Georgia, Times, "Times New Roman", serif;
             }
-            a:not(.btn), a.btn.btn-link {
+            a:not(.btn), a.btn.btn-link, button.btn.btn-link, button.btn-link {
                 color: #C69678;
+            }
+            button.btn.btn-primary, button.btn.btn-outline-primary, button.btn.btn-fill-primary {
+                background-color: #C69678;
+                border-color: #C69678;
             }
             a.btn.btn-primary, a.btn.btn-outline-primary, a.btn.btn-fill-primary {
                 background-color: #C69678;
@@ -503,7 +511,7 @@
             p, p > *, li, li > * {
                 font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
             }
-            a:not(.btn), a.btn.btn-link {
+            a:not(.btn), a.btn.btn-link, button.btn.btn-link, button.btn-link {
                 color: #6c757d;
             }
             hr {
@@ -546,30 +554,30 @@
                             <hr class="s_hr_1px s_hr_solid"/>
                         </div>
                         <p>
-                            <a class="btn btn-link" style="text-align:left" href="#">
+                            <button class="btn btn-link" style="text-align:left">
                                 Interview with Janet James&amp;nbsp;
                                 <span class="fa fa-angle-right"/>
-                            </a>
+                            </button>
                             <br/>
-                            <a class="btn btn-link" style="text-align:left" href="#">
+                            <button class="btn btn-link" style="text-align:left">
                                 Destinations for an eco-holiday&amp;nbsp;
                                 <span class="fa fa-angle-right"/>
-                            </a>
+                            </button>
                             <br/>
-                            <a class="btn btn-link" style="text-align:left" href="#">
+                            <button class="btn btn-link" style="text-align:left">
                                 Top 5 energy-boosting morning routines&amp;nbsp;
                                 <span class="fa fa-angle-right"/>
-                            </a>
+                            </button>
                             <br/>
-                            <a class="btn btn-link" style="text-align:left" href="#">
+                            <button class="btn btn-link" style="text-align:left">
                                 Delicious recipes from around the world&amp;nbsp;
                                 <span class="fa fa-angle-right"/>
-                            </a>
+                            </button>
                             <br/>
-                            <a class="btn btn-link" style="text-align:left" href="#">
+                            <button class="btn btn-link" style="text-align:left">
                                 Rainy day ideas&amp;nbsp;
                                 <span class="fa fa-angle-right"/>
-                            </a>
+                            </button>
                         </p>
                     </div>
                 </div>
@@ -583,28 +591,28 @@
                 <div class="row">
                     <div class="col-lg-6 o_cc">
                         <h3><font style="background-color: rgb(231, 148, 57);">TRAVEL</font></h3>
-                        <a href="#">
+                        <span>
                             <img class="img-fluid o_we_custom_image" src="/mass_mailing_themes/static/src/img/theme_magazine/s_default_image_product_2.jpg" alt="Man on a rock looking at mountains in the distance" style="width: 100% !important; padding: 15px 0px;"/>
-                        </a>
+                        </span>
                         <h2 style="text-align: left;">Destinations for an eco-holiday</h2>
                         <p style="text-align: left;">Bitten by the travel bug but looking to travel consciously? Eco-travel is the way forward.</p>
                         <p style="text-align: right;">
-                            <a href="#" class="btn btn-link">
+                            <button class="btn btn-link">
                                 Find out more&amp;nbsp;<span class="fa fa-angle-right"/>
-                            </a>
+                            </button>
                         </p>
                     </div>
                     <div class="col-lg-6 o_cc">
                         <h3><font style="background-color: rgb(231, 99, 99);">LIFESTYLE</font></h3>
-                        <a href="#">
+                        <span>
                             <img class="img-fluid o_we_custom_image" src="/mass_mailing_themes/static/src/img/theme_magazine/s_default_image_product_1.jpg" alt="Woman having breakfast in bed" style="width: 100% !important; padding: 15px 0px;"/>
-                        </a>
+                        </span>
                         <h2 style="text-align: left;">Top 5 energy-boosting morning routines</h2>
                         <p style="text-align: left;">Imagine waking up with more energy, more flexibility, with less stress and fewer instances of anxiously rushing out the door.</p>
                         <p style="text-align: right;">
-                            <a href="#" class="btn btn-link">
+                            <button class="btn btn-link">
                                 Find out more&amp;nbsp;<span class="fa fa-angle-right"/>
-                            </a>
+                            </button>
                         </p>
                     </div>
                 </div>
@@ -621,9 +629,9 @@
                         <h2>Delicious recipes from around the world</h2>
                         <p>Travel without leaving your kitchen with these international recipes. From Canada to Australia, Mexico to Sweden, and everywhere in between.</p>
                         <div style="text-align:right">
-                            <a href="#" class="btn btn-link">
+                            <button class="btn btn-link">
                                 Read More&amp;nbsp;<span class="fa fa-angle-right"/>
-                            </a>
+                            </button>
                         </div>
                     </div>
                     <div class="col-lg-6 px-0">
@@ -692,10 +700,14 @@
             p, p > *, li, li > * {
                 color: #6c757d;
             }
-            a:not(.btn), a.btn.btn-link{
+            a:not(.btn), a.btn.btn-link, button.btn.btn-link, button.btn-link {
                 color: #BA0013;
             }
             a.btn.btn-primary, a.btn.btn-outline-primary, a.btn.btn-fill-primary {
+                background-color: #BA0013;
+                border-color: #BA0013;
+            }
+            button.btn.btn-primary, button.btn.btn-outline-primary, button.btn.btn-fill-primary {
                 background-color: #BA0013;
                 border-color: #BA0013;
             }
@@ -736,7 +748,7 @@
                    <span style="font-size: 12px; font-weight: bolder;">Customer Service</span>
                 </p>
                 <p style="text-align: center;">
-                    <a role="button" href="#" class="btn btn-primary">READ MORE</a>
+                    <button role="button" class="btn btn-primary">READ MORE</button>
                 </p>
             </div>
         </div>
@@ -790,10 +802,14 @@
                 font-size: 18px;
                 font-weight: bolder;
             }
-            a:not(.btn), a.btn.btn-link {
+            a:not(.btn), a.btn.btn-link, button.btn.btn-link, button.btn-link {
                 color: #000000;
             }
             a.btn.btn-primary, a.btn.btn-outline-primary, a.btn.btn-fill-primary {
+                background-color: #000000;
+                border-color: #000000;
+            }
+            button.btn.btn-primary, button.btn.btn-outline-primary, button.btn.btn-fill-primary {
                 background-color: #000000;
                 border-color: #000000;
             }
@@ -928,9 +944,14 @@
                 font-weight: bolder;
                 color: #543427;
             }
-            a:not(.btn), a.btn.btn-link {
+            a:not(.btn), a.btn.btn-link, button.btn.btn-link, button.btn-link {
                 text-decoration-line: underline;
                 color: #397B21;
+            }
+            button.btn.btn-primary, button.btn.btn-outline-primary, button.btn.btn-fill-primary {
+                color: #543427;
+                background-color: #D3C5B1;
+                border-color: #D3C5B1;
             }
             a.btn.btn-primary, a.btn.btn-outline-primary, a.btn.btn-fill-primary {
                 color: #543427;
@@ -1034,22 +1055,22 @@
                         <h3>DON'T MISS THIS</h3>
                         <ul>
                             <li>
-                                <a href="#" target="_blank" data-original-title="" title="">10 Books To Read in 2022</a>
+                                <button class="btn btn-link p-0" target="_blank" data-original-title="" title="">10 Books To Read in 2022</button>
                             </li>
                             <li>
-                                <a href="#" target="_blank" data-original-title="" title="">Find Out Who's Employee Of The Month</a>
+                                <button class="btn btn-link p-0" target="_blank" data-original-title="" title="">Find Out Who's Employee Of The Month</button>
                             </li>
                             <li>
-                                <a href="#" target="_blank" data-original-title="" title="">Why You Need Two Types of Content Strategists</a>
+                                <button class="btn btn-link p-0" target="_blank" data-original-title="" title="">Why You Need Two Types of Content Strategists</button>
                             </li>
                             <li>
-                                <a href="#" target="_blank" data-original-title="" title="">7 Ways to Nurture Creativity</a>
+                                <button class="btn btn-link p-0" target="_blank" data-original-title="" title="">7 Ways to Nurture Creativity</button>
                             </li>
                             <li>
-                                <a href="#" target="_blank" data-original-title="" title="">Infographic: Our Company Throughout The Generations</a>
+                                <button class="btn btn-link p-0" target="_blank" data-original-title="" title="">Infographic: Our Company Throughout The Generations</button>
                             </li>
                             <li>
-                                <a href="#" target="_blank" data-original-title="" title="">7 Unexpected Signs You're Good At Your Job</a>
+                                <button class="btn btn-link p-0" target="_blank" data-original-title="" title="">7 Unexpected Signs You're Good At Your Job</button>
                             </li>
                         </ul>
                     </div>
@@ -1097,7 +1118,7 @@
             p, p > *, li, li > * {
                 font-size: 16px;
             }
-            a:not(.btn), a.btn.btn-link {
+            a:not(.btn), a.btn.btn-link, button.btn.btn-link, button.btn-link {
                 text-decoration-line: underline;
                 color: #212529;
             }
@@ -1108,6 +1129,10 @@
             a.btn.btn-secondary, a.btn.btn-outline-secondary, a.btn.btn-fill-secondary {
                 color: #CE0000;
                 background-color: #FFFFFF;
+                border-color: #CE0000;
+            }
+            button.btn.btn-primary, button.btn.btn-outline-primary, button.btn.btn-fill-primary {
+                background-color: #CE0000;
                 border-color: #CE0000;
             }
         </style>
@@ -1244,7 +1269,7 @@
             <div class="container s_allow_columns">
                 <img src="/mass_mailing_themes/static/src/img/theme_newsletter/FPsignature.gif" style="width: 125px" alt=""/>
                 <p style="text-align:center;" class="pt32">
-                    <a role="button" href="#" class="btn btn-primary btn-lg" target="_blank">&amp;nbsp;&amp;nbsp;Comment on this post&amp;nbsp;&amp;nbsp;</a>
+                    <button role="button" class="btn btn-primary btn-lg" target="_blank">&amp;nbsp;&amp;nbsp;Comment on this post&amp;nbsp;&amp;nbsp;</button>
                 </p>
             </div>
         </div>
@@ -1293,7 +1318,7 @@
                 font-size: 18px;
                 font-weight: bolder;
             }
-            a:not(.btn), a.btn.btn-link {
+            a:not(.btn), a.btn.btn-link, button.btn.btn-link, button.btn-link {
                 color: #35979c;
             }
         </style>
@@ -1311,7 +1336,7 @@
             <div class="container s_allow_columns">
                 <p>Registration is free, but mandatory:</p>
                 <p style="text-align: center;">
-                    <a href="#" class="btn btn-primary btn-lg">Save your seat now</a>
+                    <button class="btn btn-primary btn-lg">Save your seat now</button>
                 </p>
                 <p style="text-align: center;">
                     <span class="font-weight: bolder">
@@ -1399,7 +1424,7 @@
         </div>
         <div class="s_text_block o_mail_snippet_general px-3 pt0 pb4" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
-                <p>For more information, check the event page : <a href="#" target="_blank" rel="noreferrer">[link]</a>.</p>
+                <p>For more information, check the event page : <button class="btn btn-link p-0" target="_blank" rel="noreferrer">[link]</button>.</p>
                 <p>We're on the starting blocks to prepare an incredible event for you!
                     <br/>We hope to see you there.
                 </p>
@@ -1425,7 +1450,7 @@
                 font-size: 18px;
                 font-weight: bolder;
             }
-            a:not(.btn), a.btn.btn-link {
+            a:not(.btn), a.btn.btn-link, button.btn.btn-link, button.btn-link {
                 color: #35979c;
             }
         </style>
@@ -1438,8 +1463,8 @@
                 </div>
                 <p>Here are some photos taken during the event:</p>
                 <ul>
-                    <li><a href="#" target="_blank">Link 1</a></li>
-                    <li><a href="#" target="_blank">Link 2</a></li>
+                    <li><button class="btn btn-link p-0" target="_blank">Link 1</button></li>
+                    <li><button class="btn btn-link p-0" target="_blank">Link 2</button></li>
                 </ul>
                 <p>Don't hesitate to send us more!</p>
             </div>
@@ -1465,10 +1490,10 @@
             <div class="container s_allow_columns">
                 <p>Here are the links to our sponsors' websites if you wish to meet them:</p>
                 <ul>
-                    <li><a href="#" target="_blank">Link 1</a></li>
-                    <li><a href="#" target="_blank">Link 2</a></li>
-                    <li><a href="#" target="_blank">Link 3</a></li>
-                    <li><a href="#" target="_blank">Link 4</a></li>
+                    <li><button class="btn btn-link p-0" target="_blank">Link 1</button></li>
+                    <li><button class="btn btn-link p-0" target="_blank">Link 2</button></li>
+                    <li><button class="btn btn-link p-0" target="_blank">Link 3</button></li>
+                    <li><button class="btn btn-link p-0" target="_blank">Link 4</button></li>
                 </ul>
                 <p>You may test Odoo for free by clicking <a href="https://odoo.com/trial" target="_blank">here</a>.</p>
             </div>
@@ -1515,7 +1540,7 @@
                 color: rgb(91, 119, 143);
                 font-size: 14px;
             }
-            a:not(.btn), a.btn.btn-link {
+            a:not(.btn), a.btn.btn-link, button.btn.btn-link, button.btn-link, button.btn-link {
                 color: rgb(20, 102, 184);
             }
             a.btn.btn-primary, a.btn.btn-outline-primary, a.btn.btn-fill-primary {
@@ -1531,15 +1556,20 @@
                 border-top-color: rgb(67, 129, 219);
                 border-top-width: 2px;
             }
+            button.btn.btn-primary, button.btn.btn-outline-primary, button.btn.btn-fill-primary {
+                color: rgb(255, 255, 255);
+                background-color: rgb(67, 128, 219);
+                font-size: 14px;
+            }
         </style>
         <div class="s_header_logo o_mail_block_header_logo o_mail_snippet_general" data-snippet="s_mail_block_header_logo" data-name="Centered Logo" style="background-color: rgb(220, 234, 255);">
             <div class="container">
                 <div class="row">
                     <div class="col-lg-4"></div>
                     <div class="col-lg-4 pt16 pb16" style="text-align: center;">
-                        <a style="text-decoration:none;" href="#" target="_blank">
+                        <span style="text-decoration:none;" target="_blank">
                             <font style="font-size: 24px; background-color: rgb(20, 102, 184);" class="text-o-color-4">A+</font> <font style="color: rgb(20, 102, 184); font-size: 24px;"><span style="font-weight: normal">Training</span></font>
-                        </a>
+                        </span>
                     </div>
                     <div class="col-lg-4" style="text-align: right;"></div>
                 </div>
@@ -1581,7 +1611,7 @@
                         <p>Getting practical experience can be as likely as getting struck by lightning – <span style="font-style: italic;">thank you, coronavirus</span> – but, you can take things into your own hands and use your free time to upskill.</p>
                         <p><span style="font-weight: bolder;">And what better field to upskill in than software development?</span> Jobs have been steadily booming for years, and will continue to do so. By taking some of these free courses, you can make your CV more competitive and your portfolio more interesting.</p>
                         <p></p>
-                        <p><a href="#" target="_blank" class="btn btn-primary flat btn-lg"><span style="font-weight: bolder;">Register now</span></a></p>
+                        <p><button target="_blank" class="btn btn-primary flat btn-lg"><span style="font-weight: bolder;">Register now</span></button></p>
                     </div>
                 </div>
             </div>

--- a/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
+++ b/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
@@ -9,7 +9,7 @@
                         <i t-attf-class="fa fa-fw fa-caret-{{ props.isFolded ? 'right' : 'down' }}" role="img"/>
                     </span>
                 </t>
-                <a href="#" t-on-click.prevent="() => this.goToAction(data.link_id, data.link_model)" t-esc="data.name"/>
+                <button class="btn btn-link fw-normal p-0" t-on-click.prevent="() => this.goToAction(data.link_id, data.link_model)" t-esc="data.name"/>
                 <t t-if="data.phantom_bom">
                     <div class="fa fa-dropbox" title="This is a BoM of type Kit!" role="img" aria-label="This is a BoM of type Kit!"/>
                 </t>
@@ -35,7 +35,7 @@
             <t t-if="data.hasOwnProperty('availability_state')">
                 <span t-attf-class="{{availabilityColorClass}}" t-esc="data.availability_display"/>
                 <t t-if="['bom', 'component'].includes(data.type)">
-                    <a href="#" role="button" t-on-click.prevent="goToForecast" title="Forecast Report" t-attf-class="fa fa-fw fa-area-chart o_mrp_bom_forecast ms-1 {{availabilityColorClass}}"/>
+                    <button role="button" t-on-click.prevent="goToForecast" title="Forecast Report" t-attf-class="border-0 bg-transparent p-0 fa fa-fw fa-area-chart o_mrp_bom_forecast ms-1 {{availabilityColorClass}}"/>
                 </t>
             </t>
         </td>
@@ -45,14 +45,14 @@
         <td t-if="forecastMode">
             <div t-if="data.route_name">
                 <span t-attf-class="{{ data.route_alert ? 'text-danger' : '' }}"><t t-esc="data.route_name"/>: </span>
-                <a href="#" t-on-click.prevent="() => this.goToRoute(data.route_type)" t-esc="data.route_detail"/>
+                <button class="btn btn-link fw-normal p-0" t-on-click.prevent="() => this.goToRoute(data.route_type)" t-esc="data.route_detail"/>
             </div>
         </td>
         <td t-else=""/>
         <td t-attf-class="text-end {{ data.type == 'component' ? 'opacity-50' : '' }}" t-esc="formatMonetary(data.bom_cost)"/>
         <td t-if="showAttachments" class="text-center">
             <span t-if="data.has_attachments">
-                <a href="#" role="button" t-on-click.prevent="goToAttachment" class="fa fa-fw o_button_icon fa-files-o"/>
+                <button role="button" t-on-click.prevent="goToAttachment" class="btn btn-link p-0 fa fa-fw o_button_icon fa-files-o"/>
             </span>
         </td>
     </tr>

--- a/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.xml
+++ b/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.xml
@@ -6,7 +6,7 @@
             <div t-if="!!data.components || !!data.lines || !!data.operations" class="container-fluid">
                 <div class="d-flex mb-5">
                     <div class="me-auto">
-                        <h2><a href="#" t-on-click.prevent="goToProduct" t-esc="data.name"/></h2>
+                        <h2><button class="btn btn-link p-0 fs-2"  t-on-click.prevent="goToProduct" t-esc="data.name"/></h2>
                         <hr t-if="data.bom_code"/>
                         <h6 t-if="data.bom_code">Reference: <t t-esc="data.bom_code"/></h6>
                     </div>

--- a/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.xml
+++ b/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.xml
@@ -7,8 +7,8 @@
                 <span t-if="props.hasFoldButton" class="btn btn-light p-0" t-attf-aria-label="{{ foldButtonTitle }}" t-attf-title="{{ foldButtonTitle }}" style="margin-right: 1px">
                     <i t-attf-class="fa fa-fw fa-caret-{{ props.isFolded ? 'right' : 'down' }}" role="img"/>
                 </span>
-                <a t-if="data.id and data.model === 'mrp.workorder'" href="#" t-on-click.prevent="openWorkorder" t-out="data.name"/>
-                <a t-elif="data.id and data.model" href="#" t-on-click.prevent="openForm" t-out="data.name"/>
+                <button t-if="data.id and data.model === 'mrp.workorder'" class="btn btn-link p-0 fw-normal" t-on-click.prevent="openWorkorder" t-out="data.name"/>
+                <button t-elif="data.id and data.model" class="btn btn-link p-0 fw-normal" t-on-click.prevent="openForm" t-out="data.name"/>
                 <t t-else="" t-out="data.name"/>
                 <button t-if="data.model === 'to_order'" class="ms-2 py-0 btn btn-secondary" t-on-click="openReplenish">Replenish</button>
             </div>
@@ -32,7 +32,7 @@
         <td class="text-end" t-if="props.showOptions.receipts">
             <t t-if="data.receipt">
                 <span t-attf-class="{{ getColorClass(data.receipt.decorator) }}" t-out="data.receipt.display"/>
-                <a href="#" role="button" t-on-click.prevent="openForecast" title="Forecast Report" t-attf-class="fa fa-fw fa-area-chart ms-1 {{getColorClass(data.receipt.decorator)}}"/>
+                <button role="button" t-on-click.prevent="openForecast" title="Forecast Report" t-attf-class="border-0 bg-transparent p-0 fa fa-fw fa-area-chart ms-1 {{getColorClass(data.receipt.decorator)}}"/>
             </t>
         </td>
         <td class="text-end" t-if="props.showOptions.unitCosts" t-out="formatMonetary(data.unit_cost)"/>

--- a/addons/mrp_subcontracting/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
+++ b/addons/mrp_subcontracting/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mrp_subcontracting.BomOverviewSpecialLine" t-inherit="mrp.BomOverviewSpecialLine" t-inherit-mode="extension">
         <xpath expr="//td[@name='td_mrp_bom']" position="inside">
-            <t t-if="props.type == 'subcontracting'">Subcontracting: <a href="#" t-on-click.prevent="goToSubcontractor" t-esc="subcontracting.name"/></t>
+            <t t-if="props.type == 'subcontracting'">Subcontracting: <button class="btn btn-link p-0 fw-normal" t-on-click.prevent="goToSubcontractor" t-esc="subcontracting.name"/></t>
         </xpath>
 
         <xpath expr="//td[@name='quantity']" position="inside">

--- a/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
+++ b/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
@@ -9,16 +9,15 @@
                     t-on-mouseleave="() => this.onOptionMouseLeave()"
                     t-on-click="(ev) => this.searchWorldwide(ev)"
                 >
-                    <a
+                    <button
                         t-attf-id="{{props.id or 'autocomplete'}}_{{source_index}}_{{option_index}}"
                         role="option"
-                        href="#"
                         class="dropdown-item ui-menu-item-wrapper text-truncate text-info"
                         t-att-class="{ 'ui-state-active': isActiveSourceOption([source_index, option_index]) }"
                         t-att-aria-selected="isActiveSourceOption([source_index, option_index]) ? 'true' : 'false'"
                     >
                         Search Worldwide 🌎
-                    </a>
+                    </button>
                 </li>
             </t>
         </xpath>

--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.xml
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.xml
@@ -13,7 +13,7 @@
                 <div class="flex-grow-1 text-center" t-att-class="{ 'disable-buttons': !posState.has_chart_template || loadScenario.status === 'loading' }">
                     <p class="h1 text-primary mt-4" t-if="!posState.has_pos_config">Choose your store</p>
                     <p t-if="!posState.has_chart_template" class="h2 m-3">
-                        Please <a href="#" class="btn-link o_form_uri" role="button" t-on-click="() => action.doAction('account.action_account_config')">install a chart of accounts</a> to activate the buttons.
+                        Please <button class="btn btn-link o_form_uri p-0 fs-2" role="button" t-on-click="() => action.doAction('account.action_account_config')">install a chart of accounts</button> to activate the buttons.
                     </p>
                     <br />
                     <div t-attf-class="d-flex {{posState.is_restaurant_installed ? 'flex-column' : 'flex-column-reverse'}}">

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -100,7 +100,7 @@
                         </setting>
                         <div groups="base.group_system">
                             <p>
-                                More settings: <a href="#" name="%(action_pos_configuration)d" type="action" class="btn-link o_form_uri" role="button">Configurations > Settings</a>
+                                More settings: <button name="%(action_pos_configuration)d" type="action" class="btn-link o_form_uri p-0" role="button">Configurations > Settings</button>
                             </p>
                         </div>
                     </div>

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -117,7 +117,7 @@
            t-nocache-_dropdown_menu_class="_dropdown_menu_class">
             <t t-set="is_connected" t-value="not user_id._is_public()"/>
             <li t-if="is_connected" t-attf-class="#{_item_class} o_no_autohide_item">
-                <a href="#" role="button" data-bs-toggle="dropdown" t-attf-class="#{'' if _no_caret else 'dropdown-toggle'} #{_link_class}">
+                <button role="button" data-bs-toggle="dropdown" t-attf-class="#{'' if _no_caret else 'dropdown-toggle'} #{_link_class}">
                     <t t-if="_avatar">
                         <t t-set="avatar_source" t-value="image_data_uri(user_id.avatar_256)"/>
                         <img t-att-src="avatar_source" t-attf-class="rounded-circle o_object_fit_cover #{_avatar_class}" width="24" height="24" alt="" loading="eager"/>
@@ -126,7 +126,7 @@
                         <i t-attf-class="fa fa-1x fa-fw fa-user #{_icon_class}"/>
                     </div>
                     <span t-if="_user_name" t-attf-class="#{_user_name_class}" t-esc="user_id.name[:23] + '...' if user_id.name and len(user_id.name) &gt; 25 else user_id.name"/>
-                </a>
+                </button>
                 <div t-attf-class="dropdown-menu js_usermenu #{_dropdown_menu_class}" role="menu">
                     <a groups="base.group_user" href="/odoo" role="menuitem" class="dropdown-item ps-3" id="o_backend_user_dropdown_link">
                         <i class="fa fa-fw fa-th me-1 small text-primary-emphasis"/> Apps

--- a/addons/project/static/src/components/notebook_task_one2many_field/notebook_task_list_renderer.xml
+++ b/addons/project/static/src/components/notebook_task_one2many_field/notebook_task_list_renderer.xml
@@ -10,9 +10,9 @@
         </xpath>
 
         <xpath expr="//t[@t-foreach='controls']" position="after">
-            <a t-if="ShowX2MRecords" role="button" class="ml16 o_toggle_closed_task_button" href="#" t-on-click="() => this.toggleHideClosed()">
+            <button t-if="ShowX2MRecords" role="button" class="ml16 o_toggle_closed_task_button btn btn-link" t-on-click="() => this.toggleHideClosed()">
                 <t t-esc="toggleListHideLabel"/>
-            </a>
+            </button>
         </xpath>
     </t>
 </templates>

--- a/addons/project/static/src/components/project_right_side_panel/components/project_profitability.xml
+++ b/addons/project/static/src/components/project_right_side_panel/components/project_profitability.xml
@@ -16,11 +16,11 @@
                         <tr class="revenue_section">
                             <t t-set="revenue_label" t-value="props.labels[revenue.id] or revenue.id"/>
                             <td class="align-middle">
-                                <a class="revenue_section" t-if="revenue.action" href="#"
+                                <button class="revenue_section btn btn-link fw-normal p-0" t-if="revenue.action"
                                     t-on-click="() => this.props.onClick(revenue.action)"
                                 >
                                     <t t-esc="revenue_label"/>
-                                </a>
+                                </button>
                                 <t t-esc="revenue_label" t-else=""/>
                             </td>
                             <td t-attf-class="text-end align-middle {{ revenue.invoiced + revenue.to_invoice === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenue.invoiced + revenue.to_invoice)"/></td>
@@ -53,11 +53,11 @@
                     <tr t-foreach="costs.data" t-as="cost" t-key="cost.id" t-if="cost.billed !== 0 || cost.to_bill !== 0">
                         <t t-set="cost_label" t-value="props.labels[cost.id] or cost.id"/>
                         <td class="align-middle">
-                            <a t-if="cost.action" href="#"
+                            <button t-if="cost.action" class="btn btn-link fw-normal p-0"
                                 t-on-click="() => this.props.onClick(cost.action)"
                             >
                                 <t t-esc="cost_label"/>
-                            </a>
+                            </button>
                             <t t-esc="cost_label" t-else=""/>
                         </td>
                         <td t-attf-class="text-end align-middle {{ cost.billed + cost.to_bill === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(cost.billed + cost.to_bill)"/></td>

--- a/addons/project/static/src/views/project_project_calendar/common/project_common_calendar_popover.xml
+++ b/addons/project/static/src/views/project_project_calendar/common/project_common_calendar_popover.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-name="project.ProjectCalendarCommonPopover.footer" t-inherit="web.CalendarCommonPopover.footer" t-inherit-mode="primary">
         <xpath expr="//t[@t-if='isEventDeletable']" position="before">
-            <a href="#" class="btn btn-secondary" t-on-click="onClickViewTasks">View Tasks</a>
+            <button class="btn btn-secondary" t-on-click="onClickViewTasks">View Tasks</button>
         </xpath>
     </t>
 </templates>

--- a/addons/project/static/tests/project_notebook_task_list.test.js
+++ b/addons/project/static/tests/project_notebook_task_list.test.js
@@ -123,14 +123,14 @@ test("test Project Task Calendar Popover with task_stage_with_state_selection wi
         message: "The depend on tasks list should display all blocking tasks by default, thus we are looking for 2 in total"
     });
 
-    expect("div[name='child_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("Hide closed tasks");
-    expect("div[name='depend_on_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("Hide closed tasks");
+    expect("div[name='child_ids'] .o_field_x2many_list_row_add button.o_toggle_closed_task_button").toHaveText("Hide closed tasks");
+    expect("div[name='depend_on_ids'] .o_field_x2many_list_row_add button.o_toggle_closed_task_button").toHaveText("Hide closed tasks");
 
-    await click("div[name='child_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button");
+    await click("div[name='child_ids'] .o_field_x2many_list_row_add button.o_toggle_closed_task_button");
     await animationFrame();
 
-    expect("div[name='child_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("Show closed tasks");
-    expect("div[name='depend_on_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("Hide closed tasks");
+    expect("div[name='child_ids'] .o_field_x2many_list_row_add button.o_toggle_closed_task_button").toHaveText("Show closed tasks");
+    expect("div[name='depend_on_ids'] .o_field_x2many_list_row_add button.o_toggle_closed_task_button").toHaveText("Hide closed tasks");
 
     expect('div[name="child_ids"] .o_data_row').toHaveCount(3, {
         message: "The subtasks list should only display the open subtasks of the task, in this case 3"
@@ -139,11 +139,11 @@ test("test Project Task Calendar Popover with task_stage_with_state_selection wi
         message: "The depend on tasks list should still display all blocking tasks, in this case 2"
     });
 
-    await click("div[name='depend_on_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button");
+    await click("div[name='depend_on_ids'] .o_field_x2many_list_row_add button.o_toggle_closed_task_button");
     await animationFrame();
 
-    expect("div[name='child_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("Show closed tasks");
-    expect("div[name='depend_on_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("1 closed tasks");
+    expect("div[name='child_ids'] .o_field_x2many_list_row_add button.o_toggle_closed_task_button").toHaveText("Show closed tasks");
+    expect("div[name='depend_on_ids'] .o_field_x2many_list_row_add button.o_toggle_closed_task_button").toHaveText("1 closed tasks");
 
     expect('div[name="child_ids"] .o_data_row').toHaveCount(3, {
         message: "The subtasks list should only display the open subtasks of the task, in this case 3"

--- a/addons/project/static/tests/project_project_calendar.test.js
+++ b/addons/project/static/tests/project_project_calendar.test.js
@@ -43,6 +43,6 @@ test("check 'Edit' and 'View Tasks' buttons are in Project Calendar Popover", as
     expect(queryAllTexts(".o_popover .card-footer .btn")).toEqual(["Edit", "View Tasks", "Delete"]);
 
     await click(".o_popover .card-footer a:contains(View Tasks)");
-    await click(".o_popover .card-footer a:contains(Edit)");
+    await click(".o_popover .card-footer button:contains(Edit)");
     expect.verifySteps(["view tasks", "Edit"]);
 });

--- a/addons/purchase/static/src/views/purchase_dashboard.xml
+++ b/addons/purchase/static/src/views/purchase_dashboard.xml
@@ -10,7 +10,7 @@
                         </div>
                         <div class="g-col-12 g-col-lg-11 grid gap-1" style="--columns: 61">
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Draft RFQs" filter_name="draft_rfqs">
-                                <a href="#" class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                <button class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{ purchaseData['global']['draft']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-info-subtle text-info-emphasis' }}">
                                     <div class="fs-2">
                                         <span t-out="purchaseData['global']['draft']['all']"/>
@@ -18,20 +18,20 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['global']['draft']['priority']"/>
                                         </span>
                                     </div>New
-                                </a>
+                                </button>
                             </div>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Sent RFQs" filter_name="waiting_rfqs">
-                                <a href="#" class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 bg-secondary-subtle text-secondary-emphasis text-truncate text-wrap">
+                                <button class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 bg-secondary-subtle text-secondary-emphasis text-truncate text-wrap">
                                     <div class="fs-2">
                                         <span t-out="purchaseData['global']['sent']['all']"/>
                                         <span class="ps-4" t-if="purchaseData['global']['sent']['priority']">
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['global']['sent']['priority']"/>
                                         </span>
                                     </div>RFQ Sent
-                                </a>
+                                </button>
                             </div>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Late RFQs" filter_name="late">
-                                <a href="#" class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                <button class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{ purchaseData['global']['late']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-warning-subtle text-warning-emphasis' }}">
                                     <div class="fs-2">
                                         <span t-out="purchaseData['global']['late']['all']"/>
@@ -39,11 +39,11 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['global']['late']['priority']"/>
                                         </span>
                                     </div>Late RFQ
-                                </a>
+                                </button>
                             </div>
                             <div class="g-col-1"/>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Not Acknowledged RFQs" filter_name="not_acknowledged">
-                                <a href="#" class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                <button class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{ purchaseData['global']['not_acknowledged']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-info-subtle text-info-emphasis' }}">
                                     <div class="fs-2">
                                         <span t-out="purchaseData['global']['not_acknowledged']['all']"/>
@@ -51,10 +51,10 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['global']['not_acknowledged']['priority']"/>
                                         </span>
                                     </div>Not Acknowledged
-                                </a>
+                                </button>
                             </div>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Late Receipt RFQs" filter_name="late_receipt">
-                                <a href="#" class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                <button class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{ purchaseData['global']['late_receipt']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-danger-subtle text-danger-emphasis' }}">
                                     <div class="fs-2">
                                         <span t-out="purchaseData['global']['late_receipt']['all']"/>
@@ -62,7 +62,7 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['global']['late_receipt']['priority']"/>
                                         </span>
                                     </div>Late Receipt
-                                </a>
+                                </button>
                             </div>
                         </div>
                     </div>
@@ -72,7 +72,7 @@
                         </div>
                         <div class="g-col-12 g-col-lg-11 grid gap-1 pt-0 pt-lg-1" style="--columns: 61">
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="My Draft RFQs" filter_name="draft_rfqs,my_purchases">
-                                <a href="#" class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                <button class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{ purchaseData['my']['draft']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-info-subtle text-info-emphasis' }}">
                                     <div>
                                         <span t-out="purchaseData['my']['draft']['all']"/>
@@ -80,20 +80,20 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['my']['draft']['priority']"/>
                                         </span>
                                     </div>
-                                </a>
+                                </button>
                             </div>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="My Waiting RFQs" filter_name="waiting_rfqs,my_purchases">
-                                <a href="#" class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 bg-secondary-subtle text-secondary-emphasis text-truncate text-wrap">
+                                <button class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 bg-secondary-subtle text-secondary-emphasis text-truncate text-wrap">
                                     <div>
                                         <span t-out="purchaseData['my']['sent']['all']"/>
                                         <span class="ps-4" t-if="purchaseData['my']['sent']['priority']">
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['my']['sent']['priority']"/>
                                         </span>
                                     </div>
-                                </a>
+                                </button>
                             </div>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="My Late RFQs" filter_name="late,my_purchases">
-                                <a href="#" class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                <button class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{ purchaseData['my']['late']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-warning-subtle text-warning-emphasis' }}">
                                     <div>
                                         <span t-out="purchaseData['my']['late']['all']"/>
@@ -101,11 +101,11 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['my']['late']['priority']"/>
                                         </span>
                                     </div>
-                                </a>
+                                </button>
                             </div>
                             <div class="g-col-1"/>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="My Not Acknowledged RFQs" filter_name="not_acknowledged,my_purchases">
-                                <a href="#" class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                <button class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{ purchaseData['my']['not_acknowledged']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-info-subtle text-info-emphasis' }}">
                                     <div>
                                         <span t-out="purchaseData['my']['not_acknowledged']['all']"/>
@@ -113,10 +113,10 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['my']['not_acknowledged']['priority']"/>
                                         </span>
                                     </div>
-                                </a>
+                                </button>
                             </div>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="My Late Receipt RFQs" filter_name="late_receipt,my_purchases">
-                                <a href="#" class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                <button class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{ purchaseData['my']['late_receipt']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-danger-subtle text-danger-emphasis' }}">
                                     <div>
                                         <span t-out="purchaseData['my']['late_receipt']['all']"/>
@@ -124,7 +124,7 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['my']['late_receipt']['priority']"/>
                                         </span>
                                     </div>
-                                </a>
+                                </button>
                             </div>
                         </div>
                     </div>

--- a/addons/purchase_stock/static/src/purchase_stock_forecasted/forecasted_details.xml
+++ b/addons/purchase_stock/static/src/purchase_stock_forecasted/forecasted_details.xml
@@ -8,8 +8,8 @@
                 <td>
                     <t t-foreach="props.docs.draft_purchase_orders" t-as="purchase_order" t-key="purchase_order_index">
                         <t t-if="purchase_order_index > 0"> | </t>
-                        <a t-attf-href="#" t-out="purchase_order.name"
-                            class="fw-bold"
+                        <button t-out="purchase_order.name"
+                            class="fw-bold btn btn-link p-0"
                             t-on-click.prevent="() => this.props.openView('purchase.order', 'form', purchase_order.id)"/>
                     </t>
                 </td>

--- a/addons/sale/static/src/xml/sales_team_progress_bar_template.xml
+++ b/addons/sale/static/src/xml/sales_team_progress_bar_template.xml
@@ -8,9 +8,9 @@
         </t>
         <t t-else="">
             <!-- TODO is this class needed here ? -->
-            <a t-on-click.prevent="defineInvoicingTarget" href="#" class="sale_progressbar_form_link">
+            <button t-on-click.prevent="defineInvoicingTarget" class="btn btn-link fw-normal p-0 sale_progressbar_form_link">
                 Click to define an invoicing target
-            </a>
+            </button>
         </t>
     </t>
 

--- a/addons/sale/static/tests/tours/sale_signature.js
+++ b/addons/sale/static/tests/tours/sale_signature.js
@@ -12,7 +12,7 @@ registry.category("web_tour.tours").add('sale_signature', {
     },
     {
         content: "click sign",
-        trigger: 'a:contains("Sign")',
+        trigger: 'button:contains("Sign")',
         run: "click",
     },
     {

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -137,12 +137,12 @@
                     <t t-set="entries">
                         <div class="d-flex flex-column gap-4 mt-3">
                             <div class="d-flex flex-column gap-2" id="sale_order_sidebar_button">
-                                <a t-if="sale_order._has_to_be_signed()" role="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalaccept" href="#">
+                                <button t-if="sale_order._has_to_be_signed()" role="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalaccept">
                                     <i class="fa fa-check"/><t t-if="sale_order._has_to_be_paid()"> Sign &amp; Pay</t><t t-else=""> Accept &amp; Sign</t>
-                                </a>
-                                <a t-elif="sale_order._has_to_be_paid()" role="button" id="o_sale_portal_paynow" data-bs-toggle="modal" data-bs-target="#modalaccept" href="#" t-att-class="'%s' % ('btn btn-light' if sale_order.transaction_ids else 'btn btn-primary')" >
+                                </button>
+                                <button t-elif="sale_order._has_to_be_paid()" role="button" id="o_sale_portal_paynow" data-bs-toggle="modal" data-bs-target="#modalaccept" t-att-class="'%s' % ('btn btn-light' if sale_order.transaction_ids else 'btn btn-primary')" >
                                     <i class="fa fa-check"/> <t t-if="not sale_order.signature">Accept &amp; Pay</t><t t-else="">Pay Now</t>
-                                </a>
+                                </button>
                                 <div class="o_download_pdf d-flex gap-2 flex-lg-column flex-xl-row flex-wrap">
                                     <a class="btn btn-light o_print_btn o_portal_invoice_print flex-grow-1" t-att-href="sale_order.get_portal_url(report_type='pdf')" id="print_invoice_report" title="View Details" role="button" target="_blank"><i class="fa fa-print me-1"/>View Details</a>
                                 </div>
@@ -347,19 +347,19 @@
 
                         <t t-if="sale_order._has_to_be_signed()">
                             <div class="col-sm-auto mt8">
-                                <a role="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalaccept" href="#"><i class="fa fa-check"/><t t-if="sale_order._has_to_be_paid()"> Sign &amp; Pay</t><t t-else=""> Accept &amp; Sign</t></a>
+                                <button role="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalaccept"><i class="fa fa-check"/><t t-if="sale_order._has_to_be_paid()"> Sign &amp; Pay</t><t t-else=""> Accept &amp; Sign</t></button>
                             </div>
                             <div class="col-sm-auto mt8">
                                 <a role="button" class="btn btn-light" href="#discussion"><i class="fa fa-comment"/> Feedback</a>
                             </div>
                             <div class="col-sm-auto mt8">
-                                <a role="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#modaldecline" href="#"> <i class="fa fa-times"/> Reject</a>
+                                <button role="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#modaldecline"> <i class="fa fa-times"/> Reject</button>
                             </div>
                         </t>
                         <div t-elif="sale_order._has_to_be_paid()" class="col-sm-auto mt8">
-                            <a role="button" data-bs-toggle="modal" data-bs-target="#modalaccept" href="#" t-att-class="'%s' % ('btn btn-light' if sale_order.transaction_ids else 'btn btn-primary')">
+                            <button role="button" data-bs-toggle="modal" data-bs-target="#modalaccept" t-att-class="'%s' % ('btn btn-light' if sale_order.transaction_ids else 'btn btn-primary')">
                                 <i class="fa fa-check"/> <t t-if="not sale_order.signature">Accept &amp; Pay</t><t t-else="">Pay Now</t>
-                            </a>
+                            </button>
                         </div>
                     </div>
 

--- a/addons/sale/views/utm_campaign_views.xml
+++ b/addons/sale/views/utm_campaign_views.xml
@@ -7,22 +7,22 @@
         <field name="inherit_id" ref="utm.utm_campaign_view_kanban"/>
         <field name="arch" type="xml">
             <xpath expr="//footer/div" position="inside">
-                <a t-if="record.invoiced_amount" href="#" title="Revenues" role="button"
+                <button t-if="record.invoiced_amount" title="Revenues" role="button"
                     groups="sales_team.group_sale_salesman" type="object" name="action_redirect_to_invoiced"
-                    class="btn-outline-primary rounded-pill me-1 order-1">
+                    class="rounded-pill me-1 order-1 p-0">
                     <span class="badge">
                         <field name="currency_id" invisible="True"/>
                         <field name="invoiced_amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                     </span>
-                </a>
-                <a t-if="record.quotation_count" href="#" title="Quotations" role="button"
+                </button>
+                <button t-if="record.quotation_count" title="Quotations" role="button"
                     groups="sales_team.group_sale_salesman" type="object" name="action_redirect_to_quotations"
-                    class="btn-outline-primary rounded-pill me-1 order-2">
+                    class="rounded-pill me-1 order-2 p-0">
                     <span class="badge">
                         <i class="fa fa-fw fa-money me-1" aria-label="Quotations" role="img"/>
                         <field name="quotation_count"/>
                     </span>
-                </a>
+                </button>
             </xpath>
         </field>
     </record>

--- a/addons/sale_management/static/src/interactions/sale_update_line_button.js
+++ b/addons/sale_management/static/src/interactions/sale_update_line_button.js
@@ -6,10 +6,10 @@ import { rpc } from "@web/core/network/rpc";
 export class SaleUpdateLineButton extends Interaction {
     static selector = ".o_portal_sale_sidebar";
     dynamicContent = {
-        "a.js_update_line_json": {
+        "button.js_update_line_json": {
             "t-on-click.prevent.withTarget": this.onUpdateLineClick,
         },
-        "a.js_add_optional_products": {
+        "button.js_add_optional_products": {
             "t-on-click.prevent.withTarget": this.onAddOptionalProductClick,
         },
         ".js_quantity": {

--- a/addons/sale_management/views/sale_portal_templates.xml
+++ b/addons/sale_management/views/sale_portal_templates.xml
@@ -15,15 +15,14 @@
 
         <xpath expr="//section[@id='details']//t[@name='product_line_row']" position="inside">
             <td class="text-center" t-if="display_remove">
-                <a t-if="line._can_be_edited_on_portal()"
+                <button t-if="line._can_be_edited_on_portal()"
                    t-att-data-line-id="line.id"
                    t-att-data-unlink="True"
-                   href="#"
-                   class="mb8 js_update_line_json d-print-none"
+                   class="mb8 js_update_line_json d-print-none btn btn-link p-0"
                    aria-label="Remove"
                    title="Remove">
                     <span class="fa fa-trash-o"></span>
-                </a>
+                </button>
             </td>
         </xpath>
 
@@ -65,9 +64,9 @@
                                         </strong>
                                     </td>
                                     <td class="text-end" t-if="sale_order._can_be_edited_on_portal() and report_type == 'html'" name="td_option_add_button">
-                                        <a t-att-data-option-id="option.id" href="#" class="mb8 js_add_optional_products d-print-none" aria-label="Add to cart" title="Add to cart">
+                                        <button t-att-data-option-id="option.id" class="mb8 js_add_optional_products d-print-none border-0 bg-transparent p-0" aria-label="Add to cart" title="Add to cart">
                                             <span class="btn btn-secondary">Add to order</span>
-                                        </a>
+                                        </button>
                                     </td>
                                 </t>
                             </tr>
@@ -82,16 +81,16 @@
                 <div class="input-group js_quantity_container pull-right">
 
                     <span class="d-print-none input-group-text d-none d-md-inline-block">
-                        <a t-att-data-line-id="line.id" t-att-data-remove="True" href="#" class="js_update_line_json" aria-label="Remove one" title="Remove one">
+                        <button t-att-data-line-id="line.id" t-att-data-remove="True" class="js_update_line_json btn btn-link p-0" aria-label="Remove one" title="Remove one">
                             <span class="fa fa-minus"/>
-                        </a>
+                        </button>
                     </span>
                     <!-- TODO add uom in this case too -->
                     <input type="text" class="js_quantity form-control" t-att-data-line-id="line.id" t-att-value="line.product_uom_qty"/>
                     <span class="d-print-none input-group-text d-none d-md-inline-block">
-                        <a t-att-data-line-id="line.id" href="#" class="js_update_line_json" aria-label="Add one" title="Add one">
+                        <button t-att-data-line-id="line.id" class="js_update_line_json btn btn-link p-0" aria-label="Add one" title="Add one">
                             <span class="fa fa-plus"/>
-                        </a>
+                        </button>
                     </span>
                 </div>
             </t>

--- a/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability_section.xml
+++ b/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability_section.xml
@@ -7,11 +7,11 @@
                 <t t-if="this.props.revenue.isSectionFoldable">
                     <button t-attf-class="btn o_group_caret fa fa-fw me-1 #{state.isFolded ? 'fa-caret-right' : 'fa-caret-down'}" t-on-click="() => this.toggleSaleItems()"/>
                 </t>
-                <a class="revenue_section" t-if="revenue.action" href="#"
+                <button class="revenue_section btn btn-link fw-normal p-0" t-if="revenue.action"
                     t-on-click="() => this.props.onClick(revenue.action)"
                 >
                     <t t-esc="revenue_label"/>
-                </a>
+                </button>
                 <t t-esc="revenue_label" t-else=""/>
             </td>
             <td t-attf-class="text-end align-middle {{ revenue.invoiced + revenue.to_invoice === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenue.invoiced + revenue.to_invoice)"/></td>
@@ -34,9 +34,9 @@
                             <tr class="bg-light" t-foreach="sale_items" t-as="sale_item" t-key="sale_item.id">
                                 <t t-set="uom_name" t-value="sale_item.product_uom_id and sale_item.product_uom_id[1]"/>
                                 <td style="padding-left: 30px">
-                                    <a t-if="sale_item.action" href="#" t-on-click="() => this.onSaleItemActionClick(sale_item.action)">
+                                    <button t-if="sale_item.action" class="btn btn-link fw-normal p-0 text-start" t-on-click="() => this.onSaleItemActionClick(sale_item.action)">
                                         <t t-esc="sale_item.display_name"/>
-                                    </a>
+                                    </button>
                                     <t t-else="" t-esc="sale_item.display_name"/>
                                 </td>
                                 <td class="text-end align-middle"><t t-esc="formatValue(sale_item.product_uom_qty, uom_name)"/> <t t-esc="uom_name"/></td>

--- a/addons/sale_stock/static/src/xml/delay_alert.xml
+++ b/addons/sale_stock/static/src/xml/delay_alert.xml
@@ -2,7 +2,7 @@
     <div t-name="sale_stock.DelayAlertWidget" class="m-1">
         <p>The delivery
             <t t-foreach="props.late_elements" t-as="late_element" t-key="late_element.id">
-                <a t-esc="late_element.name" href="#" t-on-click="openElement" t-att-element-id="late_element.id" t-att-element-model="late_element.model"/>,
+                <button class="btn btn-link p-0 fw-normal" t-esc="late_element.name" t-on-click="openElement" t-att-element-id="late_element.id" t-att-element-model="late_element.model"/>,
             </t> will be late.
         </p>
     </div>

--- a/addons/stock/static/src/client_actions/stock_traceability_report_backend.xml
+++ b/addons/stock/static/src/client_actions/stock_traceability_report_backend.xml
@@ -62,10 +62,10 @@
                         </t>
 
                         <span t-if="col and line.reference === col" t-att-class="!line.unfoldable ? 'o_stock_reports_nofoldable' : ''">
-                            <a class="o_stock_reports_web_action" href="#" t-on-click.prevent="() => this.onClickBoundLink(line)" t-esc="col"/>
+                            <button class="o_stock_reports_web_action btn btn-link p-0 fw-normal" t-on-click.prevent="() => this.onClickBoundLink(line)" t-esc="col"/>
                         </span>
                         <span t-elif="col and ((line.picking_type_code == 'incoming' and line.location_source === col) or (line.picking_type_code == 'outgoing' and line.location_destination === col))">
-                            <a class="o_stock_report_partner_action" href="#" t-on-click.prevent="() => this.onClickPartner(line)" t-esc="col"/>
+                            <button class="o_stock_report_partner_action btn btn-link p-0 fw-normal" t-on-click.prevent="() => this.onClickPartner(line)" t-esc="col"/>
                         </span>
                         <span t-elif="col and line.lot_name === col">
                             <span class="o_stock_report_lot_action" t-esc="col" />

--- a/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.xml
+++ b/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.xml
@@ -18,7 +18,7 @@
                 <h1>
                     <t t-if="data.docs">
                         <div t-foreach="data.docs" t-as="doc" t-key="doc.id">
-                            <a href="#" t-on-click.prevent="() => this.onClickTitle(doc.id)" view-type="form" t-esc="doc.name"/>
+                            <button class="btn btn-link p-0 fs-1" t-on-click.prevent="() => this.onClickTitle(doc.id)" view-type="form" t-esc="doc.name"/>
                             <span t-esc="doc.display_state" t-attf-class="ms-1 align-text-top badge rounded-pill bg-opacity-50 {{ doc.state == 'done' ? 'bg-success' : 'bg-info' }}"/>
                         </div>
                     </t>

--- a/addons/stock/static/src/components/reception_report_table/stock_reception_report_table.xml
+++ b/addons/stock/static/src/components/reception_report_table/stock_reception_report_table.xml
@@ -6,12 +6,12 @@
             <tr class="bg-light">
                 <th>
                     <i t-if="props.source[0].priority == '1'" class="o_priority o_priority_star fa fa-star"/>
-                    <a href="#" t-on-click.prevent="() => this.onClickLink(props.source[0].model, props.source[0].id, 'form')" t-out="props.source[0].name"/>
+                    <button class="btn btn-link p-0" t-on-click.prevent="() => this.onClickLink(props.source[0].model, props.source[0].id, 'form')" t-out="props.source[0].name"/>
                     <span t-if="props.source.length > 1">
-                        (<a href="#" t-on-click.prevent="() => this.onClickLink(props.source[1].model, props.source[1].id, 'form')" t-out="props.source[1].name"/>)
+                        (<button class="btn btn-link p-0" t-on-click.prevent="() => this.onClickLink(props.source[1].model, props.source[1].id, 'form')" t-out="props.source[1].name"/>)
                     </span>
                     <span t-if="props.source[0].model == 'stock.picking' and props.source[0].partner_id">:
-                        <a href="#" t-on-click.prevent="() => this.onClickLink('res.partner', props.source[0].partner_id, 'form')" t-out="props.source[0].partner_name"/>
+                        <button class="btn btn-link p-0" t-on-click.prevent="() => this.onClickLink('res.partner', props.source[0].partner_id, 'form')" t-out="props.source[0].partner_name"/>
                     </span>
                 </th>
                 <th>Expected Delivery: <t t-esc="props.scheduledDate"/></th>

--- a/addons/stock/static/src/stock_forecasted/forecasted_details.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.xml
@@ -25,14 +25,13 @@
                 </tr>
                 <tr t-foreach="props.docs.lines" t-as="line" t-key="line_index" t-attf-class="#{line.is_matched and 'table-info'}">
                     <td t-attf-class="#{line.is_late and 'table-danger'}">
-                        <a t-if="line.document_in"
-                            href="#"
+                        <button t-if="line.document_in"
                             t-on-click.prevent="() => this.props.openView(line.document_in._name, 'form', line.document_in.id)"
                             t-out="line.document_in.name"
-                            class="fw-bold"/>
+                            class="btn btn-link p-0 fw-bold"/>
 
                         <t t-elif="line.reservation">
-                            <a t-out="line.reservation.name" href="#" class="fw-bold"
+                            <button t-out="line.reservation.name" class="btn btn-link p-0 fw-bold"
                                t-on-click.prevent="() => this.props.openView(line.reservation._name, 'form', line.reservation.id)"
                                 /> reserved
                             <button t-if="displayReserve(line)"
@@ -72,11 +71,10 @@
                             t-attf-class="o_priority o_priority_star me-1 fa fa-star#{line.move_out.picking_id.priority=='1' ? '' : '-o'}"
                             t-on-click="() => this._onClickChangePriority('stock.picking', line.move_out.picking_id)"
                             name="change_priority_link"/>
-                        <a t-if="line.document_out"
-                            href="#"
+                        <button t-if="line.document_out"
                             t-on-click.prevent="() => this.props.openView(line.document_out._name, 'form', line.document_out.id)"
                             t-out="line.document_out.name"
-                            class="fw-bold"/>
+                            class="btn btn-link p-0 fw-bold"/>
                     </td>
                     <td t-out="line.delivery_date or ''"
                         t-attf-class="#{! line.replenishment_filled and 'table-danger'}"/>

--- a/addons/stock/static/src/stock_forecasted/forecasted_header.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.xml
@@ -3,36 +3,36 @@
     <t t-name="stock.ForecastedHeader">
         <div class="d-flex flex-wrap pb-2 justify-content-between">
             <div class="o_product_name">
-                <h3>
+                <h3 class="mb-0">
                     <t t-if="props.docs.product_templates">
                         <t t-foreach="props.docs.product_templates" t-as="product_template" t-key='product_template.id'>
-                            <a href="#"
+                            <button class="btn btn-link p-0 fs-3"
                             t-on-click.prevent="() => this.props.openView('product.template', 'form', product_template.id)"
                             t-out="product_template.display_name"/>
                         </t>
                     </t>
                     <t t-elif="props.docs.product_variants">
                         <t t-foreach="props.docs.product_variants" t-as="product_variant" t-key="product_variant.id">
-                            <a href="#"
+                            <button class="btn btn-link p-0 fs-3"
                             t-on-click.prevent="() => this.props.openView('product.product', 'form', product_variant.id)"
                             t-out="product_variant.display_name"/>
                         </t>
                     </t>
                 </h3>
                 <h6 t-if="props.docs.product_templates and props.docs.product_variants and props.docs.product_templates.length != props.docs.product_variants.length"
-                    name="product_variants">
+                    name="product_variants" class="mb-1">
                     <t t-foreach="props.docs.product_variants" t-as="product_variant" t-key="product_variant.id">
-                        <a href="#"
+                        <button class="btn btn-link p-0"
                         t-on-click.prevent="() => this.props.openView('product.product', 'form', product_variant.id)">
                             [<t t-out="product_variant.combination_name"/>]
-                        </a>
+                        </button>
                     </t>
                 </h6>
             </div>
             <div class="row">
                 <div class="col-md-auto text-center">
                     <div class="h3">
-                        <a href="#"
+                        <button class="btn btn-link p-0 fs-3 lh-1"
                             t-on-click.prevent="() => this._onClickInventory()"
                            t-out="_formatFloat(this.props.docs.quantity_on_hand)"/>
                     </div>

--- a/addons/stock/static/src/widgets/stock_rescheduling_popover.xml
+++ b/addons/stock/static/src/widgets/stock_rescheduling_popover.xml
@@ -5,7 +5,7 @@
         <h6>Planning Issue</h6>
         <p>Preceding operations
         <t t-foreach="props.late_elements" t-as="late_element" t-key="late_element.id">
-            <a t-out="late_element.name" t-on-click="openElement" href="#" t-att-element-id="late_element.id" t-att-element-model="late_element.model"/>,
+            <button class="btn btn-link p-0 fw-normal" t-out="late_element.name" t-on-click="openElement" t-att-element-id="late_element.id" t-att-element-model="late_element.model"/>,
         </t>
         planned on <t t-out="props.delay_alert_date"/>.</p>
     </div>

--- a/addons/stock_account/static/src/stock_account_forecasted/forecasted_header.xml
+++ b/addons/stock_account/static/src/stock_account_forecasted/forecasted_header.xml
@@ -2,9 +2,9 @@
 <templates id="template">
     <t t-name="stock_account.ForecastedHeader" t-inherit="stock.ForecastedHeader" t-inherit-mode="extension">
         <xpath expr="//h6[@name='product_variants']" position="after">
-            <h6 t-if="() => env.user.has_group('stock.group_stock_manager')">
+            <h6 t-if="() => env.user.has_group('stock.group_stock_manager')" class="d-flex align-items-baseline">
                 Value On Hand:
-                <a href="#"
+                <button class="btn btn-link p-0 lh-1 ms-1"
                    t-out="props.docs.value"
                    t-on-click.prevent="_onClickValuation"/>
             </h6>

--- a/addons/survey/static/src/js/survey_breadcrumb.js
+++ b/addons/survey/static/src/js/survey_breadcrumb.js
@@ -3,7 +3,7 @@ import publicWidget from "@web/legacy/js/public/public_widget";
 publicWidget.registry.SurveyBreadcrumbWidget = publicWidget.Widget.extend({
     template: "survey.survey_breadcrumb_template",
     events: {
-        'click .breadcrumb-item a': '_onBreadcrumbClick',
+        'click .breadcrumb-item button': '_onBreadcrumbClick',
     },
 
     /**

--- a/addons/survey/static/src/scss/survey_templates_form.scss
+++ b/addons/survey/static/src/scss/survey_templates_form.scss
@@ -566,3 +566,7 @@ _::-webkit-full-page-media, _:future, :root .o_survey_wrap {
         overflow: auto !important;
     }
  }
+
+.survey-breadcrumb:hover {
+    text-decoration: underline;
+ }

--- a/addons/survey/static/src/scss/survey_templates_results.scss
+++ b/addons/survey/static/src/scss/survey_templates_results.scss
@@ -60,7 +60,7 @@
 
 .o_survey_results_topbar {
 
-    .nav-item.dropdown a {
+    .nav-item.dropdown a, .nav-item.dropdown button {
         min-width: 13em;
     }
     .o_survey_results_topbar_dropdown_filters {

--- a/addons/survey/static/src/xml/survey_breadcrumb_templates.xml
+++ b/addons/survey/static/src/xml/survey_breadcrumb_templates.xml
@@ -15,9 +15,9 @@
                     <t t-set="canGoBack" t-value="false" />
                 </t>
                 <t t-if="canGoBack">
-                    <a class="text-primary text-break" href="#">
+                    <button class="text-primary text-break btn btn-link p-0 survey-breadcrumb">
                         <span t-esc="page.title" />
-                    </a>
+                    </button>
                 </t>
                 <t t-else="">
                     <span t-att-class="'text-break ' + (isActivePage ? 'text-black' : 'text-muted')"

--- a/addons/survey/static/tests/tours/survey_prefill.js
+++ b/addons/survey/static/tests/tours/survey_prefill.js
@@ -63,7 +63,7 @@ registry.category("web_tour.tours").add('test_survey_prefill', {
     }, {
         // Go back to previous page
         content: 'Click on the previous page name in the breadcrumb',
-        trigger: 'ol.breadcrumb a:first',
+        trigger: 'ol.breadcrumb button:first',
         run: "click",
     }, {
         trigger: 'div.js_question-wrapper:contains("How many times did you order products on our website?") input',

--- a/addons/survey/views/survey_templates_statistics.xml
+++ b/addons/survey/views/survey_templates_statistics.xml
@@ -184,11 +184,11 @@
                     <ul class="nav o_survey_results_topbar_dropdown_filters align-items-center">
                         <t t-set="dropdown_item_classes" t-translation="off">dropdown-item d-flex align-items-center justify-content-between</t>
                         <li class="nav-item dropdown me-2 my-1">
-                            <a href="#" role="button" data-bs-toggle="dropdown"
+                            <button role="button" data-bs-toggle="dropdown"
                                t-attf-class="btn btn-outline-primary dropdown-toggle #{'active' if search_finished else ''}">
                                 <span t-if="search_finished">Completed surveys</span>
                                 <span t-else="">All surveys</span>
-                            </a>
+                            </button>
                             <div class="dropdown-menu">
                                 <a t-attf-class="#{dropdown_item_classes} filter-finished-or-not #{'active' if not search_finished else ''}">
                                     <span>All surveys</span>
@@ -201,12 +201,12 @@
                             </div>
                         </li>
                         <li t-if="survey.scoring_type != 'no_scoring'" class="nav-item dropdown me-2 my-1">
-                            <a href="#" role="button" data-bs-toggle="dropdown"
+                            <button role="button" data-bs-toggle="dropdown"
                                t-attf-class="btn btn-outline-primary dropdown-toggle #{'active' if search_passed_or_failed else ''}">
                                 <span t-if="search_failed">Failed only</span>
                                 <span t-elif="search_passed">Passed only</span>
                                 <span t-else="">Passed and Failed</span>
-                            </a>
+                            </button>
                             <div class="dropdown-menu">
                                 <a t-attf-class="#{dropdown_item_classes} filter-passed-and-failed #{'active' if not search_passed_or_failed else ''}">
                                     <span>Passed and Failed</span>
@@ -467,7 +467,7 @@
                     <t t-set="total" t-value="ceil(non_skipped_answers_count / page_record_limit) + 1"/>
                     <li t-foreach="range(1, total)" t-as="num"
                         t-att-class="'page-item o_survey_js_results_pagination %s' % ('active' if num == 1 else '')">
-                        <a href="#" class="page-link" t-esc="num"></a>
+                        <button class="page-link" t-esc="num"></button>
                     </li>
                 </ul>
                 <button class="btn btn-sm btn-primary mx-0 my-3 o_survey_question_answers_show_btn">Show All</button>

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -175,8 +175,8 @@
                             <span t-else="">Leaderboard</span>
                         </h1>
                         <div t-att-class="'o_survey_leaderboard_buttons fw-bold %s' % 'd-none' if not is_last_question else 'ms-2'">
-                            <a href="#" role="button" class="o_survey_session_close btn btn-primary mt-1"><i class="fa fa-close"/> Close</a>
-                            <a href="#" role="button" class="o_survey_session_close btn btn-primary mt-1" t-att-data-show-results="True"><i class="fa fa-bar-chart"/> Results</a>
+                            <button role="button" class="o_survey_session_close btn btn-primary mt-1"><i class="fa fa-close"/> Close</button>
+                            <button role="button" class="o_survey_session_close btn btn-primary mt-1" t-att-data-show-results="True"><i class="fa fa-bar-chart"/> Results</button>
                         </div>
                     </div>
                     <div class="justify-content-center d-flex flex-column flex-grow-1 mt-5 mb-5 pb-5 o_survey_session_leaderboard_container"/>

--- a/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
+++ b/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
@@ -162,7 +162,7 @@ var initTourSteps = function (eventName) {
 
 var browseTalksSteps = [{
     content: 'Browse Talks Menu',
-    trigger: 'a[href*="#"]:contains("Talks")',
+    trigger: 'button:contains("Talks")',
     run: "click",
 }, {
     content: 'Browse Talks Submenu',

--- a/addons/test_website/static/tests/tours/systray.js
+++ b/addons/test_website/static/tests/tours/systray.js
@@ -94,7 +94,7 @@ const cannotAddNewContent = () => [{
 
 const canEditInBackEnd = () => [{
     content: "Edit in backend",
-    trigger: '.o_menu_systray .o_website_edit_in_backend a',
+    trigger: '.o_menu_systray .o_website_edit_in_backend button',
     run: "click",
 }, {
     content: "Check that the form is editable",
@@ -107,7 +107,7 @@ const canEditInBackEnd = () => [{
 
 const canViewInBackEnd = () => [{
     content: "Go to backend",
-    trigger: '.o_menu_systray .o_website_edit_in_backend a',
+    trigger: '.o_menu_systray .o_website_edit_in_backend button',
     run: "click",
 }, {
     content: "Check that the form is read-only",

--- a/addons/web/static/tests/legacy/helpers/utils.js
+++ b/addons/web/static/tests/legacy/helpers/utils.js
@@ -1129,7 +1129,7 @@ export async function clickM2OHighlightedItem(el, fieldName, selector) {
 
 // X2Many
 export async function addRow(target, selector) {
-    await click(target.querySelector(`${selector ? selector : ""} .o_field_x2many_list_row_add a`));
+    await click(target.querySelector(`${selector ? selector : ""} .o_field_x2many_list_row_add button`));
 }
 
 export async function removeRow(target, index) {

--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -104,7 +104,7 @@
                                                 </div>
                                                 <div class="mb-0 py-2 col-12 s_website_form_submit s_website_form_no_submit_label text-end" data-name="Submit Button">
                                                     <div style="width: 200px;" class="s_website_form_label"/>
-                                                    <a href="#" role="button" class="btn btn-primary s_website_form_send">Submit</a>
+                                                    <button role="button" class="btn btn-primary s_website_form_send">Submit</button>
                                                     <span id="s_website_form_result"></span>
                                                 </div>
                                             </div>

--- a/addons/website/data/website_demo.xml
+++ b/addons/website/data/website_demo.xml
@@ -23,7 +23,7 @@
                                             </t>
                                             <h3 class="mt-2 h6">Link</h3>
                                             <t t-foreach="bs_theme_colors" t-as="color">
-                                                <a href="#" t-attf-class="badge mb-1 text-bg-#{color[0]}"><t t-esc="color[1]"/></a>
+                                                <button t-attf-class="badge mb-1 text-bg-#{color[0]}"><t t-esc="color[1]"/></button>
                                             </t>
                                             <h3 class="mt-2 h6">Autosizing</h3>
                                             <div class="h3">
@@ -65,10 +65,10 @@
                                                 <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown">Toggle</button>
                                                 <div class="dropdown-menu">
                                                     <div class="dropdown-header">Header</div>
-                                                    <a class="dropdown-item" href="#">Action</a>
-                                                    <a class="dropdown-item" href="#">Something else here</a>
+                                                    <button class="dropdown-item">Action</button>
+                                                    <button class="dropdown-item">Something else here</button>
                                                     <div class="dropdown-divider"/>
-                                                    <a class="dropdown-item" href="#">Separated link</a>
+                                                    <button class="dropdown-item">Separated link</button>
                                                 </div>
                                             </div>
 
@@ -76,36 +76,36 @@
                                             <h6 class="mt-2">Default</h6>
                                             <ul class="nav">
                                                 <li class="nav-item">
-                                                    <a class="nav-link active" aria-current="page" href="#">Active</a>
+                                                    <button class="nav-link active" aria-current="page">Active</button>
                                                 </li>
                                                 <li class="nav-item">
-                                                    <a class="nav-link" href="#">Link</a>
+                                                    <button class="nav-link">Link</button>
                                                 </li>
                                                 <li class="nav-item">
-                                                    <a class="nav-link" href="#">Link</a>
+                                                    <button class="nav-link">Link</button>
                                                 </li>
                                                 <li class="nav-item">
-                                                    <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
+                                                    <button class="nav-link disabled" tabindex="-1" aria-disabled="true">Disabled</button>
                                                 </li>
                                             </ul>
                                             <h6 class="mt-2">Tabs</h6>
                                             <ul class="nav nav-tabs">
                                                 <li class="nav-item">
-                                                    <a class="nav-link active" aria-current="page" href="#">Active</a>
+                                                    <button class="nav-link active" aria-current="page">Active</button>
                                                 </li>
                                                 <li class="nav-item">
-                                                    <a class="nav-link" href="#">Link</a>
+                                                    <button class="nav-link">Link</button>
                                                 </li>
                                                 <li class="nav-item">
-                                                    <a class="nav-link" href="#">Link</a>
+                                                    <button class="nav-link">Link</button>
                                                 </li>
                                                 <li class="nav-item">
-                                                    <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
+                                                    <button class="nav-link disabled" tabindex="-1" aria-disabled="true">Disabled</button>
                                                 </li>
                                             </ul>
                                             <h2 class="mt-4">Navbar</h2>
                                             <nav class="navbar navbar-expand-lg navbar-light bg-light">
-                                                <a class="navbar-brand" href="#">Navbar</a>
+                                                <button class="navbar-brand btn btn-link p-0">Navbar</button>
                                                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                                                 <span class="navbar-toggler-icon"></span>
                                                 </button>
@@ -113,13 +113,13 @@
                                                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                                                     <ul class="navbar-nav me-auto">
                                                         <li class="nav-item active">
-                                                            <a class="nav-link" href="#">Home <span class="visually-hidden">(current)</span></a>
+                                                            <button class="nav-link">Home <span class="visually-hidden">(current)</span></button>
                                                         </li>
                                                         <li class="nav-item">
-                                                            <a class="nav-link" href="#">Link</a>
+                                                            <button class="nav-link">Link</button>
                                                         </li>
                                                         <li class="nav-item">
-                                                            <a class="nav-link disabled" href="#">Disabled</a>
+                                                            <button class="nav-link disabled">Disabled</button>
                                                         </li>
                                                     </ul>
                                                     <form class="d-flex align-items-center my-2 my-lg-0">
@@ -178,19 +178,19 @@
                                             <nav>
                                                 <ul class="pagination">
                                                     <li class="page-item disabled">
-                                                        <a class="page-link" href="#" tabindex="-1">Previous</a>
+                                                        <button class="page-link" tabindex="-1">Previous</button>
                                                     </li>
                                                     <li class="page-item">
-                                                        <a class="page-link" href="#">1</a>
+                                                        <button class="page-link">1</button>
                                                     </li>
                                                     <li class="page-item active">
-                                                        <a class="page-link" href="#">2 <span class="visually-hidden">(current)</span></a>
+                                                        <button class="page-link">2 <span class="visually-hidden">(current)</span></button>
                                                     </li>
                                                     <li class="page-item">
-                                                        <a class="page-link" href="#">3</a>
+                                                        <button class="page-link">3</button>
                                                     </li>
                                                     <li class="page-item">
-                                                        <a class="page-link" href="#">Next</a>
+                                                        <button class="page-link">Next</button>
                                                     </li>
                                                 </ul>
                                             </nav>
@@ -199,8 +199,8 @@
                                             <h2>Breadcrumb</h2>
                                             <nav aria-label="breadcrumb">
                                                 <ol class="breadcrumb">
-                                                    <li class="breadcrumb-item"><a href="#">Home</a></li>
-                                                    <li class="breadcrumb-item"><a href="#">Library</a></li>
+                                                    <li class="breadcrumb-item"><button class="btn btn-link p-0">Home</button></li>
+                                                    <li class="breadcrumb-item"><button class="btn btn-link p-0">Library</button></li>
                                                     <li class="breadcrumb-item active" aria-current="page">Data</li>
                                                 </ol>
                                             </nav>
@@ -287,8 +287,8 @@
                                                         <li class="list-group-item">A third item</li>
                                                     </ul>
                                                     <div class="card-body">
-                                                        <a href="#" class="card-link btn btn-primary">Card link</a>
-                                                        <a href="#" class="card-link">Another link</a>
+                                                        <button class="card-link btn btn-primary">Card link</button>
+                                                        <button class="card-link btn btn-link p-0">Another link</button>
                                                     </div>
                                                 </div>
                                             </div>
@@ -517,10 +517,10 @@
                                                         <p class="small">Small text. Lorem <b>ipsum dolor sit amet</b>, consectetur adipiscing elit. <i>Integer posuere erat a ante</i>.</p>
                                                     </div>
                                                     <div class="col-5 border-start">
-                                                        <a href="#" class="mb-3 btn-block btn btn-primary">btn-primary</a>
-                                                        <a href="#" class="mb-3 btn-block btn btn-secondary">btn-secondary</a>
-                                                        <a href="#" class="mb-3 btn-block btn btn-outline-primary">btn-outline-primary</a>
-                                                        <a href="#" class="mb-3 btn-block btn btn-outline-secondary">btn-outline-secondary</a>
+                                                        <button class="mb-3 btn-block btn btn-primary">btn-primary</button>
+                                                        <button class="mb-3 btn-block btn btn-secondary">btn-secondary</button>
+                                                        <button class="mb-3 btn-block btn btn-outline-primary">btn-outline-primary</button>
+                                                        <button class="mb-3 btn-block btn btn-outline-secondary">btn-outline-secondary</button>
                                                     </div>
                                                 </div>
                                                 <hr class="my-4"/>
@@ -540,27 +540,27 @@
                                                                 <p class="card-text">Paragraph. <a class="o_translate_inline" href="#">text link</a></p>
 
                                                                 <t t-foreach="['primary','secondary', 'info', 'warning', 'danger', 'success']" t-as="btn">
-                                                                    <a href="#" t-attf-class="mb-2 btn-sm btn btn-#{btn}" t-esc="'btn-' + btn"/>
+                                                                    <button t-attf-class="mb-2 btn-sm btn btn-#{btn}" t-esc="'btn-' + btn"/>
                                                                 </t>
                                                             </div>
                                                         </div>
                                                         <nav aria-label="breadcrumb">
                                                             <ol class="breadcrumb">
-                                                                <li class="breadcrumb-item"><a href="#">Breadcrumb</a></li>
-                                                                <li class="breadcrumb-item"><a href="#">Library</a></li>
+                                                                <li class="breadcrumb-item"><button class="btn btn-link p-0">Breadcrumb</button></li>
+                                                                <li class="breadcrumb-item"><button class="btn btn-link p-0">Library</button></li>
                                                                 <li class="breadcrumb-item active">Data</li>
                                                             </ol>
                                                         </nav>
                                                         <small>TABS</small>
                                                         <ul class="nav nav-tabs mb-3">
                                                             <li class="nav-item">
-                                                                <a class="nav-link active" href="#">Active</a>
+                                                                <button class="nav-link active">Active</button>
                                                             </li>
                                                             <li class="nav-item">
-                                                                <a class="nav-link" href="#">Link</a>
+                                                                <button class="nav-link">Link</button>
                                                             </li>
                                                             <li class="nav-item">
-                                                                <a class="nav-link disabled" href="#">Disabled</a>
+                                                                <button class="nav-link disabled">Disabled</button>
                                                             </li>
                                                         </ul>
                                                         <div class="progress">
@@ -569,8 +569,8 @@
                                                     </div>
                                                     <div class="col-5 border-start">
                                                         <div t-foreach="['info', 'warning', 'danger', 'success']" t-as="btn">
-                                                            <a href="#" t-attf-class="mb-2 btn-block btn btn-#{btn}" t-esc="'btn-' + btn"/>
-                                                            <a href="#" t-attf-class="mb-3 btn-block btn btn-outline-#{btn}" t-esc="'btn-outline-' + btn"/>
+                                                            <button t-attf-class="mb-2 btn-block btn btn-#{btn}" t-esc="'btn-' + btn"/>
+                                                            <button t-attf-class="mb-3 btn-block btn btn-outline-#{btn}" t-esc="'btn-outline-' + btn"/>
                                                         </div>
                                                     </div>
                                                 </div>

--- a/addons/website/static/src/client_actions/website_preview/edit_in_backend.xml
+++ b/addons/website/static/src/client_actions/website_preview/edit_in_backend.xml
@@ -3,10 +3,10 @@
 <t t-name="website.EditInBackendSystrayItem">
     <div class="o_website_edit_in_backend d-flex">
         <span class="o_website_systray_separator d-none d-md-block w-0 border-start"/>
-        <a href="#" class="o_nav_entry btn d-flex align-items-center mx-1 border-0 rounded-0 px-2 px-md-3" accesskey="e" t-on-click="editInBackend">
+        <button class="o_nav_entry btn d-flex align-items-center mx-1 border-0 rounded-0 px-2 px-md-3" accesskey="e" t-on-click="editInBackend">
             <span class="fa fa-cog d-block d-md-none"/>
             <span class= "d-none d-md-block" t-esc="state.mainObjectName"/>
-        </a>
+        </button>
     </div>
 </t>
 </templates>

--- a/addons/website/static/src/client_actions/website_preview/mobile_preview_systray.xml
+++ b/addons/website/static/src/client_actions/website_preview/mobile_preview_systray.xml
@@ -3,10 +3,10 @@
 <t t-name="website.MobilePreviewSystrayItem">
     <div class="o_mobile_preview o_menu_systray_item d-none d-md-flex"
          t-att-class="{ 'o_mobile_preview_active': this.state.isMobile }">
-        <a href="#" accesskey="v" class="o_nav_entry mx-1 px-3"
+        <button accesskey="v" class="o_nav_entry mx-1 px-3"
            t-on-click="onClick">
             <span title="Mobile preview" role="img" aria-label="Mobile preview" class="fa fa-lg fa-mobile"/>
-        </a>
+        </button>
     </div>
 </t>
 </templates>

--- a/addons/website/static/src/client_actions/website_preview/publish_website_systray_item.js
+++ b/addons/website/static/src/client_actions/website_preview/publish_website_systray_item.js
@@ -12,10 +12,10 @@ const websiteSystrayRegistry = registry.category("website_systray");
 export class PublishSystrayItem extends Component {
     static template = xml`
         <div t-on-click="publishContent" class="o_menu_systray_item o_website_publish_container d-flex ms-auto" t-att-data-processing="state.processing and 1">
-            <a href="#" class="d-flex align-items-center mx-1 px-2 px-md-0" data-hotkey="p">
+            <button class="d-flex align-items-center mx-1 px-2 px-md-0 border-0 bg-transparent" data-hotkey="p">
                 <span class="o_nav_entry d-none d-md-block mx-0 pe-1" t-esc="this.label"/>
                 <CheckBox value="state.published" className="'form-switch d-flex justify-content-center m-0 pe-none'"/>
-            </a>
+            </button>
         </div>`;
     static components = {
         CheckBox,

--- a/addons/website/static/src/components/dialog/add_page_dialog.xml
+++ b/addons/website/static/src/components/dialog/add_page_dialog.xml
@@ -79,17 +79,16 @@
             <ul t-ref="tabs" class="nav nav-pills flex-column flex-nowrap overflow-y-auto">
                 <t t-foreach="state.pages" t-as="page" t-key="page.id">
                     <li class="nav-item">
-                        <a t-att-data-id="page.id"
+                        <button t-att-data-id="page.id"
                             t-on-click="() => this.onTabClick(page.id)"
-                            class="nav-link p-3 rounded-0"
+                            class="nav-link p-3 rounded-0 w-100 text-start"
                             t-att-class="{active: page_first}"
-                            href="#"
                             role="tab"
                             tabindex="0"
                         >
                             <span t-if="page.isPreloading" class="fa fa-spin fa-circle-o-notch me-1"/>
                             <t t-out="page.title"/>
-                        </a>
+                        </button>
                     </li>
                 </t>
             </ul>

--- a/addons/website/static/src/components/dialog/edit_menu.xml
+++ b/addons/website/static/src/components/dialog/edit_menu.xml
@@ -55,12 +55,12 @@
             <small class="float-end text-muted">
                 Drag to the right to get a submenu
             </small>
-            <a href="#" t-on-click="() => this.addMenu(false)">
+            <button class="btn btn-link p-0 fw-normal" t-on-click="() => this.addMenu(false)">
                 <i class="fa fa-plus-circle"/> Add Menu Item
-            </a><br/>
-            <a href="#" t-on-click="() => this.addMenu(true)">
+            </button><br/>
+            <button class="btn btn-link p-0 fw-normal" t-on-click="() => this.addMenu(true)">
                 <i class="fa fa-plus-circle"/> Add Mega Menu Item
-            </a>
+            </button>
         </div>
     </WebsiteDialog>
 </t>

--- a/addons/website/static/src/components/dialog/page_properties.xml
+++ b/addons/website/static/src/components/dialog/page_properties.xml
@@ -21,7 +21,7 @@
                 <t t-call="{{ constructor.popoverTemplate }}"/>
             </t>
             <div t-att-data-bs-template="depTemplate" data-bs-html="true" title="Dependencies" t-ref="action">
-                Could be used in many places, see here: <a href="#" t-on-click="showDependencies">Dependencies</a>
+                Could be used in many places, see here: <button class="btn btn-link p-0 fw-normal" t-on-click="showDependencies">Dependencies</button>
             </div>
         </t>
         <t t-else="">

--- a/addons/website/static/src/components/dialog/seo.xml
+++ b/addons/website/static/src/components/dialog/seo.xml
@@ -35,7 +35,7 @@
                 </t>
             </ul>
         </td>
-        <td class="text-center" t-on-click="() => props.removeKeyword(props.keyword)"><a href="#" class="oe_remove" t-att-title="'Remove ' + props.keyword"><i class="fa fa-trash"/></a></td>
+        <td class="text-center" t-on-click="() => props.removeKeyword(props.keyword)"><button class="oe_remove border-0 bg-transparent" t-att-title="'Remove ' + props.keyword"><i class="fa fa-trash"/></button></td>
     </tr>
 </t>
 

--- a/addons/website/static/src/components/website_loader/website_loader.xml
+++ b/addons/website/static/src/components/website_loader/website_loader.xml
@@ -5,11 +5,11 @@
          class="o_website_loader_container position-fixed fixed-top fixed-left h-100 w-100 d-flex"
          t-att-class="currentWaitingMessage.flag ? ('o_website_loader_container_' + currentWaitingMessage.flag) : ''">
         <div class="o_website_loader_container_content position-relative d-flex flex-column p-3 p-lg-5">
-            <a t-if="state.showCloseButton"
-               href="#" class="btn" style="position: absolute; right: 0; top: 0; margin: 15px;"
+            <button t-if="state.showCloseButton"
+               class="btn" style="position: absolute; right: 0; top: 0; margin: 15px;"
                t-on-click="close">
                 <i class="oi oi-close oi-large" role="presentation"/>
-            </a>
+            </button>
 
             <div class="o_website_loader_odoo_logo mb-5" style="height: 31px; width: 78px;"/>
 

--- a/addons/website/static/src/js/backend/view_hierarchy/view_hierarchy.xml
+++ b/addons/website/static/src/js/backend/view_hierarchy/view_hierarchy.xml
@@ -12,14 +12,14 @@
             <div class="o_tree_container ms-2 container mt-2" style="margin-bottom: 50px;">
                 <div t-if="siblingViews.length > 0" class="alert alert-info m-1 p-1">
                     Multiple tree exists for this view
-                    <a t-foreach="siblingViews" t-as="siblingView" t-key="siblingView.id" href="#" class="o_load_hierarchy" t-on-click.stop.prevent="() => this.onShowHierarchy(siblingView.id)">
+                    <button t-foreach="siblingViews" t-as="siblingView" t-key="siblingView.id" class="o_load_hierarchy btn btn-link p-0" t-on-click.stop.prevent="() => this.onShowHierarchy(siblingView.id)">
                         <i class="oi oi-arrow-right me-1"/>
                         <t t-esc="siblingView.display_name"/>
                         &lt;<t t-esc="siblingView.key"/>&gt;
                         <t t-if="siblingView.website_id">
                             [<t t-esc="siblingView.website_id[1]"/>]
                         </t>
-                    </a>
+                    </button>
                 </div>
                 <t t-set="viewTree" t-value="state.viewTree"/>
                 <t t-call="website.report_viewhierarchy_children"/>
@@ -37,12 +37,12 @@
             <t t-esc="viewTree.name"/> (<span class="fw-bold" t-esc="viewTree.key"/>)
             <span class="o_text_orange" t-if="viewTree.website_name" t-esc="`[${viewTree.website_name}]`"/>
         </span>
-        <a href="#" t-on-click.stop.prevent="() => this.openFormView(viewTree.id)">
+        <button class="border-0 bg-transparent p-0" t-on-click.stop.prevent="() => this.openFormView(viewTree.id)">
             <i class="fa fa-eye ms-2 text-muted" title="Go to View"/>
-        </a>
-        <a class="o_show_diff" href="#" t-on-click.stop.prevent="() => this.onShowDiffClick(viewTree.id)">
+        </button>
+        <button class="o_show_diff border-0 bg-transparent p-0" t-on-click.stop.prevent="() => this.onShowDiffClick(viewTree.id)">
             <i class="fa fa-files-o ms-2 text-muted" title="Show Arch Diff"/>
-        </a>
+        </button>
         <t t-if="state.searchedView.id === viewTree.id">
             <span class="o_tab_hint text-info ms-auto small fst-italic pe-2">Press &lt;Tab&gt; for next [<t t-esc="state.searchedView.index+1"/>/<t t-esc="state.searchedView.total"/>]</span>
         </t>

--- a/addons/website/static/src/scss/view_hierarchy.scss
+++ b/addons/website/static/src/scss/view_hierarchy.scss
@@ -24,12 +24,12 @@
     }
 
     .o_tree_entry {
-        a {
+        button {
             display: none;
         }
 
         &:hover {
-            a {
+            button {
                 display: block;
             }
         }

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -683,7 +683,7 @@ font[class*='bg-'] {
         }
     }
 
-    @at-root a.badge:hover, a:not(.dropdown-item):hover > .badge, .o_badge_clickable.badge:hover {
+    @at-root a.badge:hover, button.badge:hover, a:not(.dropdown-item):hover > .badge, .o_badge_clickable.badge:hover {
         --badge-bg: var(--badge-border-color);
         --badge-color: var(--badge-color-hover);
         text-decoration: none;

--- a/addons/website/static/src/snippets/s_searchbar/000.xml
+++ b/addons/website/static/src/snippets/s_searchbar/000.xml
@@ -6,7 +6,7 @@
     class="o_dropdown_menu show position-absolute w-100">
     <t t-if="fuzzySearch and results.length">
         <span class="dropdown-item-text">
-            <span class="text-muted">No results found for '<t t-esc="search"/>'. Showing results for '<a href="#" class="s_searchbar_fuzzy_submit" t-esc="fuzzySearch"/>'.</span>
+            <span class="text-muted">No results found for '<t t-esc="search"/>'. Showing results for '<button class="s_searchbar_fuzzy_submit btn btn-link p-0" t-esc="fuzzySearch"/>'.</span>
         </span>
     </t>
     <t t-elif="!results.length">

--- a/addons/website/static/src/systray_items/edit_in_backend.xml
+++ b/addons/website/static/src/systray_items/edit_in_backend.xml
@@ -3,10 +3,10 @@
 <t t-name="website.EditInBackendSystray">
     <div class="o_website_edit_in_backend d-flex">
         <span class="o_website_systray_separator d-none d-md-block w-0 border-start"/>
-        <a href="#" class="o_nav_entry btn d-flex align-items-center mx-1 border-0 rounded-0 px-2 px-md-3" accesskey="e" t-on-click="editInBackend">
+        <button class="o_nav_entry btn d-flex align-items-center mx-1 border-0 rounded-0 px-2 px-md-3" accesskey="e" t-on-click="editInBackend">
             <span class="fa fa-cog d-block d-md-none"/>
             <span class= "d-none d-md-block" t-esc="state.mainObjectName"/>
-        </a>
+        </button>
     </div>
 </t>
 </templates>

--- a/addons/website/static/src/systray_items/edit_website.xml
+++ b/addons/website/static/src/systray_items/edit_website.xml
@@ -2,12 +2,12 @@
 <templates xml:space="preserve">
 <t t-name="website.EditWebsiteSystray">
     <div class="o_menu_systray_item o_edit_website_container d-none d-md-flex">
-        <a t-if="!translatable and !this.websiteService.is404" href="#" class="o-website-btn-custo-primary btn position-relative d-flex align-items-center rounded-0 border-0 px-3" accesskey="a" t-on-click="startEdit">
+        <button t-if="!translatable and !this.websiteService.is404" class="o-website-btn-custo-primary btn position-relative d-flex align-items-center rounded-0 border-0 px-3" accesskey="a" t-on-click="startEdit">
             <span t-if="this.state.isLoading" class="position-absolute top-50 start-50 translate-middle">
                 <i class="fa fa-circle-o-notch fa-spin"/>
             </span>
             <span t-out="label" t-attf-class="{{ this.state.isLoading ? 'opacity-0' : 'opacity-100' }}"/>
-        </a>
+        </button>
         <Dropdown t-else="">
             <button class="o-dropdown-toggle-custo o-website-btn-custo-primary btn rounded-0 border-0 px-3" data-hotkey="a">
                 <span t-out="label"/>

--- a/addons/website/static/src/systray_items/mobile_preview.xml
+++ b/addons/website/static/src/systray_items/mobile_preview.xml
@@ -3,10 +3,10 @@
 <t t-name="website.MobilePreviewSystray">
     <div class="o_mobile_preview o_menu_systray_item d-none d-md-flex"
          t-att-class="{ 'o_mobile_preview_active': this.state.isMobile }">
-        <a href="#" accesskey="v" class="o_nav_entry mx-1 px-3"
+        <button accesskey="v" class="o_nav_entry mx-1 px-3"
            t-on-click="() => this.websiteService.context.isMobile = !this.websiteService.context.isMobile">
             <span title="Mobile preview" role="img" aria-label="Mobile preview" class="fa fa-lg fa-mobile"/>
-        </a>
+        </button>
     </div>
 </t>
 </templates>

--- a/addons/website/static/src/systray_items/new_content.xml
+++ b/addons/website/static/src/systray_items/new_content.xml
@@ -2,14 +2,14 @@
 <templates xml:space="preserve">
 <t t-name="website.NewContentElement">
     <div class="o_new_content_element col-md-4 mb8" t-att-name="props.name">
-        <a href="#"
+        <button class="bg-transparent border-0"
                 t-on-click="onClick"
                 t-att-class="props.status === MODULE_STATUS.NOT_INSTALLED ? 'o_uninstalled_module' : ''"
                 t-att-title="props.title"
                 t-att-aria-label="props.title"
                 t-att-data-module-xml-id="props.moduleXmlId">
             <t t-slot="default"/>
-        </a>
+        </button>
     </div>
 </t>
 
@@ -41,7 +41,7 @@
 
 <t t-name="website.NewContentSystray">
     <div class="o_menu_systray_item o_new_content_container d-none d-md-flex" t-on-click="onClick">
-        <a href="#" accesskey="c" class="o-website-btn-custo-secondary btn d-flex align-items-center rounded-0 border-0 px-3">New</a>
+        <button accesskey="c" class="o-website-btn-custo-secondary btn d-flex align-items-center rounded-0 border-0 px-3">New</button>
         <NewContentModal t-if="websiteContext.showNewContentModal"/>
     </div>
 </t>

--- a/addons/website/static/src/systray_items/publish.js
+++ b/addons/website/static/src/systray_items/publish.js
@@ -12,10 +12,10 @@ const websiteSystrayRegistry = registry.category('website_systray');
 class PublishSystray extends Component {
     static template = xml`
         <div t-on-click="publishContent" class="o_menu_systray_item o_website_publish_container d-flex ms-auto" t-att-data-processing="state.processing and 1">
-            <a href="#" class="d-flex align-items-center mx-1 px-2 px-md-0" data-hotkey="p">
+            <button class="d-flex align-items-center mx-1 px-2 px-md-0 bg-transparent border-0" data-hotkey="p">
                 <span class="o_nav_entry d-none d-md-block mx-0 pe-1" t-esc="this.label"/>
                 <CheckBox value="state.published" className="'form-switch d-flex justify-content-center m-0 pe-none'"/>
-            </a>
+            </button>
         </div>`;
     static components = {
         CheckBox,

--- a/addons/website/static/src/xml/website.cookies_bar.xml
+++ b/addons/website/static/src/xml/website.cookies_bar.xml
@@ -16,12 +16,12 @@
         </p>
     </t>
     <t t-name="website.cookies_bar.text_button_all">
-        <a href="#" id="cookies-consent-all" role="button"
-           class="js_close_popup o_cookies_bar_accept_all o_cookies_bar_text_button btn btn-outline-primary rounded-circle mb-1 px-2 py-1">Allow all cookies</a>
+        <button id="cookies-consent-all" role="button"
+           class="js_close_popup o_cookies_bar_accept_all o_cookies_bar_text_button btn btn-outline-primary rounded-circle mb-1 px-2 py-1">Allow all cookies</button>
     </t>
     <t t-name="website.cookies_bar.text_button_essential">
-        <a href="#" id="cookies-consent-essential" role="button"
-           class="js_close_popup o_cookies_bar_accept_essential o_cookies_bar_text_button_essential btn btn-outline-primary rounded-circle mt-1 mb-2 px-2 py-1">Only allow essential cookies</a>
+        <button id="cookies-consent-essential" role="button"
+           class="js_close_popup o_cookies_bar_accept_essential o_cookies_bar_text_button_essential btn btn-outline-primary rounded-circle mt-1 mb-2 px-2 py-1">Only allow essential cookies</button>
     </t>
     <t t-name="website.cookies_bar.discrete">
         <!-- When updating this template, do not forget to also update the
@@ -36,10 +36,10 @@
                         </p>
                     </div>
                     <div class="col-lg-4 text-end pt16 pb16">
-                        <a href="#" id="cookies-consent-essential" role="button"
-                           class="js_close_popup btn btn-outline-primary rounded-circle btn-sm px-2">Only essentials</a>
-                        <a href="#" id="cookies-consent-all" role="button"
-                           class="js_close_popup btn btn-outline-primary rounded-circle btn-sm">I agree</a>
+                        <button id="cookies-consent-essential" role="button"
+                           class="js_close_popup btn btn-outline-primary rounded-circle btn-sm px-2">Only essentials</button>
+                        <button id="cookies-consent-all" role="button"
+                           class="js_close_popup btn btn-outline-primary rounded-circle btn-sm">I agree</button>
                     </div>
                 </div>
             </div>

--- a/addons/website/static/tests/interactions/bottom_fixed_element.test.js
+++ b/addons/website/static/tests/interactions/bottom_fixed_element.test.js
@@ -36,7 +36,7 @@ const getTemplate = function (options = {}) {
     const withButtonCenter = options.withButtonCenter || false;
 
     const emptyDiv = `<div style="height: 50px; width: 150px;"></div>`;
-    const buttonEl = `<a href="#" style="background-color: white; border: solid; height: 50px; width: 150px;"></a>`;
+    const buttonEl = `<a href="#test" style="background-color: white; border: solid; height: 50px; width: 150px;"></a>`;
 
     return `
         <header style="height: 50px; background-color: #CCCCFF;"></header>

--- a/addons/website/static/tests/interactions/cookies/cookies.test.js
+++ b/addons/website/static/tests/interactions/cookies/cookies.test.js
@@ -29,8 +29,8 @@ const cookiesBarTemplate = `
                     <section>
                         <div class="container">
                             <p>
-                                <a href="#" id="cookies-consent-essential" role="button" class="js_close_popup btn btn-outline-primary">Only essentials</a>
-                                <a href="#" id="cookies-consent-all" role="button" class="js_close_popup btn btn-outline-primary">I agree</a>
+                                <a href="#test" id="cookies-consent-essential" role="button" class="js_close_popup btn btn-outline-primary">Only essentials</a>
+                                <a href="#test" id="cookies-consent-all" role="button" class="js_close_popup btn btn-outline-primary">I agree</a>
                             </p>
                         </div>
                     </section>

--- a/addons/website/static/tests/interactions/dropdown/hoverable_dropdown.edit.test.js
+++ b/addons/website/static/tests/interactions/dropdown/hoverable_dropdown.edit.test.js
@@ -17,9 +17,9 @@ test("[EDIT] onMouseLeave doesn't work in edit mode", async () => {
             <div class="dropdown" style="margin: auto;">
                 <a class="dropdown-toggle">Dropdown</a>
                 <div class="dropdown-menu">
-                    <a href="#" style="display: block;">A</a>
-                    <a href="#" style="display: block;">B</a>
-                    <a href="#" style="display: block;">C</a>
+                    <a href="#test" style="display: block;">A</a>
+                    <a href="#test" style="display: block;">B</a>
+                    <a href="#test" style="display: block;">C</a>
                 </div>
             </div>
         </header>
@@ -45,17 +45,17 @@ test("[EDIT] onMouseEnter doesn't work in edit mode if another dropdown is opene
             <div id="D1" class="dropdown" style="margin: auto;">
                 <a class="dropdown-toggle">Dropdown 1</a>
                 <div class="dropdown-menu">
-                    <a href="#" style="display: block;">A1</a>
-                    <a href="#" style="display: block;">B1</a>
-                    <a href="#" style="display: block;">C1</a>
+                    <a href="#test" style="display: block;">A1</a>
+                    <a href="#test" style="display: block;">B1</a>
+                    <a href="#test" style="display: block;">C1</a>
                 </div>
             </div>
             <div id="D2" class="dropdown" style="margin: auto;">
                 <a class="dropdown-toggle">Dropdown 2</a>
                 <div class="dropdown-menu">
-                    <a href="#" style="display: block;">A2</a>
-                    <a href="#" style="display: block;">B2</a>
-                    <a href="#" style="display: block;">C2</a>
+                    <a href="#test" style="display: block;">A2</a>
+                    <a href="#test" style="display: block;">B2</a>
+                    <a href="#test" style="display: block;">C2</a>
                 </div>
             </div>
         </header>

--- a/addons/website/static/tests/interactions/dropdown/hoverable_dropdown.test.js
+++ b/addons/website/static/tests/interactions/dropdown/hoverable_dropdown.test.js
@@ -12,9 +12,9 @@ const dropdownTemplate = `
         <div class="dropdown" style="margin: auto;">
             <a class="dropdown-toggle">Dropdown</a>
             <div class="dropdown-menu">
-                <a href="#" style="display: block;">A</a>
-                <a href="#" style="display: block;">B</a>
-                <a href="#" style="display: block;">C</a>
+                <a href="#test" style="display: block;">A</a>
+                <a href="#test" style="display: block;">B</a>
+                <a href="#test" style="display: block;">C</a>
             </div>
         </div>
     </header>

--- a/addons/website/static/tests/interactions/listing_layout.test.js
+++ b/addons/website/static/tests/interactions/listing_layout.test.js
@@ -28,7 +28,7 @@ test("listing_layout toggle to list mode", async () => {
             </section>
             <div class="o_website_grid">
                 <div class="col-lg-3 col-md-4 col-sm-6 px-2 col-xs-12">
-                    <a class="o_website_record text-decoration-none d-grid card w-100 mb-3" href="#">
+                    <a class="o_website_record text-decoration-none d-grid card w-100 mb-3" href="#test">
                         Some data
                     </a>
                 </div>
@@ -78,7 +78,7 @@ test("listing_layout toggle to grid mode", async () => {
             </section>
             <div class="o_website_list">
                 <div>
-                    <a class="o_website_record text-decoration-none d-grid card w-100 mb-3" href="#">
+                    <a class="o_website_record text-decoration-none d-grid card w-100 mb-3" href="#test">
                         Some data
                     </a>
                 </div>

--- a/addons/website/static/tests/interactions/popup/popup.test.js
+++ b/addons/website/static/tests/interactions/popup/popup.test.js
@@ -73,7 +73,7 @@ function getPopupTemplate(options = {}) {
                     <div class="modal-content oe_structure">
                         <div class="s_popup_close js_close_popup o_we_no_overlay o_not_editable" aria-label="Close">×</div>
                         <section>
-                            <a href="#" class="btn btn-primary ${extraPrimaryBtnClasses}">Primary button</a>
+                            <a href="#test" class="btn btn-primary ${extraPrimaryBtnClasses}">Primary button</a>
                             ${focusableElements ? '<button id="focus">Button 1</button>' : ""}
                         </section>
                     </div>
@@ -190,7 +190,7 @@ describe("trap focus", () => {
 
     test("focus is trapped when popup opens", async () => {
         const { core } = await startInteractions(`
-            <a href="#">Link</a>
+            <a href="#test">Link</a>
             ${getPopupTemplate({ modalId: "modal", focusableElements: true })}
         `);
         expect(core.interactions).toHaveLength(1);
@@ -211,7 +211,7 @@ describe("trap focus", () => {
 
     test("reset focus on the previous active element when popup is closed", async () => {
         const { core } = await startInteractions(`
-            <a id="showLink" href="#">Link</a>
+            <a id="showLink" href="#test">Link</a>
             ${getPopupTemplate({ modalId: "modal" })}
         `);
         expect(core.interactions).toHaveLength(1);
@@ -263,7 +263,7 @@ describe("trap focus", () => {
 
     test("intercept & reset focus with no backdrop popup", async () => {
         const { core } = await startInteractions(`
-            <a id="link1" href="#">Link</a>
+            <a id="link1" href="#test">Link</a>
             ${getPopupTemplate({ modalId: "modal", backdrop: false })}
         `);
         expect(core.interactions).toHaveLength(1);
@@ -283,9 +283,9 @@ describe("trap focus", () => {
 
     test("don't trap focus if no backdrop", async () => {
         const { core } = await startInteractions(`
-            <a id="link1" href="#">Link before</a>
+            <a id="link1" href="#test">Link before</a>
             ${getPopupTemplate({ modalId: "modal", backdrop: false, focusableElements: true })}
-            <a id="link2" href="#">Link after</a>
+            <a id="link2" href="#test">Link after</a>
         `);
         expect(core.interactions).toHaveLength(1);
         await tick();

--- a/addons/website/static/tests/interactions/ripple_effect.test.js
+++ b/addons/website/static/tests/interactions/ripple_effect.test.js
@@ -14,7 +14,7 @@ describe.current.tags("interaction_dev");
 test("ripple_effect introduces an element on click", async () => {
     const { core } = await startInteractions(`
         <div id="wrapwrap">
-            <a class="btn" href="#">Click here</a>
+            <a class="btn" href="#test">Click here</a>
         </div>
     `);
     expect(core.interactions).toHaveLength(1);

--- a/addons/website/static/tests/interactions/snippets/faq_horizontal.test.js
+++ b/addons/website/static/tests/interactions/snippets/faq_horizontal.test.js
@@ -36,7 +36,7 @@ const getTemplate = function (headerType) {
                             <img src="/web/image/website.s_faq_horizontal_default_image_1" class="img img-fluid rounded" style="width: 100% !important;" alt="" loading="lazy" data-mimetype="image/jpeg" data-original-id="278" data-original-src="/website/static/src/img/snippets_demo/s_faq_horizontal_1.jpg" data-mimetype-before-conversion="image/jpeg">
                             <p><br>The first step in the onboarding process is <b>account creation</b>. This involves signing up on our platform using your email address or social media accounts. Once you’ve created an account, you will receive a confirmation email with a link to activate your account. Upon activation, you’ll be prompted to complete your profile, which includes setting up your preferences, adding any necessary payment information, and selecting the initial features or modules you wish to use.</p>
                             <p>Next, you will be introduced to our <b>setup wizard</b>, which is designed to guide you through the basic configuration of the platform. The wizard will help you configure essential settings such as language, time zone, and notifications.</p>
-                            <p><a href="#">Read More <i class="fa fa-angle-right" role="img"></i></a></p>
+                            <p><a href="#test">Read More <i class="fa fa-angle-right" role="img"></i></a></p>
                         </span>
                         </article>
                     </div>
@@ -70,7 +70,7 @@ const getTemplate = function (headerType) {
                             <p>Our support team is available 24/7 to assist with any issues or questions you may have, ensuring that help is always within reach.</p>
                             <p>Additionally, we offer a comprehensive knowledge base, including detailed documentation, video tutorials, and community forums where you can connect with other users and share insights.</p>
                             <p>We also provide regular updates and new features based on user feedback, ensuring that our platform continues to evolve to meet your needs.</p>
-                            <p><a href="#" class="btn btn-secondary">Documentation</a></p>
+                            <p><a href="#test" class="btn btn-secondary">Documentation</a></p>
                         </span>
                         </article>
                     </div>

--- a/addons/website/static/tests/interactions/snippets/form.edit.test.js
+++ b/addons/website/static/tests/interactions/snippets/form.edit.test.js
@@ -41,7 +41,7 @@ const formXml = `
                         <div class="mb-0 py-2 col-12 s_website_form_submit text-end s_website_form_no_submit_label" data-name="Submit Button">
                             <div style="width: 200px;" class="s_website_form_label"/>
                             <span id="s_website_form_result"></span>
-                            <a href="#" role="button" class="btn btn-primary s_website_form_send">Submit</a>
+                            <a href="#test" role="button" class="btn btn-primary s_website_form_send">Submit</a>
                         </div>
                     </div>
                 </form>

--- a/addons/website/static/tests/interactions/snippets/form.test.js
+++ b/addons/website/static/tests/interactions/snippets/form.test.js
@@ -88,7 +88,7 @@ const formTemplate = /* html */ `
                         <div class="mb-0 py-2 col-12 s_website_form_submit text-end s_website_form_no_submit_label" data-name="Submit Button">
                             <div style="width: 200px;" class="s_website_form_label"></div>
                             <span id="s_website_form_result"></span>
-                            <a href="#" role="button" class="btn btn-primary s_website_form_send">Submit</a>
+                            <a href="#test" role="button" class="btn btn-primary s_website_form_send">Submit</a>
                         </div>
                     </div>
                 </form>

--- a/addons/website/static/tests/tours/dropdowns_and_header_hide_on_scroll.js
+++ b/addons/website/static/tests/tours/dropdowns_and_header_hide_on_scroll.js
@@ -11,7 +11,7 @@ const checkIfUserMenuNotMasked = function () {
     return [
         {
             content: "Click on the user dropdown",
-            trigger: ":iframe #wrapwrap header li.dropdown > a:contains(mitchell admin)",
+            trigger: ":iframe #wrapwrap header li.dropdown > button:contains(mitchell admin)",
             run: "click",
         },
         checkIfVisibleOnScreen(

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -8,7 +8,7 @@ import {
 
 const toggleMegaMenu = (stepOptions) => Object.assign({}, {
     content: "Toggles the mega menu.",
-    trigger: ":iframe .top_menu .nav-item a.o_mega_menu_toggle",
+    trigger: ":iframe .top_menu .nav-item button.o_mega_menu_toggle",
     run(helpers) {
         // If the mega menu is displayed inside the extra menu items, it should
         // already be displayed.
@@ -38,7 +38,7 @@ registerWebsitePreviewTour('edit_megamenu', {
     },
     {
         content: "Trigger the link dialog (click 'Add Mega Menu Item')",
-        trigger: '.modal-body a:eq(1)',
+        trigger: '.modal-body button:contains(Add Mega Menu Item)',
         run: "click",
     },
     {
@@ -127,7 +127,7 @@ registerWebsitePreviewTour("megamenu_active_nav_link", {
     ...openLinkPopup(":iframe .top_menu .nav-item a:contains('Home')", "Home"),
     {
         content: "Click on 'Link' to open Link Dialog",
-        trigger: ".o-we-linkpopover a.js_edit_menu",
+        trigger: ".o-we-linkpopover button.js_edit_menu",
         run: "click",
     },
     {
@@ -135,7 +135,7 @@ registerWebsitePreviewTour("megamenu_active_nav_link", {
     },
     {
         content: "Trigger the link dialog (click 'Add Mega Menu Item')",
-        trigger: ".modal-body a:eq(1)",
+        trigger: ".modal-body button:contains('Add Mega Menu Item')",
         run: "click",
     },
     {
@@ -161,14 +161,14 @@ registerWebsitePreviewTour("megamenu_active_nav_link", {
     },
     {
         content: "Check for the new mega menu",
-        trigger: `:iframe .top_menu:has(.nav-item a.o_mega_menu_toggle:contains("Megatron"))`,
+        trigger: `:iframe .top_menu:has(.nav-item button.o_mega_menu_toggle:contains("Megatron"))`,
     },
     clickOnExtraMenuItem({}, true),
     toggleMegaMenu({}),
     ...openLinkPopup(":iframe .s_mega_menu_odoo_menu .nav-link:contains('Laptops')", "Laptops"),
     {
         content: "Click on 'Edit Link'",
-        trigger: ".o-we-linkpopover a.o_we_edit_link",
+        trigger: ".o-we-linkpopover button.o_we_edit_link",
         run: "click",
     },
     {
@@ -184,9 +184,10 @@ registerWebsitePreviewTour("megamenu_active_nav_link", {
         trigger: ":iframe .s_mega_menu_odoo_menu .row > div:first-child .nav > :nth-child(1)",
         run: "click",
     },
+    // TODO: all menu's active currently check bg-color for active menu
     {
         content: "Check if the new mega menu is active",
-        trigger: `:iframe .top_menu:has(.nav-item a.o_mega_menu_toggle.active:contains("MegaTron"))`,
+        trigger: `:iframe .top_menu:has(.nav-item button.o_mega_menu_toggle:contains("MegaTron"))`,
     },
 ])
 registerWebsitePreviewTour('edit_megamenu_big_icons_subtitles', {
@@ -209,7 +210,7 @@ registerWebsitePreviewTour('edit_megamenu_big_icons_subtitles', {
     },
     {
         content: "Trigger the link dialog (click 'Add Mega Menu Item')",
-        trigger: '.modal-body a:eq(1)',
+        trigger: '.modal-body button:contains(Add Mega Menu Item)',
         run: "click",
     },
     {
@@ -235,7 +236,7 @@ registerWebsitePreviewTour('edit_megamenu_big_icons_subtitles', {
     },
     {
         content: "Check for the new mega menu",
-        trigger: ':iframe .top_menu:has(.nav-item a.o_mega_menu_toggle:contains("Megaaaaa2!"))',
+        trigger: ':iframe .top_menu:has(.nav-item button.o_mega_menu_toggle:contains("Megaaaaa2!"))',
     },
     {
         trigger: ".o_website_preview.editor_enable.editor_has_snippets:not(.o_is_blocked)"

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -33,7 +33,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Trigger the link dialog (click 'Add Mega Menu Item')",
-        trigger: '.modal:not(.o_inactive_modal) .modal-body a:eq(1)',
+        trigger: '.modal:not(.o_inactive_modal) .modal-body button:contains("Add Mega Menu Item")',
         run: "click",
     },
     {
@@ -63,7 +63,7 @@ registerWebsitePreviewTour('edit_menus', {
     clickOnExtraMenuItem({}, true),
     {
         content: "There should be a new megamenu item.",
-        trigger: ':iframe .top_menu .nav-item a.o_mega_menu_toggle:contains("Megaaaaa!")',
+        trigger: ':iframe .top_menu .nav-item button.o_mega_menu_toggle:contains("Megaaaaa!")',
     },
     // Add a menu item in edit mode.
     ...clickOnEditAndWaitEditMode(),
@@ -78,7 +78,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Trigger the link dialog (click 'Add Menu Item')",
-        trigger: '.modal-body a:eq(0)',
+        trigger: '.modal-body button:contains("Add Menu Item")',
         run: "click",
     },
     {
@@ -254,7 +254,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Menu item should have a child",
-        trigger: ':iframe .top_menu .nav-item a.dropdown-toggle:contains("Home")',
+        trigger: ':iframe .top_menu .nav-item button.dropdown-toggle:contains("Home")',
         run: "click",
     },
     // Check that with the auto close of dropdown menus, the dropdowns remain
@@ -274,7 +274,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Open the Home menu after scroll",
-        trigger: ':iframe .top_menu .nav-item a.dropdown-toggle:contains("Home")',
+        trigger: ':iframe .top_menu .nav-item button.dropdown-toggle:contains("Home")',
         async run(helpers) {
             await delay(1000);
             await helpers.click();
@@ -287,7 +287,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Close the Home menu",
-        trigger: ':iframe .top_menu .nav-item:has(a.dropdown-toggle:contains("Home"))',
+        trigger: ':iframe .top_menu .nav-item:has(button.dropdown-toggle:contains("Home"))',
         run: "click",
     },
     {
@@ -296,7 +296,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Open the mega menu",
-        trigger: ':iframe .top_menu .nav-item a.o_mega_menu_toggle:contains("Megaaaaa!")',
+        trigger: ':iframe .top_menu .nav-item button.o_mega_menu_toggle:contains("Megaaaaa!")',
         run: "click",
     },
     {
@@ -319,12 +319,12 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Open the mega menu after scroll",
-        trigger: ':iframe .top_menu .nav-item a.o_mega_menu_toggle:contains("Megaaaaa!")',
+        trigger: ':iframe .top_menu .nav-item button.o_mega_menu_toggle:contains("Megaaaaa!")',
         run: "click",
     },
     {
         content: "Check that the mega menu is opened",
-        trigger: ':iframe .top_menu .nav-item:has(a.o_mega_menu_toggle:contains("Megaaaaa!")) ' +
+        trigger: ':iframe .top_menu .nav-item:has(button.o_mega_menu_toggle:contains("Megaaaaa!")) ' +
             '.s_mega_menu_odoo_menu',
     },
     ...clickOnEditAndWaitEditMode(),
@@ -356,7 +356,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Trigger link dialog (click 'Add Menu Item')",
-        trigger: '.modal-body a:eq(0)',
+        trigger: '.modal-body button:contains("Add Menu Item")',
         run: "click",
     },
     {
@@ -380,7 +380,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Trigger link dialog (click 'Add Menu Item')",
-        trigger: '.modal-body a:eq(0)',
+        trigger: '.modal-body button:contains("Add Menu Item")',
         run: "click",
     },
     {

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -56,11 +56,11 @@ registerWebsitePreviewTour('rte_translator', {
 },
 {
     content: "Open new page menu",
-    trigger: ".o_menu_systray .o_new_content_container > a",
+    trigger: ".o_menu_systray .o_new_content_container > button",
     run: "click",
 }, {
     content: "click on new page",
-    trigger: '.o_new_content_element a',
+    trigger: '.o_new_content_element button',
     run: "click",
 }, {
     content: "click on Use this template",
@@ -88,11 +88,11 @@ registerWebsitePreviewTour('rte_translator', {
     run: "click",
 }, {
     content: "Open new page menu",
-    trigger: ".o_menu_systray .o_new_content_container > a",
+    trigger: ".o_menu_systray .o_new_content_container > button",
     run: "click",
 }, {
     content: "click on new page",
-    trigger: '.o_new_content_element a',
+    trigger: '.o_new_content_element button',
     run: "click",
 }, {
     content: "click on Use this template",
@@ -147,7 +147,7 @@ registerWebsitePreviewTour('rte_translator', {
     run: "click",
 }, {
     content: "edit",
-    trigger: '.o_edit_website_container button',
+    trigger: '.o_edit_website_container .o-dropdown-toggle-custo',
     run: "click",
 },
 {

--- a/addons/website/static/tests/tours/snippet_table_of_content.js
+++ b/addons/website/static/tests/tours/snippet_table_of_content.js
@@ -95,7 +95,7 @@ registerWebsitePreviewTour('snippet_table_of_content', {
     },
     {
         content: "Toggle the mobile view",
-        trigger: '.o_mobile_preview > a',
+        trigger: '.o_mobile_preview > button',
         run: "click",
     },
     {

--- a/addons/website/static/tests/tours/translate_menu_name.js
+++ b/addons/website/static/tests/tours/translate_menu_name.js
@@ -10,7 +10,7 @@ registerWebsitePreviewTour('translate_menu_name', {
 }, () => [
     {
         content: "Open Edit dropdown",
-        trigger: '.o_edit_website_container button',
+        trigger: '.o_edit_website_container .o-dropdown-toggle-custo',
         run: "click",
     },
     {

--- a/addons/website/static/tests/tours/translate_text_options.js
+++ b/addons/website/static/tests/tours/translate_text_options.js
@@ -75,7 +75,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Click edit button",
-            trigger: ".o_menu_systray .o_edit_website_container button",
+            trigger: ".o_menu_systray .o_edit_website_container .o-dropdown-toggle-custo",
             run: "click",
         },
         {

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -42,7 +42,7 @@ registerWebsitePreviewTour('website_page_options', {
     },
     {
         content: "Enable the mobile view",
-        trigger: ".o_mobile_preview > a",
+        trigger: ".o_mobile_preview > button",
         run: "click",
     },
     {
@@ -56,7 +56,7 @@ registerWebsitePreviewTour('website_page_options', {
     },
     {
         content: "Disable the mobile view",
-        trigger: ".o_mobile_preview > a",
+        trigger: ".o_mobile_preview > button",
         run: "click",
     },
     ...clickOnEditAndWaitEditMode(),

--- a/addons/website/static/tests/tours/website_seo_notification.js
+++ b/addons/website/static/tests/tours/website_seo_notification.js
@@ -51,7 +51,7 @@ registerWebsitePreviewTour(
         ...clickOnSave(),
         {
             content: "Publish your website",
-            trigger: ".o_menu_systray_item.o_website_publish_container a",
+            trigger: ".o_menu_systray_item.o_website_publish_container button",
             run: "click",
         },
         {
@@ -66,7 +66,7 @@ registerWebsitePreviewTour(
         {
             content: "Open the dropdown menu",
             trigger:
-                ":iframe #o_main_nav .navbar-nav .dropdown.o_no_autohide_item > a.dropdown-toggle",
+                ":iframe #o_main_nav .navbar-nav .dropdown.o_no_autohide_item > button.dropdown-toggle",
             run: "click",
         },
         {

--- a/addons/website/views/snippets/s_button.xml
+++ b/addons/website/views/snippets/s_button.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_button" name="Button">
-    <a class="btn btn-primary o_snippet_drop_in_only" href="#">Button</a>
+    <button class="btn btn-primary o_snippet_drop_in_only">Button</button>
 </template>
 
 </odoo>

--- a/addons/website/views/snippets/s_carousel_cards.xml
+++ b/addons/website/views/snippets/s_carousel_cards.xml
@@ -16,7 +16,7 @@
                         <div class="card-body">
                             <h3 class="card-title">Slide title</h3>
                             <p class="card-text">A card is a flexible and extensible content container. It includes colors and powerful display options.</p>
-                            <a href="#" class="btn btn-secondary">Read More</a>
+                            <button class="btn btn-secondary">Read More</button>
                         </div>
                     </div>
                 </div>
@@ -29,7 +29,7 @@
                         <div class="card-body">
                             <h3 class="card-title">Slide title</h3>
                             <p class="card-text">A card is a flexible and extensible content container. It includes colors and powerful display options.</p>
-                            <a href="#" class="btn btn-secondary">Read More</a>
+                            <button class="btn btn-secondary">Read More</button>
                         </div>
                     </div>
                 </div>
@@ -42,7 +42,7 @@
                         <div class="card-body">
                             <h3 class="card-title">Slide title</h3>
                             <p class="card-text">A card is a flexible and extensible content container. It includes colors and powerful display options.</p>
-                            <a href="#" class="btn btn-secondary">Read More</a>
+                            <button class="btn btn-secondary">Read More</button>
                         </div>
                     </div>
                 </div>

--- a/addons/website/views/snippets/s_color_blocks_2.xml
+++ b/addons/website/views/snippets/s_color_blocks_2.xml
@@ -8,12 +8,12 @@
                 <div class="col-lg-6 o_cc o_cc4">
                     <h2 class="h3-fs">A color block</h2>
                     <p>Color blocks are a simple and effective way to <b>present and highlight your content</b>. Choose an image or a color for the background. You can even resize and duplicate the blocks to create your own layout. Add images or icons to customize the blocks.</p>
-                    <a href="#" class="btn btn-primary">More Details</a>
+                    <button class="btn btn-primary">More Details</button>
                 </div>
                 <div class="col-lg-6 o_cc o_cc5">
                     <h2 class="h3-fs">Another color block</h2>
                     <p>Color blocks are a simple and effective way to <b>present and highlight your content</b>. Choose an image or a color for the background. You can even resize and duplicate the blocks to create your own layout. Add images or icons to customize the blocks.</p>
-                    <a href="#" class="btn btn-primary">More Details</a>
+                    <button class="btn btn-primary">More Details</button>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_cta_badge.xml
+++ b/addons/website/views/snippets/s_cta_badge.xml
@@ -3,7 +3,7 @@
 
 <template name="CTA Badge" id="s_cta_badge">
     <span class="s_cta_badge d-inline-block my-3 border rounded py-2 px-3 o_cc o_cc1 o_animable" data-name="CTA Badge" style="border-radius: 32px !important;">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;What do you want to promote&amp;nbsp;? &#160;&#160;&#160;&#160;<a href="#">See more <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;What do you want to promote&amp;nbsp;? &#160;&#160;&#160;&#160;<button class="btn btn-link p-0">See more <i class="fa fa-long-arrow-right" role="img"/></button>
     </span>
 </template>
 

--- a/addons/website/views/snippets/s_discovery.xml
+++ b/addons/website/views/snippets/s_discovery.xml
@@ -5,7 +5,7 @@
     <section class="s_discovery pt136 pb136">
         <div class="container" style="text-align: center;">
             <span class="s_cta_badge o_cc o_cc1 d-inline-block my-3 border rounded py-2 px-3 o_animable" data-snippet="s_cta_badge" data-name="CTA Badge" style="border-radius: 32px !important;">
-                <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;What do you want to promote&amp;nbsp;? &#160;&#160;&#160;&#160;<a href="#">See more <i class="fa fa-long-arrow-right" role="img"/></a>
+                <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;What do you want to promote&amp;nbsp;? &#160;&#160;&#160;&#160;<button class="btn btn-link p-0">See more <i class="fa fa-long-arrow-right" role="img"/></button>
             </span>
             <h1 class="display-2" style="text-align: center;">Discover our solutions</h1>
             <p class="lead" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.<br/><br/></p>

--- a/addons/website/views/snippets/s_empowerment.xml
+++ b/addons/website/views/snippets/s_empowerment.xml
@@ -7,7 +7,7 @@
             <div class="row o_grid_mode" data-row-count="12">
                 <div class="o_grid_item g-height-12 g-col-lg-7 col-lg-7" style="grid-area: 1 / 1 / 13 / 8; --grid-item-padding-x: 24px;">
                     <span class="s_cta_badge d-inline-block my-3 border rounded py-2 px-3 o_cc o_cc1 o_animable" data-snippet="s_cta_badge" data-name="CTA Badge" style="border-radius: 32px !important;">
-                        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;What do you want to promote&amp;nbsp;? &#160;&#160;&#160;&#160;<a href="#">See more <i class="fa fa-long-arrow-right" role="img"/></a>
+                        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;What do you want to promote&amp;nbsp;? &#160;&#160;&#160;&#160;<button class="btn btn-link p-0">See more <i class="fa fa-long-arrow-right" role="img"/></button>
                     </span>
                     <h1 class="display-4">Empowering Your Success<br/>with Every Solution.</h1>
                     <p class="lead"><br/>Delivering tailored, innovative tools to help you overcome challenges and<br/> achieve your goals, ensuring your journey is fully supported.<br/><br/></p>

--- a/addons/website/views/snippets/s_media_list.xml
+++ b/addons/website/views/snippets/s_media_list.xml
@@ -13,7 +13,7 @@
                         <div class="col-lg-8 s_media_list_body">
                             <h3>Media heading</h3>
                             <p>Use this snippet to build various types of components that feature a left- or right-aligned image alongside textual content. Duplicate the element to create a list that fits your needs.</p>
-                            <a href="#">Discover more <i class="fa fa-long-arrow-right align-middle ms-1"/></a>
+                            <button class="btn btn-link p-0">Discover more <i class="fa fa-long-arrow-right align-middle ms-1"/></button>
                         </div>
                     </div>
                 </div>
@@ -36,7 +36,7 @@
                         <div class="col-lg-8 s_media_list_body">
                             <h3>Post heading</h3>
                             <p>Use this component for creating a list of featured elements to which you want to bring attention.</p>
-                            <a href="#">Continue reading <i class="fa fa-long-arrow-right align-middle ms-1"/></a>
+                            <button class="btn btn-link p-0">Continue reading <i class="fa fa-long-arrow-right align-middle ms-1"/></button>
                         </div>
                     </div>
                 </div>

--- a/addons/website/views/snippets/s_mega_menu_big_icons_subtitles.xml
+++ b/addons/website/views/snippets/s_mega_menu_big_icons_subtitles.xml
@@ -69,7 +69,7 @@
 </template>
 
 <template id="s_mega_menu_big_icons_subtitles_item">
-    <a href="#" class="nav-link px-2 my-2 rounded text-wrap" data-name="Menu Item">
+    <button class="nav-link px-2 my-2 rounded text-wrap text-start" data-name="Menu Item">
         <div class="d-flex align-items-center">
             <i t-attf-class="fa rounded rounded-circle me-3 #{_icon_classes}"/>
             <div class="flex-grow-1">
@@ -77,7 +77,7 @@
                 <span class="small"><t t-esc="_text"/></span>
             </div>
         </div>
-    </a>
+    </button>
 </template>
 
 <record id="website.s_mega_menu_big_icons_subtitles_000_scss" model="ir.asset">

--- a/addons/website/views/snippets/s_mega_menu_cards.xml
+++ b/addons/website/views/snippets/s_mega_menu_cards.xml
@@ -55,11 +55,11 @@
 
 <template id="s_mega_menu_cards_item">
     <div class="col-12 col-lg-3" data-name="Menu Item">
-        <a href="#" class="nav-link rounded text-wrap text-center p-3">
+        <button class="nav-link rounded text-wrap text-center p-3 btn-link">
             <img t-att-src="_img_src" class="mb-3 rounded shadow img-fluid" alt=""/>
             <h4 t-esc="_title"/>
             <span class="mb-0 small"><t t-esc="_text"/></span>
-        </a>
+        </button>
     </div>
 </template>
 

--- a/addons/website/views/snippets/s_mega_menu_images_subtitles.xml
+++ b/addons/website/views/snippets/s_mega_menu_images_subtitles.xml
@@ -49,7 +49,7 @@
                     <p class="text-muted small">
                         Created in 2021, the company is young and dynamic. Discover the composition of the team and their skills.
                     </p>
-                    <a href="#" class="btn btn-primary">Discover our team</a>
+                    <button class="btn btn-primary">Discover our team</button>
                 </div>
             </div>
         </div>
@@ -57,7 +57,7 @@
 </template>
 
 <template id="s_mega_menu_images_subtitles_item">
-    <a href="#" class="nav-link px-2 rounded text-wrap" data-name="Menu Item">
+    <button class="nav-link px-2 rounded text-wrap text-start" data-name="Menu Item">
         <div class="d-flex">
             <img t-att-src="_img_src" class="me-3 rounded shadow" alt=""/>
             <div class="flex-grow-1">
@@ -65,7 +65,7 @@
                 <span class="small"><t t-esc="_text"/></span>
             </div>
         </div>
-    </a>
+    </button>
 </template>
 
 <record id="website.s_mega_menu_images_subtitles_000_scss" model="ir.asset">

--- a/addons/website/views/snippets/s_mega_menu_little_icons.xml
+++ b/addons/website/views/snippets/s_mega_menu_little_icons.xml
@@ -7,50 +7,50 @@
             <div class="row">
                 <div class="col-12 col-lg-3 py-2 d-flex align-items-center">
                     <nav class="nav flex-column">
-                        <a href="#" class="nav-link px-2 rounded text-wrap" data-name="Menu Item">
+                        <button class="nav-link px-2 rounded text-wrap text-start" data-name="Menu Item">
                             <i class="s_mega_menu_little_icons_icon fa fa-eye fa-fw me-2"></i>
                             <b>About us</b>
-                        </a>
-                        <a href="#" class="nav-link px-2 text-wrap" data-name="Menu Item">
+                        </button>
+                        <button class="nav-link px-2 text-wrap text-start" data-name="Menu Item">
                             <i class="s_mega_menu_little_icons_icon fa fa-group fa-fw me-2"></i>
                             <b>Partners</b>
-                        </a>
-                        <a href="#" class="nav-link px-2 text-wrap" data-name="Menu Item">
+                        </button>
+                        <button class="nav-link px-2 text-wrap text-start" data-name="Menu Item">
                             <i class="s_mega_menu_little_icons_icon fa fa-star-o fa-fw me-2"></i>
                             <b>Customers</b>
-                        </a>
+                        </button>
                     </nav>
                 </div>
                 <div class="col-12 col-lg-3 py-2 d-flex align-items-center">
                     <nav class="nav flex-column">
-                        <a href="#" class="nav-link px-2 rounded text-wrap" data-name="Menu Item">
+                        <button class="nav-link px-2 rounded text-wrap text-start" data-name="Menu Item">
                             <i class="s_mega_menu_little_icons_icon fa fa-tags fa-fw me-2"></i>
                             <b>Products</b>
-                        </a>
-                        <a href="#" class="nav-link px-2 rounded text-wrap" data-name="Menu Item">
+                        </button>
+                        <button class="nav-link px-2 rounded text-wrap text-start" data-name="Menu Item">
                             <i class="s_mega_menu_little_icons_icon fa fa-handshake-o fa-fw me-2"></i>
                             <b>Services</b>
-                        </a>
-                        <a href="#" class="nav-link px-2 rounded text-wrap" data-name="Menu Item">
+                        </button>
+                        <button class="nav-link px-2 rounded text-wrap text-start" data-name="Menu Item">
                             <i class="s_mega_menu_little_icons_icon fa fa-headphones fa-fw me-2"></i>
                             <b>Help center</b>
-                        </a>
+                        </button>
                     </nav>
                 </div>
                 <div class="col-12 col-lg-3 py-2 d-flex align-items-center">
                     <nav class="nav flex-column">
-                        <a href="#" class="nav-link px-2 rounded text-wrap" data-name="Menu Item">
+                        <button class="nav-link px-2 rounded text-wrap text-start" data-name="Menu Item">
                             <i class="s_mega_menu_little_icons_icon fa fa-newspaper-o fa-fw me-2"></i>
                             <b>Our blog</b>
-                        </a>
-                        <a href="#" class="nav-link px-2 rounded text-wrap" data-name="Menu Item">
+                        </button>
+                        <button class="nav-link px-2 rounded text-wrap text-start" data-name="Menu Item">
                             <i class="s_mega_menu_little_icons_icon fa fa-calendar fa-fw me-2"></i>
                             <b>Events</b>
-                        </a>
-                        <a href="#" class="nav-link px-2 rounded text-wrap" data-name="Menu Item">
+                        </button>
+                        <button class="nav-link px-2 rounded text-wrap text-start" data-name="Menu Item">
                             <i class="s_mega_menu_little_icons_icon fa fa-map-o fa-fw me-2"></i>
                             <b>Guides</b>
-                        </a>
+                        </button>
                     </nav>
                 </div>
                 <div class="col-lg-3 p-4">
@@ -58,7 +58,7 @@
                     <p class="text-muted small">
                         Created in 2021, the company is young and dynamic. Discover the composition of the team and their skills.
                     </p>
-                    <a href="#" class="btn btn-primary">Discover our team</a>
+                    <button class="btn btn-primary">Discover our team</button>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_mega_menu_menu_image_menu.xml
+++ b/addons/website/views/snippets/s_mega_menu_menu_image_menu.xml
@@ -11,7 +11,7 @@
                         <t t-foreach="3" t-as="i">
                             <t t-set="text">Menu Item %s</t>
                             <t t-set="text" t-value="text % (i + 1)"/>
-                            <a href="#" class="nav-link" data-name="Menu Item"
+                            <button class="nav-link" data-name="Menu Item"
                                 t-esc="text"/>
                         </t>
                     </nav>
@@ -25,7 +25,7 @@
                         <t t-foreach="3" t-as="i">
                             <t t-set="text">Menu Item %s</t>
                             <t t-set="text" t-value="text % (i + 1)"/>
-                            <a href="#" class="nav-link" data-name="Menu Item"
+                            <button class="nav-link" data-name="Menu Item"
                                 t-esc="text"/>
                         </t>
                     </nav>

--- a/addons/website/views/snippets/s_mega_menu_menus_logos.xml
+++ b/addons/website/views/snippets/s_mega_menu_menus_logos.xml
@@ -10,59 +10,60 @@
                         <div class="col-12 col-lg-4 py-2">
                             <h4>Women</h4>
                             <nav class="nav flex-column">
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Jacket</a>
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Dresses</a>
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Tops</a>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Jacket</button>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Dresses</button>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Tops</button>
                             </nav>
                         </div>
                         <div class="col-12 col-lg-4 py-2">
                             <h4>Men</h4>
                             <nav class="nav flex-column">
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Hoodies</a>
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Blazers</a>
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Jeans</a>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Hoodies</button>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Blazers</button>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Jeans</button>
                             </nav>
                         </div>
                         <div class="col-12 col-lg-4 py-2">
                             <h4>Children</h4>
                             <nav class="nav flex-column">
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">T-shirts</a>
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Pants</a>
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Shoes</a>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">T-shirts</button>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Pants</button>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Shoes</button>
                             </nav>
                         </div>
                         <div class="w-100 d-none d-lg-block"></div>
                         <div class="col-12 col-lg-4 py-2">
                             <h4>New collection</h4>
                             <nav class="nav flex-column">
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Women</a>
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Men</a>
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Children</a>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Women</button>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Men</button>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Children</button>
                             </nav>
                         </div>
                         <div class="col-12 col-lg-4 py-2">
                             <h4>Accessories</h4>
                             <nav class="nav flex-column">
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Bags</a>
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Watches</a>
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Glasses</a>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Bags</button>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Watches</button>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Glasses</button>
                             </nav>
                         </div>
                         <div class="col-12 col-lg-4 py-2">
                             <h4>Promotions</h4>
                             <nav class="nav flex-column">
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Women</a>
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Men</a>
-                                <a href="#" class="nav-link px-0" data-name="Menu Item">Children</a>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Women</button>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Men</button>
+                                <button class="nav-link px-0 text-start" data-name="Menu Item">Children</button>
                             </nav>
                         </div>
                     </div>
                 </div>
                 <div class="col-12 col-lg-4 py-4 d-flex align-items-center justify-content-center">
-                    <a href="#" class="nav-link text-center px-0" data-name="Menu Item">
+                    <button class="nav-link text-center px-0 btn-link" data-name="Menu Item">
+                        <!-- TODO: text color -->
                         <img src="/web/image/website.s_mega_menu_menus_logos_default_image" class="mb-3 rounded shadow img-fluid" alt=""/>
                         <h4>Spring collection has arrived!</h4>
-                    </a>
+                    </button>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_mega_menu_multi_menus.xml
+++ b/addons/website/views/snippets/s_mega_menu_multi_menus.xml
@@ -16,7 +16,7 @@
                             <t t-foreach="3" t-as="i">
                                 <t t-set="text">Menu Item %s</t>
                                 <t t-set="text" t-value="text % (i + 1)"/>
-                                <a href="#" class="nav-link" data-name="Menu Item"
+                                <button class="nav-link" data-name="Menu Item"
                                    t-esc="text"/>
                             </t>
                         </nav>

--- a/addons/website/views/snippets/s_mega_menu_odoo_menu.xml
+++ b/addons/website/views/snippets/s_mega_menu_odoo_menu.xml
@@ -11,12 +11,12 @@
                         <hr class="w-100 mx-auto" style="border-top-width: 2px; border-top-color: var(--primary);"/>
                     </div>
                     <nav class="nav flex-column">
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">Laptops</a>
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">Desktop computers</a>
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">Components</a>
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">Tablets</a>
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">Smartphones</a>
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">iPhone</a>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">Laptops</button>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">Desktop computers</button>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">Components</button>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">Tablets</button>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">Smartphones</button>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">iPhone</button>
                     </nav>
                 </div>
                 <div class="col-12 col-lg-3 pt16 pb24">
@@ -25,9 +25,9 @@
                         <hr class="w-100 mx-auto" style="border-top-width: 2px; border-top-color: var(--secondary);"/>
                     </div>
                     <nav class="nav flex-column">
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">Televisions</a>
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">Office screens</a>
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">Projectors</a>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">Televisions</button>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">Office screens</button>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">Projectors</button>
                     </nav>
                 </div>
                 <div class="col-12 col-lg-3 pt16 pb24">
@@ -36,11 +36,11 @@
                         <hr class="w-100 mx-auto" style="border-top-width: 2px; border-top-color: var(--primary);"/>
                     </div>
                     <nav class="nav flex-column">
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">Camera</a>
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">GPS &amp; navigation</a>
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">Accessories</a>
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">Home audio</a>
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">Office audio</a>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">Camera</button>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">GPS &amp; navigation</button>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">Accessories</button>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">Home audio</button>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">Office audio</button>
                     </nav>
                 </div>
                 <div class="col-12 col-lg-3 pt16 pb24">
@@ -49,10 +49,10 @@
                         <hr class="w-100 mx-auto" style="border-top-width: 2px; border-top-color: var(--secondary);"/>
                     </div>
                     <nav class="nav flex-column">
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">Computers</a>
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">Electronics</a>
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">Monitors</a>
-                        <a href="#" class="nav-link px-0" data-name="Menu Item">Networks</a>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">Computers</button>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">Electronics</button>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">Monitors</button>
+                        <button class="nav-link px-0 text-start" data-name="Menu Item">Networks</button>
                     </nav>
                 </div>
             </div>

--- a/addons/website/views/snippets/s_mega_menu_thumbnails.xml
+++ b/addons/website/views/snippets/s_mega_menu_thumbnails.xml
@@ -55,12 +55,13 @@
                     </div>
                 </div>
                 <div class="col-12 col-lg-3 text-center py-2">
-                    <a href="#" class="nav-link p-0" data-name="Menu Item">
+                    <button class="nav-link p-0 btn-link" data-name="Menu Item">
+                        <!-- TODO : text color -->
                         <img class="img-fluid rounded shadow" src="/web/image/website.s_mega_menu_thumbnails_default_image_11" alt=""/>
                         <span class="d-block p-2 small">
                             <b>Discover our new products</b>
                         </span>
-                    </a>
+                    </button>
                 </div>
             </div>
         </div>
@@ -82,9 +83,9 @@
                     </p>
                 </div>
                 <div class="col-12 col-lg-3 py-2">
-                    <a href="#" class="btn btn-secondary d-block">
+                    <button class="btn btn-secondary d-block w-100">
                         <i class="s_mega_menu_thumbnails_icon fa fa-comments me-2"></i> Contact us
-                    </a>
+                    </button>
                 </div>
             </div>
         </div>
@@ -93,7 +94,7 @@
 
 <template id="s_mega_menu_thumbnails_item">
     <div class="col-6 col-lg-2 text-center py-2">
-        <a href="#" class="nav-link p-0" data-name="Menu Item">
+        <button class="nav-link p-0 btn-link" data-name="Menu Item">
             <img class="img-fluid rounded shadow" t-att-src="_img_src" alt=""/>
             <br/>
             <span class="d-block p-2 small">
@@ -101,7 +102,7 @@
                     <t t-esc="_text"/>
                 </b>
             </span>
-        </a>
+        </button>
     </div>
 </template>
 

--- a/addons/website/views/snippets/s_popup.xml
+++ b/addons/website/views/snippets/s_popup.xml
@@ -17,7 +17,7 @@
                                 <div class="col-lg-10 offset-lg-1 text-center o_cc o_cc1 jumbotron pt48 pb48">
                                     <h2 class="display-3-fs">Win $20</h2>
                                     <p class="lead">Check out now and get $20 off your first order.</p>
-                                    <a href="#" class="btn btn-primary">New customer</a>
+                                    <button class="btn btn-primary">New customer</button>
                                 </div>
                             </div>
                         </div>

--- a/addons/website/views/snippets/s_references_grid.xml
+++ b/addons/website/views/snippets/s_references_grid.xml
@@ -8,7 +8,7 @@
                 <div class="o_grid_item g-height-4 g-col-lg-5 col-lg-5" style="grid-area: 1 / 1 / 5 / 6; z-index: 1;">
                     <h2>Trusted references</h2>
                     <p class="lead">We are in good company.</p>
-                    <a href="#" class="btn btn-primary">See our case studies</a>
+                    <button class="btn btn-primary">See our case studies</button>
                 </div>
                 <div class="o_grid_item o_grid_item_image g-col-lg-2 g-height-2 col-6 col-lg-2" style="grid-area: 1 / 7 / 3 / 9; z-index: 2;">
                     <img src="/web/image/website.s_reference_demo_image_1" class="img img-fluid" alt=""/>

--- a/addons/website/views/snippets/s_showcase.xml
+++ b/addons/website/views/snippets/s_showcase.xml
@@ -37,7 +37,7 @@
                             <div class="s_hr pt0 pb16" data-snippet="s_hr">
                                 <hr class="w-100 mx-auto"/>
                             </div>
-                            <a href="#">Discover all the features</a>
+                            <button class="btn btn-link p-0">Discover all the features</button>
                         </div>
                     </div>
                 </div>

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -83,7 +83,7 @@
                     <div class="mb-0 py-2 col-12 s_website_form_submit text-end s_website_form_no_submit_label" data-name="Submit Button">
                         <div style="width: 200px;" class="s_website_form_label"/>
                         <span id="s_website_form_result"/>
-                        <a href="#" role="button" class="btn btn-primary s_website_form_send">Submit</a>
+                        <button role="button" class="btn btn-primary s_website_form_send">Submit</button>
                     </div>
                 </div>
             </form>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -15,9 +15,8 @@
         </a>
     </li>
     <li t-elif="show_dropdown" t-attf-class="#{item_class or ''} #{submenu.is_mega_menu and 'position-static'} #{offcanvas_is_leftside and 'o_mega_menu_left'} #{is_accordion_nav and 'accordion accordion-flush' or 'dropdown'}" role="presentation">
-        <a
+        <button
             t-if="not is_accordion_nav"
-            href="#"
             t-attf-class="dropdown-toggle #{link_class or ''} #{submenu.is_mega_menu and 'o_mega_menu_toggle'} #{submenu._is_active() and 'active'} #{dropdown_toggler_classes}"
             data-bs-toggle="dropdown"
             t-att-data-bs-display="'static' if submenu.is_mega_menu else None"
@@ -25,7 +24,7 @@
             role="menuitem"
         >
             <span t-field="submenu.name"/>
-        </a>
+        </button>
         <!-- Avoid rendering the mega menu element twice (Desktop + Mobile) -->
         <div
             t-if="submenu.is_mega_menu and not is_mobile"
@@ -43,8 +42,7 @@
         </div>
         <!-- Is a dropdown in desktop -> becomes accordion in Mobile / Sidebar / Hamburger -->
         <div t-elif="is_accordion_nav" class="accordion-item">
-            <a
-                href="#"
+            <button
                 t-attf-class="#{link_class or ''} accordion-button collapsed"
                 data-bs-toggle="collapse"
                 t-attf-data-bs-target=".o_accordion_target_#{submenu.id}"
@@ -52,7 +50,7 @@
                 t-attf-aria-controls="o_accordion_target_#{submenu.id}"
             >
                 <span t-field="submenu.name"/>
-            </a>
+            </button>
             <div
                 t-attf-class="o_accordion_target_#{submenu.id} accordion-collapse collapse"
                 t-attf-aria-labelledby="o_accordion_target_#{submenu.id}"
@@ -1739,10 +1737,10 @@
                             <h5 class="mb-3">Useful Links</h5>
                             <ul class="list-unstyled">
                                 <li><a href="/">Home</a></li>
-                                <li><a href="#">About us</a></li>
-                                <li><a href="#">Products</a></li>
-                                <li><a href="#">Services</a></li>
-                                <li><a href="#">Legal</a></li>
+                                <li><button class="btn btn-link p-0">About us</button></li>
+                                <li><button class="btn btn-link p-0">Products</button></li>
+                                <li><button class="btn btn-link p-0">Services</button></li>
+                                <li><button class="btn btn-link p-0">Legal</button></li>
                                 <t t-set="configurator_footer_links" t-value="[]"/>
                                 <li t-foreach="configurator_footer_links" t-as="link">
                                     <a t-att-href="link['href']" t-esc="link['text']"/>
@@ -1873,9 +1871,9 @@
                             <h5>Explore</h5>
                             <ul class="list-unstyled">
                                 <li class="list-item py-1"><a href="/">Home</a></li>
-                                <li class="list-item py-1"><a href="#">Our Company</a></li>
-                                <li class="list-item py-1"><a href="#">Case Studies</a></li>
-                                <li class="list-item py-1"><a href="#">Blog</a></li>
+                                <li class="list-item py-1"><button class="btn btn-link p-0">Our Company</button></li>
+                                <li class="list-item py-1"><button class="btn btn-link p-0">Case Studies</button></li>
+                                <li class="list-item py-1"><button class="btn btn-link p-0">Blog</button></li>
                                 <t t-set="configurator_footer_links" t-value="[]"/>
                                 <li t-foreach="configurator_footer_links" t-as="link" class="list-item py-1">
                                     <a t-att-href="link['href']" t-esc="link['text']"/>
@@ -1885,10 +1883,10 @@
                         <div class="col-lg-2 pb16">
                             <h5>Services</h5>
                             <ul class="list-unstyled">
-                                <li class="py-1"><a href="#">Documentation</a></li>
-                                <li class="py-1"><a href="#">Marketplace</a></li>
-                                <li class="py-1"><a href="#">Design</a></li>
-                                <li class="py-1"><a href="#">Resources</a></li>
+                                <li class="py-1"><button class="btn btn-link p-0">Documentation</button></li>
+                                <li class="py-1"><button class="btn btn-link p-0">Marketplace</button></li>
+                                <li class="py-1"><button class="btn btn-link p-0">Design</button></li>
+                                <li class="py-1"><button class="btn btn-link p-0">Resources</button></li>
                             </ul>
                         </div>
                         <div class="col-lg-2 pb16">
@@ -1932,9 +1930,9 @@
                         <div class="col-lg-5 d-flex align-items-center justify-content-center justify-content-lg-start pt16 pb16">
                             <ul class="list-inline mb-0 ms-3">
                                 <li class="list-inline-item"><a href="/">Home</a></li>
-                                <li class="list-inline-item"><a href="#">About us</a></li>
-                                <li class="list-inline-item"><a href="#">Products</a></li>
-                                <li class="list-inline-item"><a href="#">Services</a></li>
+                                <li class="list-inline-item"><button class="btn btn-link p-0">About us</button></li>
+                                <li class="list-inline-item"><button class="btn btn-link p-0">Products</button></li>
+                                <li class="list-inline-item"><button class="btn btn-link p-0">Services</button></li>
                                 <t t-set="configurator_footer_links" t-value="[]"/>
                                 <li t-foreach="configurator_footer_links" t-as="link" class="list-inline-item">
                                     <a t-att-href="link['href']" t-esc="link['text']"/>
@@ -2029,15 +2027,15 @@
                                 </li>
                                 <li class="list-inline-item">•</li>
                                 <li class="list-inline-item">
-                                    <a href="#">About us</a>
+                                    <button class="btn btn-link p-0">About us</button>
                                 </li>
                                 <li class="list-inline-item">•</li>
                                 <li class="list-inline-item">
-                                    <a href="#">Products</a>
+                                    <button class="btn btn-link p-0">Products</button>
                                 </li>
                                 <li class="list-inline-item">•</li>
                                 <li class="list-inline-item">
-                                    <a href="#">Terms of Services</a>
+                                    <button class="btn btn-link p-0">Terms of Services</button>
                                 </li>
                                 <t t-set="configurator_footer_links" t-value="[]"/>
                                 <t t-foreach="configurator_footer_links" t-as="link" class="list-inline-item">
@@ -2211,10 +2209,10 @@
                                         </p>
                                     </div>
                                     <div class="col-lg-4 text-end pt16 pb16">
-                                        <a href="#" id="cookies-consent-essential" role="button"
-                                           class="js_close_popup btn btn-outline-primary rounded-circle btn-sm px-2">Only essentials</a>
-                                        <a href="#" id="cookies-consent-all" role="button"
-                                           class="js_close_popup btn btn-outline-primary rounded-circle btn-sm">I agree</a>
+                                        <button id="cookies-consent-essential" role="button"
+                                           class="js_close_popup btn btn-outline-primary rounded-circle btn-sm px-2">Only essentials</button>
+                                        <button id="cookies-consent-all" role="button"
+                                           class="js_close_popup btn btn-outline-primary rounded-circle btn-sm">I agree</button>
                                     </div>
                                 </div>
                             </div>
@@ -3038,9 +3036,9 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
                         </div>
                     </div>
                 </div>
-                <a t-attf-class="btn rounded-circle p-1 lh-1 #{_button_classes or 'bg-o-color-3'} o_not_editable" data-bs-target="#o_search_modal" data-bs-toggle="modal" role="button" title="Search" href="#">
+                <button t-attf-class="btn rounded-circle p-1 lh-1 #{_button_classes or 'bg-o-color-3'} o_not_editable" data-bs-target="#o_search_modal" data-bs-toggle="modal" role="button" title="Search">
                     <i class="oi oi-search fa-stack lh-lg"/>
-                </a>
+                </button>
             </t>
             <t t-else="">
                 <t t-call="website.header_search_box_input"/>

--- a/addons/website_blog/static/src/tours/website_blog.js
+++ b/addons/website_blog/static/src/tours/website_blog.js
@@ -75,7 +75,7 @@ registerWebsitePreviewTour("blog", {
 },
 ...clickOnSave(),
 {
-    trigger: ".o_menu_systray_item.o_mobile_preview > a",
+    trigger: ".o_menu_systray_item.o_mobile_preview > button",
     content: markup(_t("Use this icon to preview your blog post on <b>mobile devices</b>.")),
     tooltipPosition: "bottom",
     run: "click",
@@ -84,7 +84,7 @@ registerWebsitePreviewTour("blog", {
     trigger: ".o_website_preview.o_is_mobile",
 },
 {
-    trigger: ".o_menu_systray_item.o_mobile_preview > a",
+    trigger: ".o_menu_systray_item.o_mobile_preview > button",
     content: _t("Once you have reviewed the content on mobile, you can switch back to the normal view by clicking here again"),
     tooltipPosition: "right",
     run: "click",
@@ -93,11 +93,11 @@ registerWebsitePreviewTour("blog", {
     trigger: ":iframe body:not(.editor_enable)",
 },
 {
-    trigger: '.o_menu_systray_item a:contains("Unpublished")',
+    trigger: '.o_menu_systray_item button:contains("Unpublished")',
     tooltipPosition: "bottom",
     content: markup(_t("<b>Publish your blog post</b> to make it visible to your visitors.")),
     run: "click",
 }, {
-    trigger: '.o_menu_systray_item a:contains("Published")',
+    trigger: '.o_menu_systray_item button:contains("Published")',
 }
 ]);

--- a/addons/website_event/static/src/js/tours/event_tour.js
+++ b/addons/website_event/static/src/js/tours/event_tour.js
@@ -15,7 +15,7 @@ patch(EventAdditionalTourSteps.prototype, {
                 tooltipPosition: 'bottom',
                 run: "click",
             }, {
-                trigger: '.o_edit_website_container a',
+                trigger: '.o_edit_website_container button',
                 content: markup(_t("With the Edit button, you can <b>customize</b> the web page visitors will see when registering.")),
                 tooltipPosition: 'bottom',
                 run: "click",
@@ -35,7 +35,7 @@ patch(EventAdditionalTourSteps.prototype, {
                 trigger: ":iframe body:not(.editor_enable) .o_wevent_event",
             },
             {
-                trigger: '.o_menu_systray_item.o_website_publish_container a',
+                trigger: '.o_menu_systray_item.o_website_publish_container button',
                 content: markup(_t("Looking great! Let's now <b>publish</b> this page so that it becomes <b>visible</b> on your website!")),
                 tooltipPosition: 'bottom',
                 run: "click",

--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -9,11 +9,11 @@ function websiteCreateEventTourSteps() {
     return [
         {
             content: "Click here to add new content to your website.",
-            trigger: ".o_menu_systray .o_new_content_container > a",
+            trigger: ".o_menu_systray .o_new_content_container > button",
             tooltipPosition: "bottom",
             run: "click",
         }, {
-            trigger: "a[data-module-xml-id='base.module_website_event']",
+            trigger: "button[data-module-xml-id='base.module_website_event']",
             content: "Click here to create a new event.",
             tooltipPosition: "bottom",
             run: "click",
@@ -68,7 +68,7 @@ function websiteCreateEventTourSteps() {
             trigger: ":iframe body:not(.editor_enable)",
         },
         {
-            trigger: ".o_menu_systray_item.o_website_publish_container a",
+            trigger: ".o_menu_systray_item.o_website_publish_container button",
             content: "Click to publish your event.",
             tooltipPosition: "top",
             run: "click",

--- a/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
@@ -21,7 +21,7 @@ registry.category("web_tour.tours").add("website_livechat_logout_after_chat_star
             run: "click",
         },
         {
-            trigger: "header#top a:contains(Mitchell Admin)",
+            trigger: "header#top span:contains(Mitchell Admin)",
             run: "click",
         },
         {

--- a/addons/website_sale/static/src/js/tours/website_sale_shop.js
+++ b/addons/website_sale/static/src/js/tours/website_sale_shop.js
@@ -15,12 +15,12 @@ registerWebsitePreviewTour("test_01_admin_shop_tour", {
     trigger: ":iframe .js_sale",
 },
 {
-    trigger: ".o_menu_systray .o_new_content_container > a",
+    trigger: ".o_menu_systray .o_new_content_container > button",
     content: _t("Let's create your first product."),
     tooltipPosition: "bottom",
     run: "click",
 }, {
-    trigger: "a[data-module-xml-id='base.module_website_sale']",
+    trigger: "button[data-module-xml-id='base.module_website_sale']",
     content: markup(_t("Select <b>New Product</b> to create it and manage its properties to boost your sales.")),
     tooltipPosition: "bottom",
     run: "click",
@@ -82,7 +82,7 @@ goBackToBlocks(),
     trigger: ":iframe body:not(.editor_enable)",
 },
 {
-    trigger: ".o_menu_systray_item.o_website_publish_container a",
+    trigger: ".o_menu_systray_item.o_website_publish_container button",
     content: _t("Click on this button so your customers can see it."),
     tooltipPosition: "bottom",
     run: "click",

--- a/addons/website_sale/static/tests/tours/website_sale_restricted_editor_ui.js
+++ b/addons/website_sale/static/tests/tours/website_sale_restricted_editor_ui.js
@@ -33,7 +33,7 @@ registerWebsitePreviewTour('website_sale_restricted_editor_ui', {
     },
     {
         content: "Click on publish/unpublish",
-        trigger: '.o_website_publish_container a:has(input:checked)',
+        trigger: '.o_website_publish_container button:has(input:checked)',
         run: "click",
     },
     {
@@ -42,7 +42,7 @@ registerWebsitePreviewTour('website_sale_restricted_editor_ui', {
     },
     {
         content: "Click on edit-in-backend",
-        trigger: '.o_menu_systray .o_website_edit_in_backend a',
+        trigger: '.o_menu_systray .o_website_edit_in_backend button',
         run: "click",
     },
     {

--- a/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
+++ b/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
@@ -13,11 +13,11 @@ registerWebsitePreviewTour('course_publisher_standard', {
     url: '/slides',
 }, () => [{
     content: 'eLearning: click on New (top-menu)',
-    trigger: 'div.o_new_content_container a',
+    trigger: 'div.o_new_content_container button',
     run: "click",
 }, {
     content: 'eLearning: click on New Course',
-    trigger: '#o_new_content_menu_choices a:contains("Course")',
+    trigger: '#o_new_content_menu_choices button:contains("Course")',
     run: "click",
 }, {
     content: 'eLearning: set name',


### PR DESCRIPTION
We use `href="#"` to activate `<a>` elements, but the default behavior of clicking
this link is prevented. However, this creates an inconsistency for middle-click
and Ctrl+Click, as these events are not prevented by default.

This commit removes `href="#"` and replaces it with the appropriate element or
class to activate the `<a>` elements correctly.

Task-4380519

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
