### PR TITLE
[FIX] web: Fix search_bar holding arrowright triggers too many name_search

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -500,7 +500,7 @@ export class SearchBar extends Component {
                 break;
             case "ArrowRight":
                 if (ev.target.selectionStart === this.state.query.length) {
-                    if (focusedItem && focusedItem.isParent) {
+                    if (focusedItem && focusedItem.isParent && !ev.repeat) {
                         ev.preventDefault();
                         if (focusedItem.isExpanded) {
                             focusedIndex = this.state.focusedIndex + 1;


### PR DESCRIPTION
Steps to reproduce:
1. Write anything in a searchbar
2. Navigate on togglable item
3. Press arrowleft
4. Hold arrowright -> It will spam name_search queries

We fix this by checking that the "arrowright" event isn't held (repeat=false).

Task: 4476832

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
