### PR TITLE
[PERF] stock_account: replace filtered with a search for product moves

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -215,8 +215,12 @@ class AccountMove(models.Model):
 
                 if product_interim_account.reconcile:
                     # Search for anglo-saxon lines linked to the product in the journal entry.
-                    product_account_moves = move.line_ids.filtered(
-                        lambda line: line.product_id == prod and line.account_id == product_interim_account and not line.reconciled)
+                    product_account_moves = self.env['account.move.line'].search([
+                        ('id', 'in', move.line_ids.ids),
+                        ('product_id', '=', prod.id),
+                        ('account_id', '=', product_interim_account.id),
+                        ('reconciled', '=', False),
+                    ])
 
                     # Search for anglo-saxon lines linked to the product in the stock moves.
                     product_stock_moves = stock_moves._get_all_related_sm(prod)


### PR DESCRIPTION
Issue -->

For large recordsets, filtered can perform less optimally. We can observe its effects when `product_account_moves` is decently sized. As a result, the outer loop, for a large `self` recordset, the method `_stock_account_anglo_saxon_reconcile_valuation` can become a bottleneck in an incoming trasnfer validation process.

Solution -->

Replace the filtered call with a search call with an equivalent domain to return the same recordset. This causes SELECT queries to fetch necessary rows from the backend.

Benchmarks --> TBD

opw-4515905


