### PR TITLE
[IMP] website: add inner snippet text

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -160,6 +160,7 @@
         'views/snippets/s_website_form_overlay.xml',
         'views/snippets/s_title_form.xml',
         'views/snippets/s_searchbar.xml',
+        'views/snippets/s_inline_text.xml',
         'views/snippets/s_button.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_card_offset.xml',

--- a/addons/website/static/src/img/snippets_thumbs/s_inline_text.svg
+++ b/addons/website/static/src/img/snippets_thumbs/s_inline_text.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="82"
+     height="60" viewBox="0 0 82 60">
+    <defs>
+        <path id="path-1" d="M56.125 31V33H19V31H56.125ZM63 27V29H19V27H63Z"/>
+        <filter id="filter-2" width="101.9%" height="113.3%" x="-1%" y="-3.3%"
+                filterUnits="objectBoundingBox">
+            <feOffset dy="1" in="SourceAlpha" result="shadowOffsetOuter1"/>
+            <feComposite in="shadowOffsetOuter1" in2="SourceAlpha" operator="out"
+                         result="shadowOffsetOuter1"/>
+            <feColorMatrix in="shadowOffsetOuter1"
+                           values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.0995137675 0"/>
+        </filter>
+    </defs>
+    <g fill="none" fill-rule="evenodd" class="snippets_thumbs">
+        <g class="s_inline_text">
+            <rect width="82" height="60" class="bg"/>
+            <g class="combined_shape">
+                <use fill="#000" filter="url(#filter-2)" xlink:href="#path-1"/>
+                <use fill="#FFF" fill-opacity=".348" xlink:href="#path-1"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -35,6 +35,7 @@ class TestSnippets(HttpCase):
             's_instagram_page',  # avoid call to instagram.com
             's_image',  # Avoid specific case where the media dialog opens on drop
             's_snippet_group',  # Snippet groups are not snippets
+            's_inline_text',
         ]
         snippets_names = ','.join({
             f"{el.attrib['data-oe-snippet-key']}:{el.attrib.get('data-o-group', '')}"

--- a/addons/website/views/snippets/s_inline_text.xml
+++ b/addons/website/views/snippets/s_inline_text.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_inline_text" name="Text">
+    <p class="o_snippet_drop_in_only">Text</p>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -427,6 +427,7 @@
 
             <!-- Inner snippets -->
             <snippets id="snippet_content" string="Inner content">
+                <t t-snippet="website.s_inline_text" string="Text" t-thumbnail="/website/static/src/img/snippets_thumbs/s_inline_text.svg"/>
                 <t t-snippet="website.s_button" string="Button" t-thumbnail="/website/static/src/img/snippets_thumbs/s_button.svg"/>
                 <t t-snippet="website.s_image" string="Image" t-thumbnail="/website/static/src/img/snippets_thumbs/s_image.svg"/>
                 <t t-snippet="website.s_video" string="Video" t-thumbnail="/website/static/src/img/snippets_thumbs/s_video.svg"/>


### PR DESCRIPTION
Previously, a "Text" inner snippet was missing, making it difficult to add text to certain elements. Users might struggle to find the correct place to click or otherwise initiate text entry, as the interaction wasn't intuitive.

This commit adds the missing "Text" inner snippet, providing a clear and easy way for users to add text inside every element where inner snippets can be dropped.

task-4554944


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
