### PR TITLE
[IMP] base: check field access during create

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -527,7 +527,6 @@ class ResPartner(models.Model):
         compute='_compute_use_partner_credit_limit', inverse='_inverse_use_partner_credit_limit',
         help='Set a value greater than 0.0 to activate a credit limit check')
     show_credit_limit = fields.Boolean(
-        default=lambda self: self.env.company.account_use_credit_limit,
         compute='_compute_show_credit_limit', groups='account.group_account_invoice,account.group_account_readonly')
     days_sales_outstanding = fields.Float(
         string='Days Sales Outstanding (DSO)',
@@ -705,8 +704,7 @@ class ResPartner(models.Model):
 
     @api.depends_context('company')
     def _compute_show_credit_limit(self):
-        for partner in self:
-            partner.show_credit_limit = self.env.company.account_use_credit_limit
+        self.show_credit_limit = self.env.company.account_use_credit_limit
 
     def _get_suggested_invoice_edi_format(self):
         # TO OVERRIDE

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -71,11 +71,11 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             'code': 'YY',
         })
 
-        cls.tax_tags = cls.env['account.account.tag'].create({
+        cls.tax_tags = cls.env['account.account.tag'].create([{
             'name': 'tax_tag_%s' % str(i),
             'applicability': 'taxes',
             'country_id': cls.company_data['company'].account_fiscal_country_id.id,
-        } for i in range(8))
+        } for i in range(8)])
 
         cls.cash_basis_tax_a_third_amount = cls.env['account.tax'].create({
             'name': 'tax_1',

--- a/addons/account/tests/test_early_payment_discount.py
+++ b/addons/account/tests/test_early_payment_discount.py
@@ -477,11 +477,11 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             })
 
     def test_intracomm_bill_with_early_payment_included(self):
-        tax_tags = self.env['account.account.tag'].create({
+        tax_tags = self.env['account.account.tag'].create([{
             'name': f'tax_tag_{i}',
             'applicability': 'taxes',
             'country_id': self.env.company.account_fiscal_country_id.id,
-        } for i in range(6))
+        } for i in range(6)])
 
         intracomm_tax = self.env['account.tax'].create({
             'name': 'tax20',

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -231,7 +231,6 @@
                 <page name="sales_purchases" position="after">
                     <page string="Invoicing" name="accounting" invisible="not is_company and parent_id" groups="account.group_account_invoice,account.group_account_readonly">
                         <field name="duplicated_bank_account_partners_count" invisible="1"/>
-                        <field name="show_credit_limit" invisible="1"/>
                         <group>
                             <group string="General" name="general" groups="account.group_account_invoice,account.group_account_readonly">
                                 <field name="bank_ids" context="{'default_partner_id': id}" domain="[('partner_id','=', id)]" widget="many2many_tags_banks" options="{'color_field': 'color', 'allow_out_payment_field': 'allow_out_payment', 'edit_tags': True}"/>

--- a/addons/product/models/ir_attachment.py
+++ b/addons/product/models/ir_attachment.py
@@ -17,9 +17,10 @@ class IrAttachment(models.Model):
                     and not attachment.res_field
             )
             if product_attachments:
-                self.env['product.document'].sudo().create(
+                self.env['product.document'].sudo().create([
                     {
                         'ir_attachment_id': attachment.id
-                    } for attachment in product_attachments
-                )
+                    }
+                    for attachment in product_attachments
+                ])
         return attachments

--- a/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -311,10 +311,10 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
             'account_type': 'income',
         })
 
-        tax_tags = self.env['account.account.tag'].create({
+        tax_tags = self.env['account.account.tag'].create([{
             'name': 'tax_tag_%s' % str(i),
             'applicability': 'taxes',
-        } for i in range(8))
+        } for i in range(8)])
 
         cash_basis_tax_a_third_amount = self.env['account.tax'].create({
             'name': 'tax_1',

--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -983,11 +983,11 @@ action = {
         ):
             with patch.object(self.env.cr, '_now', now := datetime.datetime.now()):
                 past_date = now - datetime.timedelta(1)
-                self.env["base.automation.lead.test"].create({
+                self.env["base.automation.lead.test"].create([{
                     'name': f'lead {i}',
                     # 2 without a date, 8 set in past, 5 set in future
                     'date_automation_last': False if i < 2 else past_date if i < 10 else now + datetime.timedelta(minutes=i),
-                } for i in range(15))
+                } for i in range(15)])
             with common.freeze_time('2020-01-01 03:01:01'), patch.object(self.env.cr, '_now', datetime.datetime.now()):
                 # process records
                 self.env["base.automation"]._cron_process_time_based_actions()

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -4256,6 +4256,7 @@ class BaseModel(metaclass=MetaModel):
         :raise UserError: if a loop would be created in a hierarchy of objects a result of the operation
           (such as setting an object as its own parent)
         """
+        assert isinstance(vals_list, (list, tuple))
         if not vals_list:
             return self.browse()
 


### PR DESCRIPTION
Check that creating records is done only using fields on which we have write access. Currenly, no field access is checked. We check all fields that are in the values passed to `create` and values provided through the context using 'default' keys.

When a field is not writable, make the field attribute readonly when fetching the field list.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
