### PR TITLE
[FIX] discuss: fix the dimension of the push-to-talk mobile button

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_action_list.scss
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.scss
@@ -1,8 +1,8 @@
-.o-discuss-CallActionList button:not(.btn-danger):not(.btn-success):not(.o-discuss-CallActionList-pushToTalk) {
+.o-discuss-CallActionList-bar button:not(.btn-danger):not(.btn-success) {
     background-color: var(--o-discuss-CallActionList-bgColor, #{$o-gray-800});
     color: #FFFFFF;
 }
 
-.o-discuss-CallActionList button {
+.o-discuss-CallActionList-bar button {
     aspect-ratio: 1;
 }

--- a/addons/mail/static/src/discuss/call/common/call_action_list.xml
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.CallActionList">
         <div class="o-discuss-CallActionList d-flex flex-column justify-content-center" t-attf-class="{{ className }}" t-ref="root">
-            <div class="d-flex align-items-center flex-wrap justify-content-between" t-att-class="{ 'w-100 ps-2 pe-2': isSmall }">
+            <div class="o-discuss-CallActionList-bar d-flex align-items-center flex-wrap justify-content-between" t-att-class="{ 'w-100 ps-2 pe-2': isSmall }">
                 <t t-if="isOfActiveCall and rtc.selfSession">
                     <t t-foreach="callActions.actions.slice(0, isMobileOS ? 3 : 4)" t-as="action" t-key="action_index">
                         <t t-call="discuss.CallActionList.actionButton" />


### PR DESCRIPTION
Before this commit, since https://github.com/odoo/odoo/pull/189657,

the mobile push-to-talk button was also affected by the aspect ratio affecting all buttons of the call action list. This was making the button too big and covering the whole call view.

This commit fixes this issue by introducing a dedicated selector for the bar part of the call action list.

before:
![image](https://github.com/user-attachments/assets/4634a514-9a1c-4fbc-ac11-e59a53026c98)

after:
![image](https://github.com/user-attachments/assets/2e5c640e-1e0b-47a6-b7f5-1f62cc7cdbc3)

