### PR TITLE
[FIX] website_sale: handle missing free text for product variants

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_product_configurator.js
+++ b/addons/website_sale/static/src/js/website_sale_product_configurator.js
@@ -108,7 +108,7 @@ WebsiteSale.include({
         serializedProduct.product_custom_attribute_values = [];
         for (const ptal of product.attribute_lines) {
             const selectedPtavIds = new Set(ptal.selected_attribute_value_ids);
-            const selectedCustomPtav = ptal.attribute_values.find(
+            const selectedCustomPtav = ptal.customValue && ptal.attribute_values.find(
                 ptav => ptav.is_custom && selectedPtavIds.has(ptav.id)
             );
             if (selectedCustomPtav) {


### PR DESCRIPTION
Issue
-----
When the user clicks on "Continue Shopping" without providing a value for the
selected variant, they get a Traceback.

Steps to reproduce
-----
- Install the ECommerce app
- Create an "Att" attribute
    - Set its' Display Type to "Select"
    - Add 2 values, 1 & 2
        - Set value 1 to Free text
- Create a new product "Trace"
    - Add "Att" as an attribute with values 1 & 2
- Go to the Website
- Open the Shop page
    - Edit the page to add the cart button to products & Save
- Click on the cart button of the "Trace" product
- Select the 1 variant
- Click the "Continue Shopping" button without entering a custom value

-> Traceback

Cause
-----
In website_sale_product_configurator, we append to the attribute array even when
there is no custom value provided by the user. When the Python code tries to
access the value, it creates an error because there is no 'custom_value' key.

Solution
-----
Only search for a product template attribute variant when a value is provided.

-----
Ticket:
opw-4535469