### PR TITLE
[REV] account: Fix reverse charge tax amounts when price-included

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3718,12 +3718,7 @@ class AccountMove(models.Model):
             price_untaxed = self.currency_id.round(
                 remaining_amount / (((1.0 - discount_percentage / 100.0) * (taxes.amount / 100.0)) + 1.0))
         else:
-            tax_results = taxes.with_context(force_price_include=True).compute_all(remaining_amount)
-            price_untaxed = tax_results['total_excluded'] - sum(
-                tax_data['amount']
-                for tax_data in tax_results['taxes']
-                if tax_data['is_reverse_charge']
-            )
+            price_untaxed = taxes.with_context(force_price_include=True).compute_all(remaining_amount)['total_excluded']
         return {'account_id': account_id, 'tax_ids': taxes.ids, 'price_unit': price_untaxed}
 
     @api.onchange('quick_edit_mode', 'journal_id', 'company_id')

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1089,6 +1089,11 @@ class AccountTax(models.Model):
                 base = manual_tax_amounts[str(tax.id)]['base_amount_currency']
             else:
                 total_tax_amount = sum(taxes_data[other_tax.id]['tax_amount'] for other_tax in tax_data['batch'])
+                total_tax_amount += sum(
+                    reverse_charge_taxes_data[other_tax.id]['tax_amount']
+                    for other_tax in taxes_data[tax.id]['batch']
+                    if other_tax.has_negative_factor
+                )
                 base = raw_base + tax_data['extra_base_for_base']
                 if tax_data['price_include'] and special_mode in (False, 'total_included'):
                     base -= total_tax_amount

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -360,10 +360,13 @@ export const accountTaxHelpers = {
             if (manual_tax_amounts && "base_amount_currency" in manual_tax_amounts[tax.id]) {
                 base = manual_tax_amounts[tax.id].base_amount_currency;
             } else {
-                const total_tax_amount = taxes_data[tax.id].batch.reduce(
+                let total_tax_amount = taxes_data[tax.id].batch.reduce(
                     (sum, other_tax) => sum + taxes_data[other_tax.id].tax_amount,
                     0
                 );
+                total_tax_amount += Object.values(taxes_data[tax.id].batch)
+                    .filter(other_tax => other_tax.has_negative_factor)
+                    .reduce((sum, other_tax) => sum + reverse_charge_taxes_data[other_tax.id].tax_amount, 0);
                 base = raw_base + taxes_data[tax.id].extra_base_for_base;
                 if (
                     tax_data.price_include &&

--- a/addons/account/tests/test_taxes_tax_totals_summary.py
+++ b/addons/account/tests/test_taxes_tax_totals_summary.py
@@ -2202,20 +2202,20 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
         expected_values = {
             'same_tax_base': True,
             'currency_id': self.currency.id,
-            'base_amount_currency': 100.0,
+            'base_amount_currency': 121.0,
             'tax_amount_currency': 0.0,
-            'total_amount_currency': 100.0,
+            'total_amount_currency': 121.0,
             'subtotals': [
                 {
                     'name': "Untaxed Amount",
-                    'base_amount_currency': 100.0,
+                    'base_amount_currency': 121.0,
                     'tax_amount_currency': 0.0,
                     'tax_groups': [
                         {
                             'id': self.tax_groups[0].id,
-                            'base_amount_currency': 100.0,
+                            'base_amount_currency': 121.0,
                             'tax_amount_currency': 0.0,
-                            'display_base_amount_currency': 100.0,
+                            'display_base_amount_currency': 121.0,
                         },
                     ],
                 },
@@ -2235,8 +2235,8 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
                 invoice = self.convert_document_to_invoice(document)
                 self.assert_invoice_tax_totals_summary(invoice, expected_values)
                 self.assertRecordValues(invoice.invoice_line_ids, [{
-                    'price_subtotal': 100.0,
-                    'price_total': 100.0,
+                    'price_subtotal': expected_values['total_amount_currency'],
+                    'price_total': expected_values['total_amount_currency'],
                 }])
 
     def _test_reverse_charge_division_tax(self):
@@ -2290,20 +2290,20 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
         expected_values = {
             'same_tax_base': True,
             'currency_id': self.currency.id,
-            'base_amount_currency': 79.0,
+            'base_amount_currency': 100.0,
             'tax_amount_currency': 0.0,
-            'total_amount_currency': 79.0,
+            'total_amount_currency': 100.0,
             'subtotals': [
                 {
                     'name': "Untaxed Amount",
-                    'base_amount_currency': 79.0,
+                    'base_amount_currency': 100.0,
                     'tax_amount_currency': 0.0,
                     'tax_groups': [
                         {
                             'id': self.tax_groups[0].id,
-                            'base_amount_currency': 79.0,
+                            'base_amount_currency': 100.0,
                             'tax_amount_currency': 0.0,
-                            'display_base_amount_currency': 79.0,
+                            'display_base_amount_currency': 100.0,
                         },
                     ],
                 },
@@ -2323,8 +2323,8 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
                 invoice = self.convert_document_to_invoice(document)
                 self.assert_invoice_tax_totals_summary(invoice, expected_values)
                 self.assertRecordValues(invoice.invoice_line_ids, [{
-                    'price_subtotal': 79.0,
-                    'price_total': 79.0,
+                    'price_subtotal': expected_values['total_amount_currency'],
+                    'price_total': expected_values['total_amount_currency'],
                 }])
 
     def _test_discount_with_round_globally(self):

--- a/addons/sale/tests/test_taxes_tax_totals_summary.py
+++ b/addons/sale/tests/test_taxes_tax_totals_summary.py
@@ -70,8 +70,8 @@ class TestTaxesTaxTotalsSummarySale(TestTaxCommonSale, TestTaxesTaxTotalsSummary
                 sale_order = self.convert_document_to_sale_order(document)
                 self.assert_sale_order_tax_totals_summary(sale_order, expected_values)
                 self.assertRecordValues(sale_order.order_line, [{
-                    'price_subtotal': 100.0,
-                    'price_total': 100.0,
+                    'price_subtotal': expected_values['total_amount_currency'],
+                    'price_total': expected_values['total_amount_currency'],
                 }])
 
     def test_reverse_charge_division_tax_sale_orders(self):
@@ -80,8 +80,8 @@ class TestTaxesTaxTotalsSummarySale(TestTaxCommonSale, TestTaxesTaxTotalsSummary
                 sale_order = self.convert_document_to_sale_order(document)
                 self.assert_sale_order_tax_totals_summary(sale_order, expected_values)
                 self.assertRecordValues(sale_order.order_line, [{
-                    'price_subtotal': 79.0,
-                    'price_total': 79.0,
+                    'price_subtotal': expected_values['total_amount_currency'],
+                    'price_total': expected_values['total_amount_currency'],
                 }])
 
     def test_discount_with_round_globally_sale_orders(self):


### PR DESCRIPTION
The current behavior gives annoying results and we don't remember why we did it exactly at the first place.

This reverts commit 1fd90ac27fadb1639dc15d645792ec7a71859808.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
