### PR TITLE
[FIX] odoo: prevent error when adding domain in studio approval steps

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5546,13 +5546,13 @@ class BaseModel(metaclass=MetaModel):
                     elif comparator == 'not in':
                         ok = not (value and any(x in value for x in data))
                     elif comparator == '<':
-                        ok = any(x is not None and x < value for x in data)
+                        ok = value is not None and any(x is not None and x < value for x in data)
                     elif comparator == '>':
-                        ok = any(x is not None and x > value for x in data)
+                        ok = value is not None and any(x is not None and x > value for x in data)
                     elif comparator == '<=':
-                        ok = any(x is not None and x <= value for x in data)
+                        ok = value is not None and any(x is not None and x <= value for x in data)
                     elif comparator == '>=':
-                        ok = any(x is not None and x >= value for x in data)
+                        ok = value is not None and any(x is not None and x >= value for x in data)
                     elif comparator == 'ilike':
                         data = [(x or "").lower() for x in data]
                         ok = fnmatch.filter(data, '*' + (value_esc or '').lower() + '*')


### PR DESCRIPTION
Currently, an error occurs when using **studio** to add an approval step with a domain containing `False` on a field.

**Steps to produce:**
- Install the `account` and `web_studio` modules.
- Navigate `Invoicing > Customers > Invoices` and open an existing invoice form.
- Activate **Studio** mode and add an **Approval** step on any button.
- In the Code Editor, set a domain like `[('invoice_date_due', '<=', False)]`.
- Close Studio mode and return to the invoice form.
- Observe the error.

`TypeError: '<=' not supported between instances of 'datetime.datetime' and 'NoneType'`

The error occurs because `None` is being used in comparison with `datetime.datetime` at [1], which is not supported.

This commit resolves the issue by ensuring that `value` is valid before performing comparisons.

[1] - https://github.com/odoo/odoo/blob/478277a9946a5231951451705babe00a32d16625/odoo/models.py#L5553

Sentry-6288274985

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
