### PR TITLE
[FIX] mail: replace usage of savepoints

### DIFF
--- a/addons/mail/models/mail_scheduled_message.py
+++ b/addons/mail/models/mail_scheduled_message.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
+import threading
 from collections import defaultdict
 from markupsafe import Markup
 
@@ -177,39 +178,46 @@ class ScheduledMessage(models.Model):
             This is useful when scheduled messages are sent from the _post_messages_cron.
         """
         notification_parameters_whitelist = self._notification_parameters_whitelist()
+        auto_commit = not getattr(threading.current_thread(), 'testing', False)
         for scheduled_message in self:
             message_creator = scheduled_message.create_uid
             try:
-                with self.env.cr.savepoint():
-                    scheduled_message.with_user(message_creator)._check()
-                    self.env[scheduled_message.model].browse(scheduled_message.res_id).with_user(message_creator).message_post(
-                        attachment_ids=list(scheduled_message.attachment_ids.ids),
-                        author_id=scheduled_message.author_id.id,
-                        body=scheduled_message.body,
-                        partner_ids=list(scheduled_message.partner_ids.ids),
-                        subtype_xmlid='mail.mt_note' if scheduled_message.is_note else 'mail.mt_comment',
-                        **{k: v for k, v in json.loads(scheduled_message.notification_parameters or '{}').items() if k in notification_parameters_whitelist},
-                    )
+                scheduled_message.with_user(message_creator)._check()
+                self.env[scheduled_message.model].browse(scheduled_message.res_id).with_user(message_creator).message_post(
+                    attachment_ids=list(scheduled_message.attachment_ids.ids),
+                    author_id=scheduled_message.author_id.id,
+                    body=scheduled_message.body,
+                    partner_ids=list(scheduled_message.partner_ids.ids),
+                    subtype_xmlid='mail.mt_note' if scheduled_message.is_note else 'mail.mt_comment',
+                    **{k: v for k, v in json.loads(scheduled_message.notification_parameters or '{}').items() if k in notification_parameters_whitelist},
+                )
+                if auto_commit:
+                    self.env.cr.commit()
             except Exception:
                 if raise_exception:
                     raise
                 _logger.info("Posting of scheduled message with ID %s failed", scheduled_message.id, exc_info=True)
                 # notify user about the failure (send content as user might have lost access to the record)
+                if auto_commit:
+                    self.env.cr.rollback()
                 try:
-                    with self.env.cr.savepoint():
-                        self.env['mail.thread'].message_notify(
-                            partner_ids=[message_creator.partner_id.id],
-                            subject=_("A scheduled message could not be sent"),
-                            body=_("The message scheduled on %(model)s(%(id)s) with the following content could not be sent:%(original_message)s",
-                                model=scheduled_message.model,
-                                id=scheduled_message.res_id,
-                                original_message=Markup("<br>-----<br>%s<br>-----<br>") % scheduled_message.body,
-                            )
+                    self.env['mail.thread'].message_notify(
+                        partner_ids=[message_creator.partner_id.id],
+                        subject=_("A scheduled message could not be sent"),
+                        body=_("The message scheduled on %(model)s(%(id)s) with the following content could not be sent:%(original_message)s",
+                            model=scheduled_message.model,
+                            id=scheduled_message.res_id,
+                            original_message=Markup("<br>-----<br>%s<br>-----<br>") % scheduled_message.body,
                         )
+                    )
+                    if auto_commit:
+                        self.env.cr.commit()
                 except Exception:
                     # in case even message_notify fails, make sure the failing scheduled message
                     # will be deleted
                     _logger.exception("The notification about the failed scheduled message could not be sent")
+                    if auto_commit:
+                        self.env.cr.rollback()
         self.unlink()
 
     # ------------------------------------------------------


### PR DESCRIPTION
Purpose:
--------
Replace the usage of the savepoints introduced in [this commit](https://github.com/odoo/odoo/commit/e7271331ee52596e307f402b76ff61b58ec59429) which might lead to poor performances.
See https://github.com/odoo/odoo/pull/167236 for more details.

Since commit and rollback are forbidden in tests, the part in the `test_scheduled_message_posting` test checking that the failed scheduled message was not posted has been removed.

Task-4575344
