### PR TITLE
[FIX] *: multiple tours

### DIFF
--- a/addons/barcodes/static/src/barcode_handlers.js
+++ b/addons/barcodes/static/src/barcode_handlers.js
@@ -4,6 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { getVisibleElements } from "@web/core/utils/ui";
 import { Macro } from "@web/core/macro";
+import { click, edit } from "@odoo/hoot-dom";
 
 function clickOnButton(selector) {
     const button = document.body.querySelector(selector);
@@ -34,14 +35,18 @@ function updatePager(position) {
         steps: [
             {
                 trigger: "span.o_pager_value",
-                action: "click"
+                async action(trigger) {
+                    await click(trigger);
+                },
             },
             {
                 trigger: "input.o_pager_value",
-                action: "text",
-                value: next
-            }
-        ]
+                async action(trigger) {
+                    await click(trigger);
+                    await edit(next, { confirm: "blur" });
+                },
+            },
+        ],
     }).start();
 }
 

--- a/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
@@ -1,6 +1,7 @@
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import { negate } from "@point_of_sale/../tests/tours/utils/common";
 const { DateTime } = luxon;
+import { waitFor } from "@odoo/hoot-dom";
 
 export function confirmPopup() {
     return [Dialog.confirm()];
@@ -77,12 +78,20 @@ export function createFloatingOrder() {
 export function waitRequest() {
     return [
         {
-            content: "Request Start",
-            trigger: "body:has(.fa-circle-o-notch)",
-        },
-        {
-            content: "Wait for request to finish",
-            trigger: "body:not(:has(.fa-circle-o-notch))",
+            trigger: "body",
+            content: "Wait loading is finished if it is shown",
+            timeout: 15000,
+            async run() {
+                let isLoading = false;
+                try {
+                    isLoading = await waitFor("body:has(.fa-circle-o-notch)", { timeout: 2000 });
+                } catch {
+                    /* fa-circle-o-notch will certainly never appears :'( */
+                }
+                if (isLoading) {
+                    await waitFor("body:not(:has(.fa-circle-o-notch))", { timeout: 10000 });
+                }
+            },
         },
     ];
 }

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -5,13 +5,34 @@ import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirma
 import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_util";
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
 import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
+import { queryFirst } from "@odoo/hoot-dom";
+
+//
+const clickOrderNowAndWaitLocation = (location = "Take Out") => [
+    //Because of the background animation, clicking on order now
+    //may not do anything... so we'll click until we get to take out
+    {
+        trigger: ".btn:contains(order now)",
+        async run(actions) {
+            await new Promise((resolve) => {
+                const interval = setInterval(() => {
+                    actions.click();
+                    if (queryFirst(`.o_kiosk_eating_location_box h3:contains(${location})`)) {
+                        clearInterval(interval);
+                        resolve();
+                    }
+                }, 300);
+            });
+        },
+    },
+    LandingPage.selectLocation(location),
+];
 
 registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_in", {
     checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
-        Utils.clickBtn("Order Now"),
-        LandingPage.selectLocation("Eat In"),
+        ...clickOrderNowAndWaitLocation("Eat In"),
         ProductPage.checkReferenceNotInProductName("Coca-Cola", "12345"),
         ProductPage.clickProduct("Coca-Cola"),
         Utils.clickBtn("Order"),
@@ -21,8 +42,7 @@ registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_in", {
         Utils.clickBtn("Pay"),
         Utils.clickBtn("Close"),
         Utils.checkIsNoBtn("My Order"),
-        Utils.clickBtn("Order Now"),
-        LandingPage.selectLocation("Eat In"),
+        ...clickOrderNowAndWaitLocation("Eat In"),
         Utils.checkIsDisabledBtn("Order"),
     ],
 });
@@ -31,16 +51,14 @@ registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_out", {
     checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
-        Utils.clickBtn("Order Now"),
-        LandingPage.selectLocation("Take Out"),
+        ...clickOrderNowAndWaitLocation("Take Out"),
         ProductPage.clickProduct("Coca-Cola"),
         Utils.clickBtn("Order"),
         CartPage.checkProduct("Coca-Cola", "2.53", "1"),
         Utils.clickBtn("Pay"),
         Utils.clickBtn("Close"),
         Utils.checkIsNoBtn("My Order"),
-        Utils.clickBtn("Order Now"),
-        LandingPage.selectLocation("Take Out"),
+        ...clickOrderNowAndWaitLocation("Take Out"),
         Utils.checkIsDisabledBtn("Order"),
     ],
 });
