### PR TITLE
[IMP] ir.qweb: Make t-call parametric, enable lazy XML evaluation

### DIFF
--- a/addons/digest/data/digest_data.xml
+++ b/addons/digest/data/digest_data.xml
@@ -353,24 +353,27 @@
                                                 </tr>
                                                 <tr style="vertical-align: top;">
                                                     <td t-if="kpi_info.get('kpi_col1')" class="kpi_cell" style="padding-top: 10px; border-top: 1px solid #e6e6e6;">
-                                                        <div t-call="digest.digest_tool_kpi">
-                                                            <t t-set="kpi_value" t-value="kpi_info['kpi_col1']['value']" />
-                                                            <t t-set="kpi_margin" t-value="kpi_info['kpi_col1'].get('margin')" />
-                                                            <t t-set="kpi_subtitle" t-value="kpi_info['kpi_col1']['col_subtitle']" />
+                                                        <div>
+                                                            <t t-call="digest.digest_tool_kpi"
+                                                                kpi_value="kpi_info['kpi_col1']['value']"
+                                                                kpi_margin="kpi_info['kpi_col1'].get('margin')"
+                                                                kpi_subtitle="kpi_info['kpi_col1']['col_subtitle']"/>
                                                         </div>
                                                     </td>
                                                     <td t-if="kpi_info.get('kpi_col2')" class="kpi_cell" style="padding-top: 10px; border-top: 1px solid #e6e6e6;">
-                                                        <div t-call="digest.digest_tool_kpi">
-                                                            <t t-set="kpi_value" t-value="kpi_info['kpi_col2']['value']" />
-                                                            <t t-set="kpi_margin" t-value="kpi_info['kpi_col2'].get('margin')" />
-                                                            <t t-set="kpi_subtitle" t-value="kpi_info['kpi_col2']['col_subtitle']" />
+                                                        <div>
+                                                            <t t-call="digest.digest_tool_kpi"
+                                                                kpi_value="kpi_info['kpi_col2']['value']"
+                                                                kpi_margin="kpi_info['kpi_col2'].get('margin')"
+                                                                kpi_subtitle="kpi_info['kpi_col2']['col_subtitle']"/>
                                                         </div>
                                                     </td>
                                                     <td t-if="kpi_info.get('kpi_col3')" class="kpi_cell" style="padding-top: 10px; border-top: 1px solid #e6e6e6;">
-                                                        <div t-call="digest.digest_tool_kpi">
-                                                            <t t-set="kpi_value" t-value="kpi_info['kpi_col3']['value']" />
-                                                            <t t-set="kpi_margin" t-value="kpi_info['kpi_col3'].get('margin')" />
-                                                            <t t-set="kpi_subtitle" t-value="kpi_info['kpi_col3']['col_subtitle']" />
+                                                        <div>
+                                                            <t t-call="digest.digest_tool_kpi"
+                                                                kpi_value="kpi_info['kpi_col3']['value']"
+                                                                kpi_margin="kpi_info['kpi_col3'].get('margin')"
+                                                                kpi_subtitle="kpi_info['kpi_col3']['col_subtitle']"/>
                                                         </div>
                                                     </td>
                                                 </tr>
@@ -418,7 +421,9 @@
                                 </table>
                             </td>
                         </tr>
-                        <tr t-if="display_mobile_banner" t-call="digest.digest_section_mobile" />
+                        <tr t-if="display_mobile_banner">
+                            <t t-call="digest.digest_section_mobile"/>
+                        </tr>
                     </tfoot>
                 </table>
             </td>

--- a/addons/event/report/event_event_templates.xml
+++ b/addons/event/report/event_event_templates.xml
@@ -179,8 +179,8 @@
                                 <div t-if="event.address_id" class="col-md-6 col-12 mb-3 mb-md-0 o_event_full_page_ticket_column">
                                     <div class="d-flex">
                                         <i class="fa fa-map-marker fa-2x fa-fw me-2 mt-1"/>
-                                        <div t-call="event.event_report_template_formatted_event_address">
-                                            <t t-set="multi_line_address" t-value="True"/>
+                                        <div>
+                                            <t t-call="event.event_report_template_formatted_event_address" multi_line_address="True"/>
                                         </div>
                                     </div>
                                 </div>

--- a/addons/l10n_es_edi_tbai/data/template_LROE_bizkaia.xml
+++ b/addons/l10n_es_edi_tbai/data/template_LROE_bizkaia.xml
@@ -6,20 +6,24 @@
         <template id="template_LROE_240_main">
             <lrpjfecsgap:LROEPJ240FacturasEmitidasConSGAltaPeticion
                 xmlns:lrpjfecsgap="https://www.batuz.eus/fitxategiak/batuz/LROE/esquemas/LROE_PJ_240_1_1_FacturasEmitidas_ConSG_AltaPeticion_V1_0_2.xsd"
-                t-if="is_emission and not freelancer"
-                t-call="l10n_es_edi_tbai.template_LROE_240_inner"/>
+                t-if="is_emission and not freelancer">
+                <t t-call="l10n_es_edi_tbai.template_LROE_240_inner"/>
+            </lrpjfecsgap:LROEPJ240FacturasEmitidasConSGAltaPeticion>
             <lrpficfcsgap:LROEPF140IngresosConFacturaConSGAltaPeticion
                 xmlns:lrpficfcsgap="https://www.batuz.eus/fitxategiak/batuz/LROE/esquemas/LROE_PF_140_1_1_Ingresos_ConfacturaConSG_AltaPeticion_V1_0_2.xsd"
-                t-elif="is_emission and freelancer"
-                t-call="l10n_es_edi_tbai.template_LROE_240_inner"/>
+                t-elif="is_emission and freelancer">
+                <t t-call="l10n_es_edi_tbai.template_LROE_240_inner"/>
+            </lrpficfcsgap:LROEPF140IngresosConFacturaConSGAltaPeticion>
             <lrpjfecsgap:LROEPJ240FacturasEmitidasConSGAnulacionPeticion
                 xmlns:lrpjfecsgap="https://www.batuz.eus/fitxategiak/batuz/LROE/esquemas/LROE_PJ_240_1_1_FacturasEmitidas_ConSG_AnulacionPeticion_V1_0_0.xsd"
-                t-elif="not is_emission and not freelancer"
-                t-call="l10n_es_edi_tbai.template_LROE_240_inner"/>
+                t-elif="not is_emission and not freelancer">
+                <t t-call="l10n_es_edi_tbai.template_LROE_240_inner"/>
+            </lrpjfecsgap:LROEPJ240FacturasEmitidasConSGAnulacionPeticion>
             <lrpficfcsgap:LROEPF140IngresosConFacturaConSGAnulacionPeticion
                 xmlns:lrpficfcsgap="https://www.batuz.eus/fitxategiak/batuz/LROE/esquemas/LROE_PF_140_1_1_Ingresos_ConfacturaConSG_AnulacionPeticion_V1_0_0.xsd"
-                t-elif="not is_emission and freelancer"
-                t-call="l10n_es_edi_tbai.template_LROE_240_inner"/>
+                t-elif="not is_emission and freelancer">
+                <t t-call="l10n_es_edi_tbai.template_LROE_240_inner"/>
+            </lrpficfcsgap:LROEPF140IngresosConFacturaConSGAnulacionPeticion>
         </template>
 
         <template id="template_LROE_240_inner"> <!-- To be used for both 140 and 240 -->
@@ -54,20 +58,24 @@
         <template id="template_LROE_240_main_recibidas">
             <lrpjframp:LROEPJ240FacturasRecibidasAltaModifPeticion
                 xmlns:lrpjframp="https://www.batuz.eus/fitxategiak/batuz/LROE/esquemas/LROE_PJ_240_2_FacturasRecibidas_AltaModifPeticion_V1_0_1.xsd"
-                t-if="is_emission and not freelancer"
-                t-call="l10n_es_edi_tbai.template_LROE_240_inner_recibidas"/>
+                t-if="is_emission and not freelancer">
+                <t t-call="l10n_es_edi_tbai.template_LROE_240_inner_recibidas"/>
+            </lrpjframp:LROEPJ240FacturasRecibidasAltaModifPeticion>
             <lrpfgcfamp:LROEPF140GastosConFacturaAltaModifPeticion
                 xmlns:lrpfgcfamp="https://www.batuz.eus/fitxategiak/batuz/LROE/esquemas/LROE_PF_140_2_1_Gastos_Confactura_AltaModifPeticion_V1_0_2.xsd"
-                t-elif="is_emission and freelancer"
-                t-call="l10n_es_edi_tbai.template_LROE_240_inner_recibidas"/>
+                t-elif="is_emission and freelancer">
+                <t t-call="l10n_es_edi_tbai.template_LROE_240_inner_recibidas"/>
+            </lrpfgcfamp:LROEPF140GastosConFacturaAltaModifPeticion>
             <lrpjfrap:LROEPJ240FacturasRecibidasAnulacionPeticion
                 xmlns:lrpjfrap="https://www.batuz.eus/fitxategiak/batuz/LROE/esquemas/LROE_PJ_240_2_FacturasRecibidas_AnulacionPeticion_V1_0_0.xsd"
-                t-elif="not is_emission and not freelancer"
-                t-call="l10n_es_edi_tbai.template_LROE_240_inner_recibidas"/>
+                t-elif="not is_emission and not freelancer">
+                <t t-call="l10n_es_edi_tbai.template_LROE_240_inner_recibidas"/>
+            </lrpjfrap:LROEPJ240FacturasRecibidasAnulacionPeticion>
             <lrpfgcfap:LROEPF140GastosConFacturaAnulacionPeticion
                 xmlns:lrpfgcfap="https://www.batuz.eus/fitxategiak/batuz/LROE/esquemas/LROE_PF_140_2_1_Gastos_Confactura_AnulacionPeticion_V1_0_0.xsd"
-                t-elif="not is_emission and freelancer"
-                t-call="l10n_es_edi_tbai.template_LROE_240_inner_recibidas"/>
+                t-elif="not is_emission and freelancer">
+                <t t-call="l10n_es_edi_tbai.template_LROE_240_inner_recibidas"/>
+            </lrpfgcfap:LROEPF140GastosConFacturaAnulacionPeticion>
         </template>
 
         <template id="template_LROE_240_inner_recibidas">

--- a/addons/mail/tests/test_mail_template.py
+++ b/addons/mail/tests/test_mail_template.py
@@ -233,7 +233,7 @@ class TestMailTemplate(MailCommon):
             '<p t-set="x" t-value="object.name"></p>',
             '<p t-set="x" t-value="object.name"></p>',
             '<p t-groups="base.group_system"></p>',
-            '<p t-call="template"></p>',
+            '<t t-call="template"/>',
             '<t t-set="namn" t-value="Hello {{world}} !"/>',
             '<t t-att-test="object.name"/>',
             '<p t-att-title="object.name"></p>',

--- a/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
+++ b/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
@@ -5,7 +5,9 @@
         <td name="td_mrp_bom">
             <div class="text-truncate" t-attf-style="margin-left: {{ marginMultiplicator * 20 }}px">
                 <t t-if="hasFoldButton">
-                    <span class="o_mrp_bom_unfoldable btn btn-light p-0" t-attf-aria-label="{{ props.isFolded ? 'Unfold' : 'Fold' }}" t-attf-title="{{ props.isFolded ? 'Unfold' : 'Fold' }}" style="margin-right: 1px">
+                    <t t-set="title_fold">Fold</t>
+                    <t t-set="title_unfold">Unfold</t>
+                    <span class="o_mrp_bom_unfoldable btn btn-light p-0" t-att-aria-label="props.isFolded ? title_unfold : title_fold" t-att-title="props.isFolded ? title_unfold : title_fold" style="margin-right: 1px">
                         <i t-attf-class="fa fa-fw fa-caret-{{ props.isFolded ? 'right' : 'down' }}" role="img"/>
                     </span>
                 </t>

--- a/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
+++ b/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
@@ -4,7 +4,9 @@
     <tr t-name="mrp.BomOverviewSpecialLine" t-on-click="props.toggleFolded" >
         <td name="td_mrp_bom">
             <span t-attf-style="margin-left: {{ data.level * 20 }}px"/>
-            <span t-if="hasFoldButton" t-attf-class="o_mrp_bom_{{ props.isFolded ? 'unfoldable' : 'foldable' }} btn btn-light ps-0 py-0" t-attf-aria-label="{{ props.isFolded ? 'Unfold' : 'Fold' }}" t-attf-title="{{ props.isFolded ? 'Unfold' : 'Fold' }}">
+            <t t-set="title_fold">Fold</t>
+            <t t-set="title_unfold">Unfold</t>
+            <span t-if="hasFoldButton" t-attf-class="o_mrp_bom_{{ props.isFolded ? 'unfoldable' : 'foldable' }} btn btn-light ps-0 py-0" t-att-aria-label="props.isFolded ? title_unfold : title_fold" t-att-title="props.isFolded ? title_unfold : title_fold">
                 <i t-attf-class="fa fa-fw fa-caret-{{ props.isFolded ? 'right' : 'down' }}" role="img"/>
                 <t t-if="props.type == 'operations'">Operations</t>
                 <t t-elif="props.type == 'byproducts'">By-Products</t>

--- a/addons/payment/views/payment_form_templates.xml
+++ b/addons/payment/views/payment_form_templates.xml
@@ -225,8 +225,8 @@
                 </div>
             </div>
             <!-- === Payment method logo === -->
-            <div t-call="payment.form_logo">
-                <t t-set="logo_pm_sudo" t-value="token_sudo.payment_method_id"/>
+            <div>
+                <t t-call="payment.form_logo" logo_pm_sudo="token_sudo.payment_method_id"/>
             </div>
         </div>
         <!-- === Inline form === -->

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -63,9 +63,9 @@
     <!-- Added by another template so that it can be disabled if needed -->
     <template id="footer_language_selector" inherit_id="portal.frontend_layout" name="Footer Language Selector">
         <xpath expr="//*[hasclass('o_footer_copyright_name')]" position="after">
-            <t id="language_selector_call" t-call="portal.language_selector">
-                <t t-set="_div_classes" t-value="(_div_classes or '') + ' dropup'"/>
-            </t>
+            <t id="language_selector_call"
+                t-call="portal.language_selector"
+                _div_classes="(_div_classes or '') + ' dropup'"/>
         </xpath>
     </template>
 

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -198,7 +198,7 @@
               <div id="quote_content" class="o_portal_content col-12 col-lg-8 col-xxl-9">
                   <!-- main content -->
                   <div id="portal_purchase_content">
-                      <div t-call="purchase.purchase_order_portal_content"/>
+                      <div><t t-call="purchase.purchase_order_portal_content"/></div>
                   </div>
 
                   <!-- chatter -->
@@ -411,7 +411,7 @@
     <xpath expr="////div[@id='portal_purchase_content']" position="replace">
       <div id="portal_purchase_content">
         <t t-set="update_dates" t-value="True"/>
-        <div t-call="purchase.purchase_order_portal_content"/>
+        <div><t t-call="purchase.purchase_order_portal_content"/></div>
       </div>
     </xpath>
   </template>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -133,7 +133,7 @@
                 t-att-data-order-amount-total="sale_order.amount_total"
             >
                 <!-- Sidebar -->
-                <t t-call="portal.portal_record_sidebar" id="sale_order_portal_sidebar">
+                <t t-call="portal.portal_record_sidebar">
                     <t t-set="classes" t-value="'col-lg-4 col-xxl-3 d-print-none'"/>
                     <t t-set="title">
                         <t t-if="sale_order.state in 'draft,sent' and sale_order.prepayment_percent != 1.0">
@@ -293,17 +293,15 @@
                     <div role="dialog" class="modal fade" id="modalaccept" name="sale_order_modal_sign_and_pay">
                         <div
                             t-if="sale_order._has_to_be_signed() and not payment_amount"
-                            t-call="sale.sale_order_portal_sign_modal"
                             class="modal-dialog"
-                        />
+                        ><t t-call="sale.sale_order_portal_sign_modal"/></div>
                         <div
                             t-elif="not sale_order._has_to_be_signed()
                                     and sale_order._has_to_be_paid()
                                     or (payment_amount and sale_order.state != 'cancel')"
                             name="sale_order_modal_validate"
-                            t-call="sale.sale_order_portal_pay_modal"
                             class="modal-dialog"
-                        />
+                        ><t t-call="sale.sale_order_portal_pay_modal"/></div>
                     </div>
 
                     <!-- modal relative to the action reject -->
@@ -371,7 +369,7 @@
 
                     <!-- main content -->
                     <div t-attf-class="#{'pb-5' if report_type == 'html' else ''}" id="portal_sale_content">
-                        <div t-call="#{sale_order._get_name_portal_content_view()}"/>
+                        <div><t t-call="#{sale_order._get_name_portal_content_view()}"/></div>
                     </div>
 
                     <!-- bottom actions -->
@@ -507,16 +505,16 @@
                         class="fw-bold"
                     />
                 </div>
-                <div t-if="company_mismatch" t-call="payment.company_mismatch_warning"/>
+                <div t-if="company_mismatch"><t t-call="payment.company_mismatch_warning"/></div>
                 <div
                     t-elif="not sale_order._has_to_be_paid() and not payment_amount"
                     class="alert alert-danger"
                 >
                     The order is not in a state requiring customer payment.
                 </div>
-                <div t-else="" id="payment_method" t-call="payment.form" class="text-start mt-0" >
+                <div t-else="" id="payment_method" class="text-start mt-0" >
                     <!-- Inject the order ID to allow Stripe to check if tokenization is required. -->
-                    <t t-set="sale_order_id" t-value="sale_order.id"/>
+                    <t t-call="payment.form" sale_order_id="sale_order.id"/>
                 </div>
             </main>
         </div>

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -37,29 +37,26 @@
         <xpath expr="//footer" position="after">
             <div class="py-3 m-0 p-0 text-end">
                 <div class="o_survey_progress_wrapper d-inline-block pe-1 text-start">
-                    <t t-call="survey.survey_progression"
-                        t-if="survey and survey.questions_layout != 'one_page' and answer and answer.state == 'in_progress' and (not question or not question.is_page) and not survey_form_readonly">
+                    <t t-if="survey and survey.questions_layout != 'one_page' and answer and answer.state == 'in_progress' and (not question or not question.is_page) and not survey_form_readonly">
                         <t t-if="survey.questions_layout == 'page_per_section'">
                             <t t-set="page_ids" t-value="survey.page_ids.ids"/>
                             <t t-set="page_number" t-value="page_ids.index(page.id) + (1 if survey.progression_mode == 'number' else 0)"/>
                         </t>
                         <t t-else="">
-                            <t t-if="not answer.is_session_answer and survey.questions_selection == 'random'">
-                                <t t-set="page_ids" t-value="answer.predefined_question_ids.ids"/>
-                            </t>
-                            <t t-else="">
-                                <t t-set="page_ids" t-value="survey.question_ids.ids"/>
-                            </t>
+                            <t t-if="not answer.is_session_answer and survey.questions_selection == 'random'"
+                                t-set="page_ids" t-value="answer.predefined_question_ids.ids"/>
+                            <t t-else="" t-set="page_ids" t-value="survey.question_ids.ids"/>
                             <t t-set="page_number" t-value="page_ids.index(question.id)"/>
                         </t>
+                        <t t-call="survey.survey_progression"/>
                     </t>
                 </div>
                 <div class="o_survey_brand_message float-end rounded me-3 border">
-                    <div class="px-2 py-2 d-inline-block" t-call="web.brand_promotion_message">
-                        <t t-set="_message"></t>
-                        <t t-set="_utm_medium" t-valuef="survey"/>
+                    <div class="px-2 py-2 d-inline-block">
+                        <t t-call="web.brand_promotion_message" _message.f="" _utm_medium.f="survey"/>
                     </div>
-                    <div t-if="not no_survey_navigation" class="o_survey_navigation_wrapper d-inline-block d-print-none" t-call="survey.survey_navigation">
+                    <div t-if="not no_survey_navigation" class="o_survey_navigation_wrapper d-inline-block d-print-none">
+                        <t t-call="survey.survey_navigation"/>
                     </div>
                 </div>
             </div>

--- a/addons/survey/views/survey_templates_statistics.xml
+++ b/addons/survey/views/survey_templates_statistics.xml
@@ -18,7 +18,7 @@
         <div class="o_survey_statistics_header mt32">
             <h2 t-field="survey.title"/>
             <div class="d-flex align-items-start">
-                <div t-if="question_and_page_data" t-call="survey.survey_results_filters" class="o_survey_results_topbar d-print-none"/>
+                <div t-if="question_and_page_data" class="o_survey_results_topbar d-print-none"><t t-call="survey.survey_results_filters"/></div>
                 <h3 t-else="">
                     Sorry, no one answered this survey yet.
                 </h3>
@@ -74,7 +74,7 @@
                 <h3 class="mt16 text-uppercase" t-field="question.title"/>
                 <hr class="mt-2 mb-4"/>
             </div>
-            <div t-else="" class="mt-2 o_survey_results_question_wrapper" t-call="survey.survey_page_statistics_question" />
+            <div t-else="" class="mt-2 o_survey_results_question_wrapper"><t t-call="survey.survey_page_statistics_question"/></div>
         </div>
     </template>
 
@@ -283,7 +283,7 @@
                             <td>
                                 <t t-if="question.question_type == 'numerical_box'">
                                     <t t-set="right_answer" t-value="common_line[0] == question.answer_numerical_box"/>
-                                    <span t-call="survey.survey_remove_unnecessary_decimals"><t t-set="value_to_format" t-value="common_line[0]"/></span>
+                                    <span><t t-call="survey.survey_remove_unnecessary_decimals" value_to_format="common_line[0]"/></span>
                                     <i t-if="right_answer" class="fa fa-check"/>
                                 </t>
                                 <t t-elif="question.question_type == 'date'">
@@ -299,8 +299,8 @@
                             </td>
                             <td><span t-esc="common_line[1]"></span></td>
                             <td t-if="question.is_scored_question">
-                                <span t-if="right_answer" t-call="survey.survey_remove_unnecessary_decimals">
-                                    <t t-set="value_to_format" t-value="question.answer_score"/>
+                                <span t-if="right_answer">
+                                    <t t-call="survey.survey_remove_unnecessary_decimals" value_to_format="question.answer_score"/>
                                 </span>
                                 <span t-else="">0</span>
                             </td>
@@ -357,8 +357,8 @@
                         <tr t-foreach="table_data" t-as="choice_data">
                             <td>
                                 <p class="text-nowrap my-0">
