### PR TITLE
[FIX] mail: format message datetime with `formatDateTime`

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -6,7 +6,7 @@ import { assignDefined, assignIn } from "@mail/utils/common/misc";
 
 import { toRaw } from "@odoo/owl";
 
-import { deserializeDateTime } from "@web/core/l10n/dates";
+import { deserializeDateTime, formatDateTime } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { omit } from "@web/core/utils/objects";
 import { url } from "@web/core/utils/urls";
@@ -213,7 +213,7 @@ export class Message extends Record {
     }
 
     get datetimeShort() {
-        return this.datetime.toLocaleString(DateTime.DATETIME_SHORT_WITH_SECONDS);
+        return formatDateTime(this.datetime);
     }
 
     get isSelfMentioned() {


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Go to Settings / Languages;
2. customize the date or time format of the active lang;
3. open a chatter;
4. hover over the date text of a message.

Issue
-----
Customized format isn't used for the tooltip.

Cause
-----
In v16.0 & earlier, this tooltip was formatted using the web util `getLangDatetimeFormat`. This util has been superseded, and had been replaced with the builtin `DATETIME_SHORT` when `discuss` got refactored in 7710c3331ebd2, before getting replaced again with `DATETIME_SHORT_WITH_SECONDS` via 941e28cee11cc.

Solution
--------
Use the `formatDateTime` util from `web`. With the default values, this should be the same as `DATETIME_SHORT_WITH_SECONDS`, but allows for user customization.

opw-4266569