### PR TITLE
[FIX] account: fix switched values in move sending setting

### DIFF
--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -1081,3 +1081,24 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         wizard.action_send_and_print()
         self.assertTrue(invoice.is_move_sent)
         self.assertTrue(invoice.invoice_pdf_report_id)
+
+    def test_get_sending_settings(self):
+        invoice = self.init_invoice("out_invoice", amounts=[1000], post=True)
+        wizard = self.create_send_and_print(invoice)
+        
+        expected_results = {
+            'sending_methods': ['email'],
+            'invoice_edi_format': False,
+            'extra_edis': [],
+            'pdf_report': self.env.ref('account.account_invoices'),
+            'author_user_id': self.env.user.id,
+            'author_partner_id': self.env.user.partner_id.id,
+            'mail_template': self.env.ref('account.email_template_edi_invoice'),
+            'mail_lang': 'en_US',
+            'mail_body': wizard.mail_body,
+            'mail_subject': 'company_1_data Invoice (Ref INV/2019/00001)',
+            'mail_partner_ids': invoice.partner_id.ids,
+            'mail_attachments_widget': [{'id': 'placeholder_INV_2019_00001.pdf', 'name': 'INV_2019_00001.pdf', 'mimetype': 'application/pdf', 'placeholder': True}],
+        }
+        results = wizard._get_sending_settings()
+        self.assertDictEqual(results, expected_results)

--- a/addons/account/wizard/account_move_send_wizard.py
+++ b/addons/account/wizard/account_move_send_wizard.py
@@ -244,8 +244,8 @@ class AccountMoveSendWizard(models.TransientModel):
             'invoice_edi_format': self.invoice_edi_format,
             'extra_edis': self.extra_edis or [],
             'pdf_report': self.pdf_report_id,
-            'author_user_id': self.env.user.partner_id.id,
-            'author_partner_id': self.env.user.id,
+            'author_user_id': self.env.user.id,
+            'author_partner_id': self.env.user.partner_id.id,
         }
         if self.sending_methods and 'email' in self.sending_methods:
             send_settings.update({


### PR DESCRIPTION
### Steps to reproduce:
- Duplicate a user
- Login to this user
- In Accounting select an invoice and try to send it by post

### Cause:
The keys `author_user_id` and `author_partner_id` have switched values. They should be like in the [batch](https://github.com/odoo/odoo/blob/becbccbef5f2aa6b062d8b3714c233dbeaca9c98/addons/account/wizard/account_move_send_batch_wizard.py#L91-L92).

opw-4531514