### PR TITLE
[IMP] point_of_sale, pos_*:  simplify ORM serialization of recursive relationships

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -92,6 +92,7 @@
         ],
         'web.assets_unit_tests': [
             # for the related_models.test.js
+            'point_of_sale/static/src/app/models/utils/recursive_serialization.js',
             'point_of_sale/static/src/app/models/related_models.js',
             # for the data_service.test.js
             'point_of_sale/static/src/app/models/utils/indexed_db.js',

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -111,6 +111,8 @@ class PosSession(models.Model):
                     'relation': params.comodel_name,
                     'type': params.type,
                 }
+                if params.type == 'many2one' and params.ondelete:
+                    relations[name]['ondelete'] = params.ondelete
                 if params.type == 'one2many' and params.inverse_name:
                     relations[name]['inverse_name'] = params.inverse_name
                 if params.type == 'many2many':

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -166,7 +166,7 @@ export class PosOrderline extends Base {
 
         // Remove those that needed to be removed.
         for (const lotLine of lotLinesToRemove) {
-            this.pack_lot_ids = this.pack_lot_ids.filter((pll) => pll.id !== lotLine.id);
+            lotLine.delete();
         }
 
         for (const newLotLine of newPackLotLines) {

--- a/addons/point_of_sale/static/src/app/models/utils/recursive_serialization.js
+++ b/addons/point_of_sale/static/src/app/models/utils/recursive_serialization.js
@@ -1,0 +1,227 @@
+import { serializeDateTime } from "@web/core/l10n/dates";
+
+const simpleSerialization = (record, opts, { X2MANY_TYPES, DATE_TIME_TYPE }) => {
+    const result = {};
+    const ownFields = record.model.fields;
+    for (const name in ownFields) {
+        const field = ownFields[name];
+        if (field.type === "many2one") {
+            result[name] = record[name]?.id || record.raw[name] || false;
+        } else if (X2MANY_TYPES.has(field.type)) {
+            const ids = [...record[name]].map((record) => record.id);
+            result[name] = ids.length ? ids : record.raw[name] || [];
+        } else if (DATE_TIME_TYPE.has(field.type) && typeof record[name] === "object") {
+            result[name] = serializeDateTime(record[name]);
+        } else if (typeof record[name] === "object") {
+            result[name] = JSON.stringify(record[name]);
+        } else {
+            result[name] = record[name] !== undefined ? record[name] : false;
+        }
+    }
+    return result;
+};
+
+const deepSerialization = (
+    record,
+    opts,
+    {
+        DYNAMIC_MODELS,
+        X2MANY_TYPES,
+        DATE_TIME_TYPE,
+        serialized = {},
+        uuidMapping = {},
+        parentRelInverseName = null,
+        stack = [],
+    }
+) => {
+    const result = {};
+    const { fields, name: currentModel } = record.model;
+
+    const recursiveSerialize = (childRecord, parentRelInverseName) =>
+        deepSerialization(childRecord, opts, {
+            DYNAMIC_MODELS,
+            X2MANY_TYPES,
+            DATE_TIME_TYPE,
+            serialized,
+            uuidMapping,
+            parentRelInverseName,
+            stack,
+        });
+
+    // We only care about the fields present in python model
+    for (const [fieldName, field] of Object.entries(fields)) {
+        if (field.local || field.related || field.compute || field.dummy) {
+            continue;
+        }
+
+        const relatedModel = field.relation;
+        const targetModel = field.model;
+        const relatedCommands = record.models.commands[relatedModel];
+        const modelCommands = record.models.commands[currentModel];
+
+        if (DYNAMIC_MODELS.includes(relatedModel) && !serialized[relatedModel]) {
+            serialized[relatedModel] = {};
+        }
+        if (DYNAMIC_MODELS.includes(currentModel) && !serialized[currentModel]) {
+            serialized[currentModel] = { [record.uuid]: record.uuid };
+        }
+        if (DYNAMIC_MODELS.includes(targetModel) && !uuidMapping[targetModel]) {
+            uuidMapping[targetModel] = {};
+        }
+        if (X2MANY_TYPES.has(field.type) && record[fieldName]) {
+            if (DYNAMIC_MODELS.includes(relatedModel)) {
+                const toUpdate = [];
+                const toCreate = [];
+
+                for (const childRecord of record[fieldName]) {
+                    if (serialized[relatedModel][childRecord.uuid]) {
+                        continue;
+                    }
+
+                    if (
+                        typeof childRecord.id === "number" &&
+                        relatedCommands.update.has(childRecord.id)
+                    ) {
+                        toUpdate.push(childRecord);
+                        if (opts.clear) {
+                            relatedCommands.update.delete(childRecord.id);
+                        }
+                    } else if (typeof childRecord.id !== "number") {
+                        toCreate.push(childRecord);
+                    }
+                    serialized[relatedModel][childRecord.uuid] = childRecord.uuid;
+                }
+                // The stack defers processing of x2many relationships to ensure objects are only serialized
+                // once in their first encountered parent, preventing redundant serialization.
+                stack.push([
+                    result,
+                    fieldName,
+                    () => [
+                        ...(result[fieldName] || []),
+                        ...toUpdate.map((childRecord) => [
+                            1,
+                            childRecord.id,
+                            recursiveSerialize(childRecord, field.inverse_name),
+                        ]),
+                        ...toCreate.map((childRecord) => [
+                            0,
+                            0,
+                            recursiveSerialize(childRecord, field.inverse_name),
+                        ]),
+                    ],
+                ]);
+            } else {
+                result[fieldName] = record[fieldName].map((childRecord) => {
+                    if (typeof childRecord.id !== "number") {
+                        throw new Error(
+                            `Trying to create a non serializable record '${relatedModel}'`
+                        );
+                    }
+                    return childRecord.id;
+                });
+            }
+
+            if (modelCommands.unlink.has(fieldName) || modelCommands.delete.has(fieldName)) {
+                result[fieldName] = result[fieldName] || [];
+                const processRecords = (records, cmdCode) => {
+                    for (const { id, parentId } of records) {
+                        const isAlreadyDeleted = serialized[relatedModel]?.["_deleted_" + id];
+                        if (parentId === record.id && !isAlreadyDeleted) {
+                            const isCascadeDelete =
+                                record.models[relatedModel]?.fields[field.inverse_name]?.ondelete;
+                            if (isCascadeDelete) {
+                                serialized[relatedModel]["_deleted_" + id] = true;
+                            }
+                            result[fieldName].push([cmdCode, id]);
+                        }
+                    }
+                };
+                processRecords(modelCommands.unlink.get(fieldName) || [], 3);
+                processRecords(modelCommands.delete.get(fieldName) || [], 2);
+
+                if (opts.clear) {
+                    [modelCommands.unlink, modelCommands.delete].forEach((commands) => {
+                        const commandList = commands.get(fieldName) || [];
+                        const remainingCommands = commandList.filter(
+                            ({ parentId }) => parentId !== record.id
+                        );
+                        if (remainingCommands.length) {
+                            commands.set(fieldName, remainingCommands);
+                        } else {
+                            commands.delete(fieldName);
+                        }
+                    });
+                }
+            }
+            continue;
+        }
+
+        if (field.type === "many2one") {
+            const recordId = record[fieldName]?.id;
+            if (DYNAMIC_MODELS.includes(relatedModel) && record[fieldName]) {
+                if (
+                    fieldName !== parentRelInverseName && //mapping not needed for direct child
+                    record.uuid &&
+                    serialized[relatedModel][record[fieldName].uuid]
+                ) {
+                    if (typeof recordId !== "number") {
+                        //  mapping is only needed for newly created records
+                        uuidMapping[targetModel][record.uuid] ??= {};
+                        uuidMapping[targetModel][record.uuid][fieldName] = record[fieldName].uuid;
+                    }
+                }
+                serialized[relatedModel][record[fieldName].uuid] = record[fieldName];
+            }
+            if (typeof recordId === "number" && recordId >= 0) {
+                result[fieldName] = record[fieldName].id;
+            }
+            continue;
+        }
+        if (DATE_TIME_TYPE.has(field.type) && typeof record[fieldName] === "object") {
+            result[fieldName] = serializeDateTime(record[fieldName]);
+            continue;
+        }
+        if (fieldName === "id") {
+            if (typeof record[fieldName] === "number") {
+                result[fieldName] = record[fieldName];
+            }
+            continue;
+        }
+        result[fieldName] = record[fieldName] !== undefined ? record[fieldName] : false;
+    }
+
+    while (stack.length) {
+        const [res, key, getValue] = stack.pop();
+        res[key] = getValue();
+    }
+
+    // Cleanup: remove empty entries from uuidMapping.
+    for (const key in uuidMapping) {
+        if (
+            uuidMapping[key] &&
+            typeof uuidMapping[key] === "object" &&
+            Object.keys(uuidMapping[key]).length === 0
+        ) {
+            delete uuidMapping[key];
+        }
+    }
+
+    return result;
+};
+
+export const recursiveSerialization = (record, opts, { X2MANY_TYPES, DATE_TIME_TYPE }) => {
+    if (!opts.orm) {
+        return simpleSerialization(record, opts, { X2MANY_TYPES, DATE_TIME_TYPE });
+    }
+    const uuidMapping = {};
+    const result = deepSerialization(record, opts, {
+        DYNAMIC_MODELS: record._dynamicModels,
+        X2MANY_TYPES,
+        DATE_TIME_TYPE,
+        uuidMapping,
+    });
+    if (Object.keys(uuidMapping).length !== 0) {
+        result.relations_uuid_mapping = uuidMapping;
+    }
+    return result;
+};

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1247,7 +1247,6 @@ export class PosStore extends WithLazyGetterTrap {
             if (options.throw) {
                 throw error;
             }
-
             console.warn("Offline mode active, order will be synced later");
             return error;
         } finally {

--- a/addons/point_of_sale/static/tests/unit/recursive_serialization.test.js
+++ b/addons/point_of_sale/static/tests/unit/recursive_serialization.test.js
@@ -1,0 +1,465 @@
+import { expect, test } from "@odoo/hoot";
+import { createRelatedModels } from "@point_of_sale/app/models/related_models";
+import { uuidv4 } from "@point_of_sale/utils";
+
+const getModels = () =>
+    createRelatedModels(
+        {
+            "pos.order": {
+                groups: {
+                    name: "groups",
+                    model: "pos.order",
+                    relation: "pos.order.line.group",
+                    type: "one2many",
+                    inverse_name: "order_id",
+                },
+
+                lines: {
+                    name: "lines",
+                    model: "pos.order",
+                    relation: "pos.order.line",
+                    type: "one2many",
+                    inverse_name: "order_id",
+                },
+
+                total: {
+                    name: "total",
+                    type: "float",
+                },
+
+                uuid: { type: "char" },
+            },
+            "pos.order.line": {
+                order_id: {
+                    name: "order_id",
+                    model: "pos.order.line",
+                    relation: "pos.order",
+                    type: "many2one",
+                    ondelete: "cascade",
+                },
+
+                attribute_ids: {
+                    name: "attribute_ids",
+                    model: "pos.order.line",
+                    relation: "product.attribute",
+                    type: "many2many",
+                },
+
+                combo_parent_id: {
+                    name: "combo_parent_id",
+                    model: "pos.order.line",
+                    relation: "pos.order.line",
+                    type: "many2one",
+                },
+                combo_line_ids: {
+                    name: "combo_line_ids",
+                    model: "pos.order.line",
+                    relation: "pos.order.line",
+                    type: "one2many",
+                    inverse_name: "combo_parent_id",
+                },
+                group_id: {
+                    name: "group_id",
+                    model: "pos.order.line",
+                    relation: "pos.order.line.group",
+                    type: "many2one",
+                    ondelete: "cascade",
+                },
+                quantity: {
+                    name: "quantity",
+                    type: "float",
+                },
+                pack_lot_ids: {
+                    name: "pack_lot_ids",
+                    model: "pos.order.line",
+                    relation: "pos.lot",
+                    type: "one2many",
+                    inverse_name: "line_id",
+                },
+                uuid: { type: "char" },
+            },
+
+            "pos.order.line.group": {
+                order_id: {
+                    name: "order_id",
+                    model: "pos.order.line.group",
+                    relation: "pos.order",
+                    type: "many2one",
+                },
+
+                lines: {
+                    name: "lines",
+                    model: "pos.order.line.group",
+                    relation: "pos.order.line",
+                    type: "one2many",
+                    inverse_name: "group_id",
+                },
+
+                index: {
+                    name: "index",
+                    type: "integer",
+                },
+
+                uuid: { type: "char" },
+            },
+            "product.attribute": {},
+
+            "pos.lot": {
+                line_id: {
+                    name: "line_id",
+                    model: "pos.lot",
+                    relation: "pos.order.line",
+                    type: "many2one",
+                },
+                lot_name: {
+                    name: "lot_name",
+                    type: "char",
+                },
+            },
+        },
+        {},
+        { dynamicModels: ["pos.order", "pos.order.line", "pos.order.line.group", "pos.lot"] }
+    ).models;
+
+test("simple serialization", () => {
+    const models = getModels();
+    const order = models["pos.order"].create({ uuid: uuidv4() });
+    const line1 = models["pos.order.line"].create({ order_id: order, uuid: uuidv4(), quantity: 1 });
+    const line2 = models["pos.order.line"].create({ order_id: order, uuid: uuidv4(), quantity: 2 });
+    order.total = 10;
+
+    const result = order.serialize({ orm: true });
+    {
+        expect(result.uuid).not.toBeEmpty();
+        expect(result.total).toBe(10);
+        expect(result.lines.length).toBe(2);
+
+        expect(result.lines[0][0]).toBe(0);
+        expect(result.lines[0][1]).toBe(0);
+        expect(result.lines[0][2].id).toBe(undefined);
+        expect(result.lines[0][2].uuid).toBe(line1.uuid);
+        expect(result.lines[0][2].quantity).toBe(1);
+
+        expect(result.lines[1][0]).toBe(0);
+        expect(result.lines[1][1]).toBe(0);
+        expect(result.lines[1][2].id).toBe(undefined);
+        expect(result.lines[1][2].uuid).toBe(line2.uuid);
+        expect(result.lines[1][2].quantity).toBe(2);
+
+        expect(result.relations_uuid_mapping).toBe(undefined);
+    }
+
+    // Update line
+    line1.update({ id: 11 }, { silent: true });
+    line2.update({ id: 111 }, { silent: true });
+
+    line1.quantity = 99;
+    {
+        const result = order.serialize({ orm: true, clear: true });
+        expect(result.lines.length).toBe(1);
+        expect(result.lines[0][0]).toBe(1);
+        expect(result.lines[0][1]).toBe(11);
+        expect(result.lines[0][2].quantity).toBe(99);
+    }
+
+    // Delete line
+    line1.delete();
+    {
+        const result = order.serialize({ orm: true });
+        expect(result.lines.length).toBe(1);
+        expect(result.lines[0][0]).toBe(3);
+        expect(result.lines[0][1]).toBe(11);
+    }
+});
+
+test("serialization of non-dynamic model relationships", () => {
+    const models = getModels();
+    const order = models["pos.order"].create({ uuid: uuidv4() });
+
+    const att1 = models["product.attribute"].create({ id: 99 });
+    const att2 = models["product.attribute"].create({ id: 999 });
+    const line = models["pos.order.line"].create({ order_id: order, uuid: uuidv4(), quantity: 1 });
+    line.attribute_ids.push(att1);
+    line.attribute_ids.push(att2);
+    {
+        const result = order.serialize({ orm: true, clear: true });
+        expect(result.lines[0][2].attribute_ids).toEqual([99, 999]);
+    }
+
+    const att3 = models["product.attribute"].create({ id: 9999 });
+    line.attribute_ids.push(att3);
+    {
+        const result = order.serialize({ orm: true, clear: true });
+        expect(result.lines[0][2].attribute_ids).toEqual([99, 999, 9999]);
+    }
+
+    line.attribute_ids.pop();
+    line.attribute_ids.pop();
+    {
+        const result = order.serialize({ orm: true, clear: true });
+        expect(result.lines[0][2].attribute_ids).toEqual([99]);
+    }
+
+    line.attribute_ids.pop();
+    {
+        const result = order.serialize({ orm: true, clear: true });
+        expect(result.lines[0][2].attribute_ids).toEqual([]);
+    }
+});
+
+test("serialization of dynamic model without uuid", () => {
+    const models = getModels();
+    const order = models["pos.order"].create({ uuid: uuidv4() });
+
+    const line1 = models["pos.order.line"].create({
+        order_id: order,
+        uuid: uuidv4(),
+    });
+
+    const lot1 = models["pos.lot"].create({ line_id: line1, lot_name: "lot1" });
+    {
+        const result = order.serialize({ orm: true, clear: true });
+        expect(result.lines.length).toBe(1);
+        const pack_lot_ids = result.lines[0][2].pack_lot_ids;
+        expect(pack_lot_ids.length).toBe(1);
+        expect(pack_lot_ids[0][0]).toBe(0);
+        expect(pack_lot_ids[0][0]).toBe(0);
+        expect(pack_lot_ids[0][2]).toEqual({ lot_name: "lot1" });
+    }
+
+    lot1.update({ id: 99 }, { silent: true });
+
+    const lot2 = models["pos.lot"].create({ line_id: line1, lot_name: "lot2" });
+    {
+        const result = order.serialize({ orm: true, clear: true });
+        expect(result.lines.length).toBe(1);
+        const pack_lot_ids = result.lines[0][2].pack_lot_ids;
+        expect(pack_lot_ids.length).toBe(1);
+        expect(pack_lot_ids[0][0]).toBe(0);
+        expect(pack_lot_ids[0][1]).toBe(0);
+        expect(pack_lot_ids[0][2]).toEqual({ lot_name: "lot2" });
+    }
+
+    lot2.update({ id: 999 }, { silent: true });
+    lot2.delete();
+    lot1.delete();
+
+    {
+        const result = order.serialize({ orm: true, clear: true });
+        expect(result.lines.length).toBe(1);
+        const pack_lot_ids = result.lines[0][2].pack_lot_ids;
+        expect(pack_lot_ids.length).toBe(2);
+        expect(pack_lot_ids).toEqual([
+            [3, 999],
+            [3, 99],
+        ]);
+    }
+});
+
+test("nested lines relationship", () => {
+    const models = getModels();
+    const order = models["pos.order"].create({ uuid: uuidv4() });
+    const parentLine = models["pos.order.line"].create({ order_id: order, uuid: uuidv4() });
+    const line1 = models["pos.order.line"].create({
+        order_id: order,
+        combo_parent_id: parentLine,
+        uuid: uuidv4(),
+    });
+    const line2 = models["pos.order.line"].create({
+        order_id: order,
+        combo_parent_id: parentLine,
+        uuid: uuidv4(),
+    });
+
+    {
+        const result = order.serialize({ orm: true });
+        expect(result.lines.length).toBe(3);
+        expect(result.lines[0][2].combo_line_ids).toBeEmpty();
+        expect(result.lines[0][2].combo_parent_id).toBeEmpty();
+        expect(result.lines[1][2].combo_line_ids).toBeEmpty();
+        expect(result.lines[1][2].combo_parent_id).toBeEmpty();
+        expect(result.lines[2][2].combo_line_ids).toBeEmpty();
+        expect(result.lines[2][2].combo_parent_id).toBeEmpty();
+
+        const { relations_uuid_mapping } = result;
+        expect(Object.keys(relations_uuid_mapping["pos.order.line"]).length).toBe(2);
+        expect(relations_uuid_mapping["pos.order.line"][line1.uuid]["combo_parent_id"]).toBe(
+            parentLine.uuid
+        );
+        expect(relations_uuid_mapping["pos.order.line"][line2.uuid]["combo_parent_id"]).toBe(
+            parentLine.uuid
+        );
+    }
+
+    // Update line: the uuid mapping must be present
+    parentLine.update({ id: 11 }, { silent: true });
+    line1.update({ id: 12 }, { silent: true });
+    line2.update({ id: 13 }, { silent: true });
+
+    line1.quantity = 99;
+    {
+        const result = order.serialize({ orm: true, clear: true });
+        expect(result.lines.length).toBe(1);
+        expect(result.lines[0][0]).toBe(1);
+        expect(result.lines[0][1]).toBe(12);
+        expect(result.lines[0][2].quantity).toBe(99);
+        expect(result.relations_uuid_mapping).toBe(undefined);
+    }
+});
+
+test("recursive relationship with group of lines", () => {
+    const models = getModels();
+
+    const order = models["pos.order"].create({ uuid: uuidv4() });
+    const group1 = models["pos.order.line.group"].create({
+        order_id: order,
+        uuid: uuidv4(),
+        index: 1,
+    });
+    const group2 = models["pos.order.line.group"].create({
+        order_id: order,
+        uuid: uuidv4(),
+        index: 2,
+    });
+
+    const line1 = models["pos.order.line"].create({
+        order_id: order,
+        group_id: group1,
+        uuid: uuidv4(),
+    });
+    const line2 = models["pos.order.line"].create({
+        order_id: order,
+        group_id: group1,
+        uuid: uuidv4(),
+    });
+
+    expect(order.lines.length).toBe(2);
+    expect(order.groups.length).toBe(2);
+    expect(order.groups[0].lines.length).toBe(2);
+
+    {
+        const result = order.serialize({ orm: true });
+        expect(result.lines.length).toBe(2);
+        expect(result.lines[0][2].group_id).toBeEmpty();
+        expect(result.lines[1][2].group_id).toBeEmpty();
+
+        expect(result.groups.length).toBe(2);
+
+        expect(result.groups[0][0]).toBe(0);
+        expect(result.groups[0][1]).toBe(0);
+        expect(result.groups[0][2].index).toBe(1);
+        expect(result.groups[0][2].lines).toBeEmpty();
+
+        expect(result.groups[1][0]).toBe(0);
+        expect(result.groups[1][1]).toBe(0);
+        expect(result.groups[1][2].index).toBe(2);
+        expect(result.groups[0][2].lines).toBeEmpty();
+
+        const { relations_uuid_mapping } = result;
+        expect(Object.keys(relations_uuid_mapping["pos.order.line"]).length).toBe(2);
+        expect(relations_uuid_mapping["pos.order.line"][line1.uuid]["group_id"]).toBe(group1.uuid);
+        expect(relations_uuid_mapping["pos.order.line"][line2.uuid]["group_id"]).toBe(group1.uuid);
+    }
+
+    group1.update({ id: 210 }, { silent: true });
+    group2.update({ id: 211 }, { silent: true });
+    line1.update({ id: 110 }, { silent: true });
+    line2.update({ id: 111 }, { silent: true });
+
+    // Move line2 to another group
+    line2.update({ group_id: group2 });
+    expect(order.groups[1].lines.length).toBe(1);
+    {
+        const result = order.serialize({ orm: true, clear: true });
+        expect(result.groups).toBeEmpty();
+        expect(result.lines.length).toBe(1);
+        expect(result.lines[0][0]).toBe(1);
+        expect(result.lines[0][1]).toBe(111);
+        expect(result.lines[0][2].group_id).toBe(group2.id);
+        expect(result.relations_uuid_mapping).toBe(undefined);
+    }
+
+    // Delete line
+    line1.delete();
+    //update the group, to be sure the lines are empty
+    group1.index = 3;
+    group2.index = 4;
+    {
+        const result = order.serialize({ orm: true, clear: true });
+        expect(result.groups.length).toBe(2);
+        expect(result.groups[0][0]).toBe(1);
+        expect(result.groups[0][1]).toBe(group1.id);
+        expect(result.groups[0][2].index).toBe(3);
+        expect(result.groups[0][2].lines).toBeEmpty();
+        expect(result.groups[1][0]).toBe(1);
+        expect(result.groups[1][1]).toBe(group2.id);
+        expect(result.groups[1][2].index).toBe(4);
+        expect(result.groups[1][2].lines).toBeEmpty();
+
+        expect(result.lines.length).toBe(1);
+        expect(result.lines[0][0]).toBe(3);
+        expect(result.lines[0][1]).toBe(110);
+        expect(result.relations_uuid_mapping).toBe(undefined);
+    }
+
+    {
+        //All update/delete have been cleared
+        const result = order.serialize({ orm: true, clear: true });
+        expect(result.groups).toBeEmpty();
+        expect(result.lines).toBeEmpty();
+    }
+});
+
+test("grouped lines and nested lines", () => {
+    const models = getModels();
+
+    const order = models["pos.order"].create({ uuid: uuidv4() });
+    const group1 = models["pos.order.line.group"].create({
+        order_id: order,
+        uuid: uuidv4(),
+        index: 1,
+    });
+    const group2 = models["pos.order.line.group"].create({
+        order_id: order,
+        uuid: uuidv4(),
+        index: 2,
+    });
+    const parentLine = models["pos.order.line"].create({ order_id: order, uuid: uuidv4() });
+    const line1 = models["pos.order.line"].create({
+        order_id: order,
+        group_id: group1,
+        combo_parent_id: parentLine,
+        uuid: uuidv4(),
+    });
+    const line2 = models["pos.order.line"].create({
+        order_id: order,
+        group_id: group1,
+        combo_parent_id: parentLine,
+        uuid: uuidv4(),
+    });
+    const line3 = models["pos.order.line"].create({
+        order_id: order,
+        group_id: group2,
+        uuid: uuidv4(),
+    });
+
+    {
+        const result = order.serialize({ orm: true, clear: true });
+
+        expect(result.lines.length).toBe(4);
+        expect(result.groups.length).toBe(2);
+        const { relations_uuid_mapping } = result;
+        expect(Object.keys(relations_uuid_mapping["pos.order.line"]).length).toBe(3);
+        expect(relations_uuid_mapping["pos.order.line"][line1.uuid]["group_id"]).toBe(group1.uuid);
+        expect(relations_uuid_mapping["pos.order.line"][line2.uuid]["group_id"]).toBe(group1.uuid);
+        expect(relations_uuid_mapping["pos.order.line"][line1.uuid]["combo_parent_id"]).toBe(
+            parentLine.uuid
+        );
+        expect(relations_uuid_mapping["pos.order.line"][line2.uuid]["combo_parent_id"]).toBe(
+            parentLine.uuid
+        );
+
+        expect(relations_uuid_mapping["pos.order.line"][line3.uuid]["combo_parent_id"]).toBeEmpty();
+        expect(relations_uuid_mapping["pos.order.line"][line3.uuid]["group_id"]).toBe(group2.uuid);
+    }
+});

--- a/addons/pos_loyalty/static/src/app/models/pos_order_line.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order_line.js
@@ -42,13 +42,6 @@ patch(PosOrderline, {
 });
 
 patch(PosOrderline.prototype, {
-    serialize(options = {}) {
-        const json = super.serialize(...arguments);
-        if (options.orm && json.coupon_id < 0) {
-            json.coupon_id = undefined;
-        }
-        return json;
-    },
     setOptions(options) {
         if (options.eWalletGiftCardProgram) {
             this._e_wallet_program_id = options.eWalletGiftCardProgram;

--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -24,7 +24,6 @@ class PosOrder(models.Model):
     @api.model
     def sync_from_ui(self, orders):
         result = super().sync_from_ui(orders)
-
         order_ids = self.browse([o['id'] for o in result["pos.order"]])
         if order_ids:
             config_id = order_ids.config_id.ids[0] if order_ids else False
@@ -32,28 +31,4 @@ class PosOrder(models.Model):
         else:
             result['restaurant.order.course'] = []
         return result
-
-    def _process_order(self, order, existing_order):
-        restaurant_course_lines = order.pop("restaurant_course_lines", None)
-        order_id = super()._process_order(order, existing_order)
-        self._update_course_lines(order_id, restaurant_course_lines)
-        return order_id
-
-    def _update_course_lines(self, order_id, restaurant_course_lines):
-        """
-        Assigns the `course_id` field of order lines based on the relationship defined in the `order_course_lines` dictionary.
-        This dictionary links each course UUID to its corresponding list of line UUIDs.
-        """
-        if not restaurant_course_lines:
-            return
-        courses = self.env['restaurant.order.course'].search_read([('order_id', '=', order_id)], fields=['uuid', 'id'], load=False)
-        course_id_by_uuid = {c['uuid']: c['id'] for c in courses}
-        line_uuids = set()
-        for course_line_uuids in restaurant_course_lines.values():
-            line_uuids.update(course_line_uuids)
-        line_uuids = list(line_uuids)
-        lines = self.env['pos.order.line'].search([('order_id', '=', order_id), ('uuid', 'in', line_uuids)])
-        for course_uuid, line_uuids in restaurant_course_lines.items():
-            course_id = course_id_by_uuid.get(course_uuid)
-            if course_id:
-                lines.filtered(lambda l: l.uuid in line_uuids).write({'course_id': course_id})
+    

--- a/addons/pos_restaurant/static/src/app/models/pos_order.js
+++ b/addons/pos_restaurant/static/src/app/models/pos_order.js
@@ -73,34 +73,6 @@ patch(PosOrder.prototype, {
         }
         return super.setPartner(...arguments);
     },
-    serialize(options = {}) {
-        const data = super.serialize(...arguments);
-        if (options.orm === true && this.lines.length) {
-            if (this.hasCourses()) {
-                data.restaurant_course_lines = this.getORMCourseMappings(data);
-            }
-        }
-        return data;
-    },
-    getORMCourseMappings(serializedData) {
-        // Map each course uuid to its corresponding list line uuids to ensure proper assignment of new created course
-        const updatedLineIds = (serializedData.lines || [])
-            .filter((line) => line[0] === 1)
-            .map((line) => line[1]);
-        return this.lines.reduce((mapping, line) => {
-            if (
-                line.course_id &&
-                (typeof line.id === "string" || // New line
-                    typeof line.course_id.id === "string" || // New course
-                    updatedLineIds.includes(line.id)) // Updated line
-            ) {
-                const courseUuid = line.course_id.uuid;
-                mapping[courseUuid] = mapping[courseUuid] || [];
-                mapping[courseUuid].push(line.uuid);
-            }
-            return mapping;
-        }, {});
-    },
     cleanCourses() {
         if (!this.hasCourses()) {
             return;
@@ -127,8 +99,8 @@ patch(PosOrder.prototype, {
                 course.index = newIndex + 1;
                 return course;
             });
-        removedCourses.forEach((c) => {
-            c.delete();
+        removedCourses.forEach((course) => {
+            course.delete();
         });
         if (cleanedCourses.length !== originalLength) {
             this.course_ids = cleanedCourses;

--- a/addons/pos_restaurant/static/src/app/models/pos_order_line.js
+++ b/addons/pos_restaurant/static/src/app/models/pos_order_line.js
@@ -12,13 +12,6 @@ patch(PosOrderline.prototype, {
         orderline.note = this.note;
         return orderline;
     },
-    serialize(options = {}) {
-        const data = super.serialize(...arguments);
-        if (options.orm && data.course_id) {
-            delete data.course_id;
-        }
-        return data;
-    },
     getDisplayClasses() {
         return {
             ...super.getDisplayClasses(),

--- a/addons/pos_restaurant/static/src/app/models/restaurant_order_course.js
+++ b/addons/pos_restaurant/static/src/app/models/restaurant_order_course.js
@@ -9,16 +9,6 @@ export class RestaurantOrderCourse extends Base {
         super.setup(vals);
         this.uiState = {};
     }
-    serialize(options = {}) {
-        const data = super.serialize(...arguments);
-        if (options.orm === true) {
-            // The line_ids relationship is serialized in pos_order (restaurant_course_lines)
-            // using a course_uuid -> line_uuids mapping to prevent inserting the same new line
-            // multiple times in the data model.
-            delete data.line_ids;
-        }
-        return data;
-    }
     get name() {
         return _t("Course") + " " + this.index;
     }

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -138,7 +138,7 @@ patch(PosStore.prototype, {
                     orphanLine.qty
                 );
             } else {
-                const serializedLine = orphanLine.serialize({ orm: true });
+                const serializedLine = orphanLine.serialize();
                 serializedLine.order_id = destOrder.id;
                 delete serializedLine.uuid;
                 delete serializedLine.id;
@@ -296,7 +296,7 @@ patch(PosStore.prototype, {
 
             for (const detail of beforeMergeDetails) {
                 const line = order.lines.find((l) => l.uuid === detail.uuid);
-                const serializedLine = line.serialize({ orm: true });
+                const serializedLine = line.serialize();
                 delete serializedLine.uuid;
                 delete serializedLine.id;
                 const course = courseByLines[detail.uuid];

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -70,5 +70,5 @@ class PosOrder(models.Model):
         if not self.env.context.get('from_self'):
             return open_order
         elif open_order:
-            del order['table_id']
+            order.pop('table_id', None)
         return self.env['pos.order'].search([('uuid', '=', order.get('uuid'))], limit=1)


### PR DESCRIPTION
pos_* = pos_restaurant, pos_loyalty

Previously, the ORM serialization of recursive records required extra code to handle references between newly created records (e.g., combo lines referencing other new lines or a restaurant course referencing order lines already associated with an order). This commit adds support for these relationships of these recursive relationships, eliminating the need for additionnal code to maintain. As a result, any new recursive relationships are introduced transparently and with less overhead.
