### PR TITLE
[IMP] website_sale: publish combo demo data

### DIFF
--- a/addons/website_sale/data/demo.xml
+++ b/addons/website_sale/data/demo.xml
@@ -57,6 +57,9 @@
         <record id="product.product_order_01" model="product.product">
             <field name="is_published" eval="True"/>
         </record>
+        <record id="product.office_combo" model="product.product">
+            <field name="is_published" eval="True"/>
+        </record>
 
         <record id="product.product_product_4" model="product.product">
             <field name="is_published" eval="True"/>


### PR DESCRIPTION
Publishing the combo demo data on eCommerce makes it easier to test the combo configurator.
