### PR TITLE
[IMP] web: native pull to refresh in PWA on mobile

### DIFF
--- a/addons/web/static/src/webclient/webclient_layout.scss
+++ b/addons/web/static/src/webclient/webclient_layout.scss
@@ -9,7 +9,14 @@
     height: 100%;
     display: flex;
     flex-flow: column nowrap;
-    overflow: hidden;
+
+    @media (display-mode: browser) {
+      overflow: hidden;
+    }
+    // For iOS devices
+    @supports (-webkit-touch-callout: none) {
+      overflow: hidden;
+    }
 
     > .o_action_manager {
       direction: ltr; //Define direction attribute here so when rtlcss preprocessor run, it converts it to rtl


### PR DESCRIPTION
This commit reintroduces the Pull to Refresh feature.
It's only available for mobile Progressive Web App (PWA).

Note that this feature is blocked by iOS devices and we have to
keep `overflow: hidden` as it's used when you open the Discuss
systray on small screens.

task-4307214