### PR TITLE
[FIX] website_hr_recruitment: fix required field in job application form

### DIFF
--- a/addons/website_hr_recruitment/static/src/interactions/hr_recruitment_form.js
+++ b/addons/website_hr_recruitment/static/src/interactions/hr_recruitment_form.js
@@ -24,6 +24,7 @@ export class HrRecruitmentForm extends Interaction {
         this.linkedinInputEl = this.el.querySelector("#recruitment4");
         this.linkedinMessageEl = document.querySelector("#linkedin-message");
         this.warningMessageEl = document.querySelector("#warning-message");
+        this.resumeInputEl = document.querySelector("#recruitment6");
         this.isIncomplete = false;
     }
 


### PR DESCRIPTION
Steps to Reproduce:
- Install the website_hr_recruitment module.
- Go to the "Job Application Form".
- Unable to submit the form with either Linkedin or Resume.

Cause:
- The query selector for the Resume Input element is missing in setup().

Fix:
- Added missing query selector for Resume Input element in setup().

task-4558747

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
