### PR TITLE
[IMP] {purchase_,sale_,}stock: prevent fractional qtys with serials

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -96,6 +96,18 @@ class PurchaseOrderLine(models.Model):
                 if virtual_available < 0:
                     line.forecasted_issue = True
 
+    @api.onchange('product_qty')
+    def _onchange_product_qty_warning(self):
+        if self.product_id.tracking == 'serial' and not self.product_qty.is_integer():
+            self.product_qty = float_round(self.product_qty, precision_digits=0, rounding_method='UP')
+            return {
+                'warning': {
+                    'title': self.env._("Fractional quantity"),
+                    'message': self.env._("Products tracked with serial numbers cannot be purchased in fractional amounts."
+                                          " The quantity has been rounded up to the nearest whole number."),
+                }
+            }
+
     @api.model_create_multi
     def create(self, vals_list):
         lines = super().create(vals_list)

--- a/addons/repair/data/repair_demo.xml
+++ b/addons/repair/data/repair_demo.xml
@@ -20,7 +20,7 @@
             'location_id': obj().env.ref('stock.stock_location_stock').id,
             'product_id': obj().env.ref('product.product_product_11').id,
             'uom_id': obj().env.ref('uom.product_uom_unit').id,
-            'product_uom_qty': '1.0',
+            'product_uom_qty': 1.0,
             'state': 'draft',
             'repair_line_type': 'add',
             'company_id': obj().env.ref('base.main_company').id,

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 from odoo import api, fields, models, _
 from odoo.fields import Domain
-from odoo.tools import float_compare
+from odoo.tools import float_compare, float_round
 from odoo.exceptions import UserError
 
 
@@ -255,6 +255,18 @@ class SaleOrderLine(models.Model):
         super()._compute_customer_lead() # Reset customer_lead when the product is modified
         for line in self:
             line.customer_lead = line.product_id.with_company(line.company_id).sale_delay
+
+    @api.onchange('product_uom_qty')
+    def _onchange_product_uom_qty_warning(self):
+        if self.product_id.tracking == 'serial' and not self.product_uom_qty.is_integer():
+            self.product_uom_qty = float_round(self.product_uom_qty, precision_digits=0, rounding_method='UP')
+            return {
+                'warning': {
+                    'title': self.env._("Fractional quantity"),
+                    'message': self.env._("Products tracked with serial numbers cannot be sold in fractional amounts."
+                                          " The quantity has been rounded up to the nearest whole number."),
+                }
+            }
 
     def _inverse_customer_lead(self):
         for line in self:

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1389,6 +1389,21 @@ Please change the quantity done or the rounding precision in your settings.""",
                 'warning': {'title': _('Warning'), 'message': _('Unavailable Serial numbers. Please correct the serial numbers encoded: %(serial_numbers_to_locations)s', serial_numbers_to_locations=sn_to_location)}
             }
 
+    @api.onchange('quantity')
+    def _onchange_quantity_warning(self):
+        if self.product_id.tracking == 'serial' and not self.quantity.is_integer():
+            # Although we can't provide fractional amounts, we opt to round up the quantities
+            # to make sure the minimum required amount is provided.
+            self.quantity = float_round(self.quantity, precision_digits=0, rounding_method='UP')
+            return {
+                'warning': {
+                    'title': self.env._("Fractional quantity"),
+                    'message': self.env._("Products tracked with serial numbers cannot be transferred in fractional amounts."
+                                          " The quantity has been rounded up to the nearest whole number."),
+                }
+            }
+
+
     def _key_assign_picking(self):
         self.ensure_one()
         keys = (self.reference_ids, self.location_id, self.location_dest_id, self.picking_type_id)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1403,7 +1403,6 @@ Please change the quantity done or the rounding precision in your settings.""",
                 }
             }
 
-
     def _key_assign_picking(self):
         self.ensure_one()
         keys = (self.reference_ids, self.location_id, self.location_dest_id, self.picking_type_id)

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -11,7 +11,7 @@ from psycopg2 import Error
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
-from odoo.tools import SQL
+from odoo.tools import SQL, float_round
 
 _logger = logging.getLogger(__name__)
 
