### PR TITLE
[FIX] base: display user timezone mismatch

### DIFF
--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -233,6 +233,7 @@
                                                 title="Add a language"/>
                                         </div>
                                         <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': 'tz_offset'}" />
+                                        <field name="tz_offset" invisible="1"/> <!-- needed for the timezone_mismatch widget -->
                                     </group>
                                     <group string="Menus Customization" groups="base.group_no_one"
                                         invisible="share">
@@ -442,6 +443,7 @@
                                         />
                                     </div>
                                     <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': 'tz_offset'}" readonly="0"/>
+                                    <field name="tz_offset" invisible="1"/> <!-- needed for the timezone_mismatch widget -->
                                 </group>
                             </group>
                             <group name="signature">


### PR DESCRIPTION
**Issue**
The timezone mismatch alert on the user view is not displayed as previously.
Expected behavior: like in previous versions, show a warning to the user.
![tz_mismatch](https://github.com/user-attachments/assets/cd3dadb5-813e-4071-ae2e-4941c42afb23)


**Cause**
A previous change (https://github.com/odoo/odoo/pull/137031) made invisible fields unnecessary if they are used in a python expression in the view. However, the field is needed here since it's used in a js widget.
