### PR TITLE
[FIX] tools: avoid error on bytes read

### DIFF
--- a/odoo/tools/json.py
+++ b/odoo/tools/json.py
@@ -6,6 +6,7 @@ import re
 import markupsafe
 from .func import lazy
 from .misc import ReadonlyDict
+from locale import getpreferredencoding
 
 JSON_SCRIPTSAFE_MAPPER = {
     '&': r'\u0026',
@@ -69,5 +70,12 @@ def json_default(obj):
     if isinstance(obj, ReadonlyDict):
         return dict(obj)
     if isinstance(obj, bytes):
-        return obj.decode()
+        # Impossible to guess the encoding, but we can try common ones.
+        local_encoding = getpreferredencoding()
+        for encoding in ['utf-8', 'latin1', 'iso-8859-1', 'iso-8859-15', 'ascii', local_encoding]:
+            try:
+                return obj.decode(encoding)
+            except UnicodeDecodeError:
+                continue
+        raise UnicodeDecodeError("Unable to decode bytes with common encodings")
     return str(obj)


### PR DESCRIPTION
Since [this first commit], reading bytes not encoded in UTF-8 raises an error. The problematic code was moved from odoo/tools/date_utils.py to odoo/tools/json.py by [this other commit] after the bug was introduced.

Steps to reproduce:
- Install the documents app.
- Call search_read on documents.document to read the raw field.

=> A UnicodeDecodeError is raised on some documents.

The `ustr()` function is deprecated, so the fix is just about using the same logic. As it is impossible to guess the encoding of the bytes, we try to decode them with common encodings.

[this first commit]: https://github.com/odoo/odoo/commit/6a68e93f924cc78ba15bc78d981b1bf115e57a0d
[this other commit]: https://github.com/odoo/odoo/commit/5ef4c07ada1b47cd08a0fc7a2dd626f92d79b715

opw-4457853
