### PR TITLE
[IMP] *: remove href="#"

### DIFF
--- a/addons/event/static/src/client_action/event_barcode.xml
+++ b/addons/event/static/src/client_action/event_barcode.xml
@@ -6,7 +6,7 @@
         <div class="o_event_barcode_bg o_home_menu_background">
             <div class="o_event_barcode_main container d-flex flex-column h-100 h-sm-auto bg-view shadow">
                 <div class="d-flex align-items-center justify-content-between my-3">
-                    <a t-if="!isDisplayStandalone" href="#" class="o_event_previous_menu float-start"><i class="oi oi-chevron-left fa-lg" t-on-click.prevent="() => this.onClickBackToEvents()"></i></a>
+                    <button t-if="!isDisplayStandalone" href="#" class="o_event_previous_menu float-start btn btn-link"><i class="oi oi-chevron-left fa-lg" t-on-click.prevent="() => this.onClickBackToEvents()"></i></button>
                     <span class="fs-2 me-auto ms-2" t-out="data.name"/>
                     <a t-if="!isDisplayStandalone" class="btn btn-secondary d-flex align-items-center justify-content-center fw-bolder" href="/scoped_app?app_id=event&amp;path=scoped_app/registration-desk" target="_blank">Install</a>
                 </div>

--- a/addons/event_booth/data/mail_templates.xml
+++ b/addons/event_booth/data/mail_templates.xml
@@ -7,13 +7,13 @@
         <p>
             <span>
                 Booth
-                <a href="#" t-att-data-oe-model="booth._name" t-att-data-oe-id="booth.id" t-out="booth.name"/>
+                <a t-att-data-oe-model="booth._name" t-att-data-oe-id="booth.id" t-out="booth.name" class="cursor-pointer"/>
             </span>
             <span t-out="'booked by' if booth.partner_id else 'has been reserved by'"/>
             <span>
-                <a href="#" t-att-data-oe-model="booth.partner_id._name or booth.env.user.partner_id._name"
+                <a t-att-data-oe-model="booth.partner_id._name or booth.env.user.partner_id._name"
                    t-att-data-oe-id="booth.partner_id.id or booth.env.user.partner_id.id"
-                   t-out="booth.partner_id.name or booth.env.user.partner_id.name"/>
+                   t-out="booth.partner_id.name or booth.env.user.partner_id.name" class="cursor-pointer"/>
             </span>
         </p>
         <ul t-if="booth.partner_id" name="contact_details">

--- a/addons/event_sale/data/mail_templates.xml
+++ b/addons/event_sale/data/mail_templates.xml
@@ -5,14 +5,14 @@
     <div>
         <p>
             <span>Registration modification for attendee:</span>
-            <a href="#" data-oe-model="event.registration" t-att-data-oe-id="registration.id"><t t-out="registration.name"/></a>.
+            <a data-oe-model="event.registration" t-att-data-oe-id="registration.id" class="cursor-pointer"><t t-out="registration.name"/></a>.
             <span>Manual actions may be needed.</span>
         </p>
         <div class="mt16">
             <p>Exception:</p>
             <ul>
                 <li>
-                    <a href="#" data-oe-model="event.registration" t-att-data-oe-id="registration.id"><t t-out="registration.name"/></a>:
+                    <a href="#" data-oe-model="event.registration" t-att-data-oe-id="registration.id" class="cursor-pointer"><t t-out="registration.name"/></a>:
                     <span><t t-out="record_type"/> changed from <strong><t t-out="old_name"/></strong> to <strong><t t-out="new_name"/></strong></span>
                 </li>
             </ul>

--- a/addons/mail/data/mail_templates_chatter.xml
+++ b/addons/mail/data/mail_templates_chatter.xml
@@ -52,7 +52,7 @@
                 <t t-if="edit">This <t t-esc="self.env['ir.model']._get(self._name).name.lower()"/> has been modified from:</t>
                 <t t-else="">This <t t-esc="self.env['ir.model']._get(self._name).name.lower()"/> has been created from:</t>
                 <t t-foreach="origin" t-as="o">
