### PR TITLE
[IMP] website, *: add configurator pages inside new page templates

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -720,7 +720,10 @@ class Website(Home):
                 continue
             for template in View.search([
                 ('mode', '=', 'primary'),
+                '|',
                 ('key', 'like', escape_psql(f'new_page_template_sections_{group["id"]}_')),
+                ('key', 'like', f'configurator_pages_{group["id"]}'),
+                request.website.website_domain(),
             ], order='key'):
                 try:
                     html_tree = html.fromstring(View.with_context(inherit_branding=False)._render_template(
@@ -741,6 +744,7 @@ class Website(Home):
                     group['templates'].append({
                         'key': template.key,
                         'template': html.tostring(html_tree),
+                        'is_from_configurator': 'configurator_pages' in template.key,
                     })
                 except Exception as error:
                     if hasattr(error, 'qweb'):

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -939,7 +939,7 @@ class Website(models.Model):
             return replacement
 
         # Configure the pages
-        for page_code in requested_pages:
+        for index, page_code in enumerate(requested_pages):
             snippet_list = configurator_snippets.get(page_code, [])
             if page_code == 'homepage':
                 page_view_id = self.with_context(website_id=website.id).viewref('website.homepage')
@@ -983,6 +983,11 @@ class Website(models.Model):
                     logger.warning(e)
             page_view_id.save(value=f'<div class="oe_structure">{"".join(rendered_snippets)}</div>',
                               xpath="(//div[hasclass('oe_structure')])[last()]")
+            # Copy the configurator pages to preserve the original untouched
+            # pages in the landing page category when creating a new page.
+            page_view_id.copy({
+                'key': f"{index}_{page_view_id.key}_configurator_pages_landing",
+            })
 
         # Configure the images
         images = custom_resources.get('images', {})

--- a/addons/website/static/src/components/dialog/add_page_dialog.xml
+++ b/addons/website/static/src/components/dialog/add_page_dialog.xml
@@ -19,7 +19,7 @@
 </t>
 
 <t t-name="website.AddPageTemplatePreviewWrapper">
-    <div t-ref="holder" class="o_page_template position-relative placeholder-glow mx-auto transition-base" t-att-class="{ 'mt-4': !props.firstRow }">
+    <div t-ref="holder" class="o_page_template position-relative placeholder-glow mx-auto transition-base" t-att-class="{ 'mt-4': !props.firstRow }" t-att-data-configurator-page="props.template and props.template.is_from_configurator">
         <div t-ref="preview" class="o_page_template_preview border border-white bg-white rounded" t-out="0" inert="inert"/>
         <span class="placeholder position-absolute top-0 w-100 h-100 rounded" t-attf-style="animation-duration: #{props.animationDelay + 500}ms"/>
         <button class="btn o_button_area position-absolute top-0 w-100 h-100 start-0 cursor-pointer rounded" t-on-click="select">

--- a/addons/website/static/tests/tours/configurator_translation.js
+++ b/addons/website/static/tests/tours/configurator_translation.js
@@ -3,70 +3,84 @@ import { translatedTermsGlobal } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { clickOnEditAndWaitEditMode } from "@website/js/tours/tour_utils";
 
+function runConfiguratorFlow(industrySearchText, featureOrPageName) {
+    return [
+        // Configurator first screen
+        {
+            content: "Click next",
+            trigger: "button.o_configurator_show",
+            run: "click",
+        },
+        // Make sure "Back" works
+        {
+            content: "Use browser's Back",
+            trigger: "button.o_change_website_type",
+            run() {
+                window.history.back();
+            },
+        },
+        {
+            content: "Return to description screen",
+            trigger: "button.o_configurator_show",
+            run: "click",
+        },
+        // Description screen
+        {
+            content: "Select a website type",
+            trigger: "button.o_change_website_type",
+            run: "click",
+        },
+        {
+            content: "Insert a website industry",
+            trigger: ".o_configurator_industry input",
+            run: "edit ab",
+        },
+        {
+            content: "Select a website industry from the autocomplete",
+            trigger: `.o_configurator_industry_wrapper ul li a:contains(${industrySearchText})`,
+            run: "click",
+        },
+        {
+            content: "Choose from the objective list",
+            trigger: "button.o_change_website_purpose",
+            run: "click",
+        },
+        // Palette screen
+        {
+            content: "Choose a palette card",
+            trigger: ".palette_card",
+            run: "click",
+        },
+        // Features screen
+        {
+            content: "Select feature or page",
+            trigger: `.card:contains(${featureOrPageName})`,
+            run: "click",
+        },
+        {
+            id: "build_website",
+            content: "Click on build my website",
+            trigger: "button.btn-primary",
+            run: "click",
+        },
+        {
+            content: "Loader should be shown",
+            trigger: ".o_website_loader_container",
+            expectUnloadPage: true,
+        },
+        {
+            content: "Wait until the configurator is finished",
+            trigger: ":iframe [data-view-xmlid='website.homepage']",
+            timeout: 30000,
+        },
+    ];
+}
+
 registry.category("web_tour.tours").add('configurator_translation', {
     url: '/website/configurator',
     steps: () => [
-    // Configurator first screen
+    ...runConfiguratorFlow("in fr", "Parseltongue_privacy"),
     {
-        content: "click next",
-        trigger: 'button.o_configurator_show',
-        run: "click",
-    },
-    // Make sure "Back" works
-    {
-        content: "use browser's Back",
-        trigger: 'button.o_change_website_type',
-        run() {
-            window.history.back();
-        },
-    }, {
-        content: "return to description screen",
-        trigger: 'button.o_configurator_show',
-        run: "click",
-    },
-    // Description screen
-    {
-        content: "select a website type",
-        trigger: 'button.o_change_website_type',
-        run: "click",
-    }, {
-        content: "insert a website industry",
-        trigger: '.o_configurator_industry input',
-        run: "edit ab",
-    }, {
-        content: "select a website industry from the autocomplete",
-        trigger: '.o_configurator_industry_wrapper ul li a:contains("in fr")',
-        run: "click",
-    }, {
-        content: "choose from the objective list",
-        trigger: 'button.o_change_website_purpose',
-        run: "click",
-    },
-    // Palette screen
-    {
-        content: "chose a palette card",
-        trigger: '.palette_card',
-        run: "click",
-    },
-    // Features screen
-    {
-        content: "select confidentialité",
-        trigger: '.card:contains(Parseltongue_privacy)',
-        run: "click",
-    }, {
-        id: "build_website",
-        content: "Click on build my website",
-        trigger: 'button.btn-primary',
-        run: "click",
-    }, {
-        content: "Loader should be shown",
-        trigger: ".o_website_loader_container",
-        expectUnloadPage: true,
-    }, {
-        content: "Wait until the configurator is finished",
-        trigger: ":iframe [data-view-xmlid='website.homepage']",
-        timeout: 30000,
-    }, {
         content: "Check if the current interface language is active and monkey patch terms",
         trigger: "body",
         run() {
@@ -90,3 +104,39 @@ registry.category("web_tour.tours").add('configurator_translation', {
          trigger: ':iframe #wrapwrap:not(.odoo-editor-editable)',
     }
 ]});
+
+registry.category("web_tour.tours").add("configurator_page_creation", {
+    url: "/website/configurator",
+    steps: () => [
+        ...runConfiguratorFlow("abbey", "Pricing"),
+        // Verify configurator page templates exist in landing pages category.
+        {
+            content: "Open create content menu",
+            trigger: ".o_new_content_container button",
+            run: "click",
+        },
+        {
+            content: "Create a new page",
+            trigger: "button[title='New Page']",
+            run: "click",
+        },
+        {
+            content: "Click on landing pages category",
+            trigger: "[data-id='landing']",
+            run: "click",
+        },
+        {
+            content: "Check if configurator pages exist",
+            trigger: "[data-id='landing'] .o_page_template[data-configurator-page]",
+        },
+        {
+            content: "Configurator pages should appear at the start of the landing category",
+            trigger: "[data-id='landing'] .row > :first-child .o_page_template:first-of-type[data-configurator-page]",
+        },
+        {
+            content: "Exit dialog",
+            trigger: ".modal-header .btn-close",
+            run: "click",
+        },
+    ],
+});

--- a/addons/website/tests/test_configurator.py
+++ b/addons/website/tests/test_configurator.py
@@ -96,6 +96,11 @@ class TestConfigurator(TestConfiguratorCommon):
     def test_configurator_params_step(self):
         self.start_tour('/website/configurator/3', 'configurator_params_step', login='admin')
 
+    def test_configurator_page_creation(self):
+        website = self.env['website'].create({
+            'name': "New website",
+        })
+        self.start_tour('/website/force/%s?path=%%2Fwebsite%%2Fconfigurator' % website.id, 'configurator_page_creation', login='admin')
 
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestConfiguratorTranslation(TestConfiguratorCommon):

--- a/addons/website_sale/static/tests/tours/configurator_translation.js
+++ b/addons/website_sale/static/tests/tours/configurator_translation.js
@@ -30,3 +30,29 @@ patch(registry.category('web_tour.tours').get('configurator_translation'), {
     },
 
 });
+/*
+ * @override of website tour to include eCommerce configuration steps
+ */
+patch(registry.category("web_tour.tours").get("configurator_page_creation"), {
+    steps() {
+        const originalSteps = super.steps();
+        const websiteBuildStepIndex = originalSteps.findIndex(
+            (step) => step.id === "build_website"
+        );
+        originalSteps.splice(
+            websiteBuildStepIndex + 1,
+            0,
+            {
+                content: "Choose a shop page style",
+                trigger: ".o_configurator_screen:contains('online catalog') .button_area",
+                run: "click",
+            },
+            {
+                content: "Choose a product page style",
+                trigger: ".o_configurator_screen:contains('product page') .button_area",
+                run: "click",
+            }
+        );
+        return originalSteps;
+    },
+});


### PR DESCRIPTION
*=website_sale

**Purpose:**
During the website configurator flow, users select specific pages they want to include on their site. Previously, there was no way to reuse those pages after the initial setup. This PR adds the ability to reuse selected configurator pages by showing them as templates under the Landing Pages category in the “New Page” dialog. These pages are displayed in their original, untouched form to ensure consistent reuse.

**Key Changes:**
1. In `configurator_apply`, Create a copy of selected pages to preserve originals, so they remain reusable even if the user modifies them.
2. In `get_new_page_templates`, include copied configurator page keys so they appear under the landing category as selectable templates.

This improves the reusability of configurator pages.

task-4252670