### PR TITLE
[FIX] l10n_fr_pos_cert: prevent error when modifying the price

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/xml/OrderSummary.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/OrderSummary.xml
@@ -7,7 +7,7 @@
                     Old unit price:
                     <span class="oldPrice">
                         <s>
-                            <t t-esc="env.utils.formatCurrency(line.get_taxed_lst_unit_price())" /> / Units
+                            <t t-esc="env.utils.formatCurrency(line.getTaxedlstUnitPrice())" /> / Units
                         </s>
                     </span>
                 </li>


### PR DESCRIPTION
Before this commit, modifying the price would cause an error due to a refactoring that converted variable names to camelCase. The function `get_taxed_lst_unit_price` was omitted during this update.

opw-4574142

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
