### PR TITLE
[IMP] web: employee/manager feedback toggle tooltip

### DIFF
--- a/addons/web/static/src/views/fields/boolean_toggle/boolean_toggle_field.js
+++ b/addons/web/static/src/views/fields/boolean_toggle/boolean_toggle_field.js
@@ -14,6 +14,22 @@ export class BooleanToggleField extends BooleanField {
         const changes = { [this.props.name]: newValue };
         await this.props.record.update(changes, { save: this.props.autosave });
     }
+
+    get hasTooltip() {
+        return this.tooltipHelp;
+    }
+    get tooltipHelp() {
+        const field = this.props.record.fields[this.props.name];
+        let help =  field.help || "";
+        return help;
+    }
+    get tooltipInfo() {
+        return JSON.stringify({
+            field: {
+                help: this.tooltipHelp,
+            },
+        });
+    }
 }
 
 export const booleanToggleField = {

--- a/addons/web/static/src/views/fields/boolean_toggle/boolean_toggle_field.xml
+++ b/addons/web/static/src/views/fields/boolean_toggle/boolean_toggle_field.xml
@@ -8,6 +8,9 @@
         <xpath expr="//CheckBox" position="inside">
             &#8203; <!-- Zero width space needed to set height -->
         </xpath>
+        <xpath expr="//CheckBox" position="after">
+            <span class="text-info" t-if="hasTooltip" t-att="{'data-tooltip-template': 'web.FieldTooltip', 'data-tooltip-info': tooltipInfo, 'data-tooltip-touch-tap-to-show': 'true'}">?</span>
+        </xpath>
     </t>
 
 </templates>


### PR DESCRIPTION
The `help` parameter is used in the `employee_feedback_published` and `manager_feedback_published` fields to add a tooltip. The help message is extracted inside the `BooleanToggleField` component and used in its template. The `web.FieldTooltip` is used as a `data-tooltip-template`. The tooltip is visible only if the `help` parameter has a value."

task-4558176

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
