### PR TITLE
[FIX] point_of_sale: singleton error when opening session

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1501,7 +1501,7 @@ class PosSession(models.Model):
         }
     
     def _get_captured_payments_domain(self):
-        return [('session_id', '=', self.id), ('pos_order_id.state', 'in', ['paid', 'invoiced'])]
+        return [('session_id', 'in', self.ids), ('pos_order_id.state', 'in', ['done', 'paid', 'invoiced'])]
 
     def open_frontend_cb(self):
         """Open the pos interface with config_id as an extra argument.


### PR DESCRIPTION
before this commit, opening sessions menu raising a single ton error.

* navigate to point of sale app
* click on orders -> session
* traceback is shown

self.env['pos.payment']._read_group(self._get_captured_payments_domain(), ['session_id'], ['amount:sum'])
  File "/home/dev/Git/17.0/git/odoo/addons/point_of_sale/models/pos_session.py", line 1504, in _get_captured_payments_domain
    return [('session_id', '=', self.id), ('pos_order_id.state', 'in', ['paid', 'invoiced'])]
  File "/home/dev/Git/17.0/git/odoo/odoo/fields.py", line 5159, in __get__
    raise ValueError("Expected singleton: %s" % record)
ValueError: Expected singleton: pos.session(1562, 1561, 1560, 1559, 1558, 1557, 1506, 1505, 1504, 1503, 1502, 1501, 1498, 1497, 1496, 

introduced in: https://github.com/odoo/odoo/commit/0ee6d2881150c04631efc9f38f0e098b0a10dee9

after this commit, without any issues, the sessions
 will opened.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
