### PR TITLE
[FIX] web: isObject should validate basic objects

### DIFF
--- a/addons/web/static/src/core/l10n/translation.js
+++ b/addons/web/static/src/core/l10n/translation.js
@@ -4,6 +4,7 @@ import { formatList } from "@web/core/l10n/utils";
 import { isIterable } from "@web/core/utils/arrays";
 import { Deferred } from "@web/core/utils/concurrency";
 import { htmlEscape } from "@web/core/utils/html";
+import { isObject } from "@web/core/utils/objects";
 import { sprintf } from "@web/core/utils/strings";
 
 export const translationLoaded = Symbol("translationLoaded");
@@ -124,7 +125,7 @@ export async function loadLanguages(orm) {
 function _safeFormatAndSprintf(str, ...values) {
     let hasMarkup = false;
     let valuesObject = values;
-    if (values.length === 1 && Object.prototype.toString.call(values[0]) === "[object Object]") {
+    if (values.length === 1 && isObject(values[0])) {
         valuesObject = values[0];
     }
     for (const [key, value] of Object.entries(valuesObject)) {
@@ -149,7 +150,7 @@ function _safeFormatAndSprintf(str, ...values) {
  * @returns {any[]|[Object]}
  */
 function _escapeNonMarkup(values) {
-    if (Object.prototype.toString.call(values[0]) === "[object Object]") {
+    if (isObject(values[0])) {
         const sanitized = {};
         for (const [key, value] of Object.entries(values[0])) {
             sanitized[key] = htmlEscape(value);

--- a/addons/web/static/src/core/utils/objects.js
+++ b/addons/web/static/src/core/utils/objects.js
@@ -7,7 +7,7 @@
  * @param {(a: T[keyof T], b: T[keyof T]) => boolean} [comparisonFn]
  */
 export function shallowEqual(obj1, obj2, comparisonFn = (a, b) => a === b) {
-    if (!isObject(obj1) || !isObject(obj2)) {
+    if (obj1 !== Object(obj1) || obj2 !== Object(obj2)) {
         return obj1 === obj2;
     }
     const obj1Keys = Reflect.ownKeys(obj1);
@@ -39,10 +39,25 @@ export function deepCopy(object) {
 }
 
 /**
- * @param {unknown} object
+ * Returns whether the given value is an object, i.e. an instance of the `Object`
+ * class or of one of its direct subclass.
+ *
+ * Note: this may wrongly validate any object implementing a modified `toString`
+ * explicitly returning `"[object Object]"`.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ * @example
+ *  // true
+ *  isObject({ a: 1 });
+ *  isObject(Object.create(null));
+ * @example
+ *  // false
+ *  isObject([1, 2, 3]);
+ *  isObject(new Map([["a", 1]]));
  */
-export function isObject(object) {
-    return !!object && (typeof object === "object" || typeof object === "function");
+export function isObject(value) {
+    return Object.prototype.toString.call(value) === "[object Object]";
 }
 
 /**

--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -1,3 +1,5 @@
+import { isObject } from "./objects";
+
 export const nbsp = "\u00a0";
 
 /**
@@ -96,7 +98,7 @@ export function intersperse(str, indices, separator = "") {
  * @returns {string}
  */
 export function sprintf(s, ...values) {
-    if (values.length === 1 && Object.prototype.toString.call(values[0]) === "[object Object]") {
+    if (values.length === 1 && isObject(values[0])) {
         const valuesDict = values[0];
         s = s.replace(/%\(([^)]+)\)s/g, (match, value) => valuesDict[value]);
     } else if (values.length > 0) {
@@ -328,7 +330,8 @@ export function unaccent(str, caseSensitive) {
  */
 export function isEmail(value) {
     // http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
-    const re = /^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
+    const re =
+        /^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
     return re.test(value);
 }
 

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -514,7 +514,7 @@ const isValidFieldValue = (record, fieldDef) => {
             return Number.isInteger(value);
         }
         case "json":
-            return typeof value === "string" || isObject(value);
+            return typeof value === "string" || Array.isArray(value) || isObject(value);
         case "many2many":
         case "one2many": {
             return (

--- a/addons/web/static/tests/_framework/mock_server/mock_server.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_server.js
@@ -163,7 +163,7 @@ const ensureError = (error) => (error instanceof Error ? error : new Error(error
 const getAssignAction = (options) => {
     const shouldAdd = options?.mode === "add";
     return function assign(target, key, value) {
-        if (shouldAdd && isObject(target[key])) {
+        if (shouldAdd && target[key] === Object(target[key])) {
             // Add value
             if (Array.isArray(target[key])) {
                 target[key].push(...value);

--- a/addons/web/static/tests/core/utils/objects.test.js
+++ b/addons/web/static/tests/core/utils/objects.test.js
@@ -3,11 +3,11 @@ import { describe, expect, test } from "@odoo/hoot";
 import {
     deepCopy,
     deepEqual,
+    deepMerge,
     isObject,
     omit,
     pick,
     shallowEqual,
-    deepMerge,
 } from "@web/core/utils/objects";
 
 describe.current.tags("headless");
@@ -98,16 +98,20 @@ test("isObject", () => {
     expect(isObject(10)).toBe(false);
     expect(isObject(10.01)).toBe(false);
 
-    expect(isObject([])).toBe(true);
-    expect(isObject([1, 2])).toBe(true);
+    expect(isObject([])).toBe(false);
+    expect(isObject([1, 2])).toBe(false);
+
+    expect(isObject(() => {})).toBe(false);
+    expect(isObject(new Set())).toBe(false);
+    expect(isObject(new Map())).toBe(false);
+    expect(isObject(new Date())).toBe(false);
+    expect(isObject(document.body)).toBe(false);
+    expect(isObject(new (class AAA extends Array {})())).toBe(false);
 
     expect(isObject({})).toBe(true);
     expect(isObject({ a: 1 })).toBe(true);
-
-    expect(isObject(() => {})).toBe(true);
-    expect(isObject(new Set())).toBe(true);
-    expect(isObject(new Map())).toBe(true);
-    expect(isObject(new Date())).toBe(true);
+    expect(isObject(Object.create(null))).toBe(true);
+    expect(isObject(new (class AAA {})())).toBe(true);
 });
 
 test("omit", () => {

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -13007,23 +13007,7 @@ test("group by properties and drag and drop", async () => {
         },
     ];
     Partner._records[1].parent_id = 1;
-    Partner._records[1].properties = [
-        {
-            name: "my_char",
-            string: "My Char",
-            type: "char",
-            value: "aaa",
-        },
-    ];
     Partner._records[2].parent_id = 1;
-    Partner._records[2].properties = [
-        {
-            name: "my_char",
-            string: "My Char",
-            type: "char",
-            value: "bbb",
-        },
-    ];
     Partner._records[3].parent_id = 2;
 
     onRpc("web_read_group", () => ({


### PR DESCRIPTION
This commit modifies the `isObject` helper in Web to only validate "basic" objects (or "dictionnaries"), i.e. direct instances of the `Object` class, such as `{}` or `Object.create(null)`.

The reason for this change is that the previous implementation validated any non-primitive value (basically a glorified `x instanceof Object`), and this has been determined to not be the most generic use case; in most cases, we only want to validate basic objects, and discriminate against any other JavaScript object (`Date`, `Map`, `Array`, `Function`, etc.).

As such, cases where the previous implementation was legitimate have been replaced with `x instanceof Object`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
