### PR TITLE
[FIX] payment_stripe: connect to Stripe as a company

### DIFF
--- a/addons/payment_stripe/models/payment_provider.py
+++ b/addons/payment_stripe/models/payment_provider.py
@@ -333,7 +333,7 @@ class PaymentProvider(models.Model):
                 self.company_id.country_id.code, self.company_id.country_id.code
             ),
             'email': self.company_id.email,
-            'business_type': 'individual',
+            'business_type': 'company',
             'company[address][city]': self.company_id.city or '',
             'company[address][country]': const.COUNTRY_MAPPING.get(
                 self.company_id.country_id.code, self.company_id.country_id.code or ''
@@ -343,15 +343,6 @@ class PaymentProvider(models.Model):
             'company[address][postal_code]': self.company_id.zip or '',
             'company[address][state]': self.company_id.state_id.name or '',
             'company[name]': self.company_id.name,
-            'individual[address][city]': self.company_id.city or '',
-            'individual[address][country]': const.COUNTRY_MAPPING.get(
-                self.company_id.country_id.code, self.company_id.country_id.code or ''
-            ),
-            'individual[address][line1]': self.company_id.street or '',
-            'individual[address][line2]': self.company_id.street2 or '',
-            'individual[address][postal_code]': self.company_id.zip or '',
-            'individual[address][state]': self.company_id.state_id.name or '',
-            'individual[email]': self.company_id.email or '',
             'business_profile[name]': self.company_id.name,
         }
 


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Set up a company located in United Arab Emirates;
2. go to Payment Providers / Stripe;
3. click the Connect Stripe button;

Issue
-----
> **Validation Error**
> Stripe Proxy error: an error occurred while setting up your Stripe account.
> Stripe gave us the following information: 'individual' is not a supported business type in the country AE.

Cause
-----
The initial payload sent to Stripe to connect in live mode is with `business_type: individual`. This default works for most locales, but for some, e.g. `l10n_ae`, a "registered business" is required.

Solution
--------
Connect to Stripe using `business_type: company`.

This value can still be changed later _after_ entering live mode via `connect.stripe.com`.

opw-4545565