@@ -852,8 +852,6 @@ class StockQuant(models.Model):
         if self.env.context.get('packaging_uom_id') and product_id.product_tmpl_id.categ_id.packaging_reserve_method == "full":
             available_quantity = self.env.context.get('packaging_uom_id')._check_qty(available_quantity, product_id.uom_id, "DOWN")
 
-        quantity = min(quantity, available_quantity)
-
         # `quantity` is in the quants unit of measure. There's a possibility that the move's
         # unit of measure won't be respected if we blindly reserve this quantity, a common usecase
         # is if the move's unit of measure's rounding does not allow fractional reservation. We chose
@@ -863,12 +861,16 @@ class StockQuant(models.Model):
         # `available_quantity` is brought by a chained move line. In this case, `_prepare_move_line_vals`
         # will take care of changing the UOM to the UOM of the product.
         if not strict and uom_id and product_id.uom_id != uom_id:
-            quantity_move_uom = product_id.uom_id._compute_quantity(quantity, uom_id, rounding_method='DOWN')
+            quantity_move_uom = product_id.uom_id._compute_quantity(min(quantity, available_quantity), uom_id, rounding_method='DOWN')
             quantity = uom_id._compute_quantity(quantity_move_uom, product_id.uom_id, rounding_method='HALF-UP')
-
-        if product_id.tracking == 'serial':
-            if product_id.uom_id.compare(quantity, int(quantity)) != 0:
-                quantity = 0
+        # Products tracked with serial numbers cannot be reserved in fractional amounts. Rounding is necessary.
+        # If the reserved quantity is insufficient, we round down to provide all we have at hand as floor(reserved_quantity).
+        # Otherwise, we round up to make sure we can provide enough to cover the desired fractional amount.
+        elif product_id.tracking == 'serial':
+            quantity = min(float_round(quantity, precision_digits=0, rounding_method='UP'),
+                           float_round(available_quantity, precision_digits=0, rounding_method='DOWN'))
+        else:
+            quantity = min(quantity, available_quantity)
 
         reserved_quants = []
 

--- a/addons/stock/static/src/widgets/generate_serial.js
+++ b/addons/stock/static/src/widgets/generate_serial.js
@@ -4,7 +4,7 @@ import { x2ManyCommands } from "@web/core/orm_service";
 import { Dialog } from '@web/core/dialog/dialog';
 import { useService, useAutofocus } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
-import { parseInteger  } from "@web/views/fields/parsers";
+import { InvalidNumberError, parseFloat, parseInteger } from "@web/views/fields/parsers";
 import { getId } from "@web/model/relational_model/utils";
 import { Component, onMounted, onWillStart } from "@odoo/owl";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
