### PR TITLE
[FIX] mass_mailing: fix the template not being filtered based on the model

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -532,7 +532,7 @@ export class MassMailingHtmlField extends HtmlField {
             $themeSelectorNew.appendTo(this.wysiwyg.$iframeBody);
         }
 
-        if (this.env.mailingFilterTemplates && this.wysiwyg) {
+        if (this.wysiwyg) {
             this._hideIrrelevantTemplates(this.props.record);
         }
         this.wysiwyg.odooEditor.activateContenteditable();


### PR DESCRIPTION
Bug
===
1. Create a mailing for an event registration
2. Add that mailing to the template
3. Create a new mailing for "mailing list" => The "event registration" template is proposed and it should be.

Since 5226dc972560870d03e7e4bc5a838f1951b90ac7 , we removed the JS form view, which added `mailingFilterTemplates: true` in the env. That environment variable was responsible for the HTML component to filter the templates based on the model.

Task-4568452