### PR TITLE
[FIX] website_hr_recruitment: drop BooleanToggleFieldLabeled

### DIFF
--- a/addons/website_hr_recruitment/i18n/website_hr_recruitment.pot
+++ b/addons/website_hr_recruitment/i18n/website_hr_recruitment.pot
@@ -591,6 +591,12 @@ msgid ""
 msgstr ""
 
 #. module: website_hr_recruitment
+#. odoo-javascript
+#: code:addons/website_hr_recruitment/static/src/fields/boolean_toggle_labeled_field.xml:0
+msgid "Not Published"
+msgstr ""
+
+#. module: website_hr_recruitment
 #: model_terms:ir.ui.view,arch_db:website_hr_recruitment.snippet_options
 msgid "Offices Filter"
 msgstr ""
@@ -653,6 +659,8 @@ msgid "Products"
 msgstr ""
 
 #. module: website_hr_recruitment
+#. odoo-javascript
+#: code:addons/website_hr_recruitment/static/src/fields/boolean_toggle_labeled_field.xml:0
 #: model_terms:ir.ui.view,arch_db:website_hr_recruitment.hr_job_search_view_inherit
 #: model_terms:ir.ui.view,arch_db:website_hr_recruitment.hr_job_website_inherit
 #: model_terms:ir.ui.view,arch_db:website_hr_recruitment.view_hr_job_tree_inherit_website

--- a/addons/website_hr_recruitment/static/src/fields/boolean_toggle_labeled_field.js
+++ b/addons/website_hr_recruitment/static/src/fields/boolean_toggle_labeled_field.js
@@ -58,8 +58,8 @@ export const booleanToggleFieldLabeled = {
         return {
             autosave: "autosave" in options ? Boolean(options.autosave) : true,
             readonly: dynamicInfo.readonly,
-            true_label: options.true_label,
-            false_label: options.false_label,
+            true_label: _t(options.true_label),
+            false_label: _t(options.false_label),
         };
     },
 };

--- a/addons/website_hr_recruitment/static/src/fields/boolean_toggle_labeled_field.xml
+++ b/addons/website_hr_recruitment/static/src/fields/boolean_toggle_labeled_field.xml
@@ -3,6 +3,8 @@
 
     <t t-name="website_hr_recruitment.BooleanToggleFieldLabeled" t-inherit="web.BooleanToggleField" >
         <xpath expr="//CheckBox" position="inside">
+            <label invisible="1" string="Published"/>
+            <label invisible="1" string="Not Published"/>
             <t t-out="this.state.label"></t>
         </xpath>
     </t>


### PR DESCRIPTION
- add the _t() to translate the labels coming from options.
- add the label values to the template to be available on the pot file

Task: 4488490

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
