### PR TITLE
[FIX] website_forum: ensure correct forum on posts

### DIFF
--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -315,9 +315,12 @@ class Post(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        defaults_to_check = self.default_get(['content', 'forum_id'])
         for vals in vals_list:
-            if 'content' in vals and vals.get('forum_id'):
-                vals['content'] = self._update_content(vals['content'], vals['forum_id'])
+            content = vals.get('content', defaults_to_check.get('content'))
+            if content:
+                forum_id = vals.get('forum_id', defaults_to_check.get('forum_id'))
+                vals['content'] = self._update_content(content, forum_id)
 
         posts = super(Post, self.with_context(mail_create_nolog=True)).create(vals_list)
 


### PR DESCRIPTION
Creating a post using default values in context was bypassing the karma check when adding link or image.

This no-so-sexy solution just ensure that whatever the way the post is created (using or not default values in context),
the check is properly executed.

Task-4114387


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
