### PR TITLE
[IMP] core: Improve performance of import

### DIFF
--- a/odoo/addons/base/models/ir_fields.py
+++ b/odoo/addons/base/models/ir_fields.py
@@ -207,7 +207,7 @@ class IrFieldsConverter(models.AbstractModel):
         try:
             return json.loads(value), []
         except ValueError:
-            msg = _("'%s' does not seem to be a valid JSON for field '%%(field)s'")
+            msg = self.env._("'%s' does not seem to be a valid JSON for field '%%(field)s'")
             raise self._format_import_error(ValueError, msg, value)
 
     def _str_to_properties(self, model, field, value):
@@ -217,17 +217,17 @@ class IrFieldsConverter(models.AbstractModel):
             try:
                 value = json.loads(value)
             except ValueError:
-                msg = _("Unable to import'%%(field)s' Properties field as a whole, target individual property instead.")
+                msg = self.env._("Unable to import'%%(field)s' Properties field as a whole, target individual property instead.")
                 raise self._format_import_error(ValueError, msg)
 
         if not isinstance(value, list):
-            msg = _("Unable to import'%%(field)s' Properties field as a whole, target individual property instead.")
+            msg = self.env._("Unable to import'%%(field)s' Properties field as a whole, target individual property instead.")
             raise self._format_import_error(ValueError, msg, {'value': value})
 
         warnings = []
         for property_dict in value:
             if not (property_dict.keys() >= {'name', 'type', 'string'}):
-                msg = _("'%(value)s' does not seem to be a valid Property value for field '%%(field)s'. Each property need at least 'name', 'type' and 'string' attribute.")
+                msg = self.env._("'%(value)s' does not seem to be a valid Property value for field '%%(field)s'. Each property need at least 'name', 'type' and 'string' attribute.")
                 raise self._format_import_error(ValueError, msg, {'value': property_dict})
 
             val = property_dict.get('value')
@@ -244,7 +244,7 @@ class IrFieldsConverter(models.AbstractModel):
                     if val in (sel_val, sel_label)
                 ), None)
                 if not new_val:
-                    msg = _("'%(value)s' does not seem to be a valid Selection value for '%(label_property)s' (subfield of '%%(field)s' field).")
+                    msg = self.env._("'%(value)s' does not seem to be a valid Selection value for '%(label_property)s' (subfield of '%%(field)s' field).")
                     raise self._format_import_error(ValueError, msg, {'value': val, 'label_property': property_dict['string']})
                 property_dict['value'] = new_val
 
@@ -257,7 +257,7 @@ class IrFieldsConverter(models.AbstractModel):
                         if tag in (tag_val, tag_label)
                     ), None)
                     if not val_tag:
-                        msg = _("'%(value)s' does not seem to be a valid Tag value for '%(label_property)s' (subfield of '%%(field)s' field).")
+                        msg = self.env._("'%(value)s' does not seem to be a valid Tag value for '%(label_property)s' (subfield of '%%(field)s' field).")
                         raise self._format_import_error(ValueError, msg, {'value': tag, 'label_property': property_dict['string']})
                     new_val.append(val_tag)
                 property_dict['value'] = new_val
@@ -267,7 +267,7 @@ class IrFieldsConverter(models.AbstractModel):
                 if not warnings:
                     property_dict['value'] = new_val
                 else:
-                    msg = _("Unknown value '%(value)s' for boolean '%(label_property)s' property (subfield of '%%(field)s' field).")
+                    msg = self.env._("Unknown value '%(value)s' for boolean '%(label_property)s' property (subfield of '%%(field)s' field).")
                     raise self._format_import_error(ValueError, msg, {'value': val, 'label_property': property_dict['string']})
 
             elif property_type in ('many2one', 'many2many'):
@@ -283,7 +283,7 @@ class IrFieldsConverter(models.AbstractModel):
                 ids = []
                 fake_field = FakeField(comodel_name=property_dict['comodel'], name=property_dict['string'])
                 for reference in references:
-                    id_, __, ws = self.db_id_for(model, fake_field, subfield, reference)
+                    id_, ws = self.db_id_for(model, fake_field, subfield, reference)
                     ids.append(id_)
                     warnings.extend(ws)
 
@@ -293,14 +293,14 @@ class IrFieldsConverter(models.AbstractModel):
                 try:
                     property_dict['value'] = int(val)
                 except ValueError:
-                    msg = _("'%(value)s' does not seem to be an integer for field '%(label_property)s' property (subfield of '%%(field)s' field).")
+                    msg = self.env._("'%(value)s' does not seem to be an integer for field '%(label_property)s' property (subfield of '%%(field)s' field).")
                     raise self._format_import_error(ValueError, msg, {'value': val, 'label_property': property_dict['string']})
 
             elif property_type == 'float':
                 try:
                     property_dict['value'] = float(val)
                 except ValueError:
