### PR TITLE
[FIX] stock: update precision rounding in package location computation

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1484,7 +1484,7 @@ class QuantPackage(models.Model):
         for package in self:
             package.location_id = False
             package.company_id = False
-            quants = package.quant_ids.filtered(lambda q: float_compare(q.quantity, 0, q.product_uom_id.rounding) > 0)
+            quants = package.quant_ids.filtered(lambda q: float_compare(q.quantity, 0, precision_rounding=q.product_uom_id.rounding) > 0)
             if quants:
                 package.location_id = quants[0].location_id
                 if all(q.company_id == quants[0].company_id for q in package.quant_ids):


### PR DESCRIPTION
### Issue:

The spec of the `float_compare` method was not used correctly here: https://github.com/odoo/odoo/blob/dc2821d768a7b4afbb5918e4343c00abeeb31670/odoo/tools/float_utils.py#L141 https://github.com/odoo/odoo/blob/dc2821d768a7b4afbb5918e4343c00abeeb31670/addons/stock/models/stock_quant.py#L1487

opw-4574169
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
