### PR TITLE
[IMP] html_editor: apply shape to cropper

### DIFF
--- a/addons/html_editor/static/src/main/media/image_crop.js
+++ b/addons/html_editor/static/src/main/media/image_crop.js
@@ -256,7 +256,6 @@ export class ImageCrop extends Component {
         if (rect.top < viewportTop || viewportBottom - rect.bottom < 100) {
             await scrollTo(this.media, {
                 behavior: "smooth",
-                isAnchor: true,
                 ...(scrollable && { scrollable }),
             });
         }

--- a/addons/html_editor/static/src/main/media/image_crop.js
+++ b/addons/html_editor/static/src/main/media/image_crop.js
@@ -5,6 +5,7 @@ import {
     loadImage,
     loadImageInfo,
 } from "@html_editor/utils/image_processing";
+import { IMAGE_SHAPES } from "./image_plugin";
 import { _t } from "@web/core/l10n/translation";
 import {
     Component,
@@ -175,6 +176,17 @@ export class ImageCrop extends Component {
             this.aspectRatios[this.aspectRatio].value,
             this.media.dataset
         );
+
+        this.cropper.element.addEventListener("ready", () => {
+            const cropperMove = this.cropperWrapper.el.querySelector(".cropper-face.cropper-move");
+            for (const shape of IMAGE_SHAPES) {
+                if (this.media.classList.contains(shape)) {
+                    cropperMove.classList.add(shape);
+                } else {
+                    cropperMove.classList.remove(shape);
+                }
+            }
+        });
     }
     /**
      * Updates the DOM image with cropped data and associates required

--- a/addons/html_editor/static/src/main/media/image_crop.scss
+++ b/addons/html_editor/static/src/main/media/image_crop.scss
@@ -8,6 +8,10 @@
 
     .o_we_cropper_wrapper {
         position: absolute;
+
+        .cropper-face.cropper-move {
+            opacity: .2;
+        }
     }
 
     .o_we_crop_buttons {

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -15,6 +15,13 @@ function hasShape(imagePlugin, shapeName) {
     return () => imagePlugin.isSelectionShaped(shapeName);
 }
 
+export const IMAGE_SHAPES = [
+    "rounded",
+    "rounded-circle",
+    "shadow",
+    "img-thumbnail",
+];
+
 export class ImagePlugin extends Plugin {
     static id = "image";
     static dependencies = ["history", "link", "powerbox", "dom", "selection"];


### PR DESCRIPTION
When cropping images to which a shape has been applied, the cropper tool doesn't take the shape into account, which can be disturbing especially in the case of rounded images.

This applies the shape to the cropper tool so the user can see what the final, cropped result will look like.

-----

When trying to crop an image at the bottom of the viewport, an async call was waiting forever, causing the instance of cropper not to be defined. This is because we forced scrolling down even though it wasn't necessary, then waiting for scrolling to end (which never happened since it never even started).

task-4493009

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
