### PR TITLE
[FIX] portal: prevent error when salesperson has no email

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -412,15 +412,15 @@
             <h5>Your contact</h5>
             <hr class="mt-1"/>
             <h6 t-esc="sales_user.name"/>
-            <div class="d-flex align-items-baseline mb-1">
+            <div t-if="sales_user.email_normalized" class="d-flex align-items-baseline mb-1">
                 <i class="fa fa-envelope fa-fw me-1 text-600"/>
                 <a class="text-break w-100" t-att-href="'mailto:'+sales_user.email" t-esc="sales_user.email"/>
             </div>
-            <div class="d-flex flex-nowrap align-items-center mb-1">
+            <div t-if="sales_user.phone" class="d-flex flex-nowrap align-items-center mb-1">
                 <i class="fa fa-phone fa-fw me-1 text-600"/>
                 <span t-esc="sales_user.phone"/>
             </div>
-            <div class="d-flex flex-nowrap align-items-center mb-1">
+            <div t-if="sales_user.city" class="d-flex flex-nowrap align-items-center mb-1">
                 <i class="fa fa-map-marker fa-fw me-1 text-600"/>
                 <span t-esc="sales_user.city"/>
             </div>


### PR DESCRIPTION
Steps to reproduce:
1. Create a user partner without an email address.
2. Assign the newly created user as the salesperson of another user.
3. Log in with the user to trigger the traceback.

Issue:
Attempting to concatenate `False` with a string (`'mailto:'`) in the portal contact template caused a `TypeError`.

Fix:
Added `t-if="sales_user.email"` to ensure the email field is present before rendering the link.

task-4458848


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
