### PR TITLE
[FIX] mail: no access to reactions for public users

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -404,7 +404,7 @@ export class Message extends Record {
 
     /** @param {import("models").Thread} thread the thread where the message is shown */
     canAddReaction(thread) {
-        return Boolean(!this.is_transient && this.thread);
+        return Boolean(!this.is_transient && this.thread?.can_react);
     }
 
     /** @param {import("models").Thread} thread the thread where the message is shown */

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -91,6 +91,8 @@ export class Thread extends Record {
     get canUnpin() {
         return this.channel_type === "chat" && this.importantCounter === 0;
     }
+    /** @type {boolean} */
+    can_react = true;
     channelMembers = Record.many("ChannelMember", {
         inverse: "thread",
         onDelete: (r) => r.delete(),

--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -44,10 +44,13 @@ class PortalChatter(http.Controller):
         store = Store()
         thread = request.env[thread_model]._get_thread_with_access(thread_id, **kwargs)
         partner = request.env.user.partner_id
-        if thread and request.env.user._is_public():
-            if portal_partner := get_portal_partner(
+        if thread:
+            mode = request.env[thread_model]._get_mail_message_access([thread_id], "create")
+            can_react = request.env[thread_model]._get_thread_with_access(thread_id, mode, **kwargs)
+            store.add(thread, {"can_react": bool(can_react)}, as_thread=True)
+            if request.env.user._is_public() and (portal_partner := get_portal_partner(
                 thread, kwargs.get("hash"), kwargs.get("pid"), kwargs.get("token")
-            ):
+            )):
                 partner = portal_partner
         store.add({"self": Store.one(partner, fields=["active", "avatar_128", "name", "user"])})
         if request.env.user.has_group("website.group_website_restricted_editor"):

--- a/addons/website_slides/static/tests/tours/slides_course_reviews.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews.js
@@ -5,7 +5,7 @@ import { registry } from "@web/core/registry";
 /**
  * This tour test that a log note isn't considered
  * as a course review. And also that a member can
- * add only one review.
+ * add only one review and react to them.
  */
 registry.category("web_tour.tours").add("course_reviews", {
     url: "/slides",
@@ -46,6 +46,29 @@ registry.category("web_tour.tours").add("course_reviews", {
         },
         {
             trigger: "div.o_portal_chatter_composer_body textarea:value(Great course!)",
+            run: "edit Mid course!",
+        },
+        {
+            trigger: ".modal.modal_shown.show button.o_portal_chatter_composer_btn",
+            run: "click",
+        },
+        {
+            content: "Reload page (fetch message)",
+            trigger: "#chatterRoot:shadow .o-mail-Chatter",
+            run() {
+                location.reload();
+            },
+        },
+        {
+            trigger: "a[id=review-tab]",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message-textContent:contains(Mid course!)",
+            run: "hover && click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message [title='Add a Reaction']",
         },
     ],
 });

--- a/addons/website_slides/static/tests/tours/slides_course_reviews_reaction_public.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews_reaction_public.js
@@ -1,0 +1,33 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+
+/**
+ * This tour tests that a public user can not react to messages
+ */
+registry.category("web_tour.tours").add("course_reviews_reaction_public", {
+    url: "/slides",
+    steps: () => [
+        {
+            trigger: "a:contains(Basics of Gardening - Test)",
+            run: "click",
+        },
+        {
+            trigger: "a[id=review-tab]",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message-textContent:contains(Bad course!)",
+            run: "hover && click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-Message-actions",
+            run: async () => {
+                const addReactionButton = document.querySelector('#chatterRoot').shadowRoot.querySelector("[title='Add a Reaction']")
+                if (addReactionButton) {
+                    throw new Error("Public user is able to react");
+                }
+            },
+        },
+    ],
+});

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -196,6 +196,15 @@ class TestUi(TestUICommon):
 
         self.start_tour('/slides', 'course_reviews', login=user_demo.login)
 
+    def test_course_reviews_reaction_public(self):
+        self.channel.message_post(
+            body="Bad course!",
+            message_type="comment",
+            rating_value="1",
+            subtype_xmlid="mail.mt_comment"
+        )
+
+        self.start_tour("/slides", "course_reviews_reaction_public", login=None)
 
 @tests.common.tagged('post_install', '-at_install')
 class TestUiPublisher(HttpCaseGamification):


### PR DESCRIPTION
Before this commit, as a public user in website chatter:
- Trying to add a reaction would result in a traceback.
- The link created from the "Copy Link" action would lead to an unauthorized page.

Steps to reproduce:
- Install website module and add course page
- As public user open a course
- Go to reviews
- Add a reaction to any message -> traceback
- Copy link to any message
- Open said link -> unauthorized page

This commit fixes the issues by adding a "can_react" field in the portal store init.

task-4551910
