### PR TITLE
 [IMP] account: imp partner credit limit

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1997,7 +1997,7 @@ class AccountMove(models.Model):
         partner_id = record.partner_id.commercial_partner_id
         credit_to_invoice = partner_id.credit_to_invoice - exclude_amount
         total_credit = partner_id.credit + credit_to_invoice + current_amount
-        if not partner_id.credit_limit or total_credit <= partner_id.credit_limit:
+        if partner_id.credit_limit_mode == 'no_limit' or total_credit <= partner_id.credit_limit:
             return ''
         msg = _(
             '%(partner_name)s has reached its credit limit of: %(credit_limit)s',

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -156,7 +156,8 @@ class ResCompany(models.Model):
     )
     account_use_credit_limit = fields.Boolean(
         string='Sales Credit Limit', help='Enable the use of credit limit on partners.')
-
+    default_credit_limit = fields.Monetary(help='This is the default credit limit that will be used'
+                                                ' for partners that do not have a custom limit.')
     batch_payment_sequence_id = fields.Many2one(
         comodel_name='ir.sequence',
         readonly=True,

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -518,15 +518,33 @@ class ResPartner(models.Model):
         groups='account.group_account_invoice,account.group_account_readonly'
     )
     credit_limit = fields.Float(
-        string='Credit Limit', help='Credit limit specific to this partner.',
+        help='Company default credit limit.',
         groups='account.group_account_invoice,account.group_account_readonly',
-        company_dependent=True, copy=False, readonly=False)
-    use_partner_credit_limit = fields.Boolean(
-        string='Partner Limit', groups='account.group_account_invoice,account.group_account_readonly',
-        compute='_compute_use_partner_credit_limit', inverse='_inverse_use_partner_credit_limit',
-        help='Set a value greater than 0.0 to activate a credit limit check')
+        compute='_compute_credit_limit',
+        copy=False)
+    custom_credit_limit = fields.Float(
+        help='Credit limit specific to this partner.',
+        groups='account.group_account_invoice,account.group_account_readonly',
+        company_dependent=True, copy=False,
+    )
     show_credit_limit = fields.Boolean(
         compute='_compute_show_credit_limit', groups='account.group_account_invoice,account.group_account_readonly')
