### PR TITLE
[IMP] web,*: add `month_overflow` option to calendar archs

### DIFF
--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -36,6 +36,7 @@
                 date_start="date_start"
                 date_stop="date_stop"
                 mode="month"
+                month_overflow="0"
                 quick_create="0"
                 color="color"
                 event_limit="5">

--- a/addons/hr_work_entry_contract/static/src/views/work_entry_calendar/work_entry_calendar_model.js
+++ b/addons/hr_work_entry_contract/static/src/views/work_entry_calendar/work_entry_calendar_model.js
@@ -11,13 +11,6 @@ export class WorkEntryCalendarModel extends CalendarModel {
         this.generateWorkEntries = generateWorkEntries;
     }
 
-    computeRange() {
-        const { scale, date } = this.meta;
-        const start = date.startOf(scale);
-        const end = date.endOf(scale);
-        return { start, end };
-    }
-
     makeFilterAll() {
         return {
             ...super.makeFilterAll(...arguments),

--- a/addons/web/static/src/views/calendar/calendar_arch_parser.js
+++ b/addons/web/static/src/views/calendar/calendar_arch_parser.js
@@ -38,6 +38,7 @@ export class CalendarArchParser {
         let isTimeHidden = false;
         let formViewId = false;
         let showDatePicker = true;
+        let monthOverflow = true;
         const popoverFieldNodes = {};
         const filtersInfo = {};
 
@@ -115,6 +116,9 @@ export class CalendarArchParser {
                     }
                     if (node.hasAttribute("show_date_picker")) {
                         showDatePicker = exprToBoolean(node.getAttribute("show_date_picker"));
+                    }
+                    if (node.hasAttribute("month_overflow")) {
+                        monthOverflow = exprToBoolean(node.getAttribute("month_overflow"));
                     }
 
                     break;
@@ -203,6 +207,7 @@ export class CalendarArchParser {
             quickCreateViewId,
             isDateHidden,
             isTimeHidden,
+            monthOverflow,
             popoverFieldNodes,
             scale,
             scales,

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -106,6 +106,7 @@ export class CalendarCommonRenderer extends Component {
             selectMinDistance: 5, // needed to not trigger select when click
             selectMirror: true,
             selectable: this.props.model.canCreate,
+            showNonCurrentDates: this.props.model.monthOverflow,
             slotLabelFormat: is24HourFormat() ? HOUR_FORMATS[24] : HOUR_FORMATS[12],
             snapDuration: { minutes: 15 },
             timeZone: luxon.Settings.defaultZone.name,
@@ -171,10 +172,9 @@ export class CalendarCommonRenderer extends Component {
             title: record.title,
             start: record.start.toISO(),
             end:
-                ["week", "month"].includes(this.props.model.scale) && allDay ||
-                (record.isAllDay ||
-                    (allDay && record.end.toMillis() !== record.end.startOf("day").toMillis())
-                )
+                (["week", "month"].includes(this.props.model.scale) && allDay) ||
+                record.isAllDay ||
+                (allDay && record.end.toMillis() !== record.end.startOf("day").toMillis())
                     ? record.end.plus({ days: 1 }).toISO()
                     : record.end.toISO(),
             allDay: allDay,

--- a/addons/web/static/tests/views/calendar/calendar_arch_parser.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_arch_parser.test.js
@@ -22,6 +22,7 @@ const DEFAULT_ARCH_RESULTS = {
     quickCreateViewId: null,
     isDateHidden: false,
     isTimeHidden: false,
+    monthOverflow: true,
     popoverFieldNodes: {},
     scale: "week",
     scales: ["day", "week", "month", "year"],

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -4672,6 +4672,104 @@ test(`calendar with option show_date_picker set to false and filters`, async () 
     expect(`.o_sidebar_toggler`).toHaveCount(1);
 });
 
+test(`calendar with option month_overflow not set (default)`, async () => {
+    Event._records = [
+        {
+            id: 1,
+            name: "event november",
+            start: "2016-11-30 10:00:00",
+            stop: "2016-11-30 15:00:00",
+            user_id: serverState.userId,
+            partner_id: 1,
+        },
+        {
+            id: 2,
+            name: "event december",
+            start: "2016-12-14 10:00:00",
+            stop: "2016-12-14 15:00:00",
+            user_id: serverState.userId,
+            partner_id: 1,
+        },
+        {
+            id: 3,
+            name: "event january",
+            start: "2017-01-02 10:00:00",
+            stop: "2016-01-02 15:00:00",
+            user_id: serverState.userId,
+            partner_id: 1,
+        },
+    ];
+
+    onRpc("search_read", ({ kwargs }) => {
+        expect.step("search_read");
+        expect(kwargs.domain).toEqual([
+            ["start", "<=", "2017-01-07 22:59:59"],
+            ["start", ">=", "2016-11-26 23:00:00"],
+        ]);
+    });
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `
+            <calendar date_start="start" mode="month">
+                <field name="name"/>
+            </calendar>
+        `,
+    });
+    expect(`.o_event`).toHaveCount(3);
+    expect(".fc-day-disabled").toHaveCount(0);
+    expect.verifySteps(["search_read"]);
+});
+
+test(`calendar with option month_overflow set to false`, async () => {
+    Event._records = [
+        {
+            id: 1,
+            name: "event november",
+            start: "2016-11-30 10:00:00",
+            stop: "2016-11-30 15:00:00",
+            user_id: serverState.userId,
+            partner_id: 1,
+        },
+        {
+            id: 2,
+            name: "event december",
+            start: "2016-12-14 10:00:00",
+            stop: "2016-12-14 15:00:00",
+            user_id: serverState.userId,
+            partner_id: 1,
+        },
+        {
+            id: 3,
+            name: "event january",
+            start: "2017-01-02 10:00:00",
+            stop: "2016-01-02 15:00:00",
+            user_id: serverState.userId,
+            partner_id: 1,
+        },
+    ];
+
+    onRpc("search_read", ({ kwargs }) => {
+        expect.step("search_read");
+        expect(kwargs.domain).toEqual([
+            ["start", "<=", "2016-12-31 22:59:59"],
+            ["start", ">=", "2016-11-30 23:00:00"],
+        ]);
+    });
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `
+            <calendar date_start="start" mode="month" month_overflow="0">
+                <field name="name"/>
+            </calendar>
+        `,
+    });
+    expect(".o_event").toHaveCount(1);
+    expect(".fc-day-disabled").toHaveCount(11);
+    expect.verifySteps(["search_read"]);
+});
+
 test.tags("desktop");
 test(`can not select invalid scale from datepicker`, async () => {
     await mountView({

--- a/odoo/addons/base/rng/calendar_view.rng
+++ b/odoo/addons/base/rng/calendar_view.rng
@@ -29,6 +29,7 @@
             <rng:optional><rng:attribute name="edit"/></rng:optional>
             <rng:optional><rng:attribute name="scales"/></rng:optional>
             <rng:optional><rng:attribute name="show_date_picker"/></rng:optional>
+            <rng:optional><rng:attribute name="month_overflow"/></rng:optional>
             <rng:optional>
                 <rng:attribute name="mode">
                     <rng:choice>


### PR DESCRIPTION
*hr_work_entry,hr_work_entry_contract

This option only applies in "month" mode. If true, which is the default, last days from the previous month and first days of the next month are displayed, and if they contain events, those events are fetched and displayed as well. The option can be set to a falsy value to disable this, meaning that those days of sibling months will be greyed out and their events won't be fetched.

We use this new option in the Work Entries calendar view, which allows to remove a js override, and to have the sibling months' days properly greyed out.

Task-4564270

Documentation PR https://github.com/odoo/documentation/pull/12024