### PR TITLE
[IMP] profiler: Add memory profiling

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -21,6 +21,7 @@ This module provides the core of the Odoo Web Client.
         'views/base_document_layout_views.xml',
         'views/partner_view.xml',
         'views/speedscope_template.xml',
+        'views/memory_template.xml',
         'views/speedscope_config_wizard.xml',
         'views/neutralize_views.xml',
         'views/ir_ui_view_views.xml',

--- a/addons/web/controllers/profiling.py
+++ b/addons/web/controllers/profiling.py
@@ -23,22 +23,16 @@ class Profiling(Controller):
             return Response(response='error: %s' % e, status=500, mimetype='text/plain')
 
     @route([
-        '/web/speedscope',
         '/web/speedscope/<profile>',
     ], type='http', sitemap=False, auth='user', readonly=True)
     def speedscope(self, profile=None, action=False, **kwargs):
-        if not profile:
-            raise request.not_found()
+        profiles = request.env['ir.profile'].browse(int(p) for p in profile.split(',')).exists()
         profile_str = profile
-        profiles = request.env['ir.profile'].browse((int(p) for p in profile.split(',')))
-        if not kwargs and not action:
-            context = {
-                'profile_str': profile_str,
-                'profiles': profiles,
-            }
-            return request.render('web.config_speedscope_index', context)
-        speedscope_result = profiles._generate_speedscope(profiles._parse_params(kwargs))
-        if action == 'download_json':
+        if not profiles:
+            raise request.not_found()
+        params = kwargs or profiles._default_profile_params()
+        speedscope_result = profiles._generate_speedscope(profiles._parse_params(params))
+        if action == 'speedscope_download_json':
             headers = [
                 ('Content-Type', 'application/json'),
                 ('X-Content-Type-Options', 'nosniff'),
@@ -53,8 +47,33 @@ class Profiling(Controller):
             'cdn': icp.sudo().get_param('speedscope_cdn', "https://cdn.jsdelivr.net/npm/speedscope@1.13.0/dist/release/")
         }
         response = request.render('web.view_speedscope_index', context)
-        if action == 'download_html':
+        if action == 'speedscope_download_html':
             response.headers['Content-Disposition'] = content_disposition(f'profile_{profile_str}.html')
             response.headers['X-Content-Type-Options'] = 'nosniff'
             response.headers['Content-Type'] = 'text/html'
         return response
+
+    @route([
+      '/web/profile_config/<profile>',
+    ], type='http', sitemap=False, auth='user', readonly=True)
+    def profile_config(self, profile=None, action=False, **kwargs):
+        profile_str = profile
+        profiles = request.env['ir.profile'].browse(int(p) for p in profile_str.split(',')).exists()
+        if not profiles:
+            raise request.not_found()
+
+        if action == 'memory_open':
+            memory_profile = profiles._generate_memory_profile(profiles._parse_params(kwargs))
+            encoded_memory_profile = json.dumps(memory_profile).encode('utf_8')
+            context = {
+                'profile': profiles,
+                'memory_graph': base64.b64encode(encoded_memory_profile).decode('utf-8'),
+                }
+            return request.render('web.view_memory', context)
+
+        context = {
+            'default_params': profiles._default_profile_params(),
+            'profile_str': profile_str,
+            'profiles': profiles,
+        }
+        return request.render('web.config_speedscope_index', context)

--- a/addons/web/static/src/webclient/debug/profiling/profiling_item.xml
+++ b/addons/web/static/src/webclient/debug/profiling/profiling_item.xml
@@ -34,6 +34,22 @@
                                 <option value="1" t-att-selected="interval === '1'">1</option>
                             </select>
                         </div>
