### PR TITLE
[FIX] l10n_in_sale: compute FPOS based on POS for Indian Compliance

### DIFF
--- a/addons/l10n_in_sale/models/sale_order.py
+++ b/addons/l10n_in_sale/models/sale_order.py
@@ -18,7 +18,55 @@ class SaleOrder(models.Model):
             ('special_economic_zone', 'Special Economic Zone'),
             ('deemed_export', 'Deemed Export'),
             ('uin_holders', 'UIN Holders'),
-        ], string="GST Treatment", readonly=False, compute="_compute_l10n_in_gst_treatment", store=True)
+        ], string="GST Treatment", readonly=False, compute="_compute_l10n_in_gst_treatment", store=True, precompute=True)
+
+    @api.depends('partner_id', 'partner_shipping_id', 'l10n_in_gst_treatment')
+    def _compute_fiscal_position_id(self):
+
+        def _get_fiscal_state(order, foreign_state):
+            """
+            Maps each order to its corresponding fiscal state based on its type,
+            fiscal conditions, and the state of the associated partner or company.
+            """
+
+            if (
+                order.country_code != 'IN'
+                # Partner's FP takes precedence through super
+                or order.partner_shipping_id.property_account_position_id
+                or order.partner_id.property_account_position_id
+            ):
+                return False
+            elif order.l10n_in_gst_treatment == 'special_economic_zone':
+                # Special Economic Zone
+                return foreign_state
+            
+            # Computing Place of Supply for particular order
+            partner_state = (
+                order.partner_id.commercial_partner_id == order.partner_shipping_id.commercial_partner_id
+                and order.partner_shipping_id.state_id
+                or order.partner_id.state_id
+            )
+            if not partner_state:
+                partner_state = order.partner_id.commercial_partner_id.state_id or order.company_id.state_id
+            if partner_state.country_id.code != 'IN':
+                partner_state = foreign_state
+            return partner_state
+
+        FiscalPosition = self.env['account.fiscal.position']
+        foreign_state = self.env['res.country.state'].search([('code', '!=', 'IN')], limit=1)
+        for state_id, orders in self.grouped(lambda order: _get_fiscal_state(order, foreign_state)).items():
+            if state_id:
+                virtual_partner = self.env['res.partner'].new({
+                    'state_id': state_id.id,
+                    'country_id': state_id.country_id.id,
+                })
+                # Group orders by company to avoid multi-company conflicts
+                for company_id, company_orders in orders.grouped('company_id').items():
+                    company_orders.fiscal_position_id = FiscalPosition.with_company(
+                        company_id.id
+                    )._get_fiscal_position(virtual_partner)
+            else:
+                super(SaleOrder, orders)._compute_fiscal_position_id()
 
     @api.depends('partner_id')
     def _compute_l10n_in_gst_treatment(self):

--- a/addons/l10n_in_sale/tests/__init__.py
+++ b/addons/l10n_in_sale/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_l10n_in_sale_fiscal_position

--- a/addons/l10n_in_sale/tests/test_l10n_in_sale_fiscal_position.py
+++ b/addons/l10n_in_sale/tests/test_l10n_in_sale_fiscal_position.py
@@ -1,0 +1,103 @@
+from odoo import Command, fields
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+chart_template_ref = 'in'
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestSaleFiscal(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        # Company
+        cls.default_company_state = cls.env.ref('base.state_in_gj')
+        cls.default_company = cls.setup_company_data(
+            company_name='Odoo In test',
+            chart_template=chart_template_ref,
+            state_id=cls.default_company_state.id,
+        )['company']
+        # Partner
+        cls.partner_intra_state = cls.partner_a.copy({
+            'state_id': cls.default_company_state.id,
+            'country_id': cls.env.ref('base.in').id,
+        })
+        cls.partner_inter_state = cls.partner_b.copy({
+            'state_id': cls.env.ref('base.state_in_mh').id,
+            'country_id': cls.env.ref('base.in').id,
+        })
+        cls.partner_foreign = cls.env['res.partner'].create({
+            'name': 'Partner Outside India',
+            'state_id': cls.env.ref('base.state_us_1').id,
+            'country_id': cls.env.ref('base.us').id,
+        })
+
+    def _assert_order_fiscal_position(self, fpos_ref, partner, post=True):
+        test_order = self.env['sale.order'].create({
+            'partner_id': partner,
+            'company_id': self.env.company.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'product_uom_qty': 10,
+                }),
+            ],
+        })
+        if post:
+            test_order.action_confirm()
+        self.assertEqual(
+            test_order.fiscal_position_id,
+            self.env['account.chart.template'].with_company(self.env.company).ref(fpos_ref)
+        )
+        return test_order
+
+    def test_l10n_in_sale_fiscal_position(self):
+        '''
+        According to GST: Compare place of supply (instead of delivery address) with company state
+        '''
+
+        self.env.company = self.default_company
+        template = self.env['account.chart.template']
+        company_state = self.env.company.state_id
+
+        # Sub-test: Intra-State
+        with self.subTest(scenario="Intra-State"):
+            self._assert_order_fiscal_position(
+                fpos_ref='fiscal_position_in_intra_state',
+                partner=self.partner_intra_state.id,
+            )
+
+        # Sub-test: Inter-State
+        with self.subTest(scenario="Inter-State"):
+            self._assert_order_fiscal_position(
+                fpos_ref='fiscal_position_in_inter_state',
+                partner=self.partner_inter_state.id,
+            )
+
+        # Sub-test: Export (Outside India)
+        with self.subTest(scenario="Export"):
+            sale_order = self._assert_order_fiscal_position(
+                fpos_ref='fiscal_position_in_export_sez_in',
+                partner=self.partner_foreign.id,
+                post=False,
+            )
+
+        # Sub-test: SEZ (Special Economic Zone)
+        with self.subTest(scenario="SEZ"):
+            # Here fpos should Intra-State. But due to `l10n_in_gst_treatment` it will be SEZ
+            sale_order = self.env['sale.order'].with_company(self.env.company).create({
+                'date_order': fields.Date.from_string('2019-01-01'),
+                'partner_id': self.partner_intra_state.id,  # Intra-State Partner
+                'l10n_in_gst_treatment': 'special_economic_zone',
+                'order_line': [Command.create({
+                    'product_id': self.product_a.id,
+                    'product_uom_qty': 10,
+                    'name': 'product test 1',
+                    'price_unit': 40,
+                })]
+            })
+
+            self.assertEqual(
+                sale_order.fiscal_position_id,
+                template.ref('fiscal_position_in_export_sez_in')
+            )


### PR DESCRIPTION
*FPOS - Fiscal Position
*POS - Place of Supply

- Before this commit: The fiscal position was determined based on the partner's shipping address (`partner_shipping_id`) in sales orders, which did not align with Indian tax regulations.

- After this commit: The fiscal position is now computed based on the place of supply, ensuring compliance with Indian tax requirements.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
