### PR TITLE
[FIX] mail: prevent error while creating a thread from a file message

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1161,7 +1161,7 @@ class Channel(models.Model):
                 "channel_member_ids": [Command.create({"partner_id": self.env.user.partner_id.id})],
                 "channel_type": "channel",
                 "from_message_id": message.id,
-                "name": name or (message.body.striptags()[:30] if message else _("New Thread")),
+                "name": name or (message.body.striptags()[:30] if message.body else _("New Thread")),
                 "parent_channel_id": self.id,
             }
         )

--- a/addons/mail/static/tests/tours/discuss_sub_channel_search_tour.js
+++ b/addons/mail/static/tests/tours/discuss_sub_channel_search_tour.js
@@ -1,4 +1,4 @@
-import { contains, scroll } from "@web/../tests/utils";
+import { contains, dragenterFiles, dropFiles, scroll } from "@web/../tests/utils";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
@@ -88,6 +88,49 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
                     });
                 }
             },
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("create_thread_for_attachment_without_body", {
+    steps: () => [
+        {
+            content: "Open general channel",
+            trigger: '.o-mail-DiscussSidebarChannel-itemName:contains("general")',
+            run: "click",
+        },
+        {
+            content: "Drop a file",
+            trigger: ".o-mail-Discuss-main",
+            async run() {
+                const files = [new File(["hi there"], "file2.txt", { type: "text/plain" })];
+                await dragenterFiles(".o-mail-Discuss-main", files);
+                await dropFiles(".o-Dropzone", files);
+            },
+        },
+        {
+            content: "Click on send button",
+            trigger: ".o-mail-Composer-send",
+            run: "click",
+        },
+        {
+            content: "Hover on attachment",
+            trigger: '.o-mail-Message .o-mail-AttachmentCard:contains("file2.txt")',
+            run: "hover",
+        },
+        {
+            content: "Click on expand button",
+            trigger: '.o-mail-Message [title="Expand"]',
+            run: "click",
+        },
+        {
+            content: "Create a new thread",
+            trigger: '.o-dropdown-item:contains("Create Thread")',
+            run: "click",
+        },
+        {
+            content: "Check a new thread is created",
+            trigger: '.o-mail-Discuss:contains("New Thread")',
         },
     ],
 });

--- a/addons/mail/tests/test_attachment_controller.py
+++ b/addons/mail/tests/test_attachment_controller.py
@@ -78,3 +78,6 @@ class TestAttachmentController(TestAttachmentControllerCommon):
                 (self.user_public, False),
             ),
         )
+
+    def test_send_attachment_without_body(self):
+        self.start_tour("/odoo/discuss", "create_thread_for_attachment_without_body",login="admin")


### PR DESCRIPTION
This error occurs when a user sends a file without a message, and `Create Thread`.

Step to Reproduce :

- Install and open module `Discuss`.
- Open Channel and send any file from `Attach files` without a message.
- Hover over the sent file, click on `Expand`, and then click `Create Thread`

AttributeError: 'str' object has no attribute 'striptags'

This issue occurs when data is `str` instead of an HTML object.

This commit fixes the error by ensuring .striptags() is only used when the data is in the correct format.

sentry - 6304779383

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr