### PR TITLE
[FIX] web,mail: support optional record props in useRecordObserver

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -101,7 +101,7 @@ patch(Chatter.prototype, {
                 await mailImpactingFieldsPromise;
                 mailImpactingFieldsPromise = null;
             }
-            this.updateRecipients(record);
+            return this.updateRecipients(record);
         });
         this.attachmentPopout = usePopoutAttachment();
         Object.assign(this.state, {

--- a/addons/mail/static/src/core/web/recipients_input.js
+++ b/addons/mail/static/src/core/web/recipients_input.js
@@ -6,7 +6,7 @@ import { isEmail } from "@web/core/utils/strings";
 import { useService } from "@web/core/utils/hooks";
 import { useOpenMany2XRecord, useSelectCreate } from "@web/views/fields/relational_utils";
 
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { rpc } from "@web/core/network/rpc";
 
 export class RecipientsInput extends Component {
@@ -18,10 +18,6 @@ export class RecipientsInput extends Component {
 
     setup() {
         this.orm = useService("orm");
-        this.state = useState({
-            thread: this.props.thread,
-        });
-
         this.openFormViewToCreateResPartner = useOpenMany2XRecord({
             fieldString: _t("Additional Contact"),
             resModel: "res.partner",
@@ -155,8 +151,8 @@ export class RecipientsInput extends Component {
                     if (isEmail(email)) {
                         createOption.onSelectOption = async () => {
                             const partners = await rpc("/mail/partner/from_email", {
-                                thread_model: this.state.thread.model,
-                                thread_id: this.state.thread.id,
+                                thread_model: this.props.thread.model,
+                                thread_id: this.props.thread.id,
                                 emails: [email],
                             });
                             if (partners.length) {
@@ -218,7 +214,7 @@ export class RecipientsInput extends Component {
                     }
                 },
                 onDelete: () => {
-                    this.state.thread[recipientField] = this.state.thread[recipientField].filter(
+                    this.props.thread[recipientField] = this.props.thread[recipientField].filter(
                         (additionalOrSuggestedRecipient) =>
                             additionalOrSuggestedRecipient.partner_id !== recipient.partner_id ||
                             additionalOrSuggestedRecipient.email !== recipient.email
@@ -226,10 +222,10 @@ export class RecipientsInput extends Component {
                 },
             });
         };
-        for (const recipient of this.state.thread.suggestedRecipients) {
+        for (const recipient of this.props.thread.suggestedRecipients) {
             createTagForRecipient(recipient, "suggestedRecipients");
         }
-        for (const recipient of this.state.thread.additionalRecipients) {
+        for (const recipient of this.props.thread.additionalRecipients) {
             createTagForRecipient(recipient, "additionalRecipients");
         }
         return tags;
@@ -238,8 +234,8 @@ export class RecipientsInput extends Component {
     /** @return {Array[SuggestedRecipient]}*/
     getAllMailThreadRecipients() {
         return [
-            ...this.state.thread.suggestedRecipients,
-            ...this.state.thread.additionalRecipients,
+            ...this.props.thread.suggestedRecipients,
+            ...this.props.thread.additionalRecipients,
         ];
     }
 
@@ -258,14 +254,14 @@ export class RecipientsInput extends Component {
         if (this.hasRecipient(recipient)) {
             return;
         }
-        this.state.thread.additionalRecipients.push(recipient);
+        this.props.thread.additionalRecipients.push(recipient);
     }
 
     /** @returns {string} */
     getPlaceholder() {
         const hasRecipients =
-            this.state.thread.suggestedRecipients.length ||
-            this.state.thread.additionalRecipients.length;
+            this.props.thread.suggestedRecipients.length ||
+            this.props.thread.additionalRecipients.length;
         return hasRecipients ? "" : _t("Followers only");
     }
 

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -718,8 +718,10 @@ export function isRelational(field) {
 export function useRecordObserver(callback) {
     const component = useComponent();
     let alive = true;
-    let props = component.props;
-    const fct = () => {
+    const observeRecord = (props) => {
+        if (!props.record) {
+            return;
+        }
         const def = new Deferred();
         let firstCall = true;
         effect(
@@ -752,12 +754,10 @@ export function useRecordObserver(callback) {
     onWillDestroy(() => {
         alive = false;
     });
-    onWillStart(() => fct());
+    onWillStart(() => observeRecord(component.props));
     onWillUpdateProps((nextProps) => {
-        const currentRecordId = props.record.id;
-        props = nextProps;
-        if (props.record.id !== currentRecordId) {
-            return fct();
+        if (nextProps.record !== component.props.record) {
+            return observeRecord(nextProps);
         }
     });
 }


### PR DESCRIPTION
This commit is a followup of https://github.com/odoo/odoo/pull/188642 to fix an issue with the
newly merged email recipients.

As the record props is optional on the chatter component but the feature
is nicely supported by the use of useRecordObserver, it is natural that
the hook will not crash if `props.record` is `undefined`.

This fix also supports a setup without a `record` and a props update
including a record (which would not work if we simply wrapped the use of
the hook to the existence of the record props).

In `RecipientsInput` Component, thread is now read directly from the props so
that a re-render is properly done when a new instance is given as props (i.e.
when switching to the next record in a Form view).

Task-4496350

Co-authored-by: Florian Charlier <flch@odoo.com>
Co-authored-by: abd-msyukyu-odoo <abd@odoo.com>