### PR TITLE
[FIX] account: remove untranslated product name prefix from lines

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -171,14 +171,7 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
     }
 
     get label() {
-        let label = this.props.record.data.name;
-        if (label.includes(this.productName)) {
-            label = label.replace(this.productName, "");
-            if (label.includes("\n")) {
-                label = label.replace("\n", "");
-            }
-        }
-        return label;
+        return this.props.record.data.name;
     }
 
     get Many2XAutocompleteProps() {
@@ -224,10 +217,7 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
 
     updateLabel(value) {
         this.props.record.update({
-          name:
-            this.productName && this.productName !== value
-              ? `${this.productName}\n${value}`
-              : value,
+          name: value,
         });
     }
 }


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have a partner using a different language;
2. set up an invoice or quotation for the partner;
3. add a line with a product;
4. click on the line to add a description below the product name;
5. preview the document.

Issue
-----
The product name is shown twice: once untranslated and once translated.

Cause
-----
Commit cf7290cbd8cc1 auto-prefixes the product's name to the line's label, and attempts to remove it for display. This only works when user & partner use the same language. As the product name is added to the label in the partner lang, it will no longer match the product name in user lang, leading to duplicate lines getting displayed for the partner, with the first using an inappropriate language.

Solution
--------
The description is already auto-filled using the product's name, translated to the partner's language. By not prefixing the product's name a second time, users don't have to empty the description first before editing it, and product names are no longer displayed in the wrong language.

opw-4496918