### PR TITLE
[FIX] survey: fix survey sample data

### DIFF
--- a/addons/survey/models/survey_survey_template.py
+++ b/addons/survey/models/survey_survey_template.py
@@ -189,6 +189,7 @@ class SurveyTemplate(models.Model):
             'scoring_type': 'scoring_with_answers',
             'questions_layout': 'page_per_question',
             'session_speed_rating': True,
+            'session_speed_rating_time_limit': 90,
             'question_and_page_ids': [
                 (0, 0, { # survey.question
                     'title': _('What is the best way to catch the attention of an audience?'),


### PR DESCRIPTION
Fix the traceback appearing when trying to create live session sample data. The live session survey is initialized with the 'session_speed_rating' field set to True meaning a 'session_speed_rating_time_limit' value is required but wasn't given.

related PR: odoo/odoo#115141

Task-4569972

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
