### PR TITLE
[FIX] account: restore account group codes in Chart of Accounts sidebar

### DIFF
--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -159,7 +159,7 @@
                         <filter string="Account Type" name="accounttype" domain="" context="{'group_by':'account_type'}"/>
                     </group>
                     <searchpanel class="account_root w-auto">
-                        <field name="root_id" icon="fa-filter" limit="0"/>
+                        <field name="root_id" icon="fa-filter" limit="false"/>
                     </searchpanel>
                 </search>
             </field>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -373,7 +373,7 @@
                         <filter string="Matching" name="group_by_matching" domain="[]" context="{'group_by': 'matching_number'}"/>
                     </group>
                     <searchpanel class="account_root w-auto">
-                        <field name="account_root_id" icon="fa-filter" groupby="account_id" limit="0"/>
+                        <field name="account_root_id" icon="fa-filter" groupby="account_id" limit="false"/>
                     </searchpanel>
                 </search>
             </field>


### PR DESCRIPTION
The Chart of Accounts sidebar does not display account group codes due to the limit
being set to `0`.

In earlier versions, `limit="0"` was used to indicate no limit at all, as the default
value (`200`) was not sufficient. However, in version 18.1, a change in the Odoo
framework introduced a stricter limit check in this [commit](https://github.com/odoo/odoo/blob/88dff02bae41ff794ac3e60acab061acfc8e19ca/odoo/orm/models.py#L5596-L5597).
With this update, `limit=0` is now interpreted as a **hard limit of zero records**,
meaning nothing is retrieved from the dataset. As a result, account groups no longer
appear in the sidebar.

Previously, `limit="0"` would effectively disable any limit. To achieve the same
behavior in 18.1+, `limit` must be explicitly set to `False` or `None`.

Steps to Reproduce:
1. Navigate to Accounting → Configurations → Chart of Accounts.
2. Observe that the account group codes are missing from the sidebar.

opw-4538769

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
