### PR TITLE
[FIX] account: prevent side effects from repeated currency changes

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -703,7 +703,7 @@ class AccountMoveLine(models.Model):
         for line in self:
             if line.amount_currency is False:
                 line.amount_currency = line.currency_id.round(line.balance * line.currency_rate)
-            if line.currency_id == line.company_id.currency_id:
+            if line.currency_id == line.company_id.currency_id and not line.move_id.is_invoice(True):
                 line.amount_currency = line.balance
 
     @api.depends_context('order_cumulated_balance', 'domain_cumulated_balance')
@@ -1558,6 +1558,13 @@ class AccountMoveLine(models.Model):
         yield
         after = existing()
         for line in after:
+            if (
+                (changed('balance') or changed('move_type'))
+                 and not self.env.is_protected(self._fields['amount_currency'], line)
+                 and (not changed('amount_currency') or (line not in before and not line.amount_currency))
+                 and line.currency_id == line.company_id.currency_id
+            ):
+                line.amount_currency = line.balance
             if (
                 line.display_type == 'product'
                 and not self.env.is_protected(self._fields['amount_currency'], line)

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4619,3 +4619,19 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         })
         values = invoice._get_invoice_portal_extra_values()
         self.assertIn('payment_state', values)
+
+    def test_multiple_currency_change(self):
+        """
+        Test amount currency and balance are correctly recomputed when switching currency multiple times
+        """
+        currency_a = self.env.company.currency_id
+        currency_b = self.currency_data['currency']
+
+        invoice = self.init_invoice(move_type='out_invoice', partner=self.partner_a, invoice_date='2016-01-20',
+                                    products=self.product_a, currency=currency_b)
+        initial_balance = invoice.line_ids[0].balance
+        # Simulate updating currency: Foreign currency -> Company currency -> Foreign Currency -> Save
+        with Form(invoice) as move_form:
+            for currency in (currency_a, currency_b):
+                move_form.currency_id = currency
+        self.assertEqual(invoice.line_ids[0].balance, initial_balance, "Balance with original currency should be the same.")


### PR DESCRIPTION
Steps top reproduce:
- have two currencies A (company) and B (other)
- create an invoice with currency B and and invoice line with a tax; save
- change currency to A and switch back to currency B and only after; save

Issue:
- The tax will not be correct
- do the flow multiple times and the tax becomes less and less correct
https://github.com/odoo/odoo/blob/f6ffeed0e2a455d512e5f8b0d086e3c833de65cb/addons/account/models/account_move_line.py#L992

Cause:
When saving, the rate is 2 https://github.com/odoo/odoo/blob/f6ffeed0e2a455d512e5f8b0d086e3c833de65cb/addons/account/models/account_move_line.py#L974

but the tax amount is still 10
https://github.com/odoo/odoo/blob/f6ffeed0e2a455d512e5f8b0d086e3c833de65cb/addons/account/models/account_move_line.py#L993

Therefore we divide 10 by the rate 2 -> giving 5
Repeat the process and the tax amount will be less anb less.

Solution:
cherry-pick of commit https://github.com/odoo-dev/odoo/commit/37d1eb365b588cec37f0ff3f22324fc63dde7f1e

opw-4352651