### PR TITLE
[FIX] stock_account: Display of SN on invoice for everyone

### DIFF
--- a/addons/stock_account/views/report_invoice.xml
+++ b/addons/stock_account/views/report_invoice.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template id="stock_account_report_invoice_document" inherit_id="account.report_invoice_document">
         <xpath expr="//div[@id='right-elements']" position="after">
-          <t groups="stock_account.group_lot_on_invoice">
+          <t>
             <t t-set="lot_values" t-value="o._get_invoiced_lot_values()"/>
             <div t-if="not lot_values" class="oe_structure">&#8203;</div>
             <table t-else="" class="table table-sm mt-2" style="width: 50%;" name="invoice_snln_table">


### PR DESCRIPTION
Problem:
The Serial Number of a product is not being displayed on an invoice. The Serial number should be displayed on the invoice if there is a product tracked by Serial Number in the invoice. The groups is preventing the display of this Serial Number section: https://github.com/odoo/odoo/blob/d99e44f22634ac589a940d85fab84ca2b2e85332/addons/stock_account/views/report_invoice.xml#L5

Steps to reproduce:
-Make a SO of a product with a serial number
-Deliver it
-Create an invoice
-Preview it and the Serial Number of the product won't be displayed

Fix:
The groups tag was removed so that everyone can see the Serial Number of the product being bought.

opw-4489382