### PR TITLE
[FIX] discuss: add logging in case of TURN request failure

### DIFF
--- a/addons/mail/models/mail_ice_server.py
+++ b/addons/mail/models/mail_ice_server.py
@@ -3,8 +3,10 @@
 
 from odoo import fields, models
 from odoo.addons.mail.tools.credentials import get_twilio_credentials
+import logging
 import requests
 
+_logger = logging.getLogger(__name__)
 
 class MailIceServer(models.Model):
     _name = 'mail.ice.server'
@@ -47,4 +49,6 @@ class MailIceServer(models.Model):
                     response_content = response.json()
                     if response_content:
                         return response_content['ice_servers']
+                else:
+                    _logger.warning(f"Failed to obtain TURN servers, status code: {response.status_code}, content: {response.content}.")
         return self._get_local_ice_servers()


### PR DESCRIPTION
Before this commit, the response from the request that obtains the TURN servers from twilio would fail silently. This commit fixes this issue by logging the status code and te content of the response in case of failure.

