### PR TITLE
[FIX] pos_sale: ensure lot/serial number selection while settling so

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -90,6 +90,10 @@ class SaleOrderLine(models.Model):
             pos_lines = sale_line.pos_order_line_ids.filtered(lambda order_line: order_line.order_id.state not in ['cancel', 'draft'])
             sale_line.qty_invoiced += sum([self._convert_qty(sale_line, pos_line.qty, 'p2s') for pos_line in pos_lines], 0)
 
+    def get_lot_names(self):
+        self.ensure_one()
+        return self.move_ids.move_line_ids.lot_id.mapped('name')
+
     def _get_sale_order_fields(self):
         return ["product_id", "display_name", "price_unit", "product_uom_qty", "tax_id", "qty_delivered", "qty_invoiced", "discount", "qty_to_invoice", "price_total", "is_downpayment"]
 

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -113,10 +113,11 @@ patch(PosStore.prototype, {
             }
             const newLine = await this.addLineToCurrentOrder(newLineValues, {}, false);
             previousProductLine = newLine;
+            const lotNames = await this.data.call("sale.order.line", "get_lot_names", [line.id]);
             if (
                 newLine.get_product().tracking !== "none" &&
                 (this.pickingType.use_create_lots || this.pickingType.use_existing_lots) &&
-                line.pack_lot_ids?.length > 0
+                lotNames
             ) {
                 if (!useLoadedLots && !userWasAskedAboutLoadedLots) {
                     useLoadedLots = await ask(this.dialog, {
@@ -128,7 +129,7 @@ patch(PosStore.prototype, {
                 if (useLoadedLots) {
                     newLine.setPackLotLines({
                         modifiedPackLotLines: [],
-                        newPackLotLines: (line.lot_names || []).map((name) => ({
+                        newPackLotLines: (lotNames || []).map((name) => ({
                             lot_name: name,
                         })),
                     });

--- a/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
+++ b/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
@@ -15,18 +15,22 @@ function selectNthOrder(n) {
     ];
 }
 
-export function settleNthOrder(n) {
-    return [
+export function settleNthOrder(n, hasLot = false) {
+    const steps = [
         ...selectNthOrder(n),
         {
             content: `Choose to settle the order`,
             trigger: `.modal:not(.o_inactive_modal) .selection-item:contains('Settle the order')`,
             run: "click",
         },
-        {
-            trigger: "body:not(:has(.modal))",
-        },
     ];
+    if (hasLot) {
+        steps.push(Dialog.confirm("Ok"));
+    }
+    steps.push({
+        trigger: "body:not(:has(.modal))",
+    });
+    return steps;
 }
 
 export function downPaymentFirstOrder(amount) {


### PR DESCRIPTION
Steps to reproduce:
===
- Ensure the product has "track inventory" by lot/serial number.
- Create and confirm a Sales Order (SO) with this product.
- Open the POS session.
- Click on the control button → Quotation/Order.
- Settle the SO.
- The lot/serial number is not selected on the order line.

Issue:
===
- The system does not fetch and assign the lot/serial number when settling SO.

Fix:
===
- Added a method `get_lot_names` in `sale.order.line` to fetch assigned lot/serial numbers.

related-https://github.com/odoo/enterprise/pull/79055
task-4558015

