### PR TITLE
[FIX] point_of_sale: traceback when pressing a key on the floor screen

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -69,7 +69,7 @@ export class Navbar extends Component {
             if (!isSpecialKey) {
                 this.bufferedInput += event.key;
             }
-            if (document.activeElement == this.inputRef.el) {
+            if (document.activeElement == this.inputRef?.el) {
                 this.checkInput(event);
             } else {
                 this.timeout = setTimeout(() => {


### PR DESCRIPTION
Before this commit:
==========
- A traceback occurred when pressing any key on the keyboard while on the floor screen.

After this commit:
==========
- The issue is resolved, preventing the traceback.

task-4566466