### PR TITLE
[IMP] sale_management: hide selected optional products from PDF quote

### DIFF
--- a/addons/sale_management/report/sale_report_templates.xml
+++ b/addons/sale_management/report/sale_report_templates.xml
@@ -2,14 +2,23 @@
 <odoo>
 <template id="report_saleorder_document_inherit_sale_management" inherit_id="sale.report_saleorder_document">
     <xpath expr="//div[@name='signature']" position="after">
-        <div t-if="not (doc.sale_order_option_ids and doc.state in ['draft', 'sent'])" class="oe_structure">&#8203;</div>
+        <div
+            t-if="(
+                not doc.sale_order_option_ids
+                or doc.state not in ['draft', 'sent']
+                or not any(not option.is_present for option in doc.sale_order_option_ids)
+            )"
+            class="oe_structure"
+        >
+            &#8203;
+        </div>
         <div t-else="">
             <t t-set="has_option_discount" t-value="any(option.discount != 0.0 for option in doc.sale_order_option_ids)" />
             <h4 name="h_optional_products">
                 <span>Options</span>
             </h4>
             <table name="table_optional_products" class="table table-sm">
-                <thead class="fw-bold">
+                <thead class="fw-bold" style="display: table-row-group;">
                     <tr>
                         <td name="th_option_name" class="text-start">Description</td>
                         <td t-if="has_option_discount" name="th_option_discount" class="text-start">Disc.%</td>
@@ -17,7 +26,7 @@
                     </tr>
                 </thead>
                 <tbody class="sale_tbody">
-                    <tr t-foreach="doc.sale_order_option_ids" t-as="option">
+                    <tr t-foreach="doc.sale_order_option_ids" t-as="option" t-if="not option.is_present">
                         <td name="td_option_name">
                             <span t-field="option.name">Extra Chips</span>
                         </td>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

- Hides optional products from PDF quotes that are already present in the Sale order line.

**Current behavior before PR:**

- When an optional product is added to the sale order line, we can still see the product in the optional product table, which is not necessary as it is already in the sale order line.

**Desired behavior after PR is merged:**

- We won't be able to see optional products that are added to the sale order line. 

- If there is a single optional product in the optional products tab and that too is added in the sale order line then we won't be able to see the whole table body with the title.


task-**[4484672](https://www.odoo.com/odoo/project/4106/tasks/4484672)**



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
