### PR TITLE
[FIX] website_sale: prevent an error when proceess a payment

### DIFF
--- a/addons/payment_demo/static/src/js/express_checkout_form.js
+++ b/addons/payment_demo/static/src/js/express_checkout_form.js
@@ -55,6 +55,7 @@ paymentExpressCheckoutForm.include({
                 'zip': shippingInfo.querySelector('#o_payment_demo_shipping_zip').value,
                 'city': shippingInfo.querySelector('#o_payment_demo_shipping_city').value,
                 'country': shippingInfo.querySelector('#o_payment_demo_shipping_country').value,
+                'state': shippingInfo.querySelector('#o_payment_demo_shipping_state').value
             };
             // Call the shipping address update route to fetch the shipping options.
             const availableCarriers = await rpc(
@@ -85,7 +86,8 @@ paymentExpressCheckoutForm.include({
                     'street2': '23',
                     'country': 'BE',
                     'city':'Ramillies',
-                    'zip':'1367'
+                    'zip':'1367',
+                    'state': 'BE-WBR'
                 },
             }
         );

--- a/addons/payment_demo/views/payment_demo_templates.xml
+++ b/addons/payment_demo/views/payment_demo_templates.xml
@@ -166,6 +166,19 @@
                         />
                     </div>
                     <div class="col mb-0">
+                        <label for="o_payment_demo_shipping_state" class="mt-1">
+                            <small><b>State</b></small>
+                        </label>
+                        <select id="o_payment_demo_shipping_state"
+                                class="form-select"
+                                disabled="true"
+                        >
+                            <option t-att-value="customer.state_id.code or 'BE-WBR'"
+                                    t-out="customer.state_id.name or 'Walloon Brabant'"
+                            />
+                        </select>
+                    </div>
+                    <div class="col mb-0">
                         <label for="o_payment_demo_shipping_country" class="mt-1">
                             <small><b>Country</b></small>
                         </label>


### PR DESCRIPTION
An error occurs when a user attempts to make a payment without specifying a 'state' in the address.

Step to produce:

- Install the `website_sale` module.
- Enable Demo payment method.
- Navigate to `/shop`, add a product, and open the cart.
- Click on the Checkout button and enter an address without a 'state'.
- Click on `Pay With Demo` for payment.

`KeyError: 'state'`

This issue occurs because the system attempts to retrieve the 'state' from the address at [1], but it is missing in it.

Link [1]: https://github.com/odoo/odoo/blob/169bbab49bb345c1243b02da0a1510e45faba64e/addons/website_sale/controllers/main.py#L1666

To resolve this issue, add a `state` in the payment express checkout form as a label to ensure that the address always contains a 'state', And provide a default value in 'state' if it is not available in address.

Sentry-6295883035

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
