### PR TITLE
[IMP] core: run autovacuum after install/uninstall

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -5,6 +5,7 @@
 
 """
 
+import datetime
 import itertools
 import logging
 import sys
@@ -545,6 +546,12 @@ def load_modules(registry, force_demo=False, status=None, update_module=False):
 
             # Cleanup orphan records
             env['ir.model.data']._process_end(processed_modules)
+            # Cleanup cron
+            vacuum_cron = env.ref('base.autovacuum_job', raise_if_not_found=False)
+            if vacuum_cron:
+                # trigger after a small delay to give time for assets to regenerate
+                vacuum_cron._trigger(at=datetime.datetime.now() + datetime.timedelta(minutes=1))
+
             env.flush_all()
 
         for kind in ('init', 'demo', 'update'):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
After installation or uninstallation, trigger the autovacuum cron so that it executes ASAP.

Current behavior before PR:
Installing and uninstalling modules may create a lot of garbage in the file store, and that garbage seem to last for too long.
In particular, many asset files will be regenerated, and old assets immediately become garbage.

Desired behavior after PR is merged:
After installation or uninstallation, trigger the autovacuum cron so that it executes ASAP.
Ideally, it shouldn't be run before old assets are discarded.  So maybe the cron should be triggered after some little delay.

task-3970360

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
