### PR TITLE
[FIX] website_sale: traceback on shop access

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -456,7 +456,7 @@ class Website(models.Model):
                 ('partner_id', '=', self.env.user.partner_id.id),
                 ('website_id', '=', self.id),
                 ('state', '=', 'draft'),
-            ])
+            ], limit=1)
             if abandonned_cart_sudo:
                 if not request.env.cr.readonly:
                     # Force the recomputation of the pricelist and fiscal position when resurrecting


### PR DESCRIPTION
Commit e3a3c589fad2de2d9199ab2c2f096e6987b3671c
refactored the logic handling the cart, but
didn't handle well the situation where two
open draft carts were available for a logged in
user, leading to a traceback when accessing the
ecommerce.

This should fix the raised 'expected singleton ...'


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
