### PR TITLE
[FIX] point_of_sale: traceback when deleting ongoing orders offline

### DIFF
--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -709,9 +709,12 @@ export class PosData extends Reactive {
 
     async callRelated(model, method, args = [], kwargs = {}, queue = true) {
         const data = await this.execute({ type: "call", model, method, args, kwargs, queue });
-        this.deviceSync?.dispatch && this.deviceSync.dispatch(data);
-        const results = this.models.loadData(data, [], true);
-        return results;
+        if (data) {
+            this.deviceSync?.dispatch && this.deviceSync.dispatch(data);
+            const results = this.models.loadData(data, [], true);
+            return results;
+        }
+        return false;
     }
 
     async create(model, values, queue = true) {


### PR DESCRIPTION
Steps:
- Open POS.
- Create draft orders.
- Open the ticket screen.
- Go offline.
- Try to delete ongoing orders.
- Traceback

Fix:
- Prevent function calls with `undefined` data when POS is offline.

Task: 4555167
