### PR TITLE
[FIX] pos: long product name break mobile UI

### DIFF
--- a/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml
+++ b/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml
@@ -4,8 +4,8 @@
         <div t-attf-class="{{ bannerClass }}"
             class="section-product-info-title d-flex flex-column text-info bg-opacity-25 mx-n3 mt-n3 mb-3 px-3 py-3">
             <div class="d-flex" t-att-class="{ 'justify-content-between': !this.ui.isSmall }">
-                <div>
-                    <div class="h4" t-esc="props.product.productDisplayName"/>
+                <div class="w-60">
+                    <div class="h4 text-break" t-esc="props.product.productDisplayName"/>
                     <div t-if="this.props.product.is_storable" class="h4">
                         <span>On hand: </span>
                         <span t-if="this.fetchStock.status === 'success' || this.props.info"><t t-esc="this.state.available_quantity"/> Units</span>

--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
@@ -14,14 +14,14 @@
             <div t-if="props.imageUrl" class="product-img rounded-top rounded-3">
                 <img class="w-100 bg-100" t-att-src="props.imageUrl" t-att-alt="props.name" />
             </div>
-            <div class="product-content d-flex flex-row px-2 justify-content-between rounded-bottom rounded-3 flex-shrink-1" t-att-class="{'h-100' : !props.imageUrl}">
-                <div class="overflow-hidden lh-sm product-name my-2"
-                    t-att-class="{'no-image d-flex justify-content-center align-items-center text-center fs-4': !props.imageUrl}"
+            <div class="product-content d-flex flex-column px-2 justify-content-evenly rounded-bottom rounded-3 flex-shrink-1" t-att-class="{'h-100' : !props.imageUrl}">
+                <div class="overflow-hidden lh-sm text-break product-name mt-1 mb-1"
+                    t-att-class="{'no-image justify-content-center align-items-center text-center fs-4': !props.imageUrl}"
                     t-attf-id="article_product_{{props.productId}}"
                     t-esc="props.name" />
                 <h1 t-if="props.productCartQty"
                     t-out="this.productQty"
-                    class="product-cart-qty text-muted display-6 fw-bolder m-0 mt-auto" />
+                    class="product-cart-qty text-muted display-6 fw-bolder position-absolute bottom-0 end-0 mb-0 me-1" />
             </div>
             <div t-if="props.comboExtraPrice" class="d-flex px-2 pb-1">
                 <span class="price-extra px-2 py-0 rounded-pill text-bg-info">

--- a/addons/point_of_sale/static/src/app/store/select_lot_popup/select_lot_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/select_lot_popup/select_lot_popup.xml
@@ -3,8 +3,10 @@
     <t t-name="point_of_sale.EditListPopup">
         <Dialog title="props.title">
             <t t-set-slot="header">
-                <h4 class="modal-title title" t-esc="props.title" />
-                <span class="sub-title" t-esc="props.name"/>
+                <div class="d-flex text-truncate">
+                    <h4 class="modal-title title me-2" t-esc="props.title" />
+                    <span class="sub-title text-truncate my-auto" t-esc="props.name"/>
+                </div>
             </t>
             <div t-ref="root">
                 <div class="edit-list-inputs" t-ref="edit-list-inputs" t-on-scroll="onScroll">


### PR DESCRIPTION
Steps:
===
- Give product name very long without image.
- Open pos in mobile view.

Issue:
===
- We have weird result
![image](https://github.com/user-attachments/assets/3e2c82dd-a2cb-4b99-aee6-095b9e17c914)


Fix:
===
- Truncated long product names for better readability.
![image](https://github.com/user-attachments/assets/c48899ab-0050-4e31-9aee-4c23bf2a2b5b)


Task: 4513829