### PR TITLE
[FIX] website_blog, *: resolve multiple ui and redirection issues

### DIFF
--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -149,7 +149,7 @@ class WebsiteBlog(http.Controller):
             all_tags = tools.lazy(lambda: blogs.all_tags(join=True) if not blog else blogs.all_tags().get(blog.id, request.env['blog.tag']))
         tag_category = tools.lazy(lambda: sorted(all_tags.mapped('category_id'), key=lambda category: category.name.upper()))
         other_tags = tools.lazy(lambda: sorted(all_tags.filtered(lambda x: not x.category_id), key=lambda tag: tag.name.upper()))
-        nav_list = tools.lazy(self.nav_list)
+        nav_list = tools.lazy(lambda: self.nav_list(blog))
         # for performance prefetch the first post with the others
         post_ids = (first_post | posts).ids
         # and avoid accessing related blogs one by one

--- a/addons/website_blog/static/tests/tours/blog_sidebar_with_date_and_tag.js
+++ b/addons/website_blog/static/tests/tours/blog_sidebar_with_date_and_tag.js
@@ -1,0 +1,45 @@
+/** @odoo-module **/
+
+import wTourUtils from "@website/js/tours/tour_utils";
+
+wTourUtils.registerWebsitePreviewTour(
+    "blog_sidebar_with_date_and_tag",
+    {
+        test: true,
+        url: "/blog",
+    },
+    () => [
+        {
+            content: "Click on the 'Nature' blog category to filter blog posts.",
+            trigger: "iframe b:contains('Nature')",
+        },
+        {
+            content: "Check if the archive dropdown contains exactly 1 option: January.",
+            trigger: "iframe select[name=archive]",
+            run: function () {
+                const optionEls = this.$anchor[0].querySelectorAll("optgroup option");
+                const length = optionEls.length;
+                const monthName = optionEls[0].textContent;
+                if (length !== 1 && !monthName.includes("January")) {
+                    throw new Error("There should be 1 option in the select");
+                }
+            },
+        },
+        {
+            content: "Click on the 'Space' blog category to switch filters.",
+            trigger: "iframe b:contains('Space')",
+        },
+        {
+            content: "Verify that the archive dropdown now contains only 1 option: February.",
+            trigger: "iframe select[name=archive]",
+            run: function () {
+                const optionEls = this.$anchor[0].querySelectorAll("optgroup option");
+                const length = optionEls.length;
+                const monthName = optionEls[0].textContent;
+                if (length !== 1 && !monthName.includes("February")) {
+                    throw new Error("There should be 1 option in the select");
+                }
+            },
+        },
+    ]
+);

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -3,6 +3,7 @@
 
 import odoo.tests
 from odoo.addons.website_blog.tests.common import TestWebsiteBlogCommon
+from datetime import datetime
 
 
 @odoo.tests.tagged('post_install', '-at_install')
@@ -65,3 +66,31 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get('Content-Type'), 'image/png')
         self.assertRegex(response.headers.get('Content-Disposition', ''), r'mail_message-\d+-author_avatar\.png')
+
+    def test_sidebar_with_date_and_tag(self):
+        Blog = self.env['blog.blog']
+        Post = self.env['blog.post']
+
+        Blog1 = Blog.create({'name': 'Nature'})
+        Blog2 = Blog.create({'name': 'Space'})
+
+        # Create first blog post (Feb 2025)
+        Post.create({
+            'name': 'First Blog Post',
+            'blog_id': Blog1.id,
+            'author_id': self.user_public.id,
+            'is_published': True,
+            'published_date': datetime(2025, 2, 10, 12, 0, 0),
+        })
+
+        # Create second blog post (Jan 2025)
+        Post.create({
+            'name': 'Second Blog Post',
+            'blog_id': Blog2.id,
+            'author_id': self.user_public.id,
+            'is_published': True,
+            'published_date': datetime(2025, 1, 15, 14, 30, 0),
+        })
+
+        self.env.ref("website_blog.opt_blog_sidebar_show").active = True
+        self.start_tour("/blog", "blog_sidebar_with_date_and_tag", login="admin")

--- a/addons/website_mail/static/src/js/follow.js
+++ b/addons/website_mail/static/src/js/follow.js
@@ -27,6 +27,21 @@ publicWidget.registry.follow = publicWidget.Widget.extend({
         this.isUser = false;
         var $jsFollowEls = this.$el.find('.js_follow');
 
+        // TODO handle from xml in master
+        // We explicitly added the input element because
+        // groups="base.group_public" is applied to it. As a result, in
+        // internal or portal use, only the Subscribe/Unsubscribe buttons
+        // are displayed. This ensures that the input element is included if
+        // the user is not a public user.
+        if (
+            !$jsFollowEls[0].querySelector(".js_follow_email") &&
+            !$jsFollowEls[0].querySelector(".js_follow_icons_container")
+        ) {
+            const inputEl = document.createElement("input");
+            inputEl.setAttribute("class", "js_follow_email form-control");
+            $jsFollowEls[0].prepend(inputEl);
+        }
+
         var always = function (data) {
             self.isUser = data[0].is_user;
             const $jsFollowToEnable = $jsFollowEls.filter(function () {


### PR DESCRIPTION
\*: website_mail

This PR addresses several issues in the blog module, including:

Commit [1]: retain follow-us input button when logged in.

- Steps to reproduce:
1. Go to any blog post.
2. Enable the sidebar.
3. Select any category (e.g., Travel).
Issue: A subscribe button appears in the 'Follow Us' section.

- Solution: Currently, the input field is only shown to public users. This happens because the input element is restricted by the `base.groups_public` group in the XML code. Since this is an XML change in v17.0 (stable version), we need to implement the fix in JS instead. After that, we will adapt the code from the master branch.


Commit [2]: remove unnecessary months from blog category.

- Steps to reproduce:
1. Have a blog post in a category (e.g., Astronomy) published in Feb-2025.
2. In another category (e.g., Travel), have blog posts in both Jan-2025 and Feb-2025.
3. When selecting the Astronomy category, the sidebar `Archives` filter shows all months, even if no blog post exists in Jan 2025.

- Solution: It will now show only months that contain blog posts for the selected category. Filter out from the backend according to their publishing date.

[1]: https://github.com/odoo/odoo/pull/197172/commits/b844accf13899bd2dbfca6c7592cda092df45bec
[2]: https://github.com/odoo/odoo/pull/197172/commits/91cb63ffdad0d18a0c3e2105b978e5107ff3ab99

task-4546888