### PR TITLE
[FIX] point_of_sale, pos_restaurant: fix random error in test

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1716,7 +1716,7 @@ export class PosStore extends Reactive {
         }
     }
 
-    async printReceipts(order, printer, title, lines, fullReceipt = false, diningModeUpdate) {
+    async getRenderedReceipt(order, title, lines, fullReceipt = false, diningModeUpdate) {
         let time;
         if (order.write_date) {
             time = order.write_date?.split(" ")[1].split(":");
@@ -1740,6 +1740,18 @@ export class PosStore extends Reactive {
             changedlines: lines,
             fullReceipt: fullReceipt,
         });
+
+        return receipt;
+    }
+
+    async printReceipts(order, printer, title, lines, fullReceipt = false, diningModeUpdate) {
+        const receipt = await this.getRenderedReceipt(
+            order,
+            title,
+            lines,
+            fullReceipt,
+            diningModeUpdate
+        );
         const result = await printer.printReceipt(receipt);
         return result.successful;
     }


### PR DESCRIPTION
The `PreparationPrinterContent` test was checking if the preparation receipt was containing a specific string. But the check was performed on the `.render-container` which is generated for printing and erased just after. That was causing a random error in the test.

Now we call internal `pos_store` method that generate the receipt content and we check if the string is present in the content.

runbot error id: 114884
