### PR TITLE
[FIX] account_edi_ubl_cii: Always use PDF-A/3

### DIFF
--- a/addons/account_edi_ubl_cii/wizard/account_move_send.py
+++ b/addons/account_edi_ubl_cii/wizard/account_move_send.py
@@ -193,8 +193,7 @@ class AccountMoveSend(models.TransientModel):
         writer.addAttachment('factur-x.xml', xml_facturx, subtype='text/xml')
 
         # PDF-A.
-        if invoice_data.get('ubl_cii_xml_options', {}).get('ubl_cii_format') == 'facturx' \
-                and not writer.is_pdfa:
+        if not writer.is_pdfa:
             try:
                 writer.convert_to_pdfa()
             except Exception as e:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Generating a PDF valid for Factur-X is currently extremely path-dependent, and thus needlessly confusing for the user. Since a Factur-X XML is always attached to the PDF, the PDF should also always be PDF-A/3 to ensure it's Factur-X compliant.

Current behavior before PR:

To make sure a valid Factur-X including PDF-A/3 is generated, all the following things have to be true:
- The commercial partner of the invoice has "Factur-X (CII)" as its EDI Format set
- The user generates the PDF via the Send&Print button (to open the account.move.send wizard)
- The user remembers to check the Factur-X checkbox in the wizard or they have the Setting "Generate Peppol format by default" (invoice_is_ubl_cii) activated. Both are False by default
- This is the first time a PDF is generated for the invoice (because otherwise invoice_pdf_report_id is set and it re-uses that file)

If any of those conditions aren't met, most notably when PDFs generated via the "Print" actions, it attaches the Factur-X XML, but does not convert the PDF to PDF-A/3, creating a faulty file.
This inability to generate a valid PDF-A/3 via the "Print" actions stems from the way that _render_qweb_pdf_prepare_streams() in account_edi_ubl_cii performs its Factur-X injection: It does not transfer the necessary data to ever reach the PDF-A/3 conversion branch in _hook_invoice_document_after_pdf_report_render(). On analysis, trying to inject the data to make it fetch and correctly transfer the 'ubl_cii_xml_options' option block of the invoice_data dict would take a lot of extra logic, for the net "benefit" of these valid-looking but not actually Factur-X PDFs being generated in certain cases.

Desired behavior after PR is merged:

Every invoice PDF has a Factur-X XML attached and is in the PDF-A/3 Format, suitable to be used as a Factur-X electronic invoice. This way, Odoo systems are automatically compliant with the Electronic Invoicing requirement laws, and also prevent customer confusion about why sometimes the generated PDFs are valid Factur-X and sometimes they are not despite having the XML attached.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
