### PR TITLE
[IMP] discuss: upgrade to SFU as fallback for p2p failures

### DIFF
--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -88,6 +88,13 @@ class RtcController(http.Controller):
         # sudo: discuss.channel.rtc.session - member of current user can leave call
         member.sudo()._rtc_leave_call(session_id)
 
+    @http.route("/mail/rtc/channel/upgrade_connection", methods=["POST"], type="jsonrpc", auth="user")
+    def channel_upgrade(self, channel_id):
+        member = request.env["discuss.channel.member"].search([("channel_id", "=", channel_id), ("is_self", "=", True)])
+        if not member:
+            raise NotFound()
+        member.sudo()._join_sfu(force=True)
+
     @http.route("/mail/rtc/channel/cancel_call_invitation", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def channel_call_cancel_invitation(self, channel_id, member_ids=None):

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -332,8 +332,8 @@ class DiscussChannelMember(models.Model):
             self.channel_id.message_post(body=_("%s started a live conference", self.partner_id.name or self.guest_id.name), message_type='notification')
             self._rtc_invite_members()
 
-    def _join_sfu(self, ice_servers=None):
-        if len(self.channel_id.rtc_session_ids) < SFU_MODE_THRESHOLD:
+    def _join_sfu(self, ice_servers=None, force=False):
+        if len(self.channel_id.rtc_session_ids) < SFU_MODE_THRESHOLD and not force:
             if self.channel_id.sfu_channel_uuid:
                 self.channel_id.sfu_channel_uuid = None
                 self.channel_id.sfu_server_url = None

--- a/addons/mail/static/src/discuss/call/common/peer_to_peer.js
+++ b/addons/mail/static/src/discuss/call/common/peer_to_peer.js
@@ -12,6 +12,7 @@ export const UPDATE_EVENT = Object.freeze({
     CONNECTION_CHANGE: "connection_change",
     DISCONNECT: "disconnect",
     INFO_CHANGE: "info_change",
+    RECOVERY: "recovery",
     TRACK: "track",
 });
 const LOG_LEVEL = Object.freeze({
@@ -574,10 +575,8 @@ export class PeerToPeer extends EventTarget {
      * @param {LOG_LEVEL[keyof LOG_LEVEL]} logLevel
      */
     setLoggingLevel(logLevel) {
-        const makeLog = (level) => {
-            return (id, message) => {
-                this.dispatchEvent(new CustomEvent("log", { detail: { id, level, message } }));
-            };
+        const makeLog = (level) => (id, message) => {
+            this.dispatchEvent(new CustomEvent("log", { detail: { id, level, message } }));
         };
         this._loggingFunctions = {
             [LOG_LEVEL.DEBUG]: () => {},
@@ -661,6 +660,7 @@ export class PeerToPeer extends EventTarget {
                 if (!peer?.connection || !this.channelId || (connectionSuccess && iceSuccess)) {
                     return;
                 }
+                this._emitUpdate({ name: UPDATE_EVENT.RECOVERY, payload: { id } });
                 this._emitLog(id, `attempting to recover connection: ${reason}`, LOG_LEVEL.ERROR);
                 this._busNotify(INTERNAL_EVENT.DISCONNECT, { targets: [peer.id] });
                 this.removePeer(peer.id);


### PR DESCRIPTION
This commit makes it so that in the case of unsuccessful peer-to-peer
connections, the client will request to the Odoo server to upgrade
the channel with a SFU.