### PR TITLE
[IMP] im_livechat: do not post message when chat bot leaves

### DIFF
--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -376,7 +376,7 @@ class ChatbotScriptStep(models.Model):
             if bot_member := channel_sudo.channel_member_ids.filtered(
                 lambda m: m.partner_id == self.chatbot_script_id.operator_partner_id
             ):
-                channel_sudo._action_unfollow(partner=bot_member.partner_id)
+                channel_sudo._action_unfollow(partner=bot_member.partner_id, post_leave_message=False)
             # finally, rename the channel to include the operator's name
             channel_sudo.write(
                 {

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -438,7 +438,7 @@ class DiscussChannel(models.Model):
     def action_unfollow(self):
         self._action_unfollow(self.env.user.partner_id)
 
-    def _action_unfollow(self, partner=None, guest=None):
+    def _action_unfollow(self, partner=None, guest=None, post_leave_message=True):
         self.ensure_one()
         self.message_unsubscribe(partner.ids)
         custom_store = Store(self, {"is_pinned": False, "isLocallyPinned": False})
@@ -452,15 +452,16 @@ class DiscussChannel(models.Model):
             target = partner or guest
             target._bus_send_store(custom_store, notification_type="discuss.channel/leave")
             return
-        notification = Markup('<div class="o_mail_notification">%s</div>') % _(
-            "left the channel"
-        )
-        # sudo: mail.message - post as sudo since the user just unsubscribed from the channel
-        member.channel_id.sudo().message_post(
-            body=notification, subtype_xmlid="mail.mt_comment", author_id=partner.id
-        )
-        # send custom store after message_post to avoid is_pinned reset to True
-        member._bus_send_store(custom_store, notification_type="discuss.channel/leave")
+        if post_leave_message:
+            notification = Markup('<div class="o_mail_notification">%s</div>') % _(
+                "left the channel"
+            )
+            # sudo: mail.message - post as sudo since the user just unsubscribed from the channel
+            member.channel_id.sudo().message_post(
+                body=notification, subtype_xmlid="mail.mt_comment", author_id=partner.id
+            )
+            # send custom store after message_post to avoid is_pinned reset to True
+            member._bus_send_store(custom_store, notification_type="discuss.channel/leave")
         member.unlink()
         self._bus_send_store(
             self,


### PR DESCRIPTION
When a visitor is forwarded to an operator, the chat bot leaves the channel and a message is posted. The notification which indicates than an operator joined the channel is enough. This PR removes the chat bot leave notification.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
