### PR TITLE
[IMP] core: backport api.private

### DIFF
--- a/addons/web/controllers/dataset.py
+++ b/addons/web/controllers/dataset.py
@@ -6,7 +6,7 @@ import warnings
 from odoo import http
 from odoo.api import call_kw
 from odoo.http import request
-from odoo.models import check_method_name
+from odoo.service.model import get_public_method
 from .utils import clean_action
 
 
@@ -29,8 +29,9 @@ class DataSet(http.Controller):
         return {'value': value}
 
     def _call_kw(self, model, method, args, kwargs):
-        check_method_name(method)
-        return call_kw(request.env[model], method, args, kwargs)
+        Model = request.env[model]
+        get_public_method(Model, method)  # Don't use the result, call_kw will redo the getattr
+        return call_kw(Model, method, args, kwargs)
 
     @http.route('/web/dataset/call', type='json', auth="user")
     def call(self, model, method, args, domain_id=None, context_id=None):

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -23,12 +23,12 @@ from odoo import api, fields, models, tools, _
 from odoo.exceptions import ValidationError, AccessError, UserError
 from odoo.http import request
 from odoo.modules.module import get_resource_from_path, get_resource_path
+from odoo.service.model import get_public_method
 from odoo.tools import config, ConstantMapping, get_diff, pycompat, apply_inheritance_specs, locate_node, str2bool
 from odoo.tools.convert import _fix_multiple_roots
 from odoo.tools import safe_eval, lazy, lazy_property, frozendict
 from odoo.tools.view_validation import valid_view, get_variable_names, get_domain_identifiers, get_dict_asts
 from odoo.tools.translate import xml_translate, TRANSLATED_ATTRS
-from odoo.models import check_method_name
 from odoo.osv.expression import expression
 
 _logger = logging.getLogger(__name__)
@@ -1596,8 +1596,8 @@ actual arch.
                     )
                     self._raise_view_error(msg, node)
                 try:
