### PR TITLE
[FIX] website: redirect to website page if configurator_done is true

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -384,7 +384,9 @@ class Website(models.Model):
     @api.model
     def configurator_init(self):
         r = dict()
-        company = self.get_current_website().company_id
+        theme = self.env["ir.module.module"].search([("name", "=", "theme_default")])
+        current_website = self.get_current_website()
+        company = current_website.company_id
         configurator_features = self.env['website.configurator.feature'].search([])
         r['features'] = [{
             'id': feature.id,
@@ -398,6 +400,8 @@ class Website(models.Model):
         r['logo'] = False
         if not company.uses_default_logo:
             r['logo'] = company.logo.decode('utf-8')
+        if current_website.configurator_done:
+            r['redirect_url'] = theme.button_choose_theme()
         try:
             result = self._website_api_rpc('/api/website/1/configurator/industries', {'lang': self.env.context.get('lang')})
             r['industries'] = result['industries']

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -643,6 +643,12 @@ export class Configurator extends Component {
 
             await store.start(() => this.getInitialState());
             this.updateStorage(store);
+            if (store.redirect_url) {
+                // If redirect_url exists, it means configurator_done is already
+                // true, so we can skip the configurator flow.
+                this.clearStorage();
+                await this.action.doAction(store.redirect_url);
+            }
             if (!store.industries) {
                 await this.skipConfigurator();
             }
@@ -686,6 +692,7 @@ export class Configurator extends Component {
         const r = {
             industries: results.industries,
             logo: results.logo ? 'data:image/png;base64,' + results.logo : false,
+            redirect_url: results.redirect_url,
         };
         r.industries = r.industries.map((industry, index) => ({
             ...industry,


### PR DESCRIPTION
**Steps to reproduce:**
1. Go to definition of default_website and add `<field name="configurator_done" eval="True"/>` .
2. install website module.

**Issue:**
Users are incorrectly redirected to the configurator screen instead of the website page. However, refreshing the page correctly redirects to the home screen as the server-side route is triggered on reload.

**Reason:**
The issue started in Odoo 16. Until Odoo 15, redirection to the configurator route is handled using ir.actions.act_url, which triggered a full page reload, ensuring the server route executed.
From Odoo 16 onwards, this action is removed, and a direct client action is attached. Within `configurator.js`, navigation is now handled using the `history.pushState` method which replace the current url and does not trigger a reload. As a result, even when navigating to the configurator route, the server route is not executed, leading to incorrect redirection.

**Fix:**
Added a check in configurator.js to verify the configurator status. If it is true, the user is redirected to the website page instead of the configurator. Otherwise, the normal configurator flow continues.

**Key Changes:**
1. In configurator_init, added a check: if configurator_done is True, set the default theme using button_choose_theme and store its result (a dict containing the next action to execute) as redirect_url.
2. In the Configurator component, added redirect_url to the store, and inside the onWillStart method, checked if redirect_url exists. If it does, redirect to the home screen using doAction.

This PR ensures the correct redirection behavior when users follow the Industries installation flow.

task-4555467