### PR TITLE
[FIX] pos_loyalty: fix history for ewallet program

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -182,13 +182,14 @@ patch(PaymentScreen.prototype, {
                     }
                 }
             }
-            const loyaltyPoints = await this.currentOrder.getLoyaltyPoints().map((item) => ({
-                order_id: this.currentOrder.id,
-                card_id: item.couponId,
-                spent: item.points.spent,
-                won: item.points.won,
-                total: item.points.total,
+
+            const loyaltyPoints = Object.keys(couponData).map((coupon_id) => ({
+                order_id: order.id,
+                card_id: coupon_id,
+                spent: couponData[coupon_id].points < 0 ? -couponData[coupon_id].points : 0,
+                won: couponData[coupon_id].points > 0 ? couponData[coupon_id].points : 0,
             }));
+
             const couponUpdates = payload.coupon_updates.map((item) => ({
                 id: item.id,
                 old_id: item.old_id,

--- a/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
@@ -147,3 +147,30 @@ registry.category("web_tour.tours").add("PosLoyaltyPointsEwallet", {
             PosLoyalty.finalizeOrder("Cash", "90.00"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("EWalletLoyaltyHistory", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            ProductScreen.clickDisplayedProduct("Top-up eWallet"),
+            PosLoyalty.orderTotalIs("50.00"),
+            ProductScreen.clickPartnerButton(),
+            PartnerList.clickPartner("AAAAAAA"),
+            PosLoyalty.finalizeOrder("Cash", "50"),
+
+            ProductScreen.addOrderline("Whiteboard Pen", "2", "6", "12.00"),
+            PosLoyalty.eWalletButtonState({ highlighted: false }),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("AAAAAAA"),
+            PosLoyalty.eWalletButtonState({
+                highlighted: true,
+                text: getEWalletText("Pay"),
+                click: true,
+            }),
+            PosLoyalty.orderTotalIs("0.00"),
+            PosLoyalty.finalizeOrder("Cash", "0"),
+        ].flat(),
+});

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2496,3 +2496,24 @@ class TestUi(TestPointOfSaleHttpCommon):
         coupon = loyalty_program.coupon_ids
         self.assertEqual(len(coupon), 1, "Coupon not generated")
         self.assertEqual(coupon.expiration_date, date.today() + timedelta(days=2), "Coupon not generated with correct expiration date")
+
+    def test_ewallet_loyalty_history(self):
+        """
+        This will test that all transactions made on an ewallet are registered in the loyalty history
+        """
+        LoyaltyProgram = self.env['loyalty.program']
+        # Deactivate all other programs to avoid interference
+        (LoyaltyProgram.search([])).write({'pos_ok': False})
+        # But activate the ewallet_product_50 because it's shared among new ewallet programs.
+        self.env.ref('loyalty.ewallet_product_50').write({'active': True})
+        # Create ewallet program
+        ewallet_program = self.create_programs([('arbitrary_name', 'ewallet')])['arbitrary_name']
+        # Create test partners
+        partner_aaa = self.env['res.partner'].create({'name': 'AAAAAAA'})
+        # Run the tour to topup ewallets.
+        self.start_pos_tour("EWalletLoyaltyHistory")
+        # Check that ewallets are created for partner_aaa.
+        ewallet_aaa = self.env['loyalty.card'].search([('partner_id', '=', partner_aaa.id), ('program_id', '=', ewallet_program.id)])
+        loyalty_history = self.env['loyalty.history'].search([('card_id','=',ewallet_aaa.id)])
+        self.assertEqual(loyalty_history.mapped("issued"), [0.0, 50.0])
+        self.assertEqual(loyalty_history.mapped("used"), [12.0, 0.0])


### PR DESCRIPTION
When adding/using point in ewallet program, the loyalty history was not updated correctly.

Steps to reproduce:
-------------------
* Create a new ewallet program
* Create an ewallet card for customer C
* Add some points to the ewallet card
* Open PoS and make an order that you pay with the ewallet card
* Check the history of the ewallet card
> Observation: The transaction made in the PoS does not appear

Why the fix:
------------
The required data are already present in `couponData` so we should use it instead of computing it. Also the method `getLoyaltyPoints` is not returning the points for ewallet program so it should not be used in this case.

opw-4546985