### PR TITLE
[FIX] sale: adapt tax to early payment discount computation

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -490,12 +490,13 @@ class SaleOrder(models.Model):
                 )
             order.team_id = cached_teams[key]
 
-    @api.depends('order_line.price_subtotal', 'currency_id', 'company_id')
+    @api.depends('order_line.price_subtotal', 'currency_id', 'company_id', 'payment_term_id')
     def _compute_amounts(self):
         AccountTax = self.env['account.tax']
         for order in self:
             order_lines = order.order_line.filtered(lambda x: not x.display_type)
             base_lines = [line._prepare_base_line_for_taxes_computation() for line in order_lines]
+            base_lines += order._add_base_lines_for_early_payment_discount()
             AccountTax._add_tax_details_in_base_lines(base_lines, order.company_id)
             AccountTax._round_base_lines_tax_details(base_lines, order.company_id)
             tax_totals = AccountTax._get_tax_totals_summary(
@@ -506,6 +507,43 @@ class SaleOrder(models.Model):
             order.amount_untaxed = tax_totals['base_amount_currency']
             order.amount_tax = tax_totals['tax_amount_currency']
             order.amount_total = tax_totals['total_amount_currency']
+
+    def _add_base_lines_for_early_payment_discount(self):
+        """
+        When applying a payment term with an early payment discount, and when said payment term computes the tax on the
+        'mixed' setting, the tax computation is always based on the discounted amount untaxed.
+        Creates the necessary line for this behavior to be displayed.
+        :returns: array containing the necessary lines or empty array if the payment term isn't epd mixed
+        """
+        self.ensure_one()
+        epd_lines = []
+        if (
+            self.payment_term_id.early_discount
+            and self.payment_term_id.early_pay_discount_computation == 'mixed'
+            and self.payment_term_id.discount_percentage
+        ):
+            percentage = self.payment_term_id.discount_percentage
+            currency = self.currency_id or self.company_id.currency_id
+            for line in self.order_line.filtered(lambda x: not x.display_type):
+                line_amount_after_discount = (line.price_subtotal / 100) * percentage
+                epd_lines.append(self.env['account.tax']._prepare_base_line_for_taxes_computation(
+                    record=self,
+                    price_unit=-line_amount_after_discount,
+                    quantity=1.0,
+                    currency_id=currency,
+                    sign=1,
+                    special_type='early_payment',
+                    tax_ids=line.tax_id,
+                ))
+                epd_lines.append(self.env['account.tax']._prepare_base_line_for_taxes_computation(
+                    record=self,
+                    price_unit=line_amount_after_discount,
+                    quantity=1.0,
+                    currency_id=currency,
+                    sign=1,
+                    special_type='early_payment',
+                ))
+        return epd_lines
 
     @api.depends('order_line.invoice_lines')
     def _get_invoiced(self):
@@ -737,12 +775,13 @@ class SaleOrder(models.Model):
                 )
 
     @api.depends_context('lang')
-    @api.depends('order_line.price_subtotal', 'currency_id', 'company_id')
+    @api.depends('order_line.price_subtotal', 'currency_id', 'company_id', 'payment_term_id')
     def _compute_tax_totals(self):
         AccountTax = self.env['account.tax']
         for order in self:
             order_lines = order.order_line.filtered(lambda x: not x.display_type)
             base_lines = [line._prepare_base_line_for_taxes_computation() for line in order_lines]
+            base_lines += order._add_base_lines_for_early_payment_discount()
             AccountTax._add_tax_details_in_base_lines(base_lines, order.company_id)
             AccountTax._round_base_lines_tax_details(base_lines, order.company_id)
             order.tax_totals = AccountTax._get_tax_totals_summary(

--- a/addons/sale/tests/test_taxes_tax_totals_summary.py
+++ b/addons/sale/tests/test_taxes_tax_totals_summary.py
@@ -1,5 +1,6 @@
 from odoo.addons.account.tests.test_taxes_tax_totals_summary import TestTaxesTaxTotalsSummary
 from odoo.addons.sale.tests.common import TestTaxCommonSale
+from odoo.fields import Command
 from odoo.tests import tagged
 
 
@@ -94,3 +95,44 @@ class TestTaxesTaxTotalsSummarySale(TestTaxCommonSale, TestTaxesTaxTotalsSummary
             with self.subTest(test_index=test_index):
                 sale_order = self.convert_document_to_sale_order(document)
                 self.assert_sale_order_tax_totals_summary(sale_order, expected_values)
+
+    def test_apply_mixed_epd_discount(self):
+        """
+        When applying an epd - mixed payment term, the tax should be computed based on the discounted untaxed amount.
+        """
+        tax_a = self.percent_tax(15.0)
+        early_payment_term = self.env['account.payment.term'].create({
+            'name': "early_payment_term",
+            'early_pay_discount_computation': 'mixed',
+            'discount_percentage': 10,
+            'discount_days': 10,
+            'early_discount': True,
+            'line_ids': [
+                Command.create({
+                    'value': 'percent',
+                    'value_amount': 100,
+                    'nb_days': 20,
+                }),
+            ],
+        })
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'payment_term_id': early_payment_term.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product.id,
+                    'price_unit': 100,
+                    'tax_id': [Command.set(tax_a.ids)],
+                }),
+            ],
+        })
+        self.assert_sale_order_tax_totals_summary(
+            sale_order,
+            {
+                'base_amount_currency': 100.0,
+                'tax_amount_currency': 13.5,
+                'total_amount_currency': 113.5,
+            },
+            soft_checking=True,
+        )


### PR DESCRIPTION
When applying a payment term with an early payment discount, and when said payment term computes the tax on the 'mixed' setting (_"Always (upon invoice)"_), the tax computation is based on the discounted amount untaxed, whether or not the conditions to benefit from the discount are fulfilled.

In other words, applying this payment term will always affect the tax.

The invoices can display this behavior, while the sale order would not.

In this PR we copy the basics of the tax computation from `account` regarding this aspect.

task-4491439
