### PR TITLE
[FIX] Fixed 'CONTRIBUTING' link reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ TL;DR
 * If you [make a pull request](https://github.com/odoo/odoo/wiki/Contributing#making-pull-requests),
   do not create an issue! Use the PR description for that
 * Issues are handled with a much lower priority than pull requests
-* Use this [template](https://github.com/odoo/odoo/tree/master/.github/ISSUE_TEMPLATE.md)
+* Use this [template](https://github.com/odoo/odoo/wiki/Contributing#reporting-issues)
   when reporting issues. Please search for duplicates first!
 * Pull requests must be made against the [correct version](https://github.com/odoo/odoo/wiki/Contributing#against-which-version-should-i-submit-a-patch)
 * There are restrictions on the kind of [changes allowed in stable series](https://github.com/odoo/odoo/wiki/Contributing#what-does-stable-mean)

--- a/doc/cla/individual/alvaro-osvaldo-tm.md
+++ b/doc/cla/individual/alvaro-osvaldo-tm.md
@@ -1,0 +1,11 @@
+Uruguay, 2025-02-12
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Álvaro Osvaldo TM alvaro@osvaldo.dev.br https://github.com/alvaro-osvaldo-tm


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In the 'CONTRIBUTING.md' file , there is a list item with the text: 

> Use this **template** when reporting issues. Please search for duplicates first!

The link named 'template' should point to a pull request template.

Current behavior before PR:

The link named 'template' is broken and give a 404 error.

Desired behavior after PR is merged:

The link named 'template' now target the 'Contributing' wiki page, section  'making-pull-request' that contains the desired template.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
