### PR TITLE
[FIX] mail, *: fix type definitions

### DIFF
--- a/addons/calendar/static/src/activity/@types/models.d.ts
+++ b/addons/calendar/static/src/activity/@types/models.d.ts
@@ -1,5 +1,5 @@
 declare module "models" {
-    interface Activity {
-        calendar_event_id: Number
+    export interface Activity {
+        rescheduleMeeting: () => Promise<void>;
     }
 }

--- a/addons/hr/static/src/@types/models.d.ts
+++ b/addons/hr/static/src/@types/models.d.ts
@@ -1,0 +1,5 @@
+declare module "models" {
+    export interface Store {
+        employees: {[key: number]: {id: number, user_id: number, hasCheckedUser: boolean}};
+    }
+}

--- a/addons/hr/static/src/core/common/@types/models.d.ts
+++ b/addons/hr/static/src/core/common/@types/models.d.ts
@@ -1,0 +1,5 @@
+declare module "models" {
+    export interface Persona {
+        employeeId: number|undefined;
+    }
+}

--- a/addons/hr/static/src/core/common/persona_model_patch.js
+++ b/addons/hr/static/src/core/common/persona_model_patch.js
@@ -3,5 +3,6 @@ import { Persona } from "@mail/core/common/persona_model";
 import { patch } from "@web/core/utils/patch";
 
 patch(Persona.prototype, {
+    /** @type {number|undefined} */
     employeeId: undefined,
 });

--- a/addons/hr/static/src/store_service_patch.js
+++ b/addons/hr/static/src/store_service_patch.js
@@ -6,6 +6,7 @@ import { patch } from "@web/core/utils/patch";
 const storeServicePatch = {
     setup() {
         super.setup();
+        /** @type {{[key: number]: {id: number, user_id: number, hasCheckedUser: boolean}}} */
         this.employees = {};
     },
     async getChat(person) {

--- a/addons/hr_holidays/static/src/@types/models.d.ts
+++ b/addons/hr_holidays/static/src/@types/models.d.ts
@@ -1,0 +1,5 @@
+declare module "models" {
+    export interface Persona {
+        outOfOfficeText: Readonly<string>;
+    }
+}

--- a/addons/im_livechat/static/src/core/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/common/@types/models.d.ts
@@ -1,18 +1,50 @@
-import { ChatbotScriptStep as ChatbotScriptStepClass } from "@im_livechat/core/common/chatbot_script_step_model";
-import { ChatbotStep as ChatbotStepClass } from "@im_livechat/core/common/chatbot_step_model";
-import { Chatbot as ChatbotClass } from "@im_livechat/core/common/chatbot_model";
-import { ChatbotScriptStepAnswer as ChatbotScriptStepAnswerClass } from "@im_livechat/core/common/chatbot_script_step_answer_model";
-import { ChatbotScript as ChatbotScriptClass } from "@im_livechat/core/common/chatbot_script_model";
-import { LivechatChannelRule as LivechatChannelRuleClass } from "@im_livechat/core/common/livechat_channel_rule_model";
-
 declare module "models" {
-    export interface Thread {
-        livechat_operator_id: Persona,
-    }
-    export interface ChatbotScriptStep extends ChatbotScriptStepClass { }
-    export interface ChatbotStep extends ChatbotStepClass { }
-    export interface Chatbot extends ChatbotClass { }
-    export interface ChatbotScriptStepAnswer extends ChatbotScriptStepAnswerClass { }
-    export interface ChatbotScript extends ChatbotScriptClass { }
+    import { Chatbot as ChatbotClass } from "@im_livechat/core/common/chatbot_model";
+    import { ChatbotScript as ChatbotScriptClass } from "@im_livechat/core/common/chatbot_script_model";
+    import { ChatbotScriptStep as ChatbotScriptStepClass } from "@im_livechat/core/common/chatbot_script_step_model";
+    import { ChatbotScriptStepAnswer as ChatbotScriptStepAnswerClass } from "@im_livechat/core/common/chatbot_script_step_answer_model";
+    import { ChatbotStep as ChatbotStepClass } from "@im_livechat/core/common/chatbot_step_model";
+    import { LivechatChannel as LivechatChannelClass } from "@im_livechat/core/common/livechat_channel_model";
+    import { LivechatChannelRule as LivechatChannelRuleClass } from "@im_livechat/core/common/livechat_channel_rule_model";
+
+    export interface Chatbot extends ChatbotClass {}
+    export interface ChatbotScript extends ChatbotScriptClass {}
+    export interface ChatbotScriptStep extends ChatbotScriptStepClass {}
+    export interface ChatbotScriptStepAnswer extends ChatbotScriptStepAnswerClass {}
+    export interface ChatbotStep extends ChatbotStepClass {}
+    export interface LivechatChannel extends LivechatChannelClass {}
     export interface LivechatChannelRule extends LivechatChannelRuleClass {}
+
+    export interface ChatWindow {
+        livechatStep: undefined|"CONFIRM_CLOSE"|"FEEDBACK";
+    }
+    export interface Message {
+        chatbotStep: ChatbotStep;
+    }
+    export interface Store {
+        Chatbot: StaticMailRecord<Chatbot, typeof ChatbotClass>;
+        "chatbot.script": StaticMailRecord<ChatbotScript, typeof ChatbotScriptClass>;
+        "chatbot.script.answer": StaticMailRecord<ChatbotScriptStepAnswer, typeof ChatbotScriptStepAnswerClass>;
+        "chatbot.script.step": StaticMailRecord<ChatbotScriptStep, typeof ChatbotScriptStepClass>;
+        ChatbotStep: StaticMailRecord<ChatbotStep, typeof ChatbotStepClass>;
+        "im_livechat.channel": StaticMailRecord<LivechatChannel, typeof LivechatChannelClass>;
+        "im_livechat.channel.rule": StaticMailRecord<LivechatChannelRule, typeof LivechatChannelRuleClass>;
+    }
+    export interface Thread {
+        composerDisabled: Readonly<boolean>;
+        composerDisabledText: Readonly<string>;
+        livechat_operator_id: Persona;
+        livechatVisitorMember: ChannelMember;
+        open_chat_window: true|undefined;
+    }
+
+    export interface Models {
+        Chatbot: Chatbot;
+        "chatbot.script": ChatbotScript;
+        "chatbot.script.answer": ChatbotScriptStepAnswer;
+        "chatbot.script.step": ChatbotScriptStep;
+        ChatbotStep: ChatbotStep;
+        "im_livechat.channel": LivechatChannel;
+        "im_livechat.channel.rule": LivechatChannelRule;
+    }
 }

--- a/addons/im_livechat/static/src/core/common/chat_window_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/chat_window_model_patch.js
@@ -11,6 +11,7 @@ export const CW_LIVECHAT_STEP = {
 const chatWindowPatch = {
     setup() {
         super.setup(...arguments);
+        /** @type {undefined|"CONFIRM_CLOSE"|"FEEDBACK"} */
         this.livechatStep = CW_LIVECHAT_STEP.NONE;
     },
     close(options = {}) {

--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -27,6 +27,7 @@ patch(Thread.prototype, {
                 return visitor;
             },
         });
+        /** @type {true|undefined} */
         this.open_chat_window = Record.attr(undefined, {
             /** @this {import("models").Thread} */
             onUpdate() {
@@ -63,6 +64,6 @@ patch(Thread.prototype, {
     get composerDisabledText() {
         return this.channel_type === "livechat" && this.livechat_active === false
             ? _t("This livechat conversation has ended")
-            : null;
+            : "";
     },
 });

--- a/addons/im_livechat/static/src/core/public_web/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/public_web/@types/models.d.ts
@@ -1,17 +1,18 @@
 declare module "models" {
     export interface DiscussApp {
-        defaultLivechatCategory: DiscussAppCategory,
-        livechats: Thread,
+        defaultLivechatCategory: DiscussAppCategory;
+        livechats: Thread[];
     }
-    export interface Thread {
-        anonymous_country: Country,
-        anonymous_name: String,
-        appAsLivechats: DiscussApp,
-    }
-    export interface Store {
-        has_access_livechat: boolean,
+    export interface DiscussAppCategory {
+        livechatChannel: LivechatChannel;
     }
     export interface LivechatChannel {
-        threads: Thread[],
+        appCategory: DiscussAppCategory;
+        threads: Thread[];
+    }
+    export interface Thread {
+        anonymous_country: Country;
+        appAsLivechats: DiscussApp;
+        livechatChannel: LivechatChannel;
     }
 }

--- a/addons/im_livechat/static/src/core/web/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/web/@types/models.d.ts
@@ -1,0 +1,13 @@
+declare module "models" {
+    export interface LivechatChannel {
+        join: (param0: { notify: boolean }) => Promise<void>;
+        joinTitle: Readonly<string>;
+        leave: (param0: { notify: boolean }) => Promise<void>;
+        leaveTitle: Readonly<string>;
+    }
+    export interface Store {
+        goToOldestUnreadLivechatThread: () => boolean;
+        has_access_livechat: boolean;
+        livechatChannels: ReturnType<Store['makeCachedFetchData']>;
+    }
+}

--- a/addons/im_livechat/static/src/embed/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/embed/common/@types/models.d.ts
@@ -1,29 +1,19 @@
 declare module "models" {
-    export interface ChatWindpw {
-        hasFeedbackPanel: boolean,
-    }
-
-    export interface Message {
-        chatbotStep: ChatbotStep,
-    }
-
-    export interface Thread {
-        livechatWelcomeMessage: Message,
-        chatbot: Chatbot,
-        requested_by_operator: boolean,
-    }
-
     export interface Store {
-        livechat_rule: LivechatChannelRule;
+        activeLivechats: Thread[];
         livechat_available: boolean;
+        livechat_rule: LivechatChannelRule;
     }
-
-    export interface Models {
-        "ChatbotScriptStep": ChatbotScriptStep,
-        "ChatbotStep": ChatbotStep,
-        "Chatbot": Chatbot,
-        "ChatbotScriptStepAnswer": ChatbotScriptStepAnswer,
-        "chatbot.script": ChatbotScript,
-        "LivechatRule": LivechatRule,
+    export interface Thread {
+        _toggleChatbot: boolean;
+        chatbot: Chatbot;
+        chatbotTypingMessage: Message;
+        hasWelcomeMessage: Readonly<boolean>;
+        isLastMessageFromCustomer: Readonly<boolean>;
+        livechat_active: boolean;
+        livechat_operator_id: Persona;
+        livechatWelcomeMessage: Message;
+        requested_by_operator: boolean;
+        storeAsActiveLivechats: Store;
     }
 }

--- a/addons/im_livechat/static/src/embed/common/store_service_patch.js
+++ b/addons/im_livechat/static/src/embed/common/store_service_patch.js
@@ -10,6 +10,7 @@ const StorePatch = {
     setup() {
         super.setup(...arguments);
         this.livechat_rule = Record.one("im_livechat.channel.rule");
+        /** @type {boolean} */
         this.livechat_available = session.livechatData?.isAvailable;
         this.activeLivechats = Record.many("Thread", {
             inverse: "storeAsActiveLivechats",

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -66,7 +66,7 @@ patch(Thread.prototype, {
         });
         this.requested_by_operator = false;
     },
-
+    /** @returns {boolean} */
     get isLastMessageFromCustomer() {
         return this.newestPersistentOfAllMessage?.isSelfAuthored;
     },

--- a/addons/im_livechat/static/src/embed/cors/@types/models.d.ts
+++ b/addons/im_livechat/static/src/embed/cors/@types/models.d.ts
@@ -1,0 +1,5 @@
+declare module "models" {
+    export interface Store {
+        guest_token: string|null;
+    }
+}

--- a/addons/im_livechat/static/src/embed/cors/store_service_patch.js
+++ b/addons/im_livechat/static/src/embed/cors/store_service_patch.js
@@ -7,6 +7,7 @@ export const GUEST_TOKEN_STORAGE_KEY = "im_livechat_guest_token";
 patch(Store.prototype, {
     setup() {
         super.setup(...arguments);
+        /** @type {string|null} */
         this.guest_token = Record.attr(null, {
             compute() {
                 return expirableStorage.getItem(GUEST_TOKEN_STORAGE_KEY);

--- a/addons/mail/static/src/chatter/web/@types/models.d.ts
+++ b/addons/mail/static/src/chatter/web/@types/models.d.ts
@@ -1,17 +1,16 @@
 declare module "models" {
     import { ScheduledMessage as ScheduledMessageClass } from "@mail/chatter/web/scheduled_message_model";
 
-    export interface ScheduledMessage extends ScheduledMessageClass{}
+    export interface ScheduledMessage extends ScheduledMessageClass {}
 
     export interface Store {
-        "mail.scheduled.message": typeof ScheduledMessageClass,
+        "mail.scheduled.message": StaticMailRecord<ScheduledMessage, typeof ScheduledMessageClass>;
     }
-
     export interface Thread {
-        scheduledMessages: ScheduledMessage[],
+        scheduledMessages: ScheduledMessage[];
     }
 
     export interface Models {
-        "mail.scheduled.message": ScheduledMessage,
+        "mail.scheduled.message": ScheduledMessage;
     }
 }

--- a/addons/mail/static/src/chatter/web_portal/@types/models.d.ts
+++ b/addons/mail/static/src/chatter/web_portal/@types/models.d.ts
@@ -1,0 +1,5 @@
+declare module "models" {
+    export interface Thread {
+        fetchThreadData: (requestList: string[]) => Promise<void>;
+    }
+}

--- a/addons/mail/static/src/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/core/common/@types/models.d.ts
@@ -15,11 +15,9 @@ declare module "models" {
     import { Persona as PersonaClass } from "@mail/core/common/persona_model";
     import { ResGroups as ResGroupsClass } from "@mail/core/common/res_groups_model";
     import { Settings as SettingsClass } from "@mail/core/common/settings_model";
-    import { Store as StoreClass } from "@mail/core/common/store_service";
     import { Thread as ThreadClass } from "@mail/core/common/thread_model";
     import { Volume as VolumeClass } from "@mail/core/common/volume_model";
 
-    // define interfaces for jsdoc, including with patches
     export interface Activity extends ActivityClass {}
     export interface Attachment extends AttachmentClass {}
     export interface CannedResponse extends CannedResponseClass {}
@@ -36,30 +34,48 @@ declare module "models" {
     export interface Persona extends PersonaClass {}
     export interface ResGroups extends ResGroupsClass {}
     export interface Settings extends SettingsClass {}
-    export interface Store extends StoreClass {}
     export interface Thread extends ThreadClass {}
     export interface Volume extends VolumeClass {}
 
-    // required to propagate types in relational fields
+    export interface Store {
+        ChatHub: StaticMailRecord<ChatHub, typeof ChatHubClass>;
+        ChatWindow: StaticMailRecord<ChatWindow, typeof ChatWindowClass>;
+        Composer: StaticMailRecord<Composer, typeof ComposerClass>;
+        Failure: StaticMailRecord<Failure, typeof FailureClass>;
+        "ir.attachment": StaticMailRecord<Attachment, typeof AttachmentClass>;
+        "mail.activity": StaticMailRecord<Activity, typeof ActivityClass>;
+        "mail.canned.response": StaticMailRecord<CannedResponse, typeof CannedResponseClass>;
+        "mail.followers": StaticMailRecord<Follower, typeof FollowerClass>;
+        "mail.link.preview": StaticMailRecord<LinkPreview, typeof LinkPreviewClass>;
+        "mail.message": StaticMailRecord<Message, typeof MessageClass>;
+        "mail.notification": StaticMailRecord<Notification, typeof NotificationClass>;
+        MessageReactions: StaticMailRecord<MessageReactions, typeof MessageReactionsClass>;
+        Persona: StaticMailRecord<Persona, typeof PersonaClass>;
+        "res.country": StaticMailRecord<Country, typeof CountryClass>;
+        "res.groups": StaticMailRecord<ResGroups, typeof ResGroupsClass>;
+        Settings: StaticMailRecord<Settings, typeof SettingsClass>;
+        Thread: StaticMailRecord<Thread, typeof ThreadClass>;
+        Volume: StaticMailRecord<Volume, typeof VolumeClass>;
+    }
+
     export interface Models {
-        "ChatHub": ChatHub,
-        "ChatWindow": ChatWindow,
-        "Composer": Composer,
-        "Failure": Failure,
-        "ir.attachment": Attachment,
-        "mail.activity": Activity,
-        "mail.canned.response": CannedResponse,
-        "mail.followers": Follower,
-        "mail.link.preview": LinkPreview,
-        "mail.message": Message,
-        "mail.notification": Notification,
-        "MessageReactions": MessageReactions,
-        "Persona": Persona,
-        "res.country": Country,
-        "res.groups": ResGroups,
-        "Settings": Settings,
-        "Store": Store,
-        "Thread": Thread,
-        "Volume": Volume,
+        ChatHub: ChatHub;
+        ChatWindow: ChatWindow;
+        Composer: Composer;
+        Failure: Failure;
+        "ir.attachment": Attachment;
+        "mail.activity": Activity;
+        "mail.canned.response": CannedResponse;
+        "mail.followers": Follower;
+        "mail.link.preview": LinkPreview;
+        "mail.message": Message;
+        "mail.notification": Notification;
+        MessageReactions: MessageReactions;
+        Persona: Persona;
+        "res.country": Country;
+        "res.groups": ResGroups;
+        Settings: Settings;
+        Thread: Thread;
+        Volume: Volume;
     }
 }

--- a/addons/mail/static/src/core/common/activity_model.js
+++ b/addons/mail/static/src/core/common/activity_model.js
@@ -2,24 +2,8 @@ import { Record } from "@mail/core/common/record";
 import { assignDefined } from "@mail/utils/common/misc";
 
 export class Activity extends Record {
-    static name = "mail.activity";
+    static _name = "mail.activity";
     static id = "id";
-    /** @type {Object.<number, import("models").Activity>} */
-    static records = {};
-    /** @returns {import("models").Activity} */
-    static get(data) {
-        return super.get(data);
-    }
-    /**
-     * @template T
-     * @param {T} data
-     * @param {Object} [param1]
-     * @param {boolean} param1.broadcast
-     * @returns {T extends any[] ? import("models").Activity[] : import("models").Activity}
-     */
-    static insert(data, { broadcast = true } = {}) {
-        return super.insert(...arguments);
-    }
     /**
      * @param {Object} data
      * @param {Object} [param1]
@@ -87,8 +71,6 @@ export class Activity extends Record {
     res_id;
     /** @type {string} */
     res_name;
-    /** @type {number|false} */
-    request_partner_id;
     /** @type {'overdue'|'planned'|'today'} */
     state;
     /** @type {string} */

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -7,20 +7,6 @@ import { FileModelMixin } from "@web/core/file_viewer/file_model";
 export class Attachment extends FileModelMixin(Record) {
     static _name = "ir.attachment";
     static id = "id";
-    /** @type {Object.<number, import("models").Attachment>} */
-    static records = {};
-    /** @returns {import("models").Attachment} */
-    static get(data) {
-        return super.get(data);
-    }
-    /**
-     * @template T
-     * @param {T} data
-     * @returns {T extends any[] ? import("models").Attachment[] : import("models").Attachment}
-     */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
     static new() {
         /** @type {import("models").Attachment} */
         const attachment = super.new(...arguments);

--- a/addons/mail/static/src/core/common/canned_response_model.js
+++ b/addons/mail/static/src/core/common/canned_response_model.js
@@ -3,16 +3,6 @@ import { Record } from "@mail/core/common/record";
 export class CannedResponse extends Record {
     static _name = "mail.canned.response";
     static id = "id";
-    /** @type {Object.<number, import("models").CannedResponse>} */
-    static records = {};
-    /** @returns {import("models").CannedResponse} */
-    static get(data) {
-        return super.get(data);
-    }
-    /** @returns {import("models").CannedResponse|import("models").CannedResponse[]} */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
 
     /** @type {number} */
     id;

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -15,14 +15,6 @@ export class ChatHub extends Record {
     WINDOW = 380; // same value as $o-mail-ChatWindow-width
 
     /** @returns {import("models").ChatHub} */
-    static get(data) {
-        return super.get(data);
-    }
-    /** @returns {import("models").ChatHub|import("models").ChatHub[]} */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
-    /** @returns {import("models").ChatHub} */
     static new() {
         /** @type {import("models").ChatHub} */
         const chatHub = super.new(...arguments);

--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -5,20 +5,6 @@ import { isMobileOS } from "@web/core/browser/feature_detection";
 
 export class ChatWindow extends Record {
     static id = "thread";
-    /** @type {Object<number, import("models").ChatWindow} */
-    static records = {};
-    /** @returns {import("models").ChatWindow} */
-    static get(data) {
-        return super.get(data);
-    }
-    /**
-     * @template T
-     * @param {T} data
-     * @returns {T extends any[] ? import("models").ChatWindow[] : import("models").ChatWindow}
-     */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
 
     actionsDisabled = false;
     thread = Record.one("Thread");

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -2,14 +2,6 @@ import { OR, Record } from "@mail/core/common/record";
 
 export class Composer extends Record {
     static id = OR("thread", "message");
-    /** @returns {import("models").Composer} */
-    static get(data) {
-        return super.get(data);
-    }
-    /** @returns {import("models").Composer|import("models").Composer[]} */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
 
     clear() {
         this.attachments.length = 0;

--- a/addons/mail/static/src/core/common/country_model.js
+++ b/addons/mail/static/src/core/common/country_model.js
@@ -3,16 +3,7 @@ import { Record } from "@mail/core/common/record";
 export class Country extends Record {
     static id = "id";
     static _name = "res.country";
-    /** @type {Object.<number, import("models").Country>} */
-    static records = {};
-    /** @returns {import("models").Country} */
-    static get(data) {
-        return super.get(data);
-    }
-    /** @returns {import("models").Country|import("models").Country[]} */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
+
     /** @type {string} */
     code;
     /** @type {number} */

--- a/addons/mail/static/src/core/common/failure_model.js
+++ b/addons/mail/static/src/core/common/failure_model.js
@@ -6,16 +6,6 @@ import { _t } from "@web/core/l10n/translation";
 export class Failure extends Record {
     static nextId = markRaw({ value: 1 });
     static id = "id";
-    /** @type {Object.<number, import("models").Failure>} */
-    static records = {};
-    /** @returns {import("models").Failure} */
-    static get(data) {
-        return super.get(data);
-    }
-    /** @returns {import("models").Failure|import("models").Failure[]} */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
 
     notifications = Record.many("mail.notification", {
         /** @this {import("models").Failure} */

--- a/addons/mail/static/src/core/common/follower_model.js
+++ b/addons/mail/static/src/core/common/follower_model.js
@@ -4,20 +4,6 @@ import { rpc } from "@web/core/network/rpc";
 export class Follower extends Record {
     static _name = "mail.followers";
     static id = "id";
-    /** @type {Object.<number, import("models").Follower>} */
-    static records = {};
-    /** @returns {import("models").Follower} */
-    static get(data) {
-        return super.get(data);
-    }
-    /**
-     * @template T
-     * @param {T} data
-     * @returns {T extends any[] ? import("models").Follower[] : import("models").Follower}
-     */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
 
     thread = Record.one("Thread");
     /** @type {number} */

--- a/addons/mail/static/src/core/common/link_preview_model.js
+++ b/addons/mail/static/src/core/common/link_preview_model.js
@@ -6,18 +6,6 @@ const VIDEO_EXTENSIONS = new Set(["mp4", "mov", "avi", "mkv", "webm", "mpeg", "m
 export class LinkPreview extends Record {
     static _name = "mail.link.preview";
     static id = "id";
-    /** @returns {import("models").LinkPreview} */
-    static get(data) {
-        return super.get(data);
-    }
-    /**
-     * @template T
-     * @param {T} data
-     * @returns {T extends any[] ? import("models").LinkPreview[] : import("models").LinkPreview}
-     */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
 
     /** @type {number} */
     id;

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -17,20 +17,6 @@ const { DateTime } = luxon;
 export class Message extends Record {
     static _name = "mail.message";
     static id = "id";
-    /** @type {Object.<number, import("models").Message>} */
-    static records = {};
-    /** @returns {import("models").Message} */
-    static get(data) {
-        return super.get(data);
-    }
-    /**
-     * @template T
-     * @param {T} data
-     * @returns {T extends any[] ? import("models").Message[] : import("models").Message}
-     */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
 
     /** @param {Object} data */
     update(data) {

--- a/addons/mail/static/src/core/common/message_reactions_model.js
+++ b/addons/mail/static/src/core/common/message_reactions_model.js
@@ -3,14 +3,6 @@ import { rpc } from "@web/core/network/rpc";
 
 export class MessageReactions extends Record {
     static id = AND("message", "content");
-    /** @returns {import("models").MessageReactions} */
-    static get(data) {
-        return super.get(data);
-    }
-    /** @returns {import("models").MessageReactions|import("models").MessageReactions[]} */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
 
     /** @type {string} */
     content;

--- a/addons/mail/static/src/core/common/notification_model.js
+++ b/addons/mail/static/src/core/common/notification_model.js
@@ -5,20 +5,6 @@ import { _t } from "@web/core/l10n/translation";
 export class Notification extends Record {
     static _name = "mail.notification";
     static id = "id";
-    /** @type {Object.<number, import("models").Notification>} */
-    static records = {};
-    /** @returns {import("models").Notification} */
-    static get(data) {
-        return super.get(data);
-    }
-    /**
-     * @template T
-     * @param {T} data
-     * @returns {T extends any[] ? import("models").Notification[] : import("models").Notification}
-     * */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
 
     /** @type {number} */
     id;
@@ -39,13 +25,12 @@ export class Notification extends Record {
             if (!this.mail_message_id?.isSelfAuthored) {
                 return;
             }
-            const failure = Object.values(this.store.Failure.records).find((f) => {
-                return (
+            const failure = Object.values(this.store.Failure.records).find(
+                (f) =>
                     f.resModel === thread?.model &&
                     f.type === this.notification_type &&
                     (f.resModel !== "discuss.channel" || f.resIds.has(thread?.id))
-                );
-            });
+            );
             return this.isFailure
                 ? {
                       id: failure ? failure.id : this.store.Failure.nextId.value++,

--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -17,16 +17,6 @@ const { DateTime } = luxon;
 
 export class Persona extends Record {
     static id = AND("type", "id");
-    /** @type {Object.<number, import("models").Persona>} */
-    static records = {};
-    /** @returns {import("models").Persona} */
-    static get(data) {
-        return super.get(data);
-    }
-    /** @returns {import("models").Persona|import("models").Persona[]} */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
     static new() {
         const record = super.new(...arguments);
         record.debouncedSetImStatus = debounce(

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -36,50 +36,10 @@ export const addFieldsByPyModel = {
 export class Store extends BaseStore {
     static FETCH_DATA_DEBOUNCE_DELAY = 1;
     static OTHER_LONG_TYPING = 60000;
+
     FETCH_LIMIT = 30;
     DEFAULT_AVATAR = "/mail/static/src/img/smiley/avatar.jpg";
     isReady = new Deferred();
-
-    /** @returns {import("models").Store|import("models").Store[]} */
-    static insert() {
-        return super.insert(...arguments);
-    }
-
-    /** @type {typeof import("@mail/core/common/chat_window_model").ChatWindow} */
-    ChatWindow;
-    /** @type {typeof import("@mail/core/common/composer_model").Composer} */
-    Composer;
-    /** @type {typeof import("@mail/core/common/failure_model").Failure} */
-    Failure;
-    /** @type {typeof import("@mail/core/common/attachment_model").Attachment} */
-    ["ir.attachment"];
-    /** @type {typeof import("@mail/core/common/activity_model").Activity} */
-    ["mail.activity"];
-    /** @type {typeof import("@mail/core/common/canned_response_model").CannedResponse} */
-    ["mail.canned.response"];
-    /** @type {typeof import("@mail/core/common/follower_model").Follower} */
-    ["mail.followers"];
-    /** @type {typeof import("@mail/core/common/link_preview_model").LinkPreview} */
-    ["mail.link.preview"];
-    /** @type {typeof import("@mail/core/common/message_model").Message} */
-    ["mail.message"];
-    /** @type {typeof import("@mail/core/common/notification_model").Notification} */
-    ["mail.notification"];
-    /** @type {typeof import("@mail/core/common/message_reactions_model").MessageReactions} */
-    MessageReactions;
-    /** @type {typeof import("@mail/core/common/persona_model").Persona} */
-    Persona;
-    /** @type {typeof import("@mail/core/common/country_model").Country} */
-    ["res.country"];
-    /** @type {typeof import("@mail/core/common/res_groups_model").ResGroups} */
-    ["res.groups"];
-    /** @type {typeof import("@mail/core/common/settings_model").Settings} */
-    Settings;
-    /** @type {typeof import("@mail/core/common/thread_model").Thread} */
-    Thread;
-    /** @type {typeof import("@mail/core/common/volume_model").Volume} */
-    Volume;
-
     /** This is the current logged partner / guest */
     self = Record.one("Persona");
     /**

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -18,12 +18,6 @@ import { isMobileOS } from "@web/core/browser/feature_detection";
 
 export class Thread extends Record {
     static id = AND("model", "id");
-    /** @type {Object.<string, import("models").Thread>} */
-    static records = {};
-    /** @returns {import("models").Thread} */
-    static get(data) {
-        return super.get(data);
-    }
     /**
      * @param {string} localId
      * @returns {string}
@@ -34,10 +28,6 @@ export class Thread extends Record {
         }
         // Transform "Thread,<model> AND <id>" to "<model>_<id>""
         return localId.split(",").slice(1).join("_").replace(" AND ", "_");
-    }
-    /** @returns {import("models").Thread|import("models").Thread[]} */
-    static insert(data) {
-        return super.insert(...arguments);
     }
     static async getOrFetch(data, fieldNames = []) {
         let thread = this.get(data);

--- a/addons/mail/static/src/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/core/public_web/@types/models.d.ts
@@ -1,19 +1,22 @@
 declare module "models" {
     import { DiscussApp as DiscussAppClass } from "@mail/core/public_web/discuss_app_model";
 
-    export interface DiscussApp extends DiscussAppClass { }
+    export interface DiscussApp extends DiscussAppClass {}
+
     export interface Store {
-        DiscussApp: DiscussApp,
-        discuss: DiscussApp,
-        action_discuss_id: number,
+        discuss: DiscussApp;
+        DiscussApp: StaticMailRecord<DiscussApp, typeof DiscussAppClass>;
     }
     export interface Thread {
-        setAsDiscussThread: (pushState: boolean) => void,
-        unpin: () => Promise<void>,
-        askLeaveConfirmation: (body: string) => void,
-        leaveChannel: () => Promise<void>,
+        askLeaveConfirmation: (body: string) => Promise<void>;
+        autoOpenChatWindowOnNewMessage: Readonly<boolean>;
+        notifyMessageToUser: (message: Message) => Promise<void>;
+        setActiveURL: () => void;
+        setAsDiscussThread: (pushState: boolean) => void;
+        unpin: () => Promise<void>;
     }
+
     export interface Models {
-        "DiscussApp": DiscussApp,
+        DiscussApp: DiscussApp;
     }
 }

--- a/addons/mail/static/src/core/public_web/discuss_app_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app_model.js
@@ -2,15 +2,6 @@ import { Record } from "@mail/core/common/record";
 import { browser } from "@web/core/browser/browser";
 
 export class DiscussApp extends Record {
-    /** @returns {import("models").DiscussApp} */
-    static get(data) {
-        return super.get(data);
-    }
-    /** @returns {import("models").DiscussApp|import("models").DiscussApp[]} */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
-
     INSPECTOR_WIDTH = 300;
     /** @type {'main'|'channel'|'chat'|'livechat'} */
     activeTab = "main";

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -101,7 +101,7 @@ patch(Thread.prototype, {
             router.replaceState({ active_id: undefined });
         }
         if (this.model === "discuss.channel" && this.is_pinned) {
-            return this.store.env.services.orm.silent.call(
+            await this.store.env.services.orm.silent.call(
                 "discuss.channel",
                 "channel_pin",
                 [this.id],
@@ -109,8 +109,9 @@ patch(Thread.prototype, {
             );
         }
     },
-    askLeaveConfirmation(body) {
-        return new Promise((resolve) => {
+    /** @param {string} body */
+    async askLeaveConfirmation(body) {
+        await new Promise((resolve) => {
             this.store.env.services.dialog.add(ConfirmationDialog, {
                 body: body,
                 confirmLabel: _t("Leave Conversation"),

--- a/addons/mail/static/src/core/web/@types/models.d.ts
+++ b/addons/mail/static/src/core/web/@types/models.d.ts
@@ -1,15 +1,36 @@
 declare module "models" {
-    export interface Discuss  {
-        inbox: Thread,
-        stared: Thread,
-        history: Thread,
+    export interface Activity {
+        dateCreateFormatted: Readonly<string>;
+        dateDeadlineFormatted: Readonly<string>;
+        dateDoneFormatted: Readonly<string>;
+        edit: () => Promise<void>;
+        markAsDone: (attachmentIds: number[]) => Promise<void>;
+        markAsDoneAndScheduleNext: () => Promise<ActionDescription>;
+        remove: (param0: { broadcast: boolean }) => void;
+    }
+    export interface Message {
+        canForward: (thread: Thread) => boolean;
+        canReplyAll: (thread: Thread) => boolean;
     }
     export interface Store {
-        activityCounter: number,
-        activity_counter_bus_id: number,
-        activityGroups: Object[],
+        _onActivityBroadcastChannelMessage: (param0: { data: { type: "INSERT"|"DELETE"|"RELOAD_CHATTER", payload: Partial<Activity> } }) => void;
+        activity_counter_bus_id: number;
+        activityCounter: number;
+        activityGroups: Object[];
+        history: Thread;
+        inbox: Thread;
+        onLinkFollowed: (fromThread: Thread) => void;
+        onUpdateActivityGroups: () => void;
+        scheduleActivity: (resModel: string, resIds: number[], defaultActivityTypeId: number|undefined) => Promise<void>;
+        starred: Thread;
+        unstarAll: () => Promise<void>;
     }
     export interface Thread {
-        recipients: Follower[],
+        activities: Activity[];
+        loadMoreFollowers: () => Promise<void>;
+        loadMoreRecipients: () => Promise<void>;
+        recipients: Follower[];
+        recipientsCount: number|undefined;
+        recipientsFullyLoaded: Readonly<boolean>;
     }
 }

--- a/addons/mail/static/src/core/web/activity_model_patch.js
+++ b/addons/mail/static/src/core/web/activity_model_patch.js
@@ -18,7 +18,7 @@ patch(Activity.prototype, {
         return formatDateTime(this.create_date);
     },
     async edit() {
-        return new Promise((resolve) =>
+        await new Promise((resolve) =>
             this.store.env.services.action.doAction(
                 {
                     type: "ir.actions.act_window",
@@ -48,6 +48,7 @@ patch(Activity.prototype, {
             payload: { id: this.res_id, model: this.res_model },
         });
     },
+    /** @returns {Promise<import("@web/webclient/actions/action_service").ActionDescription>} */
     async markAsDoneAndScheduleNext() {
         const action = await this.store.env.services.orm.call(
             "mail.activity",

--- a/addons/mail/static/src/core/web/message_model_patch.js
+++ b/addons/mail/static/src/core/web/message_model_patch.js
@@ -8,6 +8,7 @@ const messagePatch = {
     canReplyAll(thread) {
         return this.canForward(thread) && !this.is_note;
     },
+    /** @param {import("models").Thread} thread */
     canForward(thread) {
         return (
             !["discuss.channel", "mail.box"].includes(thread.model) &&

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -11,6 +11,7 @@ const StorePatch = {
         super.setup(...arguments);
         this.activityCounter = 0;
         this.activity_counter_bus_id = 0;
+        /** @type {Object[]} */
         this.activityGroups = Record.attr([], {
             onUpdate() {
                 this.onUpdateActivityGroups();
@@ -62,6 +63,11 @@ const StorePatch = {
         }
     },
     onUpdateActivityGroups() {},
+    /**
+     * @param {string} resModel
+     * @param {number[]} resIds
+     * @param {number|undefined} defaultActivityTypeId
+     */
     async scheduleActivity(resModel, resIds, defaultActivityTypeId = undefined) {
         const context = {
             active_model: resModel,
@@ -71,7 +77,7 @@ const StorePatch = {
                 ? { default_activity_type_id: defaultActivityTypeId }
                 : {}),
         };
-        return new Promise((resolve) =>
+        await new Promise((resolve) =>
             this.env.services.action.doAction(
                 {
                     type: "ir.actions.act_window",
@@ -89,6 +95,10 @@ const StorePatch = {
             )
         );
     },
+    /**
+     * @param {object} param0
+     * @param {{ type: "INSERT"|"DELETE"|"RELOAD_CHATTER", payload: Partial<import("models").Activity> }} param0.data
+     */
     _onActivityBroadcastChannelMessage({ data }) {
         switch (data.type) {
             case "INSERT":
@@ -133,6 +143,7 @@ const StorePatch = {
         }
         return false;
     },
+    /** @param {import("models").Thread} fromThread */
     onLinkFollowed(fromThread) {},
 };
 patch(Store.prototype, StorePatch);

--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -6,10 +6,10 @@ import { compareDatetime } from "@mail/utils/common/misc";
 
 /** @type {import("models").Thread} */
 const threadPatch = {
-    /** @type {integer|undefined} */
-    recipientsCount: undefined,
     setup() {
         super.setup();
+        /** @type {number|undefined} */
+        this.recipientsCount = undefined;
         this.recipients = Record.many("mail.followers");
         this.activities = Record.many("mail.activity", {
             sort: (a, b) => compareDatetime(a.date_deadline, b.date_deadline) || a.id - b.id,
@@ -74,7 +74,7 @@ const threadPatch = {
         await this.store.chatHub.initPromise;
         const chatWindow = this.store.ChatWindow.get({ thread: this });
         await chatWindow?.close();
-        super.unpin(...arguments);
+        await super.unpin(...arguments);
     },
 };
 patch(Thread.prototype, threadPatch);

--- a/addons/mail/static/src/discuss/call/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/call/common/@types/models.d.ts
@@ -2,24 +2,37 @@ declare module "models" {
     import { Rtc as RtcClass } from "@mail/discuss/call/common/rtc_service";
     import { RtcSession as RtcSessionClass } from "@mail/discuss/call/common/rtc_session_model";
 
-    export interface ChannelMember {
-        rtcSession: RtcSession,
-    }
-    export interface Store {
-        allActiveRtcSessions: RtcSession[],
-        ["discuss.channel.rtc.session"]: typeof RtcSessionClass,
-        nextTalkingTime: number,
-        ringingThreads: Thread[],
-    }
     export interface Rtc extends RtcClass {}
     export interface RtcSession extends RtcSessionClass {}
+
+    export interface ChannelMember {
+        rtcSession: RtcSession;
+    }
+    export interface Persona {
+        currentRtcSession: RtcSession;
+    }
+    export interface Settings {
+        getVolume: (rtcSession: RtcSession) => number;
+    }
+    export interface Store {
+        allActiveRtcSessions: RtcSession[];
+        "discuss.channel.rtc.session": StaticMailRecord<RtcSession, typeof RtcSessionClass>;
+        nextTalkingTime: number;
+        ringingThreads: Thread[];
+        rtc: Rtc;
+        Rtc: StaticMailRecord<Rtc, typeof RtcClass>;
+    }
     export interface Thread {
-        activeRtcSession: RtcSession,
-        rtcInvitingSession: RtcSession,
-        rtcSessions: RtcSession[],
+        activeRtcSession: RtcSession;
+        hadSelfSession: boolean;
+        lastSessionIds: Set<number>;
+        rtcInvitingSession: RtcSession;
+        rtcSessions: RtcSession[];
+        videoCount: Readonly<number>;
     }
 
     export interface Models {
-        "discuss.channel.rtc.session": RtcSession,
+        "discuss.channel.rtc.session": RtcSession;
+        Rtc: Rtc;
     }
 }

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -200,15 +200,6 @@ class Network {
 }
 
 export class Rtc extends Record {
-    /** @returns {import("models").Rtc} */
-    static get(data) {
-        return super.get(...arguments);
-    }
-    /** @returns {import("models").Rtc} */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
-
     notifications = reactive(new Map());
     /** @type {Map<string, number>} timeoutId by notificationId for call notifications */
     timeouts = new Map();

--- a/addons/mail/static/src/discuss/call/common/rtc_session_model.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_session_model.js
@@ -3,20 +3,6 @@ import { Record } from "@mail/core/common/record";
 export class RtcSession extends Record {
     static _name = "discuss.channel.rtc.session";
     static id = "id";
-    /** @type {Object.<number, import("models").RtcSession>} */
-    static records = {};
-    /** @returns {import("models").RtcSession} */
-    static get(data) {
-        return super.get(data);
-    }
-    /**
-     * @template T
-     * @param {T} data
-     * @returns {T extends any[] ? import("models").RtcSession[] : import("models").RtcSession}
-     */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
     static _insert() {
         /** @type {import("models").RtcSession} */
         const session = super._insert(...arguments);

--- a/addons/mail/static/src/discuss/call/common/settings_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/settings_model_patch.js
@@ -7,6 +7,7 @@ const SettingsPatch = {
     setup() {
         super.setup(...arguments);
     },
+    /** @param {import("models").RtcSession} rtcSession */
     getVolume(rtcSession) {
         return (
             rtcSession.volume ??

--- a/addons/mail/static/src/discuss/call/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/call/common/store_service_patch.js
@@ -7,8 +7,6 @@ import { patch } from "@web/core/utils/patch";
 const StorePatch = {
     setup() {
         super.setup(...arguments);
-        /** @type {typeof import("@mail/discuss/call/common/rtc_session_model").RtcSession} */
-        this["discuss.channel.rtc.session"] = undefined;
         this.rtc = Record.one("Rtc", {
             compute() {
                 return {};

--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -18,6 +18,7 @@ const ThreadPatch = {
             },
         });
         this.hadSelfSession = false;
+        /** @type {Set<number>} */
         this.lastSessionIds = new Set();
         this.rtcInvitingSession = Record.one("discuss.channel.rtc.session", {
             /** @this {import("models").Thread} */

--- a/addons/mail/static/src/discuss/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/common/@types/models.d.ts
@@ -4,65 +4,66 @@ declare module "models" {
     export interface ChannelMember extends ChannelMemberClass {}
 
     export interface Message {
-        readonly channelMemberHaveSeen: ChannelMember[],
-        hasEveryoneSeen: boolean,
-        hasNewMessageSeparator: boolean,
-        hasSomeoneFetched: boolean,
-        hasSomeoneSeen: boolean,
-        isMessagePreviousToLastSelfMessageSeenByEveryone: boolean,
-        mentionedChannelPromises: Promise<Thread>[],
-        threadAsFirstUnread: Thread,
+        channelMemberHaveSeen: Readonly<ChannelMember[]>;
+        hasEveryoneSeen: boolean|undefined;
+        hasNewMessageSeparator: boolean;
+        hasSomeoneFetched: boolean|undefined;
+        hasSomeoneSeen: boolean|undefined;
+        isMessagePreviousToLastSelfMessageSeenByEveryone: boolean;
+        mentionedChannelPromises: Promise<Thread>[];
+        threadAsFirstUnread: Thread;
     }
-
     export interface Persona {
-        channelMembers: ChannelMember[],
+        channelMembers: ChannelMember[];
     }
-
     export interface Store {
-        channel_types_with_seen_infos: string[],
-        "discuss.channel.member": typeof ChannelMemberClass,
-        fetchChannel(channelId: number): Promise<void>,
-        getRecentChatPartnerIds(): number[],
-        readonly onlineMemberStatuses: String[],
-        sortMembers(m1: ChannelMember, m2: ChannelMember)
+        channel_types_with_seen_infos: string[];
+        createGroupChat: (param0: { default_display_mode: string, partners_to: number[], name: string }) => Promise<Thread>;
+        "discuss.channel.member": StaticMailRecord<ChannelMember, typeof ChannelMemberClass>;
+        fetchChannel: (channelId: number) => Promise<void>;
+        getRecentChatPartnerIds: () => number[];
+        onlineMemberStatuses: Readonly<string[]>;
+        sortMembers: (m1: ChannelMember, m2: ChannelMember) => number;
+        startChat: (partnerIds: number[]) => Promise<void>;
+        updateBusSubscription: (() => unknown) & { cancel: () => void };
     }
-
     export interface Thread {
-        readonly areAllMembersLoaded: boolean,
-        channel_member_ids: ChannelMember[],
-        channel_type: "chat" | "channel" | "group" | "livechat" | "whatsapp",
-        computeCorrespondent(): ChannelMember | undefined,
-        correspondent: ChannelMember,
-        readonly correspondents: ChannelMember[],
-        default_display_mode: "video_full_screen" | false | undefined,
-        fetchChannelMembers(): Promise<void>,
-        firstUnreadMessage: Message,
-        hasOtherMembersTyping: boolean,
-        readonly hasMemberList: boolean,
-        readonly hasSeenFeature: boolean,
-        readonly hasSelfAsMember: boolean,
-        invitedMembers: ChannelMember[],
-        last_interest_dt: luxon.DateTime,
-        lastInterestDt: luxon.DateTime,
-        readonly lastMessageSeenByAllId: number,
-        readonly lastSelfMessageSeenByEveryone: Message,
-        member_count: number | undefined,
-        readonly membersThatCanSeen: ChannelMember[],
-        name: string,
-        newMessageBannerText: string,
-        onClickUnreadMessagesBanner(): void,
-        onlineMembers: ChannelMember[],
-        offlineMembers: ChannelMember[],
-        otherTypingMembers: ChannelMember[],
-        selfMember: ChannelMember,
-        showUnreadBanner(): boolean,
-        typingMembers: ChannelMember[],
-        readonly hasMemberList: boolean,
-        readonly unknownMembersCount: number,
-        private _computeOfflineMembers(): ChannelMember[],
+        _computeOfflineMembers: () => ChannelMember[];
+        areAllMembersLoaded: Readonly<boolean>;
+        channel_member_ids: ChannelMember[];
+        computeCorrespondent: () => ChannelMember;
+        correspondent: ChannelMember;
+        correspondents: Readonly<ChannelMember[]>;
+        default_display_mode: "video_full_screen"|undefined;
+        fetchChannelInfoDeferred: Deferred<Thread|undefined>;
+        fetchChannelInfoState: "not_fetched"|"fetching"|"fetched";
+        fetchChannelMembers: () => Promise<void>;
+        fetchMoreAttachments: (limit: number) => Promise<void>;
+        firstUnreadMessage: Message;
+        hasMemberList: Readonly<boolean>;
+        hasOtherMembersTyping: boolean;
+        hasSeenFeature: boolean;
+        hasSelfAsMember: Readonly<boolean>;
+        invitedMembers: ChannelMember[];
+        last_interest_dt: luxon.DateTime;
+        lastInterestDt: luxon.DateTime;
+        lastMessageSeenByAllId: undefined|number;
+        lastSelfMessageSeenByEveryone: Message;
+        member_count: number|undefined;
+        membersThatCanSeen: Readonly<ChannelMember[]>;
+        name: string;
+        offlineMembers: ChannelMember[];
+        onlineMembers: ChannelMember[];
+        otherTypingMembers: ChannelMember[];
+        scrollUnread: boolean;
+        selfMember: ChannelMember;
+        showUnreadBanner: Readonly<boolean>;
+        toggleBusSubscription: boolean;
+        typingMembers: ChannelMember[];
+        unknownMembersCount: Readonly<number>;
     }
 
     export interface Models {
-        "discuss.channel.member": ChannelMember,
+        "discuss.channel.member": ChannelMember;
     }
 }

--- a/addons/mail/static/src/discuss/core/common/channel_member_model.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_model.js
@@ -10,20 +10,6 @@ const { DateTime } = luxon;
 export class ChannelMember extends Record {
     static _name = "discuss.channel.member";
     static id = "id";
-    /** @type {Object.<number, import("models").ChannelMember>} */
-    static records = {};
-    /** @returns {import("models").ChannelMember} */
-    static get(data) {
-        return super.get(data);
-    }
-    /**
-     * @template T
-     * @param {T} data
-     * @returns {T extends any[] ? import("models").ChannelMember[] : import("models").ChannelMember}
-     */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
 
     /** @type {string} */
     create_date;

--- a/addons/mail/static/src/discuss/core/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/message_model_patch.js
@@ -45,9 +45,11 @@ const messagePatch = {
                 return this.id < this.thread.lastSelfMessageSeenByEveryone.id;
             },
         });
+        /** @type {Promise<Thread>[]} */
         this.mentionedChannelPromises = [];
         this.threadAsFirstUnread = Record.one("Thread", { inverse: "firstUnreadMessage" });
     },
+    /** @returns {import("models").ChannelMember[]} */
     get channelMemberHaveSeen() {
         return this.thread.membersThatCanSeen.filter(
             (m) => m.hasSeen(this) && m.persona.notEq(this.author)

--- a/addons/mail/static/src/discuss/core/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/store_service_patch.js
@@ -25,6 +25,13 @@ const storeServicePatch = {
     get onlineMemberStatuses() {
         return ["away", "bot", "online"];
     },
+    /**
+     * @param {Object} param0
+     * @param {string} param0.default_display_mode
+     * @param {number[]} param0.partners_to
+     * @param {string} param0.name
+     * @returns {Promise<import("models").Thread>}
+     */
     async createGroupChat({ default_display_mode, partners_to, name }) {
         const data = await rpc("/discuss/channel/create_group", {
             default_display_mode,
@@ -36,6 +43,7 @@ const storeServicePatch = {
         channel.open({ focus: true });
         return channel;
     },
+    /** @param {number} channelId */
     async fetchChannel(channelId) {
         const channelIds = this.fetchParams.find(
             (fetchParams) => fetchParams[0] === "discuss.channel"
@@ -59,10 +67,14 @@ const storeServicePatch = {
             .sort((a, b) => compareDatetime(b.lastInterestDt, a.lastInterestDt) || b.id - a.id)
             .map((thread) => thread.correspondent.persona.id);
     },
+    /**
+     * @param {import("models").ChannelMember} m1
+     * @param {import("models").ChannelMember} m2
+     */
     sortMembers(m1, m2) {
         return m1.persona.name?.localeCompare(m2.persona.name) || m1.id - m2.id;
     },
-    /** @param {[number]} partnerIds */
+    /** @param {number[]} partnerIds */
     async startChat(partnerIds) {
         const partners_to = [...new Set([this.self.id, ...partnerIds])];
         if (partners_to.length === 1) {

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -67,8 +67,11 @@ const threadPatch = {
                 return this.computeCorrespondent();
             },
         });
+        /** @type {"video_full_screen"|undefined} */
         this.default_display_mode = undefined;
+        /** @type {Deferred<Thread|undefined>} */
         this.fetchChannelInfoDeferred = undefined;
+        /** @type {"not_fetched"|"fetching"|"fetched"} */
         this.fetchChannelInfoState = "not_fetched";
         this.hasOtherMembersTyping = Record.attr(false, {
             /** @this {import("models").Thread} */
@@ -155,6 +158,7 @@ const threadPatch = {
                 return res;
             },
         });
+        /** @type {number|undefined} */
         this.member_count = undefined;
         /** @type {string} name: only for channel. For generic thread, @see display_name */
         this.name = undefined;
@@ -199,6 +203,7 @@ const threadPatch = {
         });
         this.typingMembers = Record.many("discuss.channel.member", { inverse: "threadAsTyping" });
     },
+    /** @returns {import("models").ChannelMember[]} */
     _computeOfflineMembers() {
         return this.channel_member_ids.filter(
             (member) => !this.store.onlineMemberStatuses.includes(member.persona?.im_status)
@@ -218,6 +223,7 @@ const threadPatch = {
         }
         return super.avatarUrl;
     },
+    /** @returns {import("models").ChannelMember} */
     computeCorrespondent() {
         if (this.channel_type === "channel") {
             return undefined;
@@ -233,6 +239,7 @@ const threadPatch = {
         }
         return undefined;
     },
+    /** @returns {import("models").ChannelMember[]} */
     get correspondents() {
         return this.channel_member_ids.filter(({ persona }) => persona.notEq(this.store.self));
     },
@@ -349,6 +356,7 @@ const threadPatch = {
      * To be overridden.
      * The purpose is to exclude technical channel_member_ids like bots and avoid
      * "wrong" seen message indicator
+     * @returns {import("models").ChannelMember[]}
      */
     get membersThatCanSeen() {
         return this.channel_member_ids;

--- a/addons/mail/static/src/discuss/core/public/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/public/@types/models.d.ts
@@ -1,0 +1,8 @@
+declare module "models" {
+    export interface Store {
+        discuss_public_thread: Thread;
+    }
+    export interface Thread {
+        setActiveURL: () => void;
+    }
+}

--- a/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
@@ -1,31 +1,39 @@
 declare module "models" {
     import { DiscussAppCategory as DiscussAppCategoryClass } from "@mail/discuss/core/public_web/discuss_app_category_model";
 
-    export interface DiscussAppCategory extends DiscussAppCategoryClass { }
-    export interface Store {
-        DiscussAppCategory : DiscussAppCategory,
-    }
-    export interface Thread {
-        discussAppCategory: DiscussAppCategory,
-        _computeDiscussAppCategory(): DiscussAppCategory,
-    }
+    export interface DiscussAppCategory extends DiscussAppCategoryClass {}
+
     export interface DiscussApp {
         allCategories: DiscussAppCategory[];
         channels: DiscussAppCategory;
         chats: DiscussAppCategory;
+        computeChats: () => object;
+    }
+    export interface Message {
+        linkedSubChannel: Thread;
     }
     export interface Store {
-        getDiscussSidebarCategoryCounter: (categoryId: number) => number,
+        channels: ReturnType<Store['makeCachedFetchData']>;
+        DiscussAppCategory: StaticMailRecord<DiscussAppCategory, typeof DiscussAppCategoryClass>;
+        fetchSsearchConversationsSequential: () => Promise<any>;
+        getDiscussSidebarCategoryCounter: (categoryId: string) => number;
+        searchConversations: (searchValue: string) => Promise<void>;
     }
     export interface Thread {
+        _computeDiscussAppCategory: () => undefined|unknown;
+        createSubChannel: (param0: { initialMessage: Message, name: string }) => Promise<void>;
+        discussAppCategory: DiscussAppCategory;
         displayInSidebar: boolean;
         from_message_id: Message;
+        hasSubChannelFeature: Readonly<boolean>;
+        lastSubChannelLoaded: Thread|null;
+        loadMoreSubChannels: (param0: { searchTerm: string }) => Promise<Thread[]|undefined>;
+        loadSubChannelsDone: boolean;
         parent_channel_id: Thread;
-        readonly hasSubChannelFeature: boolean;
         sub_channel_ids: Thread[];
     }
 
     export interface Models {
-        "DiscussAppCategory": DiscussAppCategory,
+        DiscussAppCategory: DiscussAppCategory;
     }
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app_category_model.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app_category_model.js
@@ -4,14 +4,6 @@ import { browser } from "@web/core/browser/browser";
 
 export class DiscussAppCategory extends Record {
     static id = "id";
-    /** @returns {import("models").DiscussAppCategory} */
-    static get(data) {
-        return super.get(data);
-    }
-    /** @returns {import("models").DiscussAppCategory|import("models").DiscussAppCategory[]} */
-    static insert(data) {
-        return super.insert(...arguments);
-    }
 
     /**
      * @param {import("models").Thread} t1

--- a/addons/mail/static/src/discuss/core/public_web/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/store_service_patch.js
@@ -11,6 +11,10 @@ const StorePatch = {
         this.channels = this.makeCachedFetchData("channels_as_member");
         this.fetchSsearchConversationsSequential = useSequential();
     },
+    /**
+     * @param {string} categoryId
+     * @returns {number}
+     * */
     getDiscussSidebarCategoryCounter(categoryId) {
         return this.DiscussAppCategory.get({ id: categoryId }).threads.reduce((acc, channel) => {
             if (categoryId === "channels") {
@@ -20,6 +24,7 @@ const StorePatch = {
             }
         }, 0);
     },
+    /** @param {string} searchValue */
     async searchConversations(searchValue) {
         const data = await this.fetchSsearchConversationsSequential(async () => {
             const data = await rpc("/discuss/search", { term: searchValue });

--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -33,6 +33,7 @@ const threadPatch = {
             },
         });
         this.loadSubChannelsDone = false;
+        /** @type {import("models").Thread|null} */
         this.lastSubChannelLoaded = null;
     },
     get canLeave() {
@@ -84,7 +85,7 @@ const threadPatch = {
     /**
      * @param {*} param0
      * @param {string} [param0.searchTerm]
-     * @returns {import("models").Thread[]}
+     * @returns {Promise<import("models").Thread[]|undefined>}
      */
     async loadMoreSubChannels({ searchTerm } = {}) {
         if (this.loadSubChannelsDone) {

--- a/addons/mail/static/src/discuss/core/web/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/web/@types/models.d.ts
@@ -1,13 +1,7 @@
 declare module "models" {
-    import { Deferred } from "@web/core/utils/concurrency";
-    import { Store as StoreClass } from "@mail/core/common/store_service";
-
     export interface Store {
+        getSelfImportantChannels: () => Thread[];
+        getSelfRecentChannels: () => Thread[];
         initChannelsUnreadCounter: number;
-        channels: ReturnType<StoreClass["makeCachedFetchData"]>;
-    }
-    export interface Thread {
-        fetchChannelInfoDeferred: Promise<Thread>;
-        fetchChannelInfoState: 'not_fetched' | 'fetching' | 'fetched';
     }
 }

--- a/addons/mail/static/src/discuss/core/web/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/web/store_service_patch.js
@@ -9,9 +9,11 @@ const StorePatch = {
         super.setup(...arguments);
         this.initChannelsUnreadCounter = 0;
     },
+    /** @returns {import("models").Thread[]} */
     getSelfImportantChannels() {
         return this.getSelfRecentChannels().filter((channel) => channel.importantCounter > 0);
     },
+    /** @returns {import("models").Thread[]} */
     getSelfRecentChannels() {
         return Object.values(this.Thread.records)
             .filter((thread) => thread.model === "discuss.channel" && thread.selfMember)

--- a/addons/mail/static/src/discuss/message_pin/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/message_pin/common/@types/models.d.ts
@@ -1,12 +1,12 @@
 declare module "models" {
-
     export interface Message {
-        pinned_at: string,
+        pin: () => Deferred<boolean>;
+        pinned_at: luxon.DateTime;
+        unpin: () => Deferred<boolean>;
     }
-
     export interface Thread {
-        pinnedMessages: Message[],
-        pinnedMessagesState: "loaded"|"loading"|"error"|undefined,
+        fetchPinnedMessages: () => Promise<void>;
+        pinnedMessages: Message[];
+        pinnedMessagesState: 'loaded'|'loading'|'error'|undefined;
     }
-
 }

--- a/addons/mail/static/src/discuss/message_pin/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/message_pin/common/message_model_patch.js
@@ -11,6 +11,7 @@ patch(Message.prototype, {
         /** @type {luxon.DateTime} */
         this.pinned_at = Record.attr(undefined, { type: "datetime" });
     },
+    /** @returns {Deferred<boolean>} */
     pin() {
         if (this.pinned_at) {
             return this.unpin();
@@ -43,6 +44,7 @@ patch(Message.prototype, {
         );
         return def;
     },
+    /** @returns {Deferred<boolean>} */
     unpin() {
         const def = new Deferred();
         this.store.env.services.dialog.add(

--- a/addons/mail/static/src/discuss/voice_message/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/voice_message/common/@types/models.d.ts
@@ -1,0 +1,5 @@
+declare module "models" {
+    export interface Composer {
+        voiceAttachment: Readonly<Attachment|undefined>;
+    }
+}

--- a/addons/mail/static/src/discuss/voice_message/common/composer_model_patch.js
+++ b/addons/mail/static/src/discuss/voice_message/common/composer_model_patch.js
@@ -3,6 +3,7 @@ import { Composer } from "@mail/core/common/composer_model";
 import { patch } from "@web/core/utils/patch";
 
 patch(Composer.prototype, {
+    /** @returns {import("models").Attachment|undefined} */
     get voiceAttachment() {
         return this.attachments.find((attachment) => attachment.voice);
     },

--- a/addons/mail/static/src/model/@types/models.d.ts
+++ b/addons/mail/static/src/model/@types/models.d.ts
@@ -1,0 +1,15 @@
+declare module "models" {
+    import { Store as StoreClass } from "@mail/model/store";
+
+    export interface Store extends StoreClass {}
+
+    type StaticMailRecord<ClassInterface, JSClassType> = Omit<JSClassType, "get" | "insert" | "records"> & {
+        get: (data: any) => ClassInterface;
+        insert: <D extends object | object[]>(data: D, options?: object) => D extends object[] ? ClassInterface[] : ClassInterface;
+        records: { [localId: string]: ClassInterface };
+    };
+
+    export interface Models {
+        Store: Store;
+    }
+}

--- a/addons/portal/static/src/chatter/frontend/@types/models.d.ts
+++ b/addons/portal/static/src/chatter/frontend/@types/models.d.ts
@@ -1,0 +1,5 @@
+declare module "models" {
+    export interface Composer {
+        portalComment: boolean;
+    }
+}

--- a/addons/project/static/src/core/web/@types/models.d.ts
+++ b/addons/project/static/src/core/web/@types/models.d.ts
@@ -1,5 +1,5 @@
 declare module "models" {
     export interface Thread {
-        collaborator_ids: Persona[],
+        collaborator_ids: Persona[];
     }
 }

--- a/addons/project/static/src/project_sharing/chatter/@types/models.d.ts
+++ b/addons/project/static/src/project_sharing/chatter/@types/models.d.ts
@@ -1,0 +1,5 @@
+declare module "models" {
+    export interface Thread {
+        limitedMentions: Persona[];
+    }
+}

--- a/addons/rating/static/src/core/common/@types/models.d.ts
+++ b/addons/rating/static/src/core/common/@types/models.d.ts
@@ -1,0 +1,16 @@
+declare module "models" {
+    import { Rating as RatingClass } from "@rating/core/common/rating_model";
+
+    export interface Rating extends RatingClass {}
+
+    export interface Message {
+        rating_id: Rating;
+    }
+    export interface Store {
+        "rating.rating": StaticMailRecord<Rating, typeof RatingClass>;
+    }
+
+    export interface Models {
+        "rating.rating": Rating;
+    }
+}

--- a/addons/website_livechat/static/src/web/@types/models.d.ts
+++ b/addons/website_livechat/static/src/web/@types/models.d.ts
@@ -1,6 +1,6 @@
 declare module "models" {
     export interface Thread {
-        visitor: Persona,
-        visitorPartner: Persona,
+        visitor: Persona;
+        visitorPartner: Persona;
     }
 }

--- a/addons/website_slides/static/src/activity/@types/models.d.ts
+++ b/addons/website_slides/static/src/activity/@types/models.d.ts
@@ -1,5 +1,5 @@
 declare module "models" {
-    interface Activity {
-        request_partner_id: Persona,
+    export interface Activity {
+        request_partner_id: Persona;
     }
 }


### PR DESCRIPTION
\*: hr, hr_holidays, im_livechat, portal, product, project, rating,
website_slides.

The mail module uses type definition files to provide autocompletion
for its records. Each bundle that enrich a modal through patches extends
the origin interface.

However, doing this manually is error prone and cumbersome. Most of the
definitions are outdated: either because the patches moved in other
bundles, fields were removed, fields or methods were forgotten, and so
on.

Moreover, many models override the insert/get methods and the records
property to add typing which is often too broad (e.g. Model[]|Model for
insert return type while we could rely on the parameter type to be more
specific).

This PR fixes all those definitions thanks to a script that
automatically generates definitions in the correct bundles.