### PR TITLE
[FIX] l10n_cz: Fixed search fields in tax office model

### DIFF
--- a/addons/l10n_cz/models/l10n_cz_tax_office.py
+++ b/addons/l10n_cz/models/l10n_cz_tax_office.py
@@ -5,7 +5,7 @@ class L10nCzTaxOffice(models.Model):
     _name = 'l10n_cz.tax_office'
     _description = 'Tax office in Czech Republic'
     _order = 'workplace_code ASC'
-    _rec_names_search = ['workplace_code', 'tax_office_name']
+    _rec_names_search = ['workplace_code', 'name']
 
     workplace_code = fields.Integer(string="Territorial Office", required=True, aggregator=False)
     code = fields.Integer(string="Code", required=True, aggregator=False)


### PR DESCRIPTION
The `tax_office_name` was changed to `name` but that change was dropped in _rec_names_search of the tax office.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
