### PR TITLE
[FIX] point_of_sale: prevent error when reopening a POS session

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -9026,6 +9026,12 @@ msgstr ""
 
 #. module: point_of_sale
 #. odoo-python
+#: code:addons/point_of_sale/models/ir_sequence.py:0
+msgid "You cannot delete a sequence used in an active session: %s"
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-python
 #: code:addons/point_of_sale/models/pos_preset.py:0
 msgid "You cannot delete a preset that is linked to a POS configuration."
 msgstr ""

--- a/addons/point_of_sale/models/__init__.py
+++ b/addons/point_of_sale/models/__init__.py
@@ -51,3 +51,4 @@ from . import pos_preset
 from . import product_tag
 from . import resource_calendar_attendance
 from . import product_uom
+from . import ir_sequence

--- a/addons/point_of_sale/models/ir_sequence.py
+++ b/addons/point_of_sale/models/ir_sequence.py
@@ -1,0 +1,16 @@
+from odoo import api, models, _
+from odoo.exceptions import UserError
+
+
+class IrSequence(models.Model):
+    _inherit = 'ir.sequence'
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_sequence(self):
+        sessions = self.env['pos.session'].search(domain=['|', ('login_number_seq_id', 'in', self.ids), ('order_seq_id', 'in', self.ids)])
+        acive_sessions = sessions.filtered(lambda s: s.state != 'closed')
+        if acive_sessions:
+            raise UserError(_(
+                "You cannot delete a sequence used in an active session: %s",
+                acive_sessions.login_number_seq_id.mapped('name')
+            ))

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -416,8 +416,10 @@ class PosSession(models.Model):
 
     def unlink(self):
         self.statement_line_ids.unlink()
-        (self.order_seq_id | self.login_number_seq_id).unlink()
-        return super(PosSession, self).unlink()
+        sequences_to_unlink = (self.order_seq_id | self.login_number_seq_id)
+        result = super().unlink()
+        sequences_to_unlink.unlink()
+        return result
 
     def login(self):
         self.ensure_one()


### PR DESCRIPTION
Currently, an error occurs on reopening a POS session if its 'Login Number Sequence' record has been deleted. This results in preventing the user from accessing the session.

**Steps to produce:**
- Install the `point_of_sale` module (with demo data).
- Open the register of the **Furniture Shop** from the POS dashboard.
- Now, without closing the register of shop, Navigate to:
 `Settings > Technical > Sequences & Identifiers > Sequences (list)`.
- Delete the `Login Number Sequence of Session 3` sequence record.
- Reopen that shop session again.
- Observe the error at the backend.

**Error:**
```
UndefinedFunction
operator does not exist: integer = boolean
LINE 1: SELECT number_next FROM ir_sequence WHERE id=false FOR UPDAT...
                                                    ^
HINT:  No operator matches the given name and argument types. You might need
to add explicit type casts.
```

The error occurs because the system attempts to access the `login_number_seq_id` of the POS session at [1], but it is unavailable as the user has already deleted it.

This commit adds validation to prevent deletion of the 'Login Number Sequence' if the associated POS session is not closed.

[1] - https://github.com/odoo/odoo/blob/948f6c5afdf76b9a25daa120fec1edd21c5c08d6/addons/point_of_sale/models/pos_session.py#L404-L406

Sentry-6276299189


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
