### PR TITLE
[FIX] stock: display all information on Route Rule

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -10212,7 +10212,7 @@ msgstr ""
 msgid ""
 "When products are needed in <b>%(destination)s</b>, <br> "
 "<b>%(operation)s</b> are created from <b>%(source_location)s</b> to fulfill "
-"the need."
+"the need. %(suffix)s"
 msgstr ""
 
 #. module: stock

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -172,7 +172,7 @@ class StockRule(models.Model):
                 suffix += _("<br>If the products are not available in <b>%s</b>, a rule will be triggered to bring the missing quantity in this location.", source)
             message_dict = {
                 'pull': _(
-                    'When products are needed in <b>%(destination)s</b>, <br> <b>%(operation)s</b> are created from <b>%(source_location)s</b> to fulfill the need.',
+                    'When products are needed in <b>%(destination)s</b>, <br> <b>%(operation)s</b> are created from <b>%(source_location)s</b> to fulfill the need. %(suffix)s',
                     destination=destination,
                     operation=operation,
                     source_location=source,

--- a/addons/stock/tests/test_proc_rule.py
+++ b/addons/stock/tests/test_proc_rule.py
@@ -582,7 +582,27 @@ class TestProcRule(TransactionCase):
         stock_move._action_confirm()
         self.assertEqual(orderpoint.qty_to_order, 6)
 
-
+    def test_rule_help_message_mto_mtso(self):
+        """Verify that the rule's help message correctly displays all relevant
+        information when the procurement method is MTO or MTSO.
+        """
+        mto_rule = self.env.ref('stock.route_warehouse0_mto').rule_ids[0]
+        source_mto = mto_rule.location_src_id.display_name
+        self.assertIn(
+            f'<br>A need is created in <b>{source_mto}</b> and a rule will be triggered to fulfill it.',
+            mto_rule.rule_message,
+            'The help message should correctly display information for MTO.'
+        )
+        # Switch to MTSO
+        mto_rule.procure_method = 'mts_else_mto'
+        source_mtso = mto_rule.location_src_id.display_name
+        self.assertIn(
+            f'<br>If the products are not available in <b>{source_mtso}</b>, a rule will be triggered to bring the missing quantity in this location.',
+            mto_rule.rule_message,
+            'The help message should correctly display information for MTSO.'
+        )
+        
+        
 class TestProcRuleLoad(TransactionCase):
     def setUp(cls):
         super(TestProcRuleLoad, cls).setUp()


### PR DESCRIPTION
Problem:
The complementary information were not displayed on the form view of a rule in a route. These informations are supposed to change depending on the Supply Method that has been selected, but since version 18, they always displayed the same information. The suffix, which is used to give information depending on the Supply Method, is not being used anymore and needs to be displayed again. 

Steps to reproduce:
- Go to a route in Inventory and pick a rule
- With Pull From set as Action, change the Supply Method
- The helper on the right won't change but it should

Fix:
The suffix was added to the message that has to be displayed.

opw-4511907
