### PR TITLE
[FIX] stock: valuation layer not created for new products

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -980,15 +980,9 @@ class ProductTemplate(models.Model):
         product_templates = super().create(vals_list)
 
         if any(product_tmpl_quantities):
-            warehouse = self.env['stock.warehouse'].search(
-                [('company_id', '=', self.env.company.id)], limit=1
-            )
-            stock_quant = self.env['stock.quant']
             for product_tmpl, qty in zip(product_templates, product_tmpl_quantities):
                 if qty > 0 and product_tmpl.tracking == 'none':
-                    stock_quant._update_available_quantity(
-                        product_tmpl.product_variant_id, warehouse.lot_stock_id, qty
-                    )
+                    product_tmpl.product_variant_id.qty_available = qty
         return product_templates
 
     def write(self, vals):


### PR DESCRIPTION
Before introducing this PR https://github.com/odoo/odoo/pull/191742 creating a new product and updating 
the `Quantity on Hand` would trigger the creation of a valuation layer for 
the associated product

Steps to produce
================
- Create a new product with quantity tracking enabled.
- Set the initial quantity and define the standard price.
- Save the product form.
- Navigate to the Stock Valuation report, and you will not find a 
  valuation layer for the newly created product.

Issue
=====
The previous implementation directly created stock quants without 
generating a move record, which prevented the valuation layer from 
being updated correctly.

