### PR TITLE
[IMP] *: many2many_avatar_user

### DIFF
--- a/addons/mail/static/tests/web/fields/many2many_avatar_user.test.js
+++ b/addons/mail/static/tests/web/fields/many2many_avatar_user.test.js
@@ -39,10 +39,8 @@ test("many2many_avatar_user in kanban view", async () => {
             </kanban>
         `,
     });
-    await click(".o_kanban_record .o_field_many2many_avatar_user .o_m2m_avatar_empty", {
-        text: "+2",
-    });
-    await click(".o_kanban_record .o_field_many2many_avatar_user .o_m2m_avatar_empty");
+    expect(".o_kanban_record .o_field_many2many_avatar_user .o_m2m_avatar_empty").toHaveText("+2");
+    await click(".o_kanban_record .o_field_many2many_avatar_user .o_quick_assign");
     await contains(".o_popover > .o_field_tags > .o_tag", { count: 4 });
     await contains(".o_popover > .o_field_tags > :nth-child(1 of .o_tag)", { text: "Tapu" });
     await contains(".o_popover > .o_field_tags > :nth-child(2 of .o_tag)", { text: "Luigi" });

--- a/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.scss
+++ b/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.scss
@@ -15,6 +15,14 @@
         }
     }
 
+    .subtask_list_row {
+        @include media-breakpoint-up(sm) {
+            .o_field_widget.o_field_many2many_tags_avatar .o_quick_assign {
+                visibility: hidden !important;
+            }
+        }
+    }
+
     .subtask_list_row:hover {
         background-color: $table-hover-bg;
         @include media-breakpoint-up(sm) {

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.scss
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.scss
@@ -10,26 +10,6 @@
         font-size: 16px;
     }
 
-    .o_kanban_record {
-        @include media-breakpoint-up(sm) {
-            &:hover {
-                .o_field_widget.o_field_many2many_tags_avatar .o_quick_assign {
-                    visibility: hidden;
-                }
-            }
-        }
-    }
-
-    .o_kanban_record footer {
-        @include media-breakpoint-up(sm) {
-            &:hover {
-                .o_field_widget.o_field_many2many_tags_avatar .o_quick_assign {
-                    visibility: visible;
-                }
-            }
-        }
-    }
-
     .o_kanban_header .o_column_progress .bg-success-done {
         --bs-bg-opacity: 1;
         background-color: rgba(25, 135, 84, var(--bs-bg-opacity)) !important;

--- a/addons/web/static/src/core/tags_list/tags_list.js
+++ b/addons/web/static/src/core/tags_list/tags_list.js
@@ -8,8 +8,9 @@ export class TagsList extends Component {
     static props = {
         displayText: { type: Boolean, optional: true },
         visibleItemsLimit: { type: Number, optional: true },
-        tags: { type: Object },
+        tags: { type: Array, element: Object },
     };
+
     get visibleTagsCount() {
         return this.props.visibleItemsLimit - 1;
     }
@@ -20,13 +21,10 @@ export class TagsList extends Component {
         return this.props.tags;
     }
     get otherTags() {
-        if (
-            !this.props.visibleItemsLimit ||
-            this.props.tags.length <= this.props.visibleItemsLimit
-        ) {
-            return [];
+        if (this.props.visibleItemsLimit && this.props.tags.length > this.props.visibleItemsLimit) {
+            return this.props.tags.slice(this.visibleTagsCount);
         }
-        return this.props.tags.slice(this.visibleTagsCount);
+        return [];
     }
     get tooltipInfo() {
         return JSON.stringify({

--- a/addons/web/static/src/core/tags_list/tags_list.xml
+++ b/addons/web/static/src/core/tags_list/tags_list.xml
@@ -13,7 +13,8 @@
                 t-attf-class="{{ !tag.img ? 'o_tag_color_' + (tag.colorIndex ? tag.colorIndex : '0') : '' }}"
                 tabindex="-1"
                 t-att-data-color="tag.colorIndex"
-                t-att-title="tag.title || tag.text"
+                t-att-aria-label="tag.title || tag.text"
+                t-att-data-tooltip="tag.title || tag.text"
                 t-on-click="(ev) => tag.onClick and tag.onClick(ev)"
                 t-on-keydown="tag.onKeydown">
 
@@ -44,7 +45,7 @@
                             'btn btn-link position-relative py-0 px-1 text-danger opacity-0': tag.img,
                             'ps-1 opacity-75': !tag.img
                         }"
-                    title="Delete"
+                    data-tooltip="Delete"
                     aria-label="Delete"
                     tabIndex="-1"
                     href="#">
@@ -52,7 +53,7 @@
                 </a>
             </span>
         </t>
-        <span t-if="props.tags and otherTags.length" class="o_m2m_avatar_empty rounded text-center fw-bold" data-tooltip-template="web.TagsList.Tooltip" data-tooltip-position="right" t-att-data-tooltip-info="tooltipInfo">
+        <span t-if="otherTags.length" class="o_m2m_avatar_empty rounded text-center fw-bold cursor-default" data-tooltip-template="web.TagsList.Tooltip" data-tooltip-position="right" t-att-data-tooltip-info="tooltipInfo" t-on-click.stop="">
             <span t-if="otherTags.length > 9" t-esc="'9+'" />
             <span t-else="" t-esc="'+' + otherTags.length" />
         </span>

--- a/addons/web/static/src/core/tooltip/tooltip_service.js
+++ b/addons/web/static/src/core/tooltip/tooltip_service.js
@@ -102,6 +102,8 @@ export const tooltipService = {
             }
 
             target = el;
+            // Prevent title from showing on a parent at the same time
+            target.title = "";
             openTooltipTimeout = browser.setTimeout(() => {
                 // verify that the element is still in the DOM
                 if (target.isConnected) {
@@ -111,8 +113,6 @@ export const tooltipService = {
                         { tooltip, template, info },
                         { position }
                     );
-                    // Prevent title from showing on a parent at the same time
-                    target.title = "";
                 }
             }, delay);
         }

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
@@ -106,6 +106,7 @@ export class KanbanMany2ManyTagsAvatarFieldTagsList extends TagsList {
             closeOnClickAway: (target) => !target.closest(".modal"),
         });
     }
+
     openPopover(ev) {
         if (this.props.readonly) {
             return;
@@ -120,7 +121,7 @@ export class KanbanMany2ManyTagsAvatarFieldTagsList extends TagsList {
         });
     }
     get canDisplayQuickAssignAvatar() {
-        return !this.props.readonly && !(this.props.tags && this.otherTags.length);
+        return !this.props.readonly;
     }
 }
 

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
@@ -30,12 +30,9 @@
     <t t-name="web.KanbanMany2ManyTagsAvatarFieldTagsList" t-inherit="web.TagsList" t-inherit-mode="primary">
         <xpath expr="//t[@t-foreach='visibleTags']" position="before">
             <t t-if="canDisplayQuickAssignAvatar">
-                <a t-on-click.stop.prevent="openPopover" tabIndex="-1" href="#" title="Assign"
+                <a t-on-click.stop.prevent="openPopover" tabIndex="-1" href="#" data-tooltip="Assign"
                    aria-label="Assign" class="o_quick_assign fa fa-user-plus o_m2m_avatar btn-link d-flex align-items-center text-dark" role="button"/>
             </t>
-        </xpath>
-        <xpath expr="//span[hasclass('o_m2m_avatar_empty')]" position="attributes">
-            <attribute name="t-on-click.stop.prevent">openPopover</attribute>
         </xpath>
     </t>
 

--- a/addons/web/static/tests/views/fields/many2many_tags_avatar_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_avatar_field.test.js
@@ -34,9 +34,7 @@ class Turtle extends models.Model {
     ];
 }
 
-onRpc("has_group", () => {
-    return true;
-});
+onRpc("has_group", () => true);
 
 defineModels([Partner, Turtle]);
 
@@ -261,10 +259,10 @@ test("widget many2many_tags_avatar in kanban view", async () => {
         ".o_kanban_record:nth-child(3) .o_field_many2many_tags_avatar .o_avatar img"
     ).toHaveCount(2);
     expect(
-        `.o_kanban_record:nth-child(3) .o_field_many2many_tags_avatar .o_avatar:nth-child(1) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/5/avatar_128']`
+        `.o_kanban_record:nth-child(3) .o_field_many2many_tags_avatar .o_avatar:nth-child(1 of .o_tag) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/5/avatar_128']`
     ).toHaveCount(1);
     expect(
-        `.o_kanban_record:nth-child(3) .o_field_many2many_tags_avatar .o_avatar:nth-child(2) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/4/avatar_128']`
+        `.o_kanban_record:nth-child(3) .o_field_many2many_tags_avatar .o_avatar:nth-child(2 of .o_tag) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/4/avatar_128']`
     ).toHaveCount(1);
     expect(
         ".o_kanban_record:nth-child(3) .o_field_many2many_tags_avatar .o_m2m_avatar_empty"
@@ -283,7 +281,7 @@ test("widget many2many_tags_avatar in kanban view", async () => {
         ".o_kanban_record:nth-child(4) .o_field_many2many_tags_avatar .o_m2m_avatar_empty"
     ).toHaveText("9+");
     expect(".o_field_many2many_tags_avatar .o_field_many2many_selection").toHaveCount(0);
-    await contains(".o_kanban_record:nth-child(3) .o_field_tags > .o_m2m_avatar_empty").click();
+    await contains(".o_kanban_record:nth-child(3) .o_quick_assign", { visible: false }).click();
     await animationFrame();
     expect(".o-overlay-container input").toBeFocused();
     expect(".o-overlay-container .o_tag").toHaveCount(4);

--- a/addons/web/static/tests/views/fields/many2many_tags_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field.test.js
@@ -101,9 +101,7 @@ class Turtle extends models.Model {
 
 defineModels([Partner, PartnerType, Turtle]);
 
-onRpc("has_group", () => {
-    return true;
-});
+onRpc("has_group", () => true);
 
 test.tags("desktop");
 test("Many2ManyTagsField with and without color on desktop", async () => {
@@ -781,7 +779,7 @@ test("Many2ManyTagsField keeps focus when being edited", async () => {
     expect(".o_field_many2many_tags input").toBeFocused();
 });
 
-test("Many2ManyTagsField: tags title attribute", async () => {
+test("Many2ManyTagsField: tags data-tooltip attribute", async () => {
     Turtle._records[0].partner_ids = [2];
 
     await mountView({
@@ -797,7 +795,7 @@ test("Many2ManyTagsField: tags title attribute", async () => {
             </form>`,
     });
 
-    expect(".o_field_many2many_tags .o_tag.badge").toHaveAttribute("title", "second record");
+    expect(".o_field_many2many_tags .o_tag.badge").toHaveAttribute("data-tooltip", "second record");
 });
 
 test("Many2ManyTagsField: toggle colorpicker with multiple tags", async () => {
@@ -820,13 +818,13 @@ test("Many2ManyTagsField: toggle colorpicker with multiple tags", async () => {
     await contains(".o_field_many2many_tags .badge").click();
     expect(".o_colorlist").toHaveCount(1);
 
-    await contains(".o_field_many2many_tags [title=silver]").click();
+    await contains(".o_field_many2many_tags [data-tooltip=silver]").click();
     expect(".o_colorlist").toHaveCount(1);
 
-    await contains(".o_field_many2many_tags [title=silver]").click();
+    await contains(".o_field_many2many_tags [data-tooltip=silver]").click();
     expect(".o_colorpicker").toHaveCount(0);
 
-    await contains(".o_field_many2many_tags [title=silver]").click();
+    await contains(".o_field_many2many_tags [data-tooltip=silver]").click();
     expect(".o_colorlist").toHaveCount(1);
 
     await contains(getFixture()).click();


### PR DESCRIPTION
We make the many2many_tags_avatar field be more consistent:
- The tooltips in its various parts are now custom tooltips (managed by the tooltip service)
- The button "Assign" for modifying tags is always put in the dom when readonly=False
- The +x span is no longer clickable and has a single function: show information on the tags too numerous to display

Task ID: 4571809

For the sake of uniformity, in the views with class o_kanban_project_tasks, we make the main many2many_tags_avatar field have its button 'Assign' appear when the kanban card is hovered.

Task ID: 4535902
