### PR TITLE
[FIX] point_of_sale: broken receipt download

### DIFF
--- a/addons/point_of_sale/views/pos_assets_index.xml
+++ b/addons/point_of_sale/views/pos_assets_index.xml
@@ -39,10 +39,10 @@
             <t t-call-assets="point_of_sale.assets_debug" />
         </t>
         <t t-if="request.cookies.get('pos_color_scheme') == 'dark'">
-            <t t-call-assets="point_of_sale.assets_prod_dark" media="screen"/>
+            <t t-call-assets="point_of_sale.assets_prod_dark"/>
         </t>
         <t t-else="">
-            <t t-call-assets="point_of_sale.assets_prod" media="screen"/>
+            <t t-call-assets="point_of_sale.assets_prod"/>
         </t>
     </head>
     <body class="pos">


### PR DESCRIPTION
Before this commit:
================
- Downloading the receipt in the browser printed the entire page
  instead of just the receipt.
![image](https://github.com/user-attachments/assets/1119c696-0420-4da9-8ecb-d6af786a8be0)

After this commit:
================
- Removed `media="screen"` during asset loading for proper receipt download.
![image](https://github.com/user-attachments/assets/85edb461-970a-4dfe-968e-5c7479127524)


Task: 4570086