### PR TITLE
[FIX] website_sale: address form saved through confirm button

### DIFF
--- a/addons/l10n_ec_website_sale/static/tests/tours/website_sale_checkout_address.js
+++ b/addons/l10n_ec_website_sale/static/tests/tours/website_sale_checkout_address.js
@@ -39,7 +39,7 @@ registry.category("web_tour.tours").add("tour_new_billing_ec", {
         },
         {
             content: "Save address",
-            trigger: "button#save_address",
+            trigger: "a[name='website_sale_main_button']",
             run: "click",
         },
         {

--- a/addons/website_sale/static/src/js/address.js
+++ b/addons/website_sale/static/src/js/address.js
@@ -7,7 +7,6 @@ publicWidget.registry.websiteSaleAddress = publicWidget.Widget.extend({
     selector: '.o_wsale_address_fill',
     events: {
         'change select[name="country_id"]': '_onChangeCountry',
-        'click #save_address': '_onSaveAddress',
         "change select[name='state_id']": "_onChangeState",
     },
 
@@ -18,6 +17,10 @@ publicWidget.registry.websiteSaleAddress = publicWidget.Widget.extend({
         this._super.apply(this, arguments);
 
         this.http = this.bindService('http');
+
+        this.submitButton = document.getElementsByName('website_sale_main_button')[0]
+        this._boundSaveAddress = this._onSaveAddress.bind(this);
+        this.submitButton.addEventListener('click', this._boundSaveAddress);
 
         this._changeCountry = debounce(this._changeCountry.bind(this), 500);
         this.addressForm = document.querySelector('form.checkout_autoformat');
@@ -39,6 +42,11 @@ publicWidget.registry.websiteSaleAddress = publicWidget.Widget.extend({
         this._changeCountry(true);
 
         return def;
+    },
+
+    destroy() {
+        this.submitButton.removeEventListener("click", this._boundSaveAddress);
+        this._super(...arguments);
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -89,7 +89,7 @@ export function fillAdressForm(
     }
     steps.push({
         content: "Continue checkout",
-        trigger: "#save_address",
+        trigger: "a[name='website_sale_main_button']",
         run: "click",
     });
     return steps;

--- a/addons/website_sale/static/tests/tours/website_sale_update_address.js
+++ b/addons/website_sale/static/tests/tours/website_sale_update_address.js
@@ -25,7 +25,7 @@ registry.category("web_tour.tours").add('update_billing_shipping_address', {
         },
         {
             content: "Save address",
-            trigger: 'button#save_address',
+            trigger: "a[name='website_sale_main_button']",
             run: "click",
         },
         {

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2663,26 +2663,6 @@
 
                         <!-- Example -->
                         <input type="hidden" name="required_fields" t-att-value="'name,country_id'"/>
-
-                        <div class="d-flex flex-column flex-md-row align-items-center justify-content-between mt32 mb32">
-                            <a role="button" t-att-href="discard_url" class="btn btn-outline-secondary w-100 w-md-auto order-md-1 order-3">
-                                <i class="fw-light fa fa-angle-left me-2"/>Discard
-                            </a>
-                            <div class="position-relative w-100 d-flex d-md-none justify-content-center align-items-center order-2 my-2 opacity-75">
-                                <hr class="w-100"/>
-                                <span class="px-3">or</span>
-                                <hr class="w-100"/>
-                            </div>
-                            <button id="save_address" class="btn btn-primary w-100 w-md-auto order-1 order-md-3">
-                                <t t-if="is_anonymous_cart">
-                                    Continue checkout
-                                </t>
-                                <t t-else="">
-                                    Save address
-                                </t>
-                                <i class="fw-light fa fa-angle-right ms-2"/>
-                            </button>
-                        </div>
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
Current behavior before PR:
In the checkout flow on e-commerce, "Confirm" button doesn't do anything on website_sale.address page. You have to click on "Save address" to move on to the next page which might be confusing for the final customer. 

Desired behavior after PR is merged:
"Confirm" button triggers the form and the redirection instead of the "Save address" button which is then removed. 

task-4472450

