### PR TITLE
[FIX] html_editor: Focus editable non-deterministic error

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -859,6 +859,8 @@ export class SelectionPlugin extends Plugin {
         if (documentSelectionIsInEditable) {
             return;
         }
+        // Manualy focusing the editable is necessary to avoid some non-deterministic error in the HOOT unit tests.
+        this.editable.focus();
         const { anchorNode, anchorOffset, focusNode, focusOffset } = editableSelection;
         const selection = this.document.getSelection();
         if (selection) {

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -234,15 +234,8 @@ export class LinkPlugin extends Plugin {
         this.removeLinkShortcut = this.services.command.add(
             "Create link",
             () => {
-                // To avoid a race condition between the events spawn by :
-                // 1. the `focus editable` and
-                // 2. the odoo `Shortcut bar` closure
-                // Which can affect the link overlay opening sequence if we keep it in sync.
-                // Therefore we need to wait for the next tick before triggering openLinkTools.
-                setTimeout(() => {
-                    this.toggleLinkTools();
-                    this.dependencies.selection.focusEditable();
-                });
+                this.toggleLinkTools();
+                this.dependencies.selection.focusEditable();
             },
             {
                 hotkey: "control+k",


### PR DESCRIPTION
Fix a non-deterministic error happening during the HOOT unit Test. The cause seems to be related to the hoot mock selection which do not always return the latest focused element in the document.getSelection().

runbot-115550

Related to : #197287 & #197345


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
