### PR TITLE
[FIX] account: outbound shouldnt require validated bank account

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -1151,7 +1151,11 @@ class AccountPayment(models.Model):
         ''' draft -> posted '''
         # Do not allow posting if the account is required but not trusted
         for payment in self:
-            if payment.require_partner_bank_account and not payment.partner_bank_id.allow_out_payment:
+            if (
+                payment.require_partner_bank_account
+                and not payment.partner_bank_id.allow_out_payment
+                and payment.payment_type == 'outbound'
+            ):
                 raise UserError(_(
                     "To record payments with %(method_name)s, the recipient bank account must be manually validated. "
                     "You should go on the partner bank account of %(partner)s in order to validate it.",


### PR DESCRIPTION
The `require_partner_bank_account` flag on the payment shouldn't require the `allow_out_payment` flag on it when the payment type is `inbound` as it leads to confusion.

This generates an issue with the `l10n_it_riba` Ri.Ba. payment method. It requires the bank account, but the money is incoming, not outgoing.

Old PR for saas-17.2: odoo/odoo#195312
Enterprise PR: odoo/enterprise#78959

Task [link](https://www.odoo.com/odoo/project/967/tasks/4497749)
task-4497749