### PR TITLE
[FIX] point_of_sale: review paid order on mobile

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
@@ -5,10 +5,12 @@
         <div class="actionpad d-flex flex-column gap-2">
             <div t-if="ui.isSmall" class="d-flex gap-2">
                 <BackButton t-if="!props.showActionButton and pos.showBackButton()" onClick="() => pos.onClickBackButton()"/>
-                <SelectPartnerButton partner="props.partner"/>
-                <button class="button mobile-more-button btn btn-light btn-lg flex-fill" t-if="props.onClickMore" t-on-click="props.onClickMore">
-                    <span>Actions</span>
-                </button>
+                <t t-if="props.onClickMore">
+                    <SelectPartnerButton partner="props.partner"/>
+                    <button class="button mobile-more-button btn btn-light btn-lg flex-fill" t-on-click="props.onClickMore">
+                        <span>Actions</span>
+                    </button>
+                </t>
             </div>
             <div t-if="props.showActionButton" class="validation d-flex gap-2">
                 <BackButton t-if="pos.showBackButton()" onClick="() => pos.onClickBackButton()"/>


### PR DESCRIPTION
- Fix issue where an error occur when trying to open the customer popup on mobile from the ticket screen (while reviewing a paid order).
- Now we don't display the `Customer` selection button when we're on the ticket screen (like it was already done for the "actions" button) to avoid this error (like it's done in desktop). Also, it does not make sense to try to change the customer of a paid order.

task-id: 4571914

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
