### PR TITLE
[IMP] im_livechat, mail: view and search expertises in livechat invite

### DIFF
--- a/addons/im_livechat/models/res_partner.py
+++ b/addons/im_livechat/models/res_partner.py
@@ -4,13 +4,32 @@ from markupsafe import Markup
 
 from odoo import api, models, fields, _
 from odoo.addons.mail.tools.discuss import Store
-
+from odoo.fields import Domain
 
 class ResPartner(models.Model):
     """Update of res.partner class to take into account the livechat username."""
     _inherit = 'res.partner'
 
     user_livechat_username = fields.Char(compute='_compute_user_livechat_username')
+
+    def _get_search_for_channel_invite_term_domain(self, channel_id, search_term):
+        domain = super()._get_search_for_channel_invite_term_domain(channel_id, search_term)
+        if (channel_id and
+            self.env["discuss.channel"].search([
+                ("id", "=", int(channel_id)), ("channel_type", "=", "livechat")
+            ])):
+            languages = self.env["res.lang"].search([("name", "ilike", search_term)])
+            domain |= Domain(
+                "user_ids.res_users_settings_ids",
+                "in",
+                # sudo: res.users.settings - operators can access other operators settings
+                self.env["res.users.settings"].sudo()._search(
+                    Domain("user_id.partner_id.lang", "in", languages.mapped("code")) |
+                    Domain("livechat_lang_ids", "in", languages.ids) |
+                    Domain("livechat_expertise_ids.name", "ilike", search_term)
+                ),
+            )
+        return domain
 
     def _search_for_channel_invite_to_store(self, store: Store, channel):
         super()._search_for_channel_invite_to_store(store, channel)
@@ -34,6 +53,9 @@ class ResPartner(models.Model):
                     "invite_by_self_count": invite_by_self_count_by_partner.get(partner, 0),
                     "is_available": partner in active_livechat_partners,
                     "lang_name": lang_name_by_code[partner.lang],
+                    # sudo: res.users.settings - operators can access other operators settings
+                    "expertises": partner.user_ids.sudo().livechat_expertise_ids.mapped("name"),
+                    "languages": partner.user_ids.sudo().livechat_lang_ids.mapped("name"),
                 },
             )
 

--- a/addons/im_livechat/static/src/core/web/channel_invitation_patch.js
+++ b/addons/im_livechat/static/src/core/web/channel_invitation_patch.js
@@ -1,0 +1,12 @@
+import { ChannelInvitation } from "@mail/discuss/core/common/channel_invitation";
+import { _t } from "@web/core/l10n/translation";
+import { patch } from "@web/core/utils/patch";
+
+patch(ChannelInvitation.prototype, {
+    get searchPlaceholder() {
+        if (this.props.thread?.channel_type === "livechat") {
+            return _t("Search people, languages or expertises");
+        }
+        return super.searchPlaceholder;
+    },
+});

--- a/addons/im_livechat/static/src/core/web/channel_invitation_patch.xml
+++ b/addons/im_livechat/static/src/core/web/channel_invitation_patch.xml
@@ -5,10 +5,21 @@
             <t t-if="props.thread?.channel_type !== 'livechat' or !selectablePartner.lang_name">$0</t>
             <div t-else="" class="d-flex flex-column flex-grow-1">
                 <t>$0</t>
-                <span class="mx-2 text-truncate text-start fs-6">
-                    <i class="fa fa-comment-o me-1" aria-label="Lang"/>
-                    <t t-esc="selectablePartner.lang_name"/>
-                </span>
+                <div class="d-flex flex-wrap align-items-center gap-1 ms-2">
+                    <span class="d-flex text-start fs-6 gap-1">
+                        <i class="fa fa-fw fa-comment-o" aria-label="Lang"/>
+                        <span class="badge rounded text-bg-primary" t-esc="selectablePartner.lang_name"/>
+                        <t t-foreach="selectablePartner.languages" t-as="language" t-key="index">
+                            <span class="badge rounded text-bg-primary" t-esc="language"/>
+                        </t>
+                    </span>
+                    <span class="d-flex text-start fs-6 gap-1">
+                        <i t-if="selectablePartner.expertises.length" class="fa fa-fw fa-certificate" aria-label="Expertise"/>
+                        <t t-foreach="selectablePartner.expertises" t-as="expertise" t-key="index">
+                            <span class="badge rounded text-bg-info bg-opacity-75" style="color: #FFF" t-esc="expertise"/>
+                        </t>
+                    </span>
+                </div>
             </div>
         </xpath>
     </t>

--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -4,7 +4,7 @@ from odoo import api, fields, models
 from odoo.osv import expression
 from odoo.tools import SQL
 from odoo.addons.mail.tools.discuss import Store
-
+from odoo.fields import Domain
 
 class ResPartner(models.Model):
     _inherit = "res.partner"
@@ -30,17 +30,18 @@ class ResPartner(models.Model):
         count = self._search_for_channel_invite(store, search_term, channel_id, limit)
         return {"count": count, "data": store.get_result()}
 
+    def _get_search_for_channel_invite_term_domain(self, channel_id, search_term):
+        return (
+            Domain("name", "ilike", search_term) |
+            Domain("email", "ilike", search_term)
+        )
+
     @api.readonly
     @api.model
     def _search_for_channel_invite(self, store: Store, search_term, channel_id=None, limit=30):
         domain = expression.AND(
             [
-                expression.OR(
-                    [
-                        [("name", "ilike", search_term)],
-                        [("email", "ilike", search_term)],
-                    ]
-                ),
+                self._get_search_for_channel_invite_term_domain(channel_id, search_term),
                 [('id', '!=', self.env.user.partner_id.id)],
                 [("active", "=", True)],
                 [("user_ids", "!=", False)],

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -101,6 +101,10 @@ export class ChannelInvitation extends Component {
         );
     }
 
+    get searchPlaceholder() {
+        return _t("Search people to invite");
+    }
+
     async fetchPartnersToInvite() {
         const results = await this.sequential(() =>
             this.orm.call("res.partner", "search_for_channel_invite", [

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -11,7 +11,7 @@
     <t t-name="discuss.ChannelInvitation.main">
         <div class="d-flex flex-column flex-grow-1 bg-inherit" t-att-class="{ 'o-mail-Discuss-threadActionPopover w-100': props.hasSizeConstraints, 'px-1': !props.thread }">
             <t t-if="store.self.type === 'partner'">
-                <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-white" t-att-value="searchStr" t-ref="input" placeholder="Search people to invite" t-on-input="onInput"/>
+                <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-white" t-att-value="searchStr" t-ref="input" t-att-placeholder="searchPlaceholder" t-on-input="onInput"/>
                 <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': selectablePartners.length === 0 }">
                     <div t-if="selectablePartners.length === 0" class="small text-muted mx-1 fst-italic">
                         <t t-if="props.thread">No user found that is not already a member of this channel.</t>


### PR DESCRIPTION
This commit improves the invite people popover for livechat. Before this commit we would display the user language for Odoo next to his name in the search results, we now display the user-selected livechat languages and expertises. This commit also expands the search to be not only on the name but also the languages and expertises

task-4523464
