### PR TITLE
[FIX] point_of_sale: small orderlines UI adjustments

### DIFF
--- a/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
+++ b/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
@@ -10,7 +10,7 @@
                         <Orderline t-else="" line="line" mode="this.props.mode" />
                     </t>
                     <div t-if="order.general_customer_note"
-                        t-attf-class="{{this.props.mode === 'receipt' ? 'mt-1 bg-opacity-75 p-0 ' : 'customer-note w-100 p-2 mt-2 rounded text-break text-bg-warning bg-opacity-25 mt-0'}}">
+                        t-attf-class="{{this.props.mode === 'receipt' ? 'mt-1 bg-opacity-75 p-0 ' : 'customer-note w-100 p-2 rounded text-break text-bg-warning bg-opacity-25 mt-0'}}">
                         <div class="row flex-wrap w-100 m-0">
                             <div class="col-auto px-1">
                                 <i class="fa fa-sticky-note me-1 fa-lg" role="img"
@@ -26,7 +26,7 @@
                         </div>
                     </div>
                     <div t-if="order.internal_note"
-                        class="internal-note-container d-flex gap-2 flex-wrap">
+                        class="internal-note-container d-flex gap-2 flex-wrap m-1">
                         <t t-foreach="order.internal_note.split('\n') or []" t-as="note"
                             t-key="note_index">
                             <li t-if="note.trim() !== ''" t-esc="note"

--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
@@ -8,7 +8,8 @@
             <div t-if="props.showImage and line.product_id.getImageUrl()" class="o_line_container d-flex align-items-center justify-content-center">
                 <img t-attf-style="border-radius: 1rem;" t-att-src="line.product_id.getImageUrl()"/>
             </div>
-            <div class="d-flex flex-column w-100 p-2">
+            <div class="d-flex flex-column w-100"
+                 t-attf-class="{{ line.combo_parent_id?.getFullProductName() ? 'px-2 py-1' : 'p-2' }}">
                 <div class="line-details d-flex justify-content-between align-items-center">
                     <div class="product-name d-flex flex-grow-1 align-items-center pe-2 text-truncate">
                         <span class="qty d-inline-block px-1 fw-bolder">
@@ -34,7 +35,7 @@
                             <i class="fa fa-tag pe-1"/><t t-esc="line.allPrices.priceWithTaxBeforeDiscount"/> With a <em><t t-esc="discount" />% </em> discount
                         </t>
                     </li>
-                    <li t-if="line.customer_note" class="customer-note w-100 rounded text-break bg-opacity-25" t-att-class="{'text-bg-warning p-2 mt-2': this.props.mode === 'display'}">
+                    <li t-if="line.customer_note" class="customer-note w-100 rounded text-break bg-opacity-25" t-att-class="{'text-bg-warning p-2 mt-1 mb-1': this.props.mode === 'display'}">
                         <i class="fa fa-sticky-note me-1" role="img" aria-label="Customer Note" title="Customer Note"/>
                         <t t-esc="line.customer_note" />
                     </li>
@@ -43,7 +44,7 @@
                             <li t-if="note.trim() !== ''" t-esc="note" class="internal-note badge rounded text-bg-info" style="font-size: 0.85rem;" />
                         </t>
                     </div>
-                    <div class="mt-1 d-flex gap-2 align-items-center">
+                    <div t-if="line.product_id.tracking !== 'none'" class="mt-1 d-flex gap-2 align-items-center">
                         <t t-slot="pack-lot-icon" />
                         <div class="fst-italic">
                             <li t-foreach="line.packLotLines or []" t-as="lot" t-key="lot_index" t-esc="lot" />


### PR DESCRIPTION
- Fix missing space between "Customer Note" & "Kitchen Note"
- Reduce space for combo products (register & receipt)
- Remove empty <ul> element from order lines (when no `packLotLines`)

task-id: 4578826





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
