### PR TITLE
[FIX] uom: check parent_path

### DIFF
--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -133,6 +133,8 @@ class UomUom(models.Model):
         """ Check if `self` and `other_uom` have a common reference unit """
         self.ensure_one()
         other_uom.ensure_one()
+        if not self.parent_path or not other_uom.parent_path:
+            return False
         self_path = self.parent_path.split('/')
         other_path = other_uom.parent_path.split('/')
         common_path = []


### PR DESCRIPTION
parent_path for self and/or other_uom might not exist. And split operation cannot performed on a null value.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
