### PR TITLE
[IMP] mail, *: use lazy session info RPC

### DIFF
--- a/addons/im_livechat/controllers/webclient.py
+++ b/addons/im_livechat/controllers/webclient.py
@@ -16,15 +16,17 @@ class WebClient(WebclientController):
             },
         )
 
+    @classmethod
     def _process_request_for_internal_user(self, store: Store, name, params):
         super()._process_request_for_internal_user(store, name, params)
         if name == "im_livechat.channel":
             store.add(request.env["im_livechat.channel"].search([]), ["are_you_inside", "name"])
 
+    @classmethod
     def _process_request_for_all(self, store: Store, name, params):
         super()._process_request_for_all(store, name, params)
         if name == "init_livechat":
-            partner, guest = self.env["res.partner"]._get_current_persona()
+            partner, guest = request.env["res.partner"]._get_current_persona()
             if partner or guest:
                 store.add_global_values(store_self=Store.One(partner or guest))
             # sudo - im_livechat.channel: allow access to live chat channel to

--- a/addons/im_livechat/static/tests/embed/livechat_service.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service.test.js
@@ -81,7 +81,7 @@ test("Only necessary requests are made when creating a new chat", async () => {
     const livechatChannelId = await loadDefaultEmbedConfig();
     const operatorPartnerId = serverState.partnerId;
     onRpcBefore((route, args) => {
-        if (!route.includes("assets")) {
+        if (!route.includes("assets") && !route.includes("lazy_session_info")) {
             asyncStep(`${route} - ${JSON.stringify(args)}`);
         }
     });
@@ -89,12 +89,7 @@ test("Only necessary requests are made when creating a new chat", async () => {
     await contains(".o-livechat-LivechatButton");
     await waitForSteps([
         `/mail/action - ${JSON.stringify({
-            fetch_params: [
-                "failures", // called because mail/core/web is loaded in test bundle
-                "systray_get_activities", // called because mail/core/web is loaded in test bundle
-                "init_messaging",
-                ["init_livechat", livechatChannelId],
-            ],
+            fetch_params: [["init_livechat", livechatChannelId]],
             context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
         })}`,
     ]);
@@ -135,19 +130,6 @@ test("Only necessary requests are made when creating a new chat", async () => {
                 uid: serverState.userId,
                 allowed_company_ids: [1],
                 temporary_id: 0.8200000000000001,
-            },
-        })}`,
-        `/mail/data - ${JSON.stringify({
-            fetch_params: [
-                "failures", // called because mail/core/web is loaded in test bundle
-                "systray_get_activities", // called because mail/core/web is loaded in test bundle
-                "init_messaging",
-            ],
-            context: {
-                lang: "en",
-                tz: "taht",
-                uid: serverState.userId,
-                allowed_company_ids: [1],
             },
         })}`,
     ]);

--- a/addons/im_livechat/static/tests/messaging_service_patch.test.js
+++ b/addons/im_livechat/static/tests/messaging_service_patch.test.js
@@ -40,24 +40,11 @@ test("push notifications are Odoo toaster on Android", async () => {
             Command.create({ guest_id: guestId }),
         ],
     });
-    onRpc("/mail/data", async (request) => {
-        const { params } = await request.json();
-        if (params.fetch_params.includes("init_messaging")) {
-            asyncStep(`/mail/data - ${JSON.stringify(params)}`);
-        }
+    onRpc("/web/dataset/call_kw/ir.http/lazy_session_info", () => {
+        asyncStep("lazy_session_info");
     });
     await start();
-    await waitForSteps([
-        `/mail/data - ${JSON.stringify({
-            fetch_params: ["failures", "systray_get_activities", "init_messaging"],
-            context: {
-                lang: "en",
-                tz: "taht",
-                uid: serverState.userId,
-                allowed_company_ids: [1],
-            },
-        })}`,
-    ]);
+    await waitForSteps([`lazy_session_info`]);
     // send after init_messaging because bus subscription is done after init_messaging
     await withGuest(guestId, () =>
         rpc("/mail/message/post", {

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -12,6 +12,7 @@ from odoo.addons.mail.tools.discuss import add_guest_to_context, Store
 class DiscussChannelWebclientController(WebclientController):
     """Override to add discuss channel specific features."""
 
+    @classmethod
     def _process_request_loop(self, store: Store, fetch_params):
         """Override to add discuss channel specific features."""
         # aggregate of channels to return, to batch them in a single query when all the fetch params
@@ -28,6 +29,7 @@ class DiscussChannelWebclientController(WebclientController):
             # prefetch a lot of data that message format could use)
             store.add(channels._get_last_messages(), for_current_user=True)
 
+    @classmethod
     def _process_request_for_all(self, store: Store, name, params):
         """Override to return channel as member and last messages."""
         super()._process_request_for_all(store, name, params)

--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -25,6 +25,7 @@ class WebclientController(http.Controller):
         """
         return self._process_request(fetch_params, context=context)
 
+    @classmethod
     def _process_request(self, fetch_params, context):
         store = Store()
         if context:
@@ -32,6 +33,7 @@ class WebclientController(http.Controller):
         self._process_request_loop(store, fetch_params)
         return store.get_result()
 
+    @classmethod
     def _process_request_loop(self, store: Store, fetch_params):
         for fetch_param in fetch_params:
             name, params = (fetch_param, None) if isinstance(fetch_param, str) else fetch_param
@@ -41,6 +43,7 @@ class WebclientController(http.Controller):
             if request.env.user._is_internal():
                 self._process_request_for_internal_user(store, name, params)
 
+    @classmethod
     def _process_request_for_all(self, store: Store, name, params):
         if name == "init_messaging":
             if not request.env.user._is_public():
@@ -62,6 +65,7 @@ class WebclientController(http.Controller):
             else:
                 store.add(thread, request_list=params["request_list"], as_thread=True)
 
+    @classmethod
     def _process_request_for_logged_in_user(self, store: Store, name, params):
         if name == "failures":
             domain = [
@@ -76,6 +80,7 @@ class WebclientController(http.Controller):
             notifications = request.env["mail.notification"].sudo().search(domain, limit=100)
             notifications.mail_message_id._message_notifications_to_store(store)
 
+    @classmethod
     def _process_request_for_internal_user(self, store: Store, name, params):
         if name == "systray_get_activities":
             # sudo: bus.bus: reading non-sensitive last id

--- a/addons/mail/models/ir_http.py
+++ b/addons/mail/models/ir_http.py
@@ -1,13 +1,21 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo
-from odoo import api, models, fields
+from odoo import models
 from odoo.http import request
+from odoo.addons.mail.controllers.webclient import WebclientController
 from odoo.addons.mail.tools.discuss import Store
 
 
 class IrHttp(models.AbstractModel):
     _inherit = 'ir.http'
+
+    def lazy_session_info(self):
+        res = super().lazy_session_info()
+        res["store_data"] = WebclientController._process_request(
+            fetch_params=["failures", "systray_get_activities", "init_messaging"],
+            context=request.context)
+        return res
 
     def session_info(self):
         """Override to add the current user data (partner or guest) if applicable."""

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -259,6 +259,10 @@ export class Store extends BaseStore {
             },
             (error) => fetchDeferred.reject(error)
         );
+        this.resetFetchState();
+    }
+
+    resetFetchState() {
         this.fetchDeferred = new Deferred();
         this.fetchParams = [];
         this.fetchReadonly = true;

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -554,10 +554,8 @@ test("chat window should open when receiving a new DM", async () => {
         ],
         channel_type: "chat",
     });
-    onRpcBefore("/mail/data", async (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep("init_messaging");
-        }
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", async () => {
+        asyncStep("init_messaging");
     });
     await start();
     await waitForSteps(["init_messaging"]);

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -22,7 +22,6 @@ import {
     getService,
     mockService,
     onRpc,
-    serverState,
     waitForSteps,
 } from "@web/../tests/web_test_helpers";
 
@@ -38,14 +37,12 @@ test("simple chatter on a record", async () => {
         if (route.startsWith("/mail") || route.startsWith("/discuss")) {
             asyncStep(`${route} - ${JSON.stringify(args)}`);
         }
+        if (route.endsWith("lazy_session_info")) {
+            asyncStep("lazy_session_info");
+        }
     });
     await start();
-    await waitForSteps([
-        `/mail/data - ${JSON.stringify({
-            fetch_params: ["failures", "systray_get_activities", "init_messaging"],
-            context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
-        })}`,
-    ]);
+    await waitForSteps([`lazy_session_info`]);
     const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });
     await openFormView("res.partner", partnerId);
     await contains(".o-mail-Chatter-topbar");

--- a/addons/mail/static/tests/core/new_message_separator.test.js
+++ b/addons/mail/static/tests/core/new_message_separator.test.js
@@ -252,20 +252,19 @@ test("show new message separator when message is received while chat window is c
         channel_type: "chat",
     });
     onRpcBefore("/mail/data", (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
+        if (JSON.stringify(args.fetch_params).includes("discuss.channel")) {
             asyncStep(`/mail/data - ${JSON.stringify(args)}`);
         }
+    });
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", (args) => {
+        asyncStep("init_messaging");
     });
     setupChatHub({ opened: [channelId] });
     await start();
     await waitForSteps([
+        "init_messaging",
         `/mail/data - ${JSON.stringify({
-            fetch_params: [
-                "failures",
-                "systray_get_activities",
-                "init_messaging",
-                ["discuss.channel", [channelId]],
-            ],
+            fetch_params: [["discuss.channel", [channelId]]],
             context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
         })}`,
     ]);

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -165,10 +165,8 @@ test("should display invitations", async () => {
         channel_member_id: memberId,
         channel_id: channelId,
     });
-    onRpcBefore("/mail/data", (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep(`/mail/data - ${JSON.stringify(args)}`);
-        }
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", () => {
+        asyncStep(`init_messaging`);
     });
     mockService("mail.sound_effects", {
         play(name) {
@@ -179,12 +177,7 @@ test("should display invitations", async () => {
         },
     });
     await start();
-    await waitForSteps([
-        `/mail/data - ${JSON.stringify({
-            fetch_params: ["failures", "systray_get_activities", "init_messaging"],
-            context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
-        })}`,
-    ]);
+    await waitForSteps([`init_messaging`]);
     const [partner] = pyEnv["res.partner"].read(serverState.partnerId);
     // send after init_messaging because bus subscription is done after init_messaging
     pyEnv["bus.bus"]._sendone(

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -44,17 +44,18 @@ defineMailModels();
 test("sanity check", async () => {
     await startServer();
     onRpcBefore((route, args) => {
-        if (route.startsWith("/mail") || route.startsWith("/discuss")) {
+        if (route === "/mail/data" && args?.fetch_params?.includes("channels_as_member")) {
             asyncStep(`${route} - ${JSON.stringify(args)}`);
+        }
+        if (route.startsWith("/mail/inbox") || route.startsWith("/discuss")) {
+            asyncStep(`${route} - ${JSON.stringify(args)}`);
+        }
+        if (route.endsWith("lazy_session_info")) {
+            asyncStep("lazy_session_info");
         }
     });
     await start();
-    await waitForSteps([
-        `/mail/data - ${JSON.stringify({
-            fetch_params: ["failures", "systray_get_activities", "init_messaging"],
-            context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
-        })}`,
-    ]);
+    await waitForSteps([`lazy_session_info`]);
     await openDiscuss();
     await waitForSteps([
         `/mail/data - ${JSON.stringify({
@@ -1094,10 +1095,8 @@ test("out-of-focus notif on needaction message in channel", async () => {
             }
         },
     });
-    onRpcBefore("/mail/data", async (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep("init_messaging");
-        }
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", () => {
+        asyncStep("init_messaging");
     });
     await start();
     await contains(".o_menu_systray i[aria-label='Messages']");
@@ -1138,10 +1137,8 @@ test("receive new chat message: out of odoo focus (notification, chat)", async (
             }
         },
     });
-    onRpcBefore("/mail/data", async (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep("init_messaging");
-        }
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", () => {
+        asyncStep("init_messaging");
     });
     await start();
     await contains(".o_menu_systray i[aria-label='Messages']");
