### PR TITLE
[FIX] account: allow to select only active sending methods to send invoice for user

### DIFF
--- a/addons/account/wizard/account_move_send_wizard.py
+++ b/addons/account/wizard/account_move_send_wizard.py
@@ -127,7 +127,8 @@ class AccountMoveSendWizard(models.TransientModel):
         2. email,
         3. manual.
         """
-        methods = self.env['ir.model.fields'].get_field_selection('res.partner', 'invoice_sending_method')
+        # Fetch only active selection values from the model definition
+        methods = self.env['res.partner']._fields['invoice_sending_method'].selection
         for wizard in self:
             preferred_method = self._get_default_sending_method(wizard.move_id)
             need_fallback = not self._is_applicable_to_move(preferred_method, wizard.move_id)


### PR DESCRIPTION
Currently, a traceback is occurring when the user tries to send a 
customer invoice with the sending method as `By Post`.

To reproduce this issue:
1) Install Accounting and Unistall `snailmail`
3) Create a posted `Customer Invoice` with a customer having no Invoice Sending
   (Remove the value in customer's accounting page if he has the value)
4) Click the `Send` button and select the sending method as `To Post` 
5) Click the `Send` button in wizard

Error:-
```
ValueError: Wrong value for res.partner.invoice_sending_method: 'snailmail'
```

The selection value  `snailmail` for `invoice_sending_method` is defined in `snailmail_acount`.
But it will be uninstalled when the `snailmail` module installed.
https://github.com/odoo/odoo/blob/636d76d6dcbbe472b9d57cbe403d0758d94ad81d/addons/snailmail_account/models/res_partner.py#L7-L9

But in the `account.move.send.wizard`, the sending_method values 
are getting from the computed method `_compute_sending_method_checkboxes`.

https://github.com/odoo/odoo/blob/636d76d6dcbbe472b9d57cbe403d0758d94ad81d/addons/account/wizard/account_move_send_wizard.py#L130

We get all the selection values(including the inactive) for the field `invoice_sending_method`. 

When the user selects the `snailmail` checkbox (By Post)to send the invoice,
the value of `invoice_sending_method` for res.partner will be assigned from the below line.

https://github.com/odoo/odoo/blob/636d76d6dcbbe472b9d57cbe403d0758d94ad81d/addons/account/wizard/account_move_send_wizard.py#L269

This will lead to the above traceback as the `snailmail` value for the selection field `invoice_sending_method` in the partner is not valid.

We can resolve this issue by accessing only the active selection values for the field `invoice_sending_method`. So only the user can select the valid value for sending_method.

sentry-6091298443