### PR TITLE
[FIX] product: show archived related products

### DIFF
--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -90,7 +90,7 @@ class ProductAttribute(models.Model):
             'name': _("Related Products"),
             'res_model': 'product.template',
             'view_mode': 'tree,form',
-            'domain': [('id', 'in', self.product_tmpl_ids.ids)],
+            'domain': [('id', 'in', self.with_context(active_test=False).product_tmpl_ids.ids)],
         }
 
 


### PR DESCRIPTION
**Issue**
When displaying related products for a product attribute, only unarchived products are shown, even when the archived filter is applied.

Steps to Reproduce:

1. Install the Sales app
2. Select or create a product
3. Select or create an attribute and values
4. Archive the product
5. Go to the attribute page
6. Click on related products smart button
7. Set Archived filter
8. Observe that the archived product is not displayed.

Expected Behavior: After applying the Archived filter, related products, including archived ones, should be displayed.

Actual Behavior: Archived related products are not shown, even when the Archived filter is applied.

**Root Cause**

When the related products smart button is clicked, the action_open_related_products method is triggered. In this method, when applying the domain for related products, an implicit active_test=True filter is applied by default. This filter excludes archived records, meaning only active (unarchived) products are displayed.

**Fix**
The issue was resolved by explicitly modifying the context to include archived products by setting active_test=False when querying the related products. This ensures that both active and archived related products are shown, even when the Archived filter is applied.

opw-4565133

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
