### PR TITLE
[FIX] project: restore quick assign icon in kanban view

### DIFF
--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.scss
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.scss
@@ -20,7 +20,7 @@
         }
     }
 
-    .oe_kanban_content {
+    .oe_kanban_card {
         @include media-breakpoint-up(sm) {
             &:hover {
                 .o_field_widget.o_field_many2many_tags_avatar .o_quick_assign {

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -676,7 +676,7 @@
                             <field name="color" widget="kanban_color_picker"/>
                         </t>
                         <t t-name="card">
-                            <main t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
+                            <main class="oe_kanban_card" t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
                                 <field name="name" class="fw-bold fs-5"/>
                                 <div class="text-muted d-flex flex-column">
                                     <field t-if="record.parent_id.raw_value" invisible="context.get('default_parent_id', False)" name="parent_id"/>


### PR DESCRIPTION
Steps to Reproduce:
- go to project and navigate to the`project.task` Kanban view.
- hover over any task element.
- the quick qssign icon is hidden.

 Cause:
- the CSS class responsible for displaying the Quick Assign icon on hover was removed from the  views.

Solution:
- Added a new class to ensure the Quick Assign icon is visible when hovering over a task.

task-4461236