-                                    <span t-if="question.question_type == 'numerical_box'" t-call="survey.survey_remove_unnecessary_decimals">
-                                        <t t-set="value_to_format" t-value="choice_data['value']"/>
+                                    <span t-if="question.question_type == 'numerical_box'">
+                                        <t t-call="survey.survey_remove_unnecessary_decimals" value_to_format="choice_data['value']"/>
                                     </span>
                                     <span t-else="" t-esc="choice_data['value']"/>
                                     <i t-if="question.is_scored_question and choice_data['suggested_answer'].is_correct" class="fa fa-check"/>
@@ -377,15 +377,15 @@
                                     data-model-short-key="A" t-att-data-record-id="choice_data['suggested_answer'].id"
                                     role="img" aria-label="Filter surveys" title="Only show survey results having selected this answer"/>
                             </td>
-                            <td t-if="question.is_scored_question" t-call="survey.survey_remove_unnecessary_decimals">
-                                <t t-set="value_to_format" t-value="choice_data['suggested_answer'].answer_score"/>
+                            <td t-if="question.is_scored_question">
+                                <t t-call="survey.survey_remove_unnecessary_decimals" value_to_format="choice_data['suggested_answer'].answer_score"/>
                             </td>
                         </tr>
                     </tbody>
                 </table>
             </div>
         </div>
-        <div t-if="comment_lines" t-call="survey.question_result_comments" />
+        <div t-if="comment_lines"><t t-call="survey.question_result_comments"/></div>
     </template>
 
     <template id="question_result_matrix" name="Question: matrix result (matrix)">
@@ -431,7 +431,7 @@
                     </tbody>
                 </table>
             </div>
-        <div t-if="comment_lines" t-call="survey.question_result_comments" />
+        <div t-if="comment_lines"><t t-call="survey.question_result_comments"/></div>
         </div>
     </template>
 

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -159,10 +159,11 @@
                             <div class="progress">
                                 <div class="progress-bar fw-bold" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" aria-label="Progress bar"></div>
                             </div>
-                            <fieldset disabled="disabled" class="mt-5" t-if="question.question_type == 'matrix'" t-call="survey.question_container">
-                                <t t-set="hide_question_title" t-value="true" />
-                                <t t-set="answer" t-value="env['survey.user_input']" />
-                                <t t-set="survey_form_readonly" t-value="True"/>
+                            <fieldset disabled="disabled" class="mt-5" t-if="question.question_type == 'matrix'">
+                                <t t-call="survey.question_container"
+                                    hide_question_title="True"
+                                    answer="env['survey.user_input']"
+                                    survey_form_readonly="True"/>
                             </fieldset>
                         </div>
                     </div>

--- a/addons/web/static/src/search/breadcrumbs/breadcrumbs.xml
+++ b/addons/web/static/src/search/breadcrumbs/breadcrumbs.xml
@@ -39,7 +39,7 @@
             </t>
             <div class="d-flex gap-1 text-truncate">
                 <div class="o_last_breadcrumb_item active d-flex gap-2 align-items-center min-w-0 lh-sm">
-                    <span class="min-w-0 text-truncate" t-call="web.Breadcrumb.Name"/>
+                    <span class="min-w-0 text-truncate"><t t-call="web.Breadcrumb.Name"/></span>
                 </div>
                 <t t-call="web.Breadcrumb.Actions"/>
             </div>
@@ -47,7 +47,7 @@
 
         <div t-else="" class="o_breadcrumb d-flex gap-1 text-truncate">
             <div class="o_last_breadcrumb_item active d-flex fs-4 min-w-0 align-items-center">
-                <span class="min-w-0 text-truncate" t-call="web.Breadcrumb.Name"/>
+                <span class="min-w-0 text-truncate"><t t-call="web.Breadcrumb.Name"/></span>
             </div>
             <t t-call="web.Breadcrumb.Actions"/>
         </div>

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -742,8 +742,8 @@
             <table class="o_ignore_layout_styling table table-borderless mb-0">
                 <tbody>
                     <tr>
-                        <td t-call="web.address_layout" t-attf-class="p-0 {{'pt-3' if information_block else ''}}">
-                            <t t-set="custom_layout_address" t-value="true"/>
+                        <td t-attf-class="p-0 {{'pt-3' if information_block else ''}}">
+                            <t t-call="web.address_layout" custom_layout_address="true"/>
                         </td>
                         <td t-if="not information_block" class="align-bottom p-0 ps-2">
                             <h2 class="mb-4 text-nowrap text-end" t-out="layout_document_title"/>

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -52,9 +52,7 @@
             }
         </script>
         <t t-call-assets="web.assets_frontend_minimal" t-css="false" defer_load="True"/>
-        <t t-call="web.conditional_assets_tests">
-            <t t-set="ignore_missing_deps" t-value="True"/>
-        </t>
+        <t t-call="web.conditional_assets_tests" ignore_missing_deps="True"/>
         <t t-call-assets="web.assets_frontend_lazy" t-css="false" lazy_load="True"/>
       </xpath>
         <xpath expr="//t[@t-out='0']" position="replace">

--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -15,8 +15,7 @@
 
     <!-- Template for home and contactus -->
     <template id="website.homepage" name="Home">
-        <t t-call="website.layout">
-            <t t-set="pageName" t-value="'homepage'"/>
+        <t t-call="website.layout" pageName.f="homepage">
             <div id="wrap" class="oe_structure oe_empty"/>
         </t>
     </template>

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1259,8 +1259,7 @@ class Website(models.Model):
 
         # keep strange indentation in python file, to get it correctly in database
         new_homepage_view = '''<t name="Homepage" t-name="website.homepage">
-    <t t-call="website.layout">
-        <t t-set="pageName" t-value="'homepage'"/>
+    <t t-call="website.layout" pageName.f="homepage">
         <div id="wrap" class="oe_structure oe_empty"/>
     </t>
 </t>'''

