### PR TITLE
[FIX] pos*: error when opening session without restaurant module

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service_options.js
+++ b/addons/point_of_sale/static/src/app/models/data_service_options.js
@@ -27,7 +27,6 @@ export class DataServiceOptions {
             "pos.payment",
             "pos.pack.operation.lot",
             "product.attribute.custom.value",
-            "restaurant.order.course",
         ];
     }
 

--- a/addons/pos_restaurant/static/src/app/models/data_service_options.js
+++ b/addons/pos_restaurant/static/src/app/models/data_service_options.js
@@ -15,4 +15,7 @@ patch(DataServiceOptions.prototype, {
     get cascadeDeleteModels() {
         return [...super.cascadeDeleteModels, "restaurant.order.course"];
     },
+    get dynamicModels() {
+        return [...super.dynamicModels, "restaurant.order.course"];
+    },
 });


### PR DESCRIPTION
pos*: point_of_sale, pos_restaurant

In this commit:
==========
- Resolved a traceback that occurred when opening a POS register without the restaurant module installed.

Task-4563288
