### PR TITLE
[FIX] mail: redirect mail.message "nice" url from mail

### DIFF
--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -223,5 +223,9 @@ class MailController(http.Controller):
         if message.model == 'discuss.channel':
             url = f'/odoo/action-mail.action_discuss?active_id={message.res_id}&highlight_message_id={message_id}'
         else:
-            url = f'/odoo/{message.model}/{message.res_id}?highlight_message_id={message_id}'
+            # @see commit c63d14a0485a553b74a8457aee158384e9ae6d3f
+            # @see router.js: heuristics to discrimate a model name from an action path
+            # is the presence of dots, or the prefix m- for models
+            model_in_url = model if "." in (model := message.model) else "m-" + model
+            url = f'/odoo/{model_in_url}/{message.res_id}?highlight_message_id={message_id}'
         return request.redirect(url)


### PR DESCRIPTION
Commit c63d14a introduced new nicer urls to get to Odoo. Commit e44d13dfa9f301d7120cdb8441dfc6ca03d3d5d5 adapted the /mail/view controller for it, allowing people to copy a link to a mail.message and be redirected to it and its corresponding record.

Although one case was missing: when the model doesn't contain dots, the string is considered an action's path. So, when opening a record from a mail, there was a crash in odoo because the action could not be found.

After this commit, there is no crash, and the record is opened correctly with a nice url.

see router.js: heuristics to discrimate a model name from an action path is the presence of dots, or the prefix m- for models

opw-4564257

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
