### PR TITLE
[FIX] website: fixed duplicate attachments issue

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -288,7 +288,10 @@ export class Form extends Interaction {
         // Prepare form inputs
         const formFields = [];
         new FormData(this.el).forEach((value, key) => {
-            formFields.push({ name: key, value: value });
+            const inputElement = this.el.querySelector(`[name="${CSS.escape(key)}"]`);
+            if (inputElement && inputElement.type !== 'file') {
+                formFields.push({ name: key, value: value });
+            }
         });
         let outerIndex = 0;
         for (const inputEl of this.el.querySelectorAll("input[type=file]:not([disabled])")) {


### PR DESCRIPTION
steps:
- install website_hr_recruitment
- go to `/jobs`
- apply to any job, with a resume attachment
- open recruitment (find newly added applicant. with duplicate attachments)

description:
- while sending attachments through website, the attachments are being duplicated

cause:
- currently, the form data (including the attachments) are being processed and the attachments are being processed again, separately.

fix:
- processed normal fields and attachment fields separately.

task-4570060