### PR TITLE
[IMP] account: compute invoice salesperson from partner salesperson

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -754,13 +754,19 @@ class AccountMove(models.Model):
     # COMPUTE METHODS
     # -------------------------------------------------------------------------
 
-    @api.depends('move_type')
+    @api.depends('move_type', 'partner_id')
     def _compute_invoice_default_sale_person(self):
         # We want to modify the sale person only when we don't have one and if the move type corresponds to this condition
         # If the move doesn't correspond, we remove the sale person
         for move in self:
             if move.is_sale_document(include_receipts=True):
-                move.invoice_user_id = move.invoice_user_id or self.env.user
+                if move.partner_id:
+                    move.invoice_user_id = (
+                        move.invoice_user_id
+                        or move.partner_id.user_id
+                        or move.partner_id.commercial_partner_id.user_id
+                        or self.env.user
+                    )
             else:
                 move.invoice_user_id = False
 


### PR DESCRIPTION
For `sale.order`, the salesperson (`user_id`) on the order is set to
the partner's salesperson (`user_id` on `res.partner`) if set.

Currently, `account.move` sets the salesperson (`invoice_user_id`) to
the user creating the invoice.

With this commit, `invoice_user_id` is set to the partner's salesperson
if exists.

task-4374265