-                    <a href="#" t-att-data-oe-model="o._name" t-att-data-oe-id="o.id"> <t t-esc="o.display_name"/></a><span t-if="origin.ids[-1:] != o.ids">, </span>
+                    <a t-att-data-oe-model="o._name" t-att-data-oe-id="o.id" class="cursor-pointer"> <t t-esc="o.display_name"/></a><span t-if="origin.ids[-1:] != o.ids">, </span>
                 </t>
             </p>
         </template>

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -947,11 +947,11 @@ class DiscussChannel(models.Model):
             notification_text = '''
                 <div data-oe-type="pin" class="o_mail_notification">
                     %(user_pinned_a_message_to_this_channel)s
-                    <a href="#" data-oe-type="pin-menu">%(see_all_pins)s</a>
+                    <span data-oe-type="pin-menu" class="btn btn-link smaller fw-normal p-0">%(see_all_pins)s</span>
                 </div>
             '''
             notification = Markup(notification_text) % {
-                'user_pinned_a_message_to_this_channel': Markup('<a href="#" data-oe-type="highlight" data-oe-id="%s">%s</a>') % (
+                'user_pinned_a_message_to_this_channel': Markup('<span data-oe-type="highlight" data-oe-id="%s" class="btn btn-link smaller fw-normal p-0">%s</span>') % (
                     message_id,
                     _('%(user_name)s pinned a message to this channel.', user_name=self.self_member_id._get_html_link_title()),
                 ),
@@ -1348,10 +1348,10 @@ class DiscussChannel(models.Model):
         ) % {
             "user": self.env.user.display_name,
             "goto": Markup(
-                "<a href='#' class='o_channel_redirect' data-oe-id='%s' data-oe-model='discuss.channel'>"
+                "<span class='o_channel_redirect btn btn-link smaller fw-normal p-0' data-oe-id='%s' data-oe-model='discuss.channel'>"
             )
             % sub_channel.id,
-            "goto_end": Markup("</a>"),
+            "goto_end": Markup("</span>"),
             "thread_name": sub_channel.name,
         }
         self.message_post(

--- a/addons/mail/static/src/core/common/thread.scss
+++ b/addons/mail/static/src/core/common/thread.scss
@@ -40,7 +40,7 @@
 }
 
 .o_mail_notification {
-    & a:hover {
+    & a:hover, span:hover {
         text-decoration: underline;
     }
     display: inline;

--- a/addons/mail/static/src/core/public_web/discuss.scss
+++ b/addons/mail/static/src/core/public_web/discuss.scss
@@ -74,7 +74,7 @@
         width: $o-mail-Avatar-size;
     }
 
-    a {
+    span {
         i {
             transform: translate(-50%, -50%);
             opacity: 0;

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -12,9 +12,9 @@
                         <img class="rounded-3 object-fit-cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
                         <FileUploader t-if="!thread.parent_channel_id and thread.is_editable and thread.channel_type !== 'chat'" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
                             <t t-set-slot="toggler">
-                                <a href="#" class="position-absolute z-1 h-100 w-100 rounded-3 start-0 bottom-0" title="Upload Avatar">
+                                <span class="position-absolute z-1 h-100 w-100 rounded start-0 bottom-0 btn" title="Upload Avatar">
                                     <i class="position-absolute top-50 start-50 fa fa-sm fa-pencil text-white"/>
-                                </a>
+                                </span>
                             </t>
                         </FileUploader>
                         <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" className="'o-mail-Discuss-headerImStatus position-absolute'" member="thread.correspondent"/>

--- a/addons/product/report/product_pricelist_report_templates.xml
+++ b/addons/product/report/product_pricelist_report_templates.xml
@@ -8,10 +8,10 @@
                 <div class="col-12">
                     <h2 t-if="is_html_type">
                         Pricelist <span t-if="display_pricelist_title">:</span>
-                        <a t-if="display_pricelist_title" href="#" class="o_action"
+                        <button t-if="display_pricelist_title" class="o_action btn btn-link fs-2 p-0"
                             data-model="product.pricelist" t-att-data-res-id="pricelist.id">
                             <span t-field="pricelist.display_name">Gold Member Pricelist</span>
-                        </a>
+                        </button>
                     </h2>
                     <h2 t-else="">
                         Pricelist <span t-if="display_pricelist_title">:</span>
@@ -37,9 +37,9 @@
                             <t t-foreach="products" t-as="product">
                                 <tr>
                                     <td t-att-class="is_product_tmpl and 'fw-bold px-1' or None">
-                                        <a t-if="is_html_type" href="#" class="o_action" t-att-data-model="is_product_tmpl and 'product.template' or 'product.product'" t-att-data-res-id="product['id']">
+                                        <button t-if="is_html_type" class="o_action btn btn-link p-0" t-att-data-model="is_product_tmpl and 'product.template' or 'product.product'" t-att-data-res-id="product['id']">
                                             <span t-out="product['name']">Virtual Interior Design</span>
-                                        </a>
+                                        </button>
                                         <span t-else="" t-out="product['name']">Acme Widget</span>
                                     </td>
                                     <td groups="uom.group_uom" class="px-1" t-out="product['uom']"/>
@@ -52,7 +52,7 @@
                                 <t t-if="is_product_tmpl and 'variants' in product">
                                     <tr t-foreach="product['variants']" t-as="variant">
                                         <td class="px-1">
-                                            <a t-if="is_html_type" href="#" class="o_action ms-4" data-model="product.product" t-att-data-res-id="variant['id']">
+                                            <a t-if="is_html_type" class="o_action ms-4 btn btn-link p-0 fw-normal" data-model="product.product" t-att-data-res-id="variant['id']">
                                                 <span t-out="variant['name']">Acme Widget - Blue</span>
                                             </a>
                                             <span t-else="" class="ms-4" t-out="variant['name']">Acme Widget - Blue</span>

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1683,3 +1683,35 @@ a.no-decoration {
 body.modal-open:has(.js_sale.o_wsale_product_page) {
     overflow: hidden;
 }
+
+.o_wsale_variant_pills_shop {
+    padding: $spacer/2 $spacer;
+    border: none;
+    cursor: pointer;
+
+    &.btn.active {
+        background-color: map-get($theme-colors, 'primary');
+    }
+    &:not(.active) {
+        color: map-get($grays, '600');
+        background-color: map-get($grays, '200');
+    }
+    &:hover{
+        background-color: map-get($theme-colors, 'primary');
+        color: white;
+    }
+
+    input {
+        -moz-appearance: none;
+        -webkit-appearance: none;
+        appearance: none;
+        opacity: 0;
+    }
+}
+.btn-small-text {
+    font-size: 0.875em;
+}
+
+.o_remove:hover {
+    color: var(--link-hover-color-rgb) !important;
+}

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2817,14 +2817,13 @@
                                     name="o_wsale_cart_line_button_container"
                                     t-attf-class="d-none d-md-flex align-items-center gap-2 mt-2 {{'justify-content-between' if is_combo else ''}}"
                                 >
-                                    <a
-                                        href='#'
-                                        class="js_delete_product small"
+                                    <button
+                                        class="js_delete_product text-primary btn btn-link btn-sm p-0 btn-small-text o_remove"
                                         aria-label="Remove from cart"
                                         title="Remove from cart"
                                     >
                                         Remove
-                                    </a>
+                                    </button>
                                     <div
                                         t-if="is_combo"
                                         class="d-none d-md-block ms-auto"

--- a/addons/website_sale_collect/views/delivery_form_templates.xml
+++ b/addons/website_sale_collect/views/delivery_form_templates.xml
@@ -24,10 +24,9 @@
                     <t t-out="order_line.product_id.name"/>
                     ( <t t-out="order_line.shop_warning"/> )
                     <div name="o_wsale_unavailable_line_button_container">
-                        <a
+                        <button
                             title="Remove from cart"
-                            href='#'
-                            class="js_wsc_delete_product d-none d-md-inline-block small"
+                            class="js_wsc_delete_product d-none d-md-inline-block small btn btn-link"
                             aria-label="Remove from cart"
                         >
                             <span
@@ -36,7 +35,7 @@
                             >
                                 Remove
                             </span>
-                        </a>
+                        </button>
                         <button
                             title="Remove from cart"
                             class="js_wsc_delete_product btn btn-light d-inline-block d-md-none"

--- a/addons/website_sale_collect_wishlist/views/delivery_form_templates.xml
+++ b/addons/website_sale_collect_wishlist/views/delivery_form_templates.xml
@@ -6,10 +6,9 @@
     >
         <div name="o_wsale_unavailable_line_button_container" position="inside">
             <span class="d-none d-md-inline-block ms-1">
-                <a
+                <button
                     title="Add to Wishlist"
-                    href="#"
-                    class="o_add_wishlist js_wsc_delete_product small px-2 border-start"
+                    class="o_add_wishlist js_wsc_delete_product px-2 btn btn-link btn-small-text p-0 border-start rounded-0"
                     t-att-data-product-template-id="order_line.product_id.product_tmpl_id.id"
                     t-att-data-product-product-id="order_line.product_id.id"
                     data-action="o_wishlist"
@@ -20,7 +19,7 @@
                     >
                         Save for Later
                     </span>
-                </a>
+                </button>
             </span>
             <button
                 title="Add to Wishlist"

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -27,18 +27,17 @@
     </template>
 
     <template id="product_cart_lines" inherit_id="website_sale.cart_lines" active="True">
-        <xpath expr="//div[@name='o_wsale_cart_line_button_container']/a" position="after">
+        <xpath expr="//div[@name='o_wsale_cart_line_button_container']/button" position="after">
             <t t-if="line._is_sellable()">
                 <span class="text-300">|</span>
-                <a
-                    href="#"
-                    class="o_add_wishlist js_delete_product small"
+                <button
+                    class="o_add_wishlist js_delete_product small text-primary btn btn-link btn-sm p-0 btn-small-text o_remove"
                     t-att-data-product-template-id="line.product_id.product_tmpl_id.id"
                     t-att-data-product-product-id="line.product_id.id"
                     data-action="o_wishlist"
                 >
                     Save for Later
-                </a>
+                </button>
             </t>
         </xpath>
 


### PR DESCRIPTION
*event,event_booth,event_sale,mail,product,website_sale,webiste_sale_collect,
webiste_sale_collect_wishlist,webiste_sale_wishlist

We use href="#" to activate elements, but the default behavior of clicking this
link is prevented. However, this creates an inconsistency for middle-click and
Ctrl+Click, as these events are not prevented by default.

This commit removes href="#" and replaces it with the appropriate element or
class to activate the elements correctly..

Enterprise PR - https://github.com/odoo/enterprise/pull/85341 
Task - 4380519

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
