### PR TITLE
[FIX] stock: pervert an error when user try to generate a lot number

### DIFF
--- a/addons/stock/static/src/widgets/generate_serial.js
+++ b/addons/stock/static/src/widgets/generate_serial.js
@@ -47,10 +47,10 @@ export class GenerateDialog extends Component {
         let count;
         let qtyToProcess;
         if (this.props.move.data.has_tracking === 'lot'){
-            count = parseFloat(this.nextSerialCount.el?.value || '0');
+            count = parseFloat(this.nextSerialCount.el?.value) || 0;
             qtyToProcess = parseFloat(this.totalReceived.el?.value || this.props.move.data.product_qty);
         } else {
-            count = parseInteger(this.nextSerialCount.el?.value || '0');
+            count = parseInteger(this.nextSerialCount.el?.value) || 0;
             qtyToProcess = this.props.move.data.product_qty;
         }
         const move_line_vals = await this.orm.call("stock.move", "action_generate_lot_line_vals", [{


### PR DESCRIPTION
Currently, an error occurs when a user tries to generate a lot number without 'Quantity per Lot'.

Step to produce:

- Install the `stock` and `purchase` modules.
- Open Purchase / Orders / Requests for Quotation, Create a new record
- Add a vendor and product that is by lot, Click on 'Confirm Order', and after that click on  'Receive Products'
- Click on the Detailed button to open a 'Detailed Operation'.
- Click on `Generate Serials/Lots button` and remove the 'Quantity per Lot' value and add a double white space after that try to generate a lot number

`TypeError: '<=' not supported between instances of 'NoneType' and 'int'`

This happens because the system tries to compare between Nonetype and integer at [1].

Link [1]: https://github.com/odoo/odoo/blob/3c65ffa8aaf76de7d1aec4a85f1b34429d4c74ef/addons/stock/models/stock_move.py#L958

To resolve this issue, Modified the assignment of `count` at [2] to ensure that it is always assigned a valid numeric value instead of NaN or non-numeric.

Link [2]: https://github.com/odoo/odoo/blob/3c65ffa8aaf76de7d1aec4a85f1b34429d4c74ef/addons/stock/static/src/widgets/generate_serial.js#L49-L53

Sentry-6281418981


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
