### PR TITLE
[FIX] l10n_es_edi_sii, l10n_es_edi_tbai: allow resequencing vendor bills

### DIFF
--- a/addons/account_edi/wizard/account_resequence.py
+++ b/addons/account_edi/wizard/account_resequence.py
@@ -5,8 +5,17 @@ from odoo.exceptions import UserError
 class ReSequenceWizard(models.TransientModel):
     _inherit = 'account.resequence.wizard'
 
+    def _frozen_edi_documents(self):
+        """Get EDI documents that can't change.
+
+        Their moves are restricted and cannot be resequenced.
+        """
+        return self.move_ids.edi_document_ids.filtered(
+            lambda d: d.edi_format_id._needs_web_services() and d.state == "sent"
+        )
+
     def resequence(self):
-        edi_sent_moves = self.move_ids.edi_document_ids.filtered(lambda d: d.edi_format_id._needs_web_services() and d.state == 'sent')
+        edi_sent_moves = self._frozen_edi_documents()
         if edi_sent_moves:
             raise UserError(_("The following documents have already been sent and cannot be resequenced: %s")
                 % ", ".join(set(edi_sent_moves.move_id.mapped('name')))

--- a/addons/l10n_es_edi_sii/__init__.py
+++ b/addons/l10n_es_edi_sii/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import models
+from . import wizards
 from odoo import api, SUPERUSER_ID
 
 

--- a/addons/l10n_es_edi_sii/tests/__init__.py
+++ b/addons/l10n_es_edi_sii/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import test_edi_xml
 from . import test_edi_web_services
+from . import test_resequence

--- a/addons/l10n_es_edi_sii/tests/common.py
+++ b/addons/l10n_es_edi_sii/tests/common.py
@@ -7,6 +7,10 @@ from odoo.tools import misc
 from odoo.addons.account_edi.tests.common import AccountEdiTestCommon
 
 
+def mocked_l10n_es_edi_call_web_service_sign(edi_format, invoices, info_list):
+    return {inv: {"success": True} for inv in invoices}
+
+
 class TestEsEdiCommon(AccountEdiTestCommon):
 
     @classmethod

--- a/addons/l10n_es_edi_sii/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_sii/tests/test_edi_xml.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from .common import TestEsEdiCommon
+from .common import TestEsEdiCommon, mocked_l10n_es_edi_call_web_service_sign
 
 import json
 
@@ -7,10 +7,6 @@ from freezegun import freeze_time
 from unittest.mock import patch
 
 from odoo.tests import tagged
-
-
-def mocked_l10n_es_edi_call_web_service_sign(edi_format, invoices, info_list):
-    return {inv: {'success': True} for inv in invoices}
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')

--- a/addons/l10n_es_edi_sii/tests/test_resequence.py
+++ b/addons/l10n_es_edi_sii/tests/test_resequence.py
@@ -1,0 +1,136 @@
+from datetime import date
+
+from freezegun import freeze_time
+
+from odoo.exceptions import UserError
+from odoo.tests import Form, tagged
+
+from .common import TestEsEdiCommon, mocked_l10n_es_edi_call_web_service_sign
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestResequenceSII(TestEsEdiCommon):
+    @classmethod
+    def setUpClass(
+        cls,
+        chart_template_ref="l10n_es.account_chart_template_full",
+        edi_format_ref="l10n_es_edi_sii.edi_es_sii",
+    ):
+        cls.startClassPatcher(freeze_time("2019-06-01", tick=True))
+        super().setUpClass(
+            chart_template_ref=chart_template_ref, edi_format_ref=edi_format_ref
+        )
+        cls.classPatch(
+            cls.registry["account.edi.format"],
+            "_l10n_es_edi_call_web_service_sign",
+            mocked_l10n_es_edi_call_web_service_sign,
+        )
+        # Create 2 customer and 2 vendor invoices, in wrong date order
+        cls.customer_invoice_2 = cls.create_invoice(
+            invoice_date="2019-05-15", date="2019-05-15", invoice_line_ids=[{}]
+        )
+        cls.customer_invoice_1 = cls.create_invoice(
+            invoice_date="2019-05-01", date="2019-05-01", invoice_line_ids=[{}]
+        )
+        cls.vendor_invoice_2 = cls.create_invoice(
+            invoice_date="2019-04-15",
+            date="2019-04-15",
+            move_type="in_invoice",
+            ref="vendor/1",
+            invoice_line_ids=[{}],
+        )
+        cls.vendor_invoice_1 = cls.create_invoice(
+            invoice_date="2019-04-01",
+            date="2019-04-01",
+            move_type="in_invoice",
+            ref="vendor/2",
+            invoice_line_ids=[{}],
+        )
+        # Post them, in wrong date order
+        cls.customer_invoice_2.action_post()
+        cls.customer_invoice_1.action_post()
+        cls.vendor_invoice_2.action_post()
+        cls.vendor_invoice_1.action_post()
+
+    def setUp(self):
+        super().setUp()
+        # Send to SII
+        all_invoices = (
+            self.customer_invoice_1
+            + self.customer_invoice_2
+            + self.vendor_invoice_1
+            + self.vendor_invoice_2
+        )
+        self.generated_files = self._process_documents_web_services(
+            all_invoices, {self.edi_format.code}
+        )
+        self.assertRecordValues(
+            all_invoices,
+            [
+                {
+                    "invoice_date": date(2019, 5, 1),
+                    "date": date(2019, 5, 1),
+                    "name": "INV/2019/00002",
+                },
+                {
+                    "invoice_date": date(2019, 5, 15),
+                    "date": date(2019, 5, 15),
+                    "name": "INV/2019/00001",
+                },
+                {
+                    "invoice_date": date(2019, 4, 1),
+                    "date": date(2019, 4, 1),
+                    "name": "BILL/2019/04/0002",
+                },
+                {
+                    "invoice_date": date(2019, 4, 15),
+                    "date": date(2019, 4, 15),
+                    "name": "BILL/2019/04/0001",
+                },
+            ],
+        )
+
+    def test_customer_fails(self):
+        """Check we cannot resequence customer invoices."""
+        invoices = self.customer_invoice_1 + self.customer_invoice_2
+        wiz_f = Form(
+            self.env["account.resequence.wizard"].with_context(
+                active_model="account.move",
+                active_ids=invoices.ids,
+            )
+        )
+        wiz_f.ordering = "date"
+        wiz = wiz_f.save()
+        with self.assertRaises(
+            UserError,
+            msg="The following documents have already been sent and cannot be resequenced: INV/2019/00001, INV/2019/00002",
+        ):
+            wiz.resequence()
+
+    def test_vendor_works(self):
+        """Check we can resequence vendor bills."""
+        invoices = self.vendor_invoice_1 + self.vendor_invoice_2
+        wiz_f = Form(
+            self.env["account.resequence.wizard"].with_context(
+                active_model="account.move",
+                active_ids=invoices.ids,
+            )
+        )
+        wiz_f.ordering = "date"
+        wiz = wiz_f.save()
+        wiz.resequence()
+        self.assertRecordValues(
+            invoices,
+            [
+                {
+                    "invoice_date": date(2019, 4, 1),
+                    "date": date(2019, 4, 1),
+                    "name": "BILL/2019/04/0001",
+                },
+                {
+                    "invoice_date": date(2019, 4, 15),
+                    "date": date(2019, 4, 15),
+                    "name": "BILL/2019/04/0002",
+                },
+            ],
+        )

--- a/addons/l10n_es_edi_sii/wizards/__init__.py
+++ b/addons/l10n_es_edi_sii/wizards/__init__.py
@@ -1,5 +1,2 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-from . import account_move_reversal
 from . import account_resequence_wizard

--- a/addons/l10n_es_edi_sii/wizards/account_resequence_wizard.py
+++ b/addons/l10n_es_edi_sii/wizards/account_resequence_wizard.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class AccountResequenceWizard(models.TransientModel):
+    _inherit = "account.resequence.wizard"
+
+    def _frozen_edi_documents(self):
+        docs = super()._frozen_edi_documents()
+        # SII vendor bills are sent with ref, so they can be resequenced
+        return docs.filtered(
+            lambda doc: doc.edi_format_id.code != "es_sii"
+            or doc.move_id.is_sale_document()
+        )

--- a/addons/l10n_es_edi_tbai/tests/__init__.py
+++ b/addons/l10n_es_edi_tbai/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_edi_web_services
 from . import test_edi_xml
+from . import test_resequence

--- a/addons/l10n_es_edi_tbai/tests/test_resequence.py
+++ b/addons/l10n_es_edi_tbai/tests/test_resequence.py
@@ -1,0 +1,13 @@
+from odoo.addons.l10n_es_edi_sii.tests import test_resequence
+
+
+class TestResequenceTbai(test_resequence.TestResequenceSII):
+    @classmethod
+    def setUpClass(
+        cls,
+        chart_template_ref="l10n_es.account_chart_template_full",
+        edi_format_ref="l10n_es_edi_sii.edi_es_sii",
+    ):
+        super().setUpClass(
+            chart_template_ref=chart_template_ref, edi_format_ref=edi_format_ref
+        )

--- a/addons/l10n_es_edi_tbai/wizards/account_resequence_wizard.py
+++ b/addons/l10n_es_edi_tbai/wizards/account_resequence_wizard.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class AccountResequenceWizard(models.TransientModel):
+    _inherit = "account.resequence.wizard"
+
+    def _frozen_edi_documents(self):
+        docs = super()._frozen_edi_documents()
+        # TicketBAI/Batuz vendor bills are sent with ref, so they can be resequenced
+        return docs.filtered(
+            lambda doc: doc.edi_format_id.code != "es_tbai"
+            or doc.move_id.is_sale_document()
+        )


### PR DESCRIPTION
Before this patch, it was impossible to resequence vendor bills if already sent to SII/tbai.

However, it is required to be able to resequence them, and the move name isn't sent anymore since https://github.com/odoo/odoo/pull/195113 was merged.

Thus, here I'm lifting that constraint to allow accountants do the resequencing.

@moduon MT-8728 OPW-4567144


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
