### PR TITLE
[FIX] analytic: prevent deletion of analytic accounts used in analytic items

### DIFF
--- a/addons/analytic/__manifest__.py
+++ b/addons/analytic/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name' : 'Analytic Accounting',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Accounting/Accounting',
     'depends' : ['base', 'mail', 'uom'],
     'description': """

--- a/addons/analytic/migrations/1.2/pre-migrate.py
+++ b/addons/analytic/migrations/1.2/pre-migrate.py
@@ -1,0 +1,31 @@
+from odoo.tools import sql
+
+
+def migrate(cr, version):
+    # Select relevant ids to generate the list of x_plan_id column names, removing the id of the project plan
+    cr.execute(
+        """
+        SELECT value::int
+          FROM ir_config_parameter
+         WHERE key = 'analytic.project_plan'
+        """
+    )
+    [project_plan_id] = cr.fetchone()
+    cr.execute("SELECT id FROM account_analytic_plan WHERE id != %s AND parent_id IS NULL", [project_plan_id])
+    plan_ids = [r[0] for r in cr.fetchall()]
+    column_names = [f"x_plan{id_}_id" for id_ in plan_ids]
+    # Update on_delete for existing x_plan_id columns
+    cr.execute(
+        """
+        UPDATE ir_model_fields
+           SET on_delete = 'restrict'
+         WHERE model = 'account.analytic.line'
+           AND on_delete = 'set null'
+           AND name = ANY(%s)
+        """,
+        [column_names],
+    )
+    # Change the constraint on the table definition
+    for column in column_names:
+        sql.drop_constraint(cr, 'account_analytic_line', f'account_analytic_line_{column}_fkey')
+        sql.add_foreign_key(cr, 'account_analytic_line', column, 'account_analytic_account', 'id', 'restrict')

--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -281,6 +281,7 @@ class AccountAnalyticPlan(models.Model):
                     'ttype': 'many2one',
                     'relation': 'account.analytic.account',
                     'store': True,
+                    'on_delete': 'restrict',
                 })
                 tablename = self.env['account.analytic.line']._table
                 indexname = make_index_name(tablename, column)


### PR DESCRIPTION
To reproduce:
1. Create an Analytic Account
2. Use this Analytic Account in an account move and post it.
3. Return to the Analytic Account and delete it. The deletion goes through.
4. The move no longer has the Analytic Account.

The issue:
Currently, an Analytical Account can be deleted even if it has been used in an analytic item, be it a move or an analytic simulation. Hence, the move no longer has the analytic account that was added when the move was posted, without any warnings to the user.

Solution:
Make the fields "x_plan{id_}_id" on analytic lines ondelete='restrict'. An upgrade script is added to handle existing analytic accounts.

task-4567137

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
