### PR TITLE
[FIX] pos_self_order: set table on multiple device

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -93,7 +93,7 @@ class PosOrder(models.Model):
             })
             pos_order = pos_order.with_company(pos_order.company_id)
         else:
-            pos_order = self.env['pos.order'].browse(order.get('id'))
+            pos_order = existing_order
 
             # Save lines and payments before to avoid exception if a line is deleted
             # when vals change the state to 'paid'

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -28,6 +28,9 @@ class PosSelfOrderController(http.Controller):
         if 'picking_type_id' in order:
             del order['picking_type_id']
 
+        if table:
+            order['table_id'] = table.id
+
         order['name'] = order_reference
         order['pos_reference'] = order_reference
         order['sequence_number'] = sequence_number
@@ -49,7 +52,8 @@ class PosSelfOrderController(http.Controller):
         })
 
         order_ids.send_table_count_notification(order_ids.mapped('table_id'))
-        return self._generate_return_values(order_ids, pos_config)
+        data = self._generate_return_values(order_ids, pos_config)
+        return data
 
     def _generate_return_values(self, order, config_id):
         return {

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -52,14 +52,6 @@ class PosOrder(models.Model):
 
         return super().sync_from_ui(orders)
 
-    def _get_open_order(self, order):
-        open_order = super()._get_open_order(order)
-        if not self.env.context.get('from_self'):
-            return open_order
-        elif open_order:
-            del order['table_id']
-        return self.env['pos.order'].search([('uuid', '=', order.get('uuid'))], limit=1)
-
     def _process_saved_order(self, draft):
         res = super()._process_saved_order(draft)
 


### PR DESCRIPTION
Table is not set on the second device that want to order on table X

Steps to reproduce:

1. Setting of the self : deliver on the table
2. Use 2 mobiles
3. The first mobile open mobile menu
4. make an order
5. The order appears on the right table
6. The second device do the same, open mobile menu
7. add items to the cart
8. click on order
9. it says that it's ready at the counter

task ID: 4489980





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
