### PR TITLE
[IMP] im_livechat: do not post message when chat bot leaves

### DIFF
--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -376,7 +376,7 @@ class ChatbotScriptStep(models.Model):
             if bot_member := channel_sudo.channel_member_ids.filtered(
                 lambda m: m.partner_id == self.chatbot_script_id.operator_partner_id
             ):
-                channel_sudo._action_unfollow(partner=bot_member.partner_id)
+                channel_sudo._action_unfollow(partner=bot_member.partner_id, post_leave_message=False)
             # finally, rename the channel to include the operator's name
             channel_sudo.write(
                 {

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -291,9 +291,9 @@ class DiscussChannel(models.Model):
     def _types_allowing_unfollow(self):
         return super()._types_allowing_unfollow() + ["livechat"]
 
-    def _action_unfollow(self, partner=None, guest=None):
+    def _action_unfollow(self, partner=None, guest=None, post_leave_message=True):
         if partner and self.channel_type == "livechat" and len(self.channel_member_ids) <= 2:
             # sudo: discuss.channel - last operator left the conversation, state must be updated
             self.sudo().livechat_active = False
             self._bus_send_store(Store(self, "livechat_active"))
-        super()._action_unfollow(partner, guest)
+        super()._action_unfollow(partner, guest, post_leave_message)

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -174,7 +174,7 @@ class ChatbotCase(chatbot_common.ChatbotCase):
         def get_forward_op_bus_params():
             messages = self.env["mail.message"].search([], order="id desc", limit=3)
             # only data relevant to the test are asserted for simplicity
-            transfer_message_data = Store(messages[2]).get_result()
+            transfer_message_data = Store(messages[1]).get_result()
             transfer_message_data["mail.message"][0].update(
                 {
                     "author": {"id": self.chatbot_script.operator_partner_id.id, "type": "partner"},
@@ -185,7 +185,7 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                 }
             )
             transfer_message_data["mail.thread"][0]["display_name"] = "Testing Bot"
-            joined_message_data = Store(messages[1]).get_result()
+            joined_message_data = Store(messages[0]).get_result()
             joined_message_data["mail.message"][0].update(
                 {
                     "author": {"id": self.partner_employee.id, "type": "partner"},
@@ -196,17 +196,6 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                 }
             )
             joined_message_data["mail.thread"][0]["display_name"] = "Testing Bot"
-            left_message_data = Store(messages[0]).get_result()
-            left_message_data["mail.message"][0].update(
-                {
-                    "author": {"id": self.chatbot_script.operator_partner_id.id, "type": "partner"},
-                    "body": '<div class="o_mail_notification">left the channel</div>',
-                    # thread not renamed yet at this step
-                    "default_subject": "Testing Bot",
-                    "record_name": "Testing Bot",
-                }
-            )
-            left_message_data["mail.thread"][0]["display_name"] = "Testing Bot"
             member_emp = discuss_channel.channel_member_ids.filtered(
                 lambda m: m.partner_id == self.partner_employee
             )
@@ -218,8 +207,8 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                     ).get_result()
                 )
             )
