### PR TITLE
[FIX] website_sale: fix product page reviews website_menus callback

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -667,7 +667,11 @@ publicWidget.registry.websiteSaleProductPageReviews = publicWidget.Widget.extend
     selector: '#o_product_page_reviews',
     disabledInEditableMode: false,
 
+    /**
+     * @override
+     */
     init() {
+        this._super(...arguments);
         this.website_menus = this.bindService("website_menus");
     },
 


### PR DESCRIPTION
In [1] when public widgets were converted into interactions, the `extraMenuUpdateCallbacks` mechanism was replaced by a `registerCallback` on the `website_menus` service. The `init` method that was added to obtain the `website_menus` service did not call its super, which caused an error because some initializations were therefore missing.

This commit fixes this by adding the missing call to super.

Steps to reproduce:
- Go to a product page
- Edit
- Select the product to display the page options
- Enable "Customer"'s "Rating"

=> An error was displayed upon page reload.

[1]: https://github.com/odoo/odoo/commit/22e777c046521f3f89b62caa5876680beb7f5aba#diff-8545ff07230315c44a6ad5a96a900b2d9e6c8f104be5e19d60e2ececd0ed5190R669-R672

task-4367641