@@ -25,6 +25,7 @@ export class GenerateDialog extends Component {
         this.totalReceived = useRef('totalReceived');
         this.keepLines = useRef('keepLines');
         this.lots = useRef('lots');
+        this.notification = useService("notification");
         this.orm = useService("orm");
         if (this.props.mode === 'generate') {
             if (this.isLotTracking) {
@@ -72,14 +73,28 @@ export class GenerateDialog extends Component {
 
     async _onGenerate() {
         let count;
+        let errorMessage;
         let qtyToProcess;
-        if (this.isLotTracking) {
-            count = parseFloat(this.nextSerialCount.el?.value || '0');
-            qtyToProcess = parseFloat(this.totalReceived.el?.value || this.props.move.data.product_qty);
-        } else {
-            count = parseInteger(this.nextSerialCount.el?.value || '0');
-            qtyToProcess = this.props.move.data.product_qty;
+        let next_serial_count = this.nextSerialCount.el?.value || '0';
+        try {
+            if (this.isLotTracking) {
+                errorMessage = _t("Invalid number provided for the quantity to be allocated per lot.");
+                count = parseFloat(next_serial_count);
+                qtyToProcess = parseFloat(this.totalReceived.el?.value || this.props.move.data.product_qty);
+            } else {
+                errorMessage = _t("The number of serial numbers to be generated must be a whole number.");
+                count = parseInteger(next_serial_count);
+                qtyToProcess = this.props.move.data.product_qty;
+            }
+        } catch (error) {
+            if (error instanceof InvalidNumberError) {
+                return this.notification.add(errorMessage, {
+                    title: _t("Invalid number"),
+                    type: 'danger',
+                });
+            }
         }
+
         const move_line_vals = await this.orm.call("stock.move", "action_generate_lot_line_vals", [{
                 ...this.props.move.context,
                 default_product_id: this.props.move.data.product_id.id,

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -2886,8 +2886,7 @@ class TestStockMove(TestStockCommon):
     def test_link_assign_9(self):
         """ Create an uom "3 units" which is 3 times the units but without rounding. Create 3
         quants in stock and two chained moves. The first move will bring the 3 quants but the
-        second only validate 2 and create a backorder for the last one. Check that the reservation
-        is correctly cleared up for the last one.
+        second only validate 2 and create a backorder for the last one.
         """
         uom_3units = self.env['uom.uom'].create({
             'name': '3 units',
@@ -2942,31 +2941,24 @@ class TestStockMove(TestStockCommon):
                 ml.quantity = 0
         picking_pack_cust.move_ids.picked = True
         res_dict_for_back_order = picking_pack_cust.button_validate()
+
         backorder_wizard = self.env[(res_dict_for_back_order.get('res_model'))].browse(res_dict_for_back_order.get('res_id')).with_context(res_dict_for_back_order['context'])
         backorder_wizard.process()
         backorder = self.env['stock.picking'].search([('backorder_id', '=', picking_pack_cust.id)])
+
         backordered_move = backorder.move_ids
-
-        # due to the rounding, the backordered quantity is 0.999 ; we shoudln't be able to reserve
-        # 0.999 on a tracked by serial number quant
         backordered_move._action_assign()
-        self.assertEqual(backordered_move.quantity, 0)
+        # Missing 1 unit means our 3-pack is lacking 0,33, which is 0,99 units.
+        self.assertRecordValues(backordered_move, [
+            {'quantity': 0.33, 'uom_id': uom_3units.id, 'product_qty': 0.99},
+        ])
 
-        # force the serial number and validate
-        lot3 = self.env['stock.lot'].search([('name', '=', "lot3")])
-        backorder.write({'move_line_ids': [(0, 0, {
-            'product_id': self.product_serial.id,
-            'uom_id': self.uom_unit.id,
-            'quantity': 1,
-            'lot_id': lot3.id,
-            'package_id': False,
-            'result_package_id': False,
-            'location_id': backordered_move.location_id.id,
-            'location_dest_id': backordered_move.location_dest_id.id,
-            'move_id': backordered_move.id,
-        })]})
-        backorder.move_ids.picked = True
+        backordered_move.picked = True
         backorder.button_validate()
+        # Trying to allocate a serially tracked product in fractional amounts will round the quantity reserved.
+        self.assertRecordValues(backorder.move_line_ids, [
+            {'quantity_product_uom': 1.0, 'uom_id': self.uom_unit.id, 'lot_id': lot_id.id},
+        ])
 
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product_serial, self.customer_location), 3)
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product_serial, self.pack_location), 0)

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -1338,24 +1338,86 @@ class TestStockQuant(TestStockCommon):
         self.assertEqual(quant.inventory_diff_quantity, 0)
 
     def test_reserve_fractional_qty(self):
-        lot1 = self.env['stock.lot'].create({'name': 'lot1', 'product_id': self.product_serial.id})
-        lot2 = self.env['stock.lot'].create({'name': 'lot2', 'product_id': self.product_serial.id})
-        for lot in (lot1, lot2):
-            self.env['stock.quant']._update_available_quantity(
-                product_id=self.product_serial,
-                location_id=self.stock_location,
-                quantity=1,
-                lot_id=lot,
-            )
+        """Test reservation products tracked with a serial number
+        with different quantity vs demand inequalities."""
+
+        # Since serial numbers can only be assigned to 1 product each, we cannot reserve products tracked with a
+        # serial number in fractional quantities. If we have enough stock, we always round up to make sure we provide
+        # enough to adequately cover the demand. (eg 3,1 becomes 4,0) If we don't have enough stock, we just reserve
+        # whatever whole number we can. (eg if stock is 3,9 and demand is 3,7, then 3,0 gets reserved instead of 4,0)
+
+        # stock < demand < stock + 1 where floor(demand) = floor(stock)
+        # 1.3 < 1.4 < 2.3
+        # new demand = floor(stock) = 1.0
+        self.env['stock.quant']._update_available_quantity(
+            product_id=self.product_serial,
+            location_id=self.stock_location,
+            quantity=1.3,
+        )
         move = self.env['stock.move'].create({
             'location_id': self.stock_location.id,
             'location_dest_id': self.shelf_2.id,
             'product_id': self.product_serial.id,
-            'product_uom_qty': 1.1,
+            'product_uom_qty': 1.4,
         })
         move._action_confirm()
         move._action_assign()
-        self.assertFalse(move.quantity)
+        self.assertEqual(move.quantity, 1.0)
+
+        # stock < demand < stock + 1 where floor(demand) ≠ floor(stock)
+        # 1.3 < 2.1 < 2.3
+        # new demand = floor(stock) = 1.0
+        move.picked = False
+        move.product_uom_qty = 2.1
+        move._action_assign()
+        self.assertEqual(move.quantity, 1.0)
+
+        # stock + 1 < demand
+        # 2.3 < 5.4
+        # new demand = floor(stock) = 1.0
+        move.picked = False
+        move.product_uom_qty = 5.4
+        move._action_assign()
+        self.assertEqual(move.quantity, 1.0)
+
+        # demand < stock < demand + 1 where floor(demand) = floor(stock)
+        # 1.3 < 1.4 < 2.3
+        # new demand = floor(stock) = 1.0
+        move.picked = False
+        self.env['stock.quant']._update_available_quantity(
+            product_id=self.product_serial,
+            location_id=self.stock_location,
+            quantity=0.1,  # 1.3 + 0.1 = 1.4
+        )
+        move.product_uom_qty = 1.3
+        move._action_assign()
+        self.assertEqual(move.quantity, 1.0)
+
+        # demand < stock < demand + 1 where floor(demand) ≠ floor(stock)
+        # 1.4 < 2.1 < 2.4
+        # new demand = ceiling(demand) = 2.0
+        move.picked = False
+        self.env['stock.quant']._update_available_quantity(
+            product_id=self.product_serial,
+            location_id=self.stock_location,
+            quantity=0.7,  # 1.4 + 0.7 = 2.1
+        )
+        move.product_uom_qty = 1.4
+        move._action_assign()
+        self.assertEqual(move.quantity, 2.0)
+
+        # demand + 1 < stock
+        # 2.3 < 5.4
+        # new demand = ceiling(demand) = 2.0
+        move.picked = False
+        self.env['stock.quant']._update_available_quantity(
+            product_id=self.product_serial,
+            location_id=self.stock_location,
+            quantity=3.3,  # 2.1 + 3.3 = 5.4
+        )
+        move.product_uom_qty = 1.3
+        move._action_assign()
+        self.assertEqual(move.quantity, 2.0)
 
     def test_lot_of_product_different_from_quant(self):
         """


### PR DESCRIPTION
Trying to sell, purchase or transfer products tracked by serial numbers in fractional amounts is nonsensical. It leads to unexpected effects like the quantity of invoiced products being silently rounded down to the nearest integer, and breakage during serial number generation.

This commit adds warnings to sale and purchase views to prevent the entry of fractional values. It also adds rounding logic for stock reservations to make sure we always reserve a sufficient amount when a fractional demand comes in. Tests are also adjusted accordingly for this new behaviour.

Task ID: [4566595](https://www.odoo.com/odoo/project/966/tasks/4566595)

--

Behaviour after PR: There are now validation checks across `purchase`, `sale` and `stock` that prevent fractional quantities for products tracked by serial numbers. Blocking warnings for the former two and automatic rounding up for the latter.