-            channel_data_join["discuss.channel"][0]["chatbot"]["currentStep"]["message"] = messages[2].id
-            channel_data_join["discuss.channel"][0]["chatbot"]["steps"][0]["message"] = messages[2].id
+            channel_data_join["discuss.channel"][0]["chatbot"]["currentStep"]["message"] = messages[1].id
+            channel_data_join["discuss.channel"][0]["chatbot"]["steps"][0]["message"] = messages[1].id
             channel_data_join["discuss.channel"][0]["is_pinned"] = True
             channel_data_join["discuss.channel"][0]["livechat_operator_id"] = {
                 "id": self.chatbot_script.operator_partner_id.id,
@@ -263,8 +252,6 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                     (self.cr.dbname, "discuss.channel", discuss_channel.id, "members"),
                     (self.cr.dbname, "discuss.channel", discuss_channel.id),
                     (self.cr.dbname, "discuss.channel", discuss_channel.id),
-                    (self.cr.dbname, "discuss.channel", discuss_channel.id, "members"),
-                    (self.cr.dbname, "discuss.channel", discuss_channel.id),
                     (self.cr.dbname, "res.partner", self.chatbot_script.operator_partner_id.id),
                     (self.cr.dbname, "discuss.channel", discuss_channel.id),
                     (self.cr.dbname, "discuss.channel", discuss_channel.id),
@@ -297,7 +284,7 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                                     "id": member_emp.id,
                                     "message_unread_counter": 0,
                                     "message_unread_counter_bus_id": 0,
-                                    "new_message_separator": messages[0].id,
+                                    "new_message_separator": messages[0].id + 1,
                                     "persona": {"id": self.partner_employee.id, "type": "partner"},
                                     "syncUnread": True,
                                     "thread": {
@@ -349,14 +336,14 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                                     "create_date": fields.Datetime.to_string(
                                         member_emp.create_date
                                     ),
-                                    "fetched_message_id": messages[1].id,
+                                    "fetched_message_id": messages[0].id,
                                     "id": member_emp.id,
                                     "is_bot": False,
                                     "last_seen_dt": fields.Datetime.to_string(
                                         member_emp.last_seen_dt
                                     ),
                                     "persona": {"id": self.partner_employee.id, "type": "partner"},
-                                    "seen_message_id": messages[1].id,
+                                    "seen_message_id": messages[0].id,
                                     "thread": {
                                         "id": discuss_channel.id,
                                         "model": "discuss.channel",
@@ -389,10 +376,6 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                         "payload": {
                             "discuss.channel": [{"id": discuss_channel.id, "is_pinned": True}]
                         },
-                    },
-                    {
-                        "type": "discuss.channel/new_message",
-                        "payload": {"data": left_message_data, "id": discuss_channel.id},
                     },
                     {
                         "type": "discuss.channel/leave",

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -438,7 +438,7 @@ class DiscussChannel(models.Model):
     def action_unfollow(self):
         self._action_unfollow(self.env.user.partner_id)
 
-    def _action_unfollow(self, partner=None, guest=None):
+    def _action_unfollow(self, partner=None, guest=None, post_leave_message=True):
         self.ensure_one()
         self.message_unsubscribe(partner.ids)
         custom_store = Store(self, {"is_pinned": False, "isLocallyPinned": False})
@@ -452,13 +452,14 @@ class DiscussChannel(models.Model):
             target = partner or guest
             target._bus_send_store(custom_store, notification_type="discuss.channel/leave")
             return
-        notification = Markup('<div class="o_mail_notification">%s</div>') % _(
-            "left the channel"
-        )
-        # sudo: mail.message - post as sudo since the user just unsubscribed from the channel
-        member.channel_id.sudo().message_post(
-            body=notification, subtype_xmlid="mail.mt_comment", author_id=partner.id
-        )
+        if post_leave_message:
+            notification = Markup('<div class="o_mail_notification">%s</div>') % _(
+                "left the channel"
+            )
+            # sudo: mail.message - post as sudo since the user just unsubscribed from the channel
+            member.channel_id.sudo().message_post(
+                body=notification, subtype_xmlid="mail.mt_comment", author_id=partner.id
+            )
         # send custom store after message_post to avoid is_pinned reset to True
         member._bus_send_store(custom_store, notification_type="discuss.channel/leave")
         member.unlink()

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -77,7 +77,6 @@ class TestLivechatChatbotUI(TestGetOperatorCommon, TestWebsiteLivechatCommon, Ch
             ("I want to speak with an operator", False, False),
             ("I will transfer you to a human", operator, False),
             ("joined the channel", self.operator.partner_id, False), # human_operator has joined the channel
-            ("left the channel", self.chatbot_script.operator_partner_id, False), # chat bot operator has left the channel
         ]
 
         self.assertEqual(len(conversation_messages), len(expected_messages))


### PR DESCRIPTION
When a visitor is forwarded to an operator, the chat bot leaves the channel and a message is posted. The notification which indicates than an operator joined the channel is enough. This PR removes the chat bot leave notification.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

enterprise: https://github.com/odoo/enterprise/pull/79237
