### PR TITLE
[FIX] mrp{,_account}: constrain fifo candidates for unbuild SVL

### DIFF
--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models
+from odoo.osv import expression
 from odoo.tools import float_round, groupby
 
 
@@ -115,6 +116,15 @@ class ProductProduct(models.Model):
             if byproduct_cost_share:
                 total *= float_round(1 - byproduct_cost_share / 100, precision_rounding=0.0001)
             return bom.product_uom_id._compute_price(total / bom.product_qty, self.uom_id)
+
+    def _get_fifo_candidates_domain(self, company):
+        fifo_candidates_domain = super()._get_fifo_candidates_domain(company)
+        if self in self.env.context.get('product_unbuild_map', ()):
+            fifo_candidates_domain = expression.AND([
+                fifo_candidates_domain,
+                [('stock_move_id', 'in', self.env.context['product_unbuild_map'][self].mo_id.move_finished_ids.ids)]
+            ])
+        return fifo_candidates_domain
 
 
 class ProductCategory(models.Model):

--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from collections import defaultdict
+
 from odoo import models
 
 
@@ -44,6 +46,13 @@ class StockMove(models.Model):
     def _is_production_consumed(self):
         self.ensure_one()
         return self.location_dest_id.usage == 'production' and self.location_id._should_be_valued()
+
+    def _create_out_svl(self, forced_quantity=None):
+        product_unbuild_map = defaultdict(self.env['mrp.unbuild'].browse)
+        for move in self:
+            if move.unbuild_id:
+                product_unbuild_map[move.product_id] |= move.unbuild_id
+        return super(StockMove, self.with_context(product_unbuild_map=product_unbuild_map))._create_out_svl(forced_quantity)
 
     def _get_out_svl_vals(self, forced_quantity):
         unbuild_moves = self.filtered('unbuild_id')

--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo.addons.stock_account.tests.test_account_move import TestAccountMoveStockCommon
 from odoo.tests import Form, tagged
@@ -197,6 +198,104 @@ class TestMrpAccount(TestMrpCommon):
         bom_form = Form(self.env['mrp.bom'].with_user(mrp_manager))
         bom_form.product_id = self.dining_table
 
