### PR TITLE
[IMP] orm: Model.lock_records for update

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -6,10 +6,8 @@ import time
 
 from collections import defaultdict
 
-from psycopg2 import errors as pgerrors
-
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import LockError, UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, SQL, mute_logger, unique
 
@@ -792,22 +790,15 @@ class ResPartner(models.Model):
             raise UserError(_("The partner cannot be deleted because it is used in Accounting"))
 
     def _increase_rank(self, field, n=1):
-        if self.ids and field in ['customer_rank', 'supplier_rank']:
-            try:
-                with self.env.cr.savepoint(flush=False), mute_logger('odoo.sql_db'):
-                    self.env.execute_query(SQL("""
-                        SELECT %(field)s FROM res_partner WHERE ID IN %(partner_ids)s FOR NO KEY UPDATE NOWAIT;
-                        UPDATE res_partner SET %(field)s = %(field)s + %(n)s
-                        WHERE id IN %(partner_ids)s
-                        """,
-                        field=SQL.identifier(field),
-                        partner_ids=tuple(self.ids),
-                        n=n,
-                    ))
-                    self.invalidate_recordset([field])
-                    self.modified([field])
-            except (pgerrors.LockNotAvailable, pgerrors.SerializationFailure):
-                _logger.debug('Another transaction already locked partner rows. Cannot update partner ranks.')
+        assert isinstance(n, int) and field in ('customer_rank', 'supplier_rank')
+        try:
+            self.lock_for_update(allow_referencing=True)
+        except LockError:
+            _logger.debug('Another transaction already locked partner rows. Cannot update partner ranks.')
+            return
+        records = self.sudo()
+        for record in records:
+            record[field] += n
 
     @api.model
     def _run_vat_test(self, vat_number, default_country, partner_is_company=True):

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import psycopg2
 import pytz
 import re
 import smtplib
@@ -17,7 +15,7 @@ from unittest.mock import call, patch, PropertyMock
 from odoo import api, Command, fields, SUPERUSER_ID
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
 from odoo.addons.mail.tests.common import MailCommon
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, LockError
 from odoo.tests import common, tagged, users
 from odoo.tools import formataddr, mute_logger
 
@@ -1167,6 +1165,7 @@ class TestMailMailRace(common.TransactionCase):
             })],
         })
         notif = env['mail.notification'].search([('res_partner_id', '=', self.partner.id)])
+        notif.ensure_one()  # for patched method
         # we need to commit transaction or cr will keep the lock on notif
         cr.commit()
 
@@ -1178,8 +1177,8 @@ class TestMailMailRace(common.TransactionCase):
             with this.registry.cursor() as cr, mute_logger('odoo.sql_db'):
                 try:
                     # try ro aquire lock (no wait) on notification (should fail)
-                    cr.execute("SELECT notification_status FROM mail_notification WHERE id = %s FOR UPDATE NOWAIT", [notif.id])
-                except psycopg2.OperationalError:
+                    notif.with_env(notif.env(cr=cr)).lock_for_update()
+                except LockError:
                     # record already locked by send, all good
                     bounce_deferred.append(True)
                 else:

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -568,7 +568,7 @@ class IrModuleModule(models.Model):
             # This is done because the installation/uninstallation/upgrade can modify a currently
             # running cron job and prevent it from finishing, and since the ir_cron table is locked
             # during execution, the lock won't be released until timeout.
-            self._cr.execute("SELECT * FROM ir_cron FOR UPDATE NOWAIT")
+            self.env.cr.execute("SELECT FROM ir_cron FOR UPDATE NOWAIT")
         except psycopg2.OperationalError:
             raise UserError(_("Odoo is currently processing a scheduled action.\n"
                               "Module operations are not possible at this time, "

--- a/odoo/addons/base/tests/test_orm.py
+++ b/odoo/addons/base/tests/test_orm.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, LockError
 from odoo.tests.common import TransactionCase, tagged
 from odoo.tools import mute_logger
 from odoo import Command
@@ -152,6 +151,41 @@ class TestORM(TransactionCase):
         # check that there is no record with id 0
         recs = partner.browse([0])
         self.assertFalse(recs.exists())
+
+    def test_lock_for_update(self):
+        partner = self.env['res.partner']
+        p1, p2 = partner.search([], limit=2)
+
+        # lock p1
+        p1.lock_for_update(allow_referencing=True)
+        p1.lock_for_update(allow_referencing=False)
+
+        with self.env.registry.cursor() as cr:
+            recs = (p1 + p2).with_env(partner.env(cr=cr))
+            with self.assertRaises(LockError):
+                recs.lock_for_update()
+            sub_p2 = recs[1]
+            sub_p2.lock_for_update()
+
+            # parent transaction and read, but cannot lock the p2 records
+            p2.invalidate_model()
+            self.assertTrue(p2.name)
+            with self.assertRaises(LockError):
+                p2.lock_for_update()
+
+            # can still read from parent after locks and lock failures
+            p1.invalidate_model()
+            self.assertTrue(p1.name)
+
+        # can lock p2 now
+        p2.lock_for_update()
+
+        # cannot lock inexisting record
+        inexisting = partner.create({'name': 'inexisting'})
+        inexisting.unlink()
+        self.assertFalse(inexisting.exists())
+        with self.assertRaises(LockError):
+            inexisting.lock_for_update()
 
     def test_write_duplicate(self):
         p1 = self.env['res.partner'].create({'name': 'W'})

--- a/odoo/exceptions.py
+++ b/odoo/exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 """The Odoo Exceptions module defines a few core exception types.
@@ -88,6 +87,15 @@ class MissingError(UserError):
     .. admonition:: Example
 
         When you try to write on a deleted record.
+    """
+
+
+class LockError(UserError):
+    """Record(s) could not be locked.
+
+    .. admonition:: Example
+
+        Code tried to lock records, but could not succeed.
     """
 
 


### PR DESCRIPTION
Sometimes we need to lock records for updating them and prevent concurrent writes manually. We introduce a new method for this use case.

odoo/enterprise#79280


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
