### PR TITLE
[FIX] l10n_ar_pos: allow to open shop in debug

### DIFF
--- a/addons/l10n_ar_pos/__manifest__.py
+++ b/addons/l10n_ar_pos/__manifest__.py
@@ -19,6 +19,9 @@ Install this if you are using the Point of Sale app in Argentina.
         'point_of_sale._assets_pos': [
             'l10n_ar_pos/static/src/**/*'
         ],
+        'web.assets_tests': [
+            'l10n_ar_pos/static/tests/tours/**/*',
+        ],
     },
     'installable': True,
     'auto_install': True,

--- a/addons/l10n_ar_pos/static/src/app/models/pos_order.js
+++ b/addons/l10n_ar_pos/static/src/app/models/pos_order.js
@@ -2,14 +2,6 @@ import { PosOrder } from "@point_of_sale/app/models/pos_order";
 import { patch } from "@web/core/utils/patch";
 
 patch(PosOrder.prototype, {
-    setup() {
-        super.setup(...arguments);
-        if (this.isArgentineanCompany()) {
-            if (!this.partner_id) {
-                this.partner_id = this.session._consumidor_final_anonimo_id;
-            }
-        }
-    },
     isArgentineanCompany() {
         return this.company.country_id?.code == "AR";
     },

--- a/addons/l10n_ar_pos/static/src/app/services/pos_store.js
+++ b/addons/l10n_ar_pos/static/src/app/services/pos_store.js
@@ -16,4 +16,13 @@ patch(PosStore.prototype, {
     isArgentineanCompany() {
         return this.company.country_id?.code == "AR";
     },
+    createNewOrder() {
+        const order = super.createNewOrder(...arguments);
+
+        if (this.isArgentineanCompany() && !order.partner_id) {
+            order.partner_id = this.session._consumidor_final_anonimo_id;
+        }
+
+        return order;
+    },
 });

--- a/addons/l10n_ar_pos/static/tests/tours/l10n_ar_tour.js
+++ b/addons/l10n_ar_pos/static/tests/tours/l10n_ar_tour.js
@@ -1,0 +1,21 @@
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
+import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("PosARBaseFlow", {
+    steps: () =>
+        [
+            // Basic order flow
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("A test product"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            ReceiptScreen.clickNextOrder(),
+        ].flat(),
+});

--- a/addons/l10n_ar_pos/tests/__init__.py
+++ b/addons/l10n_ar_pos/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_pos_ar

--- a/addons/l10n_ar_pos/tests/test_pos_ar.py
+++ b/addons/l10n_ar_pos/tests/test_pos_ar.py
@@ -1,0 +1,55 @@
+from odoo.tests import tagged
+from odoo.addons.account.tests.common import AccountTestInvoicingHttpCommon
+from odoo.addons.l10n_ar.tests.common import TestAr
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestPosAR(AccountTestInvoicingHttpCommon, TestAr):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Create user.
+        cls.pos_user = cls.env['res.users'].create({
+            'name': 'A simple PoS man!',
+            'login': 'pos_user',
+            'password': 'pos_user',
+            'email': 'pos_user@test.com',
+            'groups_id': [
+                (4, cls.env.ref('base.group_user').id),
+                (4, cls.env.ref('point_of_sale.group_pos_user').id),
+                (4, cls.env.ref('account.group_account_invoice').id),
+            ],
+        })
+
+        cls.company = cls.company_data['company']
+        cls.pos_receivable_bank = cls.copy_account(cls.company.account_default_pos_receivable_account_id, {'name': 'POS Receivable'})
+        cls.outstanding_bank = cls.copy_account(cls.outbound_payment_method_line.payment_account_id, {'name': 'Outstanding'})
+
+        cls.bank_pm = cls.env['pos.payment.method'].create({
+            'name': 'Bank',
+            'journal_id': cls.company_data['default_journal_bank'].id,
+            'receivable_account_id': cls.pos_receivable_bank.id,
+            'outstanding_account_id': cls.outstanding_bank.id,
+            'company_id': cls.company.id,
+        })
+        cls.cash_pm = cls.env['pos.payment.method'].create({
+            'name': 'Cash',
+            'journal_id': cls.company_data['default_journal_cash'].id,
+            'receivable_account_id': cls.pos_receivable_bank.id,
+            'outstanding_account_id': cls.outstanding_bank.id,
+            'company_id': cls.company.id,
+        })
+
+        cls.main_pos_config = cls.env['pos.config'].create({
+            'name': 'Shop',
+            'module_pos_restaurant': False,
+            'payment_method_ids': [(4, cls.bank_pm.id), (4, cls.cash_pm.id)],
+        })
+
+    def test_basic_flow_ar(self):
+        self.product_a.available_in_pos = True
+        self.product_a.name = "A test product"
+        self.main_pos_config.open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosARBaseFlow', login="pos_user")


### PR DESCRIPTION
Currently, if you open a session in AR in debug mode the session will crash.

Steps to reproduce:
-------------------
* Install **l10n_ar_pos** and switch to AR Compatny (Extento)
* Create **Clothes shop**
* Go into debug mode
* Open shop
> Observation: Shop crashes, invalid props: 'partner' is not an object or null

Why the fix:
------------
The `ActionpadWidget` is waiting for an Object or null. https://github.com/odoo/odoo/blob/e4f5b3f42d5535f14280a5bfcb257f76772eee2a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.js#L11

https://github.com/odoo/odoo/blob/e4f5b3f42d5535f14280a5bfcb257f76772eee2a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml#L14-L20

The props is not correct as when we we the `_consumidor_final_anonimo_id` here we set the `partner_id` as an integer. It will stay as an integer. https://github.com/odoo/odoo/blob/e4f5b3f42d5535f14280a5bfcb257f76772eee2a/addons/l10n_ar_pos/static/src/app/models/pos_order.js#L9

By comparing with the `l10n_cl_edi_pos` and `l10n_pe_pos` localizations which are using `_consumidor_final_anonimo_id` in an almost similar way, they use it in `pos_store.js` when creating the order. At this point, the PosOrder has finished to setup and when we set `partner_id` to an integer it will transform it into the ResPartner object.

opw-4568758