### PR TITLE
[FIX] website_sale_collect: prevent error 403 on product page

### DIFF
--- a/addons/website_sale_collect/models/product_template.py
+++ b/addons/website_sale_collect/models/product_template.py
@@ -33,7 +33,7 @@ class ProductTemplate(models.Model):
                 res['in_store_stock'] = utils.format_product_stock_values(
                     product_or_template.sudo(),
                     free_qty=website.sudo()._get_max_in_store_product_available_qty(
-                        product_or_template
+                        product_or_template.sudo()
                     )
                 )
         return res


### PR DESCRIPTION
__Current behavior before commit:__
Since [this pr][1], a 403 error appears on the product page if the "Pick up in store" delivery method is set.

__Description of the fix:__
Add a missing sudo on the `product_or_template` like it is done 2 lines above.

__Steps to reproduce the issue on runbot:__
1. Configure and publish the delivery method "Pick up in store"
2. Go to a product page in the e-shop as a Public User

opw-4574924

[1]: https://github.com/odoo/odoo/pull/195033