### PR TITLE
[ADD] l10n_it_edi_sale: add CIG/CUP & origin_document fields to Sale Orders

### DIFF
--- a/addons/l10n_it_edi_sale/__init__.py
+++ b/addons/l10n_it_edi_sale/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/l10n_it_edi_sale/__manifest__.py
+++ b/addons/l10n_it_edi_sale/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    'name': 'Italy - Sale E-invoicing',
+    'countries': ['it'],
+    'version': '1.0',
+    'depends': [
+        'l10n_it_edi',
+        'sale',
+    ],
+    'description': 'Sale modifications for Italy E-invoicing',
+    'category': 'Accounting/Localizations/EDI',
+    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/italy.html',
+    'data': [
+        'views/sale_order_views.xml',
+    ],
+    'installable': True,
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_it_edi_sale/i18n/it.po
+++ b/addons/l10n_it_edi_sale/i18n/it.po
@@ -1,0 +1,81 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_it_edi_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-02-10 13:55+0000\n"
+"PO-Revision-Date: 2025-02-10 13:55+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields.selection,name:l10n_it_edi_sale.selection__sale_order__l10n_it_origin_document_type__agreement
+msgid "Agreement"
+msgstr "Convenzione"
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields,field_description:l10n_it_edi_sale.field_sale_order__l10n_it_cig
+msgid "CIG"
+msgstr ""
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields,field_description:l10n_it_edi_sale.field_sale_order__l10n_it_cup
+msgid "CUP"
+msgstr ""
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields.selection,name:l10n_it_edi_sale.selection__sale_order__l10n_it_origin_document_type__contract
+msgid "Contract"
+msgstr "Contratto"
+
+#. module: l10n_it_edi_sale
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi_sale.view_order_form_inherit_l10n_it_edi_sale
+msgid "Italian Electronic Invoicing"
+msgstr "Fatturazione Elettronica Italiana"
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields,field_description:l10n_it_edi_sale.field_sale_order__l10n_it_partner_pa
+msgid "L10N It Partner Pa"
+msgstr "Partner della Pubblica Amministrazione"
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields,field_description:l10n_it_edi_sale.field_sale_order__l10n_it_origin_document_date
+msgid "Origin Document Date"
+msgstr "Data Documento Origine"
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields,field_description:l10n_it_edi_sale.field_sale_order__l10n_it_origin_document_name
+msgid "Origin Document Name"
+msgstr "Nome Documento Origine"
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields,field_description:l10n_it_edi_sale.field_sale_order__l10n_it_origin_document_type
+msgid "Origin Document Type"
+msgstr "Tipo Documento Origine"
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields,help:l10n_it_edi_sale.field_sale_order__l10n_it_cup
+msgid "Public Investment Unique Identifier"
+msgstr "Codice Unico di Progetto"
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields.selection,name:l10n_it_edi_sale.selection__sale_order__l10n_it_origin_document_type__purchase_order
+msgid "Purchase Order"
+msgstr "Ordine d'Acquisto"
+
+#. module: l10n_it_edi_sale
+#: model:ir.model,name:l10n_it_edi_sale.model_sale_order
+msgid "Sales Order"
+msgstr "Ordine di vendita"
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields,help:l10n_it_edi_sale.field_sale_order__l10n_it_cig
+msgid "Tender Unique Identifier"
+msgstr "Codice Identificativo Gara"

--- a/addons/l10n_it_edi_sale/i18n/l10n_it_edi.pot
+++ b/addons/l10n_it_edi_sale/i18n/l10n_it_edi.pot
@@ -1,0 +1,81 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_it_edi_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-02-10 13:54+0000\n"
+"PO-Revision-Date: 2025-02-10 13:54+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields.selection,name:l10n_it_edi_sale.selection__sale_order__l10n_it_origin_document_type__agreement
+msgid "Agreement"
+msgstr ""
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields,field_description:l10n_it_edi_sale.field_sale_order__l10n_it_cig
+msgid "CIG"
+msgstr ""
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields,field_description:l10n_it_edi_sale.field_sale_order__l10n_it_cup
+msgid "CUP"
+msgstr ""
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields.selection,name:l10n_it_edi_sale.selection__sale_order__l10n_it_origin_document_type__contract
+msgid "Contract"
+msgstr ""
+
+#. module: l10n_it_edi_sale
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi_sale.view_order_form_inherit_l10n_it_edi_sale
+msgid "Italian Electronic Invoicing"
+msgstr ""
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields,field_description:l10n_it_edi_sale.field_sale_order__l10n_it_partner_pa
+msgid "L10N It Partner Pa"
+msgstr ""
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields,field_description:l10n_it_edi_sale.field_sale_order__l10n_it_origin_document_date
+msgid "Origin Document Date"
+msgstr ""
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields,field_description:l10n_it_edi_sale.field_sale_order__l10n_it_origin_document_name
+msgid "Origin Document Name"
+msgstr ""
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields,field_description:l10n_it_edi_sale.field_sale_order__l10n_it_origin_document_type
+msgid "Origin Document Type"
+msgstr ""
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields,help:l10n_it_edi_sale.field_sale_order__l10n_it_cup
+msgid "Public Investment Unique Identifier"
+msgstr ""
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields.selection,name:l10n_it_edi_sale.selection__sale_order__l10n_it_origin_document_type__purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: l10n_it_edi_sale
+#: model:ir.model,name:l10n_it_edi_sale.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: l10n_it_edi_sale
+#: model:ir.model.fields,help:l10n_it_edi_sale.field_sale_order__l10n_it_cig
+msgid "Tender Unique Identifier"
+msgstr ""

