### PR TITLE
[IMP] im_livechat: allow more choices for enabling the chatbot

### DIFF
--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -496,7 +496,7 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                 {
                     "channel_id": self.livechat_channel.id,
                     "chatbot_script_id": chatbot_no_operator.id,
-                    "chatbot_only_if_no_operator": True,
+                    "chatbot_enabled_condition": "only_if_no_operator",
                     "regex_url": "/",
                     "sequence": 1,
                 },
@@ -525,3 +525,42 @@ class ChatbotCase(chatbot_common.ChatbotCase):
             .chatbot_script_id,
             chatbot_operator,
         )
+
+    def test_chatbot_enabled_condition(self):
+        cases = [
+            # condition - operator_available - expected_result
+            ("only_if_no_operator", False, True),
+            ("only_if_no_operator", True, False),
+            ("only_if_operator", True, True),
+            ("only_if_operator", False, False),
+            ("always", False, True),
+            ("always", True, True),
+        ]
+        for condition, operator_available, expected_result in cases:
+            self.livechat_channel.user_ids.unlink()
+            if operator_available:
+                operator_user = new_test_user(
+                    self.env,
+                    login=f"operator_user_{condition}_{operator_available}_{expected_result}",
+                    groups="im_livechat.im_livechat_group_user,base.group_user",
+                )
+                self.env["mail.presence"]._update_presence(operator_user)
+                self.livechat_channel.user_ids = operator_user
+            self.livechat_channel.rule_ids = self.env["im_livechat.channel.rule"].create(
+                {
+                    "channel_id": self.livechat_channel.id,
+                    "chatbot_script_id": self.chatbot_script.id,
+                    "chatbot_enabled_condition": condition,
+                    "regex_url": "/",
+                    "sequence": 1,
+                }
+            )
+            matching_rule = (
+                self.env["im_livechat.channel.rule"].match_rule(self.livechat_channel.id, "/")
+                or self.env["im_livechat.channel.rule"]
+            )
+            self.assertEqual(
+                matching_rule.chatbot_script_id,
+                self.chatbot_script if expected_result else self.env["chatbot.script"],
+                f"Condition: {condition}, Operator available: {operator_available}, Expected result: {expected_result}",
+            )

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -226,10 +226,7 @@
                                 <field name="chatbot_script_id" class="oe_inline" style="width: 60% !important;"
                                        options="{'no_create': True, 'no_open': True}"/>
                             </div>
-                            <label for="chatbot_only_if_no_operator" class="oe_inline" invisible="not chatbot_script_id" string="Enabled only if no operator"/>
-                            <div class="oe_inline" invisible="not chatbot_script_id">
-                                <field name="chatbot_only_if_no_operator"/>
-                            </div>
+                            <field name="chatbot_enabled_condition" invisible="not chatbot_script_id" widget="radio"/>
                             <field name="regex_url" placeholder="e.g. /contactus"/>
                             <label for="auto_popup_timer" class="oe_inline" invisible="action != 'auto_popup'"/>
                             <div class="oe_inline" invisible="action != 'auto_popup'">


### PR DESCRIPTION
Live chat rules determine how both the live chat and chatbot should behave based on different conditions, such as the presence of an operator or the page where the chat is embedded.

Previously, there was an option to display the chatbot only when no operator was available. However, this option was too restrictive, and we would like to offer more customization.

This PR updates the option to allow selecting from three choices: "Always", "Only when no operator is available", or "Only when an operator is available".

task-4574961

upgrade: https://github.com/odoo/upgrade/pull/7221