### PR TITLE
[FIX] im_livechat: do not create new thread when posting from frontend

### DIFF
--- a/addons/im_livechat/static/src/embed/common/attachment_upload_service_patch.js
+++ b/addons/im_livechat/static/src/embed/common/attachment_upload_service_patch.js
@@ -4,7 +4,7 @@ import { patch } from "@web/core/utils/patch";
 
 patch(AttachmentUploadService.prototype, {
     async upload(thread, composer, file, options) {
-        if (thread.channel_type === "livechat") {
+        if (thread.channel_type === "livechat" && thread.isTransient) {
             thread = await this.env.services["im_livechat.livechat"].persist();
             composer = thread.composer;
             if (!thread) {

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -96,6 +96,14 @@ export class LivechatService {
         }
         if (this.state === SESSION_STATE.PERSISTED) {
             await this.busService.addChannel(`mail.guest_${this.guestToken}`);
+        } else {
+            this.store.chatHub.preFirstFetchPromise.then(() => {
+                if (!this.store.fetchParams.length) {
+                    return;
+                }
+                this.store.initialize({ force: true });
+                this.store.env.services.bus_service.start();
+            });
         }
         this.initialized = true;
         this.env.services["im_livechat.initialized"].ready.resolve();
@@ -118,7 +126,7 @@ export class LivechatService {
      * @returns {Promise<import("models").Thread|undefined>}
      */
     async persist() {
-        if (this.state === SESSION_STATE.PERSISTED) {
+        if (this.thread && !this.thread.isTransient) {
             return this.thread;
         }
         const temporaryThread = this.thread;

--- a/addons/im_livechat/static/src/embed/common/message_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/message_model_patch.js
@@ -2,7 +2,6 @@ import { Message } from "@mail/core/common/message_model";
 import { Record } from "@mail/core/common/record";
 
 import { patch } from "@web/core/utils/patch";
-import { SESSION_STATE } from "./livechat_service";
 
 /** @type {import("models").Message} */
 const messagePatch = {
@@ -13,8 +12,7 @@ const messagePatch = {
     canAddReaction(thread) {
         return (
             super.canAddReaction(thread) &&
-            (thread?.channel_type !== "livechat" ||
-                this.store.env.services["im_livechat.livechat"].state === SESSION_STATE.PERSISTED)
+            (thread?.channel_type !== "livechat" || !thread.isTransient)
         );
     },
     canReplyTo(thread) {

--- a/addons/im_livechat/static/src/embed/common/store_service_patch.js
+++ b/addons/im_livechat/static/src/embed/common/store_service_patch.js
@@ -7,11 +7,11 @@ import { patch } from "@web/core/utils/patch";
 storeService.dependencies.push("im_livechat.initialized");
 
 patch(Store.prototype, {
-    async initialize() {
+    async initialize({ force } = {}) {
         const livechatInitialized = this.env.services["im_livechat.initialized"];
         await livechatInitialized.ready;
         const livechatService = this.env.services["im_livechat.livechat"];
-        if (livechatService.state === SESSION_STATE.PERSISTED) {
+        if (livechatService.state === SESSION_STATE.PERSISTED || force) {
             try {
                 await super.initialize();
                 livechatService.thread ??= this.store.Thread.get({

--- a/addons/im_livechat/static/src/embed/common/thread_actions.js
+++ b/addons/im_livechat/static/src/embed/common/thread_actions.js
@@ -1,5 +1,3 @@
-import { SESSION_STATE } from "@im_livechat/embed/common/livechat_service";
-
 import { threadActionsRegistry } from "@mail/core/common/thread_actions";
 import "@mail/discuss/call/common/thread_actions";
 import { useComponent } from "@odoo/owl";
@@ -28,10 +26,7 @@ patch(callSettingsAction, {
         if (component.thread?.channel_type !== "livechat") {
             return super.condition(...arguments);
         }
-        return (
-            component.livechatService.state === SESSION_STATE.PERSISTED &&
-            component.rtcService.state.channel?.eq(component.thread)
-        );
+        return component.rtcService.state.channel?.eq(component.thread);
     },
     setup() {
         super.setup(...arguments);

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -3,7 +3,6 @@ import { Thread } from "@mail/core/common/thread_model";
 import "@mail/discuss/core/common/thread_model_patch";
 
 import { patch } from "@web/core/utils/patch";
-import { SESSION_STATE } from "./livechat_service";
 import { _t } from "@web/core/l10n/translation";
 
 /** @type {typeof Thread} */
@@ -88,10 +87,7 @@ patch(Thread.prototype, {
     },
     /** @returns {Promise<import("models").Message} */
     async post() {
-        if (
-            this.channel_type === "livechat" &&
-            this.store.env.services["im_livechat.livechat"].state !== SESSION_STATE.PERSISTED
-        ) {
+        if (this.channel_type === "livechat" && this.isTransient) {
             const thread = await this.store.env.services["im_livechat.livechat"].persist();
             if (!thread) {
                 return;

--- a/addons/im_livechat/static/tests/embed/livechat_service.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service.test.js
@@ -19,6 +19,7 @@ import {
     asyncStep,
     Command,
     mountWithCleanup,
+    onRpc,
     serverState,
     waitForSteps,
 } from "@web/../tests/web_test_helpers";
@@ -145,4 +146,31 @@ test("Only necessary requests are made when creating a new chat", async () => {
             thread_model: "discuss.channel",
         })}`,
     ]);
+});
+
+test("do not create new thread when operator answers to visitor", async () => {
+    const pyEnv = await startServer();
+    const livechatChannelId = await loadDefaultEmbedConfig();
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
+    onRpc("/im_livechat/get_session", async () => asyncStep("/im_livechat/get_session"));
+    onRpc("/mail/message/post", async () => asyncStep("/mail/message/post"));
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ guest_id: guestId }),
+        ],
+        channel_type: "livechat",
+        livechat_active: true,
+        livechat_channel_id: livechatChannelId,
+        livechat_operator_id: serverState.partnerId,
+        create_uid: serverState.publicUserId,
+    });
+    setupChatHub({ opened: [channelId] });
+    await start({
+        authenticateAs: pyEnv["res.users"].search_read([["id", "=", serverState.userId]])[0],
+    });
+    await insertText(".o-mail-Composer-input", "Hello!");
+    await triggerHotkey("Enter");
+    await contains(".o-mail-Message", { text: "Hello!" });
+    await waitForSteps(["/mail/message/post"]);
 });

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -51,6 +51,7 @@ export class ChatHub extends Record {
     /** From top to bottom. Bottom-most will actually be hidden */
     folded = Record.many("ChatWindow", { inverse: "hubAsFolded" });
     initPromise = new Deferred();
+    preFirstFetchPromise = new Deferred();
     loadMutex = new Mutex();
 
     async closeAll() {
@@ -80,6 +81,7 @@ export class ChatHub extends Record {
         const getThread = (data) => this.store.Thread.getOrFetch(data, ["display_name"]);
         const openPromises = opened.map(getThread);
         const foldPromises = folded.map(getThread);
+        this.preFirstFetchPromise.resolve();
         const foldThreads = await Promise.all(foldPromises);
         const openThreads = await Promise.all(openPromises);
         /** @param {import("models").Thread[]} threads */


### PR DESCRIPTION
Before this PR, when an operator answered from the frontend, a new channel was created.

This occurs because we ensure the thread is created before posting the message. However, this condition relies on the live chat service state which is not initialized in this case (the thread was created by the visitor, not the operator).

This PR fixes this condition.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
