### PR TITLE
[FIX] website_hr_recruitment: fix tour without demo data

### DIFF
--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -109,7 +109,7 @@ registerWebsitePreviewTour('website_hr_recruitment_tour_edit_form', {
 ...clickOnSave(),
 {
     content: "wait for the form values are patched",
-    trigger: ":iframe form input[name=partner_name]:value(mitchell admin)",
+    trigger: ":iframe form input[name=partner_name]:value(admin)",
 },
 {
     content: 'Go back to /jobs page after save',


### PR DESCRIPTION
The issue is introduced in this PR: odoo/odoo#197115

Reason:

When the test tour website_hr_recruitment_tour_edit_form is launched without demo data, the test failed because mitchell admin doesn't exist. Without demo data, the name of the administrator is administrator; so it's why instead of looking to mitchell admin this check will look to admin.

task-4571866

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
