### PR TITLE
[FIX] stock: show only active rules for routes

### DIFF
--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -215,6 +215,41 @@ class TestWarehouseMrp(common.TestMrpCommon):
         self.assertEqual(backorder.state, 'done')
         self.assertEqual(mo.move_raw_ids.move_line_ids.mapped('reserved_qty'), [20, 80])
 
+    def test_unarchive_mto_route_active_needed_rules_only(self):
+        """ Ensure that activating a route will activate only its relevant rules.
+            Here, unarchiving the MTO route shouldn't active pull rule for the Pre-Production
+            location if manufacture is in 1 step since this location is archived.
+        """
+
+        self.env.user.groups_id += self.env.ref('stock.group_adv_location')
+        mto_route = self.env.ref('stock.route_warehouse0_mto')
+
+        # initially 'WH: Stock → Pre-Production (MTO)' is inactive and not shown in MTO route.
+        self.assertEqual(self.warehouse_1.manufacture_steps, 'mrp_one_step')
+        self.assertFalse(self.warehouse_1.pbm_mto_pull_id.active)
+        self.assertFalse(self.warehouse_1.pbm_mto_pull_id.location_dest_id.active)
+        self.assertFalse(mto_route.active)
+        self.assertNotIn(self.warehouse_1.pbm_mto_pull_id, mto_route.rule_ids)
+
+        # Activate the MTO route and still 'WH: Stock → Pre-Production (MTO)' is not shown in MTO route.
+        mto_route.active = True
+        self.assertFalse(self.warehouse_1.pbm_mto_pull_id.active)
+        self.assertFalse(self.warehouse_1.pbm_mto_pull_id.location_dest_id.active)
+        self.assertNotIn(self.warehouse_1.pbm_mto_pull_id, mto_route.rule_ids)
+
+        # Change MRP steps mrp_one_step to pbm_sam and now that rule is shown in mto route.
+        self.warehouse_1.manufacture_steps = 'pbm_sam'
+        self.assertTrue(self.warehouse_1.pbm_mto_pull_id.active)
+        self.assertTrue(self.warehouse_1.pbm_mto_pull_id.location_dest_id.active)
+        self.assertIn(self.warehouse_1.pbm_mto_pull_id, mto_route.rule_ids)
+
+        # Revert to mrp_one_step MRP and confirm rules visibility is updated correctly
+        self.warehouse_1.manufacture_steps = 'mrp_one_step'
+        self.assertFalse(self.warehouse_1.pbm_mto_pull_id.active)
+        self.assertFalse(self.warehouse_1.pbm_mto_pull_id.location_dest_id.active)
+        self.assertNotIn(self.warehouse_1.pbm_mto_pull_id, mto_route.rule_ids)
+
+
 class TestKitPicking(common.TestMrpCommon):
     @classmethod
     def setUpClass(cls):

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -503,7 +503,7 @@ class StockRoute(models.Model):
 
     def toggle_active(self):
         for route in self:
-            route.with_context(active_test=False).rule_ids.filtered(lambda ru: ru.active == route.active).toggle_active()
+            route.with_context(active_test=False).rule_ids.sudo().filtered(lambda ru: ru.location_dest_id.active and ru.active == route.active).toggle_active()
         super().toggle_active()
 
     @api.constrains('company_id')


### PR DESCRIPTION
Issue Before This Commit:
============================

The system activate inappropriate rules in routes, including those
where the rule itself is active but it's destination location is inactive.

Steps to Reproduce:
============================

- Install the stock & MRP modules.
- Activate multi-step routes and the MTO route.
- Notice that 'WH: Stock → Pre-Production (MTO)' rule appears,
  even when the rule is active but its destination location is inactive.
- Go to the warehouse, enable the 3-step MRP then switch back to the 1-step MRP.
- Go to the MTO route and see that only active rules are now shown.

With This Commit:
============================

This commit resolves the issue where the unarchiving route unintentionally
restored all associated rules, regardless of their active status. Now, only
rules that are active and it's destination location is active are displayed in routes,
where inactive ones are filtered out based on the destination location's active status.

task - [4577280](https://www.odoo.com/odoo/project.task/4577280)
