### PR TITLE
[FIX] point_of_sale: preserve raw on record update

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -30,8 +30,13 @@ function processModelDefs(modelDefs) {
     modelDefs = clone(modelDefs);
     const inverseMap = new Map();
     const many2oneFields = [];
+    const baseData = {};
     for (const model in modelDefs) {
         const fields = modelDefs[model];
+        if (!baseData[model]) {
+            baseData[model] = {};
+        }
+
         for (const fieldName in fields) {
             const field = fields[fieldName];
 
@@ -127,7 +132,7 @@ function processModelDefs(modelDefs) {
         inverseMap.set(field, dummyField);
         inverseMap.set(dummyField, field);
     }
-    return [inverseMap, modelDefs];
+    return [inverseMap, modelDefs, baseData];
 }
 
 export class Base {
@@ -298,7 +303,7 @@ export class Base {
 export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
     const indexes = opts.databaseIndex || {};
     const database = opts.databaseTable || {};
-    const [inverseMap, processedModelDefs] = processModelDefs(modelDefs);
+    const [inverseMap, processedModelDefs, baseData] = processModelDefs(modelDefs);
     const records = mapObj(processedModelDefs, () => reactive(new Map()));
     const callbacks = mapObj(processedModelDefs, () => []);
     const commands = mapObj(processedModelDefs, () => ({
@@ -306,7 +311,6 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
         unlink: new Map(),
         update: new Set(),
     }));
-    const baseData = {};
     const missingFields = {};
 
     // object: model -> key -> keyval -> record
@@ -324,7 +328,6 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
             container[key] = reactive({});
         }
 
-        baseData[model] = {};
         return container;
     });
 
@@ -457,10 +460,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
             vals.uuid = record.uuid;
         }
 
-        if (!baseData[model][id]) {
-            baseData[model][id] = vals;
-        }
-
+        baseData[model][id] = vals;
         records[model].set(id, record);
 
         const fields = getFields(model);
@@ -627,6 +627,10 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
                             connect(field, record, record2);
                         }
                     }
+
+                    baseData[model][record.id][name] = items
+                        .filter((r) => typeof r.id === "number")
+                        .map((r) => r.id);
                 }
             } else if (field.type === "many2one" && comodelName in models) {
                 if (vals[name]) {
@@ -904,7 +908,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
      * Load the data without the relations then link the related records.
      * @param {*} rawData
      */
-    function loadData(rawData, load = [], fromSerialized = false, keepLocalRelation = false) {
+    function loadData(rawData, load = [], fromSerialized = false) {
         const results = {};
         const oldStates = {};
         const ignoreConnection = {};
@@ -924,10 +928,6 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
 
             const _records = rawData[model];
             for (const record of _records) {
-                if (!baseData[model]) {
-                    baseData[model] = {};
-                }
-
                 if (fromSerialized && typeof record.id === "string") {
                     const data = record.id.split("_");
                     const id = parseInt(data[1]);
@@ -937,8 +937,6 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
                         ID_CONTAINER[model] = id + 1;
                     }
                 }
-
-                baseData[model][record.id] = record;
 
                 const oldRecord = indexedRecords[model][modelKey][record[modelKey]];
                 if (oldRecord) {
@@ -952,7 +950,8 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
                     }
                 }
 
-                if (oldRecord && keepLocalRelation) {
+                if (oldRecord) {
+                    const raw = {};
                     for (const [field, value] of Object.entries(record)) {
                         const params = getFields(model)[field];
                         if (field === "id" || !params) {
@@ -968,11 +967,14 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
                             const existingRecords = value
                                 .map((r) => models[params.relation]?.get(r))
                                 .filter(Boolean);
+
                             if (existingRecords.length) {
                                 record[field] = [["set", ...existingRecords]];
                             } else {
                                 record[field] = [];
                             }
+
+                            raw[field] = value.filter((id) => typeof id === "number");
                         } else if (
                             params.type === "many2one" &&
                             value &&
@@ -991,6 +993,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
                     oldRecord.setup(record);
                     ignoreConnection[model].push(record.id);
                     results[model].push(oldRecord);
+                    Object.assign(baseData[model][record.id], raw);
                     continue;
                 }
 
@@ -1118,12 +1121,6 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
                 }
             }
         };
-
-        for (const [models, values] of Object.entries(rawData)) {
-            for (const value of values) {
-                baseData[models][value.id] = value;
-            }
-        }
 
         for (const [model, values] of Object.entries(results)) {
             indexRecord(model, values);

--- a/addons/point_of_sale/static/src/app/store/devices_synchronisation.js
+++ b/addons/point_of_sale/static/src/app/store/devices_synchronisation.js
@@ -123,7 +123,7 @@ export default class DevicesSynchronisation {
      * @param {Object} staticRecords - Records data that need to be synchronized.
      */
     processStaticRecords(staticRecords) {
-        return this.models.loadData(staticRecords, [], false, true);
+        return this.models.loadData(staticRecords, [], false);
     }
 
     /**
@@ -132,7 +132,7 @@ export default class DevicesSynchronisation {
      * @param {Object} dynamicRecords - Record write dates by ids and models.
      */
     processDynamicRecords(dynamicRecords) {
-        return this.models.loadData(dynamicRecords, [], false, true);
+        return this.models.loadData(dynamicRecords, [], false);
     }
 
     /**

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1269,7 +1269,7 @@ export class PosStore extends Reactive {
                 context,
             });
             const missingRecords = await this.data.missingRecursive(data);
-            const newData = this.models.loadData(missingRecords, [], false, true);
+            const newData = this.models.loadData(missingRecords, [], false);
 
             for (const line of newData["pos.order.line"]) {
                 const refundedOrderLine = line.refunded_orderline_id;

--- a/addons/pos_self_order/static/src/app/models/pos_order.js
+++ b/addons/pos_self_order/static/src/app/models/pos_order.js
@@ -6,10 +6,13 @@ import { patch } from "@web/core/utils/patch";
 patch(PosOrder.prototype, {
     setup() {
         super.setup(...arguments);
-        this.uiState = {
-            ...this.uiState,
-            lineChanges: {},
-        };
+
+        if (!this.uiState.lineChanges) {
+            this.uiState = {
+                ...this.uiState,
+                lineChanges: {},
+            };
+        }
     },
     get unsentLines() {
         return this.lines.filter(


### PR DESCRIPTION
Before this commit, when updating a record, the raw value of the field was lost if the specific record was not found locally.
