### PR TITLE
[IMP] point_of_sale: test load ticket screen offline

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -9,6 +9,7 @@ import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import { inLeftSide } from "@point_of_sale/../tests/pos/tours/utils/common";
 import { registry } from "@web/core/registry";
+import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
 
 registry.category("web_tour.tours").add("TicketScreenTour", {
     checkDelay: 50,
@@ -16,7 +17,10 @@ registry.category("web_tour.tours").add("TicketScreenTour", {
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
+            OfflineUtil.setOfflineMode(),
             Chrome.clickOrders(),
+            Dialog.confirm("Continue with limited functionality"),
+            OfflineUtil.setOnlineMode(),
             Chrome.createFloatingOrder(),
             ProductScreen.addOrderline("Desk Pad", "1", "3"),
             Chrome.clickOrders(),


### PR DESCRIPTION
- Since the fix done in thix PR (https://github.com/odoo/odoo/pull/196810) we can access the ticket screen when offline. This PR is just adding steps in existing tour to test this feature.

task-id: 4550978

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