+                        <span class="o_profiling_switch form-check form-switch mt-2" t-on-click.stop.prevent="() => this.profiling.toggleCollector('memory')">
+                            <input type="checkbox" class="form-check-input" id="profile_memory"
+                                t-att-checked="profiling.isCollectorEnabled('memory')"/>
+                            <label class="form-check-label" for="profile_memory">Record memory</label>
+                        </span>
+                        <div t-if="profiling.isCollectorEnabled('memory')" class="input-group input-group-sm mt-2" t-on-click.stop.prevent="">
+                            <div class="input-group-text">Interval</div>
+                            <select class="profile_param form-select" t-on-change="(ev) => this.changeParam('memory_interval', ev)">
+                                <t t-set="interval" t-value="profiling.state.params.memory_interval"/>
+                                <option value="">Default</option>
+                                <option value="0.01" t-att-selected="interval === '0.01'">0.01</option>
+                                <option value="0.1" t-att-selected="interval === '0.1'">0.1</option>
+                                <option value="1" t-att-selected="interval === '1'">1</option>
+                                <option value="5" t-att-selected="interval === '5'">5</option>
+                            </select>
+                        </div>
                         <div class="input-group input-group-sm mt-2">
                             <div class="input-group-text">Entry Count</div>
                             <input type="number" class="form-control" t-on-click.stop.prevent="" t-on-change="(ev) => this.changeParam('entry_count_limit', ev)" t-att-value="profiling.state.params.entry_count_limit || '0'" placeholder="None"/>

