### PR TITLE
[FIX] point_of_sale: share open orders with trusted pos

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1145,6 +1145,9 @@ export class PosStore extends Reactive {
         if (this.get_order()) {
             this.get_order().updateSavedQuantity();
         }
+        if (this.isOpenOrderShareable()) {
+            this.syncAllOrders();
+        }
 
         const order = this.createNewOrder(data);
         this.selectedOrderUuid = order.uuid;


### PR DESCRIPTION
Before this commit:
================
- Open orders were not shared across trusted POS sessions.

After this commit:
==================
- All open orders in the session will be shared with trusted POS when a new order is created.


Task: 4550175