--- a/addons/website/tests/test_disable_unused_snippets_assets.py
+++ b/addons/website/tests/test_disable_unused_snippets_assets.py
@@ -105,8 +105,7 @@ class TestDisableSnippetsAssets(TransactionCase):
 
 HOMEPAGE_UP_TO_DATE = """
 <t name="Homepage" t-name="website.homepage1">
-  <t t-call="website.layout">
-    <t t-set="pageName" t-value="'homepage'"/>
+  <t t-call="website.layout" pageName.f="homepage">
     <div id="wrap" class="oe_structure oe_empty">
       <section class="s_website_form pt16 pb16 o_colored_level" data-vcss="001" data-snippet="s_website_form" data-name="Form">
         <div class="container">
@@ -128,8 +127,7 @@ HOMEPAGE_UP_TO_DATE = """
 
 HOMEPAGE_OUTDATED = """
 <t name="Homepage" t-name="website.homepage1">
-  <t t-call="website.layout">
-    <t t-set="pageName" t-value="'homepage'"/>
+  <t t-call="website.layout" pageName.f="homepage">
     <div id="wrap" class="oe_structure oe_empty">
       <form action="/website_form/" method="post" class="s_website_form container-fluid mt32 o_fake_not_editable" enctype="multipart/form-data" data-name="Form Builder" data-model_name="mail.mail" data-success_page="/contactus-thank-you" data-snippet="s_website_form">
         <div class="container">

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -215,7 +215,7 @@ class WithContext(HttpCase):
         self.base_view = View.create({
             'name': 'Base',
             'type': 'qweb',
-            'arch': '''<t name="Homepage" t-name="website.base_view">
+            'arch': '''<t name="Homepage" t-name="test.base_view">
                         <t t-call="website.layout">
                             I am a generic page
                         </t>

--- a/addons/website/tests/test_unsplash_beacon.py
+++ b/addons/website/tests/test_unsplash_beacon.py
@@ -16,8 +16,7 @@ class TestUnsplashBeacon(odoo.tests.HttpCase):
         # Create page with unsplash image.
         page = self.env['website.page'].search([('url', '=', '/'), ('website_id', '=', 1)])
         page.arch = '''<t name="Homepage" t-name="website.homepage1">
-        <t t-call="website.layout">
-            <t t-set="pageName" t-value="'homepage'"/>
+        <t t-call="website.layout" pageName.f="homepage">
             <div id="wrap" class="oe_structure oe_empty">
                 <img src="/unsplash/pYyOZ8q7AII/306/fairy.jpg"/>
                 <!--

--- a/addons/website/views/snippets/s_accordion_image.xml
+++ b/addons/website/views/snippets/s_accordion_image.xml
@@ -9,9 +9,7 @@
                     <h2 class="h3-fs">Top questions answered</h2>
                     <p class="lead">In this section, you can address common questions efficiently.</p>
                     <p><br/></p>
-                    <t t-snippet-call="website.s_accordion">
-                        <t t-set="extra_classes" t-valuef="accordion-flush"/>
-                    </t>
+                    <t t-snippet-call="website.s_accordion" extra_classes.f="accordion-flush"/>
                 </div>
                 <div class="col-lg-5 offset-lg-1 pt16">
                     <img src="/web/image/website.s_accordion_image_default_image" class="img img-fluid mx-auto rounded" style="width: 100% !important;" alt=""/>

--- a/addons/website/views/snippets/s_dynamic_snippet.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet.xml
@@ -42,9 +42,8 @@
         </section>
     </template>
     <template id="s_dynamic_snippet" name="Dynamic Snippet">
-        <t t-call="website.s_dynamic_snippet_template">
-            <t t-set="snippet_name" t-value="'s_dynamic_snippet'"/>
-        </t>
+        <t t-call="website.s_dynamic_snippet_template"
+            snippet_name.f="s_dynamic_snippet"/>
     </template>
 
 <record id="website.s_dynamic_snippet_000_scss" model="ir.asset">

--- a/addons/website/views/snippets/s_dynamic_snippet_carousel.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet_carousel.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="s_dynamic_snippet_carousel" name="Dynamic Carousel">
-        <t t-call="website.s_dynamic_snippet_template">
-            <t t-set="snippet_name" t-value="'s_dynamic_snippet_carousel'"/>
-        </t>
+        <t t-call="website.s_dynamic_snippet_template"
+            snippet_name.f="s_dynamic_snippet_carousel"/>
     </template>
 
 <record id="website.s_dynamic_snippet_carousel_000_scss" model="ir.asset">

--- a/addons/website/views/snippets/s_faq_collapse.xml
+++ b/addons/website/views/snippets/s_faq_collapse.xml
@@ -10,9 +10,8 @@
                     <p class="lead">Here are some common questions about our company.</p>
                 </div>
                 <div class="col-lg-7 offset-lg-1 s_col_no_bgcolor" data-name="Accordion Box">
-                    <t t-call="website.s_accordion">
-                        <t t-set="extra_classes" t-valuef="accordion-flush"/>
-                    </t>
+                    <t t-call="website.s_accordion"
+                        extra_classes.f="accordion-flush"/>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_mega_menu_big_icons_subtitles.xml
+++ b/addons/website/views/snippets/s_mega_menu_big_icons_subtitles.xml
@@ -8,59 +8,50 @@
             <div class="row">
                 <div class="col-12 col-lg-4">
                     <nav class="nav flex-column w-100">
-                        <t t-call="website.s_mega_menu_big_icons_subtitles_item">
-                            <t t-set="_icon_classes" t-valuef="fa-user bg-o-color-1"/>
-                            <t t-set="_title">About us</t>
-                            <t t-set="_text">Discover our culture and our values</t>
-                        </t>
-                        <t t-call="website.s_mega_menu_big_icons_subtitles_item">
-                            <t t-set="_icon_classes" t-valuef="fa-newspaper-o bg-o-color-2"/>
-                            <t t-set="_title">Blog</t>
-                            <t t-set="_text">Latests news and case studies</t>
-                        </t>
-                        <t t-call="website.s_mega_menu_big_icons_subtitles_item">
-                            <t t-set="_icon_classes" t-valuef="fa-calendar bg-o-color-3"/>
-                            <t t-set="_title">Events</t>
-                            <t t-set="_text">Our seminars and trainings for you</t>
-                        </t>
+                        <t t-call="website.s_mega_menu_big_icons_subtitles_item"
+                            _icon_classes.f="fa-user bg-o-color-1"
+                            _title.translate="About us"
+                            _text.translate="Discover our culture and our values"/>
+                        <t t-call="website.s_mega_menu_big_icons_subtitles_item"
+                            _icon_classes.f="fa-newspaper-o bg-o-color-2"
+                            _title.translate="Blog"
+                            _text.translate="Latests news and case studies"/>
+                        <t t-call="website.s_mega_menu_big_icons_subtitles_item"
+                            _icon_classes.f="fa-calendar bg-o-color-3"
+                            _title.translate="Events"
+                            _text.translate="Our seminars and trainings for you"/>
                     </nav>
                 </div>
                 <div class="col-12 col-lg-4">
                     <nav class="nav flex-column w-100">
-                        <t t-call="website.s_mega_menu_big_icons_subtitles_item">
-                            <t t-set="_icon_classes" t-valuef="fa-star bg-o-color-5"/>
-                            <t t-set="_title">Customers</t>
-                            <t t-set="_text">They trust us since years</t>
-                        </t>
-                        <t t-call="website.s_mega_menu_big_icons_subtitles_item">
-                            <t t-set="_icon_classes" t-valuef="fa-handshake-o bg-o-color-3"/>
-                            <t t-set="_title">Services</t>
-                            <t t-set="_text">Find the perfect solution for you</t>
-                        </t>
-                        <t t-call="website.s_mega_menu_big_icons_subtitles_item">
-                            <t t-set="_icon_classes" t-valuef="fa-paint-brush bg-o-color-2"/>
-                            <t t-set="_title">Portfolio</t>
-                            <t t-set="_text">Discover our realisations</t>
-                        </t>
+                        <t t-call="website.s_mega_menu_big_icons_subtitles_item"
+                            _icon_classes.f="fa-star bg-o-color-5"
+                            _title.translate="Customers"
+                            _text.translate="They trust us since years"/>
+                        <t t-call="website.s_mega_menu_big_icons_subtitles_item"
+                            _icon_classes.f="fa-handshake-o bg-o-color-3"
+                            _title.translate="Services"
+                            _text.translate="Find the perfect solution for you"/>
+                        <t t-call="website.s_mega_menu_big_icons_subtitles_item"
+                            _icon_classes.f="fa-paint-brush bg-o-color-2"
+                            _title.translate="Portfolio"
+                            _text.translate="Discover our realisations"/>
                     </nav>
                 </div>
                 <div class="col-12 col-lg-4">
                     <nav class="nav flex-column w-100">
-                        <t t-call="website.s_mega_menu_big_icons_subtitles_item">
-                            <t t-set="_icon_classes" t-valuef="fa-question-circle bg-o-color-1"/>
-                            <t t-set="_title">F.A.Q.</t>
-                            <t t-set="_text">All informations you need</t>
-                        </t>
-                        <t t-call="website.s_mega_menu_big_icons_subtitles_item">
-                            <t t-set="_icon_classes" t-valuef="fa-shopping-basket bg-o-color-5"/>
-                            <t t-set="_title">Points of sale</t>
-                            <t t-set="_text">Find a store near you</t>
-                        </t>
-                        <t t-call="website.s_mega_menu_big_icons_subtitles_item">
-                            <t t-set="_icon_classes" t-valuef="fa-legal bg-o-color-3"/>
-                            <t t-set="_title">Legal Notice</t>
-                            <t t-set="_text">Discover our legal notice</t>
-                        </t>
+                        <t t-call="website.s_mega_menu_big_icons_subtitles_item"
+                            _icon_classes.f="fa-question-circle bg-o-color-1"
+                            _title.translate="F.A.Q."
+                            _text.translate="All informations you need"/>
+                        <t t-call="website.s_mega_menu_big_icons_subtitles_item"
+                            _icon_classes.f="fa-shopping-basket bg-o-color-5"
+                            _title.translate="Points of sale"
+                            _text.translate="Find a store near you"/>
+                        <t t-call="website.s_mega_menu_big_icons_subtitles_item"
+                            _icon_classes.f="fa-legal bg-o-color-3"
+                            _title.translate="Legal Notice"
+                            _text.translate="Discover our legal notice"/>
                     </nav>
                 </div>
             </div>

--- a/addons/website/views/snippets/s_mega_menu_cards.xml
+++ b/addons/website/views/snippets/s_mega_menu_cards.xml
@@ -5,49 +5,41 @@
     <section class="s_mega_menu_cards pt16 pb16 o_colored_level o_cc o_cc1">
         <div class="container">
             <nav class="row">
-                <t t-call="website.s_mega_menu_cards_item">
-                    <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_cards_default_image_1"/>
-                    <t t-set="_title">Our team</t>
-                    <t t-set="_text">Created in 2021, the company is young and dynamic. Discover the composition of the team and their skills.</t>
-                </t>
-                <t t-call="website.s_mega_menu_cards_item">
-                    <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_cards_default_image_2"/>
-                    <t t-set="_title">Departments</t>
-                    <t t-set="_text">Do you need specific information? Our specialists will help you with pleasure.</t>
-                </t>
-                <t t-call="website.s_mega_menu_cards_item">
-                    <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_cards_default_image_3"/>
-                    <t t-set="_title">Products</t>
-                    <t t-set="_text">We offer tailor-made products according to your needs and your budget.</t>
-                </t>
-                <t t-call="website.s_mega_menu_cards_item">
-                    <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_cards_default_image_4"/>
-                    <t t-set="_title">Customers</t>
-                    <t t-set="_text">Find out how we were able helping them and set in place solutions adapted to their needs.</t>
-                </t>
+                <t t-call="website.s_mega_menu_cards_item"
+                    _img_src.f="/web/image/website.s_mega_menu_cards_default_image_1"
+                    _title.translate="Our team"
+                    _text.translate="Created in 2021, the company is young and dynamic. Discover the composition of the team and their skills."/>
+                <t t-call="website.s_mega_menu_cards_item"
+                    _img_src.f="/web/image/website.s_mega_menu_cards_default_image_2"
+                    _title.translate="Departments"
+                    _text.translate="Do you need specific information? Our specialists will help you with pleasure."/>
+                <t t-call="website.s_mega_menu_cards_item"
+                    _img_src.f="/web/image/website.s_mega_menu_cards_default_image_3"
+                    _title.translate="Products"
+                    _text.translate="We offer tailor-made products according to your needs and your budget."/>
+                <t t-call="website.s_mega_menu_cards_item"
+                    _img_src.f="/web/image/website.s_mega_menu_cards_default_image_4"
+                    _title.translate="Customers"
+                    _text.translate="Find out how we were able helping them and set in place solutions adapted to their needs."/>
 
                 <div class="w-100 d-none d-lg-block"/>
 
-                <t t-call="website.s_mega_menu_cards_item">
-                    <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_cards_default_image_5"/>
-                    <t t-set="_title">Events</t>
-                    <t t-set="_text">From seminars to team building activities, we offer a wide choice of events to organize.</t>
-                </t>
-                <t t-call="website.s_mega_menu_cards_item">
-                    <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_cards_default_image_6"/>
-                    <t t-set="_title">Blog</t>
-                    <t t-set="_text">Stay informed of our latest news and discover what will happen in the next weeks.</t>
-                </t>
-                <t t-call="website.s_mega_menu_cards_item">
-                    <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_cards_default_image_7"/>
-                    <t t-set="_title">Deliveries</t>
-                    <t t-set="_text">Find all information about our deliveries, express deliveries and all you need to know to return a product.</t>
-                </t>
-                <t t-call="website.s_mega_menu_cards_item">
-                    <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_cards_default_image_8"/>
-                    <t t-set="_title">Points of sale</t>
-                    <t t-set="_text">Need to pick up your order at one of our stores? Discover the nearest to you.</t>
-                </t>
+                <t t-call="website.s_mega_menu_cards_item"
+                    _img_src.f="/web/image/website.s_mega_menu_cards_default_image_5"
+                    _title.translate="Events"
+                    _text.translate="From seminars to team building activities, we offer a wide choice of events to organize."/>
+                <t t-call="website.s_mega_menu_cards_item"
+                    _img_src.f="/web/image/website.s_mega_menu_cards_default_image_6"
+                    _title.translate="Blog"
+                    _text.translate="Stay informed of our latest news and discover what will happen in the next weeks."/>
+                <t t-call="website.s_mega_menu_cards_item"
+                    _img_src.f="/web/image/website.s_mega_menu_cards_default_image_7"
+                    _title.translate="Deliveries"
+                    _text.translate="Find all information about our deliveries, express deliveries and all you need to know to return a product."/>
+                <t t-call="website.s_mega_menu_cards_item"
+                    _img_src.f="/web/image/website.s_mega_menu_cards_default_image_8"
+                    _title.translate="Points of sale"
+                    _text.translate="Need to pick up your order at one of our stores? Discover the nearest to you."/>
             </nav>
         </div>
     </section>

--- a/addons/website/views/snippets/s_mega_menu_images_subtitles.xml
+++ b/addons/website/views/snippets/s_mega_menu_images_subtitles.xml
@@ -7,40 +7,34 @@
             <div class="row">
                 <div class="col-12 col-lg-4 py-2">
                     <nav class="nav flex-column w-100">
-                        <t t-call="website.s_mega_menu_images_subtitles_item">
-                            <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_images_subtitles_default_image_1"/>
-                            <t t-set="_title">About us</t>
-                            <t t-set="_text">Discover our culture and our values</t>
-                        </t>
-                        <t t-call="website.s_mega_menu_images_subtitles_item">
-                            <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_images_subtitles_default_image_2"/>
-                            <t t-set="_title">Customers</t>
-                            <t t-set="_text">They trust us since years</t>
-                        </t>
-                        <t t-call="website.s_mega_menu_images_subtitles_item">
-                            <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_images_subtitles_default_image_3"/>
-                            <t t-set="_title">Services</t>
-                            <t t-set="_text">Find the perfect solution for you</t>
-                        </t>
+                        <t t-call="website.s_mega_menu_images_subtitles_item"
+                            _img_src.f="/web/image/website.s_mega_menu_images_subtitles_default_image_1"
+                            _title.translate="About us"
+                            _text.translate="Discover our culture and our values"/>
+                        <t t-call="website.s_mega_menu_images_subtitles_item"
+                            _img_src.f="/web/image/website.s_mega_menu_images_subtitles_default_image_2"
+                            _title.translate="Customers"
+                            _text.translate="They trust us since years"/>
+                        <t t-call="website.s_mega_menu_images_subtitles_item"
+                            _img_src.f="/web/image/website.s_mega_menu_images_subtitles_default_image_3"
+                            _title.translate="Services"
+                            _text.translate="Find the perfect solution for you"/>
                     </nav>
                 </div>
                 <div class="col-12 col-lg-4 py-2">
                     <nav class="nav flex-column w-100">
-                        <t t-call="website.s_mega_menu_images_subtitles_item">
-                            <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_images_subtitles_default_image_4"/>
-                            <t t-set="_title">Blog</t>
-                            <t t-set="_text">Latests news and case studies</t>
-                        </t>
-                        <t t-call="website.s_mega_menu_images_subtitles_item">
-                            <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_images_subtitles_default_image_5"/>
-                            <t t-set="_title">Events</t>
-                            <t t-set="_text">Our seminars and trainings for you</t>
-                        </t>
-                        <t t-call="website.s_mega_menu_images_subtitles_item">
-                            <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_images_subtitles_default_image_6"/>
-                            <t t-set="_title">Help center</t>
-                            <t t-set="_text">Contact us for any issue or question</t>
-                        </t>
+                        <t t-call="website.s_mega_menu_images_subtitles_item"
+                            _img_src.f="/web/image/website.s_mega_menu_images_subtitles_default_image_4"
+                            _title.translate="Blog"
+                            _text.translate="Latests news and case studies"/>
+                        <t t-call="website.s_mega_menu_images_subtitles_item"
+                            _img_src.f="/web/image/website.s_mega_menu_images_subtitles_default_image_5"
+                            _title.translate="Events"
+                            _text.translate="Our seminars and trainings for you"/>
+                        <t t-call="website.s_mega_menu_images_subtitles_item"
+                            _img_src.f="/web/image/website.s_mega_menu_images_subtitles_default_image_6"
+                            _title.translate="Help center"
+                            _text.translate="Contact us for any issue or question"/>
                     </nav>
                 </div>
                 <div class="col-12 col-lg-4 py-2">

--- a/addons/website/views/snippets/s_mega_menu_thumbnails.xml
+++ b/addons/website/views/snippets/s_mega_menu_thumbnails.xml
@@ -8,49 +8,39 @@
                 <div class="col-12 col-lg-8 pt32 px-0">
                     <div class="container">
                         <div class="row">
-                            <t t-call="website.s_mega_menu_thumbnails_item">
-                                <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_thumbnails_default_image_1"/>
-                                <t t-set="_text">Laptops</t>
-                            </t>
-                            <t t-call="website.s_mega_menu_thumbnails_item">
-                                <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_thumbnails_default_image_2"/>
-                                <t t-set="_text">Mouse</t>
-                            </t>
-                            <t t-call="website.s_mega_menu_thumbnails_item">
-                                <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_thumbnails_default_image_3"/>
-                                <t t-set="_text">Keyboards</t>
-                            </t>
-                            <t t-call="website.s_mega_menu_thumbnails_item">
-                                <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_thumbnails_default_image_4"/>
-                                <t t-set="_text">Printers</t>
-                            </t>
-                            <t t-call="website.s_mega_menu_thumbnails_item">
-                                <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_thumbnails_default_image_5"/>
-                                <t t-set="_text">Storage</t>
-                            </t>
+                            <t t-call="website.s_mega_menu_thumbnails_item"
+                                _img_src.f="/web/image/website.s_mega_menu_thumbnails_default_image_1"
+                                _text.translate="Laptops"/>
+                            <t t-call="website.s_mega_menu_thumbnails_item"
+                                _img_src.f="/web/image/website.s_mega_menu_thumbnails_default_image_2"
+                                _text.translate="Mouse"/>
+                            <t t-call="website.s_mega_menu_thumbnails_item"
+                                _img_src.f="/web/image/website.s_mega_menu_thumbnails_default_image_3"
+                                _text.translate="Keyboards"/>
+                            <t t-call="website.s_mega_menu_thumbnails_item"
+                                _img_src.f="/web/image/website.s_mega_menu_thumbnails_default_image_4"
+                                _text.translate="Printers"/>
+                            <t t-call="website.s_mega_menu_thumbnails_item"
+                                _img_src.f="/web/image/website.s_mega_menu_thumbnails_default_image_5"
+                                _text.translate="Storage"/>
 
                             <div class="w-100 d-none d-lg-block"/>
 
-                            <t t-call="website.s_mega_menu_thumbnails_item">
-                                <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_thumbnails_default_image_6"/>
-                                <t t-set="_text">Tablets</t>
-                            </t>
-                            <t t-call="website.s_mega_menu_thumbnails_item">
-                                <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_thumbnails_default_image_7"/>
-                                <t t-set="_text">Phones</t>
-                            </t>
-                            <t t-call="website.s_mega_menu_thumbnails_item">
-                                <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_thumbnails_default_image_8"/>
-                                <t t-set="_text">Screens</t>
-                            </t>
-                            <t t-call="website.s_mega_menu_thumbnails_item">
-                                <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_thumbnails_default_image_9"/>
-                                <t t-set="_text">Gaming</t>
-                            </t>
-                            <t t-call="website.s_mega_menu_thumbnails_item">
-                                <t t-set="_img_src" t-valuef="/web/image/website.s_mega_menu_thumbnails_default_image_10"/>
-                                <t t-set="_text">Sound</t>
-                            </t>
+                            <t t-call="website.s_mega_menu_thumbnails_item"
+                                _img_src.f="/web/image/website.s_mega_menu_thumbnails_default_image_6"
+                                _text.translate="Tablets"/>
+                            <t t-call="website.s_mega_menu_thumbnails_item"
+                                _img_src.f="/web/image/website.s_mega_menu_thumbnails_default_image_7"
+                                _text.translate="Phones"/>
+                            <t t-call="website.s_mega_menu_thumbnails_item"
+                                _img_src.f="/web/image/website.s_mega_menu_thumbnails_default_image_8"
+                                _text.translate="Screens"/>
+                            <t t-call="website.s_mega_menu_thumbnails_item"
+                                _img_src.f="/web/image/website.s_mega_menu_thumbnails_default_image_9"
+                                _text.translate="Gaming"/>
+                            <t t-call="website.s_mega_menu_thumbnails_item"
+                                _img_src.f="/web/image/website.s_mega_menu_thumbnails_default_image_10"
+                                _text.translate="Sound"/>
                         </div>
                     </div>
                 </div>

--- a/addons/website/views/snippets/s_searchbar.xml
+++ b/addons/website/views/snippets/s_searchbar.xml
@@ -2,16 +2,15 @@
 <odoo>
 
 <template id="s_searchbar_input" name="Search">
-    <t t-call="website.website_search_box_input">
-        <t t-set="search_type" t-valuef="all"/>
-        <t t-set="action" t-valuef="/website/search"/>
-        <t t-set="limit" t-valuef="5"/>
-        <t t-set="display_image" t-valuef="true"/>
-        <t t-set="display_description" t-valuef="true"/>
-        <t t-set="display_extra_link" t-valuef="true"/>
-        <t t-set="display_detail" t-valuef="true"/>
-        <t t-set="default_style" t-value="True"/>
-    </t>
+    <t t-call="website.website_search_box_input"
+        search_type.f="all"
+        action.f="/website/search"
+        limit.f="5"
+        display_image.f="true"
+        display_description.f="true"
+        display_extra_link.f="true"
+        display_detail.f="true"
+        default_style="True"/>
 </template>
 <template id="s_searchbar" name="Search">
     <section class="s_searchbar o_colored_level o_cc o_cc2 pt48 pb48">

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -60,21 +60,19 @@
             >
                 <ul class="show list-group list-unstyled py-0" role="menu">
                     <t t-foreach="submenu.child_id" t-as="submenu">
-                        <t t-call="website.submenu">
-                            <t t-set="submenu_recursion" t-value="true"/>
-                            <t t-set="item_class" t-value="None"/>
-                            <t t-set="link_class" t-valuef="nav-link list-group-item list-group-item-action border-0 rounded-0 px-4 text-wrap"/>
-                        </t>
+                        <t t-call="website.submenu"
+                            submenu_recursion="true"
+                            item_class="None"
+                            link_class.f="nav-link list-group-item list-group-item-action border-0 rounded-0 px-4 text-wrap"/>
                     </t>
                 </ul>
             </div>
         </div>
         <ul t-else="" t-attf-class="dropdown-menu #{dropdown_menu_classes}" role="menu">
             <t t-foreach="submenu.child_id" t-as="submenu">
-                <t t-call="website.submenu">
-                    <t t-set="item_class" t-value="None"/>
-                    <t t-set="link_class" t-valuef="dropdown-item"/>
-                </t>
+                <t t-call="website.submenu"
+                    item_class="None"
+                    link_class.f="dropdown-item"/>
             </t>
         </ul>
     </li>
@@ -116,7 +114,7 @@
                 <t t-set="title" t-value="seo_object.sudo().website_meta_title"/>
             </t>
             <t t-else="">
-                <t t-set="title" t-value="default_title"></t>
+                <t t-set="title" t-value="default_title"/>
             </t>
         </t>
         <t t-set="x_icon" t-value="website.image_url(website, 'favicon')"/>
@@ -342,12 +340,11 @@
 
 <template id="brand_promotion" inherit_id="web.brand_promotion" name="Brand Promotion">
     <xpath expr="//t[@t-call='web.brand_promotion_message']" position="replace">
-        <t t-call="web.brand_promotion_message">
-            <t t-set="_message">
-                Create a <a target="_blank" href="http://www.odoo.com/app/website?utm_source=db&amp;utm_medium=website">free website</a>
-            </t>
-            <t t-set="_utm_medium" t-valuef="website"/>
+        <t t-set="_message">
+            Create a <a target="_blank" href="http://www.odoo.com/app/website?utm_source=db&amp;utm_medium=website">free website</a>
         </t>
+        <t t-call="web.brand_promotion_message"
+            _utm_medium.f="website"/>
     </xpath>
 </template>
 
@@ -375,11 +372,12 @@
 
 <!-- "mobile" template -->
 <template id="template_header_mobile" name="Template Header Mobile">
-    <t t-call="website.navbar">
-        <t t-set="_navbar_classes" t-valuef="o_header_mobile d-block d-lg-none shadow-sm"/>
-        <t t-set="_navbar_expand_class" t-valuef=""/>
-        <t t-set="_navbar_name" t-valuef="Mobile"/>
-        <t t-set="_side" t-valuef="offcanvas-end"></t>
+    <t t-set="is_mobile" t-value="True"/>
+
+    <t t-call="website.navbar"
+        _navbar_classes.f="o_header_mobile d-block d-lg-none shadow-sm"
+        _navbar_expand_class.f=""
+        _navbar_name.f="Mobile">
 
         <div class="o_main_nav container flex-wrap justify-content-between">
             <div class="d-flex flex-grow-1">
@@ -398,67 +396,58 @@
                 >
                 <span class="navbar-toggler-icon"/>
             </button>
-            <div t-attf-class="offcanvas #{_side} o_navbar_mobile" id="top_menu_collapse_mobile">
+            <div t-attf-class="offcanvas #{_side or 'offcanvas-end'} o_navbar_mobile" id="top_menu_collapse_mobile">
                 <div class="offcanvas-header justify-content-end o_not_editable">
                     <button type="button" class="nav-link btn-close" data-bs-dismiss="offcanvas" aria-label="Close"/>
                 </div>
                 <div class="offcanvas-body d-flex flex-column justify-content-between h-100 w-100 pt-0">
                     <ul class="navbar-nav">
                         <!-- Search bar -->
-                        <t t-call="website.placeholder_header_search_box">
-                            <t t-set="_classes" t-valuef="mb-3"/>
-                            <t t-set="_input_classes" t-valuef="rounded-start-pill text-bg-light ps-3"/>
-                            <t t-set="_submit_classes" t-valuef="rounded-end-pill bg-o-color-3 pe-3"/>
-                            <t t-set="limit" t-valuef="0"/>
-                        </t>
+                        <t t-call="website.placeholder_header_search_box"
+                            _classes.f="mb-3"
+                            _input_classes.f="rounded-start-pill text-bg-light ps-3"
+                            _submit_classes.f="rounded-end-pill bg-o-color-3 pe-3"
+                            limit.f="0"/>
                         <!-- Navbar -->
-                        <t t-call="website.navbar_nav">
-                            <t t-set="is_vertical_nav" t-valuef="True"/>
-                            <t t-set="_no_autohide_menu_mobile" t-valuef="True"/>
-                            <t t-set="is_mobile" t-value="True"/>
-
+                        <t t-call="website.navbar_nav"
+                            is_vertical_nav.f="True"
+                            _no_autohide_menu_mobile.f="True">
                             <!-- Menu -->
                             <t t-foreach="website.menu_id.child_id" t-as="submenu">
-                                <t t-call="website.submenu">
-                                    <t t-set="item_class" t-valuef="nav-item border-top #{submenu_last and 'border-bottom'}"/>
-                                    <t t-set="link_class" t-valuef="nav-link p-3 text-wrap"/>
-                                    <t t-set="dropdown_toggler_classes" t-valuef="d-flex justify-content-between align-items-center"/>
-                                    <t t-set="dropdown_menu_classes" t-valuef="position-relative rounded-0 o_dropdown_without_offset"/>
-                                </t>
+                                <t t-call="website.submenu"
+                                    item_class.f="nav-item border-top #{submenu_last and 'border-bottom'}"
+                                    link_class.f="nav-link p-3 text-wrap"
+                                    dropdown_toggler_classes.f="d-flex justify-content-between align-items-center"
+                                    dropdown_menu_classes.f="position-relative rounded-0 o_dropdown_without_offset"/>
                             </t>
                         </t>
                         <!-- Text element -->
-                        <t t-call="website.placeholder_header_text_element">
-                            <t t-set="_div_class" t-valuef="mt-2"/>
-                        </t>
+                        <t t-call="website.placeholder_header_text_element"
+                            _div_class.f="mt-2"/>
                         <!-- Social -->
-                        <t t-call="website.placeholder_header_social_links">
-                            <t t-set="_div_class" t-valuef="mt-2 border-top pt-2 o_border_contrast"/>
-                        </t>
+                        <t t-call="website.placeholder_header_social_links"
+                            _div_class.f="mt-2 border-top pt-2 o_border_contrast"/>
                     </ul>
                     <ul class="navbar-nav gap-2 mt-3 w-100">
                         <!-- Language Selector -->
-                        <t t-call="website.placeholder_header_language_selector">
-                            <t t-set="_btn_class" t-valuef="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center w-100"/>
-                            <t t-set="_txt_class" t-valuef="me-auto small"/>
-                            <t t-set="_flag_class" t-valuef="me-2"/>
-                            <t t-set="_div_classes" t-valuef="dropup"/>
-                            <t t-set="_dropdown_menu_class" t-valuef="w-100"/>
-                        </t>
+                        <t t-call="website.placeholder_header_language_selector"
+                            _btn_class.f="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center w-100"
+                            _txt_class.f="me-auto small"
+                            _flag_class.f="me-2"
+                            _div_classes.f="dropup"
+                            _dropdown_menu_class.f="w-100"/>
                         <!-- Sign In -->
-                        <t t-call="portal.placeholder_user_sign_in">
-                            <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link o_nav_link_btn'}} w-100 border text-center"/>
-                        </t>
+                        <t t-call="portal.placeholder_user_sign_in"
+                            _link_class.f="{{_additional_btn_color or 'nav-link o_nav_link_btn'}} w-100 border text-center"/>
                         <!-- User Dropdown -->
-                        <t t-call="portal.user_dropdown">
-                            <t t-set="_icon" t-value="true"/>
-                            <t t-set="_user_name" t-value="true"/>
-                            <t t-set="_user_name_class" t-valuef="me-auto small"/>
-                            <t t-set="_link_class" t-valuef="{{ _additional_btn_color or 'nav-link'}} d-flex align-items-center border-0"/>
-                            <t t-set="_icon_class" t-valuef="me-2"/>
-                            <t t-set="_item_class" t-valuef="dropdown dropup"/>
-                            <t t-set="_dropdown_menu_class" t-valuef="w-100"/>
-                        </t>
+                        <t t-call="portal.user_dropdown"
+                            _icon="true"
+                            _user_name="true"
+                            _user_name_class.f="me-auto small"
+                            _link_class.f="{{ _additional_btn_color or 'nav-link'}} d-flex align-items-center border-0"
+                            _icon_class.f="me-2"
+                            _item_class.f="dropdown dropup"
+                            _dropdown_menu_class.f="w-100"/>
                         <!-- Call To Action -->
                         <t t-call="website.header_call_to_action_large"/>
                     </ul>
@@ -475,7 +464,7 @@
 </template>
 
 <template id="template_header_mobile_position_left" inherit_id="website.template_header_mobile" active="False">
-    <xpath expr="//t[@t-set='_side']" position="replace">
+    <xpath expr="//div[@id='top_menu_collapse_mobile']" position="before">
         <t t-set="_side" t-valuef="offcanvas-start"/>
     </xpath>
     <xpath expr="//div[hasclass('o_main_nav')]" position="attributes">
@@ -487,38 +476,34 @@
 </template>
 
 <template id="template_header_mobile_align_center" inherit_id="website.template_header_mobile" active="False">
-    <xpath expr="//t[@t-call='website.navbar_nav']" position="inside">
-        <t t-set="_nav_class" t-valuef="text-center"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">text-center</attribute>
     </xpath>
-    <xpath expr="//t[@t-call='website.placeholder_header_text_element']" position="inside">
-        <t t-set="_div_class" t-valuef="align-items-center mt-2 border-top pt-2 text-center o_border_contrast"/>
+    <xpath expr="//t[@t-call='website.placeholder_header_text_element']" position="attributes">
+        <attribute name="_div_class.f">align-items-center mt-2 border-top pt-2 text-center o_border_contrast</attribute>
     </xpath>
-    <xpath expr="//t[@t-call='website.placeholder_header_social_links']" position="inside">
-        <t t-set="_div_class" t-valuef="mt-2 border-top pt-2 text-center o_border_contrast"/>
+    <xpath expr="//t[@t-call='website.placeholder_header_social_links']" position="attributes">
+        <attribute name="_div_class.f">mt-2 border-top pt-2 text-center o_border_contrast</attribute>
     </xpath>
-    <xpath expr="//t[@t-set='dropdown_toggler_classes']" position="attributes">
-        <attribute name="t-valuef"/>
-    </xpath>
-    <xpath expr="//t[@t-call='website.submenu']//t[@t-set='dropdown_menu_classes']" position="attributes">
-        <attribute name="t-valuef" add="text-center" separator=" "/>
+    <xpath expr="//t[@t-call='website.submenu']" position="attributes">
+        <attribute name="dropdown_toggler_classes.f"/>
+        <attribute name="dropdown_menu_classes.f" add="text-center" separator=" "/>
     </xpath>
 </template>
 
 <template id="template_header_mobile_align_right" inherit_id="website.template_header_mobile" active="False">
-    <xpath expr="//t[@t-call='website.navbar_nav']" position="inside">
-        <t t-set="_nav_class" t-valuef="text-end"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">text-end</attribute>
     </xpath>
-    <xpath expr="//t[@t-call='website.placeholder_header_text_element']" position="inside">
-        <t t-set="_div_class" t-valuef="align-items-end mt-2 border-top pt-2 text-end o_border_contrast"/>
+    <xpath expr="//t[@t-call='website.placeholder_header_text_element']" position="attributes">
+        <attribute name="_div_class.f">align-items-end mt-2 border-top pt-2 text-end o_border_contrast</attribute>
     </xpath>
-    <xpath expr="//t[@t-call='website.placeholder_header_social_links']" position="inside">
-        <t t-set="_div_class" t-valuef="mt-2 border-top pt-2 text-end o_border_contrast"/>
+    <xpath expr="//t[@t-call='website.placeholder_header_social_links']" position="attributes">
+        <attribute name="_div_class.f">mt-2 border-top pt-2 text-end o_border_contrast</attribute>
     </xpath>
-    <xpath expr="//t[@t-set='dropdown_toggler_classes']" position="attributes">
-        <attribute name="t-valuef"/>
-    </xpath>
-    <xpath expr="//t[@t-call='website.submenu']//t[@t-set='dropdown_menu_classes']" position="attributes">
-        <attribute name="t-valuef" add="text-end" separator=" "/>
+    <xpath expr="//t[@t-call='website.submenu']" position="attributes">
+        <attribute name="dropdown_toggler_classes.f"/>
+        <attribute name="dropdown_menu_classes.f" add="text-end" separator=" "/>
     </xpath>
 </template>
 
@@ -530,50 +515,43 @@
 
             <div id="o_main_nav" t-attf-class="o_main_nav #{header_content_width}">
                 <!-- Brand -->
-                <t t-call="website.placeholder_header_brand">
-                    <t t-set="_link_class" t-valuef="me-4"/>
-                </t>
+                <t t-call="website.placeholder_header_brand"
+                    _link_class.f="me-4"/>
                 <!-- Navbar -->
-                <t t-call="website.navbar_nav">
-                    <t t-set="_nav_class" t-valuef="me-auto"/>
-
+                <t t-call="website.navbar_nav"
+                    _nav_class.f="me-auto">
                     <!-- Menu -->
                     <t t-foreach="website.menu_id.child_id" t-as="submenu">
-                        <t t-call="website.submenu">
-                            <t t-set="item_class" t-valuef="nav-item"/>
-                            <t t-set="link_class" t-valuef="nav-link"/>
-                        </t>
+                        <t t-call="website.submenu"
+                            item_class.f="nav-item"
+                            link_class.f="nav-link"/>
                     </t>
                 </t>
                 <!-- Extra elements -->
                 <ul class="navbar-nav align-items-center gap-2 flex-shrink-0 justify-content-end ps-3">
                     <!-- Search Bar -->
-                    <t t-call="website.placeholder_header_search_box">
-                        <t t-set="_layout" t-valuef="modal"/>
-                        <t t-set="_input_classes" t-valuef="border border-end-0 p-3"/>
-                        <t t-set="_submit_classes" t-valuef="border border-start-0 px-4 bg-o-color-4"/>
-                        <t t-set="_button_classes" t-valuef="o_navlink_background text-reset"/>
-                    </t>
+                    <t t-call="website.placeholder_header_search_box"
+                        _layout.f="modal"
+                        _input_classes.f="border border-end-0 p-3"
+                        _submit_classes.f="border border-start-0 px-4 bg-o-color-4"
+                        _button_classes.f="o_navlink_background text-reset"/>
                     <!-- Text element -->
                     <t t-call="website.placeholder_header_text_element"/>
                     <!-- Social -->
                     <t t-call="website.placeholder_header_social_links"/>
                     <!-- Language Selector -->
-                    <t t-call="website.placeholder_header_language_selector">
-                        <t t-set="_btn_class" t-value="_additional_btn_color or 'nav-link'"/>
-                        <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                    </t>
+                    <t t-call="website.placeholder_header_language_selector"
+                        _btn_class="_additional_btn_color or 'nav-link'"
+                        _dropdown_menu_class.f="dropdown-menu-end"/>
                     <!-- Sign In -->
-                    <t t-call="portal.placeholder_user_sign_in">
-                        <t t-set="_link_class" t-value="_additional_btn_color or 'o_nav_link_btn nav-link border px-3'"/>
-                    </t>
+                    <t t-call="portal.placeholder_user_sign_in"
+                        _link_class="_additional_btn_color or 'o_nav_link_btn nav-link border px-3'"/>
                     <!-- User Dropdown -->
-                    <t t-call="portal.user_dropdown">
-                        <t t-set="_user_name" t-value="True"/>
-                        <t t-set="_item_class" t-valuef="dropdown"/>
-                        <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link'}} border-0"/>
-                        <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                    </t>
+                    <t t-call="portal.user_dropdown"
+                        _user_name="True"
+                        _item_class.f="dropdown"
+                        _link_class.f="{{_additional_btn_color or 'nav-link'}} border-0"
+                        _dropdown_menu_class.f="dropdown-menu-end"/>
                     <!-- Call To Action -->
                     <t t-call="website.placeholder_header_call_to_action"/>
                 </ul>
@@ -584,46 +562,42 @@
 </template>
 
 <template id="template_header_default_align_center" inherit_id="website.template_header_default" active="False">
-    <xpath expr="//t[@t-set='_nav_class']" position="replace">
-        <t t-set="_nav_class" t-valuef="mx-auto"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">mx-auto</attribute>
     </xpath>
 </template>
 
 <template id="template_header_default_align_right" inherit_id="website.template_header_default" active="False">
-    <xpath expr="//t[@t-set='_nav_class']" position="replace">
-        <t t-set="_nav_class" t-valuef="ms-auto"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">mx-auto</attribute>
     </xpath>
 </template>
 
 <!-- "Hamburger" template -->
 <template id="template_header_hamburger" inherit_id="website.layout" name="Template Header Hamburger" active="False">
     <xpath expr="//header//nav" position="replace">
-        <t t-call="website.navbar">
-            <t t-set="_navbar_classes" t-valuef="d-none d-lg-block shadow-sm"/>
-            <t t-set="_navbar_expand_class" t-valuef=""/>
+        <t t-call="website.navbar"
+            _navbar_classes.f="d-none d-lg-block shadow-sm"
+            _navbar_expand_class.f="">
 
             <div id="o_main_nav" t-attf-class="o_main_nav d-grid py-0 o_grid_header_3_cols #{header_content_width}">
                 <!-- Nav Toggler -->
-                <t t-call="website.navbar_toggler">
-                    <t t-set="_toggler_class" t-valuef="btn me-auto p-2"/>
-                </t>
+                <t t-call="website.navbar_toggler"
+                    _toggler_class.f="btn me-auto p-2"/>
                 <!-- Brand -->
-                <t t-call="website.placeholder_header_brand">
-                    <t t-set="_link_class" t-valuef="mw-100 mx-auto"/>
-                </t>
+                <t t-call="website.placeholder_header_brand"
+                    _link_class.f="mw-100 mx-auto"/>
                 <ul class="o_header_hamburger_right_col navbar-nav flex-row gap-2 align-items-center ms-auto">
                     <!-- Sign In -->
-                    <t t-call="portal.placeholder_user_sign_in">
-                        <t t-set="_link_class" t-valuef="o_navlink_background btn text-reset"/>
-                    </t>
+                    <t t-call="portal.placeholder_user_sign_in"
+                        _link_class.f="o_navlink_background btn text-reset"/>
                     <!-- User Dropdown -->
-                    <t t-call="portal.user_dropdown">
-                        <t t-set="_icon" t-value="true"/>
-                        <t t-set="_item_class" t-valuef="dropdown"/>
-                        <t t-set="_icon_class" t-valuef="fa-stack"/>
-                        <t t-set="_link_class" t-valuef="o_navlink_background btn d-flex align-items-center rounded-circle p-1 pe-2 text-reset"/>
-                        <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                    </t>
+                    <t t-call="portal.user_dropdown"
+                        _icon="true"
+                        _item_class.f="dropdown"
+                        _icon_class.f="fa-stack"
+                        _link_class.f="o_navlink_background btn d-flex align-items-center rounded-circle p-1 pe-2 text-reset"
+                        _dropdown_menu_class.f="dropdown-menu-end"/>
                 </ul>
                 <div class="offcanvas offcanvas-start o_navbar_mobile" id="top_menu_collapse">
                     <div class="offcanvas-header justify-content-end">
@@ -632,48 +606,42 @@
                     <div class="offcanvas-body d-flex flex-column justify-content-between pt-0">
                         <ul class="navbar-nav">
                             <!-- Search bar -->
-                            <t t-call="website.placeholder_header_search_box">
-                                <t t-set="_input_classes" t-valuef="rounded-start-pill ps-3 text-bg-light"/>
-                                <t t-set="_submit_classes" t-valuef="rounded-end-pill bg-o-color-3"/>
-                                <t t-set="limit" t-valuef="0"/>
-                            </t>
+                            <t t-call="website.placeholder_header_search_box"
+                                _input_classes.f="rounded-start-pill ps-3 text-bg-light"
+                                _submit_classes.f="rounded-end-pill bg-o-color-3"
+                                limit.f="0"/>
                             <!-- Navbar -->
                             <li>
-                                <t t-call="website.navbar_nav">
-                                    <t t-set="is_vertical_nav" t-valuef="True"/>
-                                    <t t-set="offcanvas_is_leftside" t-valuef="True"/>
-                                    <t t-set="_nav_class" t-valuef="mt-3"/>
-
+                                <t t-call="website.navbar_nav"
+                                    is_vertical_nav.f="True"
+                                    offcanvas_is_leftside.f="True"
+                                    _nav_class.f="mt-3">
                                     <!-- Menu -->
                                     <t t-foreach="website.menu_id.child_id" t-as="submenu">
-                                        <t t-call="website.submenu">
-                                            <t t-set="item_class" t-valuef="nav-item border-top #{submenu_last and 'border-bottom'}"/>
-                                            <t t-set="link_class" t-valuef="nav-link p-3 text-wrap"/>
-                                            <t t-set="dropdown_toggler_classes" t-valuef="d-flex justify-content-between align-items-center"/>
-                                            <t t-set="dropdown_menu_classes" t-valuef="position-relative rounded-0 o_dropdown_without_offset"/>
-                                        </t>
+                                        <t t-call="website.submenu"
+                                            item_class.f="nav-item border-top #{submenu_last and 'border-bottom'}"
+                                            link_class.f="nav-link p-3 text-wrap"
+                                            dropdown_toggler_classes.f="d-flex justify-content-between align-items-center"
+                                            dropdown_menu_classes.f="position-relative rounded-0 o_dropdown_without_offset"/>
                                     </t>
                                 </t>
                             </li>
                             <!-- Text element -->
-                            <t t-call="website.placeholder_header_text_element">
-                                <t t-set="_txt_elt_content" t-valuef="phone_mail"/>
-                                <t t-set="_div_class" t-valuef="mt-2"/>
-                            </t>
+                            <t t-call="website.placeholder_header_text_element"
+                                _txt_elt_content.f="phone_mail"
+                                _div_class.f="mt-2"/>
                             <!-- Social -->
-                            <t t-call="website.placeholder_header_social_links">
-                                <t t-set="_div_class" t-valuef="mt-2 border-top pt-2 o_border_contrast"/>
-                            </t>
+                            <t t-call="website.placeholder_header_social_links"
+                                _div_class.f="mt-2 border-top pt-2 o_border_contrast"/>
                         </ul>
                         <ul class="navbar-nav gap-2 mt-3 w-100">
                             <!-- Language Selector -->
-                            <t t-call="website.placeholder_header_language_selector">
-                                <t t-set="_btn_class" t-valuef="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center w-100"/>
-                                <t t-set="_txt_class" t-valuef="me-auto small"/>
-                                <t t-set="_flag_class" t-valuef="me-2"/>
-                                <t t-set="_div_classes" t-valuef="dropup"/>
-                                <t t-set="_dropdown_menu_class" t-valuef="w-100"/>
-                            </t>
+                            <t t-call="website.placeholder_header_language_selector"
+                                _btn_class.f="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center w-100"
+                                _txt_class.f="me-auto small"
+                                _flag_class.f="me-2"
+                                _div_classes.f="dropup"
+                                _dropdown_menu_class.f="w-100"/>
                             <!-- Call To Action -->
                             <t t-call="website.header_call_to_action_large"/>
                         </ul>
@@ -681,119 +649,110 @@
                 </div>
             </div>
         </t>
-        <t t-call="website.template_header_mobile">
-            <t t-set="_txt_elt_content" t-valuef="phone_mail"/>
-        </t>
+        <t t-call="website.template_header_mobile"
+            _txt_elt_content.f="phone_mail"/>
     </xpath>
 </template>
 
 <template id="template_header_hamburger_align_right" inherit_id="website.template_header_hamburger" active="False">
-    <xpath expr="//t[@t-set='_toggler_class']" position="replace">
-        <t t-set="_toggler_class" t-valuef="btn order-2 ms-auto p-2"/>
+    <xpath expr="//t[@t-call='website.navbar_toggler']" position="attributes">
+        <attribute name="_toggler_class.f">btn order-2 ms-auto p-2</attribute>
     </xpath>
     <xpath expr="//ul[hasclass('o_header_hamburger_right_col')]" position="attributes">
         <attribute name="class" add="order-0 me-auto" remove="ms-auto" separator=" "/>
     </xpath>
-    <xpath expr="//t[@t-call='website.placeholder_header_brand']" position="inside" >
-        <t t-set="_link_class" t-valuef="order-1 mx-auto mw-100"/>
+    <xpath expr="//t[@t-call='website.placeholder_header_brand']" position="attributes" >
+        <attribute name="_link_class.f">order-1 mx-auto mw-100</attribute>
     </xpath>
     <xpath expr="//div[@id='top_menu_collapse']" position="attributes" >
         <attribute name="class" add="offcanvas-end" remove="offcanvas-start" separator=" "/>
     </xpath>
-    <xpath expr="//t[@t-set='offcanvas_is_leftside']" position="attributes">
-        <attribute name="t-valuef" add="False" remove="True"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="offcanvas_is_leftside.f" add="False" remove="True"/>
     </xpath>
-    <xpath expr="//t[@t-call='portal.user_dropdown']//t[@t-set='_dropdown_menu_class']" position="replace"/>
+    <xpath expr="//t[@t-call='portal.user_dropdown']" position="attributes">
+        <attribute name="_dropdown_menu_class.f"/>
+    </xpath>
 </template>
 
 <template id="template_header_hamburger_mobile_align_center" inherit_id="website.template_header_hamburger" active="False">
-    <xpath expr="//t[@t-set='_nav_class']" position="replace">
-        <t t-set="_nav_class" t-valuef="my-3 text-center"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">my-3 text-center</attribute>
     </xpath>
-    <xpath expr="//t[@t-call='website.placeholder_header_text_element']" position="inside">
-        <t t-set="_div_class" t-valuef="mt-2 border-top pt-2 text-center o_border_contrast"/>
+    <xpath expr="//t[@t-call='website.placeholder_header_text_element']" position="attributes">
+        <attribute name="_div_class.f">mt-2 border-top pt-2 text-center o_border_contrast</attribute>
     </xpath>
-    <xpath expr="//t[@t-call='website.placeholder_header_social_links']" position="inside">
-        <t t-set="_div_class" t-valuef="mt-2 border-top pt-2 text-center o_border_contrast"/>
+    <xpath expr="//t[@t-call='website.placeholder_header_social_links']" position="attributes">
+        <attribute name="_div_class.f">mt-2 border-top pt-2 text-center o_border_contrast</attribute>
     </xpath>
 </template>
 
 <template id="template_header_hamburger_mobile_align_right" inherit_id="website.template_header_hamburger" active="False">
-    <xpath expr="//t[@t-set='_nav_class']" position="replace">
-        <t t-set="_nav_class" t-valuef="my-3 text-end"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">my-3 text-end</attribute>
     </xpath>
-    <xpath expr="//t[@t-call='website.placeholder_header_text_element']" position="inside">
-        <t t-set="_div_class" t-valuef="mt-2 border-top pt-2 text-end o_border_contrast"/>
+    <xpath expr="//t[@t-call='website.placeholder_header_text_element']" position="attributes">
+        <attribute name="_div_class.f">mt-2 border-top pt-2 text-end o_border_contrast</attribute>
     </xpath>
-    <xpath expr="//t[@t-call='website.placeholder_header_social_links']" position="inside">
-        <t t-set="_div_class" t-valuef="mt-2 border-top pt-2 text-end o_border_contrast"/>
+    <xpath expr="//t[@t-call='website.placeholder_header_social_links']" position="attributes">
+        <attribute name="_div_class.f">mt-2 border-top pt-2 text-end o_border_contrast</attribute>
     </xpath>
 </template>
 
 <!-- "Stretch" template -->
 <template id="template_header_stretch" inherit_id="website.layout" name="Template Header Stretch" active="False">
     <xpath expr="//header//nav" position="replace">
-        <t t-call="website.navbar">
-            <t t-set="_navbar_classes" t-valuef="d-none d-lg-block py-0 shadow-sm"/>
+        <t t-call="website.navbar"
+            _navbar_classes.f="d-none d-lg-block py-0 shadow-sm">
 
             <div id="o_main_nav" t-attf-class="o_main_nav align-items-stretch #{header_content_width}">
                 <!-- Brand -->
-                <t t-call="website.placeholder_header_brand">
-                    <t t-set="_link_class" t-valuef="d-flex align-items-center me-4 p-2"/>
-                </t>
+                <t t-call="website.placeholder_header_brand"
+                    _link_class.f="d-flex align-items-center me-4 p-2"/>
                 <!-- Navbar -->
-                <t t-call="website.navbar_nav">
-                    <t t-set="_nav_class" t-valuef="d-flex align-items-center me-auto border-end o_border_contrast"/>
-
+                <t t-call="website.navbar_nav"
+                    _nav_class.f="d-flex align-items-center me-auto border-end o_border_contrast">
                     <!-- Menu -->
                     <t t-foreach="website.menu_id.child_id" t-as="submenu">
-                        <t t-call="website.submenu">
-                            <t t-set="item_class" t-valuef="nav-item h-100 border-start o_border_contrast"/>
-                            <t t-set="link_class" t-valuef="nav-link d-flex align-items-center h-100"/>
-                        </t>
+                        <t t-call="website.submenu"
+                            item_class.f="nav-item h-100 border-start o_border_contrast"
+                            link_class.f="nav-link d-flex align-items-center h-100"/>
                     </t>
                 </t>
                 <!-- Extra elements -->
                 <ul class="o_header_stretch_elts navbar-nav flex-shrink-0 ps-2">
                     <!-- Text element -->
-                        <t t-call="website.placeholder_header_text_element">
-                            <t t-set="_txt_elt_content" t-valuef="mail_stretched"/>
-                            <t t-set="_div_class" t-valuef="h-100 border-start o_border_contrast"/>
-                        </t>
+                        <t t-call="website.placeholder_header_text_element"
+                            _txt_elt_content.f="mail_stretched"
+                            _div_class.f="h-100 border-start o_border_contrast"/>
                     <!-- Search bar -->
-                    <t t-call="website.placeholder_header_search_box">
-                        <t t-set="_input_classes" t-valuef="o_header_stretch_search_input border-0 rounded-0 bg-transparent text-reset"/>
-                        <t t-set="_submit_classes" t-valuef="o_navlink_background_hover rounded-0 text-reset"/>
-                        <t t-set="_form_classes" t-valuef="h-100 z-0"/>
-                        <t t-set="_classes" t-valuef="h-100 border-start o_border_contrast"/>
-                    </t>
+                    <t t-call="website.placeholder_header_search_box"
+                        _input_classes.f="o_header_stretch_search_input border-0 rounded-0 bg-transparent text-reset"
+                        _submit_classes.f="o_navlink_background_hover rounded-0 text-reset"
+                        _form_classes.f="h-100 z-0"
+                        _classes.f="h-100 border-start o_border_contrast"/>
                     <!-- Social -->
-                    <t t-call="website.placeholder_header_social_links">
-                        <t t-set="_div_class" t-valuef="d-flex align-items-center h-100 border-start px-2 o_border_contrast"/>
-                    </t>
+                    <t t-call="website.placeholder_header_social_links"
+                        _div_class.f="d-flex align-items-center h-100 border-start px-2 o_border_contrast"/>
                     <!-- Language Selector -->
-                    <t t-call="website.placeholder_header_language_selector">
-                        <t t-set="_div_classes" t-valuef="h-100 border-start o_border_contrast"/>
-                        <t t-set="_btn_class" t-valuef="o_navlink_background_hover btn h-100 rounded-0 text-reset"/>
-                        <t t-set="_txt_class" t-valuef="small"/>
-                        <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                    </t>
+                    <t t-call="website.placeholder_header_language_selector"
+                        _div_classes.f="h-100 border-start o_border_contrast"
+                        _btn_class.f="o_navlink_background_hover btn h-100 rounded-0 text-reset"
+                        _txt_class.f="small"
+                        _dropdown_menu_class.f="dropdown-menu-end"/>
                     <!-- Sign In -->
-                    <t t-call="portal.placeholder_user_sign_in">
-                        <t t-set="_item_class" t-valuef="border-start o_border_contrast"/>
-                        <t t-set="_link_class" t-valuef="o_navlink_background_hover btn d-flex align-items-center h-100 rounded-0 fw-bold text-reset"/>
-                    </t>
+                    <t t-call="portal.placeholder_user_sign_in"
+                        _item_class.f="border-start o_border_contrast"
+                        _link_class.f="o_navlink_background_hover btn d-flex align-items-center h-100 rounded-0 fw-bold text-reset"/>
                     <!-- User Dropdown -->
-                    <t t-call="portal.user_dropdown">
-                        <t t-set="_icon" t-value="true"/>
-                        <t t-set="_item_class" t-valuef="dropdown border-start o_border_contrast"/>
-                        <t t-set="_link_class" t-valuef="o_navlink_background_hover btn d-flex align-items-center h-100 rounded-0 text-reset"/>
-                        <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                    </t>
+                    <t t-call="portal.user_dropdown"
+                        _icon="true"
+                        _item_class.f="dropdown border-start o_border_contrast"
+                        _link_class.f="o_navlink_background_hover btn d-flex align-items-center h-100 rounded-0 text-reset"
+                        _dropdown_menu_class.f="dropdown-menu-end"/>
                     <!-- Call To Action -->
-                    <t t-call="website.header_call_to_action_stretched">
-                        <t t-set="_div_class" t-valuef="d-flex h-100 border-start o_border_contrast"/>
-                    </t>
+                    <t t-call="website.header_call_to_action_stretched"
+                        _div_class.f="d-flex h-100 border-start o_border_contrast"/>
                 </ul>
             </div>
         </t>
@@ -802,14 +761,17 @@
 </template>
 
 <template id="template_header_stretch_align_center" inherit_id="website.template_header_stretch" active="False">
-    <xpath expr="//t[@t-set='_nav_class']" position="replace">
-        <t t-set="_nav_class" t-valuef="d-flex align-items-center mx-auto border-end px-2 o_border_contrast"/>
+    <xpath expr="//t[@t-call='website.placeholder_header_social_links']" position="inside">
+        <attribute name="_div_class.f">mt-2 border-top pt-2 text-end o_border_contrast</attribute>
+    </xpath>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">d-flex align-items-center mx-auto border-end px-2 o_border_contrast</attribute>
     </xpath>
 </template>
 
 <template id="template_header_stretch_align_right" inherit_id="website.template_header_stretch" active="False">
-    <xpath expr="//t[@t-set='_nav_class']" position="replace">
-        <t t-set="_nav_class" t-valuef="d-flex align-items-center ms-auto o_border_contrast"/>
+    <xpath expr="//t[@t-call='website.placeholder_header_social_links']" position="inside">
+        <attribute name="_div_class.f">d-flex align-items-center ms-auto o_border_contrast</attribute>
     </xpath>
     <xpath expr="//ul[hasclass('o_header_stretch_elts')]" position="attributes">
         <attribute name="class" remove="ps-2" separator=" "/>
@@ -819,61 +781,54 @@
 <!-- "Vertical" template -->
 <template id="template_header_vertical" inherit_id="website.layout" name="Template Header Vertical" active="False">
     <xpath expr="//header//nav" position="replace">
-        <t t-call="website.navbar">
-            <t t-set="_navbar_classes" t-valuef="d-none d-lg-block pt-3 shadow-sm"/>
+        <t t-call="website.navbar"
+            _navbar_classes.f="d-none d-lg-block pt-3 shadow-sm">
 
             <div id="o_main_nav" t-attf-class="o_main_nav flex-wrap #{header_content_width}">
                 <div class="o_header_hide_on_scroll d-grid align-items-center w-100 o_grid_header_3_cols pb-3">
                     <ul class="navbar-nav align-items-center gap-1">
                         <!-- Search bar -->
-                        <t t-call="website.placeholder_header_search_box">
-                            <t t-set="_layout" t-valuef="modal"/>
-                            <t t-set="_input_classes" t-valuef="border border-end-0 p-3"/>
-                            <t t-set="_submit_classes" t-valuef="border border-start-0 px-4 bg-o-color-4"/>
-                            <t t-set="_button_classes" t-valuef="o_navlink_background text-reset"/>
-                        </t>
+                        <t t-call="website.placeholder_header_search_box"
+                            _layout.f="modal"
+                            _input_classes.f="border border-end-0 p-3"
+                            _submit_classes.f="border border-start-0 px-4 bg-o-color-4"
+                            _button_classes.f="o_navlink_background text-reset"/>
                         <!-- Social Links -->
                         <t t-call="website.placeholder_header_social_links"/>
                         <!-- Text element -->
                         <t t-call="website.placeholder_header_text_element"/>
                     </ul>
                     <!-- Brand -->
-                    <t t-call="website.placeholder_header_brand">
-                        <t t-set="_link_class" t-valuef="mx-auto mw-100"/>
-                    </t>
+                    <t t-call="website.placeholder_header_brand"
+                        _link_class.f="mx-auto mw-100"/>
                     <ul class="navbar-nav align-items-center gap-1 flex-wrap justify-content-end ms-auto">
                         <!-- Sign In -->
-                        <t t-call="portal.placeholder_user_sign_in">
-                            <t t-set="_link_class" t-valuef="o_navlink_background btn border-0 text-reset"/>
-                        </t>
+                        <t t-call="portal.placeholder_user_sign_in"
+                            _link_class.f="o_navlink_background btn border-0 text-reset"/>
                         <!-- User Dropdown -->
-                        <t t-call="portal.user_dropdown">
-                            <t t-set="_icon" t-value="true"/>
-                            <t t-set="_item_class" t-valuef="dropdown"/>
-                            <t t-set="_link_class" t-valuef="o_navlink_background btn d-flex align-items-center border-0 text-reset"/>
-                            <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                        </t>
+                        <t t-call="portal.user_dropdown"
+                            _icon="true"
+                            _item_class.f="dropdown"
+                            _link_class.f="o_navlink_background btn d-flex align-items-center border-0 text-reset"
+                            _dropdown_menu_class.f="dropdown-menu-end"/>
                         <!-- Language Selector -->
-                        <t t-call="website.placeholder_header_language_selector">
-                            <t t-set="_btn_class" t-valuef="o_navlink_background btn text-reset"/>
-                            <t t-set="_flag_class" t-valuef="m-2"/>
-                            <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                        </t>
+                        <t t-call="website.placeholder_header_language_selector"
+                            _btn_class.f="o_navlink_background btn text-reset"
+                            _flag_class.f="m-2"
+                            _dropdown_menu_class.f="dropdown-menu-end"/>
                         <!-- Call To Action -->
                         <t t-call="website.placeholder_header_call_to_action"/>
                     </ul>
                 </div>
                 <div class="d-flex justify-content-center w-100">
                     <!-- Navbar -->
-                    <t t-call="website.navbar_nav">
-                        <t t-set="_nav_class" t-valuef="pb-0"/>
-
+                    <t t-call="website.navbar_nav"
+                        _nav_class.f="pb-0">
                         <!-- Menu -->
                         <t t-foreach="website.menu_id.child_id" t-as="submenu">
-                            <t t-call="website.submenu">
-                                <t t-set="item_class" t-valuef="nav-item"/>
-                                <t t-set="link_class" t-valuef="nav-link"/>
-                            </t>
+                            <t t-call="website.submenu"
+                                item_class.f="nav-item"
+                                link_class.f="nav-link"/>
                         </t>
                     </t>
                 </div>
@@ -886,75 +841,65 @@
 <!-- "Search" template -->
 <template id="template_header_search" inherit_id="website.layout" name="Template Header Search" active="False">
     <xpath expr="//header//nav" position="replace">
-        <t t-call="website.navbar">
-            <t t-set="_navbar_classes" t-valuef="d-none d-lg-block p-0 shadow-sm"/>
+        <t t-call="website.navbar"
+            _navbar_classes.f="d-none d-lg-block p-0 shadow-sm">
 
             <div id="o_main_nav" class="o_main_nav flex-wrap">
                 <div aria-label="Top" class="o_header_hide_on_scroll border-bottom o_border_contrast">
                     <div t-attf-class="#{header_content_width} d-flex justify-content-between flex-wrap w-100">
                         <ul class="o_header_search_left_col navbar-nav flex-wrap">
                             <!-- Language Selector -->
-                            <t t-call="website.placeholder_header_language_selector">
-                                <t t-set="_div_classes" t-valuef="h-100 border-end o_border_contrast"/>
-                                <t t-set="_btn_class" t-valuef="o_navlink_background_hover btn btn-sm d-flex align-items-center h-100 rounded-0 p-2 text-reset"/>
-                            </t>
+                            <t t-call="website.placeholder_header_language_selector"
+                                _div_classes.f="h-100 border-end o_border_contrast"
+                                _btn_class.f="o_navlink_background_hover btn btn-sm d-flex align-items-center h-100 rounded-0 p-2 text-reset"/>
                             <!-- Text element -->
-                            <t t-call="website.placeholder_header_text_element">
-                                <t t-set="_txt_elt_content" t-valuef="sentence"/>
-                                <t t-set="_div_class" t-valuef="d-flex align-items-center h-100 border-end p-2 text-muted o_border_contrast"/>
-                            </t>
+                            <t t-call="website.placeholder_header_text_element"
+                                _txt_elt_content.f="sentence"
+                                _div_class.f="d-flex align-items-center h-100 border-end p-2 text-muted o_border_contrast"/>
                         </ul>
                         <ul class="navbar-nav flex-wrap">
                             <!-- Social Links -->
-                            <t t-call="website.placeholder_header_social_links">
-                                <t t-set="_div_class" t-valuef="d-flex align-items-center h-100 border-start px-1 o_border_contrast"/>
-                            </t>
+                            <t t-call="website.placeholder_header_social_links"
+                                _div_class.f="d-flex align-items-center h-100 border-start px-1 o_border_contrast"/>
                             <!-- Sign In -->
-                            <t t-call="portal.placeholder_user_sign_in">
-                                <t t-set="_link_class" t-valuef="o_navlink_background_hover btn btn-sm d-flex align-items-center h-100 rounded-0 border-0 border-start px-3 text-reset o_border_contrast"/>
-                            </t>
+                            <t t-call="portal.placeholder_user_sign_in"
+                                _link_class.f="o_navlink_background_hover btn btn-sm d-flex align-items-center h-100 rounded-0 border-0 border-start px-3 text-reset o_border_contrast"/>
                             <!-- User Dropdown -->
-                            <t t-call="portal.user_dropdown">
-                                <t t-set="_user_name" t-value="true"/>
-                                <t t-set="_item_class" t-valuef="dropdown border-start o_border_contrast"/>
-                                <t t-set="_link_class" t-valuef="o_navlink_background_hover btn btn-sm d-flex align-items-center h-100 rounded-0 p-2 text-reset"/>
-                                <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                            </t>
+                            <t t-call="portal.user_dropdown"
+                                _user_name="true"
+                                _item_class.f="dropdown border-start o_border_contrast"
+                                _link_class.f="o_navlink_background_hover btn btn-sm d-flex align-items-center h-100 rounded-0 p-2 text-reset"
+                                _dropdown_menu_class.f="dropdown-menu-end"/>
                         </ul>
                     </div>
                 </div>
                 <div aria-label="Bottom" t-attf-class="#{header_content_width} d-grid align-items-center w-100 py-2 o_grid_header_3_cols">
                     <!-- Navbar -->
-                    <t t-call="website.navbar_nav">
-                        <t t-set="_nav_class" t-valuef="me-4"/>
-
+                    <t t-call="website.navbar_nav"
+                        _nav_class.f="me-4">
                         <!-- Menu -->
                         <t t-foreach="website.menu_id.child_id" t-as="submenu">
-                            <t t-call="website.submenu">
-                                <t t-set="item_class" t-valuef="nav-item"/>
-                                <t t-set="link_class" t-valuef="nav-link"/>
-                            </t>
+                            <t t-call="website.submenu"
+                                item_class.f="nav-item"
+                                link_class.f="nav-link"/>
                         </t>
                     </t>
                     <!-- Brand -->
-                    <t t-call="website.placeholder_header_brand">
-                        <t t-set="_link_class" t-valuef="mw-100 mx-auto"/>
-                    </t>
+                    <t t-call="website.placeholder_header_brand"
+                        _link_class.f="mw-100 mx-auto"/>
                     <ul class="o_header_search_right_col navbar-nav align-items-center gap-2 ms-auto ps-3">
                         <!-- Search bar -->
-                        <t t-call="website.placeholder_header_search_box">
-                            <t t-set="_input_classes" t-valuef="rounded-start-pill ps-3 text-bg-light"/>
-                            <t t-set="_submit_classes" t-valuef="rounded-end-pill pe-3 bg-o-color-3"/>
-                        </t>
+                        <t t-call="website.placeholder_header_search_box"
+                            _input_classes.f="rounded-start-pill ps-3 text-bg-light"
+                            _submit_classes.f="rounded-end-pill pe-3 bg-o-color-3"/>
                         <!-- Call To Action -->
                         <t t-call="website.placeholder_header_call_to_action"/>
                     </ul>
                 </div>
             </div>
         </t>
-        <t t-call="website.template_header_mobile">
-            <t t-set="_txt_elt_content" t-valuef="sentence"/>
-        </t>
+        <t t-call="website.template_header_mobile"
+            _txt_elt_content.f="sentence"/>
     </xpath>
 </template>
 
@@ -962,11 +907,11 @@
     <xpath expr="//div[hasclass('o_grid_header_3_cols')]" position="attributes">
         <attribute name="class" add="o_grid_header_3_cols_fixed" remove="o_grid_header_3_cols_fixed" separator=" "/>
     </xpath>
-    <xpath expr="//t[@t-set='_nav_class']" position="replace">
-        <t t-set="_nav_class" t-valuef="order-1 justify-content-center mx-auto w-100 px-4"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">order-1 justify-content-center mx-auto w-100 px-4</attribute>
     </xpath>
-    <xpath expr="//t[@t-call='website.placeholder_header_brand']" position="inside" >
-        <t t-set="_link_class" t-valuef="order-0 me-auto mw-100"/>
+    <xpath expr="//t[@t-call='website.placeholder_header_brand']" position="attributes">
+        <attribute name="_link_class.f">order-0 me-auto mw-100</attribute>
     </xpath>
     <xpath expr="//ul[hasclass('o_header_search_right_col')]" position="attributes">
         <attribute name="class" add="order-2" remove="" separator=" "/>
@@ -977,11 +922,11 @@
     <xpath expr="//div[hasclass('o_grid_header_3_cols')]" position="attributes">
         <attribute name="class" add="o_grid_header_3_cols_fixed" remove="o_grid_header_3_cols_fixed" separator=" "/>
     </xpath>
-    <xpath expr="//t[@t-set='_nav_class']" position="replace">
-        <t t-set="_nav_class" t-valuef="order-2 justify-content-end ms-auto w-100 ps-4"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">order-2 justify-content-end ms-auto w-100 ps-4</attribute>
     </xpath>
     <xpath expr="//t[@t-call='website.placeholder_header_brand']" position="inside" >
-        <t t-set="_link_class" t-valuef="order-1 mx-auto mw-100"/>
+        <attribute name="_link_class.f">order-1 mx-auto mw-100</attribute>
     </xpath>
     <xpath expr="//ul[hasclass('o_header_search_right_col')]" position="attributes">
         <attribute name="class" add="order-0 me-4" remove="ps-3 ms-auto" separator=" "/>
@@ -991,89 +936,78 @@
 <!-- "Sales one" template -->
 <template id="template_header_sales_one" inherit_id="website.layout" name="Template Header Sale 1" active="False">
     <xpath expr="//header//nav" position="replace">
-        <t t-call="website.navbar">
-            <t t-set="_navbar_classes" t-valuef="o_header_force_no_radius d-none d-lg-block p-0 shadow-sm"/>
-
+        <t t-call="website.navbar"
+            _navbar_classes.f="o_header_force_no_radius d-none d-lg-block p-0 shadow-sm">
             <div id="o_main_nav" class="o_main_nav">
                 <div aria-label="Top" t-attf-class="#{header_content_width} d-flex align-items-center justify-content-between py-3">
                     <!-- Brand -->
-                    <t t-call="website.placeholder_header_brand">
-                        <t t-set="_link_class" t-valuef="me-4"/>
-                    </t>
+                    <t t-call="website.placeholder_header_brand"
+                        _link_class.f="me-4"/>
                     <!-- Navbar -->
-                    <t t-call="website.navbar_nav">
-                        <t t-set="_nav_class" t-valuef="pe-2"/>
-
+                    <t t-call="website.navbar_nav"
+                        _nav_class.f="pe-2">
                         <!-- Menu -->
                         <t t-foreach="website.menu_id.child_id" t-as="submenu">
-                            <t t-call="website.submenu">
-                                <t t-set="item_class" t-valuef="nav-item"/>
-                                <t t-set="link_class" t-valuef="nav-link"/>
-                            </t>
+                            <t t-call="website.submenu"
+                                item_class.f="nav-item"
+                                link_class.f="nav-link"/>
                         </t>
                     </t>
                     <ul class="o_header_sales_one_right_col navbar-nav align-items-center gap-1 flex-grow-1 justify-content-end">
                         <!-- Call To Action -->
-                        <t t-call="website.placeholder_header_call_to_action">
-                            <t t-set="_item_class" t-valuef="flex-grow-1"/>
-                            <t t-set="_div_class" t-valuef="d-flex align-items-center"/>
-                        </t>
+                        <t t-call="website.placeholder_header_call_to_action"
+                            _item_class.f="flex-grow-1"
+                            _div_class.f="d-flex align-items-center"/>
                         <!-- Search bar -->
-                        <t t-call="website.placeholder_header_search_box">
-                            <t t-set="_layout" t-valuef="modal"/>
-                            <t t-set="_input_classes" t-valuef="border border-end-0 p-3"/>
-                            <t t-set="_submit_classes" t-valuef="border border-start-0 px-4 bg-o-color-4"/>
-                            <t t-set="_button_classes" t-valuef="o_navlink_background text-reset"/>
-                        </t>
+                        <t t-call="website.placeholder_header_search_box"
+                            _layout.f="modal"
+                            _input_classes.f="border border-end-0 p-3"
+                            _submit_classes.f="border border-start-0 px-4 bg-o-color-4"
+                            _button_classes.f="o_navlink_background text-reset"/>
                         <!-- Sign In -->
-                        <t t-call="portal.placeholder_user_sign_in">
-                            <t t-set="_link_class" t-valuef="btn rounded-circle text-reset fw-bold o_navlink_background"/>
-                        </t>
+                        <t t-call="portal.placeholder_user_sign_in"
+                            _link_class.f="btn rounded-circle text-reset fw-bold o_navlink_background"/>
                         <!-- User Dropdown -->
-                        <t t-call="portal.user_dropdown">
-                            <t t-set="_icon" t-value="true"/>
-                            <t t-set="_item_class" t-valuef="dropdown"/>
-                            <t t-set="_icon_class" t-valuef="fa-stack"/>
-                            <t t-set="_link_class" t-valuef="btn d-flex align-items-center rounded-circle p-1 pe-3 text-reset o_navlink_background"/>
-                            <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                        </t>
+                        <t t-call="portal.user_dropdown"
+                            _icon="true"
+                            _item_class.f="dropdown"
+                            _icon_class.f="fa-stack"
+                            _link_class.f="btn d-flex align-items-center rounded-circle p-1 pe-3 text-reset o_navlink_background"
+                            _dropdown_menu_class.f="dropdown-menu-end"/>
                         <!-- Language Selector -->
-                        <t t-call="website.placeholder_header_language_selector">
-                            <t t-set="_btn_class" t-valuef="btn rounded-circle text-reset o_navlink_background"/>
-                            <t t-set="_txt_class" t-valuef="small"/>
-                            <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                        </t>
+                        <t t-call="website.placeholder_header_language_selector"
+                            _btn_class.f="btn rounded-circle text-reset o_navlink_background"
+                            _txt_class.f="small"
+                            _dropdown_menu_class.f="dropdown-menu-end"/>
                     </ul>
                 </div>
                 <div aria-label="Bottom" t-if="is_view_active('website.header_text_element') or is_view_active('website.header_social_links')" class="o_header_sales_one_bot o_header_hide_on_scroll gap-3 py-2">
                     <ul t-attf-class="#{header_content_width} navbar-nav justify-content-between align-items-center">
                         <!-- Text element -->
-                        <t t-call="website.placeholder_header_text_element">
-                            <t t-set="_txt_elt_content" t-valuef="list"/>
-                            <t t-set="_item_class" t-valuef="flex-basis-0 flex-grow-1 flex-shrink-0"/>
-                        </t>
+                        <t t-call="website.placeholder_header_text_element"
+                            _txt_elt_content.f="list"
+                            _item_class.f="flex-basis-0 flex-grow-1 flex-shrink-0"/>
                         <!-- Social -->
                         <t t-call="website.placeholder_header_social_links"/>
                     </ul>
                 </div>
             </div>
         </t>
-        <t t-call="website.template_header_mobile">
-            <t t-set="_txt_elt_content" t-valuef="list"/>
-            <t t-set="_extra_navbar_classes" t-valuef="o_header_force_no_radius"/>
-        </t>
+        <t t-call="website.template_header_mobile"
+            _txt_elt_content.f="list"
+            _extra_navbar_classes.f="o_header_force_no_radius"/>
     </xpath>
 </template>
 
 <template id="template_header_sales_one_align_center" inherit_id="website.template_header_sales_one" active="False">
-    <xpath expr="//t[@t-set='_nav_class']" position="replace">
-        <t t-set="_nav_class" t-valuef="flex-grow-1 justify-content-end pe-2"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">flex-grow-1 justify-content-end pe-2</attribute>
     </xpath>
 </template>
 
 <template id="template_header_sales_one_align_right" inherit_id="website.template_header_sales_one" active="False">
-    <xpath expr="//t[@t-set='_nav_class']" position="replace">
-        <t t-set="_nav_class" t-valuef="flex-grow-1 justify-content-end pe-2"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">flex-grow-1 justify-content-end pe-2</attribute>
     </xpath>
     <xpath expr="//ul[hasclass('o_header_sales_one_right_col')]" position="attributes">
         <attribute name="class" remove="flex-grow-1" separator=" "/>
@@ -1083,9 +1017,8 @@
 <!-- "Sales two" template -->
 <template id="template_header_sales_two" inherit_id="website.layout" name="Template Header Sale 2" active="False">
     <xpath expr="//header//nav" position="replace">
-        <t t-call="website.navbar">
-            <t t-set="_navbar_classes" t-valuef="o_header_force_no_radius d-none d-lg-block p-0 shadow-sm"/>
-
+        <t t-call="website.navbar"
+            _navbar_classes.f="o_header_force_no_radius d-none d-lg-block p-0 shadow-sm">
             <div id="o_main_nav" class="o_main_nav">
                 <div class="o_header_hide_on_scroll">
                     <div aria-label="Top" t-if="is_view_active('website.header_text_element') or is_view_active('website.header_social_links') or is_view_active('website.header_language_selector')" class="o_header_sales_two_top py-1">
@@ -1093,103 +1026,91 @@
                             <!-- Return empty placeholder if the element is not active to keep the right layout -->
                             <li class="o_header_sales_two_lang_selector_placeholder" t-if="is_view_active('website.header_language_selector') == False"/>
                             <!-- Language Selector -->
-                            <t t-call="website.placeholder_header_language_selector">
-                                <t t-set="_div_classes" t-valuef="d-flex align-items-center h-100"/>
-                                <t t-set="_btn_class" t-valuef="btn btn-sm btn-outline-secondary border-0"/>
-                            </t>
+                            <t t-call="website.placeholder_header_language_selector"
+                                _div_classes.f="d-flex align-items-center h-100"
+                                _btn_class.f="btn btn-sm btn-outline-secondary border-0"/>
                             <!-- Text element -->
                             <!-- Return empty placeholder if the element is not active to keep the right layout -->
                             <li class="o_header_sales_two_txt_elts_placeholder" t-if="is_view_active('website.header_text_element') == False"/>
-                            <t t-call="website.placeholder_header_text_element">
-                                <t t-set="_txt_elt_content" t-valuef="sentence"/>
-                                <t t-set="_div_class" t-valuef="d-flex align-items-center mx-auto"/>
-                                <t t-set="_item_class" t-valuef="d-flex align-items-center"/>
-                            </t>
+                            <t t-call="website.placeholder_header_text_element"
+                                _txt_elt_content.f="sentence"
+                                _div_class.f="d-flex align-items-center mx-auto"
+                                _item_class.f="d-flex align-items-center"/>
                             <!-- Social -->
                             <!-- Return empty placeholder if the element is not active to keep the right layout -->
                             <li class="o_header_sales_two_social_links_placeholder" t-if="is_view_active('website.header_social_links') == False"/>
-                            <t t-call="website.placeholder_header_social_links">
-                                <t t-set="_div_class" t-valuef="d-flex align-items-center justify-content-end h-100"/>
-                            </t>
+                            <t t-call="website.placeholder_header_social_links"
+                                _div_class.f="d-flex align-items-center justify-content-end h-100"/>
                         </ul>
                     </div>
                     <div aria-label="Middle" t-attf-class="#{header_content_width} d-flex justify-content-between align-items-center py-1">
                         <!-- Brand -->
-                        <t t-call="website.placeholder_header_brand">
-                            <t t-set="_link_class" t-valuef="me-4"/>
-                        </t>
+                        <t t-call="website.placeholder_header_brand"
+                            _link_class.f="me-4"/>
                         <ul class="navbar-nav align-items-center gap-1">
                             <!-- Search bar -->
-                            <t t-call="website.placeholder_header_search_box">
-                                <t t-set="_input_classes" t-valuef="rounded-start-pill ps-3 text-bg-light"/>
-                                <t t-set="_submit_classes" t-valuef="rounded-end-pill p-3 bg-o-color-3 lh-1"/>
-                            </t>
+                            <t t-call="website.placeholder_header_search_box"
+                                _input_classes.f="rounded-start-pill ps-3 text-bg-light"
+                                _submit_classes.f="rounded-end-pill p-3 bg-o-color-3 lh-1"/>
                             <!-- Sign In -->
-                            <t t-call="portal.placeholder_user_sign_in">
-                                <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link o_nav_link_btn'}} ms-2 border px-3"/>
-                            </t>
+                            <t t-call="portal.placeholder_user_sign_in"
+                                _link_class.f="{{_additional_btn_color or 'nav-link o_nav_link_btn'}} ms-2 border px-3"/>
                             <!-- User Dropdown -->
-                            <t t-call="portal.user_dropdown">
-                                <t t-set="_user_name" t-value="true"/>
-                                <t t-set="_icon" t-value="true"/>
-                                <t t-set="_icon_class" t-valuef="fa-stack"/>
-                                <t t-set="_item_class" t-valuef="dropdown"/>
-                                <t t-set="_link_class" t-valuef="btn d-flex align-items-center border-0 fw-bold text-reset o_navlink_trigger_hover"/>
-                                <t t-set="_icon_wrap_class" t-value="'position-relative me-2 p-2 rounded-circle o_navlink_background transition-base'"/>
-                                <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                            </t>
+                            <t t-call="portal.user_dropdown"
+                                _user_name="true"
+                                _icon="true"
+                                _icon_class.f="fa-stack"
+                                _item_class.f="dropdown"
+                                _link_class.f="btn d-flex align-items-center border-0 fw-bold text-reset o_navlink_trigger_hover"
+                                _icon_wrap_class.f="position-relative me-2 p-2 rounded-circle o_navlink_background transition-base"
+                                _dropdown_menu_class.f="dropdown-menu-end"/>
                         </ul>
                     </div>
                 </div>
                 <div aria-label="Bottom" class="border-top o_border_contrast">
                     <div t-attf-class="#{header_content_width} d-flex justify-content-between">
                         <!-- Navbar -->
-                        <t t-call="website.navbar_nav">
-                            <t t-set="_nav_class" t-valuef="align-items-center me-4 py-1"/>
-
+                        <t t-call="website.navbar_nav"
+                            _nav_class.f="align-items-center me-4 py-1">
                             <!-- Menu -->
                             <t t-foreach="website.menu_id.child_id" t-as="submenu">
-                                <t t-call="website.submenu">
-                                    <t t-set="item_class" t-valuef="nav-item"/>
-                                    <t t-set="link_class" t-valuef="nav-link"/>
-                                </t>
+                                <t t-call="website.submenu"
+                                    item_class.f="nav-item"
+                                    link_class.f="nav-link"/>
                             </t>
                         </t>
                         <!-- Call To Action -->
                         <ul class="navbar-nav">
-                            <t t-call="website.header_call_to_action_stretched">
-                                <t t-set="_div_class" t-valuef="d-flex h-100"/>
-                            </t>
+                            <t t-call="website.header_call_to_action_stretched"
+                                _div_class.f="d-flex h-100"/>
                         </ul>
                     </div>
                 </div>
             </div>
         </t>
-        <t t-call="website.template_header_mobile">
-            <t t-set="_txt_elt_content" t-valuef="sentence"/>
-            <t t-set="_extra_navbar_classes" t-valuef="o_header_force_no_radius"/>
-        </t>
+        <t t-call="website.template_header_mobile"
+            _txt_elt_content.f="sentence"
+            _extra_navbar_classes.f="o_header_force_no_radius"/>
     </xpath>
 </template>
 
 <template id="template_header_sales_two_align_center" inherit_id="website.template_header_sales_two" active="False">
-    <xpath expr="//t[@t-set='_nav_class']" position="replace">
-        <t t-set="_nav_class" t-valuef="mx-auto p-2"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">mx-auto p-2</attribute>
     </xpath>
 </template>
 
 <template id="template_header_sales_two_align_right" inherit_id="website.template_header_sales_two" active="False">
-    <xpath expr="//t[@t-set='_nav_class']" position="replace">
-        <t t-set="_nav_class" t-valuef="ms-auto py-2 pe-2"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">ms-auto py-2 pe-2</attribute>
     </xpath>
 </template>
 
 <!-- "Sales three" template -->
 <template id="template_header_sales_three" inherit_id="website.layout" name="Template Header Sale 3" active="False">
     <xpath expr="//header//nav" position="replace">
-        <t t-call="website.navbar">
-            <t t-set="_navbar_classes" t-valuef="o_header_force_no_radius d-none d-lg-block p-0 shadow-sm rounded-0"/>
-
+        <t t-call="website.navbar"
+            _navbar_classes.f="o_header_force_no_radius d-none d-lg-block p-0 shadow-sm rounded-0">
             <div id="o_main_nav" class="o_main_nav">
                 <div aria-label="Top" t-if="is_view_active('website.header_text_element') or is_view_active('website.header_social_links') or is_view_active('website.header_search_box') or is_view_active('website.header_call_to_action')"
                      class="o_header_sales_three_top o_header_hide_on_scroll position-relative border-bottom z-1 o_border_contrast">
@@ -1198,74 +1119,65 @@
                             <!-- Social -->
                             <t t-call="website.placeholder_header_social_links"/>
                             <!-- Text element -->
-                            <t t-call="website.placeholder_header_text_element">
-                                <t t-set="_txt_elt_content" t-valuef="list"/>
-                                <t t-set="_div_class" t-valuef="mx-auto"/>
-                                <t t-set="_item_class" t-valuef="flex-basis-0 flex-grow-1 flex-shrink-0"/>
-                            </t>
+                            <t t-call="website.placeholder_header_text_element"
+                                _txt_elt_content.f="list"
+                                _div_class.f="mx-auto"
+                                _item_class.f="flex-basis-0 flex-grow-1 flex-shrink-0"/>
                         </ul>
                         <ul class="navbar-nav">
                             <!-- Search bar -->
-                            <t t-call="website.placeholder_header_search_box">
-                                <t t-set="_input_classes" t-valuef="border-0 border-start rounded-0"/>
-                                <t t-set="_submit_classes" t-valuef="rounded-0 bg-o-color-4"/>
-                                <t t-set="_form_classes" t-valuef="h-100 z-0"/>
-                                <t t-set="_classes" t-valuef="h-100"/>
-                            </t>
+                            <t t-call="website.placeholder_header_search_box"
+                                _input_classes.f="border-0 border-start rounded-0"
+                                _submit_classes.f="rounded-0 bg-o-color-4"
+                                _form_classes.f="h-100 z-0"
+                                _classes.f="h-100"/>
                             <!-- Call To Action -->
-                            <t t-call="website.header_call_to_action_stretched">
-                                <t t-set="_div_class" t-valuef="d-flex h-100"/>
-                            </t>
+                            <t t-call="website.header_call_to_action_stretched"
+                                _div_class.f="d-flex h-100"/>
                         </ul>
                     </div>
                 </div>
                 <div aria-label="Bottom" t-attf-class="#{header_content_width} d-flex align-items-center py-2">
                     <!-- Brand -->
-                    <t t-call="website.placeholder_header_brand">
-                        <t t-set="_link_class" t-valuef="me-4"/>
-                    </t>
+                    <t t-call="website.placeholder_header_brand"
+                        _link_class.f="me-4"/>
                     <div class="flex-fill min-w-0">
                         <ul class="o_header_sales_three_small_links navbar-nav justify-content-end align-items-center gap-2 w-100 o_header_separator">
                             <!-- Language Selector -->
-                            <t t-call="website.placeholder_header_language_selector">
-                                <t t-set="_btn_class" t-valuef="nav-link d-flex align-items-center fw-bold text-uppercase o_nav-link_secondary"/>
-                                <t t-set="_txt_class" t-valuef="ms-1"/>
-                                <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                                <t t-set="_item_class" t-valuef="position-relative"/>
-                            </t>
+                            <t t-call="website.placeholder_header_language_selector"
+                                _btn_class.f="nav-link d-flex align-items-center fw-bold text-uppercase o_nav-link_secondary"
+                                _txt_class.f="ms-1"
+                                _dropdown_menu_class.f="dropdown-menu-end"
+                                _item_class.f="position-relative"/>
                             <!-- Sign In -->
-                            <t t-call="portal.placeholder_user_sign_in">
-                                <t t-set="_item_class" t-valuef="position-relative"/>
-                                <t t-set="_link_class" t-valuef="nav-link fw-bold text-uppercase o_nav-link_secondary"/>
-                            </t>
+                            <t t-call="portal.placeholder_user_sign_in"
+                                _item_class.f="position-relative"
+                                _link_class.f="nav-link fw-bold text-uppercase o_nav-link_secondary"/>
                             <!-- User Dropdown -->
-                            <t t-call="portal.user_dropdown">
-                                <t t-set="_user_name" t-value="true"/>
-                                <t t-set="_item_class" t-valuef="dropdown"/>
-                                <t t-set="_link_class" t-valuef="nav-link d-flex align-items-center fw-bold text-uppercase o_nav-link_secondary"/>
-                                <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                            </t>
+                            <t t-call="portal.user_dropdown"
+                                _user_name="true"
+                                _item_class.f="dropdown"
+                                _link_class.f="nav-link d-flex align-items-center fw-bold text-uppercase o_nav-link_secondary"
+                                _dropdown_menu_class.f="dropdown-menu-end"/>
                         </ul>
                         <!-- Navbar -->
-                        <t t-call="website.navbar_nav">
-                            <t t-set="_nav_class" t-valuef="justify-content-end"/>
+                        <t t-call="website.navbar_nav"
+                                _nav_class.f="justify-content-end">
 
                             <!-- Menu -->
                             <t t-foreach="website.menu_id.child_id" t-as="submenu">
-                                <t t-call="website.submenu">
-                                    <t t-set="item_class" t-valuef="nav-item"/>
-                                    <t t-set="link_class" t-valuef="nav-link"/>
-                                </t>
+                                <t t-call="website.submenu"
+                                    item_class.f="nav-item"
+                                    link_class.f="nav-link"/>
                             </t>
                         </t>
                     </div>
                 </div>
             </div>
         </t>
-        <t t-call="website.template_header_mobile">
-            <t t-set="_txt_elt_content" t-valuef="list"/>
-            <t t-set="_extra_navbar_classes" t-valuef="o_header_force_no_radius"/>
-        </t>
+        <t t-call="website.template_header_mobile"
+            _txt_elt_content.f="list"
+            _extra_navbar_classes.f="o_header_force_no_radius"/>
     </xpath>
 </template>
 
@@ -1278,55 +1190,47 @@
         <t t-set="_additional_btn_color" t-valuef="text-secondary"/>
     </xpath>
     <xpath expr="//header//nav" position="replace">
-        <t t-call="website.navbar">
-            <t t-set="_navbar_classes" t-valuef="o_header_sales_four_top o_header_force_no_radius d-none d-lg-block p-0 shadow-sm z-1"/>
-
+        <t t-call="website.navbar"
+            _navbar_classes.f="o_header_sales_four_top o_header_force_no_radius d-none d-lg-block p-0 shadow-sm z-1">
             <div id="o_main_nav" class="o_main_nav">
                 <div aria-label="Top" t-attf-class="#{header_content_width} d-flex">
                     <!-- Navbar -->
-                    <t t-call="website.navbar_nav">
-                        <t t-set="_nav_class" t-valuef="align-items-center me-auto pe-3"/>
-
+                    <t t-call="website.navbar_nav"
+                        _nav_class.f="align-items-center me-auto pe-3">
                         <!-- Menu -->
                         <t t-foreach="website.menu_id.child_id" t-as="submenu">
-                            <t t-call="website.submenu">
-                                <t t-set="item_class" t-valuef="nav-item small"/>
-                                <t t-set="link_class" t-valuef="nav-link"/>
-                            </t>
+                            <t t-call="website.submenu"
+                                item_class.f="nav-item small"
+                                link_class.f="nav-link"/>
                         </t>
                     </t>
                     <ul class="o_header_separator navbar-nav align-items-center gap-3 flex-shrink-0">
                         <!-- Text element -->
-                        <t t-call="website.placeholder_header_text_element">
-                            <t t-set="_txt_elt_content" t-valuef="mail"/>
-                            <t t-set="_div_class" t-valuef="d-flex align-items-center"/>
-                            <t t-set="_item_class" t-valuef="position-relative"/>
-                        </t>
+                        <t t-call="website.placeholder_header_text_element"
+                            _txt_elt_content.f="mail"
+                            _div_class.f="d-flex align-items-center"
+                            _item_class.f="position-relative"/>
                         <!-- Social -->
-                        <t t-call="website.placeholder_header_social_links">
-                            <t t-set="_div_class" t-valuef="d-flex align-items-center"/>
-                            <t t-set="_item_class" t-valuef="position-relative"/>
-                        </t>
+                        <t t-call="website.placeholder_header_social_links"
+                            _div_class.f="d-flex align-items-center"
+                            _item_class.f="position-relative"/>
                         <!-- Sign In -->
-                        <t t-call="portal.placeholder_user_sign_in">
-                            <t t-set="_item_class" t-valuef="position-relative small"/>
-                            <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center h-100 border-0 px-2 text-decoration-none"/>
-                        </t>
+                        <t t-call="portal.placeholder_user_sign_in"
+                            _item_class.f="position-relative small"
+                            _link_class.f="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center h-100 border-0 px-2 text-decoration-none"/>
                         <!-- User Dropdown -->
-                        <t t-call="portal.user_dropdown">
-                            <t t-set="_user_name" t-value="true"/>
-                            <t t-set="_item_class" t-valuef="dropdown position-relative d-flex align-items-center"/>
-                            <t t-set="_link_class" t-valuef="nav-link border-0"/>
-                            <t t-set="_user_name_class" t-valuef="small"/>
-                            <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                        </t>
+                        <t t-call="portal.user_dropdown"
+                            _user_name="true"
+                            _item_class.f="dropdown position-relative d-flex align-items-center"
+                            _link_class.f="nav-link border-0"
+                            _user_name_class.f="small"
+                            _dropdown_menu_class.f="dropdown-menu-end"/>
                         <!-- Language Selector -->
-                        <t t-call="website.placeholder_header_language_selector">
-                            <t t-set="_div_classes" t-valuef="position-relative"/>
-                            <t t-set="_btn_class" t-valuef="nav-link"/>
-                            <t t-set="_txt_class" t-valuef="small"/>
-                            <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                        </t>
+                        <t t-call="website.placeholder_header_language_selector"
+                            _div_classes.f="position-relative"
+                            _btn_class.f="nav-link"
+                            _txt_class.f="small"
+                            _dropdown_menu_class.f="dropdown-menu-end"/>
                     </ul>
                 </div>
                 <div aria-label="Bottom" class="o_header_sales_four_bot o_header_hide_on_scroll z-0">
@@ -1334,17 +1238,15 @@
                         <ul class="navbar-nav d-grid align-items-center py-2 o_grid_header_3_cols">
                             <!-- Search bar -->
                             <li class="o_header_sales_four_search_placeholder" t-if="is_view_active('website.header_search_box') == False"/>
-                            <t t-call="website.placeholder_header_search_box">
-                                <t t-set="_form_classes" t-valuef="me-auto"/>
-                                <t t-set="_input_classes" t-valuef="rounded-start-pill ps-3 text-bg-light"/>
-                                <t t-set="_submit_classes" t-valuef="rounded-end-pill bg-o-color-3 lh-1"/>
-                                <t t-set="_item_class" t-valuef="d-flex"/>
-                            </t>
+                            <t t-call="website.placeholder_header_search_box"
+                                _form_classes.f="me-auto"
+                                _input_classes.f="rounded-start-pill ps-3 text-bg-light"
+                                _submit_classes.f="rounded-end-pill bg-o-color-3 lh-1"
+                                _item_class.f="d-flex"/>
                             <!-- Brand -->
                             <li t-if="is_view_active('website.placeholder_header_brand')">
-                            <t t-call="website.placeholder_header_brand">
-                                <t t-set="_link_class" t-valuef="mx-auto mw-100"/>
-                            </t>
+                                <t t-call="website.placeholder_header_brand"
+                                    _link_class.f="mx-auto mw-100"/>
                             </li>
                             <li class="d-flex align-items-center gap-3 ms-auto mb-0">
                                 <ul class="navbar-nav align-items-center gap-2">
@@ -1357,22 +1259,21 @@
                 </div>
             </div>
         </t>
-        <t t-call="website.template_header_mobile">
-            <t t-set="_txt_elt_content" t-valuef="mail"/>
-            <t t-set="_extra_navbar_classes" t-valuef="o_header_force_no_radius"/>
-        </t>
+        <t t-call="website.template_header_mobile"
+            _txt_elt_content.f="mail"
+            _extra_navbar_classes.f="o_header_force_no_radius"/>
     </xpath>
 </template>
 
 <template id="template_header_sales_four_align_center" inherit_id="website.template_header_sales_four" active="False">
-    <xpath expr="//t[@t-set='_nav_class']" position="replace">
-        <t t-set="_nav_class" t-valuef="align-items-center mx-auto px-3"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">align-items-center mx-auto px-3</attribute>
     </xpath>
 </template>
 
 <template id="template_header_sales_four_align_right" inherit_id="website.template_header_sales_four" active="False">
-    <xpath expr="//t[@t-set='_nav_class']" position="replace">
-        <t t-set="_nav_class" t-valuef="align-items-center ms-auto pe-3"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">align-items-center ms-auto pe-3</attribute>
     </xpath>
 </template>
 
@@ -1382,9 +1283,8 @@
         <attribute name="t-attf-class" add="o_header_sidebar" separator=" "/>
     </xpath>
     <xpath expr="//header//nav" position="replace">
-        <t t-call="website.navbar">
-            <t t-set="_navbar_classes" t-valuef="o_border_right_only d-none d-lg-block shadow"/>
-
+        <t t-call="website.navbar"
+            _navbar_classes.f="o_border_right_only d-none d-lg-block shadow">
             <div id="o_main_nav" class="o_main_nav navbar-nav d-flex flex-column justify-content-between h-100 w-100">
                <div class="d-flex flex-column w-100 h-100">
                     <div class="d-flex pb-3">
@@ -1394,63 +1294,55 @@
                     <div class="d-flex flex-column justify-content-between h-100 w-100">
                         <ul class="navbar-nav p-0">
                             <!-- Search bar -->
-                            <t t-call="website.placeholder_header_search_box">
-                                <t t-set="_classes" t-valuef="mb-3"/>
-                                <t t-set="_input_classes" t-valuef="rounded-start-pill ps-3 text-bg-light"/>
-                                <t t-set="_submit_classes" t-valuef="rounded-end-pill pe-3 bg-o-color-3"/>
-                                <t t-set="limit" t-valuef="0"/>
-                            </t>
+                            <t t-call="website.placeholder_header_search_box"
+                                _classes.f="mb-3"
+                                _input_classes.f="rounded-start-pill ps-3 text-bg-light"
+                                _submit_classes.f="rounded-end-pill pe-3 bg-o-color-3"
+                                limit.f="0"/>
                             <!-- Navbar -->
                             <li>
-                                <t t-call="website.navbar_nav">
-                                    <t t-set="is_vertical_nav" t-valuef="True"/>
-                                    <t t-set="offcanvas_is_leftside" t-valuef="True"/>
-                                    <t t-set="_no_autohide_menu_mobile" t-valuef="True"/>
-
+                                <t t-call="website.navbar_nav"
+                                    is_vertical_nav.f="True"
+                                    offcanvas_is_leftside.f="True"
+                                    _no_autohide_menu_mobile.f="True">
                                     <!-- Menu -->
                                     <t t-foreach="website.menu_id.child_id" t-as="submenu">
-                                        <t t-call="website.submenu">
-                                            <t t-set="item_class" t-valuef="nav-item border-top #{submenu_last and 'border-bottom'}"/>
-                                            <t t-set="link_class" t-valuef="nav-link p-3 text-wrap"/>
-                                            <t t-set="dropdown_toggler_classes" t-valuef="d-flex justify-content-between align-items-center"/>
-                                            <t t-set="dropdown_menu_classes" t-valuef="position-relative rounded-0 o_dropdown_without_offset"/>
-                                        </t>
+                                        <t t-call="website.submenu"
+                                            item_class.f="nav-item border-top #{submenu_last and 'border-bottom'}"
+                                            link_class.f="nav-link p-3 text-wrap"
+                                            dropdown_toggler_classes.f="d-flex justify-content-between align-items-center"
+                                            dropdown_menu_classes.f="position-relative rounded-0 o_dropdown_without_offset"/>
                                     </t>
                                 </t>
                             </li>
                             <!-- Text element -->
-                            <t t-call="website.placeholder_header_text_element">
-                                <t t-set="_txt_elt_content" t-valuef="phone_mail"/>
-                                <t t-set="_div_class" t-valuef="mt-2"/>
-                            </t>
+                            <t t-call="website.placeholder_header_text_element"
+                                _txt_elt_content.f="phone_mail"
+                                _div_class.f="mt-2"/>
                             <!-- Social -->
-                            <t t-call="website.placeholder_header_social_links">
-                                <t t-set="_div_class" t-valuef="mt-2 border-top pt-2 o_border_contrast"/>
-                            </t>
+                            <t t-call="website.placeholder_header_social_links"
+                                _div_class.f="mt-2 border-top pt-2 o_border_contrast"/>
                         </ul>
                         <ul class="navbar-nav gap-2 mt-3 w-100">
                             <!-- Language Selector -->
-                            <t t-call="website.placeholder_header_language_selector">
-                                <t t-set="_btn_class" t-valuef="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center w-100"/>
-                                <t t-set="_txt_class" t-valuef="me-auto small"/>
-                                <t t-set="_flag_class" t-valuef="me-2"/>
-                                <t t-set="_div_classes" t-valuef="dropup"/>
-                                <t t-set="_dropdown_menu_class" t-valuef="w-100"/>
-                            </t>
+                            <t t-call="website.placeholder_header_language_selector"
+                                _btn_class.f="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center w-100"
+                                _txt_class.f="me-auto small"
+                                _flag_class.f="me-2"
+                                _div_classes.f="dropup"
+                                _dropdown_menu_class.f="w-100"/>
                             <!-- Sign In -->
-                            <t t-call="portal.placeholder_user_sign_in">
-                                <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link o_nav_link_btn'}} w-100 border text-center"/>
-                            </t>
+                            <t t-call="portal.placeholder_user_sign_in"
+                                _link_class.f="{{_additional_btn_color or 'nav-link o_nav_link_btn'}} w-100 border text-center"/>
                             <!-- User Dropdown -->
-                            <t t-call="portal.user_dropdown">
-                                <t t-set="_icon" t-value="true"/>
-                                <t t-set="_user_name" t-value="true"/>
-                                <t t-set="_user_name_class" t-valuef="me-auto small"/>
-                                <t t-set="_link_class" t-valuef="{{ _additional_btn_color or 'nav-link'}} d-flex align-items-center border-0"/>
-                                <t t-set="_icon_class" t-valuef="me-2"/>
-                                <t t-set="_item_class" t-valuef="dropdown dropup"/>
-                                <t t-set="_dropdown_menu_class" t-valuef="w-100"/>
-                            </t>
+                            <t t-call="portal.user_dropdown"
+                                _icon="true"
+                                _user_name="true"
+                                _user_name_class.f="me-auto small"
+                                _link_class.f="{{ _additional_btn_color or 'nav-link'}} d-flex align-items-center border-0"
+                                _icon_class.f="me-2"
+                                _item_class.f="dropdown dropup"
+                                _dropdown_menu_class.f="w-100"/>
                             <!-- Call To Action -->
                             <t t-call="website.header_call_to_action_sidebar"/>
                         </ul>
@@ -1458,46 +1350,41 @@
                 </div>
             </div>
         </t>
-        <t t-call="website.template_header_mobile">
-            <t t-set="_txt_elt_content" t-valuef="phone_mail"/>
-            <t t-set="_side" t-valuef="offcanvas-start"/>
-        </t>
+        <t t-call="website.template_header_mobile"
+            _txt_elt_content.f="phone_mail"
+            _side.f="offcanvas-start"/>
     </xpath>
 </template>
 
 <template id="template_header_sidebar_align_center" inherit_id="website.template_header_sidebar" active="False">
-    <xpath expr="//t[@t-call='website.navbar_nav']" position="inside">
-        <t t-set="_nav_class" t-valuef="text-center"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">text-center</attribute>
     </xpath>
-    <xpath expr="//t[@t-call='website.placeholder_header_text_element']" position="inside">
-        <t t-set="_div_class" t-valuef="mt-2 border-top pt-2 o_border_contrast text-center"/>
+    <xpath expr="//t[@t-call='website.placeholder_header_text_element']" position="attributes">
+        <attribute name="_div_class.f">mt-2 border-top pt-2 o_border_contrast text-center</attribute>
     </xpath>
-    <xpath expr="//t[@t-call='website.placeholder_header_social_links']" position="inside">
-        <t t-set="_div_class" t-valuef="mt-2 border-top pt-2 o_border_contrast text-center"/>
+    <xpath expr="//t[@t-call='website.placeholder_header_social_links']" position="attributes">
+        <attribute name="_div_class.f">mt-2 border-top pt-2 o_border_contrast text-center</attribute>
     </xpath>
-    <xpath expr="//t[@t-set='dropdown_toggler_classes']" position="attributes">
-        <attribute name="t-valuef"/>
-    </xpath>
-    <xpath expr="//t[@t-call='website.submenu']//t[@t-set='dropdown_menu_classes']" position="attributes">
-        <attribute name="t-valuef" add="text-center" separator=" "/>
+    <xpath expr="//t[@t-call='website.submenu']" position="attributes">
+        <attribute name="dropdown_toggler_classes.f"/>
+        <attribute name="dropdown_menu_classes.f" add="text-center" separator=" "/>
     </xpath>
 </template>
 
 <template id="template_header_sidebar_align_right" inherit_id="website.template_header_sidebar" active="False">
-    <xpath expr="//t[@t-call='website.navbar_nav']" position="inside">
-        <t t-set="_nav_class" t-valuef="text-end"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">text-end</attribute>
     </xpath>
-    <xpath expr="//t[@t-call='website.placeholder_header_text_element']" position="inside">
-        <t t-set="_div_class" t-valuef="mt-2 border-top pt-2 o_border_contrast text-end"/>
+    <xpath expr="//t[@t-call='website.placeholder_header_text_element']" position="attributes">
+        <attribute name="_div_class.f">mt-2 border-top pt-2 o_border_contrast text-end</attribute>
     </xpath>
-    <xpath expr="//t[@t-call='website.placeholder_header_social_links']" position="inside">
-        <t t-set="_div_class" t-valuef="mt-2 border-top pt-2 o_border_contrast text-end"/>
+    <xpath expr="//t[@t-call='website.placeholder_header_social_links']" position="attributes">
+        <attribute name="_div_class.f">mt-2 border-top pt-2 o_border_contrast text-end</attribute>
     </xpath>
-    <xpath expr="//t[@t-set='dropdown_toggler_classes']" position="attributes">
-        <attribute name="t-valuef"/>
-    </xpath>
-    <xpath expr="//t[@t-call='website.submenu']//t[@t-set='dropdown_menu_classes']" position="attributes">
-        <attribute name="t-valuef" add="text-end" separator=" "/>
+    <xpath expr="//t[@t-call='website.submenu']" position="attributes">
+        <attribute name="dropdown_toggler_classes.f"/>
+        <attribute name="dropdown_menu_classes.f" add="text-end" separator=" "/>
     </xpath>
 </template>
 
@@ -1505,80 +1392,72 @@
 <template id="template_header_boxed" inherit_id="website.layout" name="Template Header Rounded Box" active="False">
     <xpath expr="//header//nav" position="replace">
         <div t-attf-class="#{header_content_width} py-3 px-0">
-            <t t-call="website.navbar">
-                <t t-set="_navbar_classes" t-valuef="o_full_border d-none d-lg-block rounded-pill px-3 shadow-sm"/>
+            <t t-call="website.navbar"
+                _navbar_classes.f="o_full_border d-none d-lg-block rounded-pill px-3 shadow-sm">
 
                 <div id="o_main_nav" t-attf-class="#{header_content_width} o_main_nav">
                     <!-- Brand -->
-                    <t t-call="website.placeholder_header_brand">
-                        <t t-set="_link_class" t-valuef="me-4"/>
-                    </t>
+                    <t t-call="website.placeholder_header_brand"
+                        _link_class.f="me-4"/>
                     <!-- Navbar -->
-                    <t t-call="website.navbar_nav">
-                        <t t-set="_nav_class" t-valuef="me-auto"/>
-
+                    <t t-call="website.navbar_nav"
+                        _nav_class.f="me-auto">
                         <!-- Menu -->
                         <t t-foreach="website.menu_id.child_id" t-as="submenu">
-                            <t t-call="website.submenu">
-                                <t t-set="item_class" t-valuef="nav-item"/>
-                                <t t-set="link_class" t-valuef="nav-link"/>
-                                <t t-set="_extra_megamenu_classes" t-valuef="rounded-2"/>
-                            </t>
+                            <t t-call="website.submenu"
+                                item_class.f="nav-item"
+                                link_class.f="nav-link"
+                                _extra_megamenu_classes.f="rounded-2"/>
                         </t>
                     </t>
                     <!-- Extra elements -->
                     <ul class="navbar-nav align-items-center gap-1 flex-wrap flex-shrink-0 justify-content-end ps-3">
                         <!-- Search Bar -->
-                        <t t-call="website.placeholder_header_search_box">
-                            <t t-set="_layout" t-valuef="modal"/>
-                            <t t-set="_input_classes" t-valuef="border border-end-0 p-3"/>
-                            <t t-set="_submit_classes" t-valuef="border border-start-0 px-4 bg-o-color-4"/>
-                            <t t-set="_button_classes" t-valuef="o_navlink_background text-reset"/>
-                        </t>
+                        <t t-call="website.placeholder_header_search_box"
+                            _layout.f="modal"
+                            _input_classes.f="border border-end-0 p-3"
+                            _submit_classes.f="border border-start-0 px-4 bg-o-color-4"
+                            _button_classes.f="o_navlink_background text-reset"/>
                         <!-- Text element -->
                         <t t-call="website.placeholder_header_text_element"/>
                         <!-- Social -->
                         <t t-call="website.placeholder_header_social_links"/>
                         <!-- Language Selector -->
-                        <t t-call="website.placeholder_header_language_selector">
-                            <t t-set="_btn_class" t-valuef="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center gap-1 border-0 rounded-pill px-3"/>
-                            <t t-set="_txt_class" t-valuef="small"/>
-                            <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                        </t>
+                        <t t-call="website.placeholder_header_language_selector"
+                            _btn_class.f="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center gap-1 border-0 rounded-pill px-3"
+                            _txt_class.f="small"
+                            _dropdown_menu_class.f="dropdown-menu-end"/>
                         <!-- Sign In -->
-                        <t t-call="portal.placeholder_user_sign_in">
-                            <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link o_nav_link_btn'}} border px-3"/>
-                        </t>
+                        <t t-call="portal.placeholder_user_sign_in"
+                            _link_class.f="{{_additional_btn_color or 'nav-link o_nav_link_btn'}} border px-3"/>
                         <!-- User Dropdown -->
-                        <t t-call="portal.user_dropdown">
-                            <t t-set="_icon" t-value="true"/>
-                            <t t-set="_user_name" t-value="false"/>
-                            <t t-set="_user_name_class" t-valuef="me-auto small"/>
-                            <t t-set="_item_class" t-valuef="dropdown"/>
-                            <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center border-0 rounded-pill px-3"/>
-                            <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
-                        </t>
+                        <t t-call="portal.user_dropdown"
+                            _icon="true"
+                            _user_name="false"
+                            _user_name_class.f="me-auto small"
+                            _item_class.f="dropdown"
+                            _link_class.f="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center border-0 rounded-pill px-3"
+                            _dropdown_menu_class.f="dropdown-menu-end"/>
                         <!-- Call To Action -->
                         <t t-call="website.placeholder_header_call_to_action"/>
                     </ul>
                 </div>
             </t>
-            <t t-call="website.template_header_mobile">
-                <t t-set="_extra_navbar_classes" t-valuef="o_full_border mx-1 rounded-pill px-3"/>
-            </t>
+            <t t-call="website.template_header_mobile"
+                _extra_navbar_classes.f="o_full_border mx-1 rounded-pill px-3"/>
         </div>
     </xpath>
 </template>
 
 <template id="template_header_boxed_align_center" inherit_id="website.template_header_boxed" active="False">
-    <xpath expr="//t[@t-set='_nav_class']" position="replace">
-        <t t-set="_nav_class" t-valuef="mx-auto"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">mx-auto</attribute>
     </xpath>
 </template>
 
 <template id="template_header_boxed_align_right" inherit_id="website.template_header_boxed" active="False">
-    <xpath expr="//t[@t-set='_nav_class']" position="replace">
-        <t t-set="_nav_class" t-valuef="ms-auto"/>
+    <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
+        <attribute name="_nav_class.f">ms-auto</attribute>
     </xpath>
 </template>
 
@@ -1695,7 +1574,7 @@
 
 <!-- Features template -->
 <template id="login_layout" inherit_id="web.login_layout" name="Website Login Layout" priority="20">
-    <xpath expr="t" position="replace">
+    <xpath expr="t[@t-call]" position="replace">
         <t t-call="website.layout">
             <div class="oe_website_login_container" t-out="0"/>
         </t>
@@ -2223,14 +2102,16 @@
 
     <!-- Add the 'flags' possibility -->
     <xpath expr="//button[contains(@t-attf-class, 'dropdown-toggle')]/span" position="before">
-        <t t-if="flags" t-call="website.lang_flag">
+        <t t-if="flags">
             <t t-if="no_text and not codes" t-set="flag_lang_alt" t-value="active_lang.name.split('/').pop()"/>
-            <t t-set="flag_image_url" t-value="active_lang.flag_image_url"/>
+            <t t-call="website.lang_flag"
+                flag_image_url="active_lang.flag_image_url"/>
         </t>
     </xpath>
     <xpath expr="//*[contains(@t-attf-class, 'js_change_lang')]/span" position="before">
-        <t t-if="flags" t-call="website.lang_flag">
-            <t t-set="flag_image_url" t-value="lg.flag_image_url"/>
+        <t t-if="flags">
+            <t t-call="website.lang_flag"
+                flag_image_url="lg.flag_image_url"/>
         </t>
     </xpath>
 </template>
@@ -2260,58 +2141,58 @@
 <template id="header_language_selector" inherit_id="website.placeholder_header_language_selector" name="Header Language Selector" active="True">
     <xpath expr="." position="inside">
         <li data-name="Language Selector" t-attf-class="o_header_language_selector #{_item_class}">
-            <t id="header_language_selector_call" t-call="portal.language_selector">
-                <t t-set="_div_classes" t-value="(_div_classes or '') + ' dropdown'"/>
-            </t>
+            <t id="header_language_selector_call"
+                t-call="portal.language_selector"
+                _div_classes="(_div_classes or '') + ' dropdown'"/>
         </li>
     </xpath>
 </template>
 
 <template id="header_language_selector_inline" name="Header Language Selector Inline" inherit_id="website.header_language_selector" active="False">
-    <xpath expr="//t[@id='header_language_selector_call']" position="replace">
-        <t id="header_language_selector_call" t-call="website.language_selector_inline"/>
+    <xpath expr="//t[@id='header_language_selector_call']" position="attributes">
+        <attribute name="t-call">website.language_selector_inline</attribute>
     </xpath>
 </template>
 
 <template id="header_language_selector_flag" name="Header Language Selector Flag" inherit_id="website.header_language_selector" active="False">
-    <xpath expr="//t[@id='header_language_selector_call']" position="before">
-        <t t-set="flags" t-value="True"/>
+    <xpath expr="//t[@id='header_language_selector_call']" position="attributes">
+        <attribute name="flags">True</attribute>
     </xpath>
 </template>
 
 <template id="header_language_selector_code" name="Header Language Selector Code" inherit_id="website.header_language_selector" active="False">
-    <xpath expr="//t[@id='header_language_selector_call']" position="before">
-        <t t-set="codes" t-value="True"/>
+    <xpath expr="//t[@id='header_language_selector_call']" position="attributes">
+        <attribute name="codes">True</attribute>
     </xpath>
 </template>
 
 <template id="header_language_selector_no_text" name="Header Language Selector No Text" inherit_id="website.header_language_selector" active="False">
-    <xpath expr="//t[@id='header_language_selector_call']" position="before">
-        <t t-set="no_text" t-value="True"/>
+    <xpath expr="//t[@id='header_language_selector_call']" position="attributes">
+        <attribute name="no_text">True</attribute>
     </xpath>
 </template>
 
 <template id="footer_language_selector_inline" name="Footer Language Selector Inline" inherit_id="portal.footer_language_selector" active="True">
-    <xpath expr="//t[@id='language_selector_call']" position="replace">
-        <t id="language_selector_call" t-call="website.language_selector_inline"/>
+    <xpath expr="//t[@id='language_selector_call']" position="attributes">
+        <attribute name="t-call">website.language_selector_inline</attribute>
     </xpath>
 </template>
 
 <template id="footer_language_selector_flag" name="Footer Language Selector Flag" inherit_id="portal.footer_language_selector" active="False">
-    <xpath expr="//t[@id='language_selector_call']" position="before">
-        <t t-set="flags" t-value="True"/>
+    <xpath expr="//t[@id='language_selector_call']" position="attributes">
+        <attribute name="flags">True</attribute>
     </xpath>
 </template>
 
 <template id="footer_language_selector_code" name="Footer Language Selector Code" inherit_id="portal.footer_language_selector" active="False">
-    <xpath expr="//t[@id='language_selector_call']" position="before">
-        <t t-set="codes" t-value="True"/>
+    <xpath expr="//t[@id='language_selector_call']" position="attributes">
+        <attribute name="codes">True</attribute>
     </xpath>
 </template>
 
 <template id="footer_language_selector_no_text" name="Footer Language Selector No Text" inherit_id="portal.footer_language_selector" active="False">
-    <xpath expr="//t[@id='language_selector_call']" position="before">
-        <t t-set="no_text" t-value="True"/>
+    <xpath expr="//t[@id='language_selector_call']" position="attributes">
+        <attribute name="no_text">True</attribute>
     </xpath>
 </template>
 
@@ -2726,12 +2607,11 @@ Sitemap: <t t-out="url_root"/>sitemap.xml
     <t t-call="website.layout">
         <div id="wrap">
             <div class="container">
-                <t t-call="website.website_search_box_input">
-                    <t t-set="_form_classes" t-valuef="mt8 float-end"/>
-                    <t t-set="search_type" t-valuef="pages"/>
-                    <t t-set="action" t-valuef="/pages"/>
-                    <t t-set="search" t-value="original_search or search"/>
-                </t>
+                <t t-call="website.website_search_box_input"
+                    _form_classes.f="mt8 float-end"
+                    search_type.f="pages"
+                    action.f="/pages"
+                    search="original_search or search"/>
                 <h1 class="mt16 h3-fs">Pages</h1>
                 <t t-if="not pages">
                     <div t-if="search" class="alert alert-warning mt8" role="alert">
@@ -2765,15 +2645,14 @@ Sitemap: <t t-out="url_root"/>sitemap.xml
     <t t-call="website.layout">
         <div id="wrap">
             <div class="container pt24 pb24">
-                <t t-call="website.website_search_box_input">
-                    <t t-set="_classes" t-valuef="mt8"/>
-                    <t t-set="search_type" t-valuef="all"/>
-                    <t t-set="action" t-valuef="/website/search"/>
-                </t>
+                <t t-call="website.website_search_box_input"
+                    _classes.f="mt8"
+                    search_type.f="all"
+                    action.f="/website/search"/>
                 <h1 class="mt24 h3-fs">Search Results</h1>
                 <t t-if="not results">
                     <div class="text-center">
-                        <div t-call="website.empty_search_svg" class="mt-5 mb-3"/>
+                        <div class="mt-5 mb-3"><t t-call="website.empty_search_svg"/></div>
                         <t t-if="search">
                             Your search '<t t-out="search" />' did not match anything.
                         </t>
@@ -2992,15 +2871,14 @@ Sitemap: <t t-out="url_root"/>sitemap.xml
     the same parameters (eg. header desktop + header mobile)
 -->
 <template id="header_search_box_input" name="Header Search Box Input">
-    <t t-call="website.website_search_box_input">
-        <t t-set="search_type" t-valuef="all"/>
-        <t t-set="action" t-valuef="/website/search"/>
-        <t t-set="limit" t-value="limit or '5'"/>
-        <t t-set="display_image" t-valuef="true"/>
-        <t t-set="display_description" t-valuef="true"/>
-        <t t-set="display_extra_link" t-valuef="true"/>
-        <t t-set="display_detail" t-valuef="true"/>
-    </t>
+    <t t-call="website.website_search_box_input"
+        search_type.f="all"
+        action.f="/website/search"
+        limit="limit or '5'"
+        display_image.f="true"
+        display_description.f="true"
+        display_extra_link.f="true"
+        display_detail.f="true"/>
 </template>
 
 <!-- Extra element : Search -->
@@ -3012,9 +2890,8 @@ Sitemap: <t t-out="url_root"/>sitemap.xml
                 <div class="modal fade css_editable_mode_hidden" id="o_search_modal" aria-hidden="true" tabindex="-1">
                     <div class="modal-dialog modal-lg pt-5">
                         <div class="modal-content mt-5">
-                            <t t-call="website.header_search_box_input">
-                                <t t-set="_classes" t-valuef="input-group-lg"/>
-                            </t>
+                            <t t-call="website.header_search_box_input"
+                                _classes.f="input-group-lg"/>
                         </div>
                     </div>
                 </div>

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -294,7 +294,7 @@
     <t t-else="" t-set="opt_event_size" t-value="opt_index_sidebar and 'col-12' or 'col-xl-12'"/>
     <!-- No events -->
     <div t-if="not event_ids" class="col-12 text-center">
-        <div t-call="website_event.event_empty_events_svg" class="my-4"/>
+        <div class="my-4"><t t-call="website_event.event_empty_events_svg"/></div>
         <h3>No events scheduled yet</h3>
         <p t-if="searches['search']">We couldn't find any event matching your search for: <strong t-out="searches['search']"/>.</p>
         <p t-elif="searches['tags']">No event matching your search criteria could be found.</p>

--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -24,9 +24,9 @@
     <section id="o_wevent_event_submenu">
         <!-- Mobile -->
         <div id="o_wevent_submenu_mobile" class="container d-flex d-lg-none align-items-center py-3 pb-lg-2">
-            <a t-if="navbar__back_url" t-att-href="navbar__back_url" t-att-title="navbar__back_title or 'Go back'">
+            <a t-if="navbar_back_url" t-att-href="navbar_back_url" t-att-title="navbar_back_title or 'Go back'">
                 <i class="oi oi-chevron-left"/>
-                <span t-out="navbar__back_text or 'Go back'"/>
+                <span t-out="navbar_back_text or 'Go back'"/>
             </a>
             <a t-else="" href="/event" title="All Events">
                 <i class="oi oi-chevron-left"/>
@@ -52,19 +52,19 @@
                             <li class="breadcrumb-item" t-if="event.header_visible">
                                 <a href="/event" title="Back to All Events">All Events</a>
                             </li>
-                            <t t-if="navbar__back_url">
+                            <t t-if="navbar_back_url">
                                 <li class="breadcrumb-item">
                                     <a t-attf-href="/event/{{slug(event)}}" t-attf-title="Back to {{event.name}}" t-field="event.name"/>
                                 </li>
                                 <li class="breadcrumb-item">
-                                    <a t-att-href="navbar__back_url" t-att-title="navbar__back_title" t-out="navbar__back_text"/>
+                                    <a t-att-href="navbar_back_url" t-att-title="navbar_back_title" t-out="navbar_back_text"/>
                                 </li>
                             </t>
                             <t t-else="">
                                 <li t-attf-class="breadcrumb-item active #{'fw-bold' if not event.header_visible else ''}" aria-current="page"><span class="pe-3" t-field="event.name"/></li>
                             </t>
                         </ul>
-                        <ul t-if="not navbar__back_url" class="nav" t-att-data-menu_name="editable and 'Event Menu'" t-att-data-content_menu_id="editable and event.menu_id.id">
+                        <ul t-if="not navbar_back_url" class="nav" t-att-data-menu_name="editable and 'Event Menu'" t-att-data-content_menu_id="editable and event.menu_id.id">
                             <t t-foreach="event.menu_id.child_id" t-as="submenu">
                                 <t t-call="website.submenu">
                                     <t t-set="item_class" t-value="'nav-item'"/>
@@ -81,7 +81,7 @@
                         <t t-call="website_event.registration_template"/>
                     </div>
 
-                    <t t-if="navbar__back_url" t-call="website_event.navbar_dropdown"/>
+                    <t t-if="navbar_back_url" t-call="website_event.navbar_dropdown"/>
                 </div>
             </div>
         </div>

--- a/addons/website_event_booth/views/event_booth_templates.xml
+++ b/addons/website_event_booth/views/event_booth_templates.xml
@@ -15,7 +15,7 @@
                 <div t-if="event.is_finished" class="container">
                     <div class="row">
                         <div class="col-12 text-center">
-                            <div t-call="website_event.event_empty_events_svg" class="my-4"/>
+                            <div class="my-4"><t t-call="website_event.event_empty_events_svg"/></div>
                             <h2>Event Finished</h2>
                             <p>It's no longer possible to book a booth.</p>
                         </div>
@@ -24,7 +24,7 @@
                 <div t-elif="not event_booths" class="container">
                     <div class="row">
                         <div class="col-12 text-center">
-                            <div t-call="website_event.event_empty_events_svg" class="my-4"/>
+                            <div class="my-4"><t t-call="website_event.event_empty_events_svg"/></div>
                             <h2>Registration Not Open.</h2>
                             <p>This event is not open to exhibitors registration at this time.</p>
                             <p>Check our <a class="o_translate_inline" href="/event" title="List of Future Events" aria-label="Link to list of future events">list of future events</a>.</p>

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
@@ -208,7 +208,7 @@
 <template id="exhibitors_main" name="Exhibitors: Main Display">
     <!-- No exhibitors -->
     <div t-if="not sponsor_categories" class="col-12 text-center">
-        <div t-call="website_event.event_empty_events_svg" class="my-4"/>
+        <div class="my-4"><t t-call="website_event.event_empty_events_svg"/></div>
         <h2>No exhibitor found.</h2>
         <p t-if="search_key">We could not find any exhibitor matching your search for: <strong t-out="search_key"/>.</p>
         <p t-else="">We could not find any exhibitor at this moment.</p>
@@ -219,7 +219,7 @@
         </div>
     </div>
     <!-- Cards -->
-    <div class="col-12" t-call="website_event_exhibitor.exhibitors_display_cards"/>
+    <div class="col-12"><t t-call="website_event_exhibitor.exhibitors_display_cards"/></div>
 </template>
 
 <!-- Exhibitors: Cards-based display -->

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
@@ -5,9 +5,9 @@
     <t t-set="no_header" t-value="option_widescreen"/>
     <t t-set="no_footer" t-value="option_widescreen"/>
     <t t-call="website_event.layout">
-        <t t-set="navbar__back_url" t-value="'/event/%s/exhibitors' % (slug(event))"/>
-        <t t-set="navbar__back_title">Back to all Exhibitors</t>
-        <t t-set="navbar__back_text">All Exhibitors</t>
+        <t t-set="navbar_back_url" t-value="'/event/%s/exhibitors' % (slug(event))"/>
+        <t t-set="navbar_back_title">Back to all Exhibitors</t>
+        <t t-set="navbar_back_text">All Exhibitors</t>
 
 
         <div class="o_wevent_online o_wesponsor_index">

--- a/addons/website_event_sale/views/website_sale_templates.xml
+++ b/addons/website_event_sale/views/website_sale_templates.xml
@@ -91,8 +91,8 @@
                                             <span t-if="website_visitor_timezone != event.date_tz" class="small">(<t t-out="event.date_tz"/>)</span>
                                         </div>
                                     </div>
-                                    <div t-if="event_attendees[slot]" t-call="website_event.registration_ticket_access">
-                                        <t t-set="attendees" t-value="event_attendees[slot]"/>
+                                    <div t-if="event_attendees[slot]">
+                                        <t t-call="website_event.registration_ticket_access" attendees="event_attendees[slot]"/>
                                     </div>
                                 </div>
                                 <t t-call="website_event.event_calendar_links">

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -8,7 +8,7 @@
         <div t-if="not tracks_by_days" class="container">
             <div class="row">
                 <div class="col-12 text-center">
-                    <div t-call="website_event.event_empty_events_svg" class="my-4"/>
+                    <div class="my-4"><t t-call="website_event.event_empty_events_svg"/></div>
                     <h2 class="mb-2">No track found.</h2>
                     <p t-if="search_key">We could not find any track matching your search for: <strong t-out="search_key"/>.</p>
                     <p t-else="">We could not find any track at this moment.</p>

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -187,7 +187,7 @@
 <template id="tracks_main" name="Tracks: Main Display">
     <!-- No tracks -->
     <div t-if="not tracks" class="col-12 text-center">
-        <div t-call="website_event.event_empty_events_svg" class="my-4"/>
+        <div class="my-4"><t t-call="website_event.event_empty_events_svg"/></div>
         <h4>No track found.</h4>
         <p t-if="search_key">We could not find any track matching your search for: <strong t-out="search_key"/>.</p>
         <p t-else="">We could not find any track at this moment.</p>
@@ -198,9 +198,9 @@
         </div>
     </div>
     <!-- Cards -->
-    <div class="col-12" t-call="website_event_track.tracks_display_cards"/>
+    <div class="col-12"><t t-call="website_event_track.tracks_display_cards"/></div>
     <!-- List -->
-    <div class="col-12" t-call="website_event_track.tracks_display_list"/>
+    <div class="col-12"><t t-call="website_event_track.tracks_display_list"/></div>
 </template>
 
 <!-- Tracks: Cards-based display -->

--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -3,9 +3,9 @@
 
 <template id="event_track_main" name="Event Exhibitor">
     <t t-call="website_event.layout">
-        <t t-set="navbar__back_url" t-value="'/event/%s/track' % (slug(event))"/>
-        <t t-set="navbar__back_title">Back to All Talks</t>
-        <t t-set="navbar__back_text">All Talks</t>
+        <t t-set="navbar_back_url" t-value="'/event/%s/track' % (slug(event))"/>
+        <t t-set="navbar_back_title">Back to All Talks</t>
+        <t t-set="navbar_back_text">All Talks</t>
         <!-- Set aside block only if there are filtered tracks -->
         <t t-set="has_ongoing_or_upcoming" t-value="any(track.is_track_live or track.track_start_remaining for track in tracks_other)"/>
         <t t-set="filtered_tracks_other" t-value="tracks_other.filtered(lambda track: not (has_ongoing_or_upcoming and track.is_track_done))"/>
@@ -117,10 +117,10 @@
                     </div>
                     <div class="o_we_track_action_buttons d-flex justify-content-md-end align-items-center flex-wrap">
                         <div class="o_we_track_reminder_button my-1">
-                            <div t-if="option_track_wishlist and (track.is_track_upcoming or track.is_reminder_on or (not track.date and not track.event_id.is_finished))"
-                                t-call="website_event_track.track_widget_reminder">
-                                <t t-set="reminder_small" t-value="False"/>
-                                <t t-set="reminder_light" t-value="False"/>
+                            <div t-if="option_track_wishlist and (track.is_track_upcoming or track.is_reminder_on or (not track.date and not track.event_id.is_finished))">
+                                <t t-call="website_event_track.track_widget_reminder"
+                                    reminder_small="False"
+                                    reminder_light="False"/>
                             </div>
                         </div>
                     </div>

--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -253,7 +253,7 @@
 <template id="user_sidebar_mobile">
     <div id="o_wforum_offcanvas" class="o_website_offcanvas offcanvas offcanvas-end d-lg-none mw-75 p-0 overflow-visible">
         <button type="button" class="btn-close mt-3 ms-auto me-3" data-bs-dismiss="offcanvas" aria-label="Close"/>
-        <div class="offcanvas-header align-items-start px-0" t-call="website_forum.user_sidebar_header"/>
+        <div class="offcanvas-header align-items-start px-0"><t t-call="website_forum.user_sidebar_header"/></div>
         <div class="offcanvas-body d-flex flex-column py-0 nav">
             <t t-call="website_forum.user_sidebar_body"/>
             <div t-if="forum" class="mb-2 d-flex justify-content-center align-items-end flex-grow-1">

--- a/addons/website_forum/views/forum_forum_templates_post.xml
+++ b/addons/website_forum/views/forum_forum_templates_post.xml
@@ -70,7 +70,7 @@
                     </div>
                 </div>
             </div>
-            <div t-if="not answer" t-call="website_forum.post_stats" class="d-inline-flex align-items-center"/>
+            <div t-if="not answer" class="d-inline-flex align-items-center"><t t-call="website_forum.post_stats"/></div>
         </div>
     </div>
     <tr t-else="" class="position-relative d-flex d-lg-table-row">
@@ -245,7 +245,7 @@
                     </t>
                 </div>
             </div>
-            <div t-attf-class="d-flex align-items-center #{'mb-3' if not is_profile else ''}" t-call="website_forum.post_stats"/>
+            <div t-attf-class="d-flex align-items-center #{'mb-3' if not is_profile else ''}"><t t-call="website_forum.post_stats"/></div>
             <div class="d-grid">
                 <!-- Question Post -->
                 <t t-call="website_forum.post_display">
@@ -276,7 +276,7 @@
                 <t t-if="question.state != 'close' and question.active != False and question.can_answer and forum">
                     <div id="post_reply" class="answer_collapse position-fixed d-flex flex-column start-0 end-0 bottom-0 w-100 w-lg-50 shadow mx-auto px-3 bg-body"
                          t-if="forum and not forum.has_pending_post and (not question.uid_has_answered or question.forum_id.mode == 'discussions')">
-                        <div t-call="website_forum.post_answer" class="container my-3"/>
+                        <div class="container my-3"><t t-call="website_forum.post_answer"/></div>
                     </div>
                     <div t-elif="forum and forum.has_pending_post" class="alert alert-info text-center">
                         <b class="d-block">You have a pending post</b>
@@ -284,7 +284,7 @@
                     </div>
                 </t>
                 <t t-if="is_public_user" t-call="website_forum.forum_sign_up_cta"/>
-                <section t-if="related_posts" t-call="website_forum.forum_related_posts"/>
+                <section t-if="related_posts"><t t-call="website_forum.forum_related_posts"/></section>
             </div>
         </div>
     </t>
@@ -553,10 +553,11 @@
                 <t t-set="can_unlink_comment" t-value="user.karma >= unlink_comment_required_karma"/>
                 <div class="flex-grow-1 py-2 opacity-75">
                     <header>
-                        <span t-call="website_forum.author_box">
-                            <t t-set="object" t-value="message"/>
-                            <t t-set="compact" t-value="True"/>
-                            <t t-set="show_name" t-value="True"/>
+                        <span>
+                            <t t-call="website_forum.author_box"
+                                object="message"
+                                compact="True"
+                                show_name="True"/>
                         </span>
                         <span class="ms-2 mb-2 small text-muted"><small class="o_wforum_relative_datetime"/></span>
                         <span t-if="_question_creator == _comment_author" class="badge ms-2 border border-dark text-reset">

--- a/addons/website_forum/views/website_profile_templates.xml
+++ b/addons/website_forum/views/website_profile_templates.xml
@@ -48,7 +48,7 @@
                     <div class="mb-4">
                         <h5 class="border-bottom pb-1 d-flex align-items-center justify-content-between">
                             Questions
-                            <t t-if="count_questions &gt; 0" class="float-end" t-call="website.website_search_box_input">
+                            <t t-if="count_questions &gt; 0" t-call="website.website_search_box_input">
                                 <t t-set="_form_classes" t-valuef="d-flex flex-row align-items-center flex-wrap float-end"/>
                                 <t t-set="search_type" t-valuef="forums"/>
                                 <t t-if="forum_id" t-set="action" t-value="'/forum/%s%s' % (forum_id, ('/tag/%s/questions' % slug(tag)) if tag else '')"/>
@@ -105,7 +105,7 @@
                     <div class="mb-4">
                         <h5 class="border-bottom pb-1 d-flex align-items-center justify-content-between">
                             Answers
-                            <t t-if="count_questions &gt; 0" class="float-end" t-call="website.website_search_box_input">
+                            <t t-if="count_questions &gt; 0" t-call="website.website_search_box_input">
                                 <t t-set="_form_classes" t-valuef="d-flex flex-row align-items-center flex-wrap float-end"/>
                                 <t t-set="search_type" t-valuef="forums"/>
                                 <t t-if="forum_id" t-set="action" t-value="'/forum/%s%s' % (forum_id, '/tag/%s/questions' % slug(tag)) if tag else ''"/>
@@ -145,7 +145,7 @@
                     <div class="mb-4">
                         <h5 class="border-bottom pb-1 flex align-items-center justify-content-between" style="height:43px;">
                             Votes
-                            <t t-if="my_profile" class="float-end" t-call="website.website_search_box_input">
+                            <t t-if="my_profile" t-call="website.website_search_box_input">
                                 <t t-set="_form_classes" t-valuef="d-flex flex-row align-items-center flex-wrap float-end"/>
                                 <t t-set="search_type" t-valuef="forums"/>
                                 <t t-set="action" t-value="'/forum/%s%s' % (forum_id or 'all', '/tag/%s/questions' % slug(tag) if tag else '')"/>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -703,12 +703,9 @@
                                     <t t-if="is_view_active('website_sale.search')">
                                         <t t-set="_has_all_sibligns" t-value="hasPricelistDropdown and is_view_active('website_sale.sort') and wsale_has_filters_btn"></t>
                                         <!-- Desktop Search button -->
-                                        <div
-                                            t-attf-class="o_wsale_products_header_search_form_container {{ _has_all_sibligns and 'd-none d-sm-inline-block'}} col-xl-5 me-auto {{not hasLeftColumn and 'col-xl-6'}}"
-                                            t-call="website_sale.search"
-                                        >
+                                        <div t-attf-class="o_wsale_products_header_search_form_container {{ _has_all_sibligns and 'd-none d-sm-inline-block'}} col-xl-5 me-auto {{not hasLeftColumn and 'col-xl-6'}}">
                                             <t t-if="category" t-set="placeholder">Search in <t t-out="category.name"/></t>
-                                            <t t-set="search" t-value="original_search or search"/>
+                                            <t t-call="website_sale.search" placeholder="placeholder" search="original_search or search"/>
                                         </div>
                                         <!-- Mobile Search button -->
                                         <a
@@ -814,7 +811,7 @@
                             </div>
                             <div t-else="" class="text-center text-muted mt128 mb256">
                                 <t t-if="not search">
-                                    <div t-call="website.empty_search_svg" class="mt-5 mb-3"/>
+                                    <div class="mt-5 mb-3"><t t-call="website.empty_search_svg"/></div>
                                     <h3
                                         class="mt8"
                                         style="text-align: center;"
@@ -829,7 +826,7 @@
                                     </p>
                                 </t>
                                 <t t-else="">
-                                    <div t-call="website.empty_search_svg" class="mt-5 mb-3"/>
+                                    <div class="mt-5 mb-3"><t t-call="website.empty_search_svg"/></div>
                                     <h3 class="mt8" style="text-align: center;">No results</h3>
                                     <p style="text-align: center;">
                                         No results for "<strong t-out='search'/>"<t t-if="category"> in category "<strong t-out="category.display_name"/>"</t>.
@@ -2821,7 +2818,7 @@
             t-if="not website_sale_order or not website_sale_order.website_order_line"
             class="js_cart_lines w-100"
         >
-            <div t-call="website_sale.empty_cart_svg" class="mt-5 mb-3"/>
+            <div class="mt-5 mb-3"><t t-call="website_sale.empty_cart_svg"/></div>
             <h5 class="mb-3" style="text-align: center;">
                 Your cart is empty!
             </h5>
@@ -2902,10 +2899,7 @@
                                             />
                                         </div>
                                     </div>
-                                    <div
-                                        t-attf-class="{{'d-block d-md-none' if not is_combo else ''}}"
-                                        t-call="website_sale.cart_lines_price"
-                                    />
+                                    <div t-attf-class="{{'d-block d-md-none' if not is_combo else ''}}"><t t-call="website_sale.cart_lines_price"/></div>
                                 </div>
                                 <t t-call="website_sale.cart_line_description_following_lines"/>
                                 <ul t-if="is_combo" class="list-group">
@@ -2928,30 +2922,20 @@
                                     >
                                         Remove
                                     </a>
-                                    <div
-                                        t-if="is_combo"
-                                        class="d-none d-md-block ms-auto"
-                                        t-call="website_sale.cart_lines_quantity"
-                                    />
+                                    <div t-if="is_combo" class="d-none d-md-block ms-auto"><t t-call="website_sale.cart_lines_quantity"/></div>
                                 </div>
                             </div>
                             <div t-if="not is_combo" class="d-none d-md-block">
                                 <t t-call="website_sale.cart_lines_price"/>
-                                <div
-                                    class="d-none d-md-block mt-2"
-                                    t-call="website_sale.cart_lines_quantity"
-                                />
+                                <div class="d-none d-md-block mt-2"><t t-call="website_sale.cart_lines_quantity"/></div>
                             </div>
                         </div>
                         <div
                             name="o_wsale_cart_line_button_container_mobile"
                             class="d-flex d-md-none"
                         >
-                            <div
-                                class="d-flex d-md-none align-items-center me-auto"
-                                t-call="website_sale.cart_lines_quantity"
-                            >
-                                <t t-set="is_mobile" t-value="True"/>
+                            <div class="d-flex d-md-none align-items-center me-auto">
+                                <t t-call="website_sale.cart_lines_quantity" is_mobile="True"/>
                             </div>
                             <button
                                 class="js_delete_product btn btn-link d-inline-block d-md-none px-2"
@@ -3112,7 +3096,7 @@
             ">
                 <div class="d-flex align-items-center mb-3">
                     <h4 class="mb-0">Order summary</h4>
-                    <div t-call="website_sale.quick_reorder_button" class="ms-3 border-start ps-2"/>
+                    <div class="ms-3 border-start ps-2"><t t-call="website_sale.quick_reorder_button"/></div>
                 </div>
                 <div t-if="abandoned_proceed or access_token" class="alert alert-info mt8 mb8" role="alert"> <!-- abandoned cart choices -->
                     <t t-if="abandoned_proceed">

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -292,10 +292,9 @@
                             id="empty-wishlist-message"
                             t-attf-class="w-100 #{'d-none' if wishes else ''}"
                         >
-                            <div
-                                t-call="website_sale_wishlist.empty_wishlist_svg"
-                                class="mt-5 mb-3"
-                            />
+                            <div class="mt-5 mb-3">
+                                <t t-call="website_sale_wishlist.empty_wishlist_svg"/>
+                            </div>
                             <h5 class="mb-3" style="text-align: center;">
                                 Your wishlist is empty!
                             </h5>

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -119,11 +119,8 @@
     <t t-set="body_classname" t-value="'o_wslides_body'"/>
     <t t-call="website.layout">
         <div id="wrap" t-attf-class="wrap mt-0">
-            <div class="oe_structure oe_empty" t-call="website.record_cover">
-                <t t-set="_record" t-value="channel"/>
-                <t t-set="use_filters" t-value="True"/>
-                <t t-set="use_size" t-value="True"/>
-                <t t-set="use_text_align" t-value="True"/>
+            <div class="oe_structure oe_empty">
+            <t t-call="website.record_cover" _record="channel" use_filters="True" use_size="True" use_text_align="True">
                 <div t-attf-class="o_wslides_course_header position-relative pb-md-0 pt-2 pt-md-5 #{'pb-3' if channel.channel_type == 'training' else 'o_wslides_course_doc_header pb-5'}">
                     <t t-call="website_slides.course_nav"/>
                     <div class="container mt-5 mt-md-3 mt-xl-4">
@@ -164,6 +161,7 @@
                         </div>
                     </div>
                 </div>
+            </t>
             </div>
 
             <div class="o_wslides_course_main">
@@ -824,7 +822,7 @@
                 </div>
                 <div class="row mx-n2">
                     <t t-foreach="category['slides']" t-as="slide">
-                        <div class="col-12 col-sm-6 col-lg-4 px-2 d-flex" t-call="website_slides.lesson_card"/>
+                        <div class="col-12 col-sm-6 col-lg-4 px-2 d-flex"><t t-call="website_slides.lesson_card"/></div>
                     </t>
                 </div>
             </div>

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -1786,7 +1786,7 @@ class TestTemplating(ViewCase):
             'name': "Base View",
             'type': 'qweb',
             'arch': """<root>