--- a/addons/web/views/memory_template.xml
+++ b/addons/web/views/memory_template.xml
@@ -1,0 +1,393 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="view_memory">
+        &lt;!DOCTYPE html&gt;
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8"/>
+            <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+            <title>Memory Usage Visualization</title>
+            <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+            <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels"></script>
+            <style>
+                /* General body and layout styles */
+                body {
+                    font-family: Arial, sans-serif;
+                    margin: 20px;
+                    background-color: #f9f9f9;
+                }
+                .container {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 20px;
+                }
+
+                /* Row definitions for the new layout */
+                .top-row {
+                    height: 40vh; /* Line graph takes 40% of the viewport height */
+                }
+                .bottom-row {
+                    display: flex;
+                    gap: 20px;
+                    /* The height of this row will be determined by its content */
+                }
+
+                /* Chart container styles */
+                .chart-container {
+                    position: relative;
+                    background: #fff;
+                    border: 1px solid #ddd;
+                    border-radius: 5px;
+                    padding: 15px;
+                    height: 100%;
+                    width: 100%;
+                }
+                
+                /* Specific styling for the bottom row elements */
+                .bar-chart-wrapper {
+                    flex: 2; /* Bar chart takes 2/3 of the width */
+                    min-height: 400px; /* Minimum height for the bar chart */
+                }
+                .traceback-panel {
+                    flex: 1; /* Traceback panel takes 1/3 of the width */
+                    background: #f5f5f5;
+                    border: 1px solid #ddd;
+                    border-radius: 5px;
+                    padding: 15px;
+                    overflow-y: auto;
+                    min-height: 400px; /* Match min-height for alignment */
+                    height: fit-content; /* Adjust height to content */
+                }
+
+                /* Traceback panel content styling */
+                .traceback-header {
+                    font-weight: bold;
+                    margin-bottom: 10px;
+                    color: #333;
+                }
+                .traceback-item {
+                    background: white;
+                    margin: 5px 0;
+                    padding: 8px;
+                    border-radius: 3px;
+                    border-left: 3px solid #007acc;
+                    font-family: monospace;
+                    font-size: 12px;
+                }
+                .traceback-file {
+                    color: #007acc;
+                    font-weight: bold;
+                }
+                .copyable {
+                    cursor: pointer;
+                    user-select: all;
+                    padding: 2px 4px;
+                    border-radius: 3px;
+                    transition: background-color 0.2s;
+                }
+                .copyable:hover {
+                    background-color: #e8f4f8;
+                }
+                .traceback-line {
+                    color: #666;
+                }
+                .no-selection {
+                    color: #999;
+                    font-style: italic;
+                    text-align: center;
+                    padding-top: 50px;
+                }
+            </style>
+        </head>
+        <body>
+            <div class="container">
+                <!-- Top row for the full-width line chart -->
+                <div class="top-row">
+                    <div class="chart-container">
+                        <canvas id="totalMemoryChart"></canvas>
+                    </div>
+                </div>
+                <!-- Bottom row for the bar chart and traceback panel -->
+                <div class="bottom-row">
+                    <div class="bar-chart-wrapper chart-container" id="memoryChartContainer">
+                        <canvas id="memoryChart"></canvas>
+                    </div>
+                    <div class="traceback-panel" id="tracebackPanel">
+                        <div class="no-selection">Click a point on the top chart, then a bar below to see details.</div>
+                    </div>
+                </div>
+            </div>
+
+            <script>
+                // Get data from Odoo template
+                const rawData = JSON.parse(atob('<t t-esc="memory_graph"/>'));
+
+                // --- UTILITY FUNCTIONS ---
+                function formatBytes(bytes) {
+                    if (bytes === 0) return '0 B';
+                    const k = 1024;
+                    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+                    const i = Math.floor(Math.log(Math.abs(bytes)) / Math.log(k));
+                    const value = bytes / Math.pow(k, i);
+                    return `${value.toFixed(1)} ${sizes[i]}`;
+                }
+
+                function formatTimestamp(timestamp) {
+                    const date = new Date(timestamp * 1000);
+                    return date.toLocaleString();
+                }
+
+                function getLastFileFromTraceback(traceback) {
+                    if (!traceback || traceback.length === 0) return "unknown:0";
+                    const lastFrame = traceback[traceback.length - 1];
+                    return `${lastFrame[0]}:${lastFrame[1]}`;
+                }
+                
+                function getFullTracebackKey(traceback) {
+                    if (!traceback || traceback.length === 0) return "unknown";
+                    return traceback.map(frame => `${frame[0]}:${frame[1]}`).join(' -> ');
+                }
+
+                // --- DYNAMIC UI UPDATES ---
+                function updateChartHeight(chart, dataLength) {
+                    const container = document.getElementById('memoryChartContainer');
+                    if (dataLength === 0) {
+                        container.style.height = '400px'; // Reset to min-height
+                        chart.resize();
+                        return;
+                    }
+                    
+                    const minBarHeight = 35; // Minimum height per bar for readability
+                    const padding = 100; // Extra space for axes and labels
+                    const newHeight = Math.max(400, (dataLength * minBarHeight) + padding);
+                    
+                    container.style.height = newHeight + 'px';
+                    chart.resize();
+                }
+
+                function showTraceback(traceback, size, fullTracebackKey) {
+                    const panel = document.getElementById('tracebackPanel');
+                    if (!traceback || traceback.length === 0) {
+                        panel.innerHTML = '<div class="no-selection">No traceback available</div>';
+                        return;
+                    }
+
+                    let html = `<div class="traceback-header">Traceback (${formatBytes(size)})</div>`;
+
+                    if (fullTracebackKey) {
+                        html += `
+                            <div style="margin-bottom: 10px; padding: 8px; background: #e8f4f8; border-radius: 3px; font-size: 11px; color: #555;">
+                                <strong>Full Path:</strong> <span class="copyable" title="Click to select for copying">${fullTracebackKey}</span>
+                            </div>
+                        `;
+                    }
+
+                    traceback.forEach(frame => {
+                        const [filename, lineNo, functionName, code] = frame;
+                        html += `
+                            <div class="traceback-item">
+                                <div class="traceback-file copyable" title="Click to select for copying">${filename}:${lineNo}</div>
+                                <div>in <strong>${functionName || 'unknown'}</strong></div>
+                                ${code ? `<div class="traceback-line">${code}</div>` : ''}
+                            </div>
+                        `;
+                    });
+
+                    panel.innerHTML = html;
+                }
+
+                // --- CHART LOGIC ---
+                const totalSizes = rawData.map(entry =>
+                    entry.samples.reduce((sum, sample) => sum + sample.size, 0)
+                );
+                const lineLabels = rawData.map(entry => formatTimestamp(entry.start));
+
+                let selectedIndexes = [];
+                let currentBreakdownData = [];
+
+                const updateBarChart = () => {
+                    if (selectedIndexes.length === 1) {
+                        const entry = rawData[selectedIndexes[0]];
+                        const groupedData = {};
+                        entry.samples.forEach(sample => {
+                            const key = getLastFileFromTraceback(sample.traceback);
+                            if (!groupedData[key]) {
+                                groupedData[key] = { size: 0, traceback: sample.traceback, samples: [] };
+                            }
+                            groupedData[key].size += sample.size;
+                            groupedData[key].samples.push(sample);
+                        });
+
+                        currentBreakdownData = Object.entries(groupedData).map(([key, data]) => ({
+                            label: key,
+                            size: data.size,
+                            traceback: data.traceback,
+                            samples: data.samples
+                        })).sort((a, b) => b.size - a.size);
+
+                        breakdownChart.data.labels = currentBreakdownData.map(item => item.label);
+                        breakdownChart.data.datasets = [{
+                            label: `Memory Usage`,
+                            data: currentBreakdownData.map(item => item.size),
+                            backgroundColor: 'rgba(54, 162, 235, 0.6)',
+                            borderColor: 'rgba(54, 162, 235, 1)',
+                            borderWidth: 1
+                        }];
+                        breakdownChart.options.plugins.title.text = `Memory Breakdown for ${formatTimestamp(entry.start)}`;
+
+                    } else if (selectedIndexes.length === 2) {
+                        const [idx1, idx2] = selectedIndexes.sort((a, b) => a - b);
+                        const entry1 = rawData[idx1];
+                        const entry2 = rawData[idx2];
+
+                        const groupDataByFullTraceback = (entry) => {
+                            const grouped = {};
+                            entry.samples.forEach(sample => {
+                                const key = getFullTracebackKey(sample.traceback);
+                                if (!grouped[key]) {
+                                    grouped[key] = { size: 0, traceback: sample.traceback, lastFile: getLastFileFromTraceback(sample.traceback) };
+                                }
+                                grouped[key].size += sample.size;
+                            });
+                            return grouped;
+                        };
+
+                        const data1 = groupDataByFullTraceback(entry1);
+                        const data2 = groupDataByFullTraceback(entry2);
+                        const labelSet = new Set([...Object.keys(data1), ...Object.keys(data2)]);
+                        
+                        let diffData = [];
+                        labelSet.forEach(fullTracebackKey => {
+                            const size1 = data1[fullTracebackKey]?.size || 0;
+                            const size2 = data2[fullTracebackKey]?.size || 0;
+                            const diff = size2 - size1;
+                            if (diff !== 0) {
+                                const item = data2[fullTracebackKey] || data1[fullTracebackKey];
+                                diffData.push({ 
+                                    label: item.lastFile,
+                                    diff: diff,
+                                    traceback: item.traceback,
+                                    fullTracebackKey: fullTracebackKey
+                                });
+                            }
+                        });
+
+                        currentBreakdownData = diffData.sort((a, b) => b.diff - a.diff);
+
+                        breakdownChart.data.labels = currentBreakdownData.map(item => item.label);
+                        breakdownChart.data.datasets = [{
+                            label: `Difference`,
+                            data: currentBreakdownData.map(item => item.diff),
+                            backgroundColor: item => item.raw >= 0 ? 'rgba(75, 192, 192, 0.6)' : 'rgba(255, 99, 132, 0.6)',
+                            borderColor: item => item.raw >= 0 ? 'rgba(75, 192, 192, 1)' : 'rgba(255, 99, 132, 1)',
+                            borderWidth: 1
+                        }];
+                        breakdownChart.options.plugins.title.text = `Memory Difference: ${formatTimestamp(entry2.start)} vs ${formatTimestamp(entry1.start)}`;
+
+                    } else {
+                        currentBreakdownData = [];
+                        breakdownChart.data.labels = [];
+                        breakdownChart.data.datasets = [];
+                        breakdownChart.options.plugins.title.text = 'Memory Breakdown';
+                        document.getElementById('tracebackPanel').innerHTML = 
+                            '<div class="no-selection">Click a point on the top chart, then a bar below to see details.</div>';
+                    }
+                    
+                    updateChartHeight(breakdownChart, currentBreakdownData.length);
+                    breakdownChart.update();
+                    totalChart.update();
+                };
+
+                // --- CHART INSTANTIATION ---
+                const totalChart = new Chart(document.getElementById('totalMemoryChart'), {
+                    type: 'line',
+                    data: {
+                        labels: lineLabels,
+                        datasets: [{
+                            label: 'Total Memory Usage',
+                            data: totalSizes,
+                            fill: false,
+                            borderColor: 'rgba(75, 192, 192, 1)',
+                            tension: 0.1,
+                            pointBackgroundColor: ctx => selectedIndexes.includes(ctx.dataIndex) ? 'rgba(255, 99, 132, 1)' : 'rgba(75, 192, 192, 1)',
+                            pointRadius: ctx => selectedIndexes.includes(ctx.dataIndex) ? 7 : 4,
+                            pointBorderWidth: ctx => selectedIndexes.includes(ctx.dataIndex) ? 3 : 1
+                        }]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        plugins: {
+                            title: { display: true, text: 'Total Memory Usage Over Time (Click to select, Shift+Click to compare)' },
+                            tooltip: { callbacks: { label: context => `Total: ${formatBytes(context.raw)}` } }
+                        },
+                        onClick: (evt, elements) => {
+                            if (elements.length > 0) {
+                                const idx = elements[0].index;
+                                const isSelected = selectedIndexes.includes(idx);
+                                if (evt.native.shiftKey) {
+                                    if (isSelected) {
+                                        selectedIndexes = selectedIndexes.filter(i => i !== idx);
+                                    } else {
+                                        selectedIndexes.push(idx);
+                                        if (selectedIndexes.length > 2) selectedIndexes.shift();
+                                    }
+                                } else {
+                                    selectedIndexes = isSelected &amp;&amp; selectedIndexes.length === 1 ? [] : [idx];
+                                }
+                            } else {
+                                selectedIndexes = [];
+                            }
+                            updateBarChart();
+                        },
+                        scales: {
+                            y: { beginAtZero: true, ticks: { callback: formatBytes }, title: { display: true, text: 'Total Memory' } },
+                            x: { title: { display: true, text: 'Time' } }
+                        }
+                    }
+                });
+
+                const breakdownChart = new Chart(document.getElementById('memoryChart'), {
+                    type: 'bar',
+                    data: { labels: [], datasets: [] },
+                    options: {
+                        indexAxis: 'y',
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        layout: { padding: { right: 120 } },
+                        plugins: {
+                            legend: { display: false },
+                            title: { display: true, text: 'Memory Breakdown' },
+                            tooltip: { callbacks: { label: context => `${formatBytes(context.raw)}` } },
+                            datalabels: {
+                                anchor: 'end',
+                                align: 'right',
+                                color: '#000',
+                                font: { weight: 'bold', size: 11 },
+                                formatter: (value) => formatBytes(value),
+                                display: true,
+                                clip: false
+                            }
+                        },
+                        onClick: (evt, elements) => {
+                            if (elements.length > 0 &amp;&amp; currentBreakdownData.length > 0) {
+                                const item = currentBreakdownData[elements[0].index];
+                                const fullKey = item.fullTracebackKey || getFullTracebackKey(item.traceback);
+                                showTraceback(item.traceback, Math.abs(item.diff || item.size), fullKey);
+                            }
+                        },
+                        scales: {
+                            x: { beginAtZero: false, ticks: { callback: formatBytes }, title: { display: true, text: 'Memory Usage / Difference' } },
+                            y: { title: { display: true, text: 'File:Line' }, ticks: { maxRotation: 0, font: { size: 11 } } }
+                        }
+                    },
+                    plugins: [ChartDataLabels]
+                });
+
+                // Initial render
+                updateBarChart();
+            </script>
+        </body>
+        </html>
+    </template>
+</odoo>

