### PR TITLE
[FIX] mail: mention suggestions for portal users

### DIFF
--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -263,12 +263,7 @@ export class SuggestionService {
     sortPartnerSuggestions(partners, searchTerm = "", thread = undefined) {
         const cleanedSearchTerm = cleanTerm(searchTerm);
         const compareFunctions = partnerCompareRegistry.getAll();
-        const context = this.sortPartnerSuggestionsContext();
-        const memberPartnerIds = new Set(
-            thread?.channel_member_ids
-                .filter((member) => member.persona.type === "partner")
-                .map((member) => member.persona.id)
-        );
+        const context = this.sortPartnerSuggestionsContext(thread);
         return partners.sort((p1, p2) => {
             p1 = toRaw(p1);
             p2 = toRaw(p2);
@@ -278,7 +273,6 @@ export class SuggestionService {
             for (const fn of compareFunctions) {
                 const result = fn(p1, p2, {
                     env: this.env,
-                    memberPartnerIds,
                     searchTerm: cleanedSearchTerm,
                     thread,
                     context,

--- a/addons/mail/static/src/discuss/core/common/partner_compare.js
+++ b/addons/mail/static/src/discuss/core/common/partner_compare.js
@@ -26,7 +26,7 @@ partnerCompareRegistry.add(
 
 partnerCompareRegistry.add(
     "discuss.members",
-    (p1, p2, { thread, memberPartnerIds }) => {
+    (p1, p2, { thread, context: { memberPartnerIds } }) => {
         if (thread?.model === "discuss.channel") {
             const isMember1 = memberPartnerIds.has(p1.id);
             const isMember2 = memberPartnerIds.has(p2.id);

--- a/addons/mail/static/src/discuss/core/common/suggestion_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/suggestion_service_patch.js
@@ -80,9 +80,14 @@ const suggestionServicePatch = {
         };
     },
     /** @override */
-    sortPartnerSuggestionsContext() {
+    sortPartnerSuggestionsContext(thread) {
         return Object.assign(super.sortPartnerSuggestionsContext(), {
             recentChatPartnerIds: this.store.getRecentChatPartnerIds(),
+            memberPartnerIds: new Set(
+                thread?.channel_member_ids
+                    .filter((member) => member.persona.type === "partner")
+                    .map((member) => member.persona.id)
+            ),
         });
     },
 };

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -217,3 +217,14 @@ registry.category("web_tour.tours").add("test_04_project_sharing_chatter_message
         { trigger: ".o-mail-Message .o-mail-MessageReaction:contains('👀')" },
     ],
 });
+
+registry.category("web_tour.tours").add("portal_project_sharing_chatter_mention_users", {
+    url: "/my/projects",
+    steps: () => [
+        { trigger: "table > tbody > tr a:has(span:contains(Project Sharing))", run: "click" },
+        { trigger: ".o_project_sharing" },
+        { trigger: ".o_kanban_record:contains('Test Task')", run: "click" },
+        { trigger: ".o-mail-Composer-input", run: "edit @Georges" },
+        { trigger: ".o-mail-Composer-suggestion:contains('Georges')" },
+    ],
+});

--- a/addons/project/tests/test_project_sharing_ui.py
+++ b/addons/project/tests/test_project_sharing_ui.py
@@ -167,3 +167,21 @@ class TestProjectSharingUi(HttpCase):
             params={"action": "add", "content": "👀", "message_id": message.id},
         )
         self.start_tour("/my/projects", 'test_04_project_sharing_chatter_message_reactions', login='georges1')
+
+    def test_05_project_sharing_chatter_mention_users(self):
+        self.env["project.share.wizard"].create(
+            {
+                "res_model": "project.project",
+                "res_id": self.project_portal.id,
+                "collaborator_ids": [
+                    Command.create({"partner_id": self.partner_portal.id, "access_mode": "edit"}),
+                ],
+            }
+        )
+        self.env["project.task"].with_context({"mail_create_nolog": True}).create(
+            {
+                "name": "Test Task",
+                "project_id": self.project_portal.id,
+            }
+        )
+        self.start_tour("/my/projects", "portal_project_sharing_chatter_mention_users", login="georges1")


### PR DESCRIPTION
When a portal user searches for a partner to mention, an error occurs because the suggestion sorting logic relies on Discuss app-specific code.
This PR moves the Discuss-dependent code to its specific folder, ensuring proper functionality for portal users.

Task-4566702

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
