### PR TITLE
[FIX] purchase: match only invoice lines in matching process

### DIFF
--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -373,7 +373,7 @@ class AccountMove(models.Model):
                     # We have an invoice from an EDI document, so we try to match individual invoice lines with
                     # individual purchase order lines from referenced purchase orders.
                     matching_po_lines, matching_inv_lines = self._find_matching_po_and_inv_lines(
-                        po_lines, self.line_ids, timeout)
+                        po_lines, self.invoice_line_ids, timeout)
 
                     if matching_po_lines:
                         # We found a subset of purchase order lines that match a subset of the vendor bill lines.

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -819,6 +819,28 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
             else:
                 self.assertFalse(line.purchase_line_id in po.order_line)
 
+    def test_subset_not_match_non_invoice_lines(self):
+        """Test that a purchase line with a line of 0 as unit price won't match
+        with a non-invoice-lines (not an invoice_line_ids)
+        """
+        uom_unit = self.env.ref('uom.product_uom_unit')
+        product_order_zero_price = self.env['product.product'].create({
+            'name': "A zero price product",
+            'standard_price': 0.0,
+            'list_price': 0.0,
+            'type': 'consu',
+            'uom_id': uom_unit.id,
+            'uom_po_id': uom_unit.id,
+            'purchase_method': 'purchase',
+            'default_code': 'PROD_ORDER',
+            'taxes_id': False,
+        })
+        po = self.init_purchase(confirm=True, products=[product_order_zero_price])
+        invoice = self.init_invoice('in_invoice', partner=self.partner_a, products=[self.product_order])
+        invoice._find_and_set_purchase_orders(
+            ['my_match_reference'], invoice.partner_id.id, invoice.amount_total, from_ocr=False)
+
+        self.assertFalse(invoice.id in po.invoice_ids.ids)
 
     def test_po_match_from_ocr(self):
         po = self.init_purchase(confirm=True, products=[self.product_order, self.service_order])


### PR DESCRIPTION
Currently, an error can occur in `_find_matching_po_and_inv_lines` when some invoice lines have a price_unit of 0. This happens because the matching logic sorts and matches lines by `(price_unit, qty)`, leading to "Journal Items" (`line_ids`) being incorrectly matched with purchase order lines.

The issue arises because the `_find_matching_po_and_inv_lines` function checks all `line_ids`, instead of only `invoice_line_ids`. When a PO line has a price_unit of 0, it might match with a line that isn't an actual invoice line. As a result, `unmatched_lines` becomes incorrect, and it could remove a valid invoice line. Then, later, when calculating `inv_and_po_lines`, the process only considers `invoice_line_ids`. Since no matching line is found, an error occurs when attempting to delete the line (id is False).

Steps to reproduce:
1. Create a purchase order with:
   - 1 product A with price_unit = 0
2. Confirm the purchase order.
3. Upload an EDI XML bill (e.g., IT localization) with:
   - A reference to the purchase order
   - 1 product B with price_unit = 100

Since all bill lines are processed, a tax line or a payment term line might incorrectly match with the PO line, causing the error.

opw-4513869
