### PR TITLE
[IMP] payment: add Twint to Stripe payment methods

### DIFF
--- a/addons/payment/data/payment_method_data.xml
+++ b/addons/payment/data/payment_method_data.xml
@@ -3531,7 +3531,7 @@
         <field name="image" type="base64" file="payment/static/img/twint.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_manual_capture">partial</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([

--- a/addons/payment/data/payment_provider_data.xml
+++ b/addons/payment/data/payment_provider_data.xml
@@ -358,6 +358,7 @@
                          ref('payment.payment_method_revolut_pay'),
                          ref('payment.payment_method_sepa_direct_debit'),
                          ref('payment.payment_method_sofort'),
+                         ref('payment.payment_method_twint'),
                          ref('payment.payment_method_upi'),
                          ref('payment.payment_method_wechat_pay'),
                          ref('payment.payment_method_zip'),


### PR DESCRIPTION
Stripe has introduced Twint as a new payment method. This feature was previously unavailable in Odoo.

This commit incorporates Twint into the list of payment methods offered by the Stripe integration of Odoo.

task-4574909

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
