### PR TITLE
[FIX] base: ignore empty modifier at validation

### DIFF
--- a/odoo/tools/view_validation.py
+++ b/odoo/tools/view_validation.py
@@ -238,6 +238,8 @@ def get_expression_field_names(expression):
                     ignore 'parent.truc' and 'parent.truc.id')
     :return: set(str)
     """
+    if not expression:
+        return set()
     item_ast = ast.parse(expression.strip(), mode='eval').body
     contextual_values = _get_expression_contextual_values(item_ast)
 


### PR DESCRIPTION
When the modifier is empty we don't get any error in the fronted. It's just assumed as `False`. Since 6f06420e we have a new mechanism that adds fields to views as long as they are used in an modifier's expression. This unfortunately fails with a syntax error if the expression is empty. OTOH having an empty expression could be useful for development as a placeholder for further changes.

The presence of empty expressions causes issues during the upgrade from <17.4 to higher versions.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
