### PR TITLE
[FIX] point_of_sale: keep search word when it rerenders

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/inputs/input/input.js
+++ b/addons/point_of_sale/static/src/app/generic_components/inputs/input/input.js
@@ -1,4 +1,4 @@
-import { useRef, useState } from "@odoo/owl";
+import { useRef, useState, onPatched } from "@odoo/owl";
 import { useAutofocus } from "@web/core/utils/hooks";
 import { debounce } from "@web/core/utils/timing";
 import { TModelInput } from "@point_of_sale/app/generic_components/inputs/t_model_input";
@@ -41,12 +41,16 @@ export class Input extends TModelInput {
     };
     setup() {
         this.state = useState({ isOpen: false });
-        this.setValue = debounce(this.setValue, this.props.debounceMillis);
+        // Bind setValue to ensure that 'this' remains the component instance.
+        this.setValue = debounce(this.setValue.bind(this), this.props.debounceMillis);
         const ref =
             (this.props.autofocus &&
                 useAutofocus({ refName: "input", mobile: this.props.autofocusMobile })) ||
             useRef("input");
         this.props.getRef?.(ref);
+        onPatched(() => {
+            this.setValue.cancel(true);
+        });
     }
     setValue(newValue, tModel = this.props.tModel) {
         super.setValue(newValue, tModel);


### PR DESCRIPTION
Before this commit, when an IoT device was connected, if you kept typing in the search box, the input would be reset to its previous state with each statusLoop execution. This fix cancels the debounce on re-render, ensuring that the search word is preserved.

opw-4562152

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