-                    check_method_name(name)
-                except AccessError:
+                    get_public_method(name_manager.model, name)
+                except (AttributeError, AccessError):
                     msg = _(
                         "%(method)s on %(model)s is private and cannot be called from a button",
                         method=name, model=name_manager.model._name,

--- a/odoo/addons/test_rpc/models.py
+++ b/odoo/addons/test_rpc/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ModelA(models.Model):
@@ -11,6 +11,21 @@ class ModelA(models.Model):
     name = fields.Char(required=True)
     field_b1 = fields.Many2one("test_rpc.model_b", string="required field", required=True)
     field_b2 = fields.Many2one("test_rpc.model_b", string="restricted field", ondelete="restrict")
+
+    @api.private
+    def read_group(self, *a, **kw):
+        return super().read_group(*a, **kw)
+
+    @api.private
+    def private_method(self):
+        return "private"
+
+    def filtered(self, func):
+        return super().filtered(func)
+
+    @api.model
+    def not_depending_on_id(self, vals=None):
+        return f"got {vals}"
 
 
 class ModelB(models.Model):

--- a/odoo/addons/test_rpc/tests/test_error.py
+++ b/odoo/addons/test_rpc/tests/test_error.py
@@ -16,6 +16,16 @@ class TestError(common.HttpCase):
         # Reset the admin's lang to avoid breaking tests due to admin not in English
         self.rpc("res.users", "write", [uid], {"lang": False})
 
+    def test_01_private(self):
+        with self.assertRaisesRegex(Exception, r"Private method"), mute_logger('odoo.http'):
+            self.rpc('test_rpc.model_a', '_create')
+        with self.assertRaisesRegex(Exception, r"Private method"), mute_logger('odoo.http'):
+            self.rpc('test_rpc.model_a', 'private_method')
+        with self.assertRaisesRegex(Exception, r"Private method"), mute_logger('odoo.http'):
+            self.rpc('test_rpc.model_a', 'init')
+        with self.assertRaisesRegex(Exception, r"Private method"), mute_logger('odoo.http'):
+            self.rpc('test_rpc.model_a', 'filtered', ['id'])
+
     def test_01_create(self):
         """ Create: mandatory field not provided """
         self.rpc("test_rpc.model_b", "create", {"name": "B1"})

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -381,6 +381,22 @@ def model(method):
     return method
 
 
+def private(method):
+    """ Decorate a record-style method to indicate that the method cannot be
+        called using RPC. Example::
+
+            @api.private
+            def method(self, args):
+                ...
+
+        If you have business methods that should not be called over RPC, you
+        should prefix them with "_". This decorator may be used in case of
+        existing public methods that become non-RPC callable or for ORM
+        methods.
+    """
+    method._api_private = True
+    return method
+
 _create_logger = logging.getLogger(__name__ + '.create')
 
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2632,6 +2632,7 @@ class BaseModel(metaclass=MetaModel):
         if parent_path_compute:
             self._parent_store_compute()
 
+    @api.private
     def init(self):
         """ This method is called after :meth:`~._auto_init`, and may be
             overridden to create or modify a model's database schema.
@@ -5190,6 +5191,7 @@ class BaseModel(metaclass=MetaModel):
     # Conversion methods
     #
 
+    @api.private
     def ensure_one(self):
         """Verify that the current recordset holds a single record.
 
@@ -5203,6 +5205,7 @@ class BaseModel(metaclass=MetaModel):
         except ValueError:
             raise ValueError("Expected singleton: %s" % self)
 
+    @api.private
     def with_env(self, env):
         """Return a new version of this recordset attached to the provided environment.
 
@@ -5242,6 +5245,7 @@ class BaseModel(metaclass=MetaModel):
             return self
         return self.with_env(self.env(su=flag))
 
+    @api.private
     def with_user(self, user):
         """ with_user(user)
 
@@ -5253,6 +5257,7 @@ class BaseModel(metaclass=MetaModel):
             return self
         return self.with_env(self.env(user=user, su=False))
 
+    @api.private
     def with_company(self, company):
         """ with_company(company)
 
@@ -5287,6 +5292,7 @@ class BaseModel(metaclass=MetaModel):
 
         return self.with_context(allowed_company_ids=allowed_company_ids)
 
+    @api.private
     def with_context(self, *args, **kwargs):
         """ with_context([context][, **overrides]) -> Model
 
@@ -5326,6 +5332,7 @@ class BaseModel(metaclass=MetaModel):
             context['allowed_company_ids'] = self._context['allowed_company_ids']
         return self.with_env(self.env(context=context))
 
+    @api.private
     def with_prefetch(self, prefetch_ids=None):
         """ with_prefetch([prefetch_ids]) -> records
 
@@ -5410,6 +5417,7 @@ class BaseModel(metaclass=MetaModel):
             vals = func(self)
             return vals if isinstance(vals, BaseModel) else []
 
+    @api.private
     def mapped(self, func):
         """Apply ``func`` on all records in ``self``, and return the result as a
         list or a recordset (if ``func`` return recordsets). In the latter
@@ -5448,6 +5456,7 @@ class BaseModel(metaclass=MetaModel):
         else:
             return self._mapped_func(func)
 
+    @api.private
     def filtered(self, func):
         """Return the records in ``self`` satisfying ``func``.
 
@@ -5470,6 +5479,7 @@ class BaseModel(metaclass=MetaModel):
             self.mapped(name)
         return self.browse([rec.id for rec in self if func(rec)])
 
+    @api.private
     def filtered_domain(self, domain):
         """Return the records in ``self`` satisfying the domain and keeping the same order.
 
@@ -5584,6 +5594,7 @@ class BaseModel(metaclass=MetaModel):
         [result_ids] = stack
         return self.browse(id_ for id_ in self._ids if id_ in result_ids)
 
+    @api.private
     def sorted(self, key=None, reverse=False):
         """Return the recordset ``self`` ordered by ``key``.
 
@@ -5636,6 +5647,7 @@ class BaseModel(metaclass=MetaModel):
         else:
             records.flush_recordset(fnames)
 
+    @api.private
     def flush_model(self, fnames=None):
         """ Process the pending computations and database updates on ``self``'s
         model.  When the parameter is given, the method guarantees that at least
@@ -5647,6 +5659,7 @@ class BaseModel(metaclass=MetaModel):
         self._recompute_model(fnames)
         self._flush(fnames)
 
+    @api.private
     def flush_recordset(self, fnames=None):
         """ Process the pending computations and database updates on the records
         ``self``.   When the parameter is given, the method guarantees that at
@@ -5759,6 +5772,7 @@ class BaseModel(metaclass=MetaModel):
     #
 
     @api.model
+    @api.private
     def new(self, values=None, origin=None, ref=None):
         """ new([values], [origin], [ref]) -> record
 
@@ -5843,6 +5857,7 @@ class BaseModel(metaclass=MetaModel):
         """ Return the concatenation of two recordsets. """
         return self.concat(other)
 
+    @api.private
     def concat(self, *args):
         """ Return the concatenation of ``self`` with all the arguments (in
             linear time complexity).
@@ -5887,6 +5902,7 @@ class BaseModel(metaclass=MetaModel):
         """
         return self.union(other)
 
+    @api.private
     def union(self, *args):
         """ Return the union of ``self`` with all the arguments (in linear time
             complexity, with first occurrence order preserved).
@@ -6038,6 +6054,7 @@ class BaseModel(metaclass=MetaModel):
         else:
             self.env.invalidate_all()
 
+    @api.private
     def invalidate_model(self, fnames=None, flush=True):
         """ Invalidate the cache of all records of ``self``'s model, when the
         cached values no longer correspond to the database values.  If the
@@ -6052,6 +6069,7 @@ class BaseModel(metaclass=MetaModel):
             self.flush_model(fnames)
         self._invalidate_cache(fnames)
 
+    @api.private
     def invalidate_recordset(self, fnames=None, flush=True):
         """ Invalidate the cache of the records in ``self``, when the cached
         values no longer correspond to the database values.  If the parameter

--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -9,9 +9,9 @@ from functools import partial
 from psycopg2 import IntegrityError, OperationalError, errorcodes
 
 import odoo
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import UserError, ValidationError, AccessError
+from odoo.models import BaseModel
 from odoo.http import request
-from odoo.models import check_method_name
 from odoo.tools import DotDict
 from odoo.tools.translate import _, translate_sql_constraint
 from . import security
@@ -22,6 +22,25 @@ _logger = logging.getLogger(__name__)
 PG_CONCURRENCY_ERRORS_TO_RETRY = (errorcodes.LOCK_NOT_AVAILABLE, errorcodes.SERIALIZATION_FAILURE, errorcodes.DEADLOCK_DETECTED)
 MAX_TRIES_ON_CONCURRENCY_FAILURE = 5
 
+
+def get_public_method(model, name):
+    """ Get the public unbound method from a model.
+    When the method does not exist or is inaccessible, raise appropriate errors.
+    Accessible methods are public (in sense that python defined it:
+    not prefixed with "_") and are not decorated with `@api.private`.
+    """
+    assert isinstance(model, BaseModel), f"{model!r} is not a BaseModel for {name}"
+    cls = type(model)
+    method = getattr(cls, name, None)
+    if not callable(method):
+        raise AttributeError(f"The method '{model._name}.{name}' does not exist")  # noqa: TRY004
+    for mro_cls in cls.mro():
+        cla_method = getattr(mro_cls, name, None)
+        if not cla_method:
+            continue
+        if name.startswith('_') or getattr(cla_method, '_api_private', False):
+            raise AccessError(f"Private methods (such as '{model._name}.{name}') cannot be called remotely.")  # pylint: disable=missing-gettext
+    return method
 
 def dispatch(method, params):
     db, uid, passwd = params[0], int(params[1]), params[2]
@@ -47,6 +66,7 @@ def execute_cr(cr, uid, obj, method, *args, **kw):
     recs = env.get(obj)
     if recs is None:
         raise UserError(_("Object %s doesn't exist", obj))
+    get_public_method(recs, method)  # Don't use the result, call_kw will redo the getattr
     result = retrying(partial(odoo.api.call_kw, recs, method, args, kw), env)
     # force evaluation of lazy values before the cursor is closed, as it would
     # error afterwards if the lazy isn't already evaluated (and cached)
@@ -61,7 +81,6 @@ def execute_kw(db, uid, obj, method, args, kw=None):
 
 def execute(db, uid, obj, method, *args, **kw):
     with odoo.registry(db).cursor() as cr:
-        check_method_name(method)
         res = execute_cr(cr, uid, obj, method, *args, **kw)
         if res is None:
             _logger.info('The method %s of the object %s can not return `None` !', method, obj)


### PR DESCRIPTION
Backport a part of 40da85aab905fd4accf8c01887e62b07537ccd2f.

Make some of the ORM methods private for the sake of correctness and to prevent people from using incorrect RPC calls. We are targeting methods that return recordsets that are not returned in the correct format in RPC. This commit doesn't strictly follow our stable policy, but it's unlikely to break anything.

Small change to the original version: we are not directly modifying odoo.api.call_kw(), as it is used by _eval_xml() and we don't want to change that in stable (or we need to backport part of https://github.com/odoo/odoo/pull/182709).

#### Original commit message

Explicitly prevent calling non-public ORM methods via RPC, without breaking the API

The ORM contains a series of API methods found on Models and recordsets, next to the main CRUD methods. Those utility methods are very commonly used in server-side business logic code, and were historically named without the usual underscore prefix that should mark them as private (e.g. `_private_method()` vs `public_method()`).

Examples:
- the `browse()` method returns a recordset from a list of IDs, which is really just a proxy object prepared for other recordset operations ;
- the `fetch()` and `search_fetch()` methods populate the transactional in-memory cache for a set of fields and record ;
- and many more...

The lack of prefix makes writing business logic code a bit simpler, but causes confusion because these methods look like they are public.

Of course, calling such internal methods over RPC doesn't make sense, and may crash or cause unexpected results.

This commit marks those internal methods and prevents calling them over RPC. This is preferred over renaming them with an underscore prefix, as that would break a lot of existing code without a good reason.

All business logic code must still follow the best-practicce convention of prefixing non-public method with underscores, by default and by design, to avoid mixing different conventions. The `@api.private` decorator is reserved for exceptions for ORM methods.

task-4505030

https://github.com/odoo/enterprise/pull/79382

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
