### PR TITLE
[FIX] html_editor: update banner selector

### DIFF
--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -106,8 +106,9 @@ export class BannerPlugin extends Plugin {
             const zws = document.createTextNode("\u200B");
             bannerElement.before(zws);
         }
+        const baseContainerName = this.dependencies.baseContainer.getDefaultNodeName();
         this.dependencies.selection.setCursorStart(
-            bannerElement.querySelector(".o_editor_banner > div > p")
+            bannerElement.querySelector(`.o_editor_banner > div > ${baseContainerName}`)
         );
         this.dependencies.history.addStep();
     }

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -37,6 +37,29 @@ test("should insert a banner with focus inside followed by a paragraph", async (
     });
 });
 
+test("should insert a banner with DIV as basecontainer and focus inside it", async () => {
+    const { el, editor } = await setupEditor("<div>Test[]</div>", {
+        config: { baseContainer: "DIV" },
+    });
+    await insertText(editor, "/banner");
+    await animationFrame();
+    expect(".active .o-we-command-name").toHaveText("Banner Info");
+
+    await press("enter");
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<div class="o-paragraph">Test</div>
+            <div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
+                <div class="w-100 px-3" contenteditable="true">
+                    <div class="o-paragraph o-we-hint" placeholder='Type "/" for commands'>[]<br></div>
+                </div>
+            </div>
+            <div class="o-paragraph"><br></div>`
+        )
+    );
+});
+
 test("press 'ctrl+a' inside a banner should select all the banner content", async () => {
     const { el, editor } = await setupEditor("<p>Test[]</p>");
     await insertText(editor, "/bannerinfo");


### PR DESCRIPTION
**Problem**:
After introducing `baseContainer`, the default `baseContainer` is `div`.
To correctly update the selection to the banner, we need to update
the selector to use the default baseContainer instead of hardcoding `p`.

**Solution**:
Modify the selector to use the default baseContainer for banner
selection updates instead of `.o_editor_banner > div > p`

**Steps to Reproduce**:
1. Type `/banner`.
2. Press Enter on any banner.
3. Traceback occurs.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
