### PR TITLE
[REF] web_tour: remove pointer in tour_automatic

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -179,7 +179,7 @@ export const tourService = {
             );
 
             if (tourConfig.mode === "auto") {
-                new TourAutomatic(tour).start(pointer);
+                new TourAutomatic(tour).start();
             } else {
                 new TourInteractive(tour).start(pointer, async () => {
                     pointer.stop();


### PR DESCRIPTION
In this commit, we remove the pointer from the tour_automatic. Indeed, it has no useful use in this part of the code. There is no point in having the pointer in the tour_automatic. If we want to see the targeted element (trigger), just open the console. Each element found is logged in the console in
debug mode (tour_automatic.js:65)
As the pointer is never used and has no use in the tour automatic, we remove it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
