### PR TITLE
[FIX] hr_timesheet: report alignment issue for ticket-only selection

### DIFF
--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -39,7 +39,7 @@
                                 <t t-if="show_task and line.task_id" t-set="timesheet_record_info" t-value="'%s / %s' % (timesheet_record_info, line.task_id.sudo().name)"/>
                             </t>
                             <t t-elif="show_task" t-set="timesheet_record_info" t-value="line.task_id.sudo().name"/>
-                            <td t-if="show_task or show_project" class="align-middle">
+                            <td t-if="timesheet_record_label" class="align-middle">
                                 <span t-if="timesheet_record_info" t-out="timesheet_record_info">Research and Development/New Portal System</span>
                             </td>
                             <td class="align-middle">


### PR DESCRIPTION
Steps to reproduce:

- install helpdesk_timesheet
- Go to `Timesheets`
- Select ticket-linked timesheets only.
- print report.

Issue:

- Tickets names are not rendered on the report, causing misalignment.

Fix:

If the column `timesheet_record_label` exists, render the cell anyway.

task-4476391





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
