### PR TITLE
[FIX] web, account: fix kanban color picker layout

### DIFF
--- a/addons/account/static/src/views/account_dashboard_kanban/account_dashboard_kanban.scss
+++ b/addons/account/static/src/views/account_dashboard_kanban/account_dashboard_kanban.scss
@@ -9,6 +9,6 @@
     }
 }
   
-.file_upload_kanban_action_a {
+span:where(:has(.file_upload_kanban_action_a)) {
     @include o-kanban-dashboard-dropdown-link($link-padding-gap: $o-kanban-dashboard-dropdown-complex-gap);
 }

--- a/addons/web/static/src/scss/utils.scss
+++ b/addons/web/static/src/scss/utils.scss
@@ -274,7 +274,7 @@
 @mixin o-kanban-dashboard-dropdown-link($link-padding-gap: $o-dropdown-hpadding) {
     padding: 0;
 
-    a {
+    > a {
         margin: auto auto auto (-$link-padding-gap);
         padding: 3px $link-padding-gap;
         color: $dropdown-link-color;


### PR DESCRIPTION
This PR fixes an issue introduced in Commit[^1].
Prior to Commit[1], we were using the mixin `o-kanban-dashboard-dropdown-link` to handle the spacing of the link within the popover. This mixin was scoping this change to `<a/>` tags that are direct children.

Commit[1] was trying to change the color of the file upload link on the accounting dashboard to replicate the design of the other elements but instead of tweaking the `@include` on the Accouting side, it modified the `@mixin` directly, meaning this now affects all the links, color picker as well, resulting in a broken layout.

To fix this issue, we scope back the change to direct children while providing the desired result in the account dashboard.

[^1]: Commit[1]: odoo/odoo@334a8161cd2feb092cafedc35d94645900b40518

| Master | This PR |
|--------|--------|
| <img width="403" alt="image" src="https://github.com/user-attachments/assets/86e45c21-0c67-4e7f-b642-9148baf4edea" /> | <img width="399" alt="image" src="https://github.com/user-attachments/assets/de73c676-24e7-48d4-8b0f-4042c0bf4190" /> |

task-4574415

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr