### PR TITLE
[FIX] Stock{,_barcode}: change package location on picking validation

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1484,10 +1484,11 @@ class QuantPackage(models.Model):
         for package in self:
             package.location_id = False
             package.company_id = False
-            if package.quant_ids:
-                package.location_id = package.quant_ids[0].location_id
-                if all(q.company_id == package.quant_ids[0].company_id for q in package.quant_ids):
-                    package.company_id = package.quant_ids[0].company_id
+            quants = package.quant_ids.filtered(lambda q: float_compare(q.quantity, 0, q.product_uom_id.rounding) > 0)
+            if quants:
+                package.location_id = quants[0].location_id
+                if all(q.company_id == quants[0].company_id for q in package.quant_ids):
+                    package.company_id = quants[0].company_id
 
     @api.depends('quant_ids.owner_id')
     def _compute_owner_id(self):

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -1841,8 +1841,7 @@ class TestPacking(TestPackingCommon):
         already being reserved by an other picking.
         """
         pack = self.env['stock.quant.package'].create({'name': 'The pack to pick'})
-        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 10.0, package_id=pack)
-        destination_locations = self.env['stock.location'].create([
+        locations = self.env['stock.location'].create([
             {
                 'name': 'Depot 1',
                 'usage': 'internal',
@@ -1853,16 +1852,22 @@ class TestPacking(TestPackingCommon):
                 'usage': 'internal',
                 'location_id': self.warehouse.view_location_id.id,
             },
+            {
+                'name': 'Starting Depot',
+                'usage': 'internal',
+                'location_id': self.warehouse.view_location_id.id,
+            },
         ])
+        self.env['stock.quant']._update_available_quantity(self.productA, locations[-1], 10.0, package_id=pack)
         pickings = self.env['stock.picking'].create([
             {
                 'picking_type_id': self.warehouse.int_type_id.id,
-                'location_id': self.stock_location.id,
-                'location_dest_id': destination_locations[i].id,
+                'location_id': locations[-1].id,
+                'location_dest_id': locations[i].id,
                 'move_ids': [Command.create({
                     'name': self.productA.name,
                     'location_id':  self.stock_location.id,
-                    'location_dest_id': destination_locations[i].id,
+                    'location_dest_id': locations[i].id,
                     'product_id': self.productA.id,
                     'product_uom': self.productA.uom_id.id,
                     'product_uom_qty': 10,
@@ -1874,15 +1879,35 @@ class TestPacking(TestPackingCommon):
             pickings[i].move_ids.move_line_ids = [Command.create({
                 'product_id': self.productA.id,
                 'product_uom_id': self.productA.uom_id.id,
-                'location_id': self.stock_location.id,
-                'location_dest_id': destination_locations[i].id,
+                'location_id': locations[-1].id,
+                'location_dest_id': locations[i].id,
                 'quantity': 10.0,
                 'package_id': pack.id,
                 'result_package_id': pack.id,
-                'picked': True,
+                'picked': True, # to simulate barcode flows
             })]
-        pickings[0].button_validate()
-        self.assertEqual(pickings[0].state, 'done')
+        pickings[1].button_validate()
+        self.assertEqual(pickings[1].state, 'done')
+        # check that the package is in Depot 2 and can be moved from there
+        self.assertEqual(pack.location_id, pickings[1].location_dest_id)
+        delivery = self.env['stock.picking'].create({
+            'picking_type_id': self.warehouse.out_type_id.id,
+            'location_id': locations[1].id,
+            'location_dest_id': self.customer_location.id,
+            'move_ids': [Command.create({
+                'name': self.productA.name,
+                'location_id': locations[1].id,
+                'location_dest_id': self.customer_location.id,
+                'product_id': self.productA.id,
+                'product_uom': self.productA.uom_id.id,
+                'product_uom_qty': 10,
+            })],
+        })
+        delivery.action_confirm()
+        delivery.button_validate()
+        self.assertEqual(delivery.state, 'done')
+        # check that the package is now in the Customer location
+        self.assertEqual(pack.location_id, delivery.location_dest_id)
 
 
 @odoo.tests.tagged('post_install', '-at_install')


### PR DESCRIPTION
### Issue:

The curent compute method of the location_id field of quant packages is not accurate as it is currently set to the first existing quant and not to the only existing quant with a positive quantity for that package.

### Steps to reproduce (issue in barcode):
- In the settings enable: Multi-Step Routes, Operations > Packages
- Create a storable product
- Update the on hand quantity:
    - 10 units in package PK in WH/STOCK
- Inventory > Configuration > Warehouse Management > Locations
- Create 2 warehouse locations: WH/LOC1, WH/LOC2
- Go to the barcode app and proceed with the scans: i. Scan the internal transfer picking type ii. Scan WH/STOCK as a source location iii. Scan the package name (PK) iv. Scan WH/LOC1 as destination location
- Leave the barcode app without validation
- Go to the barcode app and proceed with the scans: i -> iii, iv'. Scan WH/LOC2 as destination location
- Validate the picking
- Proceed an other picking via the barcode app to follow up: i. Scan the internal transfer picking type ii. Scan WH/LOC2 as a source location iii. Scan the package name (PK)
#### > the package is not found and added. You rather trigger a notification: no package You are expected to scan one or more products or a package available at the picking location

### Cause of the issue:

After the picking validation, the location_id of the package should havebeen updated to WH/LOC2 but it is still WH/Stock since you have a reserved quantity on that quant and it was not cleaned:
https://github.com/odoo/odoo/blob/081215d1220d6a362087aa33c304a452893b1dca/addons/stock/models/stock_quant.py#L1482-L1490

opw-4574169
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
