### PR TITLE
[FIX] website: select at max one translation node


### DIFF
--- a/addons/website/static/src/components/translator/translator.js
+++ b/addons/website/static/src/components/translator/translator.js
@@ -255,7 +255,8 @@ export class WebsiteTranslator extends WebsiteEditorComponent {
         // Apply data-oe-readonly on nested data.
         $(this.websiteService.pageDocument).find(savableSelector)
             .filter(':has(' + savableSelector + ')')
-            .attr('data-oe-readonly', true);
+            .attr('data-oe-readonly', true)
+            .removeAttr('contenteditable');
 
         const styleEl = document.createElement('style');
         styleEl.id = "translate-stylesheet";


### PR DESCRIPTION
Steps to reproduce:
- go to a blog post with several paragraph
- edit translations

Issue 1:
- select several paragraph completely and use the translate tool
- insert the translation
=> the translation are not inserted

Issue 2:
- select 3 paragraphs but don't start at the beginning or end of
  the text
- insert translation
- see that all translations is inserted at end of paragraph 1, paragraph
  2 is emptied and paragraph 3 selected part is removed
- save
=> paragraph 1 and 2 are deleted (so we show original lang value),
   selected part of paragraph 3 is removed

Why:

In the blog post content, we are inside a "blog.post().content"
editable field, this allows the editor to select several translations
nodes which will work wrongly with the editor because translation mode
only expect to change the content of translation nodes.

The first paragraph translation is saved empty because the editor is
cloning the node with the same "data-oe-translation-source-sha"
because we are inserting several paragraphs inside it.

Fix: in translation mode, make the editable node of html fields around
translation nodes uneditable so we can't select several translation
nodes thanks to how browser handle selection and content editable.

Note: the added test step is very light, because in javascript it is
programmatically possible to select 2 separate content editable. At the
step that is added in the tour, with the fix it is not possible to
select both the H1 and P nodes.

opw-4221993
opw-4482717

pr note: opw-4221993 could possibly solved by this fix too (the video reproduction seemed to be about a bulleted list but I could not reproduce, and the original report video is deleted)