### PR TITLE
[FIX] mail: change landlineNumber field name and fix related issues.

### DIFF
--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -44,7 +44,7 @@ export class Persona extends Record {
     /** @type {boolean | undefined} */
     is_company;
     /** @type {string} */
-    landlineNumber;
+    phone;
     debouncedSetImStatus;
     storeAsTrackedImStatus = Record.one("Store", {
         /** @this {import("models").Persona} */
@@ -101,13 +101,6 @@ export class Persona extends Record {
     /** @type {luxon.DateTime} */
     write_date = Record.attr(undefined, { type: "datetime" });
     group_ids = Record.many("res.groups", { inverse: "personas" });
-
-    /**
-     * @returns {boolean}
-     */
-    get hasPhoneNumber() {
-        return Boolean(this.landlineNumber);
-    }
 
     get emailWithoutDomain() {
         return this.email.substring(0, this.email.lastIndexOf("@"));


### PR DESCRIPTION
This commit fixes the naming of the `landlineNumber` field. Previously,
this field was referred to as the `phone` field. This commit changes
its name to `phoneNumber`. Also, we had a `mobile` field that was
removed in this PR: https://github.com/odoo/odoo/pull/189739 and it
resulted in a bug in the `mobileNumber` getter in
`correspondence_details.js` as it was retrieving a `phoneNumber`
attribute from the `partner` model. In contrast, it doesn't have
this attribute.

Enterprise: https://github.com/odoo/enterprise/pull/78996