-                    msg = _("'%(value)s' does not seem to be an float for field '%(label_property)s' property (subfield of '%%(field)s' field).")
+                    msg = self.env._("'%(value)s' does not seem to be an float for field '%(label_property)s' property (subfield of '%%(field)s' field).")
                     raise self._format_import_error(ValueError, msg, {'value': val, 'label_property': property_dict['string']})
 
         return value, warnings
@@ -331,9 +331,9 @@ class IrFieldsConverter(models.AbstractModel):
 
         return True, [self._format_import_error(
             ValueError,
-            _(u"Unknown value '%s' for boolean field '%%(field)s'"),
+            self.env._("Unknown value '%s' for boolean field '%%(field)s'"),
             value,
-            {'moreinfo': _(u"Use '1' for yes and '0' for no")}
+            {'moreinfo': self.env._("Use '1' for yes and '0' for no")}
         )]
 
     @api.model
@@ -343,7 +343,7 @@ class IrFieldsConverter(models.AbstractModel):
         except ValueError:
             raise self._format_import_error(
                 ValueError,
-                _(u"'%s' does not seem to be an integer for field '%%(field)s'"),
+                self.env._("'%s' does not seem to be an integer for field '%%(field)s'"),
                 value
             )
 
@@ -354,7 +354,7 @@ class IrFieldsConverter(models.AbstractModel):
         except ValueError:
             raise self._format_import_error(
                 ValueError,
-                _(u"'%s' does not seem to be a number for field '%%(field)s'"),
+                self.env._("'%s' does not seem to be a number for field '%%(field)s'"),
                 value
             )
 
@@ -374,9 +374,9 @@ class IrFieldsConverter(models.AbstractModel):
         except ValueError:
             raise self._format_import_error(
                 ValueError,
-                _(u"'%s' does not seem to be a valid date for field '%%(field)s'"),
+                self.env._("'%s' does not seem to be a valid date for field '%%(field)s'"),
                 value,
-                {'moreinfo': _(u"Use the format '%s'", u"2012-12-31")}
+                {'moreinfo': self.env._("Use the format '%s'", u"2012-12-31")}
             )
 
     @api.model
@@ -406,9 +406,9 @@ class IrFieldsConverter(models.AbstractModel):
         except ValueError:
             raise self._format_import_error(
                 ValueError,
-                _(u"'%s' does not seem to be a valid datetime for field '%%(field)s'"),
+                self.env._("'%s' does not seem to be a valid datetime for field '%%(field)s'"),
                 value,
-                {'moreinfo': _(u"Use the format '%s'", u"2012-12-31 23:59:59")}
+                {'moreinfo': self.env._("Use the format '%s'", u"2012-12-31 23:59:59")}
             )
 
         input_tz = self._input_tz()# Apply input tz to the parsed naive datetime
@@ -485,7 +485,7 @@ class IrFieldsConverter(models.AbstractModel):
             return False, []
         raise self._format_import_error(
             ValueError,
-            _(u"Value '%s' not found in selection field '%%(field)s'"),
+            self.env._("Value '%s' not found in selection field '%%(field)s'"),
             value,
             {'moreinfo': [_label or str(item) for item, _label in selection if _label or item]}
         )
@@ -520,7 +520,7 @@ class IrFieldsConverter(models.AbstractModel):
             'view_mode': 'list,form',
             'views': [(False, 'list'), (False, 'form')],
             'context': {'create': False},
-            'help': _(u"See all possible values")}
+            'help': self.env._("See all possible values")}
         if subfield is None:
             action['res_model'] = field.comodel_name
         elif subfield in ('id', '.id'):
@@ -529,23 +529,23 @@ class IrFieldsConverter(models.AbstractModel):
 
         RelatedModel = self.env[field.comodel_name]
         if subfield == '.id':
-            field_type = _(u"database id")
+            field_type = self.env._("database id")
             if isinstance(value, str) and not self._str_to_boolean(model, field, value)[0]:
-                return False, field_type, warnings
+                return False, warnings
             try:
                 tentative_id = int(value)
             except ValueError:
                 raise self._format_import_error(
                     ValueError,
-                    _(u"Invalid database id '%s' for the field '%%(field)s'"),
+                    self.env._("Invalid database id '%s' for the field '%%(field)s'"),
                     value,
                     {'moreinfo': action})
             if RelatedModel.browse(tentative_id).exists():
                 id = tentative_id
         elif subfield == 'id':
-            field_type = _(u"external id")
+            field_type = self.env._("external id")
             if not self._str_to_boolean(model, field, value)[0]:
-                return False, field_type, warnings
+                return False, warnings
             if '.' in value:
                 xmlid = value
             else:
@@ -553,9 +553,9 @@ class IrFieldsConverter(models.AbstractModel):
             flush(xml_id=xmlid)
             id = self._xmlid_to_record_id(xmlid, RelatedModel)
         elif subfield is None:
-            field_type = _(u"name")
+            field_type = self.env._("name")
             if value == '':
-                return False, field_type, warnings
+                return False, warnings
             flush(model=field.comodel_name)
             ids = RelatedModel.name_search(name=value, operator='=')
             if ids:
@@ -573,11 +573,11 @@ class IrFieldsConverter(models.AbstractModel):
                         with self.env.cr.savepoint():
                             id, _name = RelatedModel.name_create(name=value)
                     except (Exception, psycopg2.IntegrityError):
-                        error_msg = _("Cannot create new '%s' records from their name alone. Please create those records manually and try importing again.", RelatedModel._description)
+                        error_msg = self.env._("Cannot create new '%s' records from their name alone. Please create those records manually and try importing again.", RelatedModel._description)
         else:
             raise self._format_import_error(
                 Exception,
-                _("Unknown sub-field “%s”", subfield),
+                self.env._("Unknown sub-field “%s”", subfield),
             )
 
         set_empty = False
@@ -589,9 +589,9 @@ class IrFieldsConverter(models.AbstractModel):
             skip_record = field_path in self.env.context.get('import_skip_records', [])
         if id is None and not set_empty and not skip_record:
             if error_msg:
-                message = _("No matching record found for %(field_type)s '%(value)s' in field '%%(field)s' and the following error was encountered when we attempted to create one: %(error_message)s")
+                message = self.env._("No matching record found for %(field_type)s '%(value)s' in field '%%(field)s' and the following error was encountered when we attempted to create one: %(error_message)s")
             else:
-                message = _("No matching record found for %(field_type)s '%(value)s' in field '%%(field)s'")
+                message = self.env._("No matching record found for %(field_type)s '%(value)s' in field '%%(field)s'")
 
             error_info_dict = {'moreinfo': action}
             if self.env.context.get('import_file'):
@@ -605,7 +605,7 @@ class IrFieldsConverter(models.AbstractModel):
                 message,
                 {'field_type': field_type, 'value': value, 'error_message': error_msg},
                 error_info_dict)
-        return id, field_type, warnings
+        return id, warnings
 
     def _xmlid_to_record_id(self, xmlid, model):
         """ Return the record id corresponding to the given external id,
@@ -646,10 +646,10 @@ class IrFieldsConverter(models.AbstractModel):
         fieldset = set(record)
         if fieldset - REFERENCING_FIELDS:
             raise ValueError(
-                _(u"Can not create Many-To-One records indirectly, import the field separately"))
+                self.env._("Can not create Many-To-One records indirectly, import the field separately"))
         if len(fieldset) > 1:
             raise ValueError(
-                _(u"Ambiguous specification for field '%(field)s', only provide one of name, external id or database id"))
+                self.env._("Ambiguous specification for field '%(field)s', only provide one of name, external id or database id"))
 
         # only one field left possible, unpack
         [subfield] = fieldset
@@ -662,7 +662,7 @@ class IrFieldsConverter(models.AbstractModel):
 
         subfield, w1 = self._referencing_subfield(record)
 
-        id, _, w2 = self.db_id_for(model, field, subfield, record[subfield])
+        id, w2 = self.db_id_for(model, field, subfield, record[subfield])
         return id, w1 + w2
 
     @api.model
@@ -677,7 +677,7 @@ class IrFieldsConverter(models.AbstractModel):
 
         ids = []
         for reference in record[subfield].split(','):
-            id, _, ws = self.db_id_for(model, field, subfield, reference)
+            id, ws = self.db_id_for(model, field, subfield, reference)
             ids.append(id)
             warnings.extend(ws)
 
@@ -738,7 +738,7 @@ class IrFieldsConverter(models.AbstractModel):
                 subfield, w1 = self._referencing_subfield(refs)
                 warnings.extend(w1)
                 try:
-                    id, _, w2 = self.db_id_for(model, field, subfield, record[subfield])
+                    id, w2 = self.db_id_for(model, field, subfield, record[subfield])
                     warnings.extend(w2)
                 except ValueError:
                     if subfield != 'id':

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -917,9 +917,15 @@ class Cache:
         """ Return the fields that have dirty records in cache. """
         return self._dirty.keys()
 
-    def get_dirty_records(self, model: BaseModel, field: Field) -> BaseModel:
-        """ Return the records that for which ``field`` is dirty in cache. """
-        return model.browse(self._dirty.get(field, ()))
+    def filtered_dirty_records(self, records: BaseModel, field: Field) -> BaseModel:
+        """ Filtered ``records`` where ``field`` is dirty. """
+        dirties = self._dirty.get(field, ())
+        return records.browse(id_ for id_ in records._ids if id_ in dirties)
+
+    def filtered_clean_records(self, records: BaseModel, field: Field) -> BaseModel:
+        """ Filtered ``records`` where ``field`` is not dirty. """
+        dirties = self._dirty.get(field, ())
+        return records.browse(id_ for id_ in records._ids if id_ not in dirties)
 
     def has_dirty_fields(self, records: BaseModel, fields: Collection[Field] | None = None) -> bool:
         """ Return whether any of the given records has dirty fields.

