### PR TITLE
[FIX] phone_validation: phone numbers in mexico

### DIFF
--- a/addons/phone_validation/lib/phonenumbers_patch/__init__.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/__init__.py
@@ -63,16 +63,12 @@ else:
         # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.12.57/python/phonenumbers/data/region_SN.py
         phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('SN', _local_load_region)
 
-    if parse_version(phonenumbers.__version__) < parse_version('8.12.39'):
-        # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.36/python/phonenumbers/data/region_CO.py
-        phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('CO', _local_load_region)
-
     if parse_version(phonenumbers.__version__) < parse_version('8.13.31'):
         # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.40/python/phonenumbers/data/region_KE.py
         phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('KE', _local_load_region)
 
     # MONKEY PATCHING phonemetadata to fix Brazilian phonenumbers following 2016 changes
-    def _hook_load_region(code):
+    def _hook_load_region_br(code):
         if parse_version(phonenumbers.__version__) < parse_version('8.13.39'):
             # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.39/python/phonenumbers/data/region_BR.py
             _local_load_region(code)
@@ -87,4 +83,28 @@ else:
                     leading_digits_pattern=['(?:[14689][1-9]|2[12478]|3[1-578]|5[13-5]|7[13-579][689])'],
                 )
             )
-    phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('BR', _hook_load_region)
+    phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('BR', _hook_load_region_br)
+
+    # MONKEY PATCHING phonemetadata to fix Mexican phonenumbers following 2019 changes
+    # BEFORE https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.37/python/phonenumbers/data/region_MX.py
+    # AFTER  https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.38/python/phonenumbers/data/region_MX.py
+    def _hook_load_region_mx(code):
+        phonenumbers.data._load_region(code)
+        if parse_version(phonenumbers.__version__) > parse_version('8.13.37'):
+            _region_metadata = phonenumbers.PhoneMetadata._region_metadata
+            if 'MX' in _region_metadata:
+                _region_metadata['MX'].intl_number_format.append(
+                    phonenumbers.phonemetadata.NumberFormat(
+                        pattern='(\\d)(\\d{2})(\\d{4})(\\d{4})',
+                        format='\\2 \\3 \\4',
+                        leading_digits_pattern=['1(?:33|5[56]|81)']
+                    )
+                )
+                _region_metadata['MX'].intl_number_format.append(
+                    phonenumbers.phonemetadata.NumberFormat(
+                        pattern='(\\d)(\\d{3})(\\d{3})(\\d{4})',
+                        format='\\2 \\3 \\4',
+                        leading_digits_pattern=['1']
+                    )
+                )
+    phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('MX', _hook_load_region_mx)

--- a/addons/phone_validation/tests/test_phonenumbers_patch.py
+++ b/addons/phone_validation/tests/test_phonenumbers_patch.py
@@ -142,6 +142,21 @@ class TestPhonenumbersPatch(BaseCase):
         )
         self._assert_parsing_phonenumbers(parse_test_lines_MU)
 
+    def test_region_MX_monkey_patch(self):
+        """ Test Mexican phone numbers patch for removed 1 in mobile numbers """
+        if not phonenumbers:
+            self.skipTest('Cannot test without phonenumbers module installed.')
+
+        # Phone numbers starting with 1 should have the 1 removed
+        parsed = phonenumbers.parse('15585440749', region="MX")
+        formatted = phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
+        self.assertEqual(formatted, '+52 55 8544 0749')
+
+        # Phone numbers without the 1 should still be parsed
+        parsed = phonenumbers.parse('5595440749', region="MX")
+        formatted = phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
+        self.assertEqual(formatted, '+52 55 9544 0749')
+
     def test_region_KE_monkey_patch(self):
         """Makes sure that patch for kenyan phone numbers work"""
         gt_KE_number = 711123456  # what national number we expect after parsing

--- a/addons/phone_validation/tools/phone_validation.py
+++ b/addons/phone_validation/tools/phone_validation.py
@@ -15,7 +15,12 @@ try:
 
     def phone_parse(number, country_code):
         try:
+            # Parse a first time to obtain an initial PhoneNumber object
             phone_nbr = phonenumbers.parse(number, region=country_code or None, keep_raw_input=True)
+            # Force format to international to apply metadata patches
+            formatted_intl = phonenumbers.format_number(phone_nbr, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
+            # Parse a second time with the number now formatted internationally
+            phone_nbr = phonenumbers.parse(formatted_intl, region=country_code or None, keep_raw_input=True)
         except phonenumbers.phonenumberutil.NumberParseException as e:
             raise UserError(
                 _('Unable to parse %(phone)s: %(error)s', phone=number, error=str(e))
@@ -48,12 +53,7 @@ try:
             else:
                 raise UserError(_('Impossible number %s: probably invalid number of digits.', number))
         if not phonenumbers.is_valid_number(phone_nbr):
-            # Force format with international to force metadata to apply
-            formatted_intl = phonenumbers.format_number(phone_nbr, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
-            phone_nbr_intl = phonenumbers.parse(formatted_intl, region=country_code or None, keep_raw_input=True)
-            if not phonenumbers.is_valid_number(phone_nbr_intl):
-                raise UserError(_('Invalid number %s: probably incorrect prefix.', number))
-            return phone_nbr_intl
+            raise UserError(_('Invalid number %s: probably incorrect prefix.', number))
 
         return phone_nbr
 


### PR DESCRIPTION
Current behaviour:
---
Mexican phone numbers are not managed correctly following the 2019 changes in Mexico.
(Removing a 1 in phone numbers)

Cause of the issue:
---
The phonenumbers library removing support of mexican phone numbers starting with 1 in 8.13.38
The Whatsapp API still using the mexican phone numbers starting with 1

Fixes:
---
Patched the phonenumbers library, removing 1 at the right place for mexican phone numbers.
Similar to: https://github.com/odoo/odoo/commit/53885e41867653ad45ca3aef55886c280240b76a

Changed the forcing to international format when parsing, to make sure the patches are applied before detecting an issue. 
Similar to: https://github.com/odoo/odoo/commit/29a4de8e29a2e330b8e5993c9fde23c69a2eff5e

opw-4473528

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
