### PR TITLE
[IMP] fleet: vehicle model configuration revamp

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -1,8 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
 from dateutil.relativedelta import relativedelta
+from datetime import datetime
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
@@ -13,10 +13,10 @@ from odoo.osv import expression
 #Some fields don't have the exact same name
 MODEL_FIELDS_TO_VEHICLE = {
     'transmission': 'transmission', 'model_year': 'model_year', 'electric_assistance': 'electric_assistance',
-    'color': 'color', 'seats': 'seats', 'doors': 'doors', 'trailer_hook': 'trailer_hook',
-    'default_co2': 'co2', 'co2_standard': 'co2_standard', 'default_fuel_type': 'fuel_type',
-    'power': 'power', 'horsepower': 'horsepower', 'horsepower_tax': 'horsepower_tax', 'category_id': 'category_id',
-    'vehicle_range': 'vehicle_range', 'power_unit': 'power_unit'
+    'color': 'color', 'seats': 'seats', 'doors': 'doors', 'trailer_hook': 'trailer_hook', 'default_co2': 'co2',
+    'co2_standard': 'co2_standard', 'default_fuel_type': 'fuel_type', 'power': 'power', 'horsepower': 'horsepower',
+    'horsepower_tax': 'horsepower_tax', 'category_id': 'category_id', 'vehicle_range': 'vehicle_range',
+    'power_unit': 'power_unit', 'range_unit': 'range_unit',
 }
 
 
@@ -30,6 +30,10 @@ class FleetVehicle(models.Model):
     def _get_default_state(self):
         state = self.env.ref('fleet.fleet_vehicle_state_new_request', raise_if_not_found=False)
         return state if state and state.id else False
+
+    def _get_year_selection(self):
+        current_year = datetime.now().year
+        return [(str(i), i) for i in range(1970, current_year + 1)]
 
     name = fields.Char(compute="_compute_vehicle_name", store=True)
     description = fields.Html("Vehicle Description")
@@ -48,7 +52,10 @@ class FleetVehicle(models.Model):
     license_plate = fields.Char(tracking=True,
         help='License plate number of the vehicle (i = plate number for a car)')
     vin_sn = fields.Char('Chassis Number', help='Unique number written on the vehicle motor (VIN/SN number)', tracking=True, copy=False)
-    trailer_hook = fields.Boolean(default=False, string='Trailer Hitch', compute='_compute_model_fields', store=True, readonly=False)
+    trailer_hook = fields.Boolean(default=False, string='Trailer Hitch',
+        compute='_compute_model_fields', store=True, readonly=False,
+        help="A trailer hitch is a device attached to a vehicle's chassis for towing purposes, \
+            such as pulling trailers, boats, or other vehicles.")
     driver_id = fields.Many2one('res.partner', 'Driver', tracking=True, help='Driver address of the vehicle', copy=False)
     future_driver_id = fields.Many2one('res.partner', 'Future Driver', tracking=True, help='Next Driver Address of the vehicle', copy=False, check_company=True)
     model_id = fields.Many2one('fleet.vehicle.model', 'Model',
@@ -74,9 +81,12 @@ class FleetVehicle(models.Model):
         tracking=True,
         help='Current state of the vehicle', ondelete="set null")
     location = fields.Char(help='Location of the vehicle (garage, ...)')
-    seats = fields.Integer('Seats Number', help='Number of seats of the vehicle', compute='_compute_model_fields', store=True, readonly=False)
-    model_year = fields.Char('Model Year', help='Year of the model', compute='_compute_model_fields', store=True, readonly=False)
-    doors = fields.Integer('Doors Number', help='Number of doors of the vehicle', compute='_compute_model_fields', store=True, readonly=False)
+    seats = fields.Integer('Seating Capacity', help='Number of seats of the vehicle',
+        compute='_compute_model_fields', store=True, readonly=False)
+    model_year = fields.Selection(selection='_get_year_selection', string='Model Year',
+        help='Year of the model', compute='_compute_model_fields', store=True, readonly=False)
+    doors = fields.Integer('Number of Doors', help='Number of doors of the vehicle',
+        compute='_compute_model_fields', store=True, readonly=False)
     tag_ids = fields.Many2many('fleet.vehicle.tag', 'fleet_vehicle_vehicle_tag_rel', 'vehicle_tag_id', 'tag_id', 'Tags', copy=False)
     odometer = fields.Float(compute='_get_odometer', inverse='_set_odometer', string='Last Odometer',
         help='Odometer measure of the vehicle at the moment of this log')
