### PR TITLE
[IMP] account_peppol: auto-detect sender/receiver registration

### DIFF
--- a/addons/account_peppol/tests/test_peppol_participant.py
+++ b/addons/account_peppol/tests/test_peppol_participant.py
@@ -116,10 +116,8 @@ class TestPeppolParticipant(TransactionCase):
         vals = self._get_participant_vals()
         vals['peppol_eas'] = '0208'
         wizard = self.env['peppol.registration'].create(vals)
-        with self.assertRaises(UserError), self.cr.savepoint():
-            wizard.button_peppol_sender_registration()
-            wizard.verification_code = '123456'
-            wizard.button_check_peppol_verification_code()
+        self.assertFalse(wizard.smp_registration)
+        wizard.button_register_peppol_participant()
 
     def test_create_success_sender(self):
         # should be possible to apply with all data

--- a/addons/account_peppol/wizard/peppol_registration.py
+++ b/addons/account_peppol/wizard/peppol_registration.py
@@ -53,10 +53,12 @@ class PeppolRegistration(models.TransientModel):
         string="Peppol warnings",
         compute="_compute_peppol_warnings",
     )
-    smp_registration = fields.Boolean(
+    smp_registration = fields.Boolean(  # TODO switch to computed non-stored in master
         string='Register as a receiver',
         help="If not check, you will only be able to send invoices but not receive them.",
-        default=True,
+        compute='_compute_smp_registration',
+        store=True,
+        readonly=False,
     )
 
     # -------------------------------------------------------------------------
@@ -93,7 +95,7 @@ class PeppolRegistration(models.TransientModel):
         for wizard in self:
             wizard.edi_user_id = wizard.company_id.account_edi_proxy_client_ids.filtered(lambda u: u.proxy_type == 'peppol')[:1]
 
-    @api.depends('peppol_eas', 'peppol_endpoint')
+    @api.depends('peppol_eas', 'peppol_endpoint', 'smp_registration')
     def _compute_peppol_warnings(self):
         for wizard in self:
             peppol_warnings = {}
@@ -110,7 +112,24 @@ class PeppolRegistration(models.TransientModel):
                 peppol_warnings['company_peppol_eas_warning'] = {
                     'message': _("The recommended identification method for Belgium is your Company Registry Number."),
                 }
+            if not wizard.smp_registration:
+                peppol_warnings['company_on_another_smp'] = {
+                    'message': _("Your company is already registered on another Access Point for receiving invoices."
+                                 "We will register you on Odoo as a sender only.")
+                }
             wizard.peppol_warnings = peppol_warnings or False
+
+    @api.depends('peppol_eas', 'peppol_endpoint')
+    def _compute_smp_registration(self):
+        for wizard in self:
+            wizard.smp_registration = False
+            if wizard.peppol_eas and wizard.peppol_endpoint:
+                try:
+                    edi_identification = f'{wizard.peppol_eas}:{wizard.peppol_endpoint}'
+                    wizard.edi_user_id._check_company_on_peppol(wizard.company_id, edi_identification)
+                    wizard.smp_registration = True
+                except UserError:
+                    pass
 
     @api.depends('edi_user_id')
     def _compute_edi_mode_constraint(self):

--- a/addons/account_peppol/wizard/peppol_registration_views.xml
+++ b/addons/account_peppol/wizard/peppol_registration_views.xml
@@ -19,7 +19,7 @@
 
                         <group col="1">
                             <group>
-                                <field name="smp_registration" string="Allow incoming invoices"/>
+                                <field name="smp_registration" string="Allow incoming invoices" invisible="1"/>
                                 <field name="peppol_eas"
                                        nolabel="1"
                                        class="o_field_peppol_eas_selection"/>


### PR DESCRIPTION
If the user is already registered on another SMP, we know we can only register him as a sender.
If not, we have to register him as a receiver.
A user can't be only a sender on Peppol.

task-4394408
