### PR TITLE
[FIX] web: statusbar stickyness is tricky...

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -63,6 +63,7 @@
 
 .o_form_view {
     --fieldWidget-margin-bottom: #{$o-form-spacing-unit};
+    --Ribbon-z-index: 1;
 
     @include media-breakpoint-up(md) {
         display: flex;
@@ -323,7 +324,7 @@
         @include media-breakpoint-up(md) {
             position: sticky;
             top: 0;
-            z-index: 1;
+            z-index: $zindex-sticky;
 
             &:not(.modal .o_form_statusbar) {
                 background-color: $body-bg;


### PR DESCRIPTION
This commit avoids the stacking mismatch between the statusbar and
elements using a ribbon. It also fixes an issue affecting the left
marker in a rich editor field being shown over the statusbar.

task-4504282
task-4457597