### PR TITLE
[FIX] project: prevent subtasks refreshing on edit

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -659,6 +659,7 @@
                     default_order="priority desc, sequence, state, date_deadline asc, id desc"
                 >
                     <field name="stage_id"/>
+                    <field name="sequence"/>
                     <field name="rating_count"/>
                     <field name="rating_avg"/>
                     <field name="rating_active"/>


### PR DESCRIPTION
**Problem**:

When editing the subtasks of a project task, in mobile version (kanban view), closing subtask view triggers reloading of the task's subtasks (before the update). This causes the changes to be overwritten. This issue only happens in incognito mode mobile version when debug mode is not enabled. It also affects some databases that have customized views before upgrading to 18.0 (see the ticket 4499150)

**Details**
This issue was introduced after removing the sequence field from the kanban view in this pr https://github.com/odoo/odoo/pull/174671/commits/75c9b74488f9b49b70b2949ecb5277e57024f468 The PR removed the sequence field from the kanban view of project.task, causing the sequence field not to be loaded into the child_ids of the main task. This triggers the loading of child tasks when there is a mismatch between the field names and the loaded field names of child_ids in the relevant function https://github.com/odoo/odoo/blob/18.0/addons/web/static/src/model/relational_model/static_list.js#L857-L872.

- How to reproduce:
    * Open incognito mode mobile version
    * Refresh the page
    * go to a project task that has a subtask
    * edit the subtask and try to save

See the following video: https://drive.google.com/file/d/1QT7AxgDM1DLTfm-KWhfF3IdsU4h8WpYA/view?usp=sharing

**Solution**:
Add sequence field back to the task kanban view.

opw-4499150

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
