### PR TITLE
[FIX] point_of_sale, pos_self_order: slot usage computation

### DIFF
--- a/addons/point_of_sale/models/pos_preset.py
+++ b/addons/point_of_sale/models/pos_preset.py
@@ -68,38 +68,9 @@ class PosPreset(models.Model):
     def get_available_slots(self):
         self.ensure_one()
         usage = self._compute_slots_usage()
-        date_now = datetime.now()
-        interval = timedelta(minutes=self.interval_time)
-        slots = {}
-
-        # Compute slots for next 7 days
-        next_7_days = [date_now + timedelta(days=i) for i in range(7)]
-        for day in next_7_days:
-            day_of_week = day.weekday()
-            date = day.strftime("%Y-%m-%d")
-            slots[date] = {}
-
-            if self.interval_time <= 0:
-                continue
-
-            for attendance_id in self.attendance_ids.filtered(lambda a: int(a.dayofweek) == day_of_week):
-                date_opening = datetime(day.year, day.month, day.day, int(attendance_id.hour_from % 24), int((attendance_id.hour_from % 1) * 60))
-                date_closing = datetime(day.year, day.month, day.day, int(attendance_id.hour_to % 24), int((attendance_id.hour_to % 1) * 60))
-
-                start = date_opening
-                while start <= date_closing:
-                    sql_datetime = start.strftime("%Y-%m-%d %H:%M:%S")
-                    slots[date][sql_datetime] = {
-                        'periode': attendance_id.day_period,
-                        'datetime': start,
-                        'sql_datetime': start.strftime("%Y-%m-%d %H:%M:%S"),
-                    }
-                    start += interval
-
-                for slot in slots[date].items():
-                    slot[1]['order_ids'] = usage.get(slot[1]['sql_datetime'], [])
-
-        return slots
+        return {
+            'usage_utc': usage,
+        }
 
     def _compute_slots_usage(self):
         usage = defaultdict(int)

--- a/addons/point_of_sale/static/src/app/models/pos_preset.js
+++ b/addons/point_of_sale/static/src/app/models/pos_preset.js
@@ -55,27 +55,18 @@ export class PosPreset extends Base {
         );
     }
 
-    computeAvailabilities(av) {
+    computeAvailabilities(usages) {
         this.generateSlots();
 
-        if (av) {
-            for (const [date, slots] of Object.entries(this.uiState.availabilities)) {
-                for (const [datetime, slot] of Object.entries(slots)) {
-                    const serverSlot = av[date][datetime];
+        const allSlots = Object.values(this.uiState.availabilities).reduce(
+            (acc, curr) => Object.assign(acc, curr),
+            {}
+        );
 
-                    slot.order_ids.forEach((orderId) => {
-                        if (
-                            !serverSlot.order_ids.includes(orderId) &&
-                            !this.models["pos.order"].get(orderId)
-                        ) {
-                            slot.order_ids.delete(orderId);
-                        }
-                    });
-
-                    slot.order_ids = new Set([...slot.order_ids, ...serverSlot.order_ids]);
-                    slot.isFull = slot.order_ids.size >= this.slots_per_interval;
-                }
-            }
+        for (const [datetime, slot] of Object.entries(allSlots)) {
+            const usage = usages[datetime];
+            slot.order_ids = new Set([...slot.order_ids, ...(usage || [])]);
+            slot.isFull = slot.order_ids.size >= this.slots_per_interval;
         }
 
         return this.uiState.availabilities;

--- a/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.xml
@@ -15,7 +15,10 @@
                 </option>
                 <t t-foreach="slots" t-as="slot" t-key="slot_index">
                     <option t-att-value="slot[0]" t-esc="slot[0]" disabled="1" />
-                    <option t-foreach="Object.values(slot[1])" t-as="s" t-key="s_index" t-att-value="s.sql_datetime" t-esc="s.datetime.toFormat('HH:mm')" />
+                    <option t-foreach="Object.values(slot[1])"
+                        t-as="s" t-key="s_index"
+                        t-att-value="s.datetime.toFormat('yyyy-MM-dd HH:mm:ss')"
+                        t-esc="s.datetime.toFormat('HH:mm')" />
                 </t>
             </select>
             <select t-if="preset.needsPartner and existingPartners.length"


### PR DESCRIPTION
Before computation of usage of slots were comparing order UTC date with slot local date. This was causing wrong computation of slot usage.

This commit fixes the issue by comparing order local date with slot.

