### PR TITLE
[FIX] mail: searchTerm in suggestions

### DIFF
--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -167,7 +167,7 @@ export class SuggestionService {
                 const result = fn(p1, p2, {
                     env: this.env,
                     memberPartnerIds,
-                    searchTerms: cleanedSearchTerm,
+                    searchTerm: cleanedSearchTerm,
                     thread,
                     context,
                 });

--- a/addons/mail/static/tests/suggestion/suggestion_tests.js
+++ b/addons/mail/static/tests/suggestion/suggestion_tests.js
@@ -319,3 +319,21 @@ QUnit.test("Current user that is a follower should be considered as such", async
         before: [".o-mail-Composer-suggestion", { text: "Person A(a@test.com)" }],
     });
 });
+
+QUnit.test("Suggestions that begin with the search term should have priority", async () => {
+    const pyEnv = await startServer();
+    pyEnv["res.partner"].create([{ name: "Party Partner" }, { name: "Best Partner" }]);
+    const { openFormView } = await start();
+    openFormView("res.partner", pyEnv.currentPartnerId);
+    await click("button", { text: "Send message" });
+    await insertText(".o-mail-Composer-input", "@");
+    await contains(".o-mail-Composer-suggestion", {
+        text: "Best Partner",
+        before: [".o-mail-Composer-suggestion", { text: "Party Partner" }],
+    });
+    await insertText(".o-mail-Composer-input", "part");
+    await contains(".o-mail-Composer-suggestion", {
+        text: "Party Partner",
+        before: [".o-mail-Composer-suggestion", { text: "Best Partner" }],
+    });
+});


### PR DESCRIPTION
Since odoo/odoo#128570, there was a typo in `sortPartnerSuggestions` (`searchTerms` instead of `searchTerm`) which caused searchTerm to have no effect. This PR fixes that typo and adds a test to make sure the searchTerm is included in the returned suggestions.