+    def test_two_productions_unbuild_one_sell_other_fifo(self):
+        """ Unbuild orders, when supplied with a specific MO record, should restrict their SVL
+        consumption to layers linked to moves originating from that MO record.
+        """
+        final_product = self.env['product.product'].create({
+            'type': 'product',
+            'name': 'final product',
+            'categ_id': self.categ_real.id,
+        })
+        component = self.env['product.product'].create({
+            'type': 'product',
+            'name': 'component',
+            'standard_price': 1.0,
+            'categ_id': self.categ_standard.id,
+        })
+        final_bom = self.env['mrp.bom'].create({
+            'product_id': final_product.id,
+            'product_tmpl_id': final_product.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'bom_line_ids': [Command.create({
+                'product_id': component.id,
+                'product_qty': 1,
+            })],
+        })
+        in_move = self.env['stock.move'].create({
+            'name': 'in 2 component',
+            'product_id': component.id,
+            'product_uom_qty': 2.0,
+            'location_id': self.env.ref('stock.stock_location_suppliers').id,
+            'location_dest_id': self.source_location_id,
+            'price_unit': 1,
+        })
+        in_move._action_confirm()
+        in_move._action_assign()
+        in_move.picked = True
+        in_move._action_done()
+        mo_1 = self.env['mrp.production'].create({'product_id': final_product.id})
+        mo_1.action_confirm()
+        mo_1.action_assign()
+        mo_1.button_mark_done()
+        self.assertRecordValues(
+            self.env['stock.valuation.layer'].search([('product_id', '=', (final_product.id))]),
+            # MO_1
+            [{'remaining_qty': 1.0, 'value': 1.0}]
+        )
+
+        with Form(component) as comp_form:
+            comp_form.standard_price = 2
+        mo_2 = self.env['mrp.production'].create({'product_id': final_product.id})
+        mo_2.action_confirm()
+        mo_2.action_assign()
+        mo_2.button_mark_done()
+        self.assertRecordValues(
+            self.env['stock.valuation.layer'].search([('product_id', '=', (final_product.id))]),
+            [
+                {'remaining_qty': 1.0, 'value': 1.0},
+                # MO_2 (new value to reflect change of component's `standard_price`
+                {'remaining_qty': 1.0, 'value': 2.0},
+            ]
+        )
+        unbuild_form = Form(self.env['mrp.unbuild'])
+        unbuild_form.product_id = final_product
+        unbuild_form.bom_id = final_bom
+        unbuild_form.product_qty = 1
+        unbuild_form.mo_id = mo_2
+        unbuild_order = unbuild_form.save()
+        unbuild_order.action_unbuild()
+        self.assertRecordValues(
+            self.env['stock.valuation.layer'].search([('product_id', '=', (final_product.id))]),
+            [
+                {'remaining_qty': 1.0, 'value': 1.0},
+                {'remaining_qty': 0.0, 'value': 2.0},
+                # Unbuild SVL value is derived from MO_2, as precised on the unbuild form
+                {'remaining_qty': 0.0, 'value': -2.0, 'quantity': 1.0},
+            ]
+        )
+        out_move = self.env['stock.move'].create({
+            'name': 'out 1 final',
+            'product_id': final_product.id,
+            'product_uom_qty': 1.0,
+            'location_id': self.source_location_id,
+            'location_dest_id': self.env.ref('stock.stock_location_customers').id,
+        })
+        out_move._action_confirm()
+        out_move._action_assign()
+        out_move.quantity = 1
+        out_move.picked = True
+        out_move._action_done()
+        self.assertRecordValues(
+            self.env['stock.valuation.layer'].search([('product_id', '=', (final_product.id))]),
+            [
+                {'remaining_qty': 0.0, 'value': 1.0},
+                {'remaining_qty': 0.0, 'value': 2.0},
+                {'remaining_qty': 0.0, 'value': -2.0},
+                # Out move SVL value is derived from MO_1, the only candidate origin with some `remaining_qty`
+                {'remaining_qty': 0.0, 'value': -1.0, 'quantity': 1.0},
+            ]
+        )
 
 @tagged("post_install", "-at_install")
 class TestMrpAccountMove(TestAccountMoveStockCommon):


### PR DESCRIPTION
**Current behavior:**
It's possible to end up with a negative valuation for a product with zero product qty.

**Expected behavior:**
No negative valuation for 0 product qty.

**Steps to reproduce:**
1. Create a FIFO, real-time product; create a BOM for fifo-product with some component (tracked by qty, costing method doesn't matter, `standard_price=1`)

2. Purchase 2 units of component @ $1

3. Create and fully process an MO for fifo-prod

4. Change the standard price of component from $1 -> $2

5. Create and fully process a second MO for fifo-prod

6. Unbuild the second MO (from step 5)

7. Sell 1 unit of fifo-prod

8. Check the valuation, see that both the unbuild and out move (sale) use a `unit_cost=$2` despite there having been only 1 qty valued at $2 in the valuation history

**Cause of the issue:**
SVL creation for fifo costing in an unbuild context does not limit the candidate layer search to moves linked to the actual manufacturing order specified on the unbuild form.

So despite us unbuilding the second MO in step 6, the valuation from the first MO's SVL is used.

The reason we get the correct `unit_cost` despite using the wrong layer is due to commit: 84dda96
Prior to which, the valuation would have correctly zeroed out but there would have still been this valuation mis-match behind the scenes.

**Fix:**
Constrain the fifo candidate layer search to finished moves from the unbuilt production (if actuallywhen `_action_confirm`ing unbuild moves.

opw-4416350