### PR TITLE
[FIX] account: bring demo data back

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -199,7 +199,7 @@ class AccountChartTemplate(models.AbstractModel):
         reload_template = template_code == company.chart_template
         company.chart_template = template_code
 
-        if not reload_template and (not company.root_id._existing_accounting() or self.env.ref('base.module_account').demo):
+        if not reload_template and (not company.root_id._existing_accounting() or install_demo):
             children_companies = self.env['res.company'].search([('id', 'child_of', company.id)])
             for model in ('account.move',) + TEMPLATE_MODELS[::-1]:
                 if not company.parent_id:
@@ -232,7 +232,7 @@ class AccountChartTemplate(models.AbstractModel):
         AccountGroup._adapt_parent_account_group(company=company)
 
         # Install the demo data when the first localization is instanciated on the company
-        if install_demo and self.ref('base.module_account').demo and not reload_template:
+        if install_demo and not reload_template:
             try:
                 with self.env.cr.savepoint():
                     self = self.with_context(lang=original_context_lang)


### PR DESCRIPTION
With https://github.com/odoo/odoo/pull/189000/commits/62e2c760bc4512fbcd26d27a8adecb35ce724fe2#diff-4f9678d6b87914dc6deca5942262375043388c5ad041b65ce48e0c004e5e0e0bL378 the module demo field is no longer set to true (it is only done after the demo data is installed) As a result, the accounting demo data is not actually loaded.

By changing the condition, chart demo data is installed if the param install_demo is true