### PR TITLE
Use metadata to get werkzeug version

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -146,6 +146,7 @@ import threading
 import time
 import traceback
 import warnings
+import importlib.metadata
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from hashlib import sha512
@@ -278,13 +279,18 @@ ROUTING_KEYS = {
     'alias', 'host', 'methods',
 }
 
-if parse_version(werkzeug.__version__) >= parse_version('2.0.2'):
-    # Werkzeug 2.0.2 adds the websocket option. If a websocket request
-    # (ws/wss) is trying to access an HTTP route, a WebsocketMismatch
-    # exception is raised. On the other hand, Werkzeug 0.16 does not
-    # support the websocket routing key. In order to bypass this issue,
-    # let's add the websocket key only when appropriate.
-    ROUTING_KEYS.add('websocket')
+try:
+    if parse_version(werkzeug.__version__) >= parse_version('2.0.2'):
+        # Werkzeug 2.0.2 adds the websocket option. If a websocket request
+        # (ws/wss) is trying to access an HTTP route, a WebsocketMismatch
+        # exception is raised. On the other hand, Werkzeug 0.16 does not
+        # support the websocket routing key. In order to bypass this issue,
+        # let's add the websocket key only when appropriate.
+        ROUTING_KEYS.add('websocket')
+except AttributeError:
+    # deprecate __version__ #2772 https://github.com/pallets/werkzeug/pull/2772
+    if parse_version(importlib.metadata.version("werkzeug")) >= parse_version('2.0.2'):
+        ROUTING_KEYS.add('websocket')
 
 # The default duration of a user session cookie. Inactive sessions are reaped
 # server-side as well with a threshold that can be set via an optional


### PR DESCRIPTION
In werkzeug version 3 __version__ is not available

Description of the issue/feature this PR addresses:

When running the latest version of the image I got this error:

```bash
docker compose up
[+] Running 2/2
 ✔ Container odoo-development-db-1   Running                                                                                                                                       0.0s 
 ✔ Container odoo-development-web-1  Created                                                                                                                                       0.0s 
Attaching to db-1, web-1
web-1  | Traceback (most recent call last):
web-1  |   File "/opt/odoo-18.0+e.20250124/.env/bin/odoo", line 5, in <module>
web-1  |     import odoo
web-1  |   File "/opt/odoo-18.0+e.20250124/.env/lib/python3.12/site-packages/odoo/__init__.py", line 63, in <module>
web-1  |     from . import service
web-1  |   File "/opt/odoo-18.0+e.20250124/.env/lib/python3.12/site-packages/odoo/service/__init__.py", line 5, in <module>
web-1  |     from . import model
web-1  |   File "/opt/odoo-18.0+e.20250124/.env/lib/python3.12/site-packages/odoo/service/model.py", line 13, in <module>
web-1  |     from odoo.http import request
web-1  |   File "/opt/odoo-18.0+e.20250124/.env/lib/python3.12/site-packages/odoo/http.py", line 281, in <module>
web-1  |     if parse_version(werkzeug.__version__) >= parse_version('2.0.2'):
web-1  |                      ^^^^^^^^^^^^^^^^^^^^
web-1  | AttributeError: module 'werkzeug' has no attribute '__version__'
```

Current behavior before PR:
Tries to get the version from the attribute __version__

Desired behavior after PR is merged:
Tries to get the version from the attribute __version__ and if there is an exception it will load the werkzeug version from the importlib metadata.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