--- a/addons/web/views/speedscope_config_wizard.xml
+++ b/addons/web/views/speedscope_config_wizard.xml
@@ -3,69 +3,92 @@
     <template id="config_speedscope_index">
         <link rel="stylesheet" href="/web/assets/any/web.assets_web.min.css" />
         <script src="/web/assets/any/web.assets_web.min.js" type="text/javascript"/>
-        
         <div class="container-md p-0">
-            <div class="o_form_view" style="align-items: center;">
-                <div class="o_form_sheet">
-                    <!-- Single Form -->
-                    <form id="dynamicForm" method="get" t-attf-action="/web/speedscope/{{profile_str}}">
-                        <h4>Options</h4>
-                        <div class="form-check">
-                            <input type="checkbox" class="form-check-input" id="constant_time" name="constant_time" value="True" />
-                            <label class="form-check-label" for="constant_time">Constant Time</label>
-                        </div>
-                        <!-- add more variable here -->
-                        <div class="form-check">
-                            <input type="checkbox" class="form-check-input" id="aggregate_sql" name="aggregate_sql" value="True" />
-                            <label class="form-check-label" for="aggregate_sql">Aggregate SQL</label>
-                        </div>
-                        <div class="form-check">
-                            <input type="checkbox" class="form-check-input" id="use_execution_context" name="use_execution_context" value="True" checked="1"/>
-                            <label class="form-check-label" for="use_execution_context">Use execution context</label>
-                        </div>
-                        <div t-if="len(profiles) > 1">
-                        <hr/>
-                        <h4>Multiple profile</h4>
-                            <label class="form-check-label" for="profile_aggregation_mode">Aggregation mode</label>
-                            <select class="form-select" name="profile_aggregation_mode" id="profile_aggregation_mode">
-                                <option value="tabs">Separated (one per tab)</option>
-                                <option value="temporal">Temporal (experimental)</option>
-                            </select>
-                            <span id="temporal_warning" class="alert alert-warning" style="display:none"><b>Warning:</b> Temporal mode will merge all samples.<br/>It can lead to partially invalid result in case of concurrent profiles.<br/>Use with caution </span>
-                            <script>
-                                document.getElementById('profile_aggregation_mode').addEventListener('change', function (event) {
-                                    document.getElementById('temporal_warning').style.display = event.target.value === 'temporal'? 'block': 'none';
-                                });
-                            </script>
+            <div class="o_form_view align-items-center">
+                <div class="row">
+                    <div class="col" t-if="profiles._compute_has_memory()">
+                        <div class="o_form_sheet">
+                            <form method="get" t-attf-action="/web/profile_config/{{profile_str}}">
+                                <h4>Memory profile</h4>
+                                <div class="mt-3">
+                                    <label for="memory_limit">Memory limit (in bytes)</label>
+                                    <input type="number" id="memory_limit" name="memory_limit" class="form-control" value="1000"/>
+                                </div>
 
