### PR TITLE
[FIX] spreadsheet: Ensure display name is loaded when setting filter …

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
@@ -3,6 +3,7 @@
 import { RecordsSelector } from "../records_selector/records_selector";
 import { RELATIVE_DATE_RANGE_TYPES } from "@spreadsheet/helpers/constants";
 import { DateFilterValue } from "../filter_date_value/filter_date_value";
+import { useService } from "@web/core/utils/hooks";
 
 const { Component } = owl;
 
@@ -10,6 +11,7 @@ export class FilterValue extends Component {
     setup() {
         this.getters = this.props.model.getters;
         this.relativeDateRangesTypes = RELATIVE_DATE_RANGE_TYPES;
+        this.orm = useService("orm");
     }
     onDateInput(id, value) {
         this.props.model.dispatch("SET_GLOBAL_FILTER_VALUE", { id, value });
@@ -19,11 +21,19 @@ export class FilterValue extends Component {
         this.props.model.dispatch("SET_GLOBAL_FILTER_VALUE", { id, value });
     }
 
-    onTagSelected(id, values) {
+    async onTagSelected(id, values) {
+        let records = values;
+        if (values.some((record) => record.display_name === undefined)) {
+            ({ records } = await this.orm.webSearchRead(
+                this.props.filter.modelName,
+                [["id", "in", values.map((record) => record.id)]],
+                ["display_name"]
+            ));
+        }
         this.props.model.dispatch("SET_GLOBAL_FILTER_VALUE", {
             id,
-            value: values.map((record) => record.id),
-            displayNames: values.map((record) => record.display_name),
+            value: records.map((record) => record.id),
+            displayNames: records.map((record) => record.display_name),
         });
     }
 


### PR DESCRIPTION
…value

Currently, the display name of a record is not loaded in the Records selector when we invoke the 'search more' list view and is fetched from the server after the callback to the component `FilterValue` which means that the latter only receives a list of ids and undefined display names which ultimately means that we set "undefined" as a global filter value.

Note that this was patched later with the introduction of the service `name`.

Task-4564737
OPW-4482365

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