@@ -92,11 +102,17 @@ class FleetVehicle(models.Model):
         ('power', 'kW'),
         ('horsepower', 'Horsepower')
         ], 'Power Unit', default='power', required=True)
-    horsepower = fields.Integer(compute='_compute_model_fields', store=True, readonly=False)
+    horsepower = fields.Float(compute='_compute_model_fields', store=True, readonly=False)
     horsepower_tax = fields.Float('Horsepower Taxation', compute='_compute_model_fields', store=True, readonly=False)
-    power = fields.Integer('Power', help='Power in kW of the vehicle', compute='_compute_model_fields', store=True, readonly=False)
-    co2 = fields.Float('CO2 Emissions', help='CO2 emissions of the vehicle', compute='_compute_model_fields', store=True, readonly=False, tracking=True, aggregator=None)
-    co2_standard = fields.Char('CO2 Standard', compute='_compute_model_fields', store=True, readonly=False)
+    power = fields.Float('Power', help='Power in kW of the vehicle',
+        compute='_compute_model_fields', store=True, readonly=False)
+    co2 = fields.Float('CO₂ Emissions', help='CO2 emissions of the vehicle', compute='_compute_model_fields',
+        store=True, readonly=False, tracking=True, aggregator=None)
+    co2_emission_unit = fields.Selection([('g/km', 'g/km'), ('g/mi', 'g/mi')], compute='_compute_co2_emission_unit',
+        store=True, default="g/km", required=True)
+    co2_standard = fields.Char('Emission Standard', compute='_compute_model_fields', store=True, readonly=False,
+        help="Emission Standard specifies the regulatory test procedure \
+            or guideline under which a vehicle's emissions are measured.")
     category_id = fields.Many2one('fleet.vehicle.model.category', 'Category', compute='_compute_model_fields', store=True, readonly=False)
     image_128 = fields.Image(related='model_id.image_128', readonly=True)
     contract_renewal_due_soon = fields.Boolean(compute='_compute_contract_reminder', search='_search_contract_renewal_due_soon',
@@ -125,6 +141,8 @@ class FleetVehicle(models.Model):
     ], compute='_compute_service_activity')
     vehicle_properties = fields.Properties('Properties', definition='model_id.vehicle_properties_definition', copy=True)
     vehicle_range = fields.Integer(string="Range")
+    range_unit = fields.Selection([('km', 'km'), ('mi', 'mi')],
+        compute='_compute_model_fields', store=True, readonly=False, default="km", required=True)
 
     @api.depends('log_services')
     def _compute_service_activity(self):
@@ -152,6 +170,14 @@ class FleetVehicle(models.Model):
     def _compute_vehicle_name(self):
         for record in self:
             record.name = (record.model_id.brand_id.name or '') + '/' + (record.model_id.name or '') + '/' + (record.license_plate or _('No Plate'))
+
+    @api.depends('range_unit')
+    def _compute_co2_emission_unit(self):
+        for record in self:
+            if record.range_unit == 'km':
+                record.co2_emission_unit = 'g/km'
+            else:
+                record.co2_emission_unit = 'g/mi'
 
     def _get_odometer(self):
         FleetVehicalOdometer = self.env['fleet.vehicle.odometer']

--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -46,6 +46,8 @@
                                     <field name="doors"/>
                                     <field name="model_year"/>
                                     <field name="trailer_hook"/>
+                                    <field name="color"/>
+                                    <field name="drive_type"/>
                                 </group>
                                 <group id="vehicle_information" string="Vehicle Information" invisible="vehicle_type != 'bike'">
                                     <field name="electric_assistance"/>
@@ -53,22 +55,29 @@
                                 <group string="Engine" invisible="vehicle_type != 'car'" name="group_engine">
                                     <field name="default_fuel_type" required="1"/>
                                     <label for="vehicle_range"/>
