### PR TITLE
[FIX] survey: accurate statistic calculations

### DIFF
--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -213,8 +213,8 @@ class Survey(models.Model):
 
         for survey_stats in stat.values():
             avg_total = survey_stats.pop('answer_score_avg_total')
-            survey_stats['answer_score_avg'] = avg_total / (survey_stats['answer_done_count'] or 1)
-            survey_stats['success_ratio'] = (survey_stats['success_count'] / (survey_stats['answer_done_count'] or 1.0))*100
+            survey_stats['answer_score_avg'] = avg_total / (survey_stats['answer_count'] or 1)
+            survey_stats['success_ratio'] = (survey_stats['success_count'] / (survey_stats['answer_count'] or 1.0))*100
 
         for survey in self:
             survey.update(stat.get(survey._origin.id, default_vals))

--- a/doc/cla/individual/lightsystem.md
+++ b/doc/cla/individual/lightsystem.md
@@ -1,0 +1,11 @@
+Portugal, 2024-11-20
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+João Diogo Horta Alves joao.horta.alves@gmail.com https://github.com/LightSystem


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This commit addresses inaccurate calculation of statistics in surveys. The survey fields `answer_score_avg` and `success_ratio` are affected.

Current behavior before PR:

These are currently using the number of completed surveys as the total number of surveys, but they are gathering data from all surveys, completed or not. This results in broken statistics when there are in progress or incomplete surveys.
The values become too high, including `success_ratio` being above 100%!

Desired behavior after PR is merged:

The proposed solution is simply to consider all answers to the survey so that the statistics can accurately reflect the scores across all initiated surveys.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
