### PR TITLE
[FIX] stock: resolve error portal user click time spent on subtasks

### DIFF
--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -101,7 +101,7 @@ class ReturnPicking(models.TransientModel):
     def _compute_moves_locations(self):
         for wizard in self:
             product_return_moves = [Command.clear()]
-            if not wizard.picking_id._can_return():
+            if wizard.picking_id and not wizard.picking_id._can_return():
                 raise UserError(_("You may only return Done pickings."))
             # In case we want to set specific default values (e.g. 'to_refund'), we must fetch the
             # default values for creation.


### PR DESCRIPTION
### Steps to reproduce:
- Install the helpdesk module.
- Enable the return option in the helpdesk team.
- Create a new helpdesk ticket.
- Add a customer with zero sales orders picked (i.e., no pickup is present, meaning no order has been delivered to that customer).
- Click on return.

### Issue:
- Traceback error

### Cause:
- The system tries to check the pickup state even when no sales order has been delivered for the customer, meaning no pickup is generated.

### Solution:
- First, check if any pickup is generated.
- Only proceed to check the pickup state if a pickup exists.

task-4522134



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