@@ -1180,10 +1177,8 @@ test("no out-of-focus notif on non-needaction message in channel", async () => {
             }
         },
     });
-    onRpcBefore("/mail/data", async (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep("init_messaging");
-        }
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", () => {
+        asyncStep("init_messaging");
     });
     await start();
     await contains(".o_menu_systray i[aria-label='Messages']");
@@ -1307,10 +1302,8 @@ test("out-of-focus notif takes new inbox messages into account", async () => {
     pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const partnerId = pyEnv["res.partner"].create({ name: "Dumbledore" });
     const userId = pyEnv["res.users"].create({ partner_id: partnerId });
-    onRpcBefore("/mail/data", async (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep("init_messaging");
-        }
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", () => {
+        asyncStep("init_messaging");
     });
     await start();
     await openDiscuss();
@@ -1345,10 +1338,8 @@ test("out-of-focus notif on needaction message in group chat contributes only on
         ],
         channel_type: "group",
     });
-    onRpcBefore("/mail/data", async (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep("init_messaging");
-        }
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", () => {
+        asyncStep("init_messaging");
     });
     await start();
     await openDiscuss();
@@ -1380,10 +1371,8 @@ test("inbox notifs shouldn't play sound nor open chat bubble", async () => {
     const partnerId = pyEnv["res.partner"].create({ name: "Dumbledore" });
     const userId = pyEnv["res.users"].create({ partner_id: partnerId });
     pyEnv["discuss.channel"].create({ name: "general", channel_type: "channel" });
-    onRpcBefore("/mail/data", async (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep("init_messaging");
-        }
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", () => {
+        asyncStep("init_messaging");
     });
     patchWithCleanup(OutOfFocusService.prototype, {
         _playSound() {
@@ -1433,10 +1422,8 @@ test("receive new message plays sound", async () => {
             return super.play(soundEffectName, ...args);
         },
     });
-    onRpcBefore("/mail/data", async (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep("init_messaging");
-        }
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", () => {
+        asyncStep("init_messaging");
     });
     await start();
     await contains(".o_menu_systray i[aria-label='Messages']");
@@ -1483,10 +1470,8 @@ test("message sound on receiving new message (push notif enabled)", async () => 
             return super.play(soundEffectName, ...args);
         },
     });