-                                    <div class="o_row" name="vehicle_range">
-                                        <field name="vehicle_range"/><span>km</span>
+                                    <div class="o_row">
+                                        <field name="vehicle_range"/>
+                                        <field name="range_unit"/>
                                     </div>
                                     <label for="default_co2"/>
-                                    <div class="o_row" name="default_co2">
-                                        <field name="default_co2"/><span>g/km</span>
+                                    <div class="o_row">
+                                        <field name="default_co2"/>
+                                        <field name="co2_emission_unit"/>
                                     </div>
-                                    <field name="co2_standard"/>
+                                    <field name="co2_standard" placeholder="eg. WLTP, Euro 6, or EPA, ..."/>
                                     <field name="transmission"/>
-                                    <field name="power_unit"/>
                                     <label for="power" invisible="power_unit != 'power'"/>
                                     <div class="o_row" invisible="power_unit != 'power'">
-                                        <field name="power"/><span>kW</span>
+                                        <field name="power"/>
+                                        <field name="power_unit"/>
                                     </div>
-                                    <field name="horsepower" invisible="power_unit != 'horsepower'"/>
+                                    <label for="horsepower" invisible="power_unit != 'horsepower'"/>
+                                    <div class="o_row" invisible="power_unit != 'horsepower'">
+                                        <field name="horsepower"/>
+                                        <field name="power_unit"/>
+                                    </div>
                                     <field name="horsepower_tax" invisible="power_unit != 'horsepower'"/>
+
                                 </group>
                             </group>
                         </page>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -150,22 +150,28 @@
                                     <field name="electric_assistance" invisible="vehicle_type != 'bike'"/>
                                 </group>
                                 <group string="Engine" invisible="vehicle_type != 'car'">
-                                    <field name="power_unit"/>
                                     <label for="power" invisible="power_unit != 'power'"/>
                                     <div class="o_row" invisible="power_unit != 'power'">
-                                        <field name="power"/><span>kW</span>
+                                        <field name="power"/>
+                                        <field name="power_unit"/>
                                     </div>
-                                    <field name="horsepower" invisible="power_unit != 'horsepower'"/>
+                                    <label for="horsepower" invisible="power_unit != 'horsepower'"/>
+                                    <div class="o_row" invisible="power_unit != 'horsepower'">
+                                        <field name="horsepower"/>
+                                        <field name="power_unit"/>
+                                    </div>
                                     <label for="vehicle_range"/>
                                     <div class="o_row">
-                                        <field name="vehicle_range"/><span>km</span>
+                                        <field name="vehicle_range"/>
+                                        <field name="range_unit"/>
                                     </div>
                                     <field name="fuel_type"/>
                                     <label for="co2"/>
-                                    <div class="o_row" name="co2">
-                                        <field name="co2"/><span>g/km</span>
+                                    <div class="o_row">
+                                        <field name="co2"/>
+                                        <field name="co2_emission_unit"/>
                                     </div>
-                                    <field name="co2_standard"/>
+                                    <field name="co2_standard" placeholder="eg. WLTP, Euro 6, or EPA, ..."/>
                                 </group>
                             </group>
                         </page>
@@ -197,7 +203,7 @@
                 <field name="future_driver_id"  widget="many2one_avatar" readonly="1" optional="show"/>
                 <field name="log_drivers" column_invisible="True"/>
                 <field name="vin_sn" readonly="1" optional="hide"/>
-                <field name="co2" string="CO2 Emissions g/km" optional="hide"  readonly="1"/>
+                <field name="co2" string="CO2 Emissions" optional="hide" readonly="1"/>
                 <field name="acquisition_date" readonly="1"/>
                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" readonly="1"/>
                 <field name="state_id" widget="badge" readonly="1" optional="hide"/>


### PR DESCRIPTION
Revamped fleet vehicle model configuration:

- Added tooltips for fields such as trailer hitch, number of doors, and emission standards.
- Introduced new fields for color and drive type.
- Enabled selection of CO2 emission units between g/km and g/mi.
- Enabled selection of range units between km and mi.
- Changed model year to a selection field.

These changes also apply to the fleet model.

Task-4442672
