### PR TITLE
[FIX] purchase: display po's amount in company currency if different

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -243,6 +243,8 @@ class PurchaseOrder(models.Model):
                 currency=order.currency_id or order.company_id.currency_id,
                 company=order.company_id,
             )
+            if order.currency_id != order.company_currency_id:
+                order.tax_totals['amount_total_cc'] = f"({formatLang(self.env, order.amount_total_cc, currency_obj=self.company_currency_id)})"
 
     @api.depends('company_id.account_fiscal_country_id', 'fiscal_position_id.country_id', 'fiscal_position_id.foreign_vat')
     def _compute_tax_country_id(self):

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -448,7 +448,7 @@ class TestPurchase(AccountTestInvoicingCommon):
         purchase_order_coco = po_form.save()
         self.assertEqual(purchase_order_coco.order_line.price_unit, currency_rate.rate * product.standard_price, "Value shouldn't be rounded 🍫")
         self.assertEqual(purchase_order_coco.amount_total_cc, round(purchase_order_coco.amount_total / currency_rate.rate, 2), "Company Total should be 0.14$, since 1$ = 0.5🍫")
-
+        self.assertEqual(purchase_order_coco.tax_totals['amount_total_cc'], "($\xa00.14)")
         #check if the correct currency is set on the purchase order by comparing the expected price and actual price
 
         company_a = self.company_data['company']
@@ -492,6 +492,10 @@ class TestPurchase(AccountTestInvoicingCommon):
 
         self.assertEqual(order_b.order_line.price_unit, 10.0, 'The price unit should be 10.0')
         self.assertEqual(order_b.amount_total_cc, order_b.amount_total, 'Company Total should be 10.0$')
+
+        # since the order currency matches the company currency we don't want to redisplay the total amount
+        with self.assertRaises(KeyError):
+            order_b.tax_totals['amount_total_cc']
 
     def test_discount_and_price_update_on_quantity_change(self):
         """ Purchase order line price and discount should update accordingly based on quantity


### PR DESCRIPTION
## Versions:
18.0
Reset feature from saas-17.4

## Issue:
In saas-17.4, the user could see the Purchase Order total amount in the selected company's currency if it differs from the PO's currency. This doesn't exist in 18 anymore.

## Steps to reproduce:
Ensure there are at least 2 currencies available in the `Settings` app
- Create a new purchase order;
- Change the selected `Currency` for any other;
- Look at the subtotal part that does not include the equivalent amount in the company's currency.

## Cause:
The saas-17.4 feature has not been forwarded entirely and an important part of it is missing. The company currency total amount is not updated correctly

## Fix:
Forward-port the complete feature of https://github.com/odoo/odoo/commit/202af7c12a768005df3bd97f595ead0a4c4c02b9
Include the fix from https://github.com/odoo/odoo/pull/186464/commits/7467d68309c039c50e39b6ec0b8645ef7ff42ad4


opw-4416711