### PR TITLE
[FIX] crm_livechat: saving operator_partner value before processing step

### DIFF
--- a/addons/crm_livechat/models/chatbot_script_step.py
+++ b/addons/crm_livechat/models/chatbot_script_step.py
@@ -97,14 +97,14 @@ class ChatbotScriptStep(models.Model):
             and member._get_assignment_quota() > 0
             and lead.filtered_domain(literal_eval(member.assignment_domain or "[]"))
         ]
+        previous_operator = discuss_channel.livechat_operator_id
         # sudo: im_livechat.channel - getting available operators is acceptable
         users = discuss_channel.livechat_channel_id.sudo()._get_available_operators_by_livechat_channel(
             self.env["res.users"].browse(assignable_user_ids)
         )[discuss_channel.livechat_channel_id]
         message = self._process_step_forward_operator(discuss_channel, users=users)
-        operator_partner = discuss_channel.livechat_operator_id
-        if operator_partner != self.chatbot_script_id.operator_partner_id:
-            user = next(user for user in users if user.partner_id == operator_partner)
+        if previous_operator != discuss_channel.livechat_operator_id:
+            user = next(user for user in users if user.partner_id == discuss_channel.livechat_operator_id)
             lead.user_id = user
             lead.team_id = next(team for team in teams if user in team.crm_team_member_ids.user_id)
             msg = self.env._("Created a new lead: %s", lead._get_html_link())


### PR DESCRIPTION
This error occurs when attempting to create a lead and forward it from the live chat.

Traceback : 
---
```
StopIteration: null
  File "odoo/http.py", line 2420, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1946, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 2010, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1977, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2228, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 335, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 741, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/mail/models/discuss/mail_guest.py", line 38, in wrapper
    return func(self, *args, **kwargs)
  File "addons/im_livechat/controllers/chatbot.py", line 69, in chatbot_trigger_step
    posted_message = next_step._process_step(discuss_channel)
  File "addons/crm_livechat/models/chatbot_script_step.py", line 42, in _process_step
    return self._process_step_create_lead_and_forward(discuss_channel)
  File "addons/crm_livechat/models/chatbot_script_step.py", line 107, in _process_step_create_lead_and_forward
    user = next(user for user in users if user.partner_id == operator_partner)
```

The error occurs at [1] because both `users` and `teams` are empty. As a result, `next()` attempts to retrieve an item from an empty iterator, leading to a `StopIteration` exception.

This issue arises when the bot assigned in the script is changed during an active session. Consequently, `operator_partner` refers to the old bot (the one configured at the start of the session) rather than the new one. This discrepancy causes the condition to be evaluated as True, leading to the error.

This commit resolves the error by saving the value of `operator_partner` before calling `_process_step_forward_operator`. This ensures that `operator_partner` remains the same until the end of the session.

[1]- https://github.com/odoo/odoo/blob/db62ec3b72b30b01ff04b067cf2c235bd9a8411e/addons/crm_livechat/models/chatbot_script_step.py#L101-L109

sentry-6296911936

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