-    onRpcBefore("/mail/data", async (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep("init_messaging");
-        }
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", () => {
+        asyncStep("init_messaging");
     });
     await start();
     await contains(".o_menu_systray i[aria-label='Messages']");
@@ -1552,10 +1537,8 @@ test("should auto-pin chat when receiving a new DM", async () => {
         ],
         channel_type: "chat",
     });
-    onRpcBefore("/mail/data", async (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep("init_messaging");
-        }
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", () => {
+        asyncStep("init_messaging");
     });
     await start();
     await openDiscuss();

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -799,18 +799,11 @@ test("channel - states: open from the bus", async () => {
         user_id: serverState.userId,
         is_discuss_sidebar_category_channel_open: false,
     });
-    onRpcBefore("/mail/data", (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep(`/mail/data - ${JSON.stringify(args)}`);
-        }
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", (args) => {
+        asyncStep("init_messaging");
     });
     await start();
-    await waitForSteps([
-        `/mail/data - ${JSON.stringify({
-            fetch_params: ["failures", "systray_get_activities", "init_messaging"],
-            context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
-        })}`,
-    ]);
+    await waitForSteps(["init_messaging"]);
     // send after init_messaging because bus subscription is done after init_messaging
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-channel .oi-chevron-right");
@@ -949,18 +942,11 @@ test("chat - states: open from the bus", async () => {
         user_id: serverState.userId,
         is_discuss_sidebar_category_chat_open: false,
     });
