### PR TITLE
[PERF] point_of_sale: improve get_price for categories

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -289,8 +289,20 @@ class PosGlobalState extends PosModel {
                     }
                 }
                 else {
-                    for (const correspondingProduct of products) {
-                        this._assignApplicableItems(pricelist, correspondingProduct, pricelistItem);
+                    for (const correspondingProduct of modelProducts) {
+                        if (pricelistItem.categ_id) {
+                            let pricelistItem_categ_id = pricelistItem.categ_id[0];
+                            let product_categ_id = correspondingProduct.categ && correspondingProduct.categ.id; 
+                            let parent_categ_ids = correspondingProduct.parent_category_ids;
+                            if (product_categ_id && parent_categ_ids) {
+                                if (_.contains(parent_categ_ids.concat(product_categ_id), pricelistItem_categ_id)) {
+                                    this._assignApplicableItems(pricelist, correspondingProduct, pricelistItem);
+                                }
+                            }
+                        } 
+                        else {
+                            this._assignApplicableItems(pricelist, correspondingProduct, pricelistItem);
+                        }
                     }
                 }
             }
@@ -1591,7 +1603,6 @@ class Product extends PosModel {
     }
     isPricelistItemUsable(item, date) {
         return (
-            (!item.categ_id || _.contains(this.parent_category_ids.concat(this.categ.id), item.categ_id[0])) &&
             (!item.date_start || moment.utc(item.date_start).isSameOrBefore(date)) &&
             (!item.date_end || moment.utc(item.date_end).isSameOrAfter(date))
         );


### PR DESCRIPTION
### Description:

When having a pricelist with a lot of categories, it slows down the frontend when `get_price` is triggered. This is caused by the fact that the commit eb805e8 pre-filter product and product template. However, it doesn't pre-filter the categories. This means that if a user has, for example, 2918 categories, it will need to filter them each time `get_price` is triggered on each product updated.

### Fix:

To fix that, we can just pre-filter categories so that when `get_price` is called, we just need to filter on the items related to the product.

When opening the PoS, `_loadProductProduct` is called to retrieve the products. With these changes, this method will be a little slower to speed up `get_price`, which is called at the loading and anytime the display updates (adding to cart, selecting other categories, etc.).

### Benchmark (min-max time):

`get_price`:
| N° of categ. |  Before  | After |
|--------------|----------|-------|
|         2918 | 19-408ms | 1-4ms |
|         1918 | 15-240ms | 1-4ms |
|          518 | 14-181ms | 1-4ms |

`_loadProductProduct`:
| N° of categ. |  Before  |   After   |
|--------------|----------|-----------|
|         2918 |  6-734ms | 56ms-1.4s |
|         1918 |  9-632ms | 35ms-1.2s |
|          518 |  9-331ms |  44-827ms |

### References:
eb805e85f4a3bb7113c67feeb1d7101714bd4238
opw-4520767