### PR TITLE
[FIX] website_blog: allow blog post paragraph to inherit theme font size

### DIFF
--- a/addons/website_blog/static/src/scss/website_blog.scss
+++ b/addons/website_blog/static/src/scss/website_blog.scss
@@ -74,7 +74,6 @@ $o-wblog-loader-size: 50px;
     // menu. The aim is to be able to write simple articles on the fly,
     // achieving a good design without being forced to use snippets.
     .o_wblog_read_text {
-        @include font-size(18px);
         font-weight: 300;
     }
 


### PR DESCRIPTION
Previously, changing the paragraph font size in the theme (Website > Edit > Theme > Paragraph > Font Size) did not affected the paragraphs within blog posts.

This was because blog post paragraphs used a static font size, overriding the theme's setting.

This PR removes the overriding style, allowing blog post paragraphs to inherit the font size defined in the theme.

task-4167716
