### PR TITLE
[IMP] account: allow partially reconciled reconciliations

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -2213,6 +2213,12 @@ class AccountMoveLine(models.Model):
                                     This is usefull if you want to preview the reconciliation before doing some changes
                                     on amls like changing a date or an account.
         """
+        not_reconciled_partial_matching_numbers = set(self
+            .filtered(lambda aml: not aml.reconciled and aml.matching_number and aml.matching_number.startswith('P'))
+            .mapped('matching_number')
+        )
+        self = self.filtered(lambda aml: not aml.reconciled or aml.matching_number not in not_reconciled_partial_matching_numbers)
+
         if not self:
             return
 


### PR DESCRIPTION
Description of the issue this commit addresses:

When doing partial reconciliations, it is not possible to reconcile the already reconciled journal items with the missing ones without first having to unreconcile them all.

---

Desired behavior after this commit is merged:

When a reconcile is partial, it is possible to reconcile it with unreconciled items despite the safeguard against reconciliation involving already reconciled items.

---

task-4203459

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
