### PR TITLE
[FIX] account: prevent deprecating accounts used in tax distribution

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -15913,6 +15913,13 @@ msgstr ""
 
 #. module: account
 #. odoo-python
+#: code:addons/account/models/account_account.py:0
+#, python-format
+msgid "You cannot deprecate an account that is used in a tax distribution."
+msgstr ""
+
+#. module: account
+#. odoo-python
 #: code:addons/account/models/res_config_settings.py:0
 #, python-format
 msgid ""

--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -687,6 +687,9 @@ class AccountAccount(models.Model):
                 if self.env['account.move.line'].search_count([('account_id', '=', account.id), ('currency_id', 'not in', (False, vals['currency_id']))]):
                     raise UserError(_('You cannot set a currency on this account as it already has some journal entries having a different foreign currency.'))
 
+        if vals.get('deprecated') and self.env["account.tax.repartition.line"].search_count([('account_id', 'in', self.ids)], limit=1):
+            raise UserError(_("You cannot deprecate an account that is used in a tax distribution."))
+
         return super(AccountAccount, self).write(vals)
 
     @api.ondelete(at_uninstall=False)


### PR DESCRIPTION
This commit adds a check to prevent deprecating an account that is used in tax distribution lines.

It serves as an indirect fix to avoid  future issues in other contexts. For example, in the Italian EDI flow, if an XML bill includes a tax with a distribution line linked to a deprecated account, an error will be raised by the following code: https://github.com/odoo/odoo/blob/cc3a060e67a2f1015ea02b589dcf6a7e7eff1e90/addons/account/models/account_move_line.py#L1478 This commit aims to minimize such issues by preventing them as early as possible.

Steps to reproduce:
- Try to deprecate an account that is used in tax distribution lines.

