### PR TITLE
[FIX] product: include parent companies in catalog domain

### DIFF
--- a/addons/product/models/product_catalog_mixin.py
+++ b/addons/product/models/product_catalog_mixin.py
@@ -40,7 +40,7 @@ class ProductCatalogMixin(models.AbstractModel):
         :returns: A list of tuples that represents a domain.
         :rtype: list
         """
-        return [('company_id', 'in', [self.company_id.id, False])]
+        return ['|', ('company_id', '=', False), ('company_id', 'parent_of', self.company_id.id)]
 
     def _get_product_catalog_record_lines(self, product_ids):
         """ Returns the record's lines grouped by product.

--- a/addons/sale/static/tests/tours/sale_catalog.js
+++ b/addons/sale/static/tests/tours/sale_catalog.js
@@ -1,0 +1,68 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add('sale_catalog', {
+    test: true,
+    checkDelay: 50,
+    steps: () => [
+        {
+            content: "Create a new SO",
+            trigger: '.o_list_button_add',
+            run: 'click',
+        },
+        {
+            content: "Select the customer field",
+            trigger: ".o_field_res_partner_many2one input.o_input",
+            run: 'click',
+        },
+        {
+            content: "Wait for the field to be active",
+            trigger: "input[id*='partner_id']",
+        },
+        {
+            content: "Select a customer from the dropdown",
+            trigger: ".dropdown-item",
+            run: 'click',
+        },
+        {
+            content: "Open product catalog",
+            trigger: '.o_form_view button:contains("Catalog")',
+            run: 'click',
+        },
+        {
+            content: "Type 'Restricted' into the search bar",
+            trigger: 'input.o_searchview_input',
+            run: "text Restricted",
+        },
+        {
+            content: "Search for the product",
+            trigger: '.o_searchview_autocomplete .o_menu_item',
+        },
+        {
+            content: "Add the product to the SO",
+            trigger: '.o_kanban_record:contains("Restricted Product") .fa-shopping-cart',
+            run: 'click',
+        },
+        {
+            content: "Input a custom quantity",
+            trigger: '.o_kanban_record:contains("Restricted Product") .o_input',
+            run: "text 6",
+        },
+        {
+            content: "Increase the quantity",
+            trigger: '.o_kanban_record:contains("Restricted Product") .fa-plus',
+            run: 'click',
+        },
+        {
+            content: "Close the catalog",
+            trigger: '.o-kanban-button-back',
+            run: 'click',
+        },
+        {
+            content: "Confirm the SO",
+            trigger: '.o_form_view button:contains("Confirm")',
+            run: 'click',
+        },
+    ]
+});

--- a/addons/sale/tests/__init__.py
+++ b/addons/sale/tests/__init__.py
@@ -16,6 +16,7 @@ from . import test_sale_order
 from . import test_sale_order_cancel
 from . import test_sale_order_discount
 from . import test_sale_order_down_payment
+from . import test_sale_order_product_catalog
 from . import test_sale_prices
 from . import test_sale_product_attribute_value_config
 from . import test_sale_refund

--- a/addons/sale/tests/test_sale_order_product_catalog.py
+++ b/addons/sale/tests/test_sale_order_product_catalog.py
@@ -1,0 +1,26 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestSaleOrderProductCatalog(HttpCase):
+
+    def test_sale_order_product_catalog_branch_company_tour(self):
+        """Test adding products to a SO through the catalog view when in a branch company."""
+
+        self.env['product.template'].create({
+            'name': "Restricted Product",
+            'company_id': self.env.company.id,
+        })
+        admin = self.env.ref('base.user_admin')
+        branch = self.env['res.company'].with_user(admin).create({
+            'name': "Branch Company",
+            'parent_id': self.env.company.id,
+        })
+        admin.company_id = branch
+        self.start_tour(
+            '/web#action=sale.action_quotations',
+            'sale_catalog',
+            login="admin",
+        )


### PR DESCRIPTION
Issue
-----
When in a branch company, products from the parent company are not visible in the catalog.

Steps to reproduce
-----
- Install "Sales" app
- Go to Settings > Users & Companies > Companies
- Create the "Main Company" Company
    - Add Branches to "Main Company"
- Switch companies to "Main Company"
- Create a product "A" and set the company to "Main Company"
- Switch to one of the branch companies
- Create a new Quotation

-> The product is displayed from the dropdown list but not in the Catalog

Cause
-----
Branches have a different id from their parent company. The search domain only includes the current companies but not its' parents.

We can simply include the parent company in _get_product_catalog_domain (of the product_catalog_mixin class).

-----
Ticket:
opw-4472464