### PR TITLE
[IMP] website: Add privacy page by default

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -459,7 +459,6 @@
         'about_us': ['s_text_image', 's_image_text', 's_title', 's_company_team'],
         'our_services': ['s_three_columns', 's_quotes_carousel', 's_references'],
         'pricing': ['s_comparisons'],
-        'privacy_policy': ['s_faq_collapse'],
     },
     'new_page_templates': {
         'basic': {

--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -344,19 +344,54 @@
             </div>
         </t>
     </template>
+
+    <!-- Template for privacy (optional) -->
     <template id="privacy_policy" name="Privacy Policy">
         <t t-call="website.layout">
-            <div id="wrap">
-                <div class="oe_structure">
-                    <section class="s_title parallax s_parallax_is_fixed bg-black-50 pt24 pb24" data-vcss="001" data-snippet="s_title" data-scroll-background-ratio="1">
-                        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 0;"/>
-                        <div class="o_we_bg_filter bg-black-50"/>
-                        <div class="container">
-                            <h1>Privacy Policy</h1>
+            <div id="wrap" class="oe_structure">
+                <section class="s_title parallax s_parallax_is_fixed bg-black-50 pt24 pb24"
+                         data-vcss="001" data-snippet="s_title"
+                         data-scroll-background-ratio="1">
+                    <span class="s_parallax_bg oe_img_bg"
+                          style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 0;"/>
+                    <div class="o_we_bg_filter bg-black-50"/>
+                    <div class="container">
+                        <h1>Privacy Policy</h1>
+                    </div>
+                </section>
+                <section class="s_text_block pt40 pb40 o_colored_level"
+                         data-snippet="s_text_block" data-name="Text">
+                    <div class="container s_allow_columns">
+                        <div class="s_alert alert alert-info clearfix s_alert_md w-50 css_non_editable_mode_hidden"
+                             role="alert" data-vcss="001" data-snippet="s_alert"
+                             data-name="Alert">
+                            <div class="s_alert_content">
+                                <p>💡 You can create a specific Privacy Policy page by visiting
+                                    <a href="https://Termly.io">Termly.io</a>
+                                </p>
+                            </div>
                         </div>
-                    </section>
-                </div>
-                <div class="oe_structure"/>
+                        <p>This website collects personal data to power our site analytics
+                            (Plausible Analytics), including:
+                        </p>
+                        <ul>
+                            <li>Information about your browser, network, and device</li>
+                            <li>Web pages you visited prior to coming to this website</li>
+                        </ul>
+                        <p>This information may also include details about your use of this
+                            website, including:
+                        </p>
+                        <ul>
+                            <li>Clicks</li>
+                            <li>Internal links</li>
+                            <li>Pages visited</li>
+                            <li>Searches</li>
+                        </ul>
+                        <p>Those data help us understand how you use our website and
+                            to help us improve it.
+                        </p>
+                    </div>
+                </section>
             </div>
         </t>
     </template>
@@ -392,15 +427,6 @@
         <field name="icon">fa-random</field>
         <field name="menu_sequence">35</field>
         <field name="feature_url">/pricing</field>
-    </record>
-    <record id="feature_page_privacy_policy" model="website.configurator.feature">
-        <field name="name">Privacy Policy</field>
-        <field name="description">Explain how you protect privacy</field>
-        <field name="iap_page_code">privacy_policy</field>
-        <field name="sequence">5</field>
-        <field name="page_view_id" ref="privacy_policy"/>
-        <field name="icon">fa-gavel</field>
-        <field name="feature_url">/privacy</field>
     </record>
 
     <!-- Configurator apps features -->

--- a/addons/website/static/tests/tours/configurator_translation.js
+++ b/addons/website/static/tests/tours/configurator_translation.js
@@ -54,8 +54,8 @@ registry.category("web_tour.tours").add('configurator_translation', {
     },
     // Features screen
     {
-        content: "select confidentialité",
-        trigger: '.card:contains(Parseltongue_privacy)',
+        content: "select About us",
+        trigger: '.card:contains(Parseltongue_aboutus)',
         run: "click",
     }, {
         content: "Click on build my website",

--- a/addons/website/tests/test_configurator.py
+++ b/addons/website/tests/test_configurator.py
@@ -61,8 +61,8 @@ class TestConfiguratorTranslation(TestConfiguratorCommon):
             'overwrite': True,
             'lang_ids': [(6, 0, [parseltongue.id])],
         }).lang_install()
-        feature = self.env['website.configurator.feature'].search([('name', '=', 'Privacy Policy')])
-        feature.with_context(lang=parseltongue.code).write({'name': 'Parseltongue_privacy'})
+        feature = self.env['website.configurator.feature'].search([('name', '=', 'About Us')])
+        feature.with_context(lang=parseltongue.code).write({'name': 'Parseltongue_aboutus'})
         self.env.ref('base.user_admin').write({'lang': parseltongue.code})
         website_fr = self.env['website'].create({
             'name': "New website",

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -612,3 +612,26 @@ class TestNewPage(common.TransactionCase):
         pages = self.env['website.page'].search([('url', '=', '/snippets')])
         self.assertEqual(len(pages), 1, "Exactly one page should be at /snippets.")
         self.assertNotEqual(pages.key, "website.snippets", "Page's key cannot be website.snippets.")
+
+@tagged('-at_install', 'post_install')
+class TestNewWebsite(common.TransactionCase):
+    def test_new_website_eu_privacy_page(self):
+        company_1 = self.env['res.company'].create({'name': "Company 1", "country_id":
+            self.env.ref('base.us').id})
+        company_2 = self.env['res.company'].create({'name': "Company 2", "country_id":
+            self.env.ref('base.be').id})
+        website_1 = self.env['website'].create({'name': "Website 1 (not EU)", 'company_id':
+            company_1.id})
+        website_2 = self.env['website'].create({'name': "Website 2 (in EU)", 'company_id':
+            company_2.id})
+
+        privacy_page_1 = self.env['website.page'].search([('website_id', '=', website_1.id),
+                                                          ('url', '=', '/privacy')])
+        privacy_page_2 = self.env['website.page'].search([('website_id', '=', website_2.id),
+                                                          ('url', '=', '/privacy')])
+
+        self.assertEqual(len(privacy_page_1), 0, "No privacy page should be created for a non-EU company")
+        self.assertEqual(len(privacy_page_2), 1, "One privacy page should be created for an EU company")
+
+
+

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2130,6 +2130,14 @@
     </xpath>
 </template>
 
+<template id="footer_copyright_private_policy" inherit_id="website.layout" active="False">
+    <xpath expr="//footer//span[hasclass('o_footer_copyright_name')]" position="after">
+        <span style="vertical-align: middle;">
+            <a href="/privacy">Privacy Policy</a>
+        </span>
+    </xpath>
+</template>
+
 <!-- Scroll to Top option -->
 <template id="option_footer_scrolltop" inherit_id="website.layout" active="False">
     <xpath expr="//div[@id='footer']" position="after">


### PR DESCRIPTION
To help users meet GDPR requirements, automatically create a privacy
policy page when a European customer creates a new website.

Previously, this was possible via the website configurator, but the page
content was not relevant. 

This commit updates the default privacy policy page content.

The privacy page is no longer selectable in the configurator features
but is automatically created for new websites in Europe.
(Is in Europe if the country of the company of the website is in Europe)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
