### PR TITLE
[IMP] hw_drivers: add logs for printing

### DIFF
--- a/addons/hw_drivers/controllers/driver.py
+++ b/addons/hw_drivers/controllers/driver.py
@@ -42,6 +42,7 @@ class DriverController(http.Controller):
                     _logger.info("Ignored request from %s as iot_idempotent_id %s already received from session %s",
                                  session_id, iot_idempotent_id, idempotent_session)
                     return False
+            _logger.debug("Calling action %s for device %s", data.get('action', ''), device_identifier)
             iot_device.action(data)
             return True
         return False
@@ -60,7 +61,6 @@ class DriverController(http.Controller):
         listener is a dict in witch there are a sessions_id and a dict of device_identifier to listen
         """
         req = event_manager.add_request(listener)
-
         # Search for previous events and remove events older than 5 seconds
         oldest_time = time.time() - 5
         for event in list(event_manager.events):
@@ -69,6 +69,7 @@ class DriverController(http.Controller):
                 continue
             if event['device_identifier'] in listener['devices'] and event['time'] > listener['last_event']:
                 event['session_id'] = req['session_id']
+                _logger.debug("Event %s found for device %s ", event, event['device_identifier'])
                 return event
 
         # Wait for new event

--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
@@ -192,6 +192,8 @@ class PrinterDriver(Driver):
                           self.device_identifier)
 
     def print_receipt(self, data):
+        _logger.debug("print_receipt called for printer %s", self.device_name)
+
         receipt = b64decode(data['receipt'])
         im = Image.open(io.BytesIO(receipt))
 
@@ -382,11 +384,14 @@ class PrinterDriver(Driver):
 
     def open_cashbox(self, data):
         """Sends a signal to the current printer to open the connected cashbox."""
+        _logger.debug("open_cashbox called for printer %s", self.device_name)
+
         commands = RECEIPT_PRINTER_COMMANDS[self.receipt_protocol]
         for drawer in commands['drawers']:
             self.print_raw(drawer)
 
     def _action_default(self, data):
+        _logger.debug("_action_default called for printer %s", self.device_name)
         self.print_raw(b64decode(data['document']))
 
 

--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
@@ -122,6 +122,8 @@ class PrinterDriver(Driver):
         ghostscript.Ghostscript(*args)
 
     def print_receipt(self, data):
+        _logger.debug("print_receipt called for printer %s", self.device_name)
+
         receipt = b64decode(data['receipt'])
         im = Image.open(io.BytesIO(receipt))
 
@@ -151,16 +153,22 @@ class PrinterDriver(Driver):
 
     def open_cashbox(self, data):
         """Sends a signal to the current printer to open the connected cashbox."""
+        _logger.debug("open_cashbox called for printer %s", self.device_name)
+        
         commands = RECEIPT_PRINTER_COMMANDS[self.receipt_protocol]
         for drawer in commands['drawers']:
             self.print_raw(drawer)
 
     def _action_default(self, data):
+        _logger.debug("_action_default called for printer %s", self.device_name)
+
         document = b64decode(data['document'])
         mimetype = guess_mimetype(document)
         if mimetype == 'application/pdf':
             self.print_report(document)
         else:
             self.print_raw(document)
+        _logger.debug("_action_default finished with mimetype %s for printer %s", mimetype, self.device_name)
+
 
 proxy_drivers['printer'] = PrinterDriver


### PR DESCRIPTION
Following the ticket opw-4523417 there is a lack of logging related to printing in hw_drivers module which makes it difficult to analyse the issued on the client's side, especially on Windows IoT

This PR adds
1) some logs upon receiving of a printing request via longpolling route
2) some logs when the methods of printing are being called
3) some logs when these methods have finished their job

Since for printing the Odoo database isn't notified of a succeful printing this is very much needed
