### PR TITLE
[IMP] tools,web: auto format lists in translations

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -7,7 +7,7 @@ import re
 from odoo import api, fields, models, Command, _
 from odoo.exceptions import ValidationError, UserError
 from odoo.fields import Domain
-from odoo.tools import frozendict, float_compare, format_list, Query, SQL
+from odoo.tools import frozendict, float_compare, Query, SQL
 from odoo.addons.web.controllers.utils import clean_action
 
 from odoo.addons.account.models.account_move import MAX_HASH_VERSION
@@ -1517,7 +1517,7 @@ class AccountMoveLine(models.Model):
             raise UserError(_(
                 "You cannot edit the following fields: %(fields)s.\n"
                 "The following entries are already hashed:\n%(entries)s",
-                fields=format_list(self.env, [f['string'] for f in self.fields_get(violated_fields).values()]),
+                fields=[f['string'] for f in self.fields_get(violated_fields).values()],
                 entries='\n'.join(hashed_moves.mapped('name')),
             ))
 

--- a/addons/account/wizard/account_secure_entries_wizard.py
+++ b/addons/account/wizard/account_secure_entries_wizard.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 from odoo import Command, api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.osv import expression
-from odoo.tools import format_list
 
 
 class AccountSecureEntriesWizard(models.TransientModel):
@@ -150,7 +149,7 @@ class AccountSecureEntriesWizard(models.TransientModel):
                 warnings['account_unreconciled_bank_statement_line_ids'] = {
                     'message': _("There are still unreconciled bank statement lines before the selected date. "
                                  "The entries from journal prefixes containing them will not be secured: %(prefix_info)s",
-                                 prefix_info=format_list(self.env, ignored_sequence_prefixes)),
+                                 prefix_info=ignored_sequence_prefixes),
                     'level': 'danger',
                     'action_text': _("Review"),
                     'action': wizard.company_id._get_unreconciled_statement_lines_redirect_action(wizard.unreconciled_bank_statement_line_ids),

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -3,7 +3,7 @@ from markupsafe import Markup
 from odoo import _, models, Command
 from odoo.addons.base.models.res_bank import sanitize_account_number
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import float_repr, format_list
+from odoo.tools import float_repr
 from odoo.tools.float_utils import float_round
 from odoo.tools.misc import clean_context, formatLang, html_escape
 from odoo.tools.xml_utils import find_xml_value
