### PR TITLE
[IMP] l10n_tr_nilvera: improve exception handling for connectivity issues

### DIFF
--- a/addons/l10n_tr_nilvera/lib/nilvera_client.py
+++ b/addons/l10n_tr_nilvera/lib/nilvera_client.py
@@ -38,13 +38,18 @@ class NilveraClient:
         start = datetime.utcnow()
         url = self.base_url + endpoint
 
-        response = self.__session.request(
-            method, url,
-            timeout=self.timeout_limit,
-            params=params,
-            json=json,
-            files=files,
-        )
+        try:
+            response = self.__session.request(
+                method, url,
+                timeout=self.timeout_limit,
+                params=params,
+                json=json,
+                files=files,
+            )
+        except requests.exceptions.RequestException as e:
+            _logger.error("Network error during request: %s", e)
+            raise UserError("Network connectivity issue. Please check your internet connection and try again.")
+
         end = datetime.utcnow()
         self._log_request(method, start, end, url, params, json, response)
 

--- a/addons/l10n_tr_nilvera/models/res_partner.py
+++ b/addons/l10n_tr_nilvera/models/res_partner.py
@@ -2,6 +2,7 @@ import logging
 import urllib.parse
 
 from odoo import api, fields, models
+from odoo.exceptions import UserError
 from odoo.addons.l10n_tr_nilvera.lib.nilvera_client import _get_nilvera_client
 
 
@@ -60,7 +61,11 @@ class ResPartner(models.Model):
     def _compute_nilvera_customer_status_and_alias_id(self):
         for partner in self:
             if partner.vat and partner.ubl_cii_format == 'ubl_tr':
-                partner.check_nilvera_customer()
+                try:
+                    partner.check_nilvera_customer()
+                except UserError:
+                    # In case of an internet connection issue, exit silently.
+                    continue
             else:
                 # Reset the alias if no VAT or UBL format changed.
                 partner.l10n_tr_nilvera_customer_status = 'not_checked'


### PR DESCRIPTION
Previously, if a request in the Nilvera Client failed due to connectivity issues, a traceback was thrown. This behavior caused upgrade CI failures because the internet is blocked and check_nilvera_customer would be triggered for newly created partners. This commit enhances the exception handling for all requests and fixes the upgrade CI issue by silently exiting the function when a connectivity problem is detected.

no task ID.