### PR TITLE
[FIX] website_sale_collect: fix tax calculation

### DIFF
--- a/addons/website_sale_collect/tests/test_sale_order.py
+++ b/addons/website_sale_collect/tests/test_sale_order.py
@@ -27,6 +27,30 @@ class TestSaleOrder(ClickAndCollectCommon):
         so._set_pickup_location('{"id":' + str(self.warehouse.id) + '}')
         self.assertEqual(so.warehouse_id, self.warehouse)
 
+    def test_setting_pickup_location_assigns_correct_fiscal_position(self):
+        fp_us = self.env['account.fiscal.position'].create({
+            'name': "Test US fiscal position",
+            'country_id': self.country_us.id,
+            'auto_apply': True,
+        })
+        so = self._create_in_store_delivery_order()
+        self.default_partner.country_id = self.country_us
+        warehouse = self._create_warehouse()
+        warehouse.partner_id = self.default_partner
+        so._set_pickup_location('{"id":' + str(warehouse.id) + '}')
+        self.assertEqual(so.fiscal_position_id, fp_us)
+
+    def test_selecting_not_in_store_dm_resets_fiscal_position(self):
+        fp_us = self.env['account.fiscal.position'].create({
+            'name': "Test US US fiscal position",
+            'country_id': self.country_us.id,
+            'auto_apply': True,
+        })
+        so = self._create_in_store_delivery_order()
+        so.fiscal_position_id = fp_us
+        so.set_delivery_line(self.free_delivery, 0)
+        self.assertNotEqual(so.fiscal_position_id, fp_us)
+
     def test_free_qty_calculated_from_order_wh_if_dm_is_in_store(self):
         self.warehouse_2 = self._create_warehouse()
         self.website.warehouse_id = self.warehouse_2


### PR DESCRIPTION
Before this commit the taxes were calculated based only on delivery address even if a pickup location's country was different from delivery's one. After this commit, the correct fiscal position is set on selecting pickup point.

opw-4485282

