### PR TITLE
[IMP] payment: add trustly to mollie

### DIFF
--- a/addons/payment/data/payment_provider_data.xml
+++ b/addons/payment/data/payment_provider_data.xml
@@ -285,6 +285,7 @@
                          ref('payment.payment_method_paysafecard'),
                          ref('payment.payment_method_p24'),
                          ref('payment.payment_method_sofort'),
+                         ref('payment.payment_method_trustly'),
                          ref('payment.payment_method_twint'),
                      ])]"
         />


### PR DESCRIPTION
Mollie has now started supporting Trustly as a payment method.

task-4555177

See also:
- https://github.com/odoo/upgrade/pull/7211
