### PR TITLE
[FIX] website: correct clicking on non-existing extra-menu button

### DIFF
--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -417,8 +417,15 @@ export function clickOnExtraMenuItem(stepOptions, backend = false) {
             content: "Click on the extra menu dropdown toggle if it is there and not shown",
             trigger: `${
                 backend ? ":iframe" : ""
-            } ul.top_menu .o_extra_menu_items a[role=menuitem]:not(.show)`,
-            run: "click",
+            } ul.top_menu`,
+            run(actions) {
+                // Note: the button might not exist (it only appear if there is many menu items)
+                const extraMenuButton = this.anchor.querySelector(".o_extra_menu_items a.nav-link");
+                // Don't click on the extra menu button if it's already visible.
+                if (extraMenuButton && !extraMenuButton.classList.contains("show")) {
+                    actions.click(extraMenuButton);
+                }
+            },
         },
         stepOptions
     );


### PR DESCRIPTION
The PR:
https://github.com/odoo/odoo/pull/197115
introduced some errors in the "single app" installation.

The step assumed that the "extra menu" button is always there to click it. It work on enterprise builds as there is so many menus that the "extra menu" button will always appear. But it's not the case in the single app tests.

To solve this issue, we partially revert a step to its original code

rb-116096