+                                <input type="hidden" name="profile_id" t-att-value="profile_str" />
+                                
+                                <div class="mt-3">
+                                    <button type="submit" class="btn btn-primary" name="action" value="memory_open">open</button>
+                                </div>
+                            </form>
                         </div>
-                        <hr/>
-                        <h4>Display presets</h4>
-                        <div class="form-check" t-if="any((profile.sql and profile.traces_async) for profile in profiles)">
-                            <input type="checkbox" class="form-check-input" id="combined_profile" name="combined_profile" value="True" checked="checked"/>
-                            <label class="form-check-label" for="combined_profile">Frames + sql (Combined)</label>
-                        </div>
-                        <div class="form-check" t-if="any(profile.sql for profile in profiles)">
-                            <input type="checkbox" class="form-check-input" id="sql_no_gap_profile" name="sql_no_gap_profile" value="True" checked="checked"/>
-                            <label class="form-check-label" for="sql_no_gap_profile">SQL no gap</label>
-                        </div>
-                        <div class="form-check" t-if="any(profile.sql for profile in profiles)">
-                            <input type="checkbox" class="form-check-input" id="sql_density_profile" name="sql_density_profile" value="True"/>
-                            <label class="form-check-label" for="sql_density_profile">SQL density</label>
-                        </div>
-                        <div class="form-check" t-if="any(profile.traces_async for profile in profiles)">
-                            <input type="checkbox" class="form-check-input" id="frames_profile" name="frames_profile" value="True"/>
-                            <label class="form-check-label" for="frames_profile">Frames</label>
-                        </div>
+                    </div>
 
