### PR TITLE
[FIX] website: adapt "edit link" tour step

### DIFF
--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -179,9 +179,20 @@ registerWebsitePreviewTour("megamenu_active_nav_link", {
         run: "click",
     },
     {
-        content: "Edit link",
+        content: "Click 'edit link' button if URL input is now shown",
         trigger: "#create-link",
-        run: "click",
+        async run(actions) {
+            // Note: the 'create-link' button is always here, however the input 
+            // for the URL might not be.
+            // We have to consider both cases:
+            // 1. Single-app website build: a few menu, so no extra menu added 
+            //    and the URL input is shown
+            // 2. Multi-app website build:  many menu, so extra menu added 
+            //    and the URL input is not shown
+            if (!document.querySelector("#o_link_dialog_url_input")) {
+                await actions.click();
+            }
+        },
     },
     {
         content: "Change the link",


### PR DESCRIPTION
The following PR: https://github.com/odoo/odoo/pull/190321 introduced a new website tour.
However, one of the step make the tour consistently fail with a single app website install.

The reason for the fail is that the "edit link" sub-window is opened by default if the link is not open through the "extra menu". Clicking the button (what currently do the test) do close the sub-window making the input not clickable in the following step.

![image](https://github.com/user-attachments/assets/ee32cac3-3021-47f5-95ad-c57ef5d2bb1b)
*single-app website build screenshot* the URL input is open by default

![image](https://github.com/user-attachments/assets/f1634709-faba-4d4b-95f1-6312e1a0acb3)*multi-app build screenshot* the URL input is not shown by default as the mega-menu menu-item is shown in the "extra menu" due to the amount of menu added by other website related app


After this PR:
The "edit link" button is pressed only if the input is not visible

rb-111286
