### PR TITLE
[FIX] mrp: adjusted width of product_qty field to appear on zooming

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -296,7 +296,7 @@
                                     <field name="qty_producing" class="text-start text-truncate" readonly="state == 'cancel' or (state == 'done' and is_locked)"/>
                                     /
                                 </div>
-                                <field name="product_qty" class="oe_inline text-start text-truncate" invisible="state not in ('draft', 'done')" readonly="state != 'draft'"/>
+                                <field name="product_qty" class="oe_inline text-start text-truncate" invisible="state not in ('draft', 'done')" readonly="state != 'draft'" style="width:auto!important"/>
                                 <button type="action" name="%(mrp.action_change_production_qty)d"
                                     context="{'default_mo_id': id}" class="oe_link oe_inline" style="margin: 0px; padding: 0px;" invisible="state in ('draft', 'done', 'cancel') or not id">
                                     <field name="product_qty" class="oe_inline" readonly="state != 'draft'"/>


### PR DESCRIPTION
Steps to reproduce:
 - Install manfacturing app
 - Activate the Unit of measure setting in the mrp settings
 - Go to create new manafcturing order and start zooming in with different screen resolutions

Problem:
The product_qty field starts disappearing on zooming in and this makes the user can't enter a value in it. This happens because the width:auto applied to the field of the uom beside it that takes as much space as possible so the product_qty field disappears.

opw-4560205

Description of the issue/feature this PR addresses:

Current behavior before PR: the product_qty field in the creating manufacturing order disappears while zooming in with different screen resolutions.

Desired behavior after PR is merged: The product_qty field is appearing on all zoom levels from 100 to 400 and tested on all screen resolutions in the settings of display in Ubuntu

**Before**: ![before](https://github.com/user-attachments/assets/88997248-6c36-401c-9a79-3e4bf82f38e9)


**After**: ![after](https://github.com/user-attachments/assets/6e1fb253-4553-4b45-9c0e-b37dd2613e8a)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
