### PR TITLE
[IMP] discuss: add a visual clue in the systray for active microphone

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_menu.scss
+++ b/addons/mail/static/src/discuss/call/common/call_menu.scss
@@ -1,6 +1,10 @@
 .o-discuss-CallMenu-buttonContent {
     max-width: 150px;
     @include o-mail-call-bordered(.7);
+
+    &.o-is-talking {
+        box-shadow: inset 0 0 0 2px var(--discuss-talkingColor, $o-discuss-talkingColor);
+    }
 }
 
 .o-discuss-CallMenu-animation {

--- a/addons/mail/static/src/discuss/call/common/call_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_menu.xml
@@ -4,8 +4,8 @@
     <t t-name="discuss.CallMenu">
         <div class="dropdown" t-attf-class="{{ className }}" t-ref="root">
             <button t-if="rtc.state.channel" class="user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="buttonTitle" role="button" t-on-click="rtc.state.channel.open">
-                <div class="o-discuss-CallMenu-buttonContent d-flex align-items-center o-gap-0_5 rounded-3 opacity-75 opacity-100-hover px-1">
-                    <span class="position-relative small bg-inherit">
+                <div class="o-discuss-CallMenu-buttonContent d-flex align-items-center o-gap-0_5 rounded-3 opacity-75 opacity-100-hover px-1" t-att-class="{ 'o-is-talking': rtc.selfSession?.isActuallyTalking }">
+                    <span class="position-relative small bg-transparent">
                         <i class="me-2 fa fa-fw" t-att-class="icon" />
                         <small class="d-flex position-absolute top-0 end-0 smaller bg-inherit">
                             <i class="o-discuss-CallMenu-animation fa fa-volume-up o-discuss-inCallIconColor bg-inherit"/>


### PR DESCRIPTION
This commit adds a small inset border around the call systray menu when the user is talking.

Dark mode before:
![image](https://github.com/user-attachments/assets/4c9818cb-52d6-407e-9656-230f2f095848)
Dark mode after: 
![image](https://github.com/user-attachments/assets/64f692d6-ef93-4a2e-932a-f3c1055dc163)

Light mode before:
![image](https://github.com/user-attachments/assets/61f5e250-8dd7-4891-b0c8-8add2bb1ab52)
Light mode after:
![image](https://github.com/user-attachments/assets/4ccc95ac-d175-4b6a-a7c7-9a39e169e8f2)

