### PR TITLE
[FIX] project: make 'Assign' button appear

### DIFF
--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.scss
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.scss
@@ -20,7 +20,7 @@
         }
     }
 
-    .oe_kanban_content {
+    .o_kanban_record footer {
         @include media-breakpoint-up(sm) {
             &:hover {
                 .o_field_widget.o_field_many2many_tags_avatar .o_quick_assign {


### PR DESCRIPTION
The 'Assign' button of the field many2many_tags_avatar is always invisible in the kanban views with the class o_kanban_project_tasks. This happens because the condition that make it appear when the line of the field is hovered is never met: the class oe_kanban_content no longer exists since the refactoring of the kanban archs (see task: 3992107). Here we modify a bit the css rule so that the 'Assign' button can become visible when appropriate.