### PR TITLE
[FIX] product: add 0-count attribute filtering

### DIFF
--- a/addons/product/static/src/product_catalog/search/search_panel.js
+++ b/addons/product/static/src/product_catalog/search/search_panel.js
@@ -32,7 +32,7 @@ export class ProductCatalogSearchPanel extends SearchPanel {
                 let currentAttr = sections.get(name);
                 currentAttr.get('ids').push(id);
                 currentAttr.set('count', currentAttr.get('count') + count);
-            } else {
+            } else if (count > 0) {
                 let newAttr = new Map();
                 newAttr.set('ids', [id]);
                 newAttr.set('count', count);


### PR DESCRIPTION
**Current behavior:**
In the product catalog, a search Panel is displayed. The user can check filters to find their products. When a category or another filter is checked, the attributes filters are not updated accordingly, even if they are no longer present in the products of the selected category.

**Expected behavior:**
The attributes that do not have a positive count should disappear from the Search Panel.

**Steps to reproduce:**
1. On a blank database, create two products: 
        1.1 Product A, with category CA and attributes A1 and A2.
        1.2 Product B, with category CB and attributes B1 and B2.
3. Go to Sales Order, create a new one and open the product catalog
4. The left search Panel should display the categories CA and CB, and the attributes A1, A2, B1, and B2.
5. Check the category CB.
6. Attributes A1 and A2 are still present.

**Cause of the issue:**
The search Panel JS script is modified by the `product` model, to add the Attributes section. However, the attributes are not filtered based on the selected category, and are always displayed.

**Fix:**
- Add a filtering condition in the `product` model to only display the attributes that have a positive `count`.

![all_category](https://github.com/user-attachments/assets/2121ecbb-9bed-4d3c-9f5f-c4cf309350ff)
![fix_difference](https://github.com/user-attachments/assets/612e0eeb-09c5-47eb-948f-8c8be204f862)

opw-4516166

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