@@ -237,7 +237,7 @@ class AccountEdiCommon(models.AbstractModel):
         :return: an Error message or None
         """
         if not record:
-            return custom_warning_message or _("The element %(record)s is required on %(field_list)s.", record=record, field_list=format_list(self.env, field_names))
+            return custom_warning_message or _("The element %(record)s is required on %(field_list)s.", record=record, field_list=field_names)
 
         if not isinstance(field_names, (list, tuple)):
             field_names = (field_names,)
@@ -252,7 +252,7 @@ class AccountEdiCommon(models.AbstractModel):
             return custom_warning_message or _(
                 "The element %(record)s is required on %(field_list)s.",
                 record=record,
-                field_list=format_list(self.env, field_names),
+                field_list=field_names,
             )
 
         display_field_names = record.fields_get(field_names)
@@ -260,7 +260,7 @@ class AccountEdiCommon(models.AbstractModel):
             display_field = f"'{display_field_names[field_names[0]]['string']}'"
             return _("The field %(field)s is required on %(record)s.", field=display_field, record=record.display_name)
         else:
-            display_fields = format_list(self.env, [f"'{display_field_names[x]['string']}'" for x in display_field_names])
+            display_fields = [f"'{display_field_names[x]['string']}'" for x in display_field_names]
             return _("At least one of the following fields %(field_list)s is required on %(record)s.", field_list=display_fields, record=record.display_name)
 
     # -------------------------------------------------------------------------

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -7,7 +7,6 @@ import re
 from odoo import api, fields, models
 from odoo.exceptions import UserError, AccessError, ValidationError
 from odoo.osv import expression
-from odoo.tools import format_list
 from odoo.tools.translate import _
 
 
@@ -341,7 +340,7 @@ class AccountAnalyticLine(models.Model):
         if missing_plan_names:
             raise ValidationError(_(
                 "'%(missing_plan_names)s' analytic plan(s) required on the project '%(project_name)s' linked to the timesheet.",
-                missing_plan_names=format_list(self.env, missing_plan_names),
+                missing_plan_names=missing_plan_names,
                 project_name=project.name,
             ))
         return {

--- a/addons/l10n_sa_edi/models/account_edi_format.py
+++ b/addons/l10n_sa_edi/models/account_edi_format.py
@@ -5,7 +5,6 @@ from lxml import etree
 from datetime import datetime
 from odoo import models, fields, _, api
 from odoo.exceptions import UserError
-from odoo.tools import format_list
 
 
 class AccountEdiFormat(models.Model):
@@ -426,14 +425,14 @@ class AccountEdiFormat(models.Model):
             errors.append(
                 _(
                     "- Please, set the following fields on the Supplier: %(missing_fields)s",
-                    missing_fields=format_list(self.env, supplier_missing_info),
+                    missing_fields=supplier_missing_info,
                 )
             )
         if customer_missing_info:
             errors.append(
                 _(
                     "- Please, set the following fields on the Customer: %(missing_fields)s",
-                    missing_fields=format_list(self.env, customer_missing_info),
+                    missing_fields=customer_missing_info,
                 )
             )
         if invoice.invoice_date > fields.Date.context_today(self.with_context(tz='Asia/Riyadh')):

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -120,7 +120,7 @@ class DiscussChannel(models.Model):
             raise ValidationError(
                 _(
                     "Cannot create %(channels)s: initial message should belong to parent channel.",
-                    channels=format_list(self.env, failing_channels.mapped("name")),
+                    channels=failing_channels.mapped("name"),
                 )
             )
 
@@ -138,7 +138,7 @@ class DiscussChannel(models.Model):
             raise ValidationError(
                 _(
                     "Cannot create %(channels)s: parent should not be a sub-channel and should be of type 'channel' or 'group'. The sub-channel should have the same type as the parent.",
-                    channels=format_list(self.env, failing_channels.mapped("name")),
+                    channels=failing_channels.mapped("name"),
                 ),
             )
 
@@ -353,7 +353,7 @@ class DiscussChannel(models.Model):
             raise UserError(
                 _(
                     "Cannot change initial message nor parent channel of: %(channels)s.",
-                    channels=format_list(self.env, self.mapped("name")),
+                    channels=self.mapped("name"),
                 )
             )
         if "group_public_id" in vals:
@@ -361,7 +361,7 @@ class DiscussChannel(models.Model):
                 raise UserError(
                     self.env._(
                         "Cannot change authorized group of sub-channel: %(channels)s.",
-                        channels=format_list(self.env, failing_channels.mapped("name")),
+                        channels=failing_channels.mapped("name"),
                     )
                 )
         def get_vals(channel):

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from odoo import _, api, fields, models, modules, tools
 from odoo.exceptions import AccessError
 from odoo.osv import expression
-from odoo.tools import clean_context, format_list, groupby, SQL
+from odoo.tools import clean_context, groupby, SQL
 from odoo.tools.misc import OrderedSet
 from odoo.addons.mail.tools.discuss import Store
 
@@ -563,7 +563,7 @@ class MailMessage(models.Model):
             "Records: %(records)s, User: %(user)s",
             type=self._description,
             operation=operation,
-            records=format_list(self.env, list(map(str, self.ids[:6]))),
+            records=self.ids[:6],
             user=self.env.uid,
         ))
 

--- a/addons/mail/wizard/base_partner_merge_automatic_wizard.py
+++ b/addons/mail/wizard/base_partner_merge_automatic_wizard.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import models
-from odoo.tools import format_list
 
 
 class BasePartnerMergeAutomaticWizard(models.TransientModel):
@@ -12,12 +11,9 @@ class BasePartnerMergeAutomaticWizard(models.TransientModel):
         dst_partner.message_post(
             body=self.env._(
                 "Merged with the following partners: %s",
-                format_list(
-                    self.env,
-                    [
-                        self.env._("%(partner)s <%(email)s> (ID %(id)s)", partner=p.name, email=p.email or "n/a", id=p.id)
-                        for p in src_partners
-                    ]
-                ),
+                [
+                    self.env._("%(partner)s <%(email)s> (ID %(id)s)", partner=p.name, email=p.email or "n/a", id=p.id)
+                    for p in src_partners
+                ],
             )
         )

--- a/addons/mrp_account/wizard/mrp_wip_accounting.py
+++ b/addons/mrp_account/wizard/mrp_wip_accounting.py
@@ -4,7 +4,6 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import fields, models, _, api, Command
 from odoo.exceptions import UserError
-from odoo.tools import format_list
 
 
 class MrpAccountWipAccountingLine(models.TransientModel):
@@ -51,7 +50,7 @@ class MrpAccountWipAccounting(models.TransientModel):
             if default:
                 res['journal_id'] = default.id
         if 'reference' in fields_list:
-            res['reference'] = _("Manufacturing WIP - %(orders_list)s", orders_list=productions and format_list(self.env, productions.mapped('name')) or _("Manual Entry"))
+            res['reference'] = _("Manufacturing WIP - %(orders_list)s", orders_list=productions.mapped('name') or _("Manual Entry"))
         if 'mo_ids' in fields_list:
             res['mo_ids'] = [Command.set(productions.ids)]
         return res
@@ -100,7 +99,7 @@ class MrpAccountWipAccounting(models.TransientModel):
                 'account_id': self._get_overhead_account(),
             }),
             Command.create({
-                'label': _("Manufacturing WIP - %(orders_list)s", orders_list=productions and format_list(self.env, productions.mapped('name')) or _("Manual Entry")),
+                'label': _("Manufacturing WIP - %(orders_list)s", orders_list=productions.mapped('name') or _("Manual Entry")),
                 'debit': compo_value + overhead_value,
                 'account_id': self.env.company.account_production_wip_account_id.id,
             })

--- a/addons/pos_event/static/src/app/components/popup/event_configurator_popup/event_configurator_popup.js
+++ b/addons/pos_event/static/src/app/components/popup/event_configurator_popup/event_configurator_popup.js
@@ -32,13 +32,13 @@ export class EventConfiguratorPopup extends Component {
     }
     get dialogTitle() {
         const event = this.props.tickets[0].event_id;
-        let title = _t("Select tickets for %s", [event.name]);
-
         if (event.seats_limited) {
-            title += _t(" (%s seats available)", [event.seats_available]);
+            return _t("Select tickets for %(event)s (%(seats)s seats available)", {
+                event: event.name,
+                seats: event.seats_available,
+            });
         }
-
-        return title;
+        return _t("Select tickets for %(event)s", { event: event.name });
     }
     getTicketMaxQty(ticket) {
         const event = ticket.event_id;

--- a/addons/pos_hr/models/hr_employee.py
+++ b/addons/pos_hr/models/hr_employee.py
@@ -5,7 +5,6 @@ import hashlib
 
 from odoo import api, models, _
 from odoo.exceptions import UserError
-from odoo.tools import format_list
 
 
 class HrEmployee(models.Model):
@@ -73,6 +72,6 @@ class HrEmployee(models.Model):
             for employee in self:
                 config_ids = configs_with_all_employees | configs_with_specific_employees.filtered(lambda c: employee in c.basic_employee_ids)
                 if config_ids:
-                    error_msg += _("Employee: %(employee)s - PoS Config(s): %(config_list)s \n", employee=employee.name, config_list=format_list(self.env, config_ids.mapped("name")))
+                    error_msg += _("Employee: %(employee)s - PoS Config(s): %(config_list)s \n", employee=employee.name, config_list=config_ids.mapped("name"))
 
             raise UserError(error_msg)

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -7,7 +7,7 @@ from operator import itemgetter
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import ValidationError
 from odoo.osv import expression
-from odoo.tools import float_compare, format_list, groupby
+from odoo.tools import float_compare, groupby
 from odoo.tools.image import is_image_size_above
 from odoo.tools.misc import unique
 
@@ -217,9 +217,9 @@ class ProductProduct(models.Model):
         )
 
         duplicates_as_str = "\n".join(
-            _(
+            self.env._(
                 "- Barcode \"%(barcode)s\" already assigned to product(s): %(product_list)s",
-                barcode=barcode, product_list=format_list(self.env, duplicate_products._filtered_access('read').mapped('display_name')),
+                barcode=barcode, product_list=duplicate_products._filtered_access('read').mapped('display_name'),
             )
             for barcode, duplicate_products in products_by_barcode
         )

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -993,11 +993,10 @@ class ProjectTask(models.Model):
         if fields and (not check_group_user or self.env.user._is_portal()) and not self.env.su:
             unauthorized_fields = set(fields) - (self.SELF_READABLE_FIELDS if operation == 'read' else self.SELF_WRITABLE_FIELDS)
             if unauthorized_fields:
-                unauthorized_field_list = format_list(self.env, list(unauthorized_fields))
                 if operation == 'read':
-                    error_message = _('You cannot read the following fields on tasks: %(field_list)s', field_list=unauthorized_field_list)
+                    error_message = _('You cannot read the following fields on tasks: %(field_list)s', field_list=unauthorized_fields)
                 else:
-                    error_message = _('You cannot write on the following fields on tasks: %(field_list)s', field_list=unauthorized_field_list)
+                    error_message = _('You cannot write on the following fields on tasks: %(field_list)s', field_list=unauthorized_fields)
                 raise AccessError(error_message)
 
     def _has_field_access(self, field, operation):
@@ -1982,7 +1981,7 @@ class ProjectTask(models.Model):
         # as it is a computed field. personal_stage_type_ids behaves like a M2O from the point
         # of view of the user, we therefore use this field instead.
         if 'personal_stage_type_id' in groupby:
-            # limitation: problem when both personal_stage_type_id and personal_stage_type_ids 
+            # limitation: problem when both personal_stage_type_id and personal_stage_type_ids
             # appear in read_group, but this has no functional utility
             groupby = ['personal_stage_type_ids' if fname == 'personal_stage_type_id' else fname for fname in groupby]
             if order:

--- a/addons/project_mrp_account/models/stock_move.py
+++ b/addons/project_mrp_account/models/stock_move.py
@@ -2,7 +2,6 @@
 
 from odoo import _, models
 from odoo.exceptions import ValidationError
-from odoo.tools import format_list
 
 
 class StockMove(models.Model):
@@ -28,7 +27,7 @@ class StockMove(models.Model):
             if missing_plan_names:
                 raise ValidationError(_(
                     "'%(missing_plan_names)s' analytic plan(s) required on the project '%(project_name)s' linked to the manufacturing order.",
-                    missing_plan_names=format_list(self.env, missing_plan_names),
+                    missing_plan_names=missing_plan_names,
                     project_name=project.name,
                 ))
         return res

--- a/addons/project_stock_account/models/stock_move.py
+++ b/addons/project_stock_account/models/stock_move.py
@@ -3,7 +3,6 @@
 from odoo import _, models
 from odoo.exceptions import ValidationError
 from odoo.osv.expression import OR
-from odoo.tools import format_list
 
 
 class StockMove(models.Model):
@@ -41,7 +40,7 @@ class StockMove(models.Model):
             if missing_plan_names:
                 raise ValidationError(_(
                     "'%(missing_plan_names)s' analytic plan(s) required on the project '%(project_name)s' linked to the stock picking.",
-                    missing_plan_names=format_list(self.env, missing_plan_names),
+                    missing_plan_names=missing_plan_names,
                     project_name=project.name,
                 ))
         return res

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -10,7 +10,7 @@ from werkzeug.urls import url_encode
 
 from odoo import api, Command, fields, models, _
 from odoo.osv import expression
-from odoo.tools import format_amount, format_date, format_list, formatLang, groupby, SQL
+from odoo.tools import format_amount, format_date, formatLang, groupby, SQL
 from odoo.tools.float_utils import float_is_zero, float_repr
 from odoo.exceptions import UserError, ValidationError
 
@@ -557,7 +557,7 @@ class PurchaseOrder(models.Model):
     def button_cancel(self):
         purchase_orders_with_invoices = self.filtered(lambda po: any(i.state not in ('cancel', 'draft') for i in po.invoice_ids))
         if purchase_orders_with_invoices:
-            raise UserError(_("Unable to cancel purchase order(s): %s. You must first cancel their related vendor bills.", format_list(self.env, purchase_orders_with_invoices.mapped('display_name'))))
+            raise UserError(_("Unable to cancel purchase order(s): %s. You must first cancel their related vendor bills.", purchase_orders_with_invoices.mapped('display_name')))
         self.write({'state': 'cancel'})
 
     def button_lock(self):

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -6,7 +6,6 @@ from markupsafe import Markup
 from odoo import api, Command, fields, models, SUPERUSER_ID, _
 from odoo.tools.float_utils import float_compare, float_repr
 from odoo.exceptions import UserError
-from odoo.tools import format_list
 from odoo.tools.misc import OrderedSet
 
 
@@ -130,7 +129,7 @@ class PurchaseOrder(models.Model):
 
         purchase_orders_with_receipt = self.filtered(lambda po: any(move.state == 'done' for move in po.order_line.move_ids))
         if purchase_orders_with_receipt:
-            raise UserError(_("Unable to cancel purchase order(s): %s since they have receipts that are already done.", format_list(self.env, purchase_orders_with_receipt.mapped('display_name'))))
+            raise UserError(_("Unable to cancel purchase order(s): %s since they have receipts that are already done.", purchase_orders_with_receipt.mapped('display_name')))
         for order in self:
             # If the product is MTO, change the procure_method of the closest move to purchase to MTS.
             # The purpose is to link the po that the user will manually generate to the existing moves's chain.

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-from odoo.tools import float_round, format_list
+from odoo.tools import float_round
 
 from odoo.addons.base.models.res_partner import WARNING_HELP, WARNING_MESSAGE
 
@@ -203,7 +203,7 @@ class ProductTemplate(models.Model):
                 raise ValidationError(_(
                     "The product (%(product)s) has incompatible values: %(value_list)s",
                     product=val['name'],
-                    value_list=format_list(self.env, [field_descriptions[v] for v in incompatible_fields]),
+                    value_list=[field_descriptions[v] for v in incompatible_fields],
                 ))
 
     def get_single_product_variant(self):

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 
 from odoo import api, Command, fields, models, _
 from odoo.exceptions import AccessError, UserError
-from odoo.tools import format_list
 from odoo.tools.sql import column_exists, create_column
 
 

--- a/addons/sale_timesheet/models/hr_timesheet.py
+++ b/addons/sale_timesheet/models/hr_timesheet.py
@@ -4,7 +4,6 @@ from odoo.exceptions import UserError, ValidationError
 
 from odoo import api, fields, models, _
 from odoo.osv import expression
-from odoo.tools import format_list
 from odoo.tools.misc import unquote
 
 TIMESHEET_INVOICE_TYPES = [
@@ -231,7 +230,7 @@ class AccountAnalyticLine(models.Model):
         if missing_plan_names:
             raise ValidationError(_(
                 "'%(missing_plan_names)s' analytic plan(s) required on the analytic distribution of the sale order item '%(so_line_name)s' linked to the timesheet.",
-                missing_plan_names=format_list(self.env, missing_plan_names),
+                missing_plan_names=missing_plan_names,
                 so_line_name=so_line.name,
             ))
 

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -7,7 +7,7 @@ from odoo import _, api, fields, tools, models, Command
 from odoo.addons.web.controllers.utils import clean_action
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
-from odoo.tools import OrderedSet, format_list, groupby
+from odoo.tools import OrderedSet, groupby
 from odoo.tools.float_utils import float_compare, float_is_zero, float_round
 
 
@@ -215,7 +215,7 @@ class StockMoveLine(models.Model):
                             message = _(
                                 'Serial number (%(serial_number)s) already exists in location(s): %(location_list)s. Please correct the serial number encoded.',
                                 serial_number=self.lot_name,
-                                location_list=format_list(self.env, quants.location_id.mapped('display_name'))
+                                location_list=quants.location_id.mapped('display_name')
                             )
                 elif self.lot_id:
                     counter = Counter([line.lot_id.id for line in move_lines_to_check])

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -12,7 +12,7 @@ from odoo.addons.stock.models.stock_move import PROCUREMENT_PRIORITIES
 from odoo.addons.web.controllers.utils import clean_action
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
-from odoo.tools import format_datetime, format_date, format_list, groupby, SQL
+from odoo.tools import format_datetime, format_date, groupby, SQL
 from odoo.tools.float_utils import float_compare, float_is_zero
 
 
@@ -1401,8 +1401,8 @@ class StockPicking(models.Model):
             if pickings_without_lots:
                 message += _(
                     '\n\nTransfers %(transfer_list)s: You need to supply a Lot/Serial number for products %(product_list)s.',
-                    transfer_list=format_list(self.env, pickings_without_lots.mapped('name')),
-                    product_list=format_list(self.env, products_without_lots.mapped('display_name')),
+                    transfer_list=pickings_without_lots.mapped('name'),
+                    product_list=products_without_lots.mapped('display_name'),
                 )
             if message:
                 raise UserError(message.lstrip())

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -12,7 +12,7 @@ from odoo import _, api, fields, models, SUPERUSER_ID
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
 from odoo.osv import expression
-from odoo.tools import SQL, check_barcode_encoding, format_list, groupby
+from odoo.tools import SQL, check_barcode_encoding, groupby
 from odoo.tools.float_utils import float_compare, float_is_zero
 
 _logger = logging.getLogger(__name__)
@@ -1469,7 +1469,7 @@ class StockQuant(models.Model):
                                 'before its corresponding receipt operation is validated. In this case the issue will be solved '
                                 'automatically once all steps are completed. Otherwise, the serial number should be corrected to '
                                 'prevent inconsistent data.',
-                                serial_number=lot_id.name, location_list=format_list(self.env, sn_locations.mapped('display_name')))
+                                serial_number=lot_id.name, location_list=sn_locations.mapped('display_name'))
 
                 elif source_location_id and source_location_id not in sn_locations:
                     # using an existing SN in the wrong location
@@ -1489,14 +1489,14 @@ class StockQuant(models.Model):
                                     'Source location for this move will be changed to %(recommended_location)s',
                                     serial_number=lot_id.name,
                                     source_location=source_location_id.display_name,
-                                    other_locations=format_list(self.env, sn_locations.mapped('display_name')),
+                                    other_locations=sn_locations.mapped('display_name'),
                                     recommended_location=recommended_location.display_name)
                     else:
                         message = _('Serial number (%(serial_number)s) is not located in %(source_location)s, but is located in location(s): %(other_locations)s.\n\n'
                                     'Please correct this to prevent inconsistent data.',
                                     serial_number=lot_id.name,
                                     source_location=source_location_id.display_name,
-                                    other_locations=format_list(self.env, sn_locations.mapped('display_name')))
+                                    other_locations=sn_locations.mapped('display_name'))
                         recommended_location = None
         return message, recommended_location
 

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -5,7 +5,6 @@ from collections import namedtuple
 
 from odoo import api, fields, models
 from odoo.exceptions import UserError, RedirectWarning
-from odoo.tools import format_list
 from odoo.tools.translate import _, LazyTranslate
 
 _lt = LazyTranslate(__name__)
@@ -246,7 +245,7 @@ class StockWarehouse(models.Model):
                 if move_ids:
                     raise UserError(_(
                         'You still have ongoing operations for operation types %(operations)s in warehouse %(warehouse)s',
-                        operations=format_list(self.env, move_ids.mapped('picking_type_id.name')),
+                        operations=move_ids.mapped('picking_type_id.name'),
                         warehouse=warehouse.name,
                     ))
                 else:
@@ -260,7 +259,7 @@ class StockWarehouse(models.Model):
                 if picking_type_using_locations:
                     raise UserError(_(
                         '%(operations)s have default source or destination locations within warehouse %(warehouse)s, therefore you cannot archive it.',
-                        operations=format_list(self.env, picking_type_using_locations.mapped('name')),
+                        operations=picking_type_using_locations.mapped('name'),
                         warehouse=warehouse.name,
                     ))
                 warehouse.view_location_id.write({'active': vals['active']})

--- a/addons/stock_account/wizard/stock_valuation_layer_revaluation.py
+++ b/addons/stock_account/wizard/stock_valuation_layer_revaluation.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools import float_compare, float_is_zero, format_list
+from odoo.tools import float_compare, float_is_zero
 
 
 class StockValuationLayerRevaluation(models.TransientModel):
@@ -206,7 +206,7 @@ class StockValuationLayerRevaluation(models.TransientModel):
 
         if self.adjusted_layer_ids:
             adjusted_layer_descriptions = [f"{layer.reference} (id: {layer.id})" for layer in self.adjusted_layer_ids]
-            move_description += _("\nAffected valuation layers: %s", format_list(self.env, adjusted_layer_descriptions))
+            move_description += _("\nAffected valuation layers: %s", adjusted_layer_descriptions)
 
         move_vals = [{
             'journal_id': self.account_journal_id.id or accounts['stock_journal'].id,

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -6,7 +6,7 @@ from markupsafe import Markup
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.osv.expression import AND
-from odoo.tools import float_is_zero, format_list
+from odoo.tools import float_is_zero
 
 
 class StockPickingBatch(models.Model):
@@ -316,7 +316,7 @@ class StockPickingBatch(models.Model):
                     "Please check their states and operation types.\n\n"
                     "Incompatibilities: %(incompatible_transfers)s",
                     batch=batch.name,
-                    incompatible_transfers=format_list(self.env, erroneous_pickings.mapped('name'))))
+                    incompatible_transfers=erroneous_pickings.mapped('name')))
 
     def _track_subtype(self, init_values):
         if 'state' in init_values:

--- a/addons/web/static/src/core/l10n/translation.js
+++ b/addons/web/static/src/core/l10n/translation.js
@@ -1,5 +1,7 @@
 import { markup } from "@odoo/owl";
 
+import { formatList } from "@web/core/l10n/utils";
+import { isIterable } from "@web/core/utils/arrays";
 import { Deferred } from "@web/core/utils/concurrency";
 import { htmlEscape } from "@web/core/utils/html";
 import { sprintf } from "@web/core/utils/strings";
@@ -22,6 +24,10 @@ const Markup = markup().constructor;
  * map its entries to keyworded placeholders (%(kw_placeholder)s) for
  * replacement.
  *
+ * If one or more of the extra arguments are iterables, they will be turned
+ * into language-specific formatted strings representing the elements of the
+ * list.
+ *
  * If at least one of the extra arguments is a markup, the translation and
  * non-markup content are escaped, and the result is wrapped in a markup.
  *
@@ -30,6 +36,7 @@ const Markup = markup().constructor;
  * _t("Good morning %s", user.name); // "Bonjour Marc"
  * _t("Good morning %(newcomer)s, goodbye %(departer)s", { newcomer: Marc, departer: Mitchel }); // Bonjour Marc, au revoir Mitchel
  * _t("I love %s", markup("<blink>Minecraft</blink>")); // Markup {"J'adore <blink>Minecraft</blink>"}
+ * _t("Good morning %s!", ["Mitchell", "Marc", "Louis"]); // Bonjour Mitchell, Marc et Louis !
  *
  * @param {string} term
  * @returns {string|Markup|LazyTranslatedString}
@@ -40,7 +47,7 @@ export function _t(term, ...values) {
         if (values.length === 0) {
             return translation;
         }
-        return _safeSprintf(translation, ...values);
+        return _safeFormatAndSprintf(translation, ...values);
     } else {
         return new LazyTranslatedString(term, values);
     }
@@ -58,7 +65,7 @@ class LazyTranslatedString extends String {
             if (this.values.length === 0) {
                 return translation;
             }
-            return _safeSprintf(translation, ...this.values);
+            return _safeFormatAndSprintf(translation, ...this.values);
         } else {
             throw new Error(`translation error`);
         }
@@ -102,20 +109,31 @@ export async function loadLanguages(orm) {
 }
 
 /**
- * Same behavior as sprintf, but if any of the provided values is a markup,
- * escapes all non-markup content before performing the interpolation, then
- * wraps the result in a markup.
+ * Same behavior as sprintf, but doing two additional things:
+ * - If any of the provided values is an iterable, it will format its items
+ *   as a language-specific formatted string representing the elements of the
+ *   list.
+ * - If any of the provided values is a markup, it will escape all non-markup
+ *   content before performing the interpolation, then wraps the result in a
+ *   markup.
  *
  * @param {string} str The string with placeholders (%s) to insert values into.
  * @param  {...any} values Primitive values to insert in place of placeholders.
  * @returns {string|Markup}
  */
-function _safeSprintf(str, ...values) {
-    let hasMarkup;
+function _safeFormatAndSprintf(str, ...values) {
+    let hasMarkup = false;
+    let valuesObject = values;
     if (values.length === 1 && Object.prototype.toString.call(values[0]) === "[object Object]") {
-        hasMarkup = Object.values(values[0]).some((v) => v instanceof Markup);
-    } else {
-        hasMarkup = values.some((v) => v instanceof Markup);
+        valuesObject = values[0];
+    }
+    for (const [key, value] of Object.entries(valuesObject)) {
+        // The `!(value instanceof String)` check is to prevent interpreting `Markup` and `LazyTranslatedString`
+        // objects as iterables, since they are both subclasses of `String`.
+        if (isIterable(value) && !(value instanceof String)) {
+            valuesObject[key] = formatList(value);
+        }
+        hasMarkup ||= value instanceof Markup;
     }
     if (hasMarkup) {
         return markup(sprintf(htmlEscape(str), ..._escapeNonMarkup(values)));

--- a/addons/web/static/src/core/l10n/utils/format_list.js
+++ b/addons/web/static/src/core/l10n/utils/format_list.js
@@ -71,5 +71,5 @@ const LIST_STYLES = {
 export function formatList(list, { localeCode = "", style = "standard" } = {}) {
     const locale = localeCode || user.lang || "en-US";
     const formatter = new Intl.ListFormat(locale, LIST_STYLES[style]);
-    return formatter.format(list);
+    return formatter.format(Array.from(list, String));
 }

--- a/addons/web/static/src/webclient/settings_form_view/widgets/res_config_invite_users.js
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/res_config_invite_users.js
@@ -1,6 +1,5 @@
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
-import { formatList } from "@web/core/l10n/utils";
 import { unique } from "@web/core/utils/arrays";
 import { useService } from "@web/core/utils/hooks";
 
@@ -67,12 +66,12 @@ class ResConfigInviteUsers extends Component {
                             address: invalidEmails[0],
                         });
                     case 2:
-                        return _t("Invalid email addresses: %(2 addresses)s", {
-                            "2 addresses": formatList(invalidEmails),
+                        return _t("Invalid email addresses: %(two_addresses)s", {
+                            two_addresses: invalidEmails,
                         });
                     default:
                         return _t("Invalid email addresses: %(addresses)s", {
-                            addresses: formatList(invalidEmails),
+                            addresses: invalidEmails,
                         });
                 }
             })();

--- a/addons/web/static/tests/core/l10n/translation.test.js
+++ b/addons/web/static/tests/core/l10n/translation.test.js
@@ -151,6 +151,18 @@ test("_t fills the format specifiers in translated terms with its extra argument
     expect(translatedStr).toBe("Échéance dans 513 jours");
 });
 
+test("_t fills the format specifiers in translated terms with formatted lists", async () => {
+    patchTranslations({
+        "Due in %s days": "Échéance dans %s jours",
+        "Due in %(due_dates)s days for %(user)s": "Échéance dans %(due_dates)s jours pour %(user)s",
+    });
+    await mockLang("fr_FR");
+    const translatedStr1 = _t("Due in %s days", ["30", "60", "90"]);
+    const translatedStr2 = _t("Due in %(due_dates)s days for %(user)s", {due_dates: ["30", "60", "90"], user: "Mitchell"});
+    expect(translatedStr1).toBe("Échéance dans 30, 60 et 90 jours");
+    expect(translatedStr2).toBe("Échéance dans 30, 60 et 90 jours pour Mitchell");
+});
+
 test("_t fills the format specifiers in lazy translated terms with its extra arguments", async () => {
     translatedTerms[translationLoaded] = false;
     const translatedStr = _t("Due in %s days", 513);

--- a/addons/web_hierarchy/models/ir_ui_view.py
+++ b/addons/web_hierarchy/models/ir_ui_view.py
@@ -3,7 +3,6 @@
 from lxml import etree
 
 from odoo import fields, models, _
-from odoo.tools import format_list
 
 HIERARCHY_VALID_ATTRIBUTES = {
     '__validate__',                     # ir.ui.view implementation detail
@@ -49,8 +48,8 @@ class IrUiView(models.Model):
         if remaining:
             msg = _(
                 "Invalid attributes (%(invalid_attributes)s) in hierarchy view. Attributes must be in (%(valid_attributes)s)",
-                invalid_attributes=format_list(self.env, remaining),
-                valid_attributes=format_list(self.env, HIERARCHY_VALID_ATTRIBUTES),
+                invalid_attributes=remaining,
+                valid_attributes=HIERARCHY_VALID_ATTRIBUTES,
             )
             self._raise_view_error(msg, node)
 

--- a/addons/website_slides_survey/models/survey_survey.py
+++ b/addons/website_slides_survey/models/survey_survey.py
@@ -5,7 +5,6 @@ import ast
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
-from odoo.tools import format_list
 
 
 class SurveySurvey(models.Model):
@@ -36,7 +35,7 @@ class SurveySurvey(models.Model):
                 _(
                     "- %(certification)s (Courses - %(courses)s)",
                     certification=certi.title,
-                    courses=format_list(self.env, certi.slide_channel_ids.mapped("name")),
+                    courses=certi.slide_channel_ids.mapped("name"),
                 )
                 for certi in certifications
             ]

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -15,7 +15,7 @@ from psycopg2.extras import Json
 from odoo import api, fields, models, tools, Command
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.osv import expression
-from odoo.tools import format_list, lazy_property, split_every, sql, unique, OrderedSet, SQL
+from odoo.tools import lazy_property, split_every, sql, unique, OrderedSet, SQL
 from odoo.tools.safe_eval import safe_eval, datetime, dateutil, time
 from odoo.tools.translate import _, LazyTranslate
 
@@ -921,7 +921,7 @@ class IrModelFields(models.Model):
             if not uninstalling:
                 raise UserError(_(
                     "Cannot rename/delete fields that are still present in views:\nFields: %(fields)s\nView: %(view)s",
-                    fields=format_list(self.env, [str(f) for f in fields]),
+                    fields=fields,
                     view=view.name,
                 ))
             else:

--- a/odoo/addons/test_translation_import/tests/test_term_count.py
+++ b/odoo/addons/test_translation_import/tests/test_term_count.py
@@ -218,6 +218,13 @@ class TestImport(common.TransactionCase):
             "Translation placeholders were not applied"
         )
 
+        # correctly format lists
+        self.assertEqual(
+            model_fr_BE.get_code_placeholder_translation(["1", "2", "3"]),
+            "Code, 1, 2 et 3, Français, Belgium",
+            "Translation placeholders were not applied"
+        )
+
         # source error: wrong arguments
         with self.assertRaises(TypeError):
             model_fr_BE.get_code_placeholder_translation(1, "🧀")
@@ -226,6 +233,13 @@ class TestImport(common.TransactionCase):
         self.assertEqual(
             model_fr_BE.get_code_named_placeholder_translation(num=2, symbol="🧀"),
             "Code, 2, 🧀, Français, Belgium",
+            "Translation placeholders were not applied"
+        )
+
+        # correctly format lists
+        self.assertEqual(
+            model_fr_BE.get_code_named_placeholder_translation(num=2, symbol=["1", "2", "3"]),
+            "Code, 2, 1, 2 et 3, Français, Belgium",
             "Translation placeholders were not applied"
         )
 

--- a/odoo/tools/i18n.py
+++ b/odoo/tools/i18n.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Literal, Optional, Sequence
+from typing import TYPE_CHECKING, Literal
 
 from babel import lists
 
 from odoo.tools.misc import babel_locale_parse, get_lang
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     import odoo.api
 
 XPG_LOCALE_RE = re.compile(
@@ -23,9 +24,9 @@ XPG_LOCALE_RE = re.compile(
 
 def format_list(
     env: odoo.api.Environment,
-    lst: Sequence[str],
+    lst: Iterable,
     style: Literal["standard", "standard-short", "or", "or-short", "unit", "unit-short", "unit-narrow"] = "standard",
-    lang_code: Optional[str] = None,
+    lang_code: str | None = None,
 ) -> str:
     """
     Format the items in `lst` as a list in a locale-dependent manner with the chosen style.
