### PR TITLE
[FIX] web: fix formatted_read_group groupby ['id']

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -628,7 +628,7 @@ class Base(models.AbstractModel):
 
             return formatter_many2many
 
-        if field.type == 'many2one':
+        if field.type == 'many2one' or field_name == 'id':
 
             def formatter_many2one(value):
                 if not value:

--- a/odoo/addons/test_read_group/tests/test_formatted_read_group.py
+++ b/odoo/addons/test_read_group/tests/test_formatted_read_group.py
@@ -106,6 +106,29 @@ class TestWebReadGroup(common.TransactionCase):
             ]
         )
 
+    def test_groupby_id(self):
+        Model = self.env['test_read_group.aggregate']
+        rec1, rec2 = Model.create([
+            {'value': 1, 'display_name': 'record1'},
+            {'value': 2, 'display_name': 'record2'},
+        ])
+
+        self.assertEqual(
+            Model.formatted_read_group([], groupby=['id'], aggregates=['value:sum']),
+            [
+                {
+                    '__extra_domain': [('id', '=', rec1.id)],
+                    'id': (rec1.id, "record1"),
+                    'value:sum': 1,
+                },
+                {
+                    '__extra_domain': [('id', '=', rec2.id)],
+                    'id': (rec2.id, "record2"),
+                    'value:sum': 2,
+                },
+            ],
+        )
+
     def test_limit_offset(self):
         Model = self.env['test_read_group.aggregate']
         Model.create({'key': 1, 'value': 1})


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/163300,
formatted_read_group() (new read_group()) doesn't handle groupby=['id'] correctly: it returns recordset value in the __extra_domain (wrong domain) and as the group value, which is stringified as `model(%s,)` (doesn't make sense).

Note I am not sure if we can generate a formatted_read_group() with groupby=['id'] from the webclient, but it is still a regression to fix.

Fix it using the same logic as for many2one.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