+    credit_limit_mode = fields.Selection(
+        # As this field is company dependant, it can not be set to required=True.
+        # Therefore a None value should be treated as 'company'
+        selection=[
+            ('company', 'Company'),
+            ('custom', 'Custom'),
+            ('no_limit', 'No Limit'),
+        ],
+        help='''• Company : Use the default company credit limit
+                • Custom : Set a custom credit limit
+                • No Limit : Remove credit limit''',
+        groups='account.group_account_invoice,account.group_account_readonly',
+        company_dependent=True, copy=False,
+        # compute allows for user not in 'groups' to create a partner with a default credit_limit_mode set to 'company'
+        compute='_compute_credit_limit_mode', store=True, readonly=False
+    )
     days_sales_outstanding = fields.Float(
         string='Days Sales Outstanding (DSO)',
         help='[(Total Receivable/Total Revenue) * number of days since the first invoice] for this customer',
@@ -665,16 +683,13 @@ class ResPartner(models.Model):
                 partner.invoice_edi_format_store = partner.invoice_edi_format
 
     @api.depends_context('company')
-    def _compute_use_partner_credit_limit(self):
-        company_limit = self._fields['credit_limit'].get_company_dependent_fallback(self)
+    @api.depends('credit_limit_mode')
+    def _compute_credit_limit(self):
         for partner in self:
-            partner.use_partner_credit_limit = partner.credit_limit != company_limit
-
-    def _inverse_use_partner_credit_limit(self):
-        company_limit = self._fields['credit_limit'].get_company_dependent_fallback(self)
-        for partner in self:
-            if not partner.use_partner_credit_limit:
-                partner.credit_limit = company_limit
+            if partner.credit_limit_mode == 'custom':
+                partner.credit_limit = partner.custom_credit_limit
+            else:
+                partner.credit_limit = partner.env.company.default_credit_limit
 
     @api.depends_context('company')
     def _compute_show_credit_limit(self):
@@ -691,6 +706,11 @@ class ResPartner(models.Model):
 
     def _get_account_statistics_count(self):
         return self.account_move_count + self.supplier_invoice_count
+
+    def _compute_credit_limit_mode(self):
+        for partner in self:
+            if not partner.credit_limit_mode:
+                partner.credit_limit_mode = 'company'
 
     def _get_suggested_invoice_edi_format(self):
         # TO OVERRIDE

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -230,10 +230,21 @@
                                    invisible="not show_credit_limit">
                                 <field name="credit"/>
                                 <field name="days_sales_outstanding"/>
-                                <label for="use_partner_credit_limit"/>
+                                <label for="credit_limit_mode"/>
                                 <div class="o_row">
-                                    <field name="use_partner_credit_limit"/>
-                                    <field name="credit_limit" class="oe_inline" widget="monetary" options="{'currency_field': 'currency_id'}"  invisible="not use_partner_credit_limit"/>
+                                    <!-- As credit_limit_mode is company dependent it can not be set as required on the model-->
+                                    <!-- <field name="credit_limit_mode" class="oe_inline" required="show_credit_limit"/> -->
+                                    <field name="credit_limit_mode" class="oe_inline"/>
+                                    <field name="credit_limit"
+                                        class="oe_inline"
+                                        widget="monetary" options="{'currency_field': 'currency_id'}"
+                                        invisible="credit_limit_mode != 'company' or not credit_limit_mode"
+                                    />
+                                    <field name="custom_credit_limit"
+                                        class="oe_inline"
+                                        widget="monetary" options="{'currency_field': 'currency_id'}"
+                                        invisible="credit_limit_mode != 'custom'"
+                                    />
                                 </div>
                             </group>
                         </group>

--- a/addons/point_of_sale/static/tests/unit/data/res_partner.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/res_partner.data.js
@@ -52,7 +52,6 @@ export class ResPartner extends MailResPartner {
             company_type: "person",
             fiscal_position_id: false,
             credit_limit: 0.0,
-            use_partner_credit_limit: false,
         },
         {
             id: 4,
@@ -76,7 +75,6 @@ export class ResPartner extends MailResPartner {
             company_type: "person",
             fiscal_position_id: false,
             credit_limit: 0.0,
-            use_partner_credit_limit: false,
         },
     ];
 }

--- a/addons/sale/tests/test_credit_limit.py
+++ b/addons/sale/tests/test_credit_limit.py
@@ -336,8 +336,10 @@ class TestSaleOrderCreditLimit(TestSaleCommon):
 
         # Ensure we don't have access to accounting fields
         with self.assertRaises(AccessError, msg="We shouldn't have access to credit"):
-            order.partner_id.credit_limit = 1e12
-        order.sudo().partner_id.credit_limit = self.product_a.list_price
+            order.partner_id.custom_credit_limit = 1e12
+            order.partner_id.credit_limit_mode = 'no_limit'
+        order.sudo().partner_id.credit_limit_mode = 'custom'
+        order.sudo().partner_id.custom_credit_limit = self.product_a.list_price
 
         with Form(order) as order_form:
             with order_form.order_line.new() as sol:


### PR DESCRIPTION
Before this commit:
To disable the credit limit for a partner when a default company limit was set, one had to set the partner default credit limit to 0. Which is not intuitive and logical and meant you could not set an actual 0 limit (the work around was to set a 0.001 limit).

After this commit:
Partner has a credit limit mode selection field set defining the behavior (inherit company default, have a custom limit, no limit) and a custom limit field used when mode is custom.
For this to work a dedicated default credit limit field had to be added to res_company as the previous mechanism using company dependent default values would generate corner case unwanted behaviors.

Task: 4532569

Enterprise PR: https://github.com/odoo/enterprise/pull/79158
Upgrade PR: https://github.com/odoo/upgrade/pull/7224