### PR TITLE
[FIX] hr_recruitment: fix newId errors with web_studio

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -110,7 +110,8 @@ class HrJob(models.Model):
         """, {
             'today': fields.Date.context_today(self),
             'user_id': self.env.uid,
-            'job_ids': tuple(self.ids),
+            'job_ids': tuple(self.ids or [0]),
+            # or [0] is used in case we only have newIds (web studio)
         })
         job_activities = defaultdict(dict)
         for activity in self.env.cr.dictfetchall():
@@ -216,7 +217,8 @@ class HrJob(models.Model):
                  WHERE a.company_id in %s
                     OR a.company_id is NULL
               GROUP BY s.job_id
-            """, [tuple(self.ids), tuple(self.env.companies.ids)]
+            """, [tuple(self.ids or [0]), tuple(self.env.companies.ids)]
+            # or [0] is used in case we only have newIds (web studio)
         )
 
         new_applicant_count = dict(self.env.cr.fetchall())

--- a/addons/website_hr_recruitment/models/hr_job.py
+++ b/addons/website_hr_recruitment/models/hr_job.py
@@ -71,6 +71,9 @@ class HrJob(models.Model):
     def _compute_website_url(self):
         super()._compute_website_url()
         for job in self:
+            # _slug call will fail with newId records.
+            if not job.id:
+                continue
             job.website_url = f'/jobs/{self.env["ir.http"]._slug(job)}'
 
     def set_open(self):


### PR DESCRIPTION
Fixes some compute methods that did not work with a new record (with `newId`)

Runbot Error - 116692

