### PR TITLE
[FIX] portal: Prevent crash when there is no default name on signature_form

### DIFF
--- a/addons/portal/static/src/signature_form/signature_form.js
+++ b/addons/portal/static/src/signature_form/signature_form.js
@@ -26,7 +26,11 @@ class SignatureForm extends Component {
             error: false,
             success: false,
         });
-        this.signature = useState({ name: this.props.defaultName });
+        this.signature = useState({
+            name: this.props.defaultName,
+            getSignatureImage: () => "",
+            resetSignature: () => {},
+        });
         this.nameAndSignatureProps = {
             signature: this.signature,
             fontColor: this.props.fontColor || "black",

--- a/addons/sale/static/tests/tours/sale_signature.js
+++ b/addons/sale/static/tests/tours/sale_signature.js
@@ -50,3 +50,23 @@ registry.category("web_tour.tours").add('sale_signature', {
         trigger: 'nav',
     }
 ]});
+
+
+registry.category("web_tour.tours").add("sale_signature_without_name", {
+    steps: () => [
+        {
+            content: "Sign & Pay",
+            trigger: ":iframe .o_portal_sale_sidebar .btn-primary",
+            run: "click",
+        },
+        {
+            content: "click submit",
+            trigger: ":iframe .o_portal_sign_submit:enabled",
+            run: "click",
+        },
+        {
+            content: "check error because no name",
+            trigger: ':iframe .o_portal_sign_error_msg:contains("Signature is missing.")',
+        },
+    ],
+});

--- a/addons/sale/tests/test_controllers.py
+++ b/addons/sale/tests/test_controllers.py
@@ -93,3 +93,24 @@ class TestSaleSignature(HttpCaseWithUserPortal):
         )
 
         self.start_tour("/", 'sale_signature', login="portal")
+
+    def test_02_portal_sale_signature_without_name_tour(self):
+        """The goal of this test is to make sure the portal user can sign SO."""
+
+        portal_user_partner = self.partner_portal
+        # create a SO to be signed
+        portal_user_partner.name = ""
+        sales_order = self.env['sale.order'].create({
+            'name': 'test SO',
+            'partner_id': portal_user_partner.id,
+            'state': 'sent',
+            'require_payment': False,
+        })
+        self.env['sale.order.line'].create({
+            'order_id': sales_order.id,
+            'product_id': self.env['product.product'].create({'name': 'A product'}).id,
+        })
+
+        action = sales_order.action_preview_sale_order()
+
+        self.start_tour(action['url'], 'sale_signature_without_name', login="admin")


### PR DESCRIPTION
Steps:
- install `contacts` and `sale_management`
- Open a contact in a form view and add a sub-contact
- Don't fill contact name field
- Save & Close
- Go to Quotations
- Select this new contact as Customer (it should have a name like Parent contact, Other Address)
- Add any product
- Save
- Click on `Preview`
- Click on `Sign & Pay`
- Traceback

When there is no signature name, `NameAndSignature`
does not set `resetSignature` and `getSignatureImage` on `this.signature`.
So after `SignatureForm` initialization, `onMounted` raise a traceback,
because it calls directly `this.signature.resetSignature`.

This commit adds default functions to `resetSignature` and `getSignatureImage`
to prevent the crash.

opw-4504223