-                <item><span t-call="foo"/></item>
+                <item><span><t t-call="foo"/></span></item>
             </root>""",
         })
 
@@ -1794,7 +1794,7 @@ class TestTemplating(ViewCase):
         arch = etree.fromstring(arch_string)
         self.View.distribute_branding(arch)
 
-        self.assertEqual(arch, E.root(E.item(E.span({'t-call': "foo"}))))
+        self.assertEqual(arch, E.root(E.item(E.span(E.t({'t-call': "foo"})))))
 
     def test_esc_no_branding(self):
         view = self.View.create({

--- a/odoo/addons/test_testing_utilities/tests/test_xml_tools.py
+++ b/odoo/addons/test_testing_utilities/tests/test_xml_tools.py
@@ -115,12 +115,12 @@ _</h1>
             'type': 'qweb',
             'arch_db': f'''<data>
     <item t-foreach="items" t-as="item" t-esc="item"/>
-    <addressSender t-call='{template_addresses.id}'>
+    <addressSender><t t-call='{template_addresses.id}'>
         <t t-set="address" t-value="addressSender"/>
-    </addressSender>
-    <addressRecipient t-call='{template_addresses.id}'>
+    </t></addressSender>
+    <addressRecipient><t t-call='{template_addresses.id}'>
         <t t-set="address" t-value="addressRecipient"/>
-    </addressRecipient>
+    </t></addressRecipient>
 </data>
 '''})
         expected = """<data>


