### PR TITLE
[FIX] account, pos_discount: fix base propagation for included taxes

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -813,10 +813,13 @@ class AccountTax(models.Model):
                 # t2: price-included 10% tax
                 # On a price unit of 122, base amount of t2 is computed as 122 - 1 = 121
                 if special_mode in (False, 'total_included'):
-                    if not batch['include_base_amount']:
+                    if batch['include_base_amount']:
                         for other_batch in batches_after:
-                            if other_batch['_original_price_include']:
+                            if not other_batch['is_base_affected']:
                                 add_extra_base(other_batch, tax_data, -1)
+                    else:
+                        for other_batch in batches_after:
+                            add_extra_base(other_batch, tax_data, -1)
                     for other_batch in batches_before:
                         add_extra_base(other_batch, tax_data, -1)
 
@@ -834,9 +837,10 @@ class AccountTax(models.Model):
                 # With special_mode = 'total_excluded' 109 is provided as price unit.
                 # To compute the base amount of t2, we need to add the tax amount of t1 first
                 else:  # special_mode == 'total_excluded'
-                    for other_batch in batches_after:
-                        if not other_batch['_original_price_include'] or batch['include_base_amount']:
-                            add_extra_base(other_batch, tax_data, 1)
+                    if batch['include_base_amount']:
+                        for other_batch in batches_after:
+                            if other_batch['is_base_affected']:
+                                add_extra_base(other_batch, tax_data, 1)
 
             elif not batch['_original_price_include']:
 

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -143,20 +143,26 @@ export const accountTaxHelpers = {
         for (const tax_data of batch.taxes) {
             if (batch._original_price_include) {
                 if (!special_mode || special_mode === "total_included") {
-                    if (!batch.include_base_amount) {
+                    if (batch.include_base_amount) {
                         for (const other_batch of batches_after) {
-                            if (other_batch._original_price_include) {
+                            if (!other_batch.is_base_affected) {
                                 add_extra_base(other_batch, tax_data, -1);
                             }
+                        }
+                    } else {
+                        for (const other_batch of batches_after) {
+                            add_extra_base(other_batch, tax_data, -1);
                         }
                     }
                     for (const other_batch of batches_before) {
                         add_extra_base(other_batch, tax_data, -1);
                     }
                 } else {  // special_mode === "total_excluded"
-                    for (const other_batch of batches_after) {
-                        if (!other_batch._original_price_include || batch.include_base_amount) {
-                            add_extra_base(other_batch, tax_data, 1);
+                    if (batch.include_base_amount) {
+                        for (const other_batch of batches_after) {
+                            if (other_batch.is_base_affected) {
+                                add_extra_base(other_batch, tax_data, 1);
+                            }
                         }
                     }
                 }

--- a/addons/account/tests/test_taxes_computation.py
+++ b/addons/account/tests/test_taxes_computation.py
@@ -660,6 +660,83 @@ class TestTax(TestTaxCommon):
                 {'rounding_method': 'round_globally'},
             ),
         ))
+
+        # tax       price_incl      incl_base_amount    is_base_affected
+        # ----------------------------------------------------------------
+        # tax1      T               T                   T
+        # tax2
+        # tax3                                          T
+        tax2.price_include = False
+        tax2.include_base_amount = False
+        tests.extend((
+            self._prepare_taxes_computation_test(
+                tax1 + tax2 + tax3,
+                106.0,
+                {
+                    'total_included': 115.18,
+                    'total_excluded': 100.0,
+                    'taxes_data': (
+                        (100.0, 6.0),
+                        (100.0, 6.0),
+                        (106.0, 3.18),
+                    ),
+                },
+                {
+                    'rounding_method': 'round_globally',
+                    'excluded_special_modes': ['total_included'],
+                },
+            ),
+        ))
+
+        # tax       price_incl      incl_base_amount    is_base_affected
+        # ----------------------------------------------------------------
+        # tax1      T               T                   T
+        # tax2                                          T
+        # tax3                                          T
+        tax2.is_base_affected = True
+        tests.extend((
+            self._prepare_taxes_computation_test(
+                tax1 + tax2 + tax3,
+                106.0,
+                {
+                    'total_included': 115.54,
+                    'total_excluded': 100.0,
+                    'taxes_data': (
+                        (100.0, 6.0),
+                        (106.0, 6.36),
+                        (106.0, 3.18),
+                    ),
+                },
+                {
+                    'rounding_method': 'round_globally',
+                },
+            ),
+        ))
+
+        # tax       price_incl      incl_base_amount    is_base_affected
+        # ----------------------------------------------------------------
+        # tax1      T                                   T
+        # tax2
+        # tax3                                          T
+        tax1.include_base_amount = False
+        tests.extend((
+            self._prepare_taxes_computation_test(
+                tax1 + tax2 + tax3,
+                106.0,
+                {
+                    'total_included': 115.0,
+                    'total_excluded': 100.0,
+                    'taxes_data': (
+                        (100.0, 6.0),
+                        (100.0, 6.0),
+                        (100.0, 3.0),
+                    ),
+                },
+                {
+                    'rounding_method': 'round_globally',
+                },
+            ),
+        ))
         self._assert_tests(tests)
 
     def test_division_taxes_for_l10n_br(self):
@@ -817,7 +894,7 @@ class TestTax(TestTaxCommon):
                     'taxes_data': (
                         (99.0, 1.0),
                         (100.0, 21.0),
-                        (121.0, 2.0),
+                        (100.0, 2.0),
                     ),
                 },
                 {'rounding_method': 'round_globally'},
@@ -910,7 +987,7 @@ class TestTax(TestTaxCommon):
                     'taxes_data': (
                         (100.0, 1.0),
                         (100.0, 21.0),
-                        (122.0, 2.0),
+                        (121.0, 2.0),
                     ),
                 },
                 {'rounding_method': 'round_globally'},
@@ -933,7 +1010,7 @@ class TestTax(TestTaxCommon):
                     'taxes_data': (
                         (100.0, 1.0),
                         (100.0, 21.0),
-                        (122.0, 2.0),
+                        (100.0, 2.0),
                     ),
                 },
                 {'rounding_method': 'round_globally'},

--- a/addons/pos_discount/tests/test_frontend.py
+++ b/addons/pos_discount/tests/test_frontend.py
@@ -45,6 +45,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'amount_type': 'percent',
             'amount': 10.0,
             'type_tax_use': 'none',
+            'include_base_amount': True,
             'price_include': True
         })
         tax_20 = self.env['account.tax'].create({


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Create an included tax:
  * Amount: 20%
  * Included in Price: [enabled]
  * Affect Base of Subsequent Taxes: [disabled]
- Create a retention tax:
  * Amount: -5%
  * Included in Price: [disabled]
  * Affect Base of Subsequent Taxes: [disabled]
  * Base Affected by Previous Taxes: [enabled]
- Create an invoice:
  * Price: 120.0
  * Taxes: [Both created taxes]

**Issue:**
The base amount used to compute the retention tax is including the amount of the included tax (i.e. 120.0), but it should not (i.e. 100.0) as the included tax doesn't affect the base of subsequent taxes.

**Cause:**
When "special_mode" is False, all excluded taxes following an included tax have their base affected by the included tax.

opw-4451617




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
