### PR TITLE
[FIX] mrp: create MO on mobile view

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -351,6 +351,8 @@
         <field name="model">mrp.workorder</field>
         <field name="arch" type="xml">
             <kanban class="o_mrp_workorder_kanban" create="0" sample="1">
+                <field name="workcenter_id" invisible="True"/>
+                <field name="product_uom_id" invisible="True" force_save="True"/>
                 <field name="working_user_ids"/>
                 <field name="working_state"/>
                 <field name="date_start"/>


### PR DESCRIPTION
**Current behavior:**
Trying to create an MO on mobile which has work orders is not possible.

**Expected behavior:**
Can create.

**Steps to reproduce:**
1. Install `mrp` with demo data

2. Login, in dev tools change viewport size to iPhone SE (a small screen)

3. Open Inventory -> Manufacturings

4. Click `New`, change product to stool (any variant)

5. Try to save -> `ValidationError`

**Cause of the issue:**
`workcenter_id` and `product_uom_id`  have been removed from the kanban view in commit: b1ceec4c
which is used on mobile, meaning that these required fields are not in the save vals returned to the server in the CREATE tuple.

**Fix:**
Add them back to the kanban view.

opw-4440060