### PR TITLE
[FIX] html_editor: set non-editable btn cursor to pointer

### DIFF
--- a/addons/html_editor/static/src/main/link/link.scss
+++ b/addons/html_editor/static/src/main/link/link.scss
@@ -11,7 +11,7 @@
         cursor: text;
     }
 
-    [contenteditable=false] .btn.btn-link {
+    [contenteditable=false] .btn {
         cursor: pointer;
     }
 }

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -18,7 +18,7 @@ describe("button style", () => {
             unformat(`
                 <div contenteditable="false" data-embedded="clipboard">
                     <span class="o_embedded_toolbar">
-                        <button class="btn btn-link">I am a button</button>
+                        <button class="btn">I am a button</button>
                     </span>
                 </div>
             `)


### PR DESCRIPTION
In Knowledge, non-editable buttons in embedded views (cog menu, ...) use a text cursor, which is incorrect as they are not editable buttons.

This is because the CSS rule that resets pointer cursors in the editor within non-editable elements only applies to .btn.btn-link elements.

This commit makes it so that this rule applies for all .btn elements within non-editable elements.

task-4558391
