### PR TITLE
[FIX] web, website_sale: support WEBP transparency

### DIFF
--- a/addons/web/static/src/views/fields/image/image_field.js
+++ b/addons/web/static/src/views/fields/image/image_field.js
@@ -159,7 +159,7 @@ export class ImageField extends Component {
                 canvas.width = image.width * ratio;
                 canvas.height = image.height * ratio;
                 const ctx = canvas.getContext("2d");
-                ctx.fillStyle = "rgb(255, 255, 255)";
+                ctx.fillStyle = "transparent";
                 ctx.fillRect(0, 0, canvas.width, canvas.height);
                 ctx.drawImage(
                     image,
@@ -188,6 +188,7 @@ export class ImageField extends Component {
                     ],
                 ]);
                 referenceId = referenceId || resizedId; // Keep track of original.
+                // Converted to JPEG for use in PDF files, alpha values will default to white
                 await this.orm.call("ir.attachment", "create_unique", [
                     [
                         {

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -625,7 +625,10 @@ options.registry.WebsiteSaleProductPage = options.Class.extend({
         await new Promise(resolve => imgEl.addEventListener("load", resolve));
         const originalSize = Math.max(imgEl.width, imgEl.height);
         const smallerSizes = [1024, 512, 256, 128].filter(size => size < originalSize);
-        const webpName = attachment.name.replace(/\.(jpe?g|png)$/i, ".webp");
+        const extension = attachment.name.match(/\.(jpe?|pn)g$/i)?.[0] ?? ".jpeg";
+        const webpName = attachment.name.replace(extension, ".webp");
+        const format = extension.substr(1).toLowerCase().replace(/^jpg$/, 'jpeg');
+        const mimetype = `image/${format}`;
         let referenceId = undefined;
         for (const size of [originalSize, ...smallerSizes]) {
             const ratio = size / originalSize;
@@ -633,7 +636,7 @@ options.registry.WebsiteSaleProductPage = options.Class.extend({
             canvas.width = imgEl.width * ratio;
             canvas.height = imgEl.height * ratio;
             const ctx = canvas.getContext("2d");
-            ctx.fillStyle = "rgb(255, 255, 255)";
+            ctx.fillStyle = 'transparent';
             ctx.fillRect(0, 0, canvas.width, canvas.height);
             ctx.drawImage(imgEl, 0, 0, imgEl.width, imgEl.height, 0, 0, canvas.width, canvas.height);
             const [resizedId] = await this.orm.call("ir.attachment", "create_unique", [[{
@@ -652,12 +655,12 @@ options.registry.WebsiteSaleProductPage = options.Class.extend({
             }
             referenceId = referenceId || resizedId; // Keep track of original.
             await this.orm.call("ir.attachment", "create_unique", [[{
-                name: webpName.replace(/\.webp$/, ".jpg"),
-                description: "format: jpeg",
-                datas: canvas.toDataURL("image/jpeg", 0.75).split(",")[1],
+                name: attachment.name,
+                description: `format: ${format}`,
+                datas: canvas.toDataURL(mimetype, 0.75).split(",")[1],
                 res_id: resizedId,
                 res_model: "ir.attachment",
-                mimetype: "image/jpeg",
+                mimetype: mimetype,
             }]]);
         }
     },

--- a/addons/website_sale/static/src/xml/website_sale_image_viewer.xml
+++ b/addons/website_sale/static/src/xml/website_sale_image_viewer.xml
@@ -14,7 +14,15 @@
                     <!-- Content -->
                     <div class="o_wsale_image_viewer_image position-absolute top-0 bottom-0 start-0 end-0 align-items-center justify-content-center d-flex o_with_img overflow-hidden">
                         <div class="o_wsale_image_viewer_void position-absolute align-items-center justify-content-center d-flex w-100 h-100" t-ref="imageContainer" t-att-style="imageContainerStyle">
-                            <img class="mw-100 mh-100 bg-black transition-base" t-att-src="selectedImage.src" draggable="false" alt="Viewer" t-att-style="imageStyle" t-on-wheel.stop="onWheelImage" t-on-mousedown="onMousedownImage"/>
+                            <img
+                                alt="Viewer"
+                                class="mw-100 mh-100 transition-base"
+                                draggable="false"
+                                t-att-src="selectedImage.src"
+                                t-att-style="imageStyle"
+                                t-on-mousedown="onMousedownImage"
+                                t-on-wheel.stop="onWheelImage"
+                            />
                         </div>
                     </div>
                     <t t-if="images.length > 1">


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Have a PNG image with a transparent background;
    - e.g. https://odoocdn.com/openerp_website/static/src/img/assets/png/odoo_logo.png
3. use it as main image for a product;
4. upload it again as extra image via the website editor;
5. enable click on zoom for the images;
6. click on the images.

Issue
-----
- The main image gets displayed with a black background.
- The extra image gets displayed with a white background.

Cause
-----
- The `img` element of the main image has the `bg-black` class.
- PNG images uploaded via the `website_sale` editor get converted to WEBP, and then drawn on a white canvas before getting stored.

Solution
--------
- Remove the `bg-black` class from the `img` element.
- When converting to WEBP, use a transparent canvas.
  - Do the same for WEBP images uploaded via `ImageField`.

opw-3848324