### PR TITLE
[IMP] account_payment: module can decide which invoice to notify

### DIFF
--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -231,5 +231,9 @@ class PaymentTransaction(models.Model):
             payment_id = self.source_transaction_id.payment_id
             if payment_id:
                 payment_id.message_post(body=message, author_id=author.id)
-        for invoice in self.invoice_ids:
+        for invoice in self._get_invoices_to_notify():
             invoice.message_post(body=message, author_id=author.id)
+
+    def _get_invoices_to_notify(self):
+        """ Return the invoices on which to log payment-related messages. """
+        return self.invoice_ids


### PR DESCRIPTION
Instead of directly notify the invoices link to the transaction in _log_message_on_linked_documents, the invoice return by _get_invoices_to_notify are notified.

It allow other modules to exclude some invoice






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
