### PR TITLE
[FIX] sale: fix discount translation

### DIFF
--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -109,6 +109,7 @@ class SaleOrderDiscount(models.TransientModel):
                 total_price_per_tax_groups[line.tax_id] += (discounted_price * line.product_uom_qty)
 
             discount_dp = self.env['decimal.precision'].precision_get('Discount')
+            context = {'lang': self.sale_order_id._get_lang()}  # noqa: F841
             if not total_price_per_tax_groups:
                 # No valid lines on which the discount can be applied
                 return
@@ -128,8 +129,9 @@ class SaleOrderDiscount(models.TransientModel):
                     ),
                 }]
             else:
-                vals_list = [
-                    self._prepare_discount_line_values(
+                vals_list = []
+                for taxes, subtotal in total_price_per_tax_groups.items():
+                    discount_line_value = self._prepare_discount_line_values(
                         product=discount_product,
                         amount=subtotal * self.discount_percentage,
                         taxes=taxes,
@@ -139,8 +141,8 @@ class SaleOrderDiscount(models.TransientModel):
                             percent=float_repr(self.discount_percentage * 100, discount_dp),
                             taxes=", ".join(taxes.mapped('name')),
                         ),
-                    ) for taxes, subtotal in total_price_per_tax_groups.items()
-                ]
+                    )
+                    vals_list.append(discount_line_value)
         return self.env['sale.order.line'].create(vals_list)
 
     def action_apply_discount(self):


### PR DESCRIPTION
Steps to reproduce:
- create a new quotation
- select a customer with another langage than the current user
- add a product
- add a discount using the discount button (select "global amount" or "fixed amount")

Problem:
Inside "order lines" from the quotation, the "description" column in the line created for the discount product is not translated.

https://github.com/odoo/odoo/blob/c62e8d90db481fb7ba28e888431b6a7dc5ed03cd/addons/sale/wizard/sale_order_discount.py#L126

opw-4534846