-    onRpcBefore("/mail/data", (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep(`/mail/data - ${JSON.stringify(args)}`);
-        }
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", (args) => {
+        asyncStep("init_messaging");
     });
     await start();
-    await waitForSteps([
-        `/mail/data - ${JSON.stringify({
-            fetch_params: ["failures", "systray_get_activities", "init_messaging"],
-            context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
-        })}`,
-    ]);
+    await waitForSteps(["init_messaging"]);
     // send after init_messaging because bus subscription is done after init_messaging
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");

--- a/addons/mail/static/tests/messaging/messaging.test.js
+++ b/addons/mail/static/tests/messaging/messaging.test.js
@@ -34,18 +34,11 @@ test("Receiving a new message out of discuss app should open a chat bubble", asy
         ],
         channel_type: "chat",
     });
-    onRpcBefore("/mail/data", (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep(`/mail/data - ${JSON.stringify(args)}`);
-        }
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", (args) => {
+        asyncStep("init_messaging");
     });
     await start();
-    await waitForSteps([
-        `/mail/data - ${JSON.stringify({
-            fetch_params: ["failures", "systray_get_activities", "init_messaging"],
-            context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
-        })}`,
-    ]);
+    await waitForSteps(["init_messaging"]);
     // send after init_messaging because bus subscription is done after init_messaging
     // simulate receving new message
     withUser(userId, () =>
@@ -69,18 +62,11 @@ test("Receiving a new message in discuss app should open a chat bubble after lea
         ],
         channel_type: "chat",
     });
