### PR TITLE
[FIX] point_of_sale: include product name when doing exact product mathcing

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -214,8 +214,10 @@ export class ProductProduct extends Base {
     }
 
     exactMatch(searchWord) {
-        const fields = ["barcode", "default_code"];
-        return fields.some((field) => this[field] && this[field].includes(searchWord));
+        const fields = ["barcode", "default_code", "searchString"];
+        return fields.some(
+            (field) => this[field] && this[field].toLowerCase().includes(searchWord.toLowerCase())
+        );
     }
 
     _isArchivedCombination(attributeValueIds) {

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -292,6 +292,22 @@ registry.category("web_tour.tours").add("DecimalCommaOrderlinePrice", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("SearchProducts", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.searchProduct("chair"),
+            ProductScreen.clickDisplayedProduct("Test chair 1"),
+            ProductScreen.clickDisplayedProduct("Test CHAIR 2"),
+            ProductScreen.clickDisplayedProduct("Test sofa"),
+            ProductScreen.searchProduct("CHAIR"),
+            ProductScreen.clickDisplayedProduct("Test chair 1"),
+            ProductScreen.clickDisplayedProduct("Test CHAIR 2"),
+            ProductScreen.clickDisplayedProduct("Test sofa"),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("CheckProductInformation", {
     test: true,
     steps: () =>

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -70,6 +70,20 @@ export function clickDisplayedProduct(
 
     return step;
 }
+export function searchProduct(name) {
+    return [
+        {
+            isActive: ["mobile"],
+            content: "click more button",
+            trigger: ".fa-search",
+            run: "click",
+        },
+        {
+            trigger: ".input-group input",
+            run: "edit " + name,
+        },
+    ];
+}
 export function clickInfoProduct(name) {
     return [
         {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1614,6 +1614,23 @@ class TestUi(TestPointOfSaleHttpCommon):
             self.main_pos_config.open_ui()
             self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'SearchMoreCustomer', login="pos_user")
 
+    def test_product_search(self):
+        self.env['product.product'].create({
+            'name': 'Test chair 1',
+            'available_in_pos': True,
+        })
+        self.env['product.product'].create({
+            'name': 'Test CHAIR 2',
+            'available_in_pos': True,
+        })
+        self.env['product.product'].create({
+            'name': 'Test sofa',
+            'available_in_pos': True,
+            "default_code": "CHAIR",
+        })
+        self.main_pos_config.open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'SearchProducts', login="pos_user")
+
     def test_lot(self):
         self.product1 = self.env['product.product'].create({
             'name': 'Product A',


### PR DESCRIPTION
Currently, when searching for products using the searchBar, the results can be different depending on the way you write the same word ('desk', 'DESK', 'Desk')

Steps to reproduce:
-------------------
* Create 2 products
  * Product 1: name: "Blue DESK"
  * Product 2: name: "Work table", reference: 'DESK_01'
* Open pos shop
* Search "desk"
> Observation: "Blue DESK" product is found, not "Work table"
* Search "DESK"
> Observation: "Work table" product is found, not "Blue DESK"

Why the fix:
------------

The behavior originates from https://github.com/odoo/odoo/commit/e9a27425a0c0b9da982aeaaec2accfa968ed1816

When doing a search, it looks for exact matches with the fields `barcode` and `default_code` and returns them, without looking for the matches in name. This is what happens when we search for "DESK" (simple example, the searchword should be greater than 5).

When we search for 'desk', no exact match is found as the function `exactMatches` is case sensitive. We then find the product thanks to `fuzzyLookup`.

This fix includes the name of the product in the exact match search and does not make it upper/lower case sensitive.

opw-4532712