### PR TITLE
[FIX] point_of_sale: only show OrderWidget empty state if editable

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.js
+++ b/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.js
@@ -11,7 +11,11 @@ export class OrderWidget extends Component {
         slots: { type: Object },
         total: { type: String, optional: true },
         tax: { type: String, optional: true },
+        editable: { type: Boolean, optional: true },
     };
+    static defaultProps = {
+        editable: true,
+    }
     static components = { CenteredIcon };
     setup() {
         this.scrollableRef = useRef("scrollable");

--- a/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.xml
@@ -17,7 +17,7 @@
             <t t-slot="details"/>
         </t>
         <t t-else="">
-            <CenteredIcon icon="'fa-shopping-cart fa-4x'" text="emptyCartText()"/>
+            <CenteredIcon t-if="props.editable" icon="'fa-shopping-cart fa-4x'" text="emptyCartText()"/>
             <t t-slot="details"/>
         </t>
     </t>

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -3,7 +3,7 @@
     <t t-name="point_of_sale.OrderReceipt">
         <div class="pos-receipt">
             <ReceiptHeader data="props.data.headerData" />
-            <OrderWidget lines="props.data.orderlines" t-slot-scope="scope">
+            <OrderWidget lines="props.data.orderlines" t-slot-scope="scope" editable="false">
                 <t t-set="line" t-value="scope.line"/>
                 <Orderline line="omit(scope.line, 'customerNote')" class="{ 'pe-none': true }">
                     <li t-if="line.customerNote" class="customer-note w-100 p-2 my-1 rounded text-break">


### PR DESCRIPTION
Issue:
When settling user account, the order will not have any order lines, that will display a misleading empty state on the receipt, saying: "Start adding products".

Fix:
We do not display this empty state, when the order is not editable, which is the case of, but not only, settling an account.

Note that we have another related PR https://github.com/odoo/enterprise/pull/76370 for the same ticket, which fixes only the case of settling an account. However, @adgu-odoo suggested to make the fix more general, to fix the case of not only settling an account, but also other possible cases where we show the OrderWidget in a receipt.

If this PR is merged, the other one should be closed, and vice versa.

opw-4430325