### PR TITLE
[FIX] web: Support static file references in `FileModel`

### DIFF
--- a/addons/web/static/src/core/file_viewer/file_model.js
+++ b/addons/web/static/src/core/file_viewer/file_model.js
@@ -130,6 +130,9 @@ export const FileModelMixin = (T) =>
             if (this.uploading && this.tmpUrl) {
                 return this.tmpUrl;
             }
+            if (!this.id) {
+                return this.url;
+            }
             return this.isImage ? `/web/image/${this.id}` : `/web/content/${this.id}`;
         }
     };

--- a/addons/web/static/tests/core/file_viewer/file_model_test.js
+++ b/addons/web/static/tests/core/file_viewer/file_model_test.js
@@ -1,0 +1,82 @@
+/** @odoo-module **/
+
+import { FileModel } from "@web/core/file_viewer/file_model";
+
+QUnit.module("FileModel", () => {
+    QUnit.module("URL Routing", () => {
+        QUnit.test("returns correct URL for files with ID", (assert) => {
+            const imageFile = new FileModel();
+            Object.assign(imageFile, {
+                id: 123,
+                mimetype: "image/png",
+                name: "test.png",
+            });
+
+            const regularFile = new FileModel();
+            Object.assign(regularFile, {
+                id: 456,
+                mimetype: "application/pdf",
+                name: "test.pdf",
+            });
+
+            assert.strictEqual(
+                imageFile.urlRoute,
+                "/web/image/123",
+                "Should return correct image URL route with ID"
+            );
+
+            assert.strictEqual(
+                regularFile.urlRoute,
+                "/web/content/456",
+                "Should return correct content URL route with ID"
+            );
+        });
+
+        QUnit.test("returns direct URL for files without ID", (assert) => {
+            const fileWithoutId = new FileModel();
+            const directUrl = "https://example.com/file.pdf";
+            Object.assign(fileWithoutId, {
+                id: undefined,
+                url: directUrl,
+                mimetype: "application/pdf",
+                name: "file.pdf",
+            });
+
+            assert.strictEqual(
+                fileWithoutId.urlRoute,
+                directUrl,
+                "Should return direct URL when ID is not present"
+            );
+        });
+
+        QUnit.test("prioritizes ID over direct URL when both are present", (assert) => {
+            const imageFile = new FileModel();
+            Object.assign(imageFile, {
+                id: 789,
+                url: "https://example.com/direct-image.jpg",
+                mimetype: "image/jpeg",
+                name: "image.jpg",
+            });
+
+            const regularFile = new FileModel();
+            Object.assign(regularFile, {
+                id: 101,
+                url: "https://example.com/direct-file.pdf",
+                mimetype: "application/pdf",
+                name: "document.pdf",
+            });
+
+            assert.strictEqual(
+                imageFile.urlRoute,
+                "/web/image/789",
+                "Should use ID-based route for image even when direct URL is present"
+            );
+
+            assert.strictEqual(
+                regularFile.urlRoute,
+                "/web/content/101",
+                "Should use ID-based route for regular file even when direct URL is present"
+            );
+        });
+    });
+});


### PR DESCRIPTION
Embedded files with direct paths in knowledge article templates cannot be viewed or downloaded.

### Steps to Reproduce

1. Install the `knowledge` module.
2. Open the default knowledge article (e.g., *Welcome Mitchel Admin*).
3. Scroll down to the *Odoo Survival Guide* PDF and attempt to view or download it.

An error message appears stating that the file does not exist.

### Cause

The `FileModelMixin` does not handle files without an `id`, meaning files that are not attachments fail to resolve properly.

opw-4380368
opw-4433248

Related enterprise PR: https://github.com/odoo/enterprise/pull/79209