### PR TITLE
[FIX] portal: default portal notifications to emails

### DIFF
--- a/addons/portal/wizard/portal_wizard.py
+++ b/addons/portal/wizard/portal_wizard.py
@@ -151,7 +151,8 @@ class PortalWizardUser(models.TransientModel):
         if not user_sudo:
             # create a user if necessary and make sure it is in the portal group
             company = self.partner_id.company_id or self.env.company
-            user_sudo = self.sudo().with_company(company.id)._create_user()
+            email_notification = {'default_notification_type': 'email'}
+            user_sudo = self.sudo().with_company(company.id).with_context(email_notification)._create_user()
 
         if not user_sudo.active or not self.is_portal:
             user_sudo.write({'active': True, 'groups_id': [(4, group_portal.id), (3, group_public.id)]})


### PR DESCRIPTION
Portal users can't have notifications handled in odoo. This commit protects from creation portal user with such setting by defaulting to email notification.

Reproduce
---
- i contacts,portal
- add ir.default:
	- open setting/user
	- set notification to handle in odoo
	- bug icon -> set default -> set handling notification in odoo as default
- open some contact -> gear icon -> grant portal access
- BUG: ERROR: new row for relation "res_users" violates check constraint "res_users_notification_type"

opw-4520104