### PR TITLE
[FIX] html_editor: fix focus race condition

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -236,7 +236,12 @@ export class LinkPlugin extends Plugin {
             "Create link",
             () => {
                 this.dependencies.selection.focusEditable();
-                this.openLinkTools();
+                // To avoid a race condition between the events spawn by :
+                // 1. the `focus editable` and
+                // 2. the odoo `Shortcut bar` closure
+                // Which can affect the link overlay opening sequence if we keep it in sync.
+                // Therefore we need to wait for the next tick before triggering openLinkTools.
+                setTimeout(() => this.openLinkTools());
             },
             {
                 hotkey: "control+k",


### PR DESCRIPTION
Fix a race condition between two different event that can affect the opening of the link popover when triggered via the odoo shortcut bar.

runbot-115558


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
