### PR TITLE
[IMP] web: improve the title displayed to show computed arch

### DIFF
--- a/addons/web/static/src/core/debug/debug_menu_items.xml
+++ b/addons/web/static/src/core/debug/debug_menu_items.xml
@@ -114,7 +114,7 @@
     </t>
 
     <t t-name="web.DebugMenu.GetViewDialog">
-        <Dialog title.translate="Get View">
+        <Dialog title.translate="Computed Arch">
             <pre t-esc="props.arch"/>
             <t t-set-slot="footer">
                 <button class="btn btn-primary o-default-button" t-on-click="() => props.close()">Close</button>


### PR DESCRIPTION
Before this commit, the title was "Get View", which does not make too much sense to me. I understand that it comes from the "fields_view_get", then "get_views" routes, but it is weird, because basically anything displayed in the browser is "get".

Also, it does not match the name from the menu item.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
