### PR TITLE
[FIX] account : PROFORMA displaying on confirmed invoices

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -51,7 +51,7 @@
                 <div class="clearfix invoice_main">
                     <div class="page mb-4">
                         <t t-set="layout_document_title">
-                            <span t-if="not proforma"></span>
+                            <span t-if="not proforma or o.state != 'draft' "/>
                             <span t-else="">PROFORMA</span>
                             <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">Invoice</span>
                             <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft'">Draft Invoice</span>


### PR DESCRIPTION
Previously, the "PROFORMA" label was incorrectly displayed on confirmed invoices, causing confusion for users. 

This fix ensures that the label only appears on actual proforma invoices and is removed once an invoice is confirmed.

Description of the issue/feature this PR addresses:
The "PROFORMA" label was mistakenly retained on invoices even after they were confirmed, leading to misinterpretation and potential accounting discrepancies.

Current behavior before PR:
- The "PROFORMA" label is still visible on confirmed invoices.  
- Users may misunderstand the invoice status, affecting financial processes.  

Desired behavior after PR is merged:
- The "PROFORMA" label is only displayed on proforma invoices.  
- Once an invoice is confirmed, the label is removed, ensuring clarity in financial documents.  


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
