### PR TITLE
[FIX] web: Remove starts/ends_with from expression editor

### DIFF
--- a/addons/web/static/src/core/expression_editor/expression_editor_operator_editor.js
+++ b/addons/web/static/src/core/expression_editor/expression_editor_operator_editor.js
@@ -13,8 +13,6 @@ const EXPRESSION_VALID_OPERATORS = [
     "!=",
     "set",
     "not_set",
-    "starts_with",
-    "ends_with",
     "is",
     "is_not",
 ];


### PR DESCRIPTION
Example of steps:
    - Install `web_studio`
    - Open any view editor with `web_studio`
    - Try to edit a field required condition
    - Pick a char field
    - Add `starts_with` or `ends_with` operator
    - Traceback

The solution is to remove these two operators from expression_editor as
this is not a python expression, 

`starts_with` and `ends_with` are interpreted as `=ilike`, but there is
no way to translate it easily to a python expression like for `=`, `>=`, etc..

opw-4551688