### PR TITLE
[IMP] project: rename done project status into Complete

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -177,7 +177,7 @@ class ProjectProject(models.Model):
         ('off_track', 'Off Track'),
         ('on_hold', 'On Hold'),
         ('to_define', 'Set Status'),
-        ('done', 'Done'),
+        ('done', 'Complete'),
     ], default='to_define', compute='_compute_last_update_status', store=True, readonly=False, required=True, export_string_translation=False)
     last_update_color = fields.Integer(compute='_compute_last_update_color', export_string_translation=False)
     milestone_ids = fields.One2many('project.milestone', 'project_id', copy=True, export_string_translation=False)

--- a/addons/project/models/project_update.py
+++ b/addons/project/models/project_update.py
@@ -49,7 +49,7 @@ class ProjectUpdate(models.Model):
         ('at_risk', 'At Risk'),
         ('off_track', 'Off Track'),
         ('on_hold', 'On Hold'),
-        ('done', 'Done'),
+        ('done', 'Complete'),
     ], required=True, tracking=True, export_string_translation=False)
     color = fields.Integer(compute='_compute_color', export_string_translation=False)
     progress = fields.Integer(tracking=True)


### PR DESCRIPTION
- The project status label has been updated. The status previously labeled as
`Done` has now been renamed to `Complete`.

task-4462082
