### PR TITLE
[FIX] mrp_subcontracting: mass produce SN on tracked subcontracting MO

### DIFF
--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -104,7 +104,7 @@ class MrpProduction(models.Model):
 
     def pre_button_mark_done(self):
         if self._get_subcontract_move():
-            return True
+            return super(MrpProduction, self.with_context(skip_consumption=True)).pre_button_mark_done()
         return super().pre_button_mark_done()
 
     def _should_postpone_date_finished(self, date_finished):

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -1558,6 +1558,76 @@ class TestSubcontractingTracking(TransactionCase):
         picking_receipt.button_validate()
         self.assertEqual(picking_receipt.state, 'done')
 
+    def test_flow_mass_produce_tracked_product(self):
+        """
+        Test the mass production process for subcontracted tracked final products
+        """
+        todo_nb = 3
+        resupply_sub_on_order_route = self.env['stock.route'].search([('name', '=', 'Resupply Subcontractor on Order')])
+        finished_product, component = self.env['product.product'].create([{
+            'name': 'Pepper Spray',
+            'is_storable': True,
+            'tracking': 'serial',
+        }, {
+            'name': 'Pepper',
+            'is_storable': True,
+            'route_ids': [(4, resupply_sub_on_order_route.id)],
+        }])
+
+        bom_form = Form(self.env['mrp.bom'])
+        bom_form.type = 'subcontract'
+        bom_form.subcontractor_ids.add(self.subcontractor_partner1)
+        bom_form.product_tmpl_id = finished_product.product_tmpl_id
+        with bom_form.bom_line_ids.new() as bom_line:
+            bom_line.product_id = component
+            bom_line.product_qty = 1
+        bom = bom_form.save()
+
+        self.env['stock.quant']._update_available_quantity(component, self.env.ref('stock.stock_location_stock'), todo_nb)
+
+        # Create a receipt picking from the subcontractor
+        picking_form = Form(self.env['stock.picking'])
+        picking_form.picking_type_id = self.env.ref('stock.picking_type_in')
+        picking_form.partner_id = self.subcontractor_partner1
+        with picking_form.move_ids_without_package.new() as move:
+            move.product_id = finished_product
+            move.product_uom_qty = todo_nb
+            move.quantity = todo_nb
+            move.picked = True
+        picking_receipt = picking_form.save()
+        picking_receipt.action_confirm()
+
+        mo = self.env['mrp.production'].search([('bom_id', '=', bom.id)], limit=1)
+        initial_name = mo.name
+
+        # Process the delivery of the components
+        compo_picking = mo.picking_ids
+        compo_picking.action_assign()
+        compo_picking.button_validate()
+
+        batch_produce_action = mo.button_mark_done()
+        wizard = Form(self.env['mrp.batch.produce'].with_context(**batch_produce_action['context']))
+        # Let the wizard generate all serial numbers
+        wizard.lot_name = "sn#1"
+        wizard.lot_qty = todo_nb
+        wizard = wizard.save()
+        wizard.action_generate_production_text()
+        wizard.action_prepare()
+
+        # Each generated serial number should have its own mo
+        self.assertRecordValues(mo.procurement_group_id.mrp_production_ids.sorted("name"), [
+            {"name": initial_name + "-001", "state": "to_close"},
+            {"name": initial_name + "-002", "state": "to_close"},
+            {"name": initial_name + "-003", "state": "to_close"}
+        ])
+        self.assertRecordValues(mo.procurement_group_id.mrp_production_ids.move_raw_ids, [
+            {"quantity": 1.0, "state": "assigned"},
+            {"quantity": 1.0, "state": "assigned"},
+            {"quantity": 1.0, "state": "assigned"},
+        ])
+        mo.procurement_group_id.mrp_production_ids.button_mark_done()
+        self.assertEqual(mo.procurement_group_id.mrp_production_ids.mapped("state"), ['done', 'done' , 'done'])
+
 
 @tagged('post_install', '-at_install')
 class TestSubcontractingPortal(TransactionCase):


### PR DESCRIPTION
### Steps to reproduce:
- In the settings enable "Multi-Step Routes" and "Subcontracting"
- Inventory > Configuration > Warehouse Management > Operation Types
- Unarchive "Subcontracting"
- Create a product tracked by SN with:
    - A set vendor
    - A bom of type subcontracting with your vendor set as subcontractor
- Create and confirm a PO for 3 units of your product with your vendor.
- Go to inventory > Subcontracting (operation type) > the related SBC
- Click on "Produce All" (this should pop a batch produce wizard)
#### > It does not and you have validated the MO for 0 units without backorder

### Cause of the issue:

Since Commit 5722286a36838f644bb4e95c305b65b412774d75 (saas-17.1), the `action_mass_produce` used to split a tracked MO and generate the assocated SN:
https://github.com/odoo/odoo/blob/bc5414602920ee712c45397d7992863a0b1ea161/addons/mrp/models/mrp_production.py#L2281-L2292
should be returned by the `pre_button_mark_done` to be performed: https://github.com/odoo/odoo/blob/bc5414602920ee712c45397d7992863a0b1ea161/addons/mrp/models/mrp_production.py#L2128 https://github.com/odoo/odoo/blob/bc5414602920ee712c45397d7992863a0b1ea161/addons/mrp/models/mrp_production.py#L1994-L1997
However, for subcontracted MO, the returned value of the `pre_button_mark_done` is currently always True, skipping the batch production wizard:
https://github.com/odoo/odoo/blob/bc5414602920ee712c45397d7992863a0b1ea161/addons/mrp_subcontracting/models/mrp_production.py#L105-L108

opw-4447631

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
