### PR TITLE
[FIX] point_of_sale: avoid singleton error when using search product

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -2089,7 +2089,7 @@ class PosSession(models.Model):
             ('barcode', '=', barcode),
             ('sale_ok', '=', True),
             ('available_in_pos', '=', True),
-        ])
+        ], limit=1)
         if product:
             return {'product_id': [product.id]}
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
