### PR TITLE
[IMP] website*: improve eCommerce URLs

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -67,7 +67,9 @@ class QueryURL:
                     paths[key] = "%s" % value
             elif value:
                 if isinstance(value, (list, set)):
-                    fragments.append(werkzeug.urls.url_encode([(key, item) for item in value]))
+                    fragments.append(
+                        werkzeug.urls.url_encode([(key, item) for item in value if item])
+                    )
                 else:
                     fragments.append(werkzeug.urls.url_encode([(key, value)]))
         for key in path_args:

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1716,6 +1716,13 @@ class Website(models.Model):
         self._force()
         return self.get_client_action(path)
 
+    def _get_canonical_url(self):
+        """ Returns the canonical URL of the current request. """
+        self.ensure_one()
+        return self.env['ir.http']._url_localized(
+            lang_code=request.lang.code, canonical_domain=self.get_base_url()
+        )
+
     def _is_canonical_url(self):
         """Returns whether the current request URL is canonical."""
         self.ensure_one()
@@ -1723,7 +1730,7 @@ class Website(models.Model):
         # the language in the path. It is important to also test the domain of
         # the current URL.
         current_url = request.httprequest.url_root[:-1] + request.httprequest.environ['REQUEST_URI']
-        canonical_url = self.env['ir.http']._url_localized(lang_code=request.lang.code, canonical_domain=self.get_base_url())
+        canonical_url = self._get_canonical_url()
         # A request path with quotable characters (such as ",") is never
         # canonical because request.httprequest.base_url is always unquoted,
         # and canonical url is always quoted, so it is never possible to tell

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -186,7 +186,7 @@
             </t>
         <link rel="alternate" hreflang="x-default" t-att-href="url_localized(lang_code=website.env['res.lang']._get_data(id=website._get_cached('default_lang_id')).code, canonical_domain=canonical_domain)"/>
         </t>
-        <link rel="canonical" t-att-href="url_localized(lang_code=lang,canonical_domain=canonical_domain)"/>
+        <link rel="canonical" t-att-href="website._get_canonical_url()"/>
         <!-- TODO: Once we have style in DB, add this preconnect only if a
         google font is actually used. Note that if no font is used, the
         preconnect is actually not connecting to the google servers. -->

--- a/addons/website_sale/const.py
+++ b/addons/website_sale/const.py
@@ -24,3 +24,5 @@ GMC_SUPPORTED_UOM = {
 }
 
 GMC_BASE_MEASURE = re.compile(r'(?P<base_count>\d+)?\s*(?P<base_unit>[a-z]+)')
+
+SHOP_PATH = '/shop'

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -5,6 +5,7 @@ import json
 
 from datetime import datetime
 
+from werkzeug import urls
 from werkzeug.exceptions import Forbidden, NotFound
 from werkzeug.urls import url_decode, url_encode, url_parse
 
@@ -19,7 +20,6 @@ from odoo.tools.json import scriptsafe as json_scriptsafe
 from odoo.tools.translate import _
 
 from odoo.addons.payment.controllers import portal as payment_portal
-from odoo.addons.portal.controllers.portal import _build_url_w_params
 from odoo.addons.sale.controllers import portal as sale_portal
 from odoo.addons.web_editor.tools import get_video_thumbnail
 from odoo.addons.website.controllers.main import QueryURL
@@ -210,10 +210,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
         return fuzzy_search_term, product_count, search_result
 
     def _shop_get_query_url_kwargs(
-        self, category, search, min_price, max_price, order=None, tags=None, attribute_value=None, **post
+        self, search, min_price, max_price, order=None, tags=None, attribute_value=None, **kwargs
     ):
         return {
-            'category': category,
             'search': search,
             'tags': tags,
             'min_price': min_price,
@@ -222,13 +221,13 @@ class WebsiteSale(payment_portal.PaymentPortal):
             'attribute_value': attribute_value,
         }
 
-    def _get_additional_shop_values(self, values):
+    def _get_additional_shop_values(self, values, **kwargs):
         """ Hook to update values used for rendering website_sale.products template """
         return {}
 
-    def _get_additional_extra_shop_values(self, values, **post):
-        """ Hook to update values used for rendering website_sale.products template """
-        return self._get_additional_shop_values(values)
+    def _get_product_query_string(self, **kwargs):
+        """ Hook to set the product page URL's query string. """
+        return ''
 
     @route([
         '/shop',
@@ -236,9 +235,20 @@ class WebsiteSale(payment_portal.PaymentPortal):
         '/shop/category/<model("product.public.category"):category>',
         '/shop/category/<model("product.public.category"):category>/page/<int:page>',
     ], type='http', auth="public", website=True, sitemap=sitemap_shop)
-    def shop(self, page=0, category=None, search='', min_price=0.0, max_price=0.0, ppg=False, **post):
+    def shop(self, page=0, category=None, search='', min_price=0.0, max_price=0.0, **post):
         if not request.website.has_ecommerce_access():
             return request.redirect('/web/login')
+
+        is_category_in_query = category and isinstance(category, str)
+        category = self._validate_and_get_category(category)
+        # If the category is provided as a query parameter (which is deprecated), we redirect to the
+        # "correct" shop URL, where the category has been removed from the query parameters and
+        # added to the path.
+        if is_category_in_query:
+            query = self._get_filtered_query_string(
+                request.httprequest.query_string.decode(), keys_to_remove=['category']
+            )
+            return request.redirect(f'{self._get_shop_path(category, page)}?{query}', code=301)
 
         try:
             min_price = float(min_price)
@@ -249,27 +259,11 @@ class WebsiteSale(payment_portal.PaymentPortal):
         except ValueError:
             max_price = 0
 
-        Category = request.env['product.public.category']
-        if category:
-            category = Category.search([('id', '=', int(category))], limit=1)
-            if not category or not category.can_access_from_current_website():
-                raise NotFound()
-        else:
-            category = Category
-
         website = request.env['website'].get_current_website()
         website_domain = website.website_domain()
