### PR TITLE
[FIX] mail: no traceback when clicking unread banner for deleted message

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -569,7 +569,11 @@ export class Thread extends Record {
     }
 
     get showUnreadBanner() {
-        return !this.selfMember?.hideUnreadBanner && this.selfMember?.localMessageUnreadCounter > 0;
+        return (
+            !this.selfMember?.hideUnreadBanner &&
+            this.selfMember?.localMessageUnreadCounter > 0 &&
+            this.firstUnreadMessage
+        );
     }
 
     /** @type {undefined|number[]} */


### PR DESCRIPTION
Before this commit, if a user deletes a message before the recipient sees it and the recipient tries to click on "1 new message", they get a traceback.

Steps to reproduce:
1. Have a long conversation between user A and user B
2. Scroll up with user B
3. Send message with user A
4. Delete said message
5. User B clicks on new message banner -> traceback

This commit fixes the issue by only showing the unread banner if there is an unread message.

task-4240887