### PR TITLE
[FIX] point_of_sale: prevent floating point precision issues in Sales Details report

### DIFF
--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -330,9 +330,10 @@ class ReportSaleDetails(models.AbstractModel):
     def _get_products_and_taxes_dict(self, line, products, taxes, currency):
         key2 = (line.product_id, line.price_unit, line.discount)
         key1 = line.product_id.product_tmpl_id.pos_categ_ids[0].name if len(line.product_id.product_tmpl_id.pos_categ_ids) else _('Not Categorized')
+        precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
         products.setdefault(key1, {})
         products[key1].setdefault(key2, [0.0, 0.0, 0.0])
-        products[key1][key2][0] += line.qty
+        products[key1][key2][0] = round(products[key1][key2][0] + line.qty, precision)
         products[key1][key2][1] += self._get_product_total_amount(line)
         products[key1][key2][2] += line.price_subtotal
 

--- a/addons/point_of_sale/tests/test_report_session.py
+++ b/addons/point_of_sale/tests/test_report_session.py
@@ -108,3 +108,36 @@ class TestReportSession(TestPoSCommon):
             session_name = self.env['pos.session'].browse(payment['session']).name
             payment_method_name = self.env['pos.payment.method'].browse(payment['id']).name
             self.assertEqual(payment['name'], payment_method_name + " " + session_name)
+
+    def test_report_session_3(self):
+        self.product1 = self.create_product('Product A', self.categ_basic, 100)
+        self.config.open_ui()
+        session_id = self.config.current_session_id.id
+        order_info = {'company_id': self.env.company.id,
+                'session_id': session_id,
+                'partner_id': self.partner_a.id,
+                'lines': [(0, 0, {
+                    'name': "OL/0001",
+                    'product_id': self.product1.id,
+                    'price_unit': 100,
+                    'discount': 0,
+                    'qty': 14.9,
+                    'tax_ids': [],
+                    'price_subtotal': 100,
+                    'price_subtotal_incl': 100,
+                })],
+                'pricelist_id': self.config.pricelist_id.id,
+                'amount_paid': 100.0,
+                'amount_total': 100.0,
+                'amount_tax': 0.0,
+                'amount_return': 0.0,
+                'to_invoice': False,
+                }
+        order = self.env['pos.order'].create(order_info)
+        self.make_payment(order, self.bank_pm1, 100)
+        order_info['lines'][0][2]['qty'] =  59.7
+        order = self.env['pos.order'].create(order_info)
+        self.make_payment(order, self.bank_pm1, 100)
+        self.config.current_session_id.action_pos_session_closing_control()
+        report = self.env['report.point_of_sale.report_saledetails'].get_sale_details()
+        self.assertEqual(report['products'][0]['products'][0]['quantity'], 74.6, "Quantity of product should be 74.6, as we want the sum of the quantity of the two orders")


### PR DESCRIPTION
The Sales Details report in POS sometimes displays incorrect quantities due to floating point precision errors. This happens when summing product quantities that have decimal values, leading to unintended rounding inaccuracies in the report output.

Steps to Reproduce:
1. Create a sample product to be sold in POS.
2. Check the rounding precision set for the unit of measure for this product.
3. Open a new POS session and confirm an order with `14.9` quantities of the product.
4. Create another order for the same product, this time with `59.7` as the quantity.
5. Go to POS → Reporting → Sales Details, select the relevant POS, and print the report.
6. Issue: The generated PDF report incorrectly shows `74.60000000000001` instead of `74.6`.

The sum of product quantities was not respecting the unit of measure's decimal precision, leading to floating point inaccuracies in the report.

I Applied rounding to the quantity aggregation using the decimal precision of Product Unit of Measure, ensuring consistent and correctly formatted values in the report.

opw-4430513

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