-        if ppg:
-            try:
-                ppg = int(ppg)
-                post['ppg'] = ppg
-            except ValueError:
-                ppg = False
-        if not ppg:
-            ppg = website.shop_ppg or 20
 
+        ppg = website.shop_ppg or 20
         ppr = website.shop_ppr or 4
-
         gap = website.shop_gap or "16px"
 
         request_args = request.httprequest.args
@@ -291,7 +285,10 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 post['tags'] = None
                 tags = {}
 
-        keep = QueryURL('/shop', **self._shop_get_query_url_kwargs(category and int(category), search, min_price, max_price, **post))
+        url = self._get_shop_path(category)
+        keep = QueryURL(
+            url, **self._shop_get_query_url_kwargs(search, min_price, max_price, **post)
+        )
 
         # Check if we need to refresh the cached pricelist
         now = datetime.timestamp(datetime.now())
@@ -310,7 +307,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
         else:
             conversion_rate = 1
 
-        url = '/shop'
         if search:
             post['search'] = search
 
@@ -367,6 +363,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         else:
             all_tags = ProductTag
 
+        Category = request.env['product.public.category']
         categs_domain = [('parent_id', '=', False)] + website_domain
         if search:
             search_categories = Category.search(
@@ -376,9 +373,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
         else:
             search_categories = Category
         categs = lazy(lambda: Category.search(categs_domain))
-
-        if category:
-            url = "/shop/category/%s" % request.env['ir.http']._slug(category)
 
         pager = website.pager(url=url, total=product_count, page=page, step=ppg, scope=5, url_args=post)
         offset = pager['offset']
@@ -439,6 +433,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             'products_prices': products_prices,
             'get_product_prices': lambda product: lazy(lambda: products_prices[product.id]),
             'float_round': float_round,
+            'product_query_string': self._get_product_query_string(**post),
         }
         if filter_by_price_enabled:
             values['min_price'] = min_price or available_min_price
@@ -449,11 +444,20 @@ class WebsiteSale(payment_portal.PaymentPortal):
             values.update({'all_tags': all_tags, 'tags': tags})
         if category:
             values['main_object'] = category
-        values.update(self._get_additional_extra_shop_values(values, **post))
+        values.update(self._get_additional_shop_values(values, **post))
         return request.render("website_sale.products", values)
 
-    @route(['/shop/<model("product.template"):product>'], type='http', auth="public", website=True, sitemap=sitemap_products)
-    def product(self, product, category='', search='', pricelist=None, **kwargs):
+    @route(
+        [
+            '/shop/<model("product.template"):product>',
+            '/shop/<model("product.public.category"):category>/<model("product.template"):product>',
+        ],
+        type='http',
+        auth='public',
+        website=True,
+        sitemap=sitemap_products,
+    )
+    def product(self, product, category=None, pricelist=None, **kwargs):
         if not request.website.has_ecommerce_access():
             return request.redirect('/web/login')
 
@@ -465,9 +469,30 @@ class WebsiteSale(payment_portal.PaymentPortal):
                     "Wrong format: got `pricelist=%s`, expected an integer", pricelist,
                 ))
             if not self._apply_selectable_pricelist(pricelist_id):
-                return request.redirect('/shop')
+                return request.redirect(self._get_shop_path(category))
 
