### PR TITLE
[FIX] html_editor: prevent non-deterministic fail due to link popover

### DIFF
--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -1,11 +1,12 @@
 import { describe, test } from "@odoo/hoot";
-import { press } from "@odoo/hoot-dom";
+import { press, waitFor } from "@odoo/hoot-dom";
 import { tick } from "@odoo/hoot-mock";
 import { testEditor } from "../_helpers/editor";
 import { insertText, splitBlock } from "../_helpers/user_actions";
 import { unformat } from "../_helpers/format";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { QWebPlugin } from "@html_editor/others/qweb_plugin";
+import { findInSelection } from "@html_editor/utils/selection";
 
 describe("Selection collapsed", () => {
     describe("Basic", () => {
@@ -422,10 +423,13 @@ describe("Selection collapsed", () => {
 
         async function splitBlockA(editor) {
             // splitBlock in an <a> tag will open the linkPopover which will take the focus.
-            // So we need to put the selection back into the editor
+            // So we need to wait for it to open and put the selection back into the editor.
             splitBlock(editor);
+            const editableSelection = editor.shared.selection.getSelectionData().editableSelection;
+            if (findInSelection(editableSelection, "a:not([href])")) {
+                await waitFor(".o-we-linkpopover");
+            }
             editor.shared.selection.focusEditable();
-            await tick();
         }
 
         // @todo: re-evaluate this possibly outdated comment:
@@ -460,7 +464,7 @@ describe("Selection collapsed", () => {
             });
         });
 
-        test("should insert a paragraph break outside the starting edge of an anchor", async () => {
+        test("should insert a paragraph break outside the starting edge of an anchor at start of block", async () => {
             await testEditor({
                 contentBefore: "<p><a>[]ab</a></p>",
                 stepFunction: splitBlockA,
@@ -468,6 +472,8 @@ describe("Selection collapsed", () => {
                     '<p><br></p><p>\ufeff<a class="o_link_in_selection">\ufeff[]ab\ufeff</a>\ufeff</p>',
                 contentAfter: "<p><br></p><p><a>[]ab</a></p>",
             });
+        });
+        test("should insert a paragraph break outside the starting edge of an anchor after some text", async () => {
             await testEditor({
                 contentBefore: "<p>ab<a>[]cd</a></p>",
                 stepFunction: splitBlockA,


### PR DESCRIPTION
Some tests end with the selection in a link, leading the link popover to open, which blurs the editable element. To prevent that, we would focus the editable by force, then wait a tick. But when the CPU is slow, sometimes the focus into the link popover happens too late to redirect it. This waits for the popover to open before focusing the editable.

runbot-112609

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