-    onRpcBefore("/mail/data", (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            asyncStep(`/mail/data - ${JSON.stringify(args)}`);
-        }
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", (args) => {
+        asyncStep("init_messaging");
     });
     await start();
-    await waitForSteps([
-        `/mail/data - ${JSON.stringify({
-            fetch_params: ["failures", "systray_get_activities", "init_messaging"],
-            context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
-        })}`,
-    ]);
+    await waitForSteps(["init_messaging"]);
     // send after init_messaging because bus subscription is done after init_messaging
     await openDiscuss();
     // simulate receiving new message

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -1220,10 +1220,8 @@ test("can open messaging menu even if messaging is not initialized", async () =>
     patchBrowserNotification("default");
     await startServer();
     const def = new Deferred();
-    onRpcBefore("/mail/data", async (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
-            await def;
-        }
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", async () => {
+        await def;
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -288,8 +288,11 @@ test("mark channel as fetched when a new message is loaded", async () => {
         ],
         channel_type: "chat",
     });
+    onRpcBefore("/web/dataset/call_kw/ir.http/lazy_session_info", (args) => {
+        asyncStep(`lazy_session_info`);
+    });
     onRpcBefore("/mail/data", (args) => {
-        if (args.fetch_params.includes("init_messaging")) {
+        if (JSON.stringify(args.fetch_params).includes("discuss.channel")) {
             asyncStep(`/mail/data - ${JSON.stringify(args)}`);
         }
     });
@@ -305,13 +308,9 @@ test("mark channel as fetched when a new message is loaded", async () => {
     await start();
     await contains(".o_menu_systray i[aria-label='Messages']");
     await waitForSteps([
+        `lazy_session_info`,
         `/mail/data - ${JSON.stringify({
-            fetch_params: [
-                "failures",
-                "systray_get_activities",
-                "init_messaging",
-                ["discuss.channel", [channelId]],
-            ],
+            fetch_params: [["discuss.channel", [channelId]]],
             context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
         })}`,
     ]);

--- a/addons/mail/static/tests/widgets/activity_widget.test.js
+++ b/addons/mail/static/tests/widgets/activity_widget.test.js
@@ -23,18 +23,8 @@ describe.current.tags("desktop");
 
 test("list activity widget with no activity", async () => {
     const mailDataDoneDef = new Deferred();
-    onRpc("/mail/data", async (request) => {
-        const { params } = await request.json();
-        expect(params).toEqual({
-            fetch_params: ["failures", "systray_get_activities", "init_messaging"],
-            context: {
-                lang: "en",
-                tz: "taht",
-                uid: serverState.userId,
-                allowed_company_ids: user.allowedCompanies.map((c) => c.id),
-            },
-        });
-        asyncStep("/mail/data");
+    onRpc("/web/dataset/call_kw/ir.http/lazy_session_info", () => {
+        asyncStep("lazy_session_info");
         mailDataDoneDef.resolve();
     });
     onRpc("res.users", "web_search_read", async (params) => {
@@ -68,7 +58,7 @@ test("list activity widget with no activity", async () => {
     await openListView("res.users", {
         arch: `<list><field name="activity_ids" widget="list_activity"/></list>`,
     });
-    await waitForSteps(["/mail/data", "web_search_read"]);
+    await waitForSteps(["lazy_session_info", "web_search_read"]);
     await contains(".o-mail-ActivityButton i.text-muted");
     await contains(".o-mail-ListActivity-summary", { text: "" });
 });


### PR DESCRIPTION
*: im_livechat, mail, web

The goal of this commit is to remove the first RPC made by discuss when a user opens an Odoo session to retrieve initial data (failures, systray activities and initiate messaging).

We do now do this work within the lasy_session_info RPC.

task-4341388

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