-                        <input type="hidden" name="profile_id" t-att-value="profile_str" />
-                        
-                        <div class="mt-3">
-                            <button type="submit" class="btn btn-secondary" name="action" value="download_json"><i class="fa fa-download"/> (json)</button>
-                            <button type="submit" class="btn btn-secondary" name="action" value="download_html"><i class="fa fa-download"/> (html)</button>
-                            <button type="submit" class="btn btn-primary" name="action" value="open">Open</button>
+                    <div class="col">
+                        <div class="o_form_sheet">
+                            <!-- Single Form -->
+                            <form method="get" t-attf-action="/web/speedscope/{{profile_str}}">
+                                <h4>Speedscope</h4>
+                                <div class="form-check">
+                                    <input type="checkbox" class="form-check-input" id="constant_time" name="constant_time" value="True" />
+                                    <label class="form-check-label" for="constant_time">Constant Time</label>
+                                </div>
+                                <!-- add more variable here -->
+                                <div class="form-check">
+                                    <input type="checkbox" class="form-check-input" id="aggregate_sql" name="aggregate_sql" value="True" />
+                                    <label class="form-check-label" for="aggregate_sql">Aggregate SQL</label>
+                                </div>
+                                <div class="form-check">
+                                    <input type="checkbox" class="form-check-input" id="use_execution_context" name="use_execution_context" value="True" checked="1"/>
+                                    <label class="form-check-label" for="use_execution_context">Use execution context</label>
+                                </div>
+                                <div t-if="len(profiles) > 1">
+                                <hr/>
+                                <h4>Multiple profile</h4>
+                                    <label class="form-check-label" for="profile_aggregation_mode">Aggregation mode</label>
+                                    <select class="form-select" name="profile_aggregation_mode" id="profile_aggregation_mode">
+                                        <option value="tabs">Separated (one per tab)</option>
+                                        <option value="temporal">Temporal (experimental)</option>
+                                    </select>
+                                    <span id="temporal_warning" class="alert alert-warning" style="display:none"><b>Warning:</b> Temporal mode will merge all samples.<br/>It can lead to partially invalid result in case of concurrent profiles.<br/>Use with caution </span>
+                                    <script>
+                                        document.getElementById('profile_aggregation_mode').addEventListener('change', function (event) {
+                                            document.getElementById('temporal_warning').style.display = event.target.value === 'temporal'? 'block': 'none';
+                                        });
+                                    </script>
+
+                                </div>
+                                <hr/>
+                                <h4>Display presets</h4>
+                                <t t-set="has_sql" t-value="any(profile.sql for profile in profiles)"/>
+                                <t t-set="has_traces" t-value="any(profile.traces_async for profile in profiles)"/>
+                                <div class="form-check" t-if="has_sql and has_traces">
+                                    <input type="checkbox" class="form-check-input" id="combined_profile" name="combined_profile" value="True" t-att-checked="default_params.get('combined_profile')"/>
+                                    <label class="form-check-label" for="combined_profile">Frames + sql (Combined)</label>
+                                </div>
+                                <div class="form-check" t-if="has_sql">
+                                    <input type="checkbox" class="form-check-input" id="sql_no_gap_profile" name="sql_no_gap_profile" value="True" t-att-checked="default_params.get('sql_no_gap_profile')"/>
+                                    <label class="form-check-label" for="sql_no_gap_profile">SQL no gap</label>
+                                </div>
+                                <div class="form-check" t-if="has_sql">
+                                    <input type="checkbox" class="form-check-input" id="sql_density_profile" name="sql_density_profile" value="True" t-att-checked="default_params.get('sql_density_profile')"/>
+                                    <label class="form-check-label" for="sql_density_profile">SQL density</label>
+                                </div>
+                                <div class="form-check" t-if="has_traces">
+                                    <input type="checkbox" class="form-check-input" id="frames_profile" name="frames_profile" value="True" t-att-checked="default_params.get('frames_profile')"/>
+                                    <label class="form-check-label" for="frames_profile">Frames</label>
+                                </div>
+
+                                <input type="hidden" name="profile_id" t-att-value="profile_str" />
+                                
+                                <div class="mt-3">
+                                    <button type="submit" class="btn btn-secondary" name="action" value="speedscope_download_json"><i class="fa fa-download"/> (json)</button>
+                                    <button type="submit" class="btn btn-secondary" name="action" value="speedscope_download_html"><i class="fa fa-download"/> (html)</button>
+                                    <button type="submit" class="btn btn-primary" name="action" value="speedscope_open">Open</button>
+                                </div>
+                            </form>
                         </div>
