### PR TITLE
[FIX] base: nicer error no password

### DIFF
--- a/addons/auth_ldap/models/res_users.py
+++ b/addons/auth_ldap/models/res_users.py
@@ -38,7 +38,7 @@ class Users(models.Model):
         try:
             return super()._check_credentials(credential, env)
         except AccessDenied:
-            if not (credential['type'] == 'password' and credential['password']):
+            if not (credential['type'] == 'password' and credential.get('password')):
                 raise
             passwd_allowed = env['interactive'] or not self.env.user._rpc_api_keys_only()
             if passwd_allowed and self.env.user.active:

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -477,7 +477,7 @@ class Users(models.Model):
           - { 'uid': 32, 'auth_method': 'webauthn',      'mfa': 'skip'    }
         :rtype: dict
         """
-        if not (credential['type'] == 'password' and credential['password']):
+        if not (credential['type'] == 'password' and credential.get('password')):
             raise AccessDenied()
         self.env.cr.execute(
             "SELECT COALESCE(password, '') FROM res_users WHERE id=%s",


### PR DESCRIPTION
Whenever you supply no password you are supposed to get an AccessDenied error. However in this case there will no be password supplied.

This happens because of:
https://github.com/odoo/odoo/blob/1f9f4dd165fccfaadf06c3ae68d742f5348bc9b6/addons/web/controllers/home.py#L122

When there is no value the key will also not be present. Therefore you will receive a keyerror instead of an accessdenied. This commit fixes that behavior and now you will get the accessdenied error as was originally intended.