### PR TITLE
[FIX] hr: fix traceback when clicking plans smart button in hr department

### DIFF
--- a/addons/hr/models/hr_department.py
+++ b/addons/hr/models/hr_department.py
@@ -150,7 +150,13 @@ class Department(models.Model):
             ('department_id', '=', False),
             ('department_id', 'in', self.ids),
         ]
-        action['domain'] = expression.AND([ast.literal_eval(action['domain']), domain]) if 'domain' in action else domain
+        if 'domain' in action:
+            allowed_company_ids = self.env.context.get('allowed_company_ids', [])
+            action['domain'] = expression.AND([
+                ast.literal_eval(action['domain'].replace('allowed_company_ids', str(allowed_company_ids))), domain
+            ])
+        else:
+            action['domain'] = domain
         if self.plans_count == 0:
             action['views'] = [(False, 'form')]
         return action


### PR DESCRIPTION
Currently, a traceback is occurring when the user tries to click the `plans` smart button in the hr department record.

To reproduce this issue:

1) Install hr
2) Open any hr department record
3) Click the `Plans` smart button

Error:-
```
ValueError: malformed node or string on line 1: <ast.Name object at 0x7333bacc>
```

This error was occurring because of the latest changes from the below commit, https://github.com/odoo/odoo/pull/196430/commits/ec4991330224784571d850fb87ee7940a071080a

We used `literal_eval()` from the below line to evaluate the domain in action. 
Which contains `allowed_company_ids`. This leads to the above error while evaluating in `literal_eval()`.
https://github.com/odoo/odoo/blob/b070f9a4aa179799e3412d18b8faba07349bbf7b/addons/hr/models/hr_department.py#L147-L153

The domain in the action was modified from the below commit recently, https://github.com/odoo/odoo/pull/193572/commits/c2243abca397ab6622ec85e6fe6adbfef0d7c47b

We can resolve this issue by replacing the `allowed_company_ids` by accessing 
the value of `allowed_company_ids` from context.

sentry-6285774985