### PR TITLE
[IMP] html_editor, web: colorpicker enhancement

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -83,11 +83,11 @@ export class ColorPlugin extends Plugin {
             getSelectedColors: () => this.selectedColors,
             applyColor: (color) => {
                 this.applyColor({ color, mode });
-                this.dependencies.selection.focusEditable();
             },
             applyColorPreview: (color) => this.applyColorPreview({ color, mode }),
             applyColorResetPreview: this.applyColorResetPreview.bind(this),
             colorPrefix: mode === "color" ? "text-" : "bg-",
+            onClose: () => this.dependencies.selection.focusEditable(),
         };
     }
 

--- a/addons/html_editor/static/src/main/font/color_selector.js
+++ b/addons/html_editor/static/src/main/font/color_selector.js
@@ -21,6 +21,7 @@ export class ColorSelector extends Component {
         applyColorResetPreview: Function,
         getUsedCustomColors: Function,
         colorPrefix: { type: String },
+        onClose: Function,
     };
 
     setup() {
@@ -54,7 +55,12 @@ export class ColorSelector extends Component {
                 getUsedCustomColors: this.props.getUsedCustomColors,
                 colorPrefix: this.props.colorPrefix,
             },
-            { onClose: () => this.props.applyColorResetPreview() }
+            {
+                onClose: () => {
+                    this.props.applyColorResetPreview();
+                    this.props.onClose();
+                },
+            }
         );
     }
 

--- a/addons/html_editor/static/src/main/font/color_selector.js
+++ b/addons/html_editor/static/src/main/font/color_selector.js
@@ -1,8 +1,13 @@
 import { isColorGradient } from "@web/core/utils/colors";
 import { Component, useState } from "@odoo/owl";
-import { useColorPicker } from "@web/core/color_picker/color_picker";
+import {
+    useColorPicker,
+    DEFAULT_COLORS,
+    DEFAULT_THEME_COLOR_VARS,
+} from "@web/core/color_picker/color_picker";
 import { effect } from "@web/core/utils/reactive";
 import { toolbarButtonProps } from "../toolbar/toolbar";
