### PR TITLE
[IMP] pos_restaurant: remove tax and total summary from split screen

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.xml
@@ -15,7 +15,7 @@
 
                 <div class="main d-flex flex-column flex-lg-row flex-grow-1 gap-2 overflow-hidden">
                     <div class="flex-grow-1 w-100 w-lg-50 me-0 me-lg-2 border-end border-bottom bg-view overflow-auto">
-                        <OrderDisplay order="currentOrder" t-slot-scope="scope">
+                        <OrderDisplay mode="'receipt'" order="currentOrder" t-slot-scope="scope">
                             <t t-set="line" t-value="scope.line" />
                              <Orderline line="line"
                                 mode="'split'"


### PR DESCRIPTION
In this commit:
==========
- We are removing the tax and total summary from the split screen.

task-4551695