### PR TITLE
[FIX] account: only add journal info to chain after early_stop check

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3934,9 +3934,9 @@ class AccountMove(models.Model):
 
                 if not chain_info:
                     continue
-                chain_info['journal_restrict_mode'] = journal.restrict_mode_hash_table
                 if early_stop:
                     return True
+                chain_info['journal_restrict_mode'] = journal.restrict_mode_hash_table
 
                 if 'unreconciled' in chain_info['warnings']:
                     raise UserError(_("An error occurred when computing the inalterability. All entries have to be reconciled."))


### PR DESCRIPTION
**To reproduce:**
1. Check the field 'Secure Posted Entries with Hash' in a journal with existing entries
2. Immediately return to the Dashboard, before posting new entries
3. An error is raised

**Cause:**
In odoo/odoo#196748, the secured group usability was changed to only grant access to the new features relating to securing entries if moves from a journal without "Hash on Post" are secured.

However, if before any entries are hashed, either by posting a new move in a journal with 'Hash on Post' or using the 'Secure Entries' wizard, the user returns to the dashboard, an error is raised. This is due to _get_chains_to_hash() being called with early_stop = True, in which case chain_info is an int.

**Fix:**
The key 'journal_restrict_move', which information on whether the journal is 'Hash on Post' to chain_info, should only be added after the function returns True in case of early_stop. This avoids the item assignment on an int.

no-task


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
