### PR TITLE
[IMP] l10n_in: set 'Production Environment' field to True by default

### DIFF
--- a/addons/l10n_in/demo/account_demo.py
+++ b/addons/l10n_in/demo/account_demo.py
@@ -23,6 +23,7 @@ class AccountChartTemplate(models.AbstractModel):
                     'l10n_in_is_gst_registered': True,
                     'l10n_in_tcs_feature': True,
                     'l10n_in_tds_feature': True,
+                    'l10n_in_edi_production_env': False,
                 })
                 demo_data = {
                     'res.partner.category': self._get_demo_data_res_partner_category(company),

--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -24,6 +24,7 @@ class ResCompany(models.Model):
         string="Indian Production Environment",
         help="Enable the use of production credentials",
         groups="base.group_system",
+        default=True,
     )
     l10n_in_pan = fields.Char(
         string="PAN",

--- a/addons/l10n_in/models/iap_account.py
+++ b/addons/l10n_in/models/iap_account.py
@@ -4,6 +4,7 @@ from odoo.addons.iap import jsonrpc
 DEFAULT_IAP_ENDPOINT = "https://l10n-in-edi.api.odoo.com"
 DEFAULT_IAP_TEST_ENDPOINT = "https://l10n-in-edi-demo.api.odoo.com"
 IAP_SERVICE_NAME = 'l10n_in_edi'
+TEST_GST_NUMBER = '24DUMMY1234AAZA'
 
 
 class IapAccount(models.Model):
@@ -16,10 +17,10 @@ class IapAccount(models.Model):
             "dbuuid": self.env["ir.config_parameter"].sudo().get_param("database.uuid"),
             "account_token": user_token.account_token,
         })
-        if is_production:
-            default_endpoint = DEFAULT_IAP_ENDPOINT
-        else:
+        if params.get('gstin') == TEST_GST_NUMBER:
             default_endpoint = DEFAULT_IAP_TEST_ENDPOINT
+        else:
+            default_endpoint = DEFAULT_IAP_ENDPOINT if is_production else DEFAULT_IAP_TEST_ENDPOINT
         endpoint = self.env["ir.config_parameter"].sudo().get_param(config_parameter, default_endpoint)
         url = "%s%s" % (endpoint, url_path)
         return jsonrpc(url, params=params, timeout=timeout)

--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -97,6 +97,7 @@ class ResPartner(models.Model):
         is_production = self.env.company.sudo().l10n_in_edi_production_env
         params = {
             "gstin_to_search": self.vat,
+            "gstin": self.env.company.vat,
         }
         try:
             response = self.env['iap.account']._l10n_in_connect_to_server(

--- a/addons/l10n_in/views/res_config_settings_views.xml
+++ b/addons/l10n_in/views/res_config_settings_views.xml
@@ -42,7 +42,8 @@
                             <setting name="india_production_setting"
                                      company_dependent="1"
                                      string="Production Environment"
-                                     help="Activate this to start using Indian services in the production environment.">
+                                     help="Activate this to start using Indian services in the production environment."
+                                     groups="base.group_no_one">
                                 <field name="l10n_in_edi_production_env"/>
                                 <div class='mt8'
                                     invisible="not l10n_in_edi_production_env or (not module_l10n_in_edi and not l10n_in_gstin_status_feature and not module_l10n_in_ewaybill and not l10n_in_gst_efiling_feature)">


### PR DESCRIPTION
With this commit,the default value of the 'Production Environment' field is now
set to True to prevent users from mistakenly using test credentials instead of
production settings.

Additionally, the system will determine the environment based on the GST Number.
The specific GST Number '24DUMMY1234AAZA' will be used to identify the test
environment.

task-4574504
