### PR TITLE
[FIX] l10n_fr_account: xml_id changed but not in the pot/po

### DIFF
--- a/addons/l10n_fr_account/i18n/fr.po
+++ b/addons/l10n_fr_account/i18n/fr.po
@@ -183,6 +183,7 @@ msgstr "25 - Crédit de TVA"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_26
+#: model:account.report.line,name:l10n_fr_account.tax_report_26_external
 msgid "26 - Repayment of credit requested on form n°3519 attached"
 msgstr "26 - Remboursement de crédit demandé sur formulaire n°3519 joint"
 

--- a/addons/l10n_fr_account/i18n/l10n_fr_account.pot
+++ b/addons/l10n_fr_account/i18n/l10n_fr_account.pot
@@ -179,6 +179,7 @@ msgstr ""
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_26
+#: model:account.report.line,name:l10n_fr_account.tax_report_26_external
 msgid "26 - Repayment of credit requested on form n°3519 attached"
 msgstr ""
 


### PR DESCRIPTION
In https://github.com/odoo/odoo/commit/b42c99abd362c15e86f6a745399979dd3236b75a, we changed the xml_id but we forgot to change that in the pot




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
