### PR TITLE
[FIX] account: invoice product name in both languages

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -224,10 +224,7 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
 
     updateLabel(value) {
         this.props.record.update({
-          name:
-            this.productName && this.productName !== value
-              ? `${this.productName}\n${value}`
-              : value,
+            name: value ? value : this.productName,
         });
     }
 }


### PR DESCRIPTION
When an invoice is created, the system will automatically translate the
strings into the customer language:
- In the backend the user will see the original product name and the label composed by
  translated name and translated description.
- In the printed pdf the customer will see just the translated label
However if the user modify the label in the backend, it will be saved
prepending the original product name

Steps to reproduce:
- Have a user using a language [LANG1]
- Have a customer using a language [LANG2]
- Make an invoice to the customer, add a product with both name and
  description with translation available
- Make a small change to the product label
- Save
- Print

Issue: The name of the product is duplicated, it appears in user language and customer language

opw-4444773