### PR TITLE
[FIX] point_of_sale: make parent category visible

### DIFF
--- a/addons/point_of_sale/models/pos_category.py
+++ b/addons/point_of_sale/models/pos_category.py
@@ -36,14 +36,8 @@ class PosCategory(models.Model):
     @api.model
     def _load_pos_data_domain(self, data):
         config_id = self.env['pos.config'].browse(data['pos.config']['data'][0]['id'])
-        # Load categories according to loaded products
-        product_catg_ids = []
-        for product in data['product.product']['data']:
-            product_catg_ids += product['pos_categ_ids']
-        if config_id.limit_categories and config_id.iface_available_categ_ids:
-            category_ids = config_id._get_available_categories().ids
-            product_catg_ids = list(set(product_catg_ids) & set(category_ids))
-        return [('id', 'in', product_catg_ids)]
+        domain = [('id', 'in', config_id._get_available_categories().ids)] if config_id.limit_categories and config_id.iface_available_categ_ids else []
+        return domain
 
     @api.model
     def _load_pos_data_fields(self, config_id):

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -131,7 +131,7 @@ class PosSession(models.Model):
     @api.model
     def _load_pos_data_models(self, config_id):
         return ['pos.config', 'pos.order', 'pos.order.line', 'pos.pack.operation.lot', 'pos.payment', 'pos.payment.method', 'pos.printer',
-            'pos.bill', 'res.company', 'account.tax', 'account.tax.group', 'product.product', 'pos.category', 'product.attribute', 'product.attribute.custom.value',
+                        'pos.category', 'pos.bill', 'res.company', 'account.tax', 'account.tax.group', 'product.product', 'product.attribute', 'product.attribute.custom.value',
             'product.template.attribute.line', 'product.template.attribute.value', 'product.combo', 'product.combo.item', 'product.packaging', 'res.users', 'res.partner',
             'decimal.precision', 'uom.uom', 'uom.category', 'res.country', 'res.country.state', 'res.lang', 'product.pricelist', 'product.pricelist.item', 'product.category',
             'account.cash.rounding', 'account.fiscal.position', 'account.fiscal.position.tax', 'stock.picking.type', 'res.currency', 'pos.note', 'ir.ui.view', 'product.tag', 'ir.module.module']

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -447,9 +447,6 @@ registry.category("web_tour.tours").add("PosCategoriesOrder", {
             {
                 trigger: '.category-button:eq(3) > span:contains("AAY")',
             },
-            {
-                trigger: '.category-button:not(:contains("AAD"))',
-            },
         ].flat(),
 });
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1504,20 +1504,15 @@ class TestUi(TestPointOfSaleHttpCommon):
     def test_product_categories_order(self):
         """ Verify that the order of categories doesnt change in the frontend """
         self.env['pos.category'].search([]).write({'sequence': 100})
-        catgA = self.env['pos.category'].create({
+        self.env['pos.category'].create({
             'name': 'AAA',
             'parent_id': False,
             'sequence': 1,
         })
-        catgB = self.env['pos.category'].create({
+        self.env['pos.category'].create({
             'name': 'AAC',
             'parent_id': False,
             'sequence': 3,
-        })
-        self.env['pos.category'].create({
-            'name': 'AAD',
-            'parent_id': False,
-            'sequence': 4,
         })
         parentA = self.env['pos.category'].create({
             'name': 'AAB',
@@ -1528,7 +1523,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'name': 'AAX',
             'parent_id': parentA.id,
         })
-        catgC = self.env['pos.category'].create({
+        self.env['pos.category'].create({
             'name': 'AAY',
             'parent_id': parentB.id,
         })
@@ -1536,7 +1531,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         # It's presence is checked during the tour to make sure app doesn't crash.
         self.env['product.product'].create({
             'name': 'Product in AAB and AAX',
-            'pos_categ_ids': [(6, 0, [parentA.id, parentB.id, catgA.id, catgB.id, catgC.id])],
+            'pos_categ_ids': [(6, 0, [parentA.id, parentB.id])],
             'available_in_pos': True,
         })
         self.main_pos_config.with_user(self.pos_admin).open_ui()

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -257,7 +257,7 @@ class PosConfig(models.Model):
         return encoded_images
 
     def _load_self_data_models(self):
-        return ['pos.session', 'pos.order', 'pos.order.line', 'pos.payment', 'pos.payment.method', 'res.currency', 'product.product', 'pos.category', 'product.combo', 'product.combo.item',
+        return ['pos.session', 'pos.order', 'pos.order.line', 'pos.payment', 'pos.payment.method', 'res.currency', 'pos.category', 'product.product', 'product.combo', 'product.combo.item',
             'res.company', 'account.tax', 'account.tax.group', 'pos.printer', 'res.country', 'product.pricelist', 'product.pricelist.item', 'account.fiscal.position', 'account.fiscal.position.tax',
             'res.lang', 'product.attribute', 'product.attribute.custom.value', 'product.template.attribute.line', 'product.template.attribute.value',
             'decimal.precision', 'uom.uom', 'pos.printer', 'pos_self_order.custom_link', 'restaurant.floor', 'restaurant.table', 'account.cash.rounding']


### PR DESCRIPTION
This commit reverts: https://github.com/odoo/odoo/commit/d7d3ed847f147dac23264e91b5d802cd67be6860

After discussing with POS PO the behavior introduced in the commit is not desirable and cannot be introduced in stable. 

# How to reproduce the issue:

- In Pos Product Categories, create a category "Parent",

- Create another category "Child" with its parent being "Parent"
- Create a new product with the POS category "Parent/Child"

- In the pos product displayed, the category display is "Child" and not "Parent"

https://github.com/odoo/odoo/commit/d7d3ed847f147dac23264e91b5d802cd67be6860, made the POS category visible only if there is a product in it. However, if the parent category has no products, it won't be displayed. 

opw-4561712



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
