### PR TITLE
[FIX] hr: allow read of all public fields of private employee

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -238,6 +238,11 @@ class HrEmployeePrivate(models.Model):
         self.flush_recordset(field_names)
         public = self.env['hr.employee.public'].browse(self._ids)
         public.fetch(field_names)
+        # make sure all related fields from employee are in cache
+        for field_name in field_names:
+            field = self.env['hr.employee.public']._fields[field_name]
+            if field.related and field.related_field.model_name == 'hr.employee':
+                public.mapped(field_name)
         self._copy_cache_from(public, field_names)
 
     def _check_private_fields(self, field_names):

--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -139,6 +139,14 @@ class TestSelfAccessRights(TestHrCommon):
     def testReadOtherEmployee(self):
         with self.assertRaises(AccessError):
             self.hubert_emp.with_user(self.richard).read(self.protected_fields_emp.keys())
+        # Check simple user can read all public fields of private employee
+        public_fields = [
+            field_name
+            for field_name in self.env['hr.employee.public']._fields
+            if field_name in self.env['hr.employee']._fields
+        ]
+        res = self.hubert_emp.with_user(self.richard).read(public_fields)
+        self.assertEqual(len(public_fields), len(res[0]))
 
     # Write hr.employee #
     def testWriteSelfEmployee(self):


### PR DESCRIPTION
**Steps to reproduce**
- With Studio, create a many2one field in relation to the Employee
model.
- Have a user with no "Employees" rights.
- With this user and in mobile view, click on the field to select
an employee.
-> No records found.

Note: the many2one_avatar_employee widget used in HR apps avoid this problem.

**Cause**
Issue since https://github.com/odoo/odoo/commit/e962860c6f0d8ec9e50bb376e1faab5c7bc69374
The `web_search_read` on the private employee model returns no
records when an `image_*` or `avatar_*` field is part of the requested
fields.
This is because we try to fetch these fields
https://github.com/odoo/odoo/blob/188a3fe45fb41463ff86d1fa5e930ab43fb70d0e/addons/hr/models/hr_employee.py#L240
but they are not stored on the public employee model, and will not be
put in cache.

When performing a read after that, these fields are missing from cache.
We try to fetch them from the db
https://github.com/odoo/odoo/blob/e962860c6f0d8ec9e50bb376e1faab5c7bc69374/odoo/models.py#L3185
but this fetch is again done using the public employee.

This results in missing values and is interpreted as an access error, no
data is returned in `web_search_read`.

**Solution**
Read the problematic fields to make them present in cache when the cache
of the public employee is copied to the one of the private employee.

opw-4297115