### PR TITLE
[IMP] tests: capture browser page as MHTML when screenshot is took

### DIFF
--- a/odoo/addons/base/static/tests/test_ir_model_fields_translation.js
+++ b/odoo/addons/base/static/tests/test_ir_model_fields_translation.js
@@ -20,7 +20,7 @@ function checkLoginColumn(translation) {
             run: "click",
         }, {
             content: `Login column should be ${translation}`,
-            trigger: `[data-name="login"] span:contains("${translation}")`,
+            trigger: `[data-name="login-TMP-LSE-TOUR-FAIL"] span:contains("${translation}")`, // TODO: tmp change to test tour failure
         }
     ]
 }


### PR DESCRIPTION
When a JS test fail, a screenshot is took.
This is valuable information, but might not contain enough information as we lack the DOM details.

This PR propose to use Chrome `Page.captureSnapshot` command which allow to save the page as a MHTLM file, see:
https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureSnapshot

TODO:

- [ ] disable by default
- [ ] stop stealing the screenshot path
- [x] good test (like screencast)