### PR TITLE
[FIX] account: prevent side effects from repeated currency changes

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -701,7 +701,7 @@ class AccountMoveLine(models.Model):
         for line in self:
             if line.amount_currency is False:
                 line.amount_currency = line.currency_id.round(line.balance * line.currency_rate)
-            if line.currency_id == line.company_id.currency_id:
+            if line._origin.currency_id == line.company_id.currency_id:
                 line.amount_currency = line.balance
 
     @api.depends_context('order_cumulated_balance', 'domain_cumulated_balance')


### PR DESCRIPTION
Steps top reproduce:
- have two currencies A (company) and B (other)
- create an invoice with currency B and and invoice line with a tax; save
- change currency to A and switch back to currency B and only after; save

Issue:
- The tax will not be correct
- do the flow multiple times and the tax becomes less and less correct https://github.com/odoo/odoo/blob/f6ffeed0e2a455d512e5f8b0d086e3c833de65cb/addons/account/models/account_move_line.py#L992

Cause:
wip

Solution:
wip

opw-4352651