### PR TITLE
[FIX] pos_sale: prevent error when canceling or confirming invoice

### DIFF
--- a/addons/pos_sale/models/account_move.py
+++ b/addons/pos_sale/models/account_move.py
@@ -8,6 +8,8 @@ class AccountMove(models.Model):
         if self.env.user.has_group('point_of_sale.group_pos_user'):
             for invoice in self:
                 for pos_order_line in invoice.pos_order_ids.mapped('lines'):
+                    if not pos_order_line.sale_order_line_id:
+                        continue
                     if isCancelled and "(Cancelled)" not in pos_order_line.sale_order_line_id.name:
                         name = _("%(old_name)s (Cancelled)", old_name=pos_order_line.sale_order_line_id.name)
                         pos_order_line.sale_order_line_id.name = name


### PR DESCRIPTION
Currently, multiple errors occur when the user tries to edit the invoice created by the POS application.

Steps to produce:
- Install the `pos_sale` module.
- Create a new order using the 'POS' application (with invoice).
- Open the corresponding invoice from `Invoicing > Customers > Invoices (list)`.
- Click on the `Reset to Draft` button.
- Click the `Cancel` button → encounter **Error-1**.
- Click the `Confirm` button → encounter **Error-2**.

**Error-1**: `TypeError - argument of type 'bool' is not iterable`
**Error-2**: `AttributeError - 'bool' object has no attribute 'replace'`

The issue occurs because `pos_order_line.sale_order_line_id.name` is accessed at [1], without verifying whether `sale_order_line_id` exists.

[1] - https://github.com/odoo/odoo/blob/add64f4c8a8d7e3aeb324621da14fd9b0a3660c5/addons/pos_sale/models/account_move.py#L11-L15

This commit resolves the issue by ensuring the `sale_order_line_id` exists before accessing its attributes. If no sale order is defined, the method skips further computation to prevent errors.

sentry-6272400381, 6272399674

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
