### PR TITLE
[FIX] l10n_fr_account: Auto install problem

### DIFF
--- a/addons/l10n_fr_account/__manifest__.py
+++ b/addons/l10n_fr_account/__manifest__.py
@@ -3,7 +3,6 @@
     'name': 'France - Accounting',
     'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/france.html',
     'icon': '/account/static/description/l10n.png',
-    'countries': ['fr'],
     'version': '2.1',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
@@ -34,7 +33,7 @@ configuration of their taxes and fiscal positions manually.
         'account',
         'l10n_fr',
     ],
-    'auto_install': ['account'],
+    'auto_install': ['account', 'l10n_fr'],
     'data': [
         'data/account_chart_template_data.xml',
         'data/account_data.xml',


### PR DESCRIPTION
This commit:https://github.com/odoo/odoo/commit/134324c5cf0e2e62f02d212ac27a9442e1f7a824 removed the auto-install for l10n_fr. Which has the consequence of not having l10n_fr_account installed when we have account and l10n_fr. This commit will reintroduce that but also removing the countries since it depends on l10n_fr that already has the country set up.

task: 4296946




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
