### PR TITLE
[FIX] uom: fix having multiple reference units in the same category

### DIFF
--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -83,7 +83,7 @@ class UoM(models.Model):
     ]
 
     def _check_category_reference_uniqueness(self):
-        categ_res = self.read_group(
+        categ_res = self.with_context(active_test=False).read_group(
             [("category_id", "in", self.category_id.ids)],
             ["category_id", "uom_type"],
             ["category_id", "uom_type"],

--- a/addons/uom/tests/test_uom.py
+++ b/addons/uom/tests/test_uom.py
@@ -51,7 +51,8 @@ class TestUom(UomCommon):
                 'factor_inv': 1,
                 'uom_type': 'reference',
                 'rounding': 1.0,
-                'category_id': time_category.id
+                'category_id': time_category.id,
+                'active': False,
             })
 
     def test_40_custom_uom(self):


### PR DESCRIPTION
Steps to reproduce:
* Open the form view of any UoM category.
* Add a new line in the units list.
* Without saving, Uncheck "Active" checkbox.
* Before saving, change the type of this unit to reference.
* Save the form.

Expected behavior:
An error should be thrown as it's not allowed to have more than one reference unit for some category.

Current behavior:
The record is normally saved without any errors.

This issue caused an inconsistency when upgarding a database in such state to saas18.1, where each unit points to its reference as a parent. Having multiple references in the same category caused a having a cycle in this link.

See: https://github.com/odoo/upgrade/blob/master/migrations/uom/saas~18.1.1.0/pre-migrate.py#L16-L25

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
