### PR TITLE
[FIX] point_of_sale: not make product search accent sensitive

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -382,7 +382,7 @@ export class ProductScreen extends Component {
     }
 
     getProductsBySearchWord(searchWord) {
-        const words = searchWord.toLowerCase();
+        const words = unaccent(searchWord.toLowerCase(), false);
         const products = this.pos.selectedCategory?.id
             ? this.getProductsByCategory(this.pos.selectedCategory)
             : this.products;

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -358,6 +358,8 @@ registry.category("web_tour.tours").add("SearchProducts", {
             ProductScreen.searchProduct("CHAIR"),
             ProductScreen.clickDisplayedProduct("Test chair 1"),
             ProductScreen.clickDisplayedProduct("Test CHAIR 2"),
+            ProductScreen.searchProduct("clémentine"),
+            ProductScreen.clickDisplayedProduct("clémentine"),
         ].flat(),
 });
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1572,6 +1572,10 @@ class TestUi(TestPointOfSaleHttpCommon):
             'available_in_pos': True,
             "default_code": "CHAIR_01",
         })
+        self.env['product.product'].create({
+            'name': 'clémentine',
+            'available_in_pos': True,
+        })
         self.main_pos_config.open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'SearchProducts', login="pos_user")
 


### PR DESCRIPTION
Currently, if you have a product named "clémentines" and input "clémentine" in the search bar it will not be found.

Steps to reproduce:
-------------------
* Create a product sold in POS named clémentine
* Open a shop which does not restrict categories
* Input in the search bar "clémentine"
> Observation: No product for "clémentine"

Why the fix:
------------
The product `searchString` is `unaccent` and `toLowerCase` while the searchWord is only `toLowerCase`.

https://github.com/odoo/odoo/blob/f82f768729d897fa54b04789f4e0637ed1bb27f4/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js#L397-L397

opw-4558898