### PR TITLE
[FIX] website_hr_recruitment: custom fields appear in chatter instead of notes

### DIFF
--- a/addons/website_hr_recruitment/data/config_data.xml
+++ b/addons/website_hr_recruitment/data/config_data.xml
@@ -20,12 +20,14 @@
     <data>
         <record id="hr_recruitment.model_hr_applicant" model="ir.model">
             <field name="website_form_key">apply_job</field>
+            <field name="website_form_default_field_id" ref="hr_recruitment.field_hr_applicant__applicant_notes"/>
             <field name="website_form_access">True</field>
             <field name="website_form_label">Apply for a Job</field>
         </record>
         <function model="ir.model.fields" name="formbuilder_whitelist">
             <value>hr.applicant</value>
             <value eval="[
+                'applicant_notes',
                 'email_from',
                 'partner_name',
                 'partner_phone',

--- a/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
+++ b/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
@@ -89,7 +89,7 @@ class TestWebsiteHrRecruitmentForm(odoo.tests.HttpCase):
             'partner_phone': '12345678',
             'job_id': developer_job.id,
             'department_id': research_and_development_department.id,
-            'description': 'This is a short introduction',
+            'applicant_notes': 'This is a short introduction',
             'Additional info': 'Test',
         }
         self.authenticate(None, None)
@@ -101,10 +101,4 @@ class TestWebsiteHrRecruitmentForm(odoo.tests.HttpCase):
         self.assertEqual(applicant.partner_name, 'Georges')
         self.assertEqual(applicant.email_from, 'georges@test.com')
         self.assertEqual(applicant.partner_phone, '12345678')
-        self.assertTrue(
-            any(
-                html2plaintext(message.body) == 'Other Information:\n___________\n\ndescription : This is a short introduction\nAdditional info : Test'
-                for message in applicant.message_ids
-            ),
-            "One message in the chatter should contain the extra information filled in by the applicant"
-        )
+        self.assertEqual(html2plaintext(applicant.applicant_notes), 'This is a short introduction\n\n\nOther Information:\n___________\n\nAdditional info : Test')


### PR DESCRIPTION
**Steps to Reproduce:**
1. Install the `website_hr_recruitment` module.
2. Navigate to the job application form.
3. Use the editor to add a custom text field.
4. Submit an application.

**Issue:**
The data entered in the custom field appears in the chatter section of the applicant record instead of the notes section.

**Solution:**
Setting `website_form_default_field_id` to `hr_recruitment.field_hr_applicant__applicant_notes`. Ensure that data from custom fields is correctly saved in the notes section of the applicant record.

Description of the issue/feature this PR addresses:

- In version 17.4, the [website_form_default_field_id](https://github.com/odoo/odoo/blob/saas-17.4/addons/website_hr_recruitment/data/config_data.xml#L23) was assigned to the description field, but in version 18, description field [was removed](https://github.com/odoo/odoo/commit/e0f281433eec3f34d6f720656ead51e417679cd1#diff-12b0850af29a9858b955218c748c4469b9cbe95d07fc75c656506dec3451e005L38), and a new [notes](https://github.com/odoo/odoo/commit/e0f281433eec3f34d6f720656ead51e417679cd1#diff-12b0850af29a9858b955218c748c4469b9cbe95d07fc75c656506dec3451e005R115) field was introduced. The website_form_default_field_id was left as null.
- The solution is to correctly map the custom fields to the notes section by setting the website_form_default_field_id to point to the appropriate field (applicant_notes).

 
**Current behavior before PR:**

#### Before the fix, the website_form_default_field_id was null, and custom field data would not appear in the notes section.

![image](https://github.com/user-attachments/assets/e6156561-ba7c-4304-971a-2c0de7471e85)


```psql
v_18.0=# select id,name,website_form_default_field_id from ir_model where model =  'hr.applicant';
 id  |          name          | website_form_default_field_id 
-----+------------------------+-------------------------------
 437 | {"en_US": "Applicant"} |                              
(1 row)
```
**Desired behavior after PR is merged:**
#### After the PR is applied, the website_form_default_field_id should be set to the applicant_notes field, ensuring custom fields are saved in the notes section.

![image](https://github.com/user-attachments/assets/f5d3b34c-baf9-4e0c-b0b9-011b1930f413)

```psql
v_check_fix=# select id,name,website_form_default_field_id from ir_model where model =  'hr.applicant';
 id  |          name          | website_form_default_field_id 
-----+------------------------+-------------------------------
 437 | {"en_US": "Applicant"} |                          4453
(1 row)
v_check_fix=# select id,name,model,ttype from ir_model_fields where id = 4453;
  id  |      name       |    model     | ttype 
------+-----------------+--------------+-------
 4453 | applicant_notes | hr.applicant | html
(1 row)

```



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
