### PR TITLE
[FIX] account_edi_ubl_cii: prevent typeerror while importing attachment

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -400,3 +400,4 @@ class AccountEdiXmlCII(models.AbstractModel):
             if amount_node is not None and float(amount_node.text) < 0:
                 return ('in_refund', 'out_refund'), -1
             return ('in_invoice', 'out_invoice'), 1
+        return None, None


### PR DESCRIPTION
Currently, an exception is raised when a user attempts to import an attachment with an invalid TypeCode in the XML file.

Steps to Reproduce:

1. Install the `account_edi_ubl_cii` module.
2. Navigate to Invoice Module -> Customers -> Invoices.
3. Attempt to upload an attachment with an invalid TypeCode in the XML file.
4. An error occurs.

Error:
`TypeError
cannot unpack non-iterable NoneType object
`

This issue [1] occurs when a user imports an attachment with an invalid TypeCode in the XML file [2]. The function returns None, which cannot be assigned to multiple variables, leading to an error.

[1] - https://github.com/odoo/odoo/blob/29206fb5f9c733ec8751d8d4910e4df686f29506/addons/account_edi_ubl_cii/models/account_edi_common.py#L262

[2] - https://drive.google.com/file/d/1Ww1D302rvMwM2OQBAZJNnTcI0n0xUGWQ/view

This fix resolves the issue by ensuring that if an invalid move_type_code is found, it returns None, None, preventing the error.

sentry-6303716506

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
