### PR TITLE
[FIX] base: allow saving the ir.ui.view sub-form

### DIFF
--- a/odoo/addons/base/views/ir_ui_view_views.xml
+++ b/odoo/addons/base/views/ir_ui_view_views.xml
@@ -43,6 +43,9 @@
                                     <field name="priority"/>
                                     <field name="name"/>
                                     <field name="xml_id"/>
+                                    <field name="active" invisible="1" />
+                                    <!-- Manually add active here. Otherwise that field will be readonly for the sub-list,
+                                    preventing saving changes done from a widget in the sub-form -->
                                 </tree>
                             </field>
                         </page>


### PR DESCRIPTION
Before this commit, when archiving an inheriting view from a main one (via the list and the form), the main record was not savable.

This is due to 6f06420e4a9443c52dc0cb427f8f55eb4aecabce which automatically adds missing but useful fields in a view in readonly mode.

This commit adds that field manually to be able to save the active field.

opw-4534225

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