### PR DESCRIPTION
This commit introduces major improvements to QWeb: parametric `t-call`,
lazy XML evaluation.

### 1. Parametric `t-call`
Previously, parameters passed to a template through `t-call` were defined
inside the `t-call` tag using `t-set` elements. The content inside the `t-call`
was evaluated within the context of the called template.

Now, `t-call` becomes **parametric**:
- Parameters are passed directly as **attributes** on the `t-call` tag instead
  of using internal `t-set` definitions.
- The content inside the `t-call` tag no longer has access to these parameters;
  it only sees the variables available **before the `t-call`**.
- The attributes passed to `t-call` are used **only for rendering the called
  template** and **not** for the content inside the `t-call`.

**Example before:**
```xml
<t t-call="my_template">
    <t t-set="custom" t-value="x + y" />
    <t t-set="add_class" t-valuef="o_toto_{{stuff}}" />
    <t t-set="title">Hello <t t-out="user.name"/></t>
</t>
```
**Example after:**
```xml
<t t-call="my_template"
    custom="x + y"
    add_class.f="o_toto_{{stuff}}"
    title.translate="Hello {{user.name}}" />
```

### 2. Lazy XML evaluation & streamable rendering
QWeb now supports **lazy XML evaluation**:
- All XML content is now **lazy** and only evaluated **when explicitly
  rendered**, typically when using `t-out`.
- This also applies to XML content declared **inside `t-call` blocks**: the
  content is generated **only when actually output**.
- The variables available for evaluation are those present **at the time the
  content was declared**, not when it is rendered.
- As a result, **QWeb templates are now streamable**, allowing more efficient
  and predictable rendering.

### Impact
- Simplifies and clarifies `t-call` usage.
- Prevents unexpected side effects on local contexts.
- Enables **lazy evaluation** and **streamable QWeb rendering**.
- Support translatable formated string on `t-call` parameters.
- Improves predictability, and maintainability of QWeb templates.

### NB
`t-call` on other element than <t> is now forbidden.
The parametric t-call change is backward compatible (the stream is apply for t-call with attributes/params or t-call that does not contains t-set), the old semantics will be deprecated in 19.1 (with a log warning).
The new versions are the ones with attributes (not prefixed with t-*) on the t-call tag.