### PR TITLE
[FIX] point_of_sale: allow multi currency

### DIFF
--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -141,7 +141,7 @@ class ProductTemplate(models.Model):
         different_currency = config_id.currency_id != self.env.company.currency_id
         for product in products:
             if different_currency:
-                product['lst_price'] = self.env.company.currency_id._convert(product['lst_price'], config_id.currency_id, self.env.company, fields.Date.today())
+                product['list_price'] = self.env.company.currency_id._convert(product['list_price'], config_id.currency_id, self.env.company, fields.Date.today())
             product['image_128'] = bool(product['image_128'])
 
             if len(taxes_by_company) > 1 and len(product['taxes_id']) > 1:


### PR DESCRIPTION
Before this commit, it wasn't possible to use another currency in a PoS within a single company.

opw-4520600

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
