### PR TITLE
[IMP] project: add project name to task assignation notification

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1475,8 +1475,17 @@ class ProjectTask(models.Model):
             message, msg_vals=msg_vals, model_description=model_description,
             force_email_company=force_email_company, force_email_lang=force_email_lang
         )
-        if self.stage_id:
-            render_context['subtitles'].append(_('Stage: %s', self.stage_id.name))
+        project_name = self.project_id.sudo().name
+        stage_name = self.stage_id.name
+        subtitles = ""
+        if project_name and stage_name:
+            subtitles = _('Project: %(project_name)s, Stage: %(stage_name)s', project_name=project_name, stage_name=stage_name)
+        elif project_name:
+            subtitles = _('Project: %(project_name)s', project_name=project_name)
+        elif stage_name:
+            subtitles = _('Stage: %(stage_name)s', stage_name=stage_name)
+        if subtitles:
+            render_context['subtitles'].append(subtitles)
         return render_context
 
     def _send_email_notify_to_cc(self, partners_to_notify):

--- a/addons/project/tests/test_project_flow.py
+++ b/addons/project/tests/test_project_flow.py
@@ -424,3 +424,15 @@ class TestProjectFlow(TestProjectCommon, MailCase):
         self.user_projectmanager.action_archive()
         task_1_copy = self.task_1.copy()
         self.assertFalse(task_1_copy.child_ids.user_ids)
+
+    def test_task_email_context_with_subtitles(self):
+        task = self.env['project.task'].create({
+            'name': 'Task',
+            'user_ids': [Command.set([self.user_projectuser.id])],
+            'project_id': self.project_goats.id,
+        })
+        self.assertFalse(self.project_goats.message_follower_ids)
+        self.assertEqual(self.project_goats.privacy_visibility, 'followers')
+        self.project_goats.invalidate_recordset()
+        render_context = task.with_user(self.user_projectuser)._notify_by_email_prepare_rendering_context(task.message_ids, {})
+        self.assertListEqual(render_context['subtitles'], ['Task', 'Project: Goats, Stage: New'])


### PR DESCRIPTION
Before this commit:
The project name does not appear in the task assignation notification email.

After this commit:
The project name now appears in the task assignation notification email. This ensures clarity for recipients by specifying which project the task belongs to.

task - 4472755