### PR TITLE
[FIX] pos_restaurant: prevent blank screen when canceling an order

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.ActionpadWidget">
-        <div class="actionpad d-flex flex-column gap-2">
+        <div class="actionpad d-flex flex-column gap-2" t-if="currentOrder">
             <div t-if="ui.isSmall" class="d-flex gap-2">
                 <BackButton t-if="!props.showActionButton and pos.showBackButton()" onClick="() => pos.onClickBackButton()"/>
                 <SelectPartnerButton partner="props.partner"/>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -9,7 +9,7 @@
                 type="'internal'"
                 class="buttonClass"/>
         </t>
-        <button t-if="pos.config.use_presets and !props.showRemainingButtons"
+        <button t-if="pos.config.use_presets and !props.showRemainingButtons and currentOrder"
             class="btn btn-light btn-lg flex-shrink-0 border-0"
             t-attf-class="{{`o_colorlist_item_color_${currentOrder.preset_id?.color}`}}"
             t-on-click="() => this.pos.selectPreset()">

--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.OrderSummary">
-		<OrderDisplay order="currentOrder" t-slot-scope="scope">
+		<OrderDisplay order="currentOrder" t-slot-scope="scope" t-if="currentOrder">
 			<t t-set="line" t-value="scope.line" />
 			<Orderline line="line" t-on-click="(event) => this.clickLine(event, line)">
 				<t t-set-slot="pack-lot-icon">


### PR DESCRIPTION
Issue: A blank screen appears after canceling an order.

Steps to reproduce:
- Open a POS restaurant.
- Select a table.
- Order some food.
- Reopen the order.
- Cancel the order.
