### PR TITLE
[IMP] web: Force save when accessing a child record

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -288,7 +288,7 @@
             <t t-if="hasOpenFormViewColumn">
                 <td class="o_list_record_open_form_view w-print-0 p-print-0 text-center"
                     t-on-keydown="(ev) => this.onCellKeydown(ev, group, record)"
-                    t-custom-click.stop="(ev, newWindow) => isX2Many and record.isNew ? this.displaySaveNotification() : props.onOpenFormView(record, { force: true, newWindow })"
+                    t-custom-click.stop="(ev, newWindow) => props.onOpenFormView(record, { force: true, newWindow })"
                     tabindex="-1"
                 >
                     <button class="btn btn-link align-top text-end"


### PR DESCRIPTION
Steps:
- install `project`
- open a task
- create a subtask and without saving open this one with the button "View"

Before this commit, this action is prevented with a message asking you to save the main record before opening the child form view.

Now we force the save before opening the form view.

task-3799507