### PR TITLE
[FIX] mail: prevent UnboundLocalError in bus notification for todo_activities

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -305,7 +305,7 @@ class MailActivity(models.Model):
         # send notifications about activity creation
         todo_activities = activities.filtered(lambda act: act.date_deadline <= fields.Date.today())
         if todo_activities:
-            activity.user_id._bus_send("mail.activity/updated", {"activity_created": True})
+            todo_activities.user_id._bus_send("mail.activity/updated", {"activity_created": True})
         return activities
 
     def write(self, values):


### PR DESCRIPTION
An UnboundLocalError was occurring due to referencing the variable `activity` before it was assigned a value.

Traceback : 
---
```
UnboundLocalError: cannot access local variable 'activity' where it is not associated with a value
  File "odoo/http.py", line 2416, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1942, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 2006, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1973, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2224, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 335, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 741, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/rpc/controllers.py", line 177, in jsonrpc
    return dispatch_rpc(service, method, args)
  File "odoo/http.py", line 397, in dispatch_rpc
    return dispatch(method, params)
  File "odoo/service/model.py", line 85, in dispatch
    res = execute_kw(db, uid, *params[3:])
  File "odoo/service/model.py", line 108, in execute_kw
    return execute(db, uid, obj, method, *args, **kw or {})
  File "odoo/service/model.py", line 115, in execute
    res = execute_cr(cr, uid, obj, method, *args, **kw)
  File "odoo/service/model.py", line 99, in execute_cr
    result = retrying(partial(call_kw, recs, method, args, kw), env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/service/model.py", line 62, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "<decorator-gen-44>", line 2, in create
  File "odoo/orm/decorators.py", line 317, in _model_create_multi
    return create(self, [arg])
  File "addons/mail/models/mail_activity.py", line 303, in create
    activity.user_id._bus_send("mail.activity/updated", {"activity_created": True})
```

The error occurs at [1] because `activity` is used in the `_bus_send` call without being properly initialized within that scope.

This commit will resolve the above error by passing `todo_activities` instead of `activity`, ensuring that all users linked to overdue activities are properly notified.

[1]- https://github.com/odoo/odoo/blob/f82f768729d897fa54b04789f4e0637ed1bb27f4/addons/mail/models/mail_activity.py#L306-L308

sentry-6273716627

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