+import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
 
 export class ColorSelector extends Component {
     static template = "html_editor.ColorSelector";
@@ -20,9 +25,21 @@ export class ColorSelector extends Component {
 
     setup() {
         this.state = useState({});
+        const htmlStyle = getHtmlStyle(document);
+        const defaultThemeColors = DEFAULT_THEME_COLOR_VARS.map((color) =>
+            getCSSVariableValue(color, htmlStyle)
+        );
+        this.solidColors = [
+            ...DEFAULT_COLORS.flat(),
+            ...defaultThemeColors,
+            getCSSVariableValue("body-color", htmlStyle), // Default applied color
+        ];
         effect(
             (selectedColors) => {
                 this.state.selectedColor = selectedColors[this.props.mode];
+                this.state.defaultTab = this.getCorrespondingColorTab(
+                    selectedColors[this.props.mode]
+                );
             },
             [this.props.getSelectedColors()]
         );
@@ -39,6 +56,16 @@ export class ColorSelector extends Component {
             },
             { onClose: () => this.props.applyColorResetPreview() }
         );
+    }
+
+    getCorrespondingColorTab(color) {
+        if (!color || this.solidColors.includes(color.toUpperCase())) {
+            return "solid";
+        } else if (isColorGradient(color)) {
+            return "gradient";
+        } else {
+            return "custom";
+        }
     }
 
     getSelectedColorStyle() {

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -396,6 +396,24 @@ test("clicking on button color parent does not crash", async () => {
     expect(getContent(el)).toBe(`<p><font style="color: rgb(107, 173, 222);">[test]</font></p>`);
 });
 
+test("gradient picker should be closed by default when switching gradient tab", async () => {
+    await setupEditor("<p>[test]</p>");
+
+    await expandToolbar();
+    await click(".o-we-toolbar .o-select-color-foreground");
+    await animationFrame();
+    expect(".o_font_color_selector").toHaveCount(1);
+    await click(".btn:contains('Gradient')");
+    await animationFrame();
+    expect(".o_colorpicker_widget").toHaveCount(0);
+    await click("button[title='Define a custom gradient']");
+    await animationFrame();
+    expect(".o_colorpicker_widget").toHaveCount(1);
+    await click("button[title='Define a custom gradient']"); // Should be toggleable
+    await animationFrame();
+    expect(".o_colorpicker_widget").toHaveCount(0);
+});
+
 test("gradient picker correctly shows the current selected gradient", async () => {
     await setupEditor(
         `<p><font style="background-image: linear-gradient(2deg, rgb(255, 204, 51) 10%, rgb(226, 51, 255) 90%);" class="text-gradient">[test]</font></p>`
@@ -403,6 +421,8 @@ test("gradient picker correctly shows the current selected gradient", async () =
     await expandToolbar();
     expect(".o_font_color_selector").toHaveCount(0);
     await click(".o-we-toolbar .o-select-color-foreground");
+    await animationFrame();
+    await click("button[title='Define a custom gradient']");
     await animationFrame();
     expect("button.active:contains('Linear')").toHaveCount(1);
     expect("input[name='angle']").toHaveValue("2");
@@ -417,6 +437,8 @@ test("gradient picker does change the selector gradient color", async () => {
     await expandToolbar();
     expect(".o_font_color_selector").toHaveCount(0);
     await click(".o-we-toolbar .o-select-color-foreground");
+    await animationFrame();
+    await click("button[title='Define a custom gradient']");
     await animationFrame();
     expect("button.active:contains('Linear')").toHaveCount(1);
     await contains("input[name='angle'").edit("10");
@@ -435,6 +457,8 @@ test("clicking on the angle input does not close the dropdown", async () => {
     expect(".o_font_color_selector").toHaveCount(0);
     await click(".o-we-toolbar .o-select-color-foreground");
     await animationFrame();
+    await click("button[title='Define a custom gradient']");
+    await animationFrame();
     expect("button.active:contains('Linear')").toHaveCount(1);
     await contains("input[name='angle'").click();
     expect("input[name='angle'").toHaveCount(1);
@@ -447,6 +471,8 @@ test("should be able to select farthest-corner option in radial gradient", async
     await animationFrame();
     expect(".btn:contains('Gradient')").toHaveCount(1);
     await click(".btn:contains('Gradient')");
+    await animationFrame();
+    await click("button[title='Define a custom gradient']");
     await animationFrame();
     expect("button:contains('Radial')").toHaveCount(1);
     await click(".btn:contains('Radial')");

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -150,12 +150,43 @@ test("select hex color and apply it", async () => {
     await animationFrame();
     expect("button[data-color='#017E84']").toHaveCount(1);
     expect(queryOne("button[data-color='#017E84']").style.backgroundColor).toBe("rgb(1, 126, 132)");
-    expect(getContent(el)).toBe(`<p><font style="color: rgb(1, 126, 132);">[test]</font></p>`);
+    expect(getContent(el)).toBe(`<p><font style="color: rgb(1, 126, 132);">test</font></p>`);
 
     await click(".odoo-editor-editable");
     await animationFrame();
     expect(".o_font_color_selector").toHaveCount(0);
     expect(getContent(el)).toBe(`<p><font style="color: rgb(1, 126, 132);">[test]</font></p>`);
+});
+
+test("should be able to apply hex color with opacity component", async () => {
+    const { el } = await setupEditor(`<p>[test]</p>`);
+    await expandToolbar();
+    expect(".o_font_color_selector").toHaveCount(0);
+
+    await click(".o-we-toolbar .o-select-color-foreground");
+    await animationFrame();
+    expect(".o_font_color_selector").toHaveCount(1);
+
+    await click(".btn:contains('Custom')");
+    await animationFrame();
+    await click(".o_hex_input");
+    await animationFrame();
+    expect(".o_font_color_selector").toHaveCount(1);
+
+    await edit("#017E8480"); // === rgba(1, 126, 132, 0.5)
+    await animationFrame();
+    expect("button[data-color='#017E8480']").toHaveCount(1);
+    expect(queryOne("button[data-color='#017E8480']").style.backgroundColor).toBe(
+        "rgba(1, 126, 132, 0.5)"
+    );
+    expect(getContent(el)).toBe(`<p><font style="color: rgba(1, 126, 132, 0.5);">test</font></p>`);
+
+    await click(".odoo-editor-editable");
+    await animationFrame();
+    expect(".o_font_color_selector").toHaveCount(0);
+    expect(getContent(el)).toBe(
+        `<p><font style="color: rgba(1, 126, 132, 0.5);">[test]</font></p>`
+    );
 });
 
 test("custom color tab should be opened by default if selected color is a custom color", async () => {

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -168,6 +168,41 @@ test("select hex color and apply it", async () => {
     expect(getContent(el)).toBe(`<p><font style="color: rgb(1, 126, 132);">[test]</font></p>`);
 });
 
+test("custom color tab should be opened by default if selected color is a custom color", async () => {
+    await setupEditor(`<p>a<font style="color: rgb(120, 100, 0, 0.6);">[test]</font>b</p>`);
+    await expandToolbar();
+    expect(".o_font_color_selector").toHaveCount(0);
+
+    await click(".o-we-toolbar .o-select-color-foreground");
+    await animationFrame();
+    expect(".o_font_color_selector").toHaveCount(1);
+    expect(".btn:contains('Custom')").toHaveClass("active");
+});
+
+test("gradient tab should be opened by default if selected color is a gradient color", async () => {
+    await setupEditor(
+        `<p>a<font style="background-image: linear-gradient(2deg, rgb(255, 204, 51) 10%, rgb(226, 51, 255) 90%);" class="text-gradient">[test]</font>b</p>`
+    );
+    await expandToolbar();
+    expect(".o_font_color_selector").toHaveCount(0);
+
+    await click(".o-we-toolbar .o-select-color-foreground");
+    await animationFrame();
+    expect(".o_font_color_selector").toHaveCount(1);
+    expect(".btn:contains('Gradient')").toHaveClass("active");
+});
+
+test("solid color tab should be opened by default if selected color is a theme color", async () => {
+    await setupEditor(`<p>a<font class="text-o-color-1">[test]</font>b</p>`);
+    await expandToolbar();
+    expect(".o_font_color_selector").toHaveCount(0);
+
+    await click(".o-we-toolbar .o-select-color-foreground");
+    await animationFrame();
+    expect(".o_font_color_selector").toHaveCount(1);
+    expect(".btn:contains('Solid')").toHaveClass("active");
+});
+
 test("always show the current custom color", async () => {
     const defaultTextColor = "rgb(1, 10, 100)";
     const styleContent = `* {color: ${defaultTextColor};}`;
@@ -369,8 +404,6 @@ test("gradient picker correctly shows the current selected gradient", async () =
     expect(".o_font_color_selector").toHaveCount(0);
     await click(".o-we-toolbar .o-select-color-foreground");
     await animationFrame();
-    await click(".btn:contains('Gradient')");
-    await animationFrame();
     expect("button.active:contains('Linear')").toHaveCount(1);
     expect("input[name='angle']").toHaveValue("2");
     expect("input[name='firstColorPercentage']").toHaveValue(10);
@@ -384,8 +417,6 @@ test("gradient picker does change the selector gradient color", async () => {
     await expandToolbar();
     expect(".o_font_color_selector").toHaveCount(0);
     await click(".o-we-toolbar .o-select-color-foreground");
-    await animationFrame();
-    await click(".btn:contains('Gradient')");
     await animationFrame();
     expect("button.active:contains('Linear')").toHaveCount(1);
     await contains("input[name='angle'").edit("10");
@@ -403,8 +434,6 @@ test("clicking on the angle input does not close the dropdown", async () => {
     await expandToolbar();
     expect(".o_font_color_selector").toHaveCount(0);
     await click(".o-we-toolbar .o-select-color-foreground");
-    await animationFrame();
-    await click(".btn:contains('Gradient')");
     await animationFrame();
     expect("button.active:contains('Linear')").toHaveCount(1);
     await contains("input[name='angle'").click();

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -1,15 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import {
-    click,
-    waitFor,
-    queryOne,
-    hover,
-    press,
-    waitUntil,
-    edit,
-    queryAllValues,
-    queryAll,
-} from "@odoo/hoot-dom";
+import { click, waitFor, queryOne, hover, press, waitUntil, edit, queryAll } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
@@ -113,7 +103,7 @@ test("custom text-colors used in the editor are shown in the colorpicker", async
     await click(".btn:contains('Custom')");
     await animationFrame();
     expect(".o_hex_input").toHaveValue("#00FF00");
-    expect(queryAllValues(".o_rgba_div input")).toEqual(["0", "255", "0", "100"]);
+    expect(".o_rgba_div input").toHaveCount(0);
     expect(queryAll("button[data-color='#ff0000']")).toHaveCount(1);
     expect(queryOne("button[data-color='#ff0000']").style.backgroundColor).toBe("rgb(255, 0, 0)");
     expect(queryAll("button[data-color='#00ff00']")).toHaveCount(1);
@@ -134,7 +124,7 @@ test("custom background colors used in the editor are shown in the colorpicker",
     await click(".btn:contains('Custom')");
     await animationFrame();
     expect(".o_hex_input").toHaveValue("#00FF00");
-    expect(queryAllValues(".o_rgba_div input")).toEqual(["0", "255", "0", "100"]);
+    expect(".o_rgba_div input").toHaveCount(0);
     expect(queryAll("button[data-color='#ff0000']")).toHaveCount(1);
     expect(queryOne("button[data-color='#ff0000']").style.backgroundColor).toBe("rgb(255, 0, 0)");
     expect(queryAll("button[data-color='#00ff00']")).toHaveCount(1);
@@ -425,6 +415,7 @@ test("gradient picker correctly shows the current selected gradient", async () =
     await click("button[title='Define a custom gradient']");
     await animationFrame();
     expect("button.active:contains('Linear')").toHaveCount(1);
+    expect(".o_rgba_div input").toHaveCount(0);
     expect("input[name='angle']").toHaveValue("2");
     expect("input[name='firstColorPercentage']").toHaveValue(10);
     expect("input[name='secondColorPercentage']").toHaveValue(90);

--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -5,7 +5,7 @@ import { isCSSColor, isColorGradient } from "@web/core/utils/colors";
 import { GradientPicker } from "./gradient_picker/gradient_picker";
 
 // These colors are already normalized as per normalizeCSSColor in @web/legacy/js/widgets/colorpicker
-const DEFAULT_COLORS = [
+export const DEFAULT_COLORS = [
     ["#000000", "#424242", "#636363", "#9C9C94", "#CEC6CE", "#EFEFEF", "#F7F7F7", "#FFFFFF"],
     ["#FF0000", "#FF9C00", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF", "#9C00FF", "#FF00FF"],
     ["#F7C6CE", "#FFE7CE", "#FFEFC6", "#D6EFD6", "#CEDEE7", "#CEE7F7", "#D6D6E7", "#E7D6DE"],
@@ -27,6 +27,14 @@ const DEFAULT_GRADIENT_COLORS = [
     "linear-gradient(135deg, rgb(255, 222, 202) 0%, rgb(202, 115, 69) 100%)",
 ];
 
+export const DEFAULT_THEME_COLOR_VARS = [
+    "o-color-1",
+    "o-color-2",
+    "o-color-3",
+    "o-color-4",
+    "o-color-5",
+];
+
 export class ColorPicker extends Component {
     static template = "web.ColorPicker";
     static components = { CustomColorPicker, GradientPicker };
@@ -35,6 +43,7 @@ export class ColorPicker extends Component {
             type: Object,
             shape: {
                 selectedColor: String,
+                defaultTab: String,
             },
         },
         getUsedCustomColors: Function,
@@ -54,7 +63,7 @@ export class ColorPicker extends Component {
 
         this.defaultColor = this.props.state.selectedColor;
         this.state = useState({
-            activeTab: "solid",
+            activeTab: this.props.state.defaultTab,
             currentCustomColor: this.props.state.selectedColor,
         });
         this.usedCustomColors = this.props.getUsedCustomColors();

--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -65,6 +65,7 @@ export class ColorPicker extends Component {
         this.state = useState({
             activeTab: this.props.state.defaultTab,
             currentCustomColor: this.props.state.selectedColor,
+            showGradientPicker: false,
         });
         this.usedCustomColors = this.props.getUsedCustomColors();
     }
@@ -122,6 +123,10 @@ export class ColorPicker extends Component {
         if (isColorGradient(this.props.state.selectedColor)) {
             return this.props.state.selectedColor;
         }
+    }
+
+    toggleGradientPicker() {
+        this.state.showGradientPicker = !this.state.showGradientPicker;
     }
 }
 

--- a/addons/web/static/src/core/color_picker/color_picker.scss
+++ b/addons/web/static/src/core/color_picker/color_picker.scss
@@ -2,25 +2,45 @@
     --bg: #{$o-we-toolbar-bg};
     --text-rgb: #{red($o-we-toolbar-color-text)}, #{green($o-we-toolbar-color-text)}, #{blue($o-we-toolbar-color-text)};
     --border-rgb: var(--text-rgb);
-    width: 222px;
+    width: 204px;
     box-shadow: $box-shadow;
 }
 
 .o_color_button {
-    width: 25px;
-    height: 24px;
+    width: 23px;
+    height: 22px;
+    padding: 0px;
     box-shadow: inset 0 0 0 1px rgba(var(--border-rgb), .5);
-    margin: 1px;
+    margin: 0.5px;
+}
+
+.o_font_color_selector {
+    .btn-tab {
+        min-width: 57px;
+        padding: 3px;
+        font-size: 12px;
+    }
 }
 
 .o_font_color_selector .o_colorpicker_section {
     display: flex;
     margin-bottom: 3px;
+    width: fit-content;
+    margin-left: 2px;
 }
 
 .o_font_color_selector .o_color_button.selected {
     // todo: check web_editor
     border: 3px solid $o-enterprise-action-color;
+}
+
+.o_font_color_selector .o_colorpicker_widget {
+    .o_hex_input {
+        border: 1px solid !important;
+        padding: 0 2px !important;
+        width: 8ch !important;
+        opacity: 0.7;
+    }
 }
 
 :root {

--- a/addons/web/static/src/core/color_picker/color_picker.scss
+++ b/addons/web/static/src/core/color_picker/color_picker.scss
@@ -38,7 +38,7 @@
     .o_hex_input {
         border: 1px solid !important;
         padding: 0 2px !important;
-        width: 8ch !important;
+        width: 10ch !important;
         opacity: 0.7;
     }
 }

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -1,18 +1,18 @@
 <templates xml:space="preserve">
 <t t-name="web.ColorPicker">
     <div class="o_font_color_selector user-select-none" t-on-pointerdown.stop="() => {}" data-prevent-closing-overlay="true">
-        <div class="mb-1 d-flex">
-            <button class="btn btn-sm btn-light ms-1"
+        <div class="my-1 d-flex">
+            <button class="btn btn-sm btn-light ms-1 text-truncate btn-tab"
                 t-att-class="{active: state.activeTab === 'solid'}"
                 t-on-click="() => this.setTab('solid')">
                 Solid
             </button>
-            <button class="btn btn-sm btn-light"
+            <button class="btn btn-sm btn-light text-truncate btn-tab"
                 t-att-class="{active: state.activeTab === 'custom'}"
                 t-on-click="() => this.setTab('custom')">
                 Custom
             </button>
-            <button class="btn btn-sm btn-light"
+            <button class="btn btn-sm btn-light text-truncate btn-tab"
                 t-att-class="{active: state.activeTab === 'gradient'}"
                 t-on-click="() => this.setTab('gradient')">
                 Gradient
@@ -37,7 +37,7 @@
                 </div>
 
                 <t t-foreach="DEFAULT_COLORS" t-as="line" t-key="line_index">
-                    <div class="o_color_section d-flex">
+                    <div class="o_color_section justify-content-center d-flex">
                         <t t-foreach="line" t-as="color" t-key="color_index">
                             <button class="o_color_button btn" t-att-class="{'selected': color === this.state.currentCustomColor.toUpperCase()}" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
                         </t>

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -76,8 +76,8 @@
                 </t>
             </div>
             <div class="px-2">
-                <button t-attf-style="background-image: {{ getCurrentGradientColor() }};" class="w-50 border btn" title="Define a custom gradient">Custom</button>
-                <GradientPicker onGradientChange.bind="applyColor" selectedGradient="getCurrentGradientColor()"/>
+                <button t-attf-style="background-image: {{ getCurrentGradientColor() }};" class="w-50 border btn mb-2" t-on-click="this.toggleGradientPicker" title="Define a custom gradient">Custom</button>
+                <GradientPicker t-if="state.showGradientPicker" onGradientChange.bind="applyColor" selectedGradient="getCurrentGradientColor()"/>
             </div>
         </t>
     </div>

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -66,7 +66,8 @@
                 <CustomColorPicker
                     defaultColor="this.defaultColor"
                     onColorSelect.bind="(color) => this.applyColor(color.hex)"
-                    onColorPreview.bind="onColorPreview" />
+                    onColorPreview.bind="onColorPreview" 
+                    showRgbaField="false" />
             </div>
         </t>
         <t t-if="state.activeTab==='gradient'">

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -49,7 +49,7 @@
             <div class="p-1">
                 <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut">
                     <t t-foreach="this.usedCustomColors" t-as="color" t-key="color_index">
-                        <button t-if="color !== this.state.currentCustomColor.toLowerCase()" class="o_color_button btn" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
+                        <button t-if="color !== this.state.currentCustomColor?.toLowerCase()" class="o_color_button btn" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
                     </t>
                     <button class="o_color_button btn selected" t-att-data-color="this.state.currentCustomColor" t-attf-style="background-color: {{this.state.currentCustomColor}}"/>
                 </div>

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
@@ -21,6 +21,7 @@ export class CustomColorPicker extends Component {
         onColorSelect: { type: Function, optional: true },
         onColorPreview: { type: Function, optional: true },
         onInputEnter: { type: Function, optional: true },
+        showRgbaField: { type: Boolean, optional: true },
     };
     static defaultProps = {
         document: window.document,
@@ -30,6 +31,7 @@ export class CustomColorPicker extends Component {
         onColorSelect: () => {},
         onColorPreview: () => {},
         onInputEnter: () => {},
+        showRgbaField: true,
     };
 
     setup() {

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
@@ -197,10 +197,7 @@ export class CustomColorPicker extends Component {
             a = 100;
         }
 
-        // We update the hexadecimal code by transforming into a css color and
-        // ignoring the opacity (we don't display opacity component in hexa as
-        // not supported on all browsers)
-        const hex = convertRgbaToCSSColor(r, g, b);
+        const hex = convertRgbaToCSSColor(r, g, b, a);
         if (!hex) {
             return;
         }
@@ -233,7 +230,7 @@ export class CustomColorPicker extends Component {
             return;
         }
         // We receive an hexa as we ignore the opacity
-        const hex = convertRgbaToCSSColor(rgb.red, rgb.green, rgb.blue);
+        const hex = convertRgbaToCSSColor(rgb.red, rgb.green, rgb.blue, a);
         Object.assign(
             this.colorComponents,
             { hue: h, saturation: s, lightness: l },
@@ -254,6 +251,10 @@ export class CustomColorPicker extends Component {
             return;
         }
         Object.assign(this.colorComponents, { opacity: a });
+        const r = this.colorComponents.red;
+        const g = this.colorComponents.green;
+        const b = this.colorComponents.blue;
+        Object.assign(this.colorComponents, { hex: convertRgbaToCSSColor(r, g, b, a) });
         this._updateCssColor();
     }
     /**
@@ -459,7 +460,7 @@ export class CustomColorPicker extends Component {
      */
     onHexColorInput(ev) {
         const hexColorValue = ev.target.value.replaceAll("#", "");
-        if (hexColorValue.length === 6) {
+        if (hexColorValue.length === 6 || hexColorValue.length === 8) {
             this._updateHex(`#${hexColorValue}`);
             this._updateUI();
             this._colorSelected();

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
@@ -81,7 +81,7 @@ export class CustomColorPicker extends Component {
             const defaultCssColor = this.props.selectedColor
                 ? this.props.selectedColor
                 : this.props.defaultColor;
-            const rgba = convertCSSColorToRgba(defaultCssColor);
+            const rgba = convertCSSColorToRgba(defaultCssColor) || convertCSSColorToRgba("#FF0000");
             if (rgba) {
                 this._updateRgba(rgba.red, rgba.green, rgba.blue, rgba.opacity);
             }

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.scss
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.scss
@@ -36,7 +36,7 @@
             font-size: 11px;
         }
         .o_hex_div input {
-            width: 7ch;
+            width: 9ch;
         }
         .o_rgba_div input {
             margin-right: 3px;

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.xml
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.xml
@@ -22,7 +22,7 @@
                     t-on-input="onHexColorInput"/>
                 <label class="flex-grow-0 ms-1 mb-0">hex</label>
             </div>
-            <div class="o_rgba_div px-1 d-flex align-items-baseline">
+            <div t-if="props.showRgbaField" class="o_rgba_div px-1 d-flex align-items-baseline">
                 <input type="text" t-attf-class="o_red_input {{input_classes}}" data-color-method="rgb" size="1"/>
                 <input type="text" t-attf-class="o_green_input {{input_classes}}" data-color-method="rgb" size="1"/>
                 <input type="text" t-attf-class="o_blue_input {{input_classes}}" data-color-method="rgb" size="1"/>

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.xml
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.xml
@@ -17,7 +17,7 @@
         <div class="o_color_picker_inputs d-flex justify-content-between mb-2" t-on-change="debouncedOnChangeInputs">
             <t t-set="input_classes" t-value="'p-0 border-0 text-center font-monospace bg-transparent'" />
 
-            <div class="o_hex_div px-1 d-flex align-items-baseline">
+            <div class="o_hex_div px-1 d-flex align-items-baseline me-1">
                 <input type="text" t-attf-class="o_hex_input {{input_classes}}" data-color-method="hex" size="1"
                     t-on-input="onHexColorInput"/>
                 <label class="flex-grow-0 ms-1 mb-0">hex</label>

--- a/addons/web/static/src/core/color_picker/gradient_picker/gradient_picker.xml
+++ b/addons/web/static/src/core/color_picker/gradient_picker/gradient_picker.xml
@@ -91,7 +91,7 @@
                 onColorPreview.bind="onColorChange"
                 defaultColor="this.colors[this.state.currentColorIndex].hex"
                 selectedColor="this.colors[this.state.currentColorIndex].hex"
-                />
+                showRgbaField="false" />
         </div>
     </t>
 </templates>

--- a/addons/web/static/src/core/utils/colors.js
+++ b/addons/web/static/src/core/utils/colors.js
@@ -144,14 +144,8 @@ export function convertHslToRgb(h, s, l) {
 }
 /**
  * Converts RGBA color components to a normalized CSS color: if the opacity
- * is invalid or equal to 100, a hex is returned; otherwise a rgba() css color
- * is returned.
- *
- * Those choice have multiple reason:
- * - A hex color is more common to c/c from other utilities on the web and is
- *   also shorter than rgb() css colors
- * - Opacity in hexadecimal notations is not supported on all browsers and is
- *   also less common to use.
+ * is invalid or equal to 100, a hex color excluding opacity is returned;
+ * otherwise a hex color including opacity component is returned.
  *
  * @static
  * @param {integer} r - [0, 255]
@@ -177,13 +171,21 @@ export function convertRgbaToCSSColor(r, g, b, a) {
     ) {
         return false;
     }
-    if (typeof a !== "number" || isNaN(a) || a < 0 || Math.abs(a - 100) < Number.EPSILON) {
-        const rr = r < 16 ? "0" + r.toString(16) : r.toString(16);
-        const gg = g < 16 ? "0" + g.toString(16) : g.toString(16);
-        const bb = b < 16 ? "0" + b.toString(16) : b.toString(16);
+    const rr = r < 16 ? "0" + r.toString(16) : r.toString(16);
+    const gg = g < 16 ? "0" + g.toString(16) : g.toString(16);
+    const bb = b < 16 ? "0" + b.toString(16) : b.toString(16);
+    if (
+        typeof a !== "number" ||
+        isNaN(a) ||
+        a < 0 ||
+        a > 100 ||
+        Math.abs(a - 100) < Number.EPSILON
+    ) {
         return `#${rr}${gg}${bb}`.toUpperCase();
     }
-    return `rgba(${r}, ${g}, ${b}, ${parseFloat((a / 100.0).toFixed(3))})`;
+    const alpha = Math.round((a / 100) * 255);
+    const aa = alpha < 16 ? "0" + alpha.toString(16) : alpha.toString(16);
+    return `#${rr}${gg}${bb}${aa}`.toUpperCase();
 }
 /**
  * Converts a CSS color (rgb(), rgba(), hexadecimal) to RGBA color components.


### PR DESCRIPTION
**This PR aims to do following colorpicker related improvements:**

1) Opening the colorpicker, the appropriate color tab ("Solid", "Custom", or "Gradient") is opened by default based
  on the selected color. For example, if selected text is having gradient text-color then "Gradient" tab is opened by default when opening colorpicker

2) Custom gradient picker is closed by default when switching to "Gradient" tab. It gets opened or closed when clicking "Custom" button.

3) Hide rgba input field from custom colorpicker.

4) Allow hex color format up to 8 characters in custom colorpicker to support opacity.

5) Reduces size of color buttons by 2px.

6) Adds border and transparency to the hex input field in custom colorpicker.

7) Adds text-overflow ellipsis effect to tab button so that it doesn't cause a horizontal scrollbar effect if button text is too long.

task-4535310




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