@@ -49,16 +67,14 @@ registry.category("web_tour.tours").add("self_kiosk_each_counter_takeaway_in", {
     checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
-        Utils.clickBtn("Order Now"),
-        LandingPage.selectLocation("Eat In"),
+        ...clickOrderNowAndWaitLocation("Eat In"),
         ProductPage.clickProduct("Coca-Cola"),
         Utils.clickBtn("Order"),
         CartPage.checkProduct("Coca-Cola", "2.53", "1"),
         Utils.clickBtn("Pay"),
         Utils.clickBtn("Close"),
         Utils.checkIsNoBtn("My Order"),
-        Utils.clickBtn("Order Now"),
-        LandingPage.selectLocation("Eat In"),
+        ...clickOrderNowAndWaitLocation("Eat In"),
         Utils.checkIsDisabledBtn("Order"),
     ],
 });
@@ -67,16 +83,14 @@ registry.category("web_tour.tours").add("self_kiosk_each_counter_takeaway_out", 
     checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
-        Utils.clickBtn("Order Now"),
-        LandingPage.selectLocation("Take Out"),
+        ...clickOrderNowAndWaitLocation("Take Out"),
         ProductPage.clickProduct("Coca-Cola"),
         Utils.clickBtn("Order"),
         CartPage.checkProduct("Coca-Cola", "2.53", "1"),
         Utils.clickBtn("Pay"),
         Utils.clickBtn("Close"),
         Utils.checkIsNoBtn("My Order"),
-        Utils.clickBtn("Order Now"),
-        LandingPage.selectLocation("Take Out"),
+        ...clickOrderNowAndWaitLocation("Take Out"),
         Utils.checkIsDisabledBtn("Order"),
     ],
 });
