### PR TITLE
[FIX] base_iban: Enable auto install

### DIFF
--- a/addons/base_iban/__manifest__.py
+++ b/addons/base_iban/__manifest__.py
@@ -11,6 +11,7 @@ The ability to extract the correctly represented local accounts from IBAN accoun
 with a single statement.
     """,
     'depends': ['account', 'web'],
+    'auto_install': True,
     'data': [
         'views/partner_view.xml',
         'views/setup_wizards_view.xml'


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Currently, if `hr_payroll` and accounting is installed, the `hr_payroll_account` is not installed automatically. Which should be the case since its marked as `auto_install`.

Current behavior before PR:

Desired behavior after PR is merged:
The module is required for `hr_payroll_account` to auto_install. This should fix that issue. Auto-install for Payroll localisation with accounting should work as long as the user has accounting and payroll installed.

Enterprise PR: https://github.com/odoo/enterprise/pull/75695

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr


Task# 4201469