### PR TITLE
[FIX] l10n_my_edi_extended: prevent error while evaluating record

### DIFF
--- a/addons/l10n_my_edi_extended/models/account_move.py
+++ b/addons/l10n_my_edi_extended/models/account_move.py
@@ -149,12 +149,11 @@ class AccountMove(models.Model):
         if moves and xml_contents:
             errors = moves._l10n_my_edi_submit_documents(xml_contents)
 
-            if errors:
-                for move in moves:
-                    move.message_post(body=AccountMoveSend._format_error_html({
-                        'error_title': _('Error when sending the invoices to the E-invoicing service.'),
-                        'errors': errors[move],
-                    }))
+            for move in moves.filtered(lambda m: m in errors):
+                move.message_post(body=AccountMoveSend._format_error_html({
+                    'error_title': _('Error when sending the invoices to the E-invoicing service.'),
+                    'errors': errors[move],
+                }))
 
             # At this point we will need to commit as we reached the api, and we could have a mix of failed and valid invoice.
             if moves._can_commit():
@@ -177,12 +176,11 @@ class AccountMove(models.Model):
             retry += 1
         # While technically an in_progress status is not an error, it won't hurt much to display it as such.
         # The "error" message in this case should be clear enough.
-        if errors:
-            for move in moves:
-                move.message_post(body=AccountMoveSend._format_error_html({
-                    'error_title': _('Error when sending the invoices to the E-invoicing service.'),
-                    'errors': errors[move],
-                }))
+        for move in moves.filtered(lambda m: m in errors):
+            move.message_post(body=AccountMoveSend._format_error_html({
+                'error_title': _('Error when sending the invoices to the E-invoicing service.'),
+                'errors': errors[move],
+            }))
         # We commit again if possible, to ensure that the invoice status is set in the database in case of errors later.
         if self._can_commit():
             self._cr.commit()


### PR DESCRIPTION
Currently, an exception is raised when evaluating multiple records, where some records are complete and correct while others contain errors.

error:
```ValueError
KeyError(account.move(43,)) while evaluating
'if records:\n           action = records.action_l10n_my_edi_send_invoice()'
```

[1]- https://github.com/odoo/odoo/blob/8eacfdcc2b65c62848d7939121c64928b76a80ed/addons/l10n_my_edi_extended/models/account_move.py#L181

[2]- https://github.com/odoo/odoo/blob/8eacfdcc2b65c62848d7939121c64928b76a80ed/addons/l10n_my_edi_extended/models/account_move.py#L153

This commit fixes the issue by filtering only those records that have errors during evaluation,  and I have added a test for this issue.

sentry - 6298401222

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