@@ -85,8 +99,7 @@ registry.category("web_tour.tours").add("self_order_kiosk_cancel", {
     checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
-        Utils.clickBtn("Order Now"),
-        LandingPage.selectLocation("Take Out"),
+        ...clickOrderNowAndWaitLocation("Take Out"),
         ProductPage.clickProduct("Coca-Cola"),
         ProductPage.clickProduct("Fanta"),
         Utils.clickBtn("Order"),
@@ -94,8 +107,7 @@ registry.category("web_tour.tours").add("self_order_kiosk_cancel", {
         CartPage.checkProduct("Fanta", "2.53", "1"),
         CartPage.clickBack(),
         ...ProductPage.clickCancel(),
-        Utils.clickBtn("Order Now"),
-        LandingPage.selectLocation("Eat In"),
+        ...clickOrderNowAndWaitLocation("Eat In"),
         Utils.checkIsDisabledBtn("Order"),
     ],
 });

--- a/addons/pos_self_order/tests/test_self_order_kiosk.py
+++ b/addons/pos_self_order/tests/test_self_order_kiosk.py
@@ -22,16 +22,16 @@ class TestSelfOrderKiosk(SelfOrderCommonTest):
         self_route = self.pos_config._get_self_order_route()
 
         # Kiosk, each, table
-        self.start_tour(self_route, "self_kiosk_each_table_takeaway_in")
-        self.start_tour(self_route, "self_kiosk_each_table_takeaway_out")
+        self.start_tour(self_route, "self_kiosk_each_table_takeaway_in", timeout=120)
+        self.start_tour(self_route, "self_kiosk_each_table_takeaway_out", timeout=120)
 
         self.pos_config.write({
             'self_ordering_service_mode': 'counter',
         })
 
         # Kiosk, each, counter
-        self.start_tour(self_route, "self_kiosk_each_counter_takeaway_in")
-        self.start_tour(self_route, "self_kiosk_each_counter_takeaway_out")
+        self.start_tour(self_route, "self_kiosk_each_counter_takeaway_in", timeout=120)
+        self.start_tour(self_route, "self_kiosk_each_counter_takeaway_out", timeout=120)
 
         # Cancel behavior
         self.start_tour(self_route, "self_order_kiosk_cancel")

--- a/addons/test_website/static/tests/tours/restricted_editor.js
+++ b/addons/test_website/static/tests/tours/restricted_editor.js
@@ -9,7 +9,7 @@ import {
 
 const checkNoTranslate = {
     content: "Check there is no translate button",
-    trigger: ".o_menu_systray:not(:contains(.o_translate_website_container))",
+    trigger: ".o_menu_systray:not(:has(.o_translate_website_container)):contains(edit)",
 };
 const translate = [{
     content: "Open Edit menu",

--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -264,13 +264,16 @@ registerWebsitePreviewTour(
     },
     () => [
         {
+            trigger: ":iframe #wrapwrap",
+        },
+        {
             content: "Open Site menu",
             trigger: 'button[data-menu-xmlid="website.menu_site"]',
             run: "click",
         },
         {
             content: "Open HTML / CSS Editor",
-            trigger: 'a[data-menu-xmlid="website.menu_ace_editor"]',
+            trigger: '.o_popover a[data-menu-xmlid="website.menu_ace_editor"]:contains(/^HTML/)',
             run: "click",
         },
         {

--- a/addons/website_slides/static/tests/tours/slides_tour_tools.js
+++ b/addons/website_slides/static/tests/tours/slides_tour_tools.js
@@ -40,6 +40,23 @@ const addContentToSection = (prefix, sectionName) => ({
     run: "click",
 });
 
+const clickOnAddTagDropdown = (prefix) => [
+    {
+        content: "Wait content is loaded before continue to avoid miss click",
+        trigger: `${prefix} img[src*='boulonnate']`,
+    },
+    {
+        content: "eLearning: click on Add Tag",
+        trigger: `${prefix} a.o_wslides_js_channel_tag_add`,
+        run: "click",
+    },
+    {
+        content: "eLearning: click on tag dropdown",
+        trigger: `${prefix} button.o_select_menu_toggler:first`,
+        run: "click",
+    },
+];
+
 var addVideoToSection = function (sectionName, saveAsDraft, backend = false) {
     const prefix = backend ? ':iframe ' : '';
 	var base_steps = [
@@ -258,19 +275,8 @@ const addPdfToSection = function (sectionName, pageName, backend) {
 var addExistingCourseTag = function (backend = false) {
     const prefix = backend ? ':iframe ' : '';
 	return [
+        ...clickOnAddTagDropdown(prefix),
 {
-    content: "Wait content is loaded before continue to avoid miss click",
-    trigger: prefix + "img[src*='boulonnate']",
-},
-{
-    content: 'eLearning: click on Add Tag',
-    trigger: prefix + 'a.o_wslides_js_channel_tag_add',
-    run: "click",
-}, {
-    content: 'eLearning: click on tag dropdown',
-    trigger: prefix + 'button.o_select_menu_toggler:first',
-    run: "click",
-}, {
     content: 'eLearning: select advanced tag',
     trigger: prefix + 'div.o_select_menu_item_label:contains("Advanced")',
     run: "click",
@@ -286,16 +292,9 @@ var addExistingCourseTag = function (backend = false) {
 
 var addNewCourseTag = function (courseTagName, backend) {
     const prefix = backend ? ':iframe ' : '';
-	return [
-{
-    content: 'eLearning: click on Add Tag',
-    trigger: prefix + 'a.o_wslides_js_channel_tag_add',
-    run: "click",
-}, {
-    content: 'eLearning: click on tag dropdown',
-	trigger: prefix + 'button.o_select_menu_toggler:first',
-    run: "click",
-}, {
+    return [
+        ...clickOnAddTagDropdown(prefix),
+        {
     content: 'eLearning: add a new course tag',
 	trigger: prefix + 'input.dropdown-item:first',
 	run: "edit 123",
@@ -322,11 +321,11 @@ var addNewCourseTag = function (courseTagName, backend) {
 };
 
 export default {
-	addSection: addSection,
-	addImageToSection: addImageToSection,
-	addPdfToSection: addPdfToSection,
-	addVideoToSection: addVideoToSection,
-	addArticleToSection: addArticleToSection,
-	addExistingCourseTag: addExistingCourseTag,
-	addNewCourseTag: addNewCourseTag,
+    addSection: addSection,
+    addImageToSection: addImageToSection,
+    addPdfToSection: addPdfToSection,
+    addVideoToSection: addVideoToSection,
+    addArticleToSection: addArticleToSection,
+    addExistingCourseTag: addExistingCourseTag,
+    addNewCourseTag: addNewCourseTag,
 };


### PR DESCRIPTION
Here is description of modifications for each tour:
    modified:   addons/barcodes/static/src/barcode_handlers.js
        Use hoot event instead of custom event defined in macro.js to
        uniform code and behaviors.
    modified:   addons/l10n_br_website_sale/static/tests/tours/brazilian_address.js
        Add a delay to wait the form is loaded to avoid problem with
        _selectState(id) function.
	modified:   addons/point_of_sale/static/tests/tours/utils/chrome_util.js
        Use waitFor in run of step because .fa-circle-o-notch should not
        appears ... then of course body:not(:has(.fa-circle-o-notch)) also
        not and then tour crashes.
	modified:   addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
        Because of the background animation, clicking on order now
        may not do anything... so we'll click until we get to take out.
	modified:   addons/pos_self_order/tests/test_self_order_kiosk.py
        Let's see comment of previous file ... We could need more time
        for the tours.
	modified:   addons/test_website/static/tests/tours/restricted_editor.js
        :contains(text) => Check that textContent.test(regex)
        :has(class) => Check the element classList contains the class
	modified:   addons/website/static/tests/tours/html_editor.js
        Additionnal steps to ensure tour take the good way.
	modified:   addons/website_slides/static/tests/tours/slides_tour_tools.js
        Uniformize the behavior for two tours with clickOnAddTagDropdown

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