@@ -56,7 +57,7 @@ def format_list(
     See https://www.unicode.org/reports/tr35/tr35-49/tr35-general.html#ListPatterns for more details.
 
     :param env: the current environment.
-    :param lst: the sequence of items to format into a list.
+    :param lst: the iterable of items to format into a list.
     :param style: the style to format the list with.
     :param lang_code: the locale (i.e. en_US).
     :return: the formatted list.
@@ -65,7 +66,7 @@ def format_list(
     # Some styles could be unavailable for the chosen locale
     if style not in locale.list_patterns:
         style = "standard"
-    return lists.format_list(lst, style, locale)
+    return lists.format_list([str(el) for el in lst], style, locale)
 
 
 def py_to_js_locale(locale: str) -> str:


### PR DESCRIPTION
To localize a list of items in a translated string, you can use the functions `format_list()` (Python) or `formatList()` (Javascript) and pass the result of this call as argument to your translation function.

However, users would need to import the function each time, call it on lists and pass the `env` (for Python). This can be cumbersome.

In order to ease the default case, we now allow users to directly pass an iterable as argument to the translation functions. This argument would then automatically be correctly formatted using the above functions.

If users don't want to use the default list formatting, they can still manually preprocess the value with their preferred options of course.

[task-4533664](https://www.odoo.com/odoo/project.task/4533664)

Related to https://github.com/odoo/enterprise/pull/79302