### PR TITLE
[FIX] l10n_id: qris access rights

### DIFF
--- a/addons/l10n_id/models/res_bank.py
+++ b/addons/l10n_id/models/res_bank.py
@@ -44,7 +44,7 @@ class ResBank(models.Model):
                 return _("You cannot generate a QRIS QR code with a bank account that is not in Indonesia.")
             if currency.name not in ['IDR']:
                 return _("You cannot generate a QRIS QR code with a currency other than IDR")
-            if not (self.l10n_id_qris_api_key and self.l10n_id_qris_mid):
+            if not (self.sudo().l10n_id_qris_api_key and self.sudo().l10n_id_qris_mid):
                 return _("To use QRIS QR code, Please setup the QRIS API Key and Merchant ID on the bank's configuration")
             return None
 


### PR DESCRIPTION
Problem: When a non-admin user tries to send an invoice by email or print an invoice report, an access error is thrown because the fields l10n_id_qris_api_key and l10n_id_qris_mid are locked behind the Admin/Settings group.

Purpose: Non-admin users should be able to send and print invoices regardless of their admin rights. Apply sudo when accessing those specific fields.

Steps to reproduce on Runbot:
ADMIN
1. Install Contacts, Accounting, l10n_id
2. Enable QR Codes in Settings > Accounting
3. Give Marc Demo basic accounting and bank rights, but no admin rights

MARC DEMO
1. Switch to ID Company
2. Create and confirm invoice
3. Attempt to send and/or print invoice
4. Access Error is thrown

opw-4529074

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
