### PR TITLE
[IMP] point_of_sale: disable load order button when no selected order

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -104,7 +104,10 @@
                     </div>
                     <div class="switchpane d-flex w-100 gap-2 p-2 mt-2" t-if="ui.isSmall">
                         <t t-set="_selectedSyncedOrder" t-value="getSelectedOrder()" />
-                        <button class="btn-switchpane load-order-button primary btn btn-primary btn-lg lh-lg w-50 py-3" t-if="!isOrderSynced" t-on-click="() => this._setOrder(_selectedSyncedOrder)">
+                        <button class="btn-switchpane load-order-button primary btn btn-primary btn-lg lh-lg w-50 py-3"
+                            t-att-disabled="!_selectedSyncedOrder"
+                            t-if="!isOrderSynced"
+                            t-on-click="() => this._setOrder(_selectedSyncedOrder)">
                             <span class="d-block">Load Order</span>
                         </button>
                         <button class="btn-switchpane btn btn-lg lh-lg w-50 py-3 secondary review-button" t-att-class="{'btn-primary': isOrderSynced, 'btn-light': !isOrderSynced}" t-on-click="switchPane">
@@ -172,7 +175,9 @@
                             </t>
                             <div t-else="" class="pads border-top d-flex gap-2" >
                                 <BackButton onClick="() => pos.onClickBackButton()"/>
-                                <button class="button validation load-order-button w-100 btn btn-lg btn-primary py-3" t-on-click="() => this._setOrder(_selectedSyncedOrder)">
+                                <button class="button validation load-order-button w-100 btn btn-lg btn-primary py-3"
+                                    t-att-disabled="!_selectedSyncedOrder"
+                                    t-on-click="() => this._setOrder(_selectedSyncedOrder)">
                                     <span class="d-block">Load Order</span>
                                 </button>
                             </div>


### PR DESCRIPTION
Before it was possible to click on "load order" button even when there was no selected order. This commit disables the button when there is no selected order.

taskId: 4562723


