### PR TITLE
[FIX] auth_totp(_mail): notification system needs mail in dependencies

### DIFF
--- a/addons/auth_totp_mail/models/res_users.py
+++ b/addons/auth_totp_mail/models/res_users.py
@@ -42,6 +42,33 @@ class ResUsers(models.Model):
 
         return res
 
+    def authenticate(self, credential, user_agent_env):
+        """Send an alert on new connection.
+
+        - 2FA enabled -> only for new device
+        - Not enabled -> no alert
+        """
+        auth_info = super().authenticate(credential, user_agent_env)
+
+        user = self.env(user=auth_info['uid']).user
+
+        if request and user.email and user._mfa_type():
+            # Check the `request` object to ensure that we will be able to get the
+            # user information (like IP, user-agent, etc) and the cookie `td_id`.
+            # (Can be unbounded if executed from a server action or a unit test.)
+
+            key = request.cookies.get('td_id')
+            if not key or not request.env['auth_totp.device']._check_credentials_for_uid(
+                    scope="browser", key=key, uid=user.id):
+                # 2FA enabled but not a trusted device
+                user._notify_security_setting_update(
+                    subject=_('New Connection to your Account'),
+                    content=_('A new device was used to sign in to your account.'),
+                )
+                _logger.info("New device alert email sent for user <%s> to <%s>", user.login, user.email)
+
+        return auth_info
+
     def _notify_security_setting_update_prepare_values(self, content, suggest_2fa=True, **kwargs):
         """" Prepare rendering values for the 'mail.account_security_alert' qweb template
 


### PR DESCRIPTION
Bug
===
The notification system needs a function defined in mail, but auth_totp doesn't have mail in its dependencies. So, installing it without mail will result in a crash.