### PR TITLE
[FIX] website: fix countdown end message

### DIFF
--- a/addons/website/static/src/snippets/s_countdown/countdown.edit.js
+++ b/addons/website/static/src/snippets/s_countdown/countdown.edit.js
@@ -1,0 +1,16 @@
+import { Countdown } from "./countdown";
+import { registry } from "@web/core/registry";
+
+const CountdownEdit = (I) => class extends I {
+    get shouldHideCountdown() {
+        return false;
+    }
+    handleEndCountdownAction() { }
+};
+
+registry
+    .category("public.interactions.edit")
+    .add("website.countdown", {
+        Interaction: Countdown,
+        mixin: CountdownEdit,
+    });

--- a/addons/website/static/src/snippets/s_countdown/countdown.js
+++ b/addons/website/static/src/snippets/s_countdown/countdown.js
@@ -88,8 +88,10 @@ export class Countdown extends Interaction {
             if (this.hereBeforeTimerEnds) {
                 this.waitForTimeout(() => window.location = redirectUrl, 500);
             } else {
-                if (!this.el.querySelector(".s_countdown_end_redirect_message").length) {
-                    const container = this.el.querySelector("> .container, > .container-fluid, > .o_container_small");
+                if (!this.el.querySelector(".s_countdown_end_redirect_message")) {
+                    const container = this.el.querySelector(
+                        ":scope > .container, :scope > .container-fluid, :scope > .o_container_small"
+                    );
                     this.renderAt("website.s_countdown.end_redirect_message", {
                         redirectUrl: redirectUrl,
                     }, container);
@@ -189,6 +191,10 @@ export class Countdown extends Interaction {
         return this.display.includes(unit);
     }
 
+    get shouldHideCountdown() {
+        return this.isFinished && this.el.classList.contains("hide-countdown");
+    }
+
     /**
      * Draws the whole countdown, including one countdown for each time unit.
      */
@@ -199,7 +205,6 @@ export class Countdown extends Interaction {
         }
         this.updateTimediff();
 
-        const hideCountdown = this.isFinished && !this.editableMode && this.el.classList.contains("hide-countdown");
         if (this.layout === "text") {
             const canvasEls = this.el.querySelectorAll(".s_countdown_canvas_flex");
             for (const canvasEl of canvasEls) {
@@ -214,7 +219,7 @@ export class Countdown extends Interaction {
                 this.textWrapperEl.appendChild(spanEl);
                 this.insert(this.textWrapperEl, this.wrapperEl);
             }
-            this.textWrapperEl.classList.toggle("d-none", hideCountdown);
+            this.textWrapperEl.classList.toggle("d-none", this.shouldHideCountdown);
 
             const countdownText = this.timeDiff.map(e => e.nb + " " + e.label).join(", ");
             this.el.querySelector(".s_countdown_text").innerText = countdownText.toLowerCase();
@@ -226,8 +231,8 @@ export class Countdown extends Interaction {
                 ctx.canvas.height = this.size;
                 this.clearCanvas(ctx);
 
-                canvas.classList.toggle("d-none", hideCountdown);
-                if (hideCountdown) {
+                canvas.classList.toggle("d-none", this.shouldHideCountdown);
+                if (this.shouldHideCountdown) {
                     continue;
                 }
 
@@ -248,9 +253,7 @@ export class Countdown extends Interaction {
 
         if (this.isFinished) {
             clearInterval(this.setInterval);
-            if (!this.editableMode) {
-                this.handleEndCountdownAction();
-            }
+            this.handleEndCountdownAction();
         }
     }
 
@@ -401,9 +404,3 @@ export class Countdown extends Interaction {
 registry
     .category("public.interactions")
     .add("website.countdown", Countdown);
-
-registry
-    .category("public.interactions.edit")
-    .add("website.countdown", {
-        Interaction: Countdown,
-    });

--- a/addons/website/static/tests/interactions/snippets/countdown.edit.test.js
+++ b/addons/website/static/tests/interactions/snippets/countdown.edit.test.js
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
+import { switchToEditMode } from "../../helpers";
+import { tick } from "@odoo/hoot-dom";
+
+describe.current.tags("interaction_dev");
+setupInteractionWhiteList("website.countdown");
+
+const getTemplate = function (options = { endAction: "nothing", endTime: "98765432100" }) {
+    return `
+        <div style="background-color: white;">
+            <section class="s_countdown pt48 pb48 ${options.endAction === "message_no_countdown" ? "hide-countdown" : ""}"
+            data-display="dhms"
+            data-end-action="${options.endAction}"
+            data-size="175"
+            data-layout="circle"
+            data-layout-background="none"
+            data-progress-bar-style="surrounded"
+            data-progress-bar-weight="thin"
+            id="countdown-section"
+            data-text-color="o-color-1"
+            data-layout-background-color="400"
+            data-progress-bar-color="o-color-1"
+            data-end-time="${options.endTime}">
+                <div class="container">
+                    <div class="s_countdown_canvas_wrapper"
+                    style="
+                        display: flex;
+                        justify-content: center;
+                        align-items: center;">
+                    </div>
+                </div>
+                ${["message", "message_no_countdown"].includes(options.endAction) ? endMessage : ""}
+            </section>
+        </div>
+    `
+};
+
+const endMessage = `
+    <div class="s_countdown_end_message d-none">
+        <div class="oe_structure">
+            <section class="s_picture pt64 pb64" data-snippet="s_picture">
+                <div class="container">
+                    <h2 style="text-align: center;">Happy Odoo Anniversary!</h2>
+                    <p style="text-align: center;">As promised, we will offer 4 free tickets to our next summit.<br/>Visit our Facebook page to know if you are one of the lucky winners.</p>
+                    <div class="row s_nb_column_fixed">
+                        <div class="col-lg-12" style="text-align: center;">
+                            <figure class="figure">
+                                <img src="/web/image/website.library_image_18" class="figure-img img-fluid rounded" alt="Countdown is over - Firework"/>
+                            </figure>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </div>
+`;
+
+test("past date: end message is not shown and countdown remains visible", async () => {
+    const { core } = await startInteractions(
+        getTemplate({ endAction: "message_no_countdown", endTime: "1" }),
+        { waitForStart: true, editMode: true }
+    );
+    await switchToEditMode(core);
+
+    await tick();
+    expect(".s_countdown_end_message:not(.d-none)").toHaveCount(0);
+    expect(".s_countdown_canvas_flex canvas:not(.d-none)").toHaveCount(4);
+});

--- a/addons/website/static/tests/interactions/snippets/countdown.test.js
+++ b/addons/website/static/tests/interactions/snippets/countdown.test.js
@@ -4,19 +4,19 @@ import {
 } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
-import { queryAll, queryOne } from "@odoo/hoot-dom";
+import { queryAll, queryOne, tick } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
 
 setupInteractionWhiteList("website.countdown");
 
 describe.current.tags("interaction_dev");
 
-const getTemplate = function (options = {}) {
+const getTemplate = function (options = { endAction: "nothing", endTime: "98765432100" }) {
     return `
         <div style="background-color: white;">
-            <section class="s_countdown pt48 pb48"
+            <section class="s_countdown pt48 pb48 ${options.endAction === "message_no_countdown" ? "hide-countdown" : ""}"
             data-display="dhms"
-            data-end-action="nothing"
+            data-end-action="${options.endAction}"
             data-size="175"
             data-layout="circle"
             data-layout-background="none"
@@ -26,7 +26,7 @@ const getTemplate = function (options = {}) {
             data-text-color="o-color-1"
             data-layout-background-color="400"
             data-progress-bar-color="o-color-1"
-            data-end-time="12345678900">
+            data-end-time="${options.endTime}">
                 <div class="container">
                     <div class="s_countdown_canvas_wrapper"
                     style="
@@ -35,10 +35,31 @@ const getTemplate = function (options = {}) {
                         align-items: center;">
                     </div>
                 </div>
+                ${["message", "message_no_countdown"].includes(options.endAction) ? endMessage : ""}
             </section>
         </div>
     `
 };
+
+const endMessage = `
+    <div class="s_countdown_end_message d-none">
+        <div class="oe_structure">
+            <section class="s_picture pt64 pb64" data-snippet="s_picture">
+                <div class="container">
+                    <h2 style="text-align: center;">Happy Odoo Anniversary!</h2>
+                    <p style="text-align: center;">As promised, we will offer 4 free tickets to our next summit.<br/>Visit our Facebook page to know if you are one of the lucky winners.</p>
+                    <div class="row s_nb_column_fixed">
+                        <div class="col-lg-12" style="text-align: center;">
+                            <figure class="figure">
+                                <img src="/web/image/website.library_image_18" class="figure-img img-fluid rounded" alt="Countdown is over - Firework"/>
+                            </figure>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </div>
+`;
 
 const wasDataChanged = function (data1, data2, l) {
     for (let i = 0; i < l; i++) {
@@ -114,4 +135,24 @@ test("countdown is stopped correctly", async () => {
     expect(queryAll(".s_countdown_end_message")).toHaveLength(0);
     expect(queryAll(".s_countdown_text_wrapper")).toHaveLength(0);
     expect(queryAll(".s_countdown_end_redirect_message")).toHaveLength(0);
+});
+
+test("past date: redirect end message is shown", async () => {
+    await startInteractions(getTemplate({ endAction: "redirect", endTime: 1 }));
+    await tick();
+    expect(".s_countdown_end_redirect_message").toHaveCount(1);
+});
+
+test("past date: end message is shown", async () => {
+    await startInteractions(getTemplate({ endAction: "message", endTime: 1 }));
+    await tick();
+    expect(".s_countdown_end_message:not(.d-none)").toHaveCount(1);
+    expect(".s_countdown_canvas_flex canvas:not(.d-none)").toHaveCount(4);
+});
+
+test("past date: end message is shown without countdown", async () => {
+    await startInteractions(getTemplate({ endAction: "message_no_countdown", endTime: 1 }));
+    await tick();
+    expect(".s_countdown_end_message:not(.d-none)").toHaveCount(1);
+    expect(".s_countdown_canvas_flex canvas:not(.d-none)").toHaveCount(0);
 });


### PR DESCRIPTION
1) With the introduction of [Interactions], the property `editableMode` was forgotten in the `Countdown` interaction.

Steps to reproduce:
- Drop a countdown snippet
- Select a "Due date" a few seconds in the future
- Select "At the end" > Show message and hide countdown
- Save => The end message was never shown.

2) In the same commit, some jQuery selectors were wrongly refactored.

Steps to reproduce:
- Drop a countdown snippet
- Select a "Due date" in the past
- Select "At the end" > "Redirect"
- (If the previous fix is already applied: save) => Traceback

[Interactions]: https://github.com/odoo/odoo/commit/b9b3a605e0f4c5da3a258c980107d6162da7f44f

task-4568335