### PR TITLE
[FIX] html_editor: prevent non-deterministic fail due to link popover

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -136,7 +136,7 @@ export class LinkPlugin extends Plugin {
         "color",
     ];
     // @phoenix @todo: do we want to have createLink and insertLink methods in link plugin?
-    static shared = ["createLink", "insertLink", "getPathAsUrlCommand"];
+    static shared = ["createLink", "insertLink", "getPathAsUrlCommand", "closeOverlay"];
     resources = {
         user_commands: [
             {
@@ -748,6 +748,10 @@ export class LinkPlugin extends Plugin {
         blockToSplit = targetNode;
         splitOrLineBreakCallback({ ...params, targetNode, targetOffset, blockToSplit });
         return true;
+    }
+
+    closeOverlay() {
+        this.overlay?.close();
     }
 }
 

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -422,10 +422,10 @@ describe("Selection collapsed", () => {
 
         async function splitBlockA(editor) {
             // splitBlock in an <a> tag will open the linkPopover which will take the focus.
-            // So we need to put the selection back into the editor
+            // So we need to close it and put the selection back into the editor
             splitBlock(editor);
+            editor.shared.link.closeOverlay();
             editor.shared.selection.focusEditable();
-            await tick();
         }
 
         // @todo: re-evaluate this possibly outdated comment:
@@ -460,7 +460,7 @@ describe("Selection collapsed", () => {
             });
         });
 
-        test("should insert a paragraph break outside the starting edge of an anchor", async () => {
+        test("should insert a paragraph break outside the starting edge of an anchor at start of block", async () => {
             await testEditor({
                 contentBefore: "<p><a>[]ab</a></p>",
                 stepFunction: splitBlockA,
@@ -468,6 +468,8 @@ describe("Selection collapsed", () => {
                     '<p><br></p><p>\ufeff<a class="o_link_in_selection">\ufeff[]ab\ufeff</a>\ufeff</p>',
                 contentAfter: "<p><br></p><p><a>[]ab</a></p>",
             });
+        });
+        test("should insert a paragraph break outside the starting edge of an anchor after some text", async () => {
             await testEditor({
                 contentBefore: "<p>ab<a>[]cd</a></p>",
                 stepFunction: splitBlockA,


### PR DESCRIPTION
Some tests end with the selection in a link, leading the link popover to open, which blurs the editable element. To prevent that, we would focus the editable by force, then wait a tick. But when the CPU is slow, sometimes the focus into the link popover happens too late to redirect it. This closes the popover by force before focusing the editable so it can't steal the focus again.

runbot-112609

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
