### PR TITLE
[FIX] website_sale_wishlist: display image as table cell

### DIFF
--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -206,7 +206,7 @@
                                         t-att-data-product-id="wish.product_id.id"
                                         t-att-data-product-tracking-info="'product_tracking_info' in combination_info and json.dumps(combination_info['product_tracking_info'])"
                                     >
-                                        <td class='td-img align-middle d-none d-md-block'>
+                                        <td class='td-img align-middle d-none d-md-table-cell'>
                                             <a t-att-href="wish.product_id.website_url">
                                                 <img t-attf-src="/web/image/product.product/#{wish.product_id.id}/image_128" class="img img-fluid" style="margin:auto;" alt="Product image"/>
                                             </a>


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Add 5+ lines to a product's eCommerce description;
2. add this product to your wishlist;
3. open wishlist.

Issue
-----
The table's border is broken, left of the image.

Cause
-----
Commit 196f34c6b5271 added the Bootstrap classes `d-none d-md-block` to the table row, in order to hide the image on small devices. The `d-md-block` class cancels out its existing `align-middle` class, which only affects `inline` or `table-cell` elements, not `block` elements. Consequently, the `vertical-align: middle` CSS rule is ignored, leaving the image unaligned on top of the table.

Solution
--------
Replace `d-md-block` with `d-md-table-cell`.

opw-4260090