-                    </form>
+                    </div>
                 </div>
             </div>
         </div>

--- a/odoo/addons/base/tests/test_profiler.py
+++ b/odoo/addons/base/tests/test_profiler.py
@@ -6,7 +6,7 @@ import time
 from unittest.mock import patch
 
 from odoo.exceptions import AccessError
-from odoo.tests.common import BaseCase, TransactionCase, tagged, new_test_user
+from odoo.tests.common import BaseCase, TransactionCase, tagged, new_test_user, HttpCase
 from odoo.tools import profiler
 from odoo.tools.profiler import Profiler, ExecutionContext
 from odoo.tools.speedscope import Speedscope
@@ -704,3 +704,10 @@ class TestSyncRecorder(BaseCase):
         stacks_lines = [[frame[1] for frame in stack] for stack in stacks]
         self.assertEqual(stacks_lines[1][0] + 1, stacks_lines[3][0],
                          "Call of b() in a() should be one line before call of c()")
+
+
+@tagged('-standard', 'profiling_memory')
+class TestMemoryProfiler(HttpCase):
+    def test_memory_profiler(self):
+        with Profiler(collectors=['memory'], db=None):
+            self.env['base.module.update'].create({}).update_module()

--- a/odoo/addons/base/views/ir_profile_views.xml
+++ b/odoo/addons/base/views/ir_profile_views.xml
@@ -27,6 +27,7 @@
                 <field name="entry_count"/>
                 <field name="sql_count" optional="hide"/>
                 <field name="speedscope_url" widget="url"/>
+                <field name="config_url" widget="url"/>
                 <field name="duration"/>
                 <field name="cpu_duration" optional="hide"/>
             </list>
@@ -46,6 +47,7 @@
                     <!-- Do not rely on sql field for the invisible attrs to avoid fetching whole trace from server. -->
                     <field name="sql_count" invisible="sql_count == 0"/>
                     <field name="speedscope_url" widget="url"/>
+                    <field name="config_url" widget="url"/>
                 </group>
                 <group invisible="not qweb">
                     <field name="qweb" widget="profiling_qweb_view" nolabel="1"/>


### PR DESCRIPTION
This pr introduces a memory collector for the profiler

Example of output installing a translation

<img width="1884" height="874" alt="image" src="https://github.com/user-attachments/assets/96a3ecb5-4b02-48f2-aac9-f29a3a9b48eb" />


Note:

Tracemalloc and memory collectors are process wide. There should be no two memory collector running at the same time. We want prevent memory from on request tainting the other and another thread closing the memory collection from another thread. To prevent this memory profiling was made to be a thread safe event.
Which required locks on starting the memory profiler. This lock will only affect users who are memory profiling, but the rest of the requests will work as normal.