### PR TITLE
[IMP] html_editor: refine link popover and make link preview live

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -461,15 +461,25 @@ export class LinkPlugin extends Plugin {
                     this.dependencies.dom.insert(link);
                 }
             }
-            this.closeLinkTools(cursorsToRestore);
-            this.dependencies.selection.focusEditable();
-            this.dependencies.history.addStep();
         };
 
+        const restoreSavePoint = this.dependencies.history.makeSavePoint();
         const props = {
             linkElement,
             isImage: isImage,
-            onApply: applyCallback,
+            onApply: (...args) => {
+                delete this._isNavigatingByMouse;
+                applyCallback(...args);
+                this.closeLinkTools(cursorsToRestore);
+                this.dependencies.selection.focusEditable();
+                this.dependencies.history.addStep();
+            },
+            onChange: applyCallback,
+            onDiscard: () => {
+                restoreSavePoint();
+                this.closeLinkTools();
+                this.dependencies.selection.focusEditable();
+            },
             onRemove: () => {
                 this.removeLinkInDocument();
                 this.linkInDocument = null;

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -35,17 +35,6 @@ export class LinkPopover extends Component {
         // alpha -> epsilon classes. This is currently done by removing
         // all btn-* classes anyway.
     ];
-    buttonSizesData = [
-        { size: "sm", label: _t("Small") },
-        { size: "", label: _t("Medium") },
-        { size: "lg", label: _t("Large") },
-    ];
-    buttonStylesData = [
-        { style: "fill", label: _t("Fill") },
-        { style: "fill,rounded-circle", label: _t("Fill + Rounded") },
-        { style: "outline", label: _t("Outline") },
-        { style: "outline,rounded-circle", label: _t("Outline + Rounded") },
-    ];
     setup() {
         this.ui = useService("ui");
         this.notificationService = useService("notification");
@@ -73,13 +62,11 @@ export class LinkPopover extends Component {
                 this.props.linkElement.className
                     .match(/btn(-[a-z0-9_-]*)(primary|secondary)/)
                     ?.pop() || "",
-            buttonSize: this.props.linkElement.className.match(/btn-(sm|lg)/)?.[1] || "",
-            buttonStyle: this.initButtonStyle(this.props.linkElement.className),
             isImage: this.props.isImage,
         });
 
         this.editingWrapper = useRef("editing-wrapper");
-        this.inputRef = useRef(this.state.isImage || this.state.label !== "" ? "url" : "label");
+        this.inputRef = useRef(this.state.isImage || "label");
         useEffect(
             (el) => {
                 if (el) {
@@ -93,15 +80,6 @@ export class LinkPopover extends Component {
                 this.loadAsyncLinkPreview();
             }
         });
-    }
-    initButtonStyle(className) {
-        const styleArray = [
-            className.match(/btn-([a-z0-9_]+)-(primary|secondary)/)?.[1],
-            className.match(/rounded-circle/)?.pop(),
-        ];
-        return styleArray.every(Boolean)
-            ? styleArray.join(",")
-            : styleArray.join("") || className.match(/flat/)?.pop() || "";
     }
     onClickApply() {
         this.state.editing = false;
@@ -290,20 +268,10 @@ export class LinkPopover extends Component {
     }
 
     get classes() {
-        const shapes = this.state.buttonStyle ? this.state.buttonStyle.split(",") : [];
-        const style = ["outline", "fill"].includes(shapes[0]) ? `${shapes[0]}-` : "fill-";
-        const shapeClasses = shapes.slice(style ? 1 : 0).join(" ");
         if (!this.state.type) {
             return "";
         }
-        let className = `btn btn-${style}${this.state.type}`;
-        if (shapeClasses) {
-            className += ` ${shapeClasses}`;
-        }
-        if (this.state.buttonSize) {
-            className += ` btn-${this.state.buttonSize}`;
-        }
-        return className;
+        return `btn btn-fill-${this.state.type}`;
     }
 
     async uploadFile() {

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -17,7 +17,7 @@
                         <div class="input-group mb-1">
                             <input t-ref="url" class="o_we_href_input_link form-control form-control-sm" t-model="state.url" title="URL" placeholder="Paste or type your URL" t-on-keydown="onKeydownEnter"/>
                             <span class="ms-1" t-if="props.canUpload and !state.url">
-                                or <button class="btn btn-secondary btn-sm" t-on-click="uploadFile">Upload File</button>
+                                or <button class="btn btn-secondary btn-sm" t-on-click="uploadFile"><i class="fa fa-upload"/></button>
                             </span>
 
                         </div>
@@ -31,22 +31,6 @@
                                     </t>
                                 </t>
                             </select>
-                            <div t-if="state.type !== 'custom' and state.type !==  ''" class="input-group mb-1">
-                                    <select name="link_style_size" class="form-select form-select-sm link-style" t-on-change="(ev)=>this.state.buttonSize = ev.target.value">
-                                        <t t-foreach="this.buttonSizesData" t-as="buttonSizesData" t-key="buttonSizesData.size">
-                                            <option t-att-value="buttonSizesData.size" t-att-selected="state.buttonSize === buttonSizesData.size">
-                                                <span t-esc="buttonSizesData.label"/>
-                                            </option>
-                                        </t>
-                                    </select>
-                                    <select name="link_style_shape" class="form-select form-select-sm link-style ms-1" t-on-change="(ev)=>this.state.buttonStyle = ev.target.value">
-                                        <t t-foreach="this.buttonStylesData" t-as="buttonStylesData" t-key="buttonStylesData.style">
-                                            <option t-att-value="buttonStylesData.style" t-att-selected="state.buttonStyle === buttonStylesData.style">
-                                                <span t-esc="buttonStylesData.label"/>
-                                            </option>
-                                        </t>
-                                    </select>
-                            </div>
                             <button class="o_we_apply_link btn btn-sm btn-primary" t-att-class="{'ms-1': state.type ===  ''}" t-on-click="onClickApply">Apply</button>
                         </div>
                     </div>

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -12,17 +12,28 @@
                 <div t-else="" class="d-flex">
                     <div class="col p-2" style="max-width: 250px;">
                         <div class="input-group mb-1">
-                            <input t-ref="label" class="o_we_label_link form-control form-control-sm" t-model="state.label" title="Label" placeholder="Add a label for your link"/>
+                            <input t-ref="label"
+                                class="o_we_label_link form-control form-control-sm"
+                                t-model="state.label"
+                                title="Label"
+                                placeholder="Add a label for your link"
+                                t-on-input="onChange"/>
                         </div>
                         <div class="input-group mb-1">
-                            <input t-ref="url" class="o_we_href_input_link form-control form-control-sm" t-model="state.url" title="URL" placeholder="Paste or type your URL" t-on-keydown="onKeydownEnter"/>
+                            <input t-ref="url"
+                                class="o_we_href_input_link form-control form-control-sm"
+                                t-model="state.url"
+                                title="URL"
+                                placeholder="Paste or type your URL"
+                                t-on-keydown="onKeydownEnter"
+                                t-on-input="onChange"/>
                             <span class="ms-1" t-if="props.canUpload and !state.url">
                                 or <button class="btn btn-secondary btn-sm" t-on-click="uploadFile"><i class="fa fa-upload"/></button>
                             </span>
 
                         </div>
                         <div class="input-group">
-                            <select name="link_type" class="form-select form-select-sm" t-att-class="{'mb-1': state.type !==  ''}" t-on-change="(ev)=>this.state.type = ev.target.value">
+                            <select name="link_type" class="form-select form-select-sm w-100 mb-1" t-model="state.type" t-on-change="onChange">
                                 <t t-foreach="this.colorsData" t-as="colorData" t-key="colorData.type">
                                     <t t-if="colorData.type !== 'custom'">
                                         <option t-att-value="colorData.type" t-att-selected="state.type === colorData.type" t-attf-class="o_btn_preview">
@@ -31,18 +42,8 @@
                                     </t>
                                 </t>
                             </select>
-                            <button class="o_we_apply_link btn btn-sm btn-primary" t-att-class="{'ms-1': state.type ===  ''}" t-on-click="onClickApply">Apply</button>
-                        </div>
-                    </div>
-
-                    <div t-if="!this.ui.isSmall and state.url" class="col o_link_dialog_preview" style="max-width: 125px;border-left: 1px solid var(--border-color);">
-                        <div class="text-center p-2">
-                            <label>Preview</label>
-                            <div style="max-width: 100px; max-height: 200px;" class="text-truncate">
-                                <a href="#" t-if="state.url" id="link-preview" aria-label="Preview" title="Preview" t-attf-class="{{classes}} text-truncate" style="max-width: 90px;">
-                                    <t t-esc="state.label or state.url"/>
-                                </a>
-                            </div>
+                            <button class="o_we_apply_link btn btn-sm btn-primary" t-on-click="onClickApply">Apply</button>
+                            <button class="o_we_discard_link btn btn-sm btn-dark ms-1" t-on-click="props.onDiscard">Discard</button>
                         </div>
                     </div>
                 </div>

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -955,44 +955,46 @@ test("link preview in Link Popover", async () => {
     expect(".o-we-linkpopover input.o_we_label_link").toHaveValue("This website", {
         message: "The label input field should match the link's content",
     });
-    expect(".o-we-linkpopover a#link-preview").toHaveText("This website", {
-        message: "Link label in preview should match label input field",
-    });
 
     await contains(".o-we-linkpopover input.o_we_label_link").edit("Bad new label");
     expect(".o-we-linkpopover input.o_we_label_link").toHaveValue("Bad new label", {
         message: "The label input field should match the link's content",
     });
-    expect(".o-we-linkpopover a#link-preview").toHaveText("Bad new label", {
-        message: "Link label in preview should match label input field",
-    });
-    // Move selection outside to discard
-    setSelectionInHtmlField(".test_target");
+    // Click on Discard button to undo changes.
+    await contains(".o-we-linkpopover .o_we_discard_link").click();
     await waitForNone(".o-we-linkpopover", { root: document, timeout: 500 });
     expect(".o-we-linkpopover").toHaveCount(0);
     expect(".test_target a").toHaveText("This website");
 
-    // Select link label to open the floating toolbar.
-    setSelectionInHtmlField(".test_target a");
-    await animationFrame();
     // Click on the edit link icon
     await contains("a.o_we_edit_link").click();
     expect(".o-we-linkpopover input.o_we_label_link").toHaveValue("This website", {
         message: "The label input field should match the link's content",
     });
-    expect(".o-we-linkpopover a#link-preview").toHaveText("This website", {
-        message: "Link label in preview should match label input field",
-    });
 
     // Open the popover option to edit the link
     await contains(".o-we-linkpopover input.o_we_label_link").edit("New label");
-    expect(".o-we-linkpopover a#link-preview").toHaveText("New label", {
-        message: "Preview should be updated on label input field change",
-    });
 
     // Click "Save".
     await contains(".o-we-linkpopover .o_we_apply_link").click();
     expect(".test_target a").toHaveText("New label", {
+        message: "The link's label should be updated",
+    });
+
+    // Click on the edit link icon
+    await contains("a.o_we_edit_link").click();
+    expect(".o-we-linkpopover input.o_we_label_link").toHaveValue("New label", {
+        message: "The label input field should match the link's content",
+    });
+
+    // Open the popover option to edit the link
+    await contains(".o-we-linkpopover input.o_we_label_link").edit("Final label");
+
+    // Move selection outside for auto-save.
+    setSelectionInHtmlField(".test_target");
+    await waitForNone(".o-we-linkpopover", { root: document, timeout: 500 });
+    expect(".o-we-linkpopover").toHaveCount(0);
+    expect(".test_target a").toHaveText("Final label", {
         message: "The link's label should be updated",
     });
 });

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -529,13 +529,14 @@ describe("Link creation", () => {
             await click('.o-we-toolbar button[name="link"]');
             expect(getContent(el)).toBe("<p>H[ello</p><p>wor]ld</p>");
         });
-        test("when you open link popover with a label, url input should be focus by default ", async () => {
+        test("when you open link popover, url label should be focus by default", async () => {
             const { el } = await setupEditor("<p>[Hello]</p>");
             await waitFor(".o-we-toolbar");
             await click(".o-we-toolbar .fa-link");
             await waitFor(".o-we-linkpopover", { timeout: 1500 });
-            expect(".o-we-linkpopover input.o_we_href_input_link").toBeFocused();
+            expect(".o-we-linkpopover input.o_we_label_link").toBeFocused();
 
+            queryOne(".o-we-linkpopover input.o_we_href_input_link").focus();
             await fill("test.com");
             await click(".o_we_apply_link");
             expect(cleanLinkArtifacts(getContent(el))).toBe(
@@ -662,47 +663,29 @@ describe.tags("desktop");
 describe("Link formatting in the popover", () => {
     test("click on link, the link popover should load the current format correctly", async () => {
         await setupEditor(
-            '<p><a href="http://test.com/" class="btn btn-outline-primary rounded-circle btn-lg">link2[]</a></p>'
+            '<p><a href="http://test.com/" class="btn btn-fill-primary">link2[]</a></p>'
         );
         await waitFor(".o-we-linkpopover");
         await click(".o_we_edit_link");
         const linkPreviewEl = await waitFor("#link-preview");
-        expect(linkPreviewEl).toHaveClass([
-            "btn",
-            "btn-outline-primary",
-            "rounded-circle",
-            "btn-lg",
-        ]);
+        expect(linkPreviewEl).toHaveClass(["btn", "btn-fill-primary"]);
         expect(queryOne('select[name="link_type"]').selectedIndex).toBe(1);
-        expect(queryOne('select[name="link_style_size"]').selectedIndex).toBe(2);
-        expect(queryOne('select[name="link_style_shape"]').selectedIndex).toBe(3);
     });
     test("after changing the link format, the link preview should be updated", async () => {
         await setupEditor(
-            '<p><a href="http://test.com/" class="btn btn-fill-secondary rounded-circle btn-sm">link2[]</a></p>'
+            '<p><a href="http://test.com/" class="btn btn-fill-secondary">link2[]</a></p>'
         );
         await waitFor(".o-we-linkpopover");
         await click(".o_we_edit_link");
 
         const linkPreviewEl = await waitFor("#link-preview");
-        expect(linkPreviewEl).toHaveClass([
-            "btn",
-            "rounded-circle",
-            "btn-fill-secondary",
-            "btn-sm",
-        ]);
+        expect(linkPreviewEl).toHaveClass(["btn", "btn-fill-secondary"]);
         expect(queryOne('select[name="link_type"]').selectedIndex).toBe(2);
-        expect(queryOne('select[name="link_style_size"]').selectedIndex).toBe(0);
-        expect(queryOne('select[name="link_style_shape"]').selectedIndex).toBe(1);
 
         await click('select[name="link_type"');
         await select("primary");
-        await click('select[name="link_style_size"');
-        await select("lg");
-        await click('select[name="link_style_shape"');
-        await select("fill,rounded-circle");
         await animationFrame();
-        expect(linkPreviewEl).toHaveClass(["btn", "btn-fill-primary", "rounded-circle", "btn-lg"]);
+        expect(linkPreviewEl).toHaveClass(["btn", "btn-fill-primary"]);
     });
     test("after applying the link format, the link's format should be updated", async () => {
         const { el } = await setupEditor('<p><a href="http://test.com/">link2[]</a></p>');
@@ -714,16 +697,13 @@ describe("Link formatting in the popover", () => {
         await click('select[name="link_type"');
         await select("secondary");
         await animationFrame();
-        await click('select[name="link_style_shape"');
-        await select("outline,rounded-circle");
-        await animationFrame();
 
         const linkPreviewEl = queryOne("#link-preview");
-        expect(linkPreviewEl).toHaveClass(["btn", "btn-outline-secondary", "rounded-circle"]);
+        expect(linkPreviewEl).toHaveClass(["btn", "btn-fill-secondary"]);
 
         await click(".o_we_apply_link");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="http://test.com/" class="btn btn-outline-secondary rounded-circle">link2[]</a></p>'
+            '<p><a href="http://test.com/" class="btn btn-fill-secondary">link2[]</a></p>'
         );
     });
     test("no preview of the link when the url is empty", async () => {
@@ -1125,16 +1105,16 @@ describe("upload file via link popover", () => {
         execCommand(editor, "openLinkTools");
         await waitFor(".o-we-linkpopover");
         // Upload button should be visible
-        expect("button:contains('Upload File')").toHaveCount(1);
+        expect("button i[class='fa fa-upload']").toHaveCount(1);
         await click(".o_we_href_input_link");
         await press("a");
         await animationFrame();
         // Upload button should NOT be visible
-        expect("button:contains('Upload File')").toHaveCount(0);
+        expect("button i[class='fa fa-upload']").toHaveCount(0);
         await press("Backspace");
         await animationFrame();
         // Upload button should be visible again
-        expect("button:contains('Upload File')").toHaveCount(1);
+        expect("button i[class='fa fa-upload']").toHaveCount(1);
     });
     const patchUpload = (editor) => {
         const mockedUploadPromise = new Promise((resolve) => {
@@ -1152,7 +1132,7 @@ describe("upload file via link popover", () => {
         const mockedUpload = patchUpload(editor);
         execCommand(editor, "openLinkTools");
         await waitFor(".o-we-linkpopover");
-        await click("button:contains('Upload File')");
+        await click("button i[class='fa fa-upload']");
         await mockedUpload;
         await animationFrame();
         // URL input gets filled with the attachments's URL
@@ -1176,7 +1156,7 @@ describe("upload file via link popover", () => {
         // Fill label input
         await contains(".o-we-linkpopover input.o_we_label_link").fill("label");
         // Upload a file
-        await click("button:contains('Upload File')");
+        await click("button i[class='fa fa-upload']");
         await mockedUpload;
         await animationFrame();
         // Label remains unchanged


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- The popover displayed a link preview when a URL was applied.
- `buttonSizesData` and `buttonStylesData` were present in the popover.
- Changes made in the popover were not directly applied to the link.
- When a link label is present, focus moves to the URL input.

### Desired behavior after PR is merged:

- Removed link preview from popover and made changes live on the link.
- Removed `buttonSizesData` and `buttonStylesData` from the popover.
- Popover now contains only label, URL, and button type fields.
- Selecting or inputting any value updates the link immediately.
- Focus defaults to the label field.
- Added a discard button to revert changes applied to the link.

task-4535304