### PR TITLE
[FIX] sale_stock: Sale order line propagates in intercompany transfers

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -112,7 +112,7 @@ class StockPicking(models.Model):
             sale_order = move.picking_id.sale_id
             # Creates new SO line only when pickings linked to a sale order and
             # for moves with qty. done and not already linked to a SO line.
-            if not sale_order or move.location_dest_id.usage != 'customer' or move.sale_line_id or not move.picked:
+            if not sale_order or move.location_dest_id.usage not in ['customer', 'transit'] or move.sale_line_id or not move.picked:
                 continue
             product = move.product_id
             so_line_vals = {

--- a/addons/sale_stock/tests/test_sale_stock_multicompany.py
+++ b/addons/sale_stock/tests/test_sale_stock_multicompany.py
@@ -108,3 +108,42 @@ class TestSaleStockMultiCompany(TestSaleCommon, ValuationReconciliationTestCommo
         sale_order.action_confirm()
 
         self.assertTrue(sale_order.picking_ids.move_ids)
+
+    def test_intercompany_transfer_sale_order_workflow(self):
+        company2 = self.company_data_2['company']
+
+        so = self.env['sale.order'].create({
+            'partner_id': company2.partner_id.id,
+            'order_line': [(0, 0, {
+                'name': self.product_a.name,
+                'product_id': self.product_a.id,
+                'product_uom_qty': 5.0,
+                'product_uom': self.product_a.uom_id.id,
+                'price_unit': self.product_a.list_price})],
+        })
+        so.action_confirm()
+
+        picking = so.picking_ids
+
+        # create another move
+        self.env['stock.move'].create({
+            'picking_id': picking.id,
+            'location_id': picking.location_id.id,
+            'location_dest_id': picking.location_dest_id.id,
+            'name': self.product_b.name,
+            'product_id': self.product_b.id,
+            'product_uom_qty': 1,
+            'product_uom': self.product_b.uom_id.id,
+            'quantity': 1,
+        })
+
+        # ensure we have to moves in the picking
+        self.assertEqual(len(picking.move_ids), 2)
+
+        # make the moves as picked
+        picking.move_ids.picked = True
+
+        picking.button_validate()
+
+        # make sure an order line is created for the new stock move
+        self.assertEqual(len(picking.sale_id.order_line), 2)


### PR DESCRIPTION
Steps to Reproduce:

- Create two companies: A and B.
- In Company A, create a sale order for Company B with product P1.
- Confirm the sale order and navigate to the associated picking.
- Add a new product P2 and confirm the picking.

Issue:
No sale order line is created for the newly added move in the picking.

Technical Reason:

Before v17.2, intercompany transfers used the "Partner/Customers" location (type: "customer") as the destination. The logic for creating a sale order line checked move.location_dest_id.usage != 'customer', which correctly allowed the sale order line to be created. In v17.2, intercompany transfers now use "Virtual Locations/Inter-company transit" (type: "transit") as the destination. Since 'transit' != 'customer', the condition incorrectly bypasses sale order line creation. Fix:

Modify the condition to check if the destination location is either 'customer' or 'transit'. This ensures that sale order lines are correctly generated for intercompany transfers.

Task-4455830