### PR TITLE
[FIX] point_of_sale, pos_[discount, sale]: prevent error on installing module

### DIFF
--- a/addons/point_of_sale/data/point_of_sale_data.xml
+++ b/addons/point_of_sale/data/point_of_sale_data.xml
@@ -24,7 +24,7 @@
 
         <record id="product_product_tip" model="product.product">
             <field name="name">Tips</field>
-            <field name="categ_id" ref="product.product_category_services"/>
+            <field name="categ_id" eval="ref('product.product_category_services', raise_if_not_found=False)"/>
             <field name="default_code">TIPS</field>
             <field name="weight">0.01</field>
             <field name="available_in_pos">False</field>

--- a/addons/pos_discount/data/pos_discount_data.xml
+++ b/addons/pos_discount/data/pos_discount_data.xml
@@ -8,7 +8,7 @@
             <field name="list_price">0.00</field>
             <field name="weight">0.00</field>
             <field name="type">consu</field>
-            <field name="categ_id" ref="product.product_category_services"/>
+            <field name="categ_id" eval="ref('product.product_category_services', raise_if_not_found=False)"/>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="default_code">DISC</field>
             <field name="purchase_ok">False</field>

--- a/addons/pos_sale/data/pos_sale_data.xml
+++ b/addons/pos_sale/data/pos_sale_data.xml
@@ -13,7 +13,7 @@
             <field name="weight">0.00</field>
             <field name="type">service</field>
             <field name="taxes_id" eval="[(5,)]"/>
-            <field name="categ_id" ref="product.product_category_services"/>
+            <field name="categ_id" eval="ref('product.product_category_services', raise_if_not_found=False)"/>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="purchase_ok">False</field>
         </record>


### PR DESCRIPTION
Currently a `ParseError` arises when the user installs the `pos_discount` and `pos_sale` modules after deleting the `Service` category in `Invoicing`.

Steps to reproduce:
---
- Install `Invoicing` application (without demo data)
- Invoicing > Configuration > Categories > Delete `Services`
- Now install `pos_discount` and `pos_sale` modules

Traceback:
---
```
ValueError: External ID not found in the system: product.product_category_services

ParseError: while parsing /home/odoo/src/odoo/saas-18.1/addons/pos_discount/data/pos_discount_data.xml:4, somewhere inside <record id="product_product_consumable" model="product.product">
            <field name="name">Discount</field>
            <field name="available_in_pos">False</field>
            <field name="standard_price">0.00</field>
            <field name="list_price">0.00</field>
            <field name="weight">0.00</field>
            <field name="type">consu</field>
            <field name="categ_id" ref="product.product_category_services"/>
            <field name="uom_id" ref="uom.product_uom_unit"/>
            <field name="default_code">DISC</field>
            <field name="purchase_ok">False</field>
        </record>
```

The error occurs because the user deleted the category and then installed `pos_discount` and `pos_sale` modules, which reference the missing product category.

This commit resolves the error by providing a False value for the field if the product category is missing.

sentry-6291223593

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
