### PR TITLE
[FIX] website_sale_collect: skip if radio null

### DIFF
--- a/addons/website_sale_collect/static/src/js/checkout.js
+++ b/addons/website_sale_collect/static/src/js/checkout.js
@@ -51,11 +51,14 @@ publicWidget.registry.WebsiteSaleCheckout.include({
         }
         // TODO: move logic below to `_isDeliveryMethodReady` override on master
         const checkedRadio = this.el.querySelector('input[name="o_delivery_radio"]:checked');
-        const deliveryContainer = this._getDeliveryMethodContainer(checkedRadio);
-        const hasWarning = (
-            checkedRadio.dataset.deliveryType === 'in_store'
-            && deliveryContainer.querySelector('[name="unavailable_products_warning"]')
-        );
+        let hasWarning = false;
+        if (checkedRadio) {
+            const deliveryContainer = this._getDeliveryMethodContainer(checkedRadio);
+            hasWarning = (
+                checkedRadio.dataset.deliveryType === 'in_store'
+                && deliveryContainer.querySelector('[name="unavailable_products_warning"]')
+            );
+        }
         return this._super.apply(this, arguments) && !hasWarning;
     },
 


### PR DESCRIPTION
Steps to reproduce:
1) Install Click & Collect
2) Configure a standard delivery to deliver only to Belgium and publish
3) Unpublish the others
4) Go to /shop page add a storable product
5) Proceed to /checkout add two addresses one with US country, the other
  with Belgium
6) Try to click on US partner then on Belgium then again on US
7) Observe traceback

After this commit we skip the check in _canEnableMainButton if a radio element is not found.

