### PR TITLE
[IMP] web, tools: namespace webclient translations 

### DIFF
--- a/addons/web/static/src/core/l10n/localization_service.js
+++ b/addons/web/static/src/core/l10n/localization_service.js
@@ -44,12 +44,12 @@ export const localizationService = {
             multi_lang: multiLang,
         } = await response.json();
 
-        // FIXME We flatten the result of the python route.
         // Eventually, we want a new python route to return directly the good result.
         const terms = {};
         for (const addon of Object.keys(modules)) {
+            terms[addon] ??= {};
             for (const message of modules[addon].messages) {
-                terms[message.id] = message.string;
+                terms[addon][message.id] = message.string;
             }
         }
 

--- a/addons/web/static/src/core/template_inheritance.js
+++ b/addons/web/static/src/core/template_inheritance.js
@@ -58,7 +58,7 @@ function getXpath(operation) {
             const templateName = parent.getAttribute("t-name") || parent.getAttribute("t-inherit");
             console.warn(
                 `Error-prone use of @class in template "${templateName}" (or one of its inheritors).` +
-                " Use the hasclass(*classes) function to filter elements by their classes"
+                    " Use the hasclass(*classes) function to filter elements by their classes"
             );
         }
     }

--- a/addons/web/static/src/core/template_inheritance.js
+++ b/addons/web/static/src/core/template_inheritance.js
@@ -20,15 +20,9 @@ function addBefore(target, operation) {
     if (previousSibling?.nodeType === Node.TEXT_NODE) {
         const [text1, text2] = previousSibling.data.split(RSTRIP_REGEXP);
         previousSibling.data = text1.trimEnd();
-        if (nodes[0].nodeType === Node.TEXT_NODE) {
-            mergeTextNodes(previousSibling, nodes[0]);
-        }
         if (text2 && nodes.some((n) => n.nodeType !== Node.TEXT_NODE)) {
             const textNode = document.createTextNode(text2);
             target.before(textNode);
-            if (textNode.previousSibling.nodeType === Node.TEXT_NODE) {
-                mergeTextNodes(textNode.previousSibling, textNode);
-            }
         }
     }
 }
@@ -142,16 +136,6 @@ function getNodes(element, operation) {
     return nodes;
 }
 
-/**
- * @param {Text} first
- * @param {Text} second
- * @param {boolean} [trimEnd=true]
- */
-function mergeTextNodes(first, second, trimEnd = true) {
-    first.data = (trimEnd ? first.data.trimEnd() : first.data) + second.data;
-    second.remove();
-}
-
 function splitAndTrim(str, separator) {
     return str.split(separator).map((s) => s.trim());
 }
@@ -201,12 +185,12 @@ function modifyAttributes(target, operation) {
 function removeNode(node) {
     const { nextSibling, previousSibling } = node;
     node.remove();
-    if (nextSibling?.nodeType === Node.TEXT_NODE && previousSibling?.nodeType === Node.TEXT_NODE) {
-        mergeTextNodes(
-            previousSibling,
-            nextSibling,
-            previousSibling.parentElement.firstChild === previousSibling
-        );
+    if (
+        nextSibling?.nodeType === Node.TEXT_NODE &&
+        previousSibling?.nodeType === Node.TEXT_NODE &&
+        previousSibling.parentElement.firstChild === previousSibling
+    ) {
+        previousSibling.data = previousSibling.data.trimEnd();
     }
 }
 

--- a/addons/web/static/src/core/templates.js
+++ b/addons/web/static/src/core/templates.js
@@ -1,4 +1,4 @@
-import { applyInheritance } from "@web/core/template_inheritance";
+import { applyContextToTextNode, applyInheritance } from "@web/core/template_inheritance";
 
 const parser = new DOMParser();
 /** @type {((document: Document) => void)[]} */
@@ -93,6 +93,11 @@ function _getTemplate(name, blockId = null) {
         }
         const templateString = templates[name];
         parsedTemplates[name] = getParsedTemplate(templateString);
+        const inheritFrom = parsedTemplates[name].getAttribute("t-inherit");
+        if (!inheritFrom) {
+            const addon = info[name].url.split("/")[1];
+            parsedTemplates[name].setAttribute("t-translation-context", addon);
+        }
     }
     let processedTemplate = parsedTemplates[name];
 
@@ -158,6 +163,7 @@ let processedTemplates = {};
 export function getTemplate(name) {
     if (!processedTemplates[name]) {
         processedTemplates[name] = _getTemplate(name);
+        applyContextToTextNode();
     }
     return processedTemplates[name];
 }

--- a/addons/web/static/src/env.js
+++ b/addons/web/static/src/env.js
@@ -2,7 +2,7 @@ import { App, EventBus } from "@odoo/owl";
 import { SERVICES_METADATA } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 import { getTemplate } from "@web/core/templates";
-import { _t } from "@web/core/l10n/translation";
+import { __namespacedGettext as _translateFn } from "@web/core/l10n/translation";
 import { session } from "@web/session";
 import { isMacOS } from "@web/core/browser/feature_detection";
 
@@ -15,7 +15,6 @@ import { isMacOS } from "@web/core/browser/feature_detection";
  * @property {import("services").Services} services
  * @property {EventBus} bus
  * @property {string} debug
- * @property {(str: string) => string} _t
  * @property {boolean} [isSmall]
  */
 
@@ -237,7 +236,9 @@ export async function mountComponent(component, target, appConfig = {}) {
         warnIfNoStaticProps: !session.test_mode,
         name: component.constructor.name,
         translatableAttributes: ["data-tooltip"],
-        translateFn: _t,
+        translateFn(str, ctx) {
+            return _translateFn(ctx, str);
+        },
         customDirectives,
         globalValues,
         ...appConfig,


### PR DESCRIPTION
# [IMP] web, tools: namespace webclient translations
## Before this commit:
Client-side translations are loaded into a big dictionary in RAM, where the key is the source term and the value is the translation.

This design is problematic because it doesn't allow a same term to have different translations in different modules: since there is only one entry per term, they would overwrite each other.

Practical example: "Bar" in the context of pos_restaurant is a place where you serve drinks, while "Bar" in the context of spreadsheets is a completely different thing. In French, they should be translated differently: "Bar" for the former, "Barre" for the latter.

## After this commit:
An additional level of depth is added at the top of the translation dictionary, corresponding to the name of the module it comes from, so that translations are now retrieved like this: `translations[module][terms]`.

This allows the same term to be translated differently in different modules. It also mirrors the namespacing mechanism applied to translation on the server side.

> [!NOTE]  
> Providing multiple translations for the same term *within* the same module is still not possible.

> [!CAUTION]
> Since translation no longer leaks between modules, if a translation is undefined in module A but defined in module B, module A won't benefit from the translation from module B.

task-4457503
opw-4407750
opw-4300506
opw-4455322
opw-4017059
opw-4611936