--- a/addons/l10n_it_edi_sale/models/__init__.py
+++ b/addons/l10n_it_edi_sale/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/addons/l10n_it_edi_sale/models/sale_order.py
+++ b/addons/l10n_it_edi_sale/models/sale_order.py
@@ -1,0 +1,66 @@
+from odoo import api, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    l10n_it_origin_document_type = fields.Selection(
+        string="Origin Document Type",
+        selection=[('purchase_order', 'Purchase Order'), ('contract', 'Contract'), ('agreement', 'Agreement')],
+        copy=False,
+    )
+    l10n_it_origin_document_name = fields.Char(
+        string="Origin Document Name",
+        copy=False,
+    )
+    l10n_it_origin_document_date = fields.Date(
+        string="Origin Document Date",
+        copy=False,
+    )
+    l10n_it_cig = fields.Char(
+        string="CIG",
+        copy=False,
+        help="Tender Unique Identifier",
+    )
+    l10n_it_cup = fields.Char(
+        string="CUP",
+        copy=False,
+        help="Public Investment Unique Identifier",
+    )
+    # Technical field for showing the above fields or not
+    l10n_it_partner_pa = fields.Boolean(compute='_compute_l10n_it_partner_pa')
+
+    @api.depends('partner_id.commercial_partner_id.l10n_it_pa_index', 'company_id')
+    def _compute_l10n_it_partner_pa(self):
+        for order in self:
+            partner = order.partner_id.commercial_partner_id
+            order.l10n_it_partner_pa = partner and (partner._l10n_it_edi_is_public_administration() or len(partner.l10n_it_pa_index or '') == 7)
+
+    def _prepare_invoice(self):
+        res = super()._prepare_invoice()
+        has_origin_document_fields_filled = any([
+            self.l10n_it_origin_document_type,
+            self.l10n_it_origin_document_name,
+            self.l10n_it_origin_document_date
+        ])
+        has_cup_or_cig_fields_filled = self.l10n_it_cig or self.l10n_it_cup
+        # If at least one of the origin_document fields is filled, we do not fill missing values with the sale order
+        # values to avoid having mismatched origin_document information (e.g. user-entered doc name but SO date)
+        if has_origin_document_fields_filled:
+            res.update({
+                "l10n_it_origin_document_type": self.l10n_it_origin_document_type,
+                "l10n_it_origin_document_name": self.l10n_it_origin_document_name,
+                "l10n_it_origin_document_date": self.l10n_it_origin_document_date,
+                "l10n_it_cig": self.l10n_it_cig,
+                "l10n_it_cup": self.l10n_it_cup,
+            })
+        # Otherwise, if the CUP and/or CIG are filled but origin_document fields are not, pass SO values to invoice
+        elif has_cup_or_cig_fields_filled:
+            res.update({
+                "l10n_it_origin_document_type": "purchase_order",
+                "l10n_it_origin_document_name": self.name,
+                "l10n_it_origin_document_date": self.date_order,
+                "l10n_it_cig": self.l10n_it_cig,
+                "l10n_it_cup": self.l10n_it_cup,
+            })
+        return res

--- a/addons/l10n_it_edi_sale/tests/__init__.py
+++ b/addons/l10n_it_edi_sale/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_edi_sale_order_pa

