### PR TITLE
[FIX] hr_attendance: error in kiosk mode manual selection

### DIFF
--- a/addons/hr_attendance/static/src/components/card_layout/card_layout.js
+++ b/addons/hr_attendance/static/src/components/card_layout/card_layout.js
@@ -6,9 +6,10 @@ const { DateTime } = luxon;
 export class CardLayout extends Component {
     static template = "hr_attendance.CardLayout";
     static props = {
-        kioskModeClasses: { type: String, optional: true },
         slots: Object,
         fromTrialMode: { type: Boolean, optional: true },
+        companyImageUrl: { type: String },
+        kioskReturn: { type: Function },
     };
     static defaultProps = {
         kioskModeClasses: "",

--- a/addons/hr_attendance/static/src/components/manual_selection/manual_selection.js
+++ b/addons/hr_attendance/static/src/components/manual_selection/manual_selection.js
@@ -20,9 +20,10 @@ export class KioskManualSelection extends Component {
     };
     static props = {
         displayBackButton: { type: Boolean },
-        token: { type: Number },
+        token: { type: String },
         departments: { type: Array },
         onSelectEmployee: { type: Function },
+        onClickBack: { type: Function },
     };
 
     setup() {
@@ -127,16 +128,3 @@ export class KioskManualSelection extends Component {
         await this._fetchEmployeeData();
     }
 }
-
-KioskManualSelection.template = "hr_attendance.public_kiosk_manual_selection";
-KioskManualSelection.components = {
-    Dropdown,
-    DropdownItem,
-};
-KioskManualSelection.props = {
-    employees: { type: Array },
-    displayBackButton: { type: Boolean },
-    departments: { type: Array },
-    onSelectEmployee: { type: Function },
-    onClickBack: { type: Function },
-};

--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
@@ -22,10 +22,10 @@ class kioskAttendanceApp extends Component{
         token: { type: String },
         companyId: { type: Number },
         companyName: { type: String },
-        employees: { type: Array },
         departments: { type: Array },
         kioskMode: { type: String },
         barcodeSource: { type: String },
+        fromTrialMode: { type: Boolean },
     };
     static components = {
         KioskBarcodeScanner,


### PR DESCRIPTION
Issue reproducible on runbot: a blank page appears when clicking on
"Identify manually" in the Attendance kiosk mode with the error
`Cannot find the definition of component "Pager"` in the console,
because the Pager component is missing from the components declaration.

Note: also add correct props validation to make kiosk mode work in
debug mode.

opw-4573687
