### PR TITLE
[IMP] stock(_sms): support delivery order confirmation via whatsapp

### DIFF
--- a/addons/stock/models/res_company.py
+++ b/addons/stock/models/res_company.py
@@ -42,6 +42,10 @@ class ResCompany(models.Model):
         help="""Day of the month when the annual inventory should occur. If zero or negative, then the first day of the month will be selected instead.
         If greater than the last day of a month, then the last day of the month will be selected instead.""")
 
+    # used for sending stock text confirmation
+    stock_text_confirmation = fields.Boolean("Stock Text Confirmation")
+    stock_confirmation_type = fields.Selection([('sms', 'SMS')], default='sms')
+
     def _create_transit_location(self):
         '''Create a transit location with company_id being the given company_id. This is needed
            in case of resuply routes between warehouses belonging to the same company, because
@@ -210,3 +214,7 @@ class ResCompany(models.Model):
                 'property_stock_customer': inter_company_location.id,
                 'property_stock_supplier': inter_company_location.id,
             })
+
+    def _get_text_validation(self, confirmation_type):
+        self.ensure_one()
+        return bool(self.stock_text_confirmation and self.stock_confirmation_type == confirmation_type)

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -54,6 +54,8 @@ class ResConfigSettings(models.TransientModel):
         help="Character(s) used to separate data contained within an aggregate barcode (i.e. a barcode containing multiple barcode encodings)")
     module_stock_fleet = fields.Boolean("Dispatch Management System")
     replenish_on_order = fields.Boolean("Replenish on Order (MTO)", compute='_compute_replenish_on_order', inverse='_inverse_replenish_on_order')
+    stock_text_confirmation = fields.Boolean(related='company_id.stock_text_confirmation', string='Stock Text Validation with stock move', readonly=False)
+    stock_confirmation_type = fields.Selection(related='company_id.stock_confirmation_type', string='Stock Text Validation type', readonly=False)
 
     def _compute_replenish_on_order(self):
         route = self.env.ref('stock.route_warehouse0_mto', raise_if_not_found=False)
@@ -75,6 +77,11 @@ class ResConfigSettings(models.TransientModel):
         if not self.group_stock_production_lot:
             self.group_lot_on_delivery_slip = False
             self.module_product_expiry = False
+
+    @api.onchange('stock_confirmation_type', 'stock_text_confirmation')
+    def _onchange_stock_confirmation_fields(self):
+        if self.stock_text_confirmation and self.stock_confirmation_type == 'sms':
+            self.module_stock_sms = True
 
     @api.onchange('group_stock_adv_location')
     def onchange_adv_location(self):

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -64,8 +64,15 @@
                             <setting id="stock_move_email" company_dependent="1" string="Email Confirmation" help="Send an automatic confirmation email when Delivery Orders are done">
                                 <field name="stock_move_email_validation"/>
                             </setting>
-                            <setting id="stock_sms" company_dependent="1" help="Send an automatic confirmation SMS Text Message when Delivery Orders are done">
-                                <field name="module_stock_sms"/>
+                            <setting id="stock_text_confirmation" company_dependent="1" help="Send an automatic confirmation Text Message when Delivery Orders are done" string="Text Confirmation">
+                                <field name="stock_text_confirmation"/>
+                                <field name="module_stock_sms" invisible="1"/>
+                                <div class="content-group" id="module_install_warning" invisible="not stock_text_confirmation">
+                                    <field name="stock_confirmation_type" required="stock_text_confirmation"/>
+                                    <div class="mt16 text-warning" id="module_install_warning_sms" invisible="stock_confirmation_type != 'sms'">
+                                        <strong>Save</strong> this page and come back here to set up the feature.
+                                    </div>
+                                </div>
                             </setting>
                             <setting id="signature_delivery_orders" help="Require a signature on your delivery orders">
                                 <field name="group_stock_sign_delivery"/>

--- a/addons/stock_sms/__init__.py
+++ b/addons/stock_sms/__init__.py
@@ -12,5 +12,16 @@ def _assign_default_sms_template_picking_id(env):
     default_sms_template_id = env.ref('stock_sms.sms_template_data_stock_delivery', raise_if_not_found=False)
     if default_sms_template_id:
         company_ids_without_default_sms_template_id.write({
+            'stock_text_confirmation': True,
             'stock_sms_confirmation_template_id': default_sms_template_id.id,
         })
+
+
+def _reset_sms_text_confirmation(env):
+    company_ids_with_sms_text_confirmation = env['res.company'].search([
+        ('stock_text_confirmation', '=', True),
+        ('stock_confirmation_type', '=', 'sms'),
+    ])
+    company_ids_with_sms_text_confirmation.write({
+        'stock_text_confirmation': False,
+    })

--- a/addons/stock_sms/__manifest__.py
+++ b/addons/stock_sms/__manifest__.py
@@ -18,5 +18,6 @@
     'auto_install': True,
     'post_init_hook': '_assign_default_sms_template_picking_id',
     'author': 'Odoo S.A.',
+    'uninstall_hook': '_reset_sms_text_confirmation',
     'license': 'LGPL-3',
 }

--- a/addons/stock_sms/models/res_company.py
+++ b/addons/stock_sms/models/res_company.py
@@ -13,7 +13,6 @@ class ResCompany(models.Model):
         except ValueError:
             return False
 
-    stock_move_sms_validation = fields.Boolean("SMS Confirmation", default=True)
     stock_sms_confirmation_template_id = fields.Many2one(
         'sms.template', string="SMS Template",
         domain="[('model', '=', 'stock.picking')]",

--- a/addons/stock_sms/models/res_config_settings.py
+++ b/addons/stock_sms/models/res_config_settings.py
@@ -7,8 +7,5 @@ from odoo import fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    stock_move_sms_validation = fields.Boolean(
-        related='company_id.stock_move_sms_validation',
-        string='SMS Validation with stock move', readonly=False)
     stock_sms_confirmation_template_id = fields.Many2one(
         related='company_id.stock_sms_confirmation_template_id', readonly=False)

--- a/addons/stock_sms/models/stock_picking.py
+++ b/addons/stock_sms/models/stock_picking.py
@@ -18,13 +18,13 @@ class StockPicking(models.Model):
     def _check_warn_sms(self):
         warn_sms_pickings = self.browse()
         for picking in self:
-            is_delivery = picking.company_id.stock_move_sms_validation \
+            is_delivery = picking.company_id._get_text_validation('sms') \
                     and picking.picking_type_id.code == 'outgoing' \
                     and picking.partner_id.phone
             if is_delivery \
                     and not modules.module.current_test \
                     and not picking.company_id.has_received_warning_stock_sms \
-                    and picking.company_id.stock_move_sms_validation:
+                    and picking.company_id._get_text_validation('sms'):
                 warn_sms_pickings |= picking
         return warn_sms_pickings
 
@@ -46,7 +46,7 @@ class StockPicking(models.Model):
     def _send_confirmation_email(self):
         super()._send_confirmation_email()
         if not self.env.context.get('skip_sms') and not modules.module.current_test:
-            pickings = self.filtered(lambda p: p.company_id.stock_move_sms_validation and p.picking_type_id.code == 'outgoing' and p.partner_id.phone)
+            pickings = self.filtered(lambda p: p.company_id._get_text_validation('sms') and p.picking_type_id.code == 'outgoing' and p.partner_id.phone)
             for picking in pickings:
                 # Sudo as the user has not always the right to read this sms template.
                 template = picking.company_id.sudo().stock_sms_confirmation_template_id

--- a/addons/stock_sms/views/res_config_settings_views.xml
+++ b/addons/stock_sms/views/res_config_settings_views.xml
@@ -6,18 +6,17 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="stock.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='module_stock_sms']" position="replace">
-                <field name="stock_move_sms_validation"/>
+            <xpath expr="//div[@id='module_install_warning_sms']" position="attributes">
+                <attribute name="invisible">1</attribute>
             </xpath>
-            <xpath expr="//setting[@id='stock_sms']" position="attributes">
-                <attribute name="string">SMS Confirmation</attribute>
-            </xpath>
-            <xpath expr="//setting[@id='stock_sms']" position="inside">
-                <div class="row mt16" invisible="not stock_move_sms_validation">
-                    <label for="stock_sms_confirmation_template_id" string="SMS Template" class="col-lg-4 o_light_label"/>
-                    <field name="stock_sms_confirmation_template_id" class="oe_inline" required="stock_move_sms_validation" context="{'default_model': 'stock.picking'}"/>
+            <xpath expr="//setting[@id='stock_text_confirmation']" position="inside">
+                <div class="row mt16" invisible="stock_confirmation_type != 'sms' or not stock_text_confirmation">
+                    <field name="stock_sms_confirmation_template_id"
+                        class="oe_inline"
+                        required="stock_confirmation_type == 'sms'"
+                        context="{'default_model': 'stock.picking'}"/>
                 </div>
-                <widget name="iap_buy_more_credits" service_name="sms" invisible="not stock_move_sms_validation"/>
+                <widget name="iap_buy_more_credits" service_name="sms" invisible="stock_confirmation_type != 'sms' or not stock_text_confirmation"/>
             </xpath>
         </field>
     </record>

--- a/addons/stock_sms/wizard/confirm_stock_sms.py
+++ b/addons/stock_sms/wizard/confirm_stock_sms.py
@@ -24,7 +24,7 @@ class ConfirmStockSms(models.TransientModel):
             if not company.has_received_warning_stock_sms:
                 company.sudo().write({
                     'has_received_warning_stock_sms': True,
-                    'stock_move_sms_validation': False,
+                    'stock_text_confirmation': False,
                 })
         pickings_to_validate = self.env['stock.picking'].browse(self.env.context.get('button_validate_picking_ids'))
         return pickings_to_validate.button_validate()


### PR DESCRIPTION
PURPOSE

This commit enhances the text confirmation feature to support WhatsApp alongside SMS while validating a delivery order.

SPECIFICATION

- Enabling `Text Confirmation` in shipping settings activates this option.
- Users can then opt for either SMS or WhatsApp as a confirmation mode for delivery orders.
- The option to select WhatsApp has been added in the `stock_enterprise` module.

TECHNICAL SPECIFICATIONS

- Moved `stock_move_sms_validation` from Stock-SMS to the stock module and replaced it with `stock_text_confirmation` in the `res.company` model.
- Added the `stock_confirmation_type` field in the stock module in the `res.company` model as a selection field allowing users to choose between SMS and WhatsApp.

Related Upgrade PR: https://github.com/odoo/upgrade/pull/7195

Task-3510974