--- a/addons/l10n_it_edi_sale/tests/test_edi_sale_order_pa.py
+++ b/addons/l10n_it_edi_sale/tests/test_edi_sale_order_pa.py
@@ -1,0 +1,101 @@
+import datetime
+
+from freezegun import freeze_time
+
+from odoo import Command
+from odoo.addons.l10n_it_edi.tests.common import TestItEdi
+from odoo.tests.common import tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestItEdiSaleOrderPa(TestItEdi):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.pricelist = cls.env['product.pricelist'].with_company(cls.company).create({
+            'name': 'EUR pricelist',
+            'currency_id': cls.company.currency_id.id,
+            'company_id': False,
+        })
+
+        cls.module = 'l10n_it_edi_sale'
+
+    def get_sales_order_vals(self, **kwargs):
+        return {
+            'company_id': self.company.id,
+            'partner_id': self.italian_partner_b.id,
+            'pricelist_id': self.pricelist.id,
+            **kwargs,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 100.0,
+                    'product_uom_qty': 1,
+                    'tax_id': [Command.set(self.default_tax.ids)],
+                }),
+            ],
+        }
+
+    def create_sale_order_and_invoice(self, sale_order_vals):
+        order = self.env['sale.order'].create(sale_order_vals)
+        order.action_confirm()
+        invoice = order._create_invoices()
+        invoice.action_post()
+        return invoice
+
+    def test_invoice_from_sale_order_pa_partner_no_origin_fields(self):
+        """ Tests that CUP and CIG from the sales order are passed to invoice.
+            As the origin_document fields are not filled in the SO, but CUP/CIG are,
+            origin_document fields in invoice are filled according to the Sales Order.
+        """
+        sale_order_vals = self.get_sales_order_vals(
+            name='Test Sale Order 1',
+            l10n_it_cup='0123456789',
+            l10n_it_cig='0987654321',
+        )
+        with freeze_time("2024-03-01"):
+            invoice = self.create_sale_order_and_invoice(sale_order_vals)
+        self.assertRecordValues(invoice, [{
+            'l10n_it_cup': '0123456789',
+            'l10n_it_cig': '0987654321',
+            'l10n_it_origin_document_name': 'Test Sale Order 1',
+            'l10n_it_origin_document_type': 'purchase_order',
+            'l10n_it_origin_document_date': datetime.date(2024, 3, 1),
+        }])
+
+    def test_invoice_from_sale_order_pa_partner_with_origin_fields(self):
+        """ Tests that, if at least one of the origin_documents fields is filled in the Sales Order,
+            only those values are passed to the invoice (no default values taken from the SO are used,
+            like the SO date). CUP and/or CIG filled in the Sales Order are passed to the invoice.
+        """
+        sale_order_vals = self.get_sales_order_vals(
+            l10n_it_cup='0123456789',
+            l10n_it_origin_document_type='contract',
+            l10n_it_origin_document_date=datetime.date(2024, 2, 23),
+        )
+        with freeze_time("2024-03-02"):
+            invoice = self.create_sale_order_and_invoice(sale_order_vals)
+        self.assertRecordValues(invoice, [{
+            'l10n_it_cup': '0123456789',
+            'l10n_it_cig': None,
+            'l10n_it_origin_document_name': None,
+            'l10n_it_origin_document_type': 'contract',
+            'l10n_it_origin_document_date': datetime.date(2024, 2, 23),
+        }])
+
+    def test_invoice_from_sale_order_pa_partner_no_pa_fields(self):
+        """ As none of the PA fields (origin_documents, CUP, CIG) are filled, the origin_document
+            fields should not be automatically filled with the Sales Order values.
+        """
+        with freeze_time("2024-03-03"):
+            invoice = self.create_sale_order_and_invoice(self.get_sales_order_vals())
+        self.assertRecordValues(invoice, [{
+            'l10n_it_cig': None,
+            'l10n_it_cup': None,
+            'l10n_it_origin_document_name': None,
+            'l10n_it_origin_document_type': None,
+            'l10n_it_origin_document_date': None,
+        }])
+

--- a/addons/l10n_it_edi_sale/views/sale_order_views.xml
+++ b/addons/l10n_it_edi_sale/views/sale_order_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_order_form_inherit_l10n_it_edi_sale" model="ir.ui.view">
+        <field name="name">order.form.inherit.l10n.it.edi.sale</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='sale_reporting']" position="after">
+                <field name="l10n_it_partner_pa" invisible="1"/>
+                <group name="it_edi_sale_order"
+                       string="Italian Electronic Invoicing"
+                       invisible="country_code != 'IT' or not l10n_it_partner_pa">
+                    <field name="l10n_it_origin_document_type"/>
+                    <field name="l10n_it_origin_document_name"/>
+                    <field name="l10n_it_origin_document_date"/>
+                    <field name="l10n_it_cig"/>
+                    <field name="l10n_it_cup"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
CUP and CIG fields for the Italian Localization are available in account moves and are used when the buyer is a Public Administration or utilizes public funds for payment.

However, in some cases, these fields are already necessary in the Sales Order. Therefore, this commit adds the CUP and CIG fields to eligible Sales Orders and automatically adds said fields to the Invoice generated from the SO.

The fields Origin Document Type, Origin Document Name, Origin Document Date are also added to the Sales Order. If the fields are filled, then the values are passed to the invoice. If the fields are empty, then the Origin Document fields in the invoice are filled with information about the SO which originated it.

Task [link](https://www.odoo.com/odoo/project/967/tasks/4290997)
task-4290997

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
