### PR TITLE
[IMP] mail: use reply-to from mail template

### DIFF
--- a/addons/mail/tests/test_mail_template.py
+++ b/addons/mail/tests/test_mail_template.py
@@ -35,7 +35,7 @@ class TestMailTemplate(MailCommon):
 
     @users('employee')
     def test_mail_compose_message_content_from_template(self):
-        form = Form(self.env['mail.compose.message'].with_context(active_ids=self.test_partner.ids))
+        form = Form(self.env['mail.compose.message'].with_context(default_model='res.partner', active_ids=self.test_partner.ids))
         form.template_id = self.mail_template
         mail_compose_message = form.save()
 

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -54,6 +54,9 @@
                         </div>
                         <field name="notified_bcc" widget="mail_composer_bcc_list" invisible="not show_notified_bcc"/>
                         <field name="subject" placeholder="Welcome to MyCompany!" required="True"/>
+                        <field name="reply_to" placeholder='Recipient Followers'
+                            invisible="reply_to_mode == 'update'"
+                            required="reply_to_mode != 'update'"/>
                     </group>
                     <field name="can_edit_body" invisible="1"/>
                     <div invisible="composition_mode == 'mass_mail'">
@@ -75,11 +78,6 @@
                             <!-- mass mailing -->
                             <field name="reply_to_force_new" invisible="1"/>
                             <field name="reply_to_mode" invisible="composition_mode != 'mass_mail'" widget="radio"/>
-                            <group>
-                                <field name="reply_to" string="Reply-to Address" placeholder='e.g: "info@mycompany.odoo.com"'
-                                    invisible="reply_to_mode == 'update' or composition_mode != 'mass_mail'"
-                                    required="reply_to_mode != 'update' and composition_mode == 'mass_mail'"/>
-                            </group>
                         </page>
                     </notebook>
                     <footer>


### PR DESCRIPTION
When sending an email using a mail template, utilize the default value set in the reply-to field.

Task-4229725
