### PR TITLE
    [FIX] l10n_es_edi_tbai: omit recipient for simplified invoices

### DIFF
--- a/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
+++ b/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
@@ -340,7 +340,7 @@ class L10nEsEdiTbaiDocument(models.Model):
             'doc': self,
             **self._get_header_values(),
             **self._get_sender_values(),
-            **(self._get_recipient_values(values['partner']) if values['partner'] and not self.is_cancel or not values['is_sale'] else {}),
+            **(self._get_recipient_values(values['partner'], values["is_simplified"]) if values['partner'] and not self.is_cancel or not values['is_sale'] else {}),
             'datetime_now': datetime.now(tz=timezone('Europe/Madrid')),
             'format_date': lambda d: datetime.strftime(d, '%d-%m-%Y'),
             'format_time': lambda d: datetime.strftime(d, '%H:%M:%S'),
@@ -387,7 +387,11 @@ class L10nEsEdiTbaiDocument(models.Model):
             'sender': sender,
         }
 
-    def _get_recipient_values(self, partner):
+    def _get_recipient_values(self, partner, is_simplified=False):
+        # TicketBAI accept recipient data for simplified invoices,
+        # but only if the partner has a VAT number
+        if is_simplified and not partner.vat:
+            return {}
         recipient_values = {
             'partner': partner,
             'partner_address': ', '.join(filter(None, [partner.street, partner.street2, partner.city])),


### PR DESCRIPTION
Since Odoo 18.0, the recipient is always included when sending
a simplified invoice. While this is allowed by TicketBAI, it is
only valid if the partner has a VAT number (NIF).

Steps to reproduce:
- Install the l10n_es_edi_tbai module and setup an ES company
- Create a simplified invoice with the partner "Simplified Invoice Partner (ES)"
- Send the invoice to TicketBAI

The following error will be returned:
"B4_1000002: Todos los registros incluidos en la petición son
incorrectos."

The Fix:
For simplified invoices, this fix ensures that the recipient is only
included in the XML if the partner has a VAT/NIF. If not, the recipient
is omitted to avoid TicketBAI validation errors.

opw-4525875
opw-4522938
opw-4553030
