### PR TITLE
[FIX] base_automation: select trigger text color

### DIFF
--- a/addons/base_automation/static/src/base_automation_trigger_selection_field.xml
+++ b/addons/base_automation/static/src/base_automation_trigger_selection_field.xml
@@ -4,9 +4,10 @@
     <t t-name="base_automation.TriggerSelectionField" t-inherit="web.SelectionField" t-inherit-mode="primary">
         <xpath expr="//t[@t-foreach='options']" position="replace">
             <t t-foreach="groupedOptions" t-as="group" t-key="group.key">
-                <optgroup t-att-label="group.name">
+                <optgroup t-att-label="group.name" class="text-black">
                     <t t-foreach="group.options" t-as="option" t-key="option.value">
                         <option
+                            class="text-black"
                             t-att-selected="option.value === value"
                             t-att-value="stringify(option.value)"
                             t-esc="option.label"/>


### PR DESCRIPTION
Since [1] the placeholder of SelectionField has seen its visual style adapted.

This adapts the custom base_automation_trigger_selection field too.

[1]: https://github.com/odoo/odoo/commit/b6598d9a2f524f37eb1a98f211d6adf027777b47

Description of the issue/feature this PR addresses:
![image](https://github.com/user-attachments/assets/ca21af91-dc1a-455c-b52c-a4b96c931cb2)

