### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: fix journal dashboard view error for non-admin users

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/views/account_journal_dashboard_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/views/account_journal_dashboard_views.xml
@@ -12,7 +12,7 @@
                 </xpath>
 
                 <xpath expr="//t[@id='account.JournalBodySalePurchase']//div" position="inside">
-                    <t t-if="record.l10n_tr_nilvera_api_key.raw_value">
+                    <t t-if="record.l10n_tr_nilvera_api_key and record.l10n_tr_nilvera_api_key.raw_value">
                         <t t-if="journal_type == 'sale'">
                             <div class="w-100">
                                 <a type="object" name="l10n_tr_nilvera_get_message_status" groups="account.group_account_invoice">Fetch Nilvera invoice status</a>


### PR DESCRIPTION
Before this commit:
Steps
1) Install the Turkish localization modules (l10n_tr, l10n_tr_nilvera) 
2) Switch to TR company
3) Create a user without administration access
4) Try to open accounting module using the created user

=> An OwlError is raised with the message `Caused by: TypeError: Cannot read properties of undefined (reading 'raw_value')`, This occurs because the `l10n_tr_nilvera_api_key` field is restricted to admin users. As a result, non-admin users experience a broken journal dashboard view due to missing access

After this commit:
The Accounting module and journal dashboard view work correctly for non-admin users

Reproducing the issue in Runbot: https://drive.google.com/file/d/1YIjvoXNDe6atVyzWC1dVU58rDFnoYH7x/view?usp=drive_link

opw-4551932