--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -201,7 +201,7 @@ class BaseString(Field[str | typing.Literal[False]]):
             return
 
         # flush dirty None values
-        dirty_records = records & cache.get_dirty_records(records, self)
+        dirty_records = cache.filtered_dirty_records(records, self)
         if any(v is None for v in cache.get_values(dirty_records, self)):
             dirty_records.flush_recordset([self.name])
 
@@ -216,7 +216,7 @@ class BaseString(Field[str | typing.Literal[False]]):
         # model translation
         if not callable(self.translate):
             # invalidate clean fields because them may contain fallback value
-            clean_records = records - cache.get_dirty_records(records, self)
+            clean_records = cache.filtered_clean_records(records, self)
             clean_records.invalidate_recordset([self.name])
             cache.update(records, self, itertools.repeat(cache_value), dirty=True)
             if lang != 'en_US' and not records.env['res.lang']._get_data(code='en_US'):

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1102,7 +1102,9 @@ class BaseModel(metaclass=MetaModel):
             # Get all following rows which have relational values attached to
             # the current record (no non-relational values)
             record_span = itertools.takewhile(
-                only_o2m_values, itertools.islice(data, index + 1, None))
+                only_o2m_values,
+                (data[j] for j in range(index + 1, len(data))),
+            )
             # stitch record row back on for relational fields
             record_span = list(itertools.chain([row], record_span))
 


### PR DESCRIPTION
The goal of these commit is to improve the performance of large csv file loading. In the same time, it also improves the performance of any imports (especially the big one).

### [IMP] core: Improve import performance

db_id_for() is heavily used when we import or load a csv file. It translates a lot of strings (unused at the end) strings with
the old _() API, which adds extra cost to find the right environment in the stack.

Use self.env._() in all the ir_fields.py file and change the API of db_id_for() to avoid returning field_type because it is never used.

Improvements:
To load l10n_us_hr_payroll/data/res.city.csv, the convert_to_record() took 15 sec, and now it takes 4.5 sec during an upgrade of l10n_us_hr_payroll modules.

### [FIX] core: avoid quadratic complexity of _extract_records()

islice() with a start index actually iterates and ignores elements until the start index is reached (see https://docs.python.org/3/library/itertools.html#itertools.islice). In this case, it leads to a quadratic behavior because we loop once on the data and a second time inside the islice() to reach at least the start index.

We make our own iterator that starts directly at the right place, since we know that the data is a list.

Performance improvements:
To load l10n_us_hr_payroll/data/res.city.csv, the convert_to_record() took 4.5 sec, and now it takes 2 sec during an upgrade of the l10n_us_hr_payroll module.

### [IMP] core: improve performance BaseString.write() for translated field.

BaseString.write() for a translated field becomes slower the more dirty data we have in the cache for that field. This can drastically slow down the import of records that already exist in the DB.

Improvements:
To reload l10n_us_hr_payroll/data/res.city.csv, the _load_records_write() took 20 sec, and now it takes 1.9 sec during an upgrade of the l10n_us_hr_payroll module.

### Global improvements

With the profiling running (with biased of the profiling)

- During installation of l10n_us_hr_payroll, load `l10n_us_hr_payroll/data/res.city.csv` 19.04 sec -> 5.18 sec:
Profiling before: [profile_before_install.json](https://github.com/user-attachments/files/18785414/profile_before_install.json)
Profiling after: [profile_after_install.json](https://github.com/user-attachments/files/18784762/profile_after.json)

- During upgrade of l10n_us_hr_payroll, load `l10n_us_hr_payroll/data/res.city.csv` 45.94 sec -> 5.19 sec:
Profiling before: [profile_before_upgrade.json](https://github.com/user-attachments/files/18785415/profile_before_upgrade.json)
Profiling after: [profile_after_upgrade.json](https://github.com/user-attachments/files/18784784/profile_2.json)



