### PR TITLE
[REM] **/tours/**: isActive auto without run

### DIFF
--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -22,7 +22,6 @@ registry.category("web_tour.tours").add('crm_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_opportunity_kanban",
 },
 {
@@ -46,7 +45,6 @@ registry.category("web_tour.tours").add('crm_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_opportunity_kanban",
 },
 {
@@ -56,7 +54,6 @@ registry.category("web_tour.tours").add('crm_tour', {
     run: "drag_and_drop(.o_opportunity_kanban .o_kanban_group:eq(2))",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_opportunity_kanban",
 },
 {
@@ -67,7 +64,6 @@ registry.category("web_tour.tours").add('crm_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_opportunity_kanban",
 },
 {
@@ -88,7 +84,6 @@ registry.category("web_tour.tours").add('crm_tour', {
     run: "drag_and_drop(.o_opportunity_kanban .o_kanban_group:eq(3))",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_opportunity_kanban",
 },
 {

--- a/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
@@ -91,7 +91,6 @@ registry.category("web_tour.tours").add("hr_holidays_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: `tr.o_data_row:first:not(:has(button[name="action_approve"])),table tbody:not(tr.o_data_row)`,
             content: "Verify leave is approved",
         },

--- a/addons/hr_recruitment/static/src/js/tours/hr_recruitment.js
+++ b/addons/hr_recruitment/static/src/js/tours/hr_recruitment.js
@@ -26,7 +26,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_hr_job_simple_form",
 },
 {
@@ -36,7 +35,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: '.o_hr_job_simple_form',
 },
 {
@@ -56,7 +54,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_applicant",
 },
 {
@@ -66,7 +63,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_hr_recruitment_kanban",
 },
 {
@@ -76,7 +72,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_applicant",
 },
 {
@@ -86,7 +81,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "drag_and_drop(.o_kanban_group:eq(1))",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_applicant",
 },
 {
@@ -96,7 +90,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_applicant_form",
 },
 {
@@ -106,7 +99,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_applicant_form",
 },
 {
@@ -116,7 +108,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_applicant_form",
 },
 {
@@ -126,7 +117,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_applicant_form",
 },
 {
@@ -136,7 +126,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_hr_employee_form_view",
 },
 {

--- a/addons/mail/static/src/js/tours/discuss_channel_tour.js
+++ b/addons/mail/static/src/js/tours/discuss_channel_tour.js
@@ -76,7 +76,6 @@ registry.category("web_tour.tours").add("discuss_channel_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o-discuss-ChannelSelector",
         },
     ],

--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
@@ -21,7 +21,6 @@
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger: ".o_mass_mailing_mailing_tree",
     },
     {

--- a/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
+++ b/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
@@ -158,7 +158,6 @@ registry.category("web_tour.tours").add('test_manufacturing_and_byproduct_sm_to_
             run: "click",
         },
         {
-            isActive: ["auto"],
             content: "wait for save completion",
             trigger: ".o_form_readonly, .o_form_saved",
         },

--- a/addons/project/static/src/js/tours/project.js
+++ b/addons/project/static/src/js/tours/project.js
@@ -22,7 +22,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_project_kanban",
 },
 {
@@ -52,7 +51,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_group",
 },
 {
@@ -67,7 +65,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_group:eq(1)",
 },
 {
@@ -77,7 +74,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_project_tasks",
 },
 {
@@ -87,7 +83,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "edit Test",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_project_tasks",
 },
 {
@@ -97,7 +92,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_project_tasks",
 },
 {
@@ -107,7 +101,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "drag_and_drop(.o_kanban_group:eq(1))",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_project_tasks",
 },
 {
@@ -117,7 +110,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_form_project_tasks",
 },
 {
@@ -127,7 +119,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_form_project_tasks",
 },
 {
@@ -137,7 +128,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_form_project_tasks",
 },
 {
@@ -146,11 +136,6 @@ registry.category("web_tour.tours").add('project_tour', {
     tooltipPosition: "bottom",
     run: "click",
 },
-{
-    trigger: ".o_form_project_tasks",
-    isActive: ["auto"],
-},
-
 {
     trigger: ".o_form_project_tasks",
 },
@@ -162,7 +147,6 @@ registry.category("web_tour.tours").add('project_tour', {
 },
 {
     trigger: ".o_form_project_tasks",
-    isActive: ["auto"],
 },
 {
     isActive: ["auto"],
@@ -205,7 +189,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "edit New Sub-task",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_form_project_tasks .o_form_dirty",
 },
 {
@@ -216,7 +199,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_form_project_tasks",
 },
 {
@@ -231,7 +213,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_widget_subtask_kanban_list .subtask_list",
 },
 {
@@ -241,7 +222,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".subtask_create_input",
 },
 {
@@ -256,7 +236,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".project_task_state_selection_menu.dropdown-menu",
 },
 {
@@ -265,7 +244,6 @@ registry.category("web_tour.tours").add('project_tour', {
     content: markup(_t("Mark the task as <b>Cancelled</b>")),
     run: "click",
 }, {
-    isActive: ["auto"],
     trigger: ".o-overlay-container:not(:visible):not(:has(.project_task_state_selection_menu))",
 }, {
     isActive: ["auto"],

--- a/addons/purchase/static/src/js/tours/purchase.js
+++ b/addons/purchase/static/src/js/tours/purchase.js
@@ -29,7 +29,6 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_purchase_order",
         },
         {
@@ -39,7 +38,6 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_purchase_order",
         },
         {
@@ -57,7 +55,6 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_field_res_partner_many2one[name='partner_id'] .o_external_button",
         },
         {
@@ -67,7 +64,6 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_purchase_order",
         },
         {
@@ -85,11 +81,9 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_field_text[name='name'] textarea:value(DESK0001)",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_purchase_order",
         },
         {
@@ -107,7 +101,6 @@ registry.category("web_tour.tours").add("purchase_tour", {
             _t("Send the request for quotation to your vendor.")
         ),
         {
-            isActive: ["auto"],
             trigger: ".modal-footer button[name='action_send_mail']",
         },
         {
@@ -117,7 +110,6 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_purchase_order",
         },
         {

--- a/addons/sale/static/src/js/tours/sale.js
+++ b/addons/sale/static/src/js/tours/sale.js
@@ -24,7 +24,6 @@ registry.category("web_tour.tours").add("sale_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_sale_order",
         },
         {
@@ -34,7 +33,6 @@ registry.category("web_tour.tours").add("sale_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_sale_order",
         },
         {
@@ -55,7 +53,6 @@ registry.category("web_tour.tours").add("sale_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_sale_order",
         },
         {
@@ -73,7 +70,6 @@ registry.category("web_tour.tours").add("sale_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".oi-arrow-right", // Wait for product creation
         },
         {

--- a/addons/survey/static/src/js/tours/survey_tour.js
+++ b/addons/survey/static/src/js/tours/survey_tour.js
@@ -27,7 +27,6 @@ registry.category("web_tour.tours").add('survey_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: '.js_question-wrapper span:contains("How frequently")',
 },
 {
@@ -37,7 +36,6 @@ registry.category("web_tour.tours").add('survey_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: '.js_question-wrapper span:contains("How many")',
 },
 {
@@ -47,7 +45,6 @@ registry.category("web_tour.tours").add('survey_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: '.js_question-wrapper span:contains("How likely")',
 },
 {

--- a/addons/web_tour/static/src/tour_service/tour_utils.js
+++ b/addons/web_tour/static/src/tour_service/tour_utils.js
@@ -215,7 +215,6 @@ export const stepUtils = {
                 run: "click",
             },
             {
-                isActive: ["auto"],
                 content: "wait for save completion",
                 trigger: ".o_form_readonly, .o_form_saved",
             },
@@ -236,7 +235,6 @@ export const stepUtils = {
                 run: "click",
             },
             {
-                isActive: ["auto"],
                 content: "wait for cancellation to complete",
                 trigger:
                     ".o_view_controller.o_list_view, .o_form_view > div > div > .o_form_readonly, .o_form_view > div > div > .o_form_saved",

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -196,7 +196,6 @@ export function clickOnEditAndWaitEditMode(position = "bottom") {
         tooltipPosition: position,
         run: "click",
     }, {
-        isActive: ["auto"], // Checking step only for automated tests
         content: "Check that we are in edit mode",
         trigger: ".o_website_preview.editor_enable.editor_has_snippets",
     }];
@@ -220,7 +219,6 @@ export function clickOnEditAndWaitEditModeInTranslatedPage(position = "bottom") 
         tooltipPosition: position,
         run: "click",
     }, {
-        isActive: ["auto"], // Checking step only for automated tests
         content: "Check that we are in edit mode",
         trigger: ".o_website_preview.editor_enable.editor_has_snippets",
     }];
@@ -272,14 +270,12 @@ export function clickOnSave(position = "bottom", timeout) {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger:
                 "body:not(.editor_enable):not(.editor_has_snippets):not(:has(.o_notification_bar))",
             noPrepend: true,
             timeout: timeout,
         },
         {
-            isActive: ["auto"],
             trigger: "[is-ready=true]:iframe",
             noPrepend: true,
         },
@@ -457,7 +453,6 @@ export function registerWebsitePreviewTour(name, options, steps) {
             // of course.
             if (options.edition) {
                 tourSteps.unshift({
-                    isActive: ["auto"],
                     content: "Wait for the edit mode to be started",
                     trigger: ".o_website_preview.editor_enable.editor_has_snippets",
                     timeout: 30000,

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -55,7 +55,6 @@ function addCheck(steps, checkX, checkNoX, xType, noSwitch = false) {
     }
     if (!selectorCheckX && selectorCheckNoX) {
         steps.push({
-            isActive: ["auto"],
             trigger: selectorCheckNoX,
         });
     }

--- a/addons/website_blog/static/src/js/tours/website_blog.js
+++ b/addons/website_blog/static/src/js/tours/website_blog.js
@@ -27,11 +27,9 @@ registerWebsitePreviewTour("blog", {
     run: "edit Test",
 },
 {
-    isActive: ["auto"],
     trigger: 'div.o_field_widget[name="blog_id"]',
 },
 {
-    isActive: ["auto"],
     trigger: "button.o_form_button_save",
     content: _t("Select the blog you want to add the post to."),
     // Without demo data (and probably in most user cases) there is only
@@ -44,7 +42,6 @@ registerWebsitePreviewTour("blog", {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: "#oe_snippets.o_loaded",
     timeout: 15000,
 },
@@ -55,7 +52,6 @@ registerWebsitePreviewTour("blog", {
     run: "editor Test",
 },
 {
-    isActive: ["auto"],
     trigger: `:iframe #wrap h1[data-oe-expression="blog_post.name"]:not(:contains(''))`,
 },
 {
@@ -87,7 +83,6 @@ registerWebsitePreviewTour("blog", {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_website_preview.o_is_mobile",
 },
 {
@@ -97,7 +92,6 @@ registerWebsitePreviewTour("blog", {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ":iframe body:not(.editor_enable)",
 },
 {
@@ -106,7 +100,6 @@ registerWebsitePreviewTour("blog", {
     content: markup(_t("<b>Publish your blog post</b> to make it visible to your visitors.")),
     run: "click",
 }, {
-    isActive: ["auto"],
     trigger: '.o_menu_systray_item a:contains("Published")',
 }
 ]);

--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -38,7 +38,6 @@ function websiteCreateEventTourSteps() {
             }
         },
         {
-            isActive: ["auto"],
             trigger: ".modal-dialog input[type=text]:not(:value(''))",
         },
         {

--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -19,7 +19,6 @@ registerBackendAndFrontendTour("question", {
     run: "edit Test",
 },
 {
-    isActive: ["auto"],
     trigger: `input[name=post_name]:not(:empty)`,
 },
 {
@@ -29,7 +28,6 @@ registerBackendAndFrontendTour("question", {
     run: "editor Test",
 },
 {
-    isActive: ["auto"],
     trigger: `.note-editable p:not(:contains(/^<br>$/))`,
 },
 {
@@ -43,7 +41,6 @@ registerBackendAndFrontendTour("question", {
     run: "edit Test",
 },
 {
-    isActive: ["auto"],
     trigger: `.o_popover input.o_select_menu_sticky:not(:contains(Please enter 2 or more characters))`,
 },
 {
@@ -83,7 +80,6 @@ registerBackendAndFrontendTour("question", {
     run: "editor Test",
 },
 {
-    isActive: ["auto"],
     trigger: `.note-editable p:not(:contains(/^<br>$/))`,
 },
 {
@@ -105,7 +101,6 @@ registerBackendAndFrontendTour("question", {
     tooltipPosition: "right",
     run: "click",
 }, {
-    isActive: ["auto"],
     content: "Check edit button is there",
     trigger: "a:contains('Edit your answer')",
 }]);

--- a/addons/website_sale/static/src/js/tours/website_sale_shop.js
+++ b/addons/website_sale/static/src/js/tours/website_sale_shop.js
@@ -14,7 +14,6 @@ registerWebsitePreviewTour("test_01_admin_shop_tour", {
 },
 () => [
 {
-    isActive: ["auto"],
     trigger: ":iframe .js_sale",
 },
 {
@@ -39,7 +38,6 @@ registerWebsitePreviewTour("test_01_admin_shop_tour", {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: "#oe_snippets.o_loaded",
 },
 {
@@ -50,7 +48,6 @@ registerWebsitePreviewTour("test_01_admin_shop_tour", {
     timeout: 30000,
 },
 {
-    isActive: ["auto"],
     trigger: ":iframe .product_price .o_dirty .oe_currency_value:not(:contains(/^1.00$/))",
 },
 {
@@ -67,7 +64,6 @@ registerWebsitePreviewTour("test_01_admin_shop_tour", {
 },
 goBackToBlocks(),
 {
-    isActive: ["auto"],
     trigger: "body:not(.modal-open)",
 },
 ...insertSnippet({
@@ -85,7 +81,6 @@ goBackToBlocks(),
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ":iframe body:not(.editor_enable)",
 },
 {


### PR DESCRIPTION
isActive: ["auto"] doesn't make sense with the "run" function in a step because tour_interactive doesn't take into account steps without the "run" function. So, in this commit, we remove all isActive: ["auto"] for steps where there is no "run" function.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
