### PR TITLE
[FIX] mail: correct margin in collapsed sidebar call participants

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -35,9 +35,9 @@
                 personas="sessions.map((s) => s.channel_member_id.persona)"
             >
                 <t t-set-slot="avatarExtraInfo" t-slot-scope="scope">
-                    <div class="o-mail-DiscussSidebarCallParticipants-status small" t-att-class="{
+                    <div class="o-mail-DiscussSidebarCallParticipants-status small bg-opacity-100" t-att-class="{
                         'position-absolute bg-inherit p-0 rounded-circle o-compact d-flex o-xsmaller text-start': compact,
-                        'ms-1 d-flex align-items-center justify-content-center': !compact,
+                        'd-flex align-items-center justify-content-center': !compact,
                     }">
                         <t t-call="mail.DiscussSidebarCallParticipants.participantShortStatus">
                             <t t-set="session" t-value="scope.persona.currentRtcSession"/>

--- a/addons/mail/static/src/discuss/core/common/avatar_stack.js
+++ b/addons/mail/static/src/discuss/core/common/avatar_stack.js
@@ -30,13 +30,11 @@ export class AvatarStack extends Component {
     };
 
     getStyle(index) {
-        let style = `width: ${this.props.size}px; height: ${this.props.size}px;`;
         if (index === 0) {
-            return style;
+            return;
         }
         // Compute cumulative offset,
         const marginDirection = this.props.direction === "v" ? "top" : "left";
-        style += `margin-${marginDirection}: -${this.props.size / 3}px`;
-        return style;
+        return `margin-${marginDirection}: -${this.props.size / 3}px`;
     }
 }

--- a/addons/mail/static/src/discuss/core/common/avatar_stack.xml
+++ b/addons/mail/static/src/discuss/core/common/avatar_stack.xml
@@ -3,8 +3,8 @@
     <t t-name="mail.AvatarStack">
         <div t-if="props.personas.length > 0" class="bg-inherit" style="margin: 1px">
             <div class="d-flex bg-inherit" t-att-class="{'flex-column': props.direction === 'v'}">
-                <span t-foreach="props.personas.slice(0, props.max)" t-as="persona" t-key="persona.localId" class="position-relative bg-inherit rounded-circle">
-                    <img t-att-src="persona.avatarUrl" t-att-title="persona.name" class="rounded-circle o_object_fit_cover d-flex" t-attf-class="{{props.avatarClass(persona)}}" t-attf-style="{{getStyle(persona_index)}}"/>
+                <span t-foreach="props.personas.slice(0, props.max)" t-as="persona" t-key="persona.localId" class="position-relative bg-transparent rounded-circle" t-attf-style="{{getStyle(persona_index)}}">
+                    <img t-att-src="persona.avatarUrl" t-att-title="persona.name" class="rounded-circle o_object_fit_cover d-flex" t-attf-class="{{props.avatarClass(persona)}}" t-attf-style="width: {{props.size}}px; height: {{props.size}}px;"/>
                     <t t-slot="avatarExtraInfo" persona="persona"/>
                 </span>
                 <span t-if="props.personas.length > props.max" class="z-1 rounded-circle bg-secondary smaller d-flex justify-content-center align-items-center user-select-none" t-attf-style="{{getStyle(props.personas.length)}}">+<t t-esc="props.personas.length - props.max"/></span>


### PR DESCRIPTION
Before this commit the short status icon shown in the collapsed sidebar call participants was misaligned to the avatar.
This was due to the margin being applied only on the avatar.
This commit fixes the issue by:
- Applying the margin to the element containing both the avatar and the short status icon.
- Removing margin on the icon.

| Before | After |
|--------|--------|
| ![Pasted image 20250211134923](https://github.com/user-attachments/assets/d9922977-37dc-45c1-9629-74929be12785) | ![Pasted image 20250211134844](https://github.com/user-attachments/assets/40bb2bad-31d6-456a-a988-64da7b43b392) | 
