### PR TITLE
[IMP] base_automation: on_create trigger is back

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -44,7 +44,6 @@ DATE_RANGE_FACTOR = {
 
 CREATE_TRIGGERS = [
     'on_create',
-
     'on_create_or_write',
     'on_priority_set',
     'on_stage_set',
@@ -128,8 +127,8 @@ class BaseAutomation(models.Model):
             ('on_priority_set', "Priority is set to"),
             ('on_archive', "On archived"),
             ('on_unarchive', "On unarchived"),
-            ('on_create_or_write', "On save"),
-            ('on_create', "On creation"),  # deprecated, use 'on_create_or_write' instead
+            ('on_create', "On create"),
+            ('on_create_or_write', "On create and edit"),
             ('on_write', "On update"),  # deprecated, use 'on_create_or_write' instead
 
             ('on_unlink', "On deletion"),

--- a/addons/base_automation/static/src/base_automation_trigger_selection_field.js
+++ b/addons/base_automation/static/src/base_automation_trigger_selection_field.js
@@ -25,7 +25,7 @@ const OPT_GROUPS = [
     },
     {
         group: { sequence: 40, key: "custom", name: _t("Custom") },
-        triggers: ["on_create_or_write", "on_unlink", "on_change"],
+        triggers: ["on_create", "on_create_or_write", "on_unlink", "on_change"],
     },
     {
         group: { sequence: 50, key: "external", name: _t("External") },
@@ -37,7 +37,7 @@ const OPT_GROUPS = [
     },
     {
         group: { sequence: 60, key: "deprecated", name: _t("Deprecated (do not use)") },
-        triggers: ["on_create", "on_write"],
+        triggers: ["on_write"],
     },
 ];
 

--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -95,7 +95,7 @@
                                     invisible="trigger in ['on_change', 'on_webhook']"
                                 />
                                 <label for="filter_domain" groups="!base.group_no_one"
-                                    invisible="trigger not in ['on_create_or_write', 'on_unlink']"
+                                    invisible="trigger not in ['on_create', 'on_create_or_write', 'on_unlink']"
                                 />
                                 <label for="filter_domain" groups="!base.group_no_one"
                                     string="Extra Conditions"
@@ -104,7 +104,7 @@
                                 <field name="filter_domain" nolabel="1" widget="domain"
                                     groups="!base.group_no_one"
                                     options="{'model': 'model_name', 'in_dialog': False, 'foldable': True}"
-                                    invisible="trigger not in ['on_create_or_write', 'on_unlink', 'on_time', 'on_time_created', 'on_time_updated']"
+                                    invisible="trigger not in ['on_create', 'on_create_or_write', 'on_unlink', 'on_time', 'on_time_created', 'on_time_updated']"
                                 />
                                 <field name="trigger_field_ids" string="When updating" placeholder="Select fields..."
                                     options="{'no_open': True, 'no_create': True}"

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -158,7 +158,8 @@ registry.category("web_tour.tours").add("test_base_automation_on_tag_added", {
                         on_time: "Based on date field",
                         on_time_created: "After creation",
                         on_time_updated: "After last update",
-                        on_create_or_write: "On save",
+                        on_create: "On create",
+                        on_create_or_write: "On create and edit",
                         on_unlink: "On deletion",
                         on_change: "On UI change",
                         on_webhook: "On webhook",
@@ -503,7 +504,7 @@ registry.category("web_tour.tours").add("test_form_view_model_id", {
                 );
                 assertEqual(
                     triggerGroups.map((el) => el.innerText).join(" // "),
-                    "User is set // Based on date fieldAfter creationAfter last update // On saveOn deletionOn UI change // On webhook"
+                    "User is set // Based on date fieldAfter creationAfter last update // On createOn create and editOn deletionOn UI change // On webhook"
                 );
             },
         },
@@ -536,7 +537,7 @@ registry.category("web_tour.tours").add("test_form_view_model_id", {
                 );
                 assertEqual(
                     triggerGroups.map((el) => el.innerText).join(" // "),
-                    "Stage is set toUser is setTag is addedPriority is set to // Based on date fieldAfter creationAfter last update // On saveOn deletionOn UI change // On webhook"
+                    "Stage is set toUser is setTag is addedPriority is set to // Based on date fieldAfter creationAfter last update // On createOn create and editOn deletionOn UI change // On webhook"
                 );
             },
         },


### PR DESCRIPTION
Since [1], the `on_create` trigger was deprecated and thus hidden. Now we can select it back.

This commit also renames the "On save" trigger to avoid ambiguity.

Taskid: opw-4492950

[1]: https://github.com/odoo/odoo/commit/76fcebd2cad9c6d97a6ce322da6b574aedeef8d4
![image](https://github.com/user-attachments/assets/28aa69b6-ecd6-4831-b2b0-f93d79ea28a5)
