### PR TITLE
[IMP] account, mrp*: hide unnecessary decimals for quantity in reports

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -146,6 +146,7 @@
 
                         <t t-set="display_discount" t-value="any(l.discount for l in o.invoice_line_ids)"/>
                         <div class="oe_structure"></div>
+                        <t t-set="format_number" t-value="lambda x: int(x) if x.is_integer() else x"/>
                         <table class="o_has_total_table table o_main_table table-borderless" name="invoice_line_table">
                             <thead>
                                 <tr>
@@ -176,7 +177,7 @@
                                                 <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">Bacon Burger</span>
                                             </td>
                                             <td name="td_quantity" class="text-end text-nowrap">
-                                                <span t-field="line.quantity">3.00</span>
+                                                <span t-out="format_number(line.quantity)">3.00</span>
                                                 <span t-field="line.product_uom_id"  groups="uom.group_uom">units</span>
                                                 <span t-if="line.product_uom_id != line.product_id.uom_id" groups="uom.group_uom" class="text-muted small">
                                                     <br/>

--- a/addons/l10n_hu_edi/views/report_invoice.xml
+++ b/addons/l10n_hu_edi/views/report_invoice.xml
@@ -70,7 +70,7 @@
                 <div t-field="o.l10n_hu_payment_mode"/>
             </div>
         </xpath>
-        <xpath expr="//table[@name='invoice_line_table']//span[@t-field='line.quantity']" position="attributes">
+        <xpath expr="//table[@name='invoice_line_table']//span[@t-out='format_number(line.quantity)']" position="attributes">
             <attribute name="t-field"/>
             <attribute name="t-out">line.quantity * sign if line.quantity != 0 else line.quantity</attribute>
         </xpath>

--- a/addons/mrp/report/mrp_production_templates.xml
+++ b/addons/mrp/report/mrp_production_templates.xml
@@ -100,6 +100,7 @@
             Components
         </span>
     </h3>
+    <t t-set="format_number" t-value="lambda x: int(x) if x.is_integer() else x"/>
     <table class="table table-sm">
         <div class="oe_structure"></div>
         <t t-set="has_product_barcode" t-value="any(m.product_id.barcode for m in o.move_raw_ids)"/>
@@ -122,7 +123,7 @@
                     </div>
                 </td>
                 <td t-attf-class="{{ 'text-end' if not has_product_barcode else '' }}">
-                    <span t-field="raw_line.product_uom_qty">25</span>
+                    <span t-out="format_number(raw_line.product_uom_qty)">25</span>
                     <span t-field="raw_line.product_uom" groups="uom.group_uom">Pieces</span>
                 </td>
                 <td t-if="has_product_barcode" width="15%" class="text-center">

--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -51,6 +51,7 @@
                 </div>
             </div>
 
+            <t t-set="format_number" t-value="lambda x: int(x) if x.is_integer() else x"/>
             <table class="o_has_total_table table o_main_table table-borderless">
                 <thead>
                     <tr>
@@ -75,7 +76,7 @@
                                     <span t-field="line.name"/>
                                 </td>
                                 <td class="text-end">
-                                    <span t-field="line.product_qty"/>
+                                    <span t-out="format_number(line.product_qty)"/>
                                     <span t-field="line.product_uom_id.name" groups="uom.group_uom"/>
                                     <span t-if="line.product_uom_id != line.product_id.uom_id" class="text-muted small">
                                         <br/>

--- a/addons/purchase/report/purchase_quotation_templates.xml
+++ b/addons/purchase/report/purchase_quotation_templates.xml
@@ -25,6 +25,7 @@
                 <span>Request for Quotation <span t-field="o.name"/></span>
             </t>
 
+            <t t-set="format_number" t-value="lambda x: int(x) if x.is_integer() else x"/>
             <table class="table table-borderless">
                 <thead style="display: table-row-group">
                     <tr>
@@ -44,7 +45,7 @@
                                     <span t-field="order_line.date_planned" t-options="{'date_only': 'true'}"/>
                                 </td>
                                 <td class="text-end">
-                                    <span t-field="order_line.product_qty"/>
+                                    <span t-out="format_number(order_line.product_qty)"/>
                                     <span t-field="order_line.product_uom_id" groups="uom.group_uom"/>
                                     <span t-if="order_line.product_uom_id != order_line.product_id.uom_id" class="text-muted small">
                                     <br/>

--- a/addons/repair/report/repair_templates_repair_order.xml
+++ b/addons/repair/report/repair_templates_repair_order.xml
@@ -40,6 +40,7 @@
                     </div>
                     <div class="oe_structure"/>
                     <h2 class="mb-3 border-bottom border-2 border-dark">Parts</h2>
+                    <t t-set="format_number" t-value="lambda x: int(x) if x.is_integer() else x"/>
                     <table class="table table-borderless o_main_table">
                         <thead>
                             <tr>
@@ -55,7 +56,7 @@
                                     <p t-if="line.repair_line_type == 'recycle'">(<i>Recycle</i>) <span t-field="line.product_id" data-oe-demo="Product C"/></p>
                                 </td>
                                 <td class="text-end">
-                                    <span t-field="line.product_uom_qty">5</span>
+                                    <span t-out="format_number(line.product_uom_qty)">5</span>
                                     <span groups="uom.group_uom" t-field="line.product_uom.name">Units</span>
                                 </td>
                             </tr>

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -72,6 +72,7 @@
             <t t-set="display_discount" t-value="any(l.discount for l in lines_to_report)"/>
 
             <div class="oe_structure"></div>
+            <t t-set="format_number" t-value="lambda x: int(x) if x.is_integer() else x"/>
             <table class="o_has_total_table table o_main_table table-borderless">
                 <!-- In case we want to repeat the header, remove "display: table-row-group" -->
                 <thead style="display: table-row-group">
@@ -107,7 +108,7 @@
                             <t t-if="not line.display_type and line.product_type != 'combo'">
                                 <td name="td_name"><span t-field="line.name">Bacon Burger</span></td>
                                 <td name="td_quantity" class="text-end text-nowrap">
-                                    <span t-field="line.product_uom_qty">3</span>
+                                    <span t-out="format_number(line.product_uom_qty)">3</span>
                                     <span t-field="line.product_uom_id">units</span>
                                     <span t-if="line.product_uom_id != line.product_id.uom_id" class="text-muted small">
                                         <t t-set="quantity_in_product_uom" t-value="line.product_uom_id._compute_quantity(line.product_uom_qty, line.product_id.uom_id)"/>


### PR DESCRIPTION
*: purchase, repair, sale

Currently, PDF reports display quantities with unnecessary decimals (e.g., '2.00' instead of '2'). Now we have updated the formatting to show whole numbers when decimals are .00, ensuring a cleaner and more readable design.

task - [4547923](https://www.odoo.com/odoo/my-tasks/4547923)