-        return request.render("website_sale.product", self._prepare_product_values(product, category, search, **kwargs))
+        is_category_in_query = category and isinstance(category, str)
+        category = self._validate_and_get_category(category)
+        query = self._get_filtered_query_string(
+            request.httprequest.query_string.decode(), keys_to_remove=['category']
+        )
+        # If the product doesn't belong to the category, we redirect to the canonical product URL,
+        # which doesn't include the category.
+        if (
+            category
+            and not product.filtered_domain([('public_categ_ids', 'child_of', category.id)])
+        ):
+            return request.redirect(f'{self._get_product_path(product)}?{query}', code=301)
+        # If the category is provided as a query parameter (which is deprecated), we redirect to the
+        # "correct" shop URL, where the category has been removed from the query parameters and
+        # added to the path.
+        if is_category_in_query:
+            return request.redirect(
+                f'{self._get_product_path(product, category)}?{query}', code=301
+            )
+        return request.render(
+            'website_sale.product', self._prepare_product_values(product, category, **kwargs)
+        )
 
     @route(
         '/shop/<model("product.template"):product_template>/document/<int:document_id>',
@@ -482,22 +507,28 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         document = request.env['product.document'].browse(document_id).sudo().exists()
         if not document or not document.active:
-            return request.redirect('/shop')
+            return request.redirect(self._get_shop_path())
 
         if not document.shown_on_product_page or not (
             document.res_id == product_template.id
             and document.res_model == 'product.template'
         ):
-            return request.redirect('/shop')
+            return request.redirect(self._get_shop_path())
 
         return request.env['ir.binary']._get_stream_from(
             document.ir_attachment_id,
         ).get_response(as_attachment=True)
 
     @route(['/shop/product/<model("product.template"):product>'], type='http', auth="public", website=True, sitemap=False)
-    def old_product(self, product, category='', search='', **kwargs):
+    def old_product(self, product, category='', **kwargs):
         # Compatibility pre-v14
-        return request.redirect(_build_url_w_params("/shop/%s" % request.env['ir.http']._slug(product), request.params), code=301)
+        # Redirect to the "correct" product URL, which doesn't include `/product`, and where the
+        # category has been removed from the query parameters and added to the path.
+        category = self._validate_and_get_category(category)
+        query = self._get_filtered_query_string(
+            request.httprequest.query_string.decode(), keys_to_remove=['category']
+        )
+        return request.redirect(f'{self._get_product_path(product, category)}?{query}', code=301)
 
     @route(['/shop/product/extra-media'], type='jsonrpc', auth='user', website=True)
     def add_product_media(self, media, type, product_product_id, product_template_id, combination_ids=None):
@@ -663,37 +694,20 @@ class WebsiteSale(payment_portal.PaymentPortal):
         # In sudo mode to check fields and conditions not accessible to the customer directly.
         return product.sudo()._is_add_to_cart_allowed()
 
-    def _product_get_query_url_kwargs(self, category, search, **kwargs):
-        return {
-            'category': category,
-            'search': search,
-            'tags': kwargs.get('tags'),
-            'min_price': kwargs.get('min_price'),
-            'max_price': kwargs.get('max_price'),
-        }
-
-    def _prepare_product_values(self, product, category, search, **kwargs):
+    def _prepare_product_values(self, product, category, **kwargs):
         ProductCategory = request.env['product.public.category']
         product_markup_data = [product._to_markup_data(request.website)]
-        if category := ProductCategory.browse(category and int(category)).exists():
+        if category:
             # Add breadcrumb's SEO data.
             product_markup_data.append(self._prepare_breadcrumb_markup_data(
                 request.website.get_base_url(), category, product.name
             ))
-        keep = QueryURL(
-            '/shop',
-            **self._product_get_query_url_kwargs(
-                category=category and category.id,
-                search=search,
-                **kwargs,
-            ),
-        )
+        keep = QueryURL(self._get_shop_path(category))
 
         # Needed to trigger the recently viewed product rpc
         view_track = request.website.viewref("website_sale.product").track
 
         return {
-            'search': search,
             'category': category,
             'keep': keep,
             'categories': ProductCategory.search([('parent_id', '=', False)]),
@@ -725,13 +739,13 @@ class WebsiteSale(payment_portal.PaymentPortal):
                     '@type': 'ListItem',
                     'position': 1,
                     'name': 'All Products',
-                    'item': f'{base_url}/shop',
+                    'item': f'{base_url}{self._get_shop_path()}',
                 },
                 {
                     '@type': 'ListItem',
                     'position': 2,
                     'name': category.name,
-                    'item': f'{base_url}/shop/category/{self.env["ir.http"]._slug(category)}',
+                    'item': f'{base_url}{self._get_shop_path(category)}',
                 },
                 {
                     '@type': 'ListItem',
@@ -788,7 +802,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                     pass
             redirect_url = decoded_url.replace(query=url_encode(args)).to_url()
 
-        return request.redirect(redirect_url or '/shop')
+        return request.redirect(redirect_url or self._get_shop_path())
 
     @route('/shop/pricelist', type='http', auth='public', website=True, sitemap=False)
     def pricelist(self, promo, **post):
@@ -1498,7 +1512,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             assert order_sudo.id == request.session.get('sale_last_order_id')
 
         if not order_sudo:
-            return request.redirect('/shop')
+            return request.redirect(self._get_shop_path())
 
         errors = self._get_shop_payment_errors(order_sudo) if order_sudo.state != 'sale' else []
         if errors:
@@ -1508,7 +1522,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         tx_sudo = order_sudo.get_portal_last_transaction()
         if order_sudo.amount_total and not tx_sudo:
-            return request.redirect('/shop')
+            return request.redirect(self._get_shop_path())
 
         if not order_sudo.amount_total and not tx_sudo:
             if order_sudo.state != 'sale':
@@ -1522,7 +1536,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         # clean context and session, then redirect to the confirmation page
         request.website.sale_reset()
         if tx_sudo and tx_sudo.state == 'draft':
-            return request.redirect('/shop')
+            return request.redirect(self._get_shop_path())
 
         return request.redirect('/shop/confirmation')
 
@@ -1540,7 +1554,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             order = request.env['sale.order'].sudo().browse(sale_order_id)
             values = self._prepare_shop_payment_confirmation_values(order)
             return request.render("website_sale.confirmation", values)
-        return request.redirect('/shop')
+        return request.redirect(self._get_shop_path())
 
     def _prepare_shop_payment_confirmation_values(self, order):
         """
@@ -1560,7 +1574,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             pdf, _ = request.env['ir.actions.report'].sudo()._render_qweb_pdf('sale.action_report_saleorder', [sale_order_id])
             pdfhttpheaders = [('Content-Type', 'application/pdf'), ('Content-Length', '%s' % len(pdf))]
             return request.make_response(pdf, headers=pdfhttpheaders)
-        return request.redirect('/shop')
+        return request.redirect(self._get_shop_path())
 
     # === CHECK METHODS === #
 
@@ -1594,7 +1608,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if not order_sudo or order_sudo.state != 'draft':
             request.session['sale_order_id'] = None
             request.session['sale_transaction_id'] = None
-            return request.redirect('/shop')
+            return request.redirect(self._get_shop_path())
 
         # Check that the cart is not empty.
         if not order_sudo.order_line:
@@ -1763,3 +1777,61 @@ class WebsiteSale(payment_portal.PaymentPortal):
             'currency_id': website.currency_id.id,
             'pricelist_id': request.pricelist.id,
         })
+
+    @staticmethod
+    def _validate_and_get_category(category):
+        """ Validate and return the `product.public.category` record corresponding to the provided
+        category, which can be a record, a record id, or a slug.
+
+        - If no category is provided, return an empty recordset.
+        - If a category is provided, but it doesn't exist or can't be accessed, raise a 404.
+        - If a valid category is provided, return the corresponding record.
+
+        :param str|product.public.category category: The category to validate and return.
+        :return: The validated category.
+        :rtype: product.public.category
+        """
+        Category = request.env['product.public.category']
+        if (
+            (category := ProductCategory.browse(category and int(category)).exists())
+            and category.can_access_from_current_website()
+        ):
+            return category
+        else:
+            return Category
+
+    @staticmethod
+    def _get_shop_path(category=None, page=0):
+        path = '/shop'
+        if category:
+            slug = request.env['ir.http']._slug
+            path += f'/category/{slug(category)}'
+        if page:
+            path += f'/page/{page}'
+        return path
+
+    @staticmethod
+    def _get_product_path(product, category=None):
+        slug = request.env['ir.http']._slug
+        path = '/shop'
+        if category:
+            path += f'/{slug(category)}'
+        path += f'/{slug(product)}'
+        return path
+
+    @staticmethod
+    def _get_filtered_query_string(query_string, keys_to_remove):
+        """ Return a filtered copy of the provided query string, where all keys in `keys_to_remove`
+        are removed.
+
+        Note: the query string shouldn't include the leading '?'.
+
+        :param str query_string: The query string to filter.
+        :param list(str) keys_to_remove: The keys to remove from the query string.
+        :return: The filtered query string.
+        :rtype: str
+        """
+        query = urls.url_parse(f'?{query_string}').decode_query()
+        for key in keys_to_remove:
+            query.pop(key, False)
+        return urls.url_encode(query)

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -10,6 +10,7 @@ from odoo.tools.translate import html_translate
 
 from odoo.addons.website.models import ir_http
 from odoo.addons.website.tools import text_from_html
+from odoo.addons.website_sale.const import SHOP_PATH
 
 _logger = logging.getLogger(__name__)
 
@@ -817,7 +818,11 @@ class ProductTemplate(models.Model):
             if with_category and categ_ids:
                 data['category'] = self.env['ir.ui.view'].sudo()._render_template(
                     "website_sale.product_category_extra_link",
-                    {'categories': categ_ids, 'slug': self.env['ir.http']._slug}
+                    {
+                        'categories': categ_ids,
+                        'slug': self.env['ir.http']._slug,
+                        'shop_path': SHOP_PATH,
+                    }
                 )
         return results_data
 

--- a/addons/website_sale/static/src/js/website_sale_price_range_option.js
+++ b/addons/website_sale/static/src/js/website_sale_price_range_option.js
@@ -16,9 +16,8 @@ publicWidget.registry.multirangePriceSelector = publicWidget.Widget.extend({
      */
     _onPriceRangeSelected(ev) {
         const range = ev.currentTarget;
-        const searchParams = new URLSearchParams(window.location.search);
-        searchParams.delete("min_price");
-        searchParams.delete("max_price");
+        const url = new URL(range.dataset.url, window.location.origin);
+        const searchParams = url.searchParams;
         if (parseFloat(range.min) !== range.valueLow) {
             searchParams.set("min_price", range.valueLow);
         }
@@ -29,6 +28,6 @@ publicWidget.registry.multirangePriceSelector = publicWidget.Widget.extend({
         if (product_list_div) {
             product_list_div.classList.add('opacity-50');
         }
-        window.location.search = searchParams.toString();
+        window.location.href = `${url.pathname}?${searchParams.toString()}`;
     },
 });

--- a/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
+++ b/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
@@ -59,7 +59,7 @@ registry.category("web_tour.tours").add('category_page_and_products_snippet_use'
             // Fetch the category's id from the url.
             const productCategoryId = window.location.href.match('/shop/category/test-category-(\\d+)')[1]
             const productGridEl = this.anchor.closest('#products_grid');
-            const regex = new RegExp(`^/shop/[\\w-/]+-(\\d+)\\?category=${productCategoryId}$`);
+            const regex = new RegExp(`^/shop/test-category-${productCategoryId}/[\\w-/]+-(\\d+)$`);
             const allPageProductIDs = [...productGridEl.querySelectorAll('.oe_product_image_link')]
                 .map(el => el.getAttribute('href').match(regex)[1]);
 

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -30,6 +30,7 @@ from . import test_website_sale_product_filters
 from . import test_website_sale_product_page
 from . import test_website_sale_product_template
 from . import test_website_sale_reorder_from_portal
+from . import test_website_sale_shop_redirects
 from . import test_website_sale_show_compare_list_price
 from . import test_website_sale_snippets
 from . import test_website_sale_visitor

--- a/addons/website_sale/tests/test_website_sale_shop_redirects.py
+++ b/addons/website_sale/tests/test_website_sale_shop_redirects.py
@@ -1,0 +1,48 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Command
+from odoo.tests import HttpCase, tagged
+
+from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleShopRedirects(HttpCase, WebsiteSaleCommon):
+
+    def test_website_sale_shop_redirects(self):
+        category_a = self.env['product.public.category'].create({'name': "Category A"})
+        category_b = self.env['product.public.category'].create({'name': "Category B"})
+        test_product = self.env['product.template'].create({
+            'name': "Test product", 'public_categ_ids': [Command.link(category_a.id)]
+        })
+        slug = self.env['ir.http']._slug
+
+        response = self.url_open(
+            f'/shop?category={category_a.id}&some-key=some-value',
+            allow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 301)
+        self.assertURLEqual(
+            response.headers.get('Location'),
+            f'/shop/category/{slug(category_a)}?some-key=some-value',
+        )
+
+        response = self.url_open(
+            f'/shop/product/{slug(test_product)}?category={category_a.id}&some-key=some-value',
+            allow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 301)
+        self.assertURLEqual(
+            response.headers.get('Location'),
+            f'/shop/{slug(category_a)}/{slug(test_product)}?some-key=some-value',
+        )
+
+        response = self.url_open(
+            f'/shop/{slug(category_b)}/{slug(test_product)}?some-key=some-value',
+            allow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 301)
+        self.assertURLEqual(
+            response.headers.get('Location'),
+            f'/shop/{slug(test_product)}?some-key=some-value',
+        )

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -60,7 +60,7 @@
         </button>
         <t t-foreach="categories" t-as="category">
             <button class="btn btn-link btn-sm p-0 text-wrap" t-out="category.name"
-                t-attf-onclick="location.href='/shop/category/#{slug(category)}';return false;"/>
+                t-attf-onclick="location.href='#{shop_path}/category/#{slug(category)}';return false;"/>
         </t>
     </template>
 
@@ -213,7 +213,10 @@
             class="oe_product_cart h-100 d-flex"
             t-att-data-publish="product.website_published and 'on' or 'off'"
         >
-            <t t-set="product_path" t-value="'/shop/%s/%s' % (slug(category), slug(product)) if category else '/shop/%s' % slug(product)"/>
+            <t
+                t-set="product_path"
+                t-value="'%s/%s/%s' % (shop_path, slug(category), slug(product)) if category else '%s/%s' % (shop_path, slug(product))"
+            />
             <t
                 t-set="product_href"
                 t-value="product_path + (product_query_string and '?' + product_query_string) + selected_attributes_hash"
@@ -357,14 +360,17 @@
     <template id="products_breadcrumb" name="Products Breadcrumb">
         <ol t-if="category" t-attf-class="breadcrumb #{_classes}">
             <li class="breadcrumb-item">
-                <a t-att-href="keep('/shop')">Products</a>
+                <a t-att-href="keep(shop_path)">Products</a>
             </li>
             <t t-foreach="category.parents_and_self" t-as="cat">
                 <li t-if="cat == category" class="breadcrumb-item">
                     <span class="d-inline-block" t-field="cat.name"/>
                 </li>
                 <li t-else="" class="breadcrumb-item">
-                    <a t-att-href="keep('/shop/category/%s' % slug(cat))" t-field="cat.name"/>
+                    <a
+                        t-att-href="keep('%s/category/%s' % (shop_path, slug(cat)))"
+                        t-field="cat.name"
+                    />
                 </li>
             </t>
         </ol>
@@ -498,7 +504,7 @@
                                     <a
                                         t-if="(search and not category) or (not search and category)"
                                         t-attf-class="btn ps-0 pe-2 {{not search and 'd-lg-none'}}"
-                                        t-att-href="keep('/shop/category/%s' % slug(category.parent_id)) if category.parent_id else keep('/shop', search=0)"
+                                        t-att-href="keep('%s/category/%s' % (shop_path, slug(category.parent_id))) if category.parent_id else keep(shop_path, search=0)"
                                         role="button"
                                         t-attf-title="Back to {{category.parent_id and category.parent_id.name or 'Shop'}}"
                                     >
@@ -521,7 +527,7 @@
                                             <t t-esc="category.name"/>
                                             <a
                                                 title="Search globally"
-                                                t-att-href="keep('/shop', search=search)"
+                                                t-att-href="keep(shop_path, search=search)"
                                             >
                                                 <i class="oi oi-close" role="img"/>
                                             </a>
@@ -669,7 +675,7 @@
                                     <p>No results for "<strong t-esc='search'/>"<t t-if="category"> in category "<strong t-esc="category.display_name"/>"</t>.</p>
                                     <a
                                         t-if="category"
-                                        t-att-href="keep('/shop', search=search)"
+                                        t-att-href="keep(shop_path, search=search)"
                                         t-attf-title="Search {{search}} globally"
                                         class="d-block pb-5"
                                     >
@@ -1058,7 +1064,7 @@
                         t-attf-class="d-flex {{'pe-3' if not c_last else ''}}"
                     >
                         <a
-                            t-att-href="keep('/shop/category/%s' % slug(c))"
+                            t-att-href="keep('%s/category/%s' % (shop_path, slug(c)))"
                             class="text-decoration-none"
                             draggable="false"
                         >
@@ -1187,7 +1193,7 @@
 
     <template id="categorie_link" name="Category Link">
         <a
-            t-att-href="keep('/shop/category/%s' % slug(c))"
+            t-att-href="keep('%s/category/%s' % (shop_path, slug(c)))"
             t-attf-class="{{c.id == category.id and 'text-decoration-underline'}} p-0"
             t-field="c.name"
         />
@@ -1204,7 +1210,7 @@
                 <ul class="nav d-flex flex-column mb-3">
                     <li class="nav-item mb-1">
                         <a
-                            t-att-href="keep('/shop')"
+                            t-att-href="keep(shop_path)"
                             t-attf-class="{{not category and 'text-decoration-underline'}} p-0"
                         >
                             All Products
@@ -1528,7 +1534,7 @@
                         <div class="col d-flex align-items-center order-1 order-lg-0">
                             <ol class="o_wsale_breadcrumb breadcrumb p-0 mb-4 m-lg-0">
                                 <li class="o_not_editable d-none d-lg-inline-block">
-                                    <a href="/shop">
+                                    <a t-att-href="shop_path">
                                         <i class="oi oi-chevron-left d-lg-none me-1" role="presentation"/>All Products
                                     </a>
                                 </li>
@@ -1539,13 +1545,13 @@
                                 >
                                     <a
                                         class="py-2 py-lg-0"
-                                        t-att-href="'/shop/category/%s' % slug(category)"
+                                        t-attf-href="{{shop_path}}/category/{{slug(category)}}"
                                     >
                                         <i class="oi oi-chevron-left d-lg-none me-1" role="presentation"/><t t-out="category.name"/>
                                     </a>
                                 </li>
                                 <li t-else="" class="o_not_editable breadcrumb-item d-lg-none">
-                                    <a class="py-2 py-lg-0" href="/shop">
+                                    <a class="py-2 py-lg-0" t-att-href="shop_path">
                                         <i class="oi oi-chevron-left me-1" role="presentation"/>All Products
                                     </a>
                                 </li>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -200,7 +200,7 @@
             <t t-set="_submit_classes" t-valuef="btn btn-{{navClass}}"/>
             <t t-set="_input_classes" t-valuef="border-0 text-bg-{{navClass}}"/>
             <t t-set="search_type" t-valuef="products"/>
-            <t t-set="action" t-value="keep('/shop'+ ('/category/'+slug(category)) if category else None, search=0) or '/shop'"/>
+            <t t-set="action" t-value="keep(search=0)"/>
             <t t-set="display_image" t-valuef="true"/>
             <t t-set="display_description" t-valuef="true"/>
             <t t-set="display_extra_link" t-valuef="true"/>
@@ -218,7 +218,11 @@
             class="oe_product_cart h-100 d-flex"
             t-att-data-publish="product.website_published and 'on' or 'off'"
         >
-            <t t-set="product_href" t-value="keep(product.website_url, page=(pager['page']['num'] if pager['page']['num']&gt;1 else None)) + selected_attributes_hash" />
+            <t t-set="product_path" t-value="'/shop/%s/%s' % (slug(category), slug(product)) if category else '/shop/%s' % slug(product)"/>
+            <t
+                t-set="product_href"
+                t-value="product_path + (product_query_string and '?' + product_query_string) + selected_attributes_hash"
+            />
             <t t-set="image_type" t-value="product._get_suitable_image_size(ppr, td_product['x'], td_product['y'])"/>
 
             <div class="oe_product_image position-relative flex-grow-0 overflow-hidden">
@@ -358,14 +362,14 @@
     <template id="products_breadcrumb" name="Products Breadcrumb">
         <ol t-if="category" t-attf-class="breadcrumb #{_classes}">
             <li class="breadcrumb-item">
-                <a href="/shop">Products</a>
+                <a t-att-href="keep('/shop')">Products</a>
             </li>
             <t t-foreach="category.parents_and_self" t-as="cat">
                 <li t-if="cat == category" class="breadcrumb-item">
                     <span class="d-inline-block" t-field="cat.name"/>
                 </li>
                 <li t-else="" class="breadcrumb-item">
-                    <a t-att-href="keep('/shop/category/%s' % slug(cat), category=0)" t-field="cat.name"/>
+                    <a t-att-href="keep('/shop/category/%s' % slug(cat))" t-field="cat.name"/>
                 </li>
             </t>
         </ol>
@@ -443,11 +447,30 @@
                                 >
                                     <t t-call="website_sale.products_categories_list"/>
                                 </div>
+                                <t
+                                    t-set="show_price_filter"
+                                    t-value="opt_wsale_filter_price and opt_wsale_attributes"
+                                />
+                                <div
+                                    t-if="attrib_values or tags or (
+                                        show_price_filter and isFilteringByPrice
+                                    )"
+                                    class="py-3 border-bottom"
+                                >
+                                    <a
+                                        t-att-href="keep(attribute_value=0, tags=0, min_price=0, max_price=0)"
+                                        t-attf-class="btn btn-{{navClass}} d-flex align-items-center py-1"
+                                        title="Clear Filters"
+                                    >
+                                        <small class="mx-auto"><b>Clear Filters</b></small>
+                                        <i class="oi oi-close" role="presentation"/>
+                                    </a>
+                                </div>
                                 <div
                                     t-attf-class="products_attributes_filters d-empty-none {{opt_wsale_categories and 'border-top'}}"
                                 />
                                 <t
-                                    t-if="opt_wsale_filter_price and opt_wsale_attributes"
+                                    t-if="show_price_filter"
                                     t-call="website_sale.filter_products_price"
                                 >
                                     <t
@@ -480,7 +503,7 @@
                                     <a
                                         t-if="(search and not category) or (not search and category)"
                                         t-attf-class="btn ps-0 pe-2 {{not search and 'd-lg-none'}}"
-                                        t-att-href="category.parent_id and keep('/shop/category/' + slug(category.parent_id), category=0) or keep('/shop/', search=0, category=0)"
+                                        t-att-href="keep('/shop/category/%s' % slug(category.parent_id)) if category.parent_id else keep('/shop', search=0)"
                                         role="button"
                                         t-attf-title="Back to {{category.parent_id and category.parent_id.name or 'Shop'}}"
                                     >
@@ -490,14 +513,21 @@
                                         <span class="text-muted">Searching</span>
                                         <span class="badge text-bg-info fw-normal base-fs">
                                             <t t-esc="search"/>
-                                            <a title="Clear search for this category" t-att-href="keep('/shop/category/' + slug(category), search=0)" class="link-info">
+                                            <a
+                                                title="Clear search for this category"
+                                                t-att-href="keep(search=0)"
+                                                class="link-info"
+                                            >
                                                 <i class="oi oi-close" role="img"/>
                                             </a>
                                         </span>
                                         <span class="text-muted">in</span>
                                         <span class="badge text-bg-primary fw-normal base-fs">
                                             <t t-esc="category.name"/>
-                                            <a title="Search globally" t-att-href="keep('/shop/', search=search, category=0)">
+                                            <a
+                                                title="Search globally"
+                                                t-att-href="keep('/shop', search=search)"
+                                            >
                                                 <i class="oi oi-close" role="img"/>
                                             </a>
                                         </span>
@@ -644,7 +674,7 @@
                                     <p>No results for "<strong t-esc='search'/>"<t t-if="category"> in category "<strong t-esc="category.display_name"/>"</t>.</p>
                                     <a
                                         t-if="category"
-                                        t-attf-href="/shop?search={{search}}"
+                                        t-att-href="keep('/shop', search=search)"
                                         t-attf-title="Search {{search}} globally"
                                         class="d-block pb-5"
                                     >
@@ -786,7 +816,7 @@
                     <a
                         role="menuitem"
                         rel="noindex,nofollow"
-                        t-att-href="keep('/shop', order=sortby[0])"
+                        t-att-href="keep(order=sortby[0])"
                         t-attf-class="dropdown-item {{_is_active and 'active'}}"
                     >
                         <span t-out="sortby[1]"/>
@@ -862,11 +892,11 @@
                                 <a t-foreach="website_sale_sortable" t-as="sortby"
                                    role="menuitem"
                                    rel="noindex,nofollow"
-                                   t-att-href="keep('/shop', order=sortby[0])"
+                                   t-att-href="keep(order=sortby[0])"
                                    class="list-group-item border-0 ps-0 pb-0">
                                     <div class="form-check d-inline-block">
                                         <input type="radio"
-                                               t-attf-onclick="location.href='#{keep('/shop', order=sortby[0])}';"
+                                               t-attf-onclick="location.href='#{keep(order=sortby[0])}';"
                                                class="form-check-input o_not_editable"
                                                name="wsale_sortby_radios_offcanvas"
                                                t-att-checked="isSortingBy and isSortingBy == sortby[1]">
@@ -903,12 +933,12 @@
                     </div>
                 </div>
 
-                <form t-if="opt_wsale_attributes or opt_wsale_attributes_top"
-                      t-attf-class="js_attributes accordion accordion-flush d-flex flex-column {{len(attributes) > 0 and 'border-bottom'}}"
-                      method="get">
-                    <input t-if="category" type="hidden" name="category" t-att-value="category.id"/>
-                    <input type="hidden" name="search" t-att-value="search"/>
-
+                <form
+                    t-if="opt_wsale_attributes or opt_wsale_attributes_top"
+                    t-attf-class="js_attributes accordion accordion-flush d-flex flex-column {{len(attributes) > 0 and 'border-bottom'}}"
+                    method="get"
+                    t-att-action="keep(attribute_value=0, tags=0)"
+                >
                     <t t-foreach="attributes" t-as="a">
                         <t t-cache="a,attrib_set">
                             <t t-set="_status" t-value="'inactive'"/>
@@ -1001,7 +1031,7 @@
             <div class="offcanvas-body d-flex justify-content-between flex-grow-0 border-top overflow-hidden">
                 <a t-attf-class="btn btn-{{navClass}} d-flex py-1 mb-2 {{(not attrib_values and not isFilteringByPrice and not tags) and 'disabled' }}"
                    t-att-aria-disabled="(not attrib_values and not isFilteringByPrice and not tags) and 'true' or 'false'"
-                   href="/shop"
+                   t-att-href="keep(attribute_value=0, tags=0, min_price=0, max_price=0)"
                    title="Clear Filters">
                     Clear Filters
                 </a>
@@ -1027,16 +1057,13 @@
         <div t-if="entries" class="o_wsale_filmstip_container d-flex align-items-stretch overflow-hidden">
             <div class="o_wsale_filmstip_wrapper pb-1 overflow-auto">
                 <ul class="o_wsale_filmstip d-flex align-items-stretch mb-0 list-unstyled overflow-visible">
-                    <t t-if="category.parent_id" t-set="backUrl" t-value="keep('/shop/category/' + slug(category.parent_id), category=0)"/>
-                    <t t-else="" t-set="backUrl" t-value="'/shop'"/>
-
                     <li
                         t-foreach="entries"
                         t-as="c"
                         t-attf-class="d-flex {{'pe-3' if not c_last else ''}}"
                     >
                         <a
-                            t-att-href="keep('/shop/category/' + slug(c), category=0)"
+                            t-att-href="keep('/shop/category/%s' % slug(c))"
                             class="text-decoration-none"
                             draggable="false"
                         >
@@ -1165,7 +1192,7 @@
 
     <template id="categorie_link" name="Category Link">
         <a
-            t-att-href="keep('/shop/category/' + slug(c), category=0)"
+            t-att-href="keep('/shop/category/%s' % slug(c))"
             t-attf-class="{{c.id == category.id and 'text-decoration-underline'}} p-0"
             t-field="c.name"
         />
@@ -1182,7 +1209,7 @@
                 <ul class="nav d-flex flex-column mb-3">
                     <li class="nav-item mb-1">
                         <a
-                            t-att-href="keep('/shop', category=0)"
+                            t-att-href="keep('/shop')"
                             t-attf-class="{{not category and 'text-decoration-underline'}} p-0"
                         >
                             All Products
@@ -1287,23 +1314,11 @@
         <xpath expr="//div[contains(@t-attf-class, 'products_attributes_filters')]" position="inside">
             <div t-if="attributes or all_tags" id="wsale_products_attributes_collapse"
                  class=" position-relative">
-                <form class="js_attributes position-relative mb-2" method="get">
-                    <input t-if="category" type="hidden" name="category" t-att-value="category.id" />
-                    <input type="hidden" name="search" t-att-value="search" />
-                    <input type="hidden" name="order" t-att-value="order"/>
-                    <div
-                        t-if="attrib_values or tags"
-                        class="accordion-item rounded-0 border-top-0 py-3"
-                    >
-                        <a
-                            t-att-href="keep('/shop' + ('/category/' + slug(category)) if category else None, attribute_value=0, tags=0)"
-                            t-attf-class="btn btn-{{navClass}} d-flex align-items-center py-1"
-                            title="Clear Filters"
-                        >
-                            <small class="mx-auto"><b>Clear Filters</b></small>
-                            <i class="oi oi-close" role="presentation"/>
-                        </a>
-                    </div>
+                <form
+                    class="js_attributes position-relative mb-2"
+                    method="get"
+                    t-att-action="keep(attribute_value=0, tags=0)"
+                >
                     <t t-foreach="attributes" t-as="a">
                         <t t-cache="a,attrib_set">
                             <div class="accordion-item nav-item mb-1 rounded-0" t-if="a.value_ids and len(a.value_ids) &gt; 1">
@@ -1418,6 +1433,7 @@
                             t-attf-class="form-range range-with-input {{_classes_input}}"
                             t-att-data-currency="website.currency_id.symbol"
                             t-att-data-currency-position="website.currency_id.position"
+                            t-att-data-url="keep(min_price=0, max_price=0)"
                             t-att-step="website.currency_id.rounding"
                             t-att-min="'%f' % (available_min_price)"
                             t-att-max="'%f' % (available_max_price)"
@@ -1436,6 +1452,7 @@
                     t-attf-class="form-range range-with-input {{_classes_input}}"
                     t-att-data-currency="website.currency_id.symbol"
                     t-att-data-currency-position="website.currency_id.position"
+                    t-att-data-url="keep(min_price=0, max_price=0)"
                     t-att-step="website.currency_id.rounding"
                     t-att-min="'%f' % (available_min_price)"
                     t-att-max="'%f' % (available_max_price)"
@@ -1516,7 +1533,7 @@
                         <div class="col d-flex align-items-center order-1 order-lg-0">
                             <ol class="o_wsale_breadcrumb breadcrumb p-0 mb-4 m-lg-0">
                                 <li class="o_not_editable d-none d-lg-inline-block">
-                                    <a t-att-href="keep(category=0, attribute_value=0, tags=0)">
+                                    <a href="/shop">
                                         <i class="oi oi-chevron-left d-lg-none me-1" role="presentation"/>All Products
                                     </a>
                                 </li>
@@ -1527,16 +1544,13 @@
                                 >
                                     <a
                                         class="py-2 py-lg-0"
-                                        t-att-href="keep('/shop/category/%s' % slug(category), category=0, attribute_value=0, tags=0)"
+                                        t-att-href="'/shop/category/%s' % slug(category)"
                                     >
                                         <i class="oi oi-chevron-left d-lg-none me-1" role="presentation"/><t t-out="category.name"/>
                                     </a>
                                 </li>
                                 <li t-else="" class="o_not_editable breadcrumb-item d-lg-none">
-                                    <a
-                                        class="py-2 py-lg-0"
-                                        t-att-href="keep(category=0, attribute_value=0, tags=0)"
-                                    >
+                                    <a class="py-2 py-lg-0" href="/shop">
                                         <i class="oi oi-chevron-left me-1" role="presentation"/>All Products
                                     </a>
                                 </li>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -205,11 +205,6 @@
             <t t-set="display_description" t-valuef="true"/>
             <t t-set="display_extra_link" t-valuef="true"/>
             <t t-set="display_detail" t-valuef="true"/>
-            <t t-if="attrib_values">
-                <t t-foreach="attrib_values" t-as="a">
-                    <input type="hidden" name="attribute_value" t-att-value="'%s-%s' % (a[0], a[1])" />
-                </t>
-            </t>
         </t>
     </template>
 

--- a/addons/website_sale_collect/controllers/main.py
+++ b/addons/website_sale_collect/controllers/main.py
@@ -8,9 +8,9 @@ from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 class WebsiteSaleCollect(WebsiteSale):
 
-    def _prepare_product_values(self, product, category, search, **kwargs):
+    def _prepare_product_values(self, product, category, **kwargs):
         """ Override of `website_sale` to configure the Click & Collect Availability widget. """
-        res = super()._prepare_product_values(product, category, search, **kwargs)
+        res = super()._prepare_product_values(product, category, **kwargs)
         if in_store_dm_sudo := request.website.sudo().in_store_dm_id:
             order_sudo = request.cart
             selected_location_data = {}

--- a/addons/website_sale_stock/controllers/website_sale.py
+++ b/addons/website_sale_stock/controllers/website_sale.py
@@ -7,8 +7,8 @@ from odoo.addons.website_sale.controllers import main
 
 class WebsiteSale(main.WebsiteSale):
 
-    def _prepare_product_values(self, product, category='', search='', **kwargs):
-        values = super()._prepare_product_values(product, category, search, **kwargs)
+    def _prepare_product_values(self, product, category, **kwargs):
+        values = super()._prepare_product_values(product, category, **kwargs)
         # We need the user mail to prefill the back of stock notification, so we put it in the value that will be sent
         values['user_email'] = request.env.user.email or request.session.get('stock_notification_email', '')
         return values

--- a/addons/website_sale_wishlist/controllers/website_sale.py
+++ b/addons/website_sale_wishlist/controllers/website_sale.py
@@ -7,8 +7,8 @@ from odoo.addons.website_sale.controllers import main
 
 class WebsiteSaleWishlist(main.WebsiteSale):
 
-    def _get_additional_shop_values(self, values):
+    def _get_additional_shop_values(self, values, **kwargs):
         """ Hook to update values used for rendering website_sale.products template """
-        vals = super()._get_additional_shop_values(values)
+        vals = super()._get_additional_shop_values(values, **kwargs)
         vals['products_in_wishlist'] = request.env['product.wishlist'].current().product_id.product_tmpl_id
         return vals


### PR DESCRIPTION
General eCommerce changes:
- Avoid empty query params in eCommerce URLs.
- Make filtering, sorting, searching, and pagination consistent in eCommerce.
- Add redirects for URLs which are no longer supported (e.g. the `category`
  query param).

Shop page changes:
- Aggregate `attribute_value` query params by attribute. E.g.:
  `attribute_value=1-1&attribute_value=1-2&attribute_value=2-3` becomes
  `attribute_value=1-1,2&attribute_value=2-3`.
- Aggregate `tags` query params into a single one. E.g.:
  `tags=1&tags=2&tags=3` becomes `tags=1,2,3`.
- Remove support for unexpected query params (e.g. `ppg`).
- Reset the page number after updating the filters.
- Clear the attributes, tags, and price range when the "Clear Filters" button
  is triggered.

Product page changes:
- Move the category from the query params to the path (same as for the shop
  page).
- Remove the category from canonical URLs.
- Validate the category (e.g. ensure that the product actually belongs to the
  category).
- Stop appending query params coming from the shop page.

task-4262785

Enterprise PR: https://github.com/odoo/enterprise/pull/79284
Upgrade PR: https://github.com/odoo/upgrade/pull/7537