### PR TITLE
[FIX] stock: improve user experience on package picking flow

### DIFF
--- a/addons/stock/views/stock_package_level_views.xml
+++ b/addons/stock/views/stock_package_level_views.xml
@@ -74,7 +74,7 @@
                 <field name="location_id" options="{'no_create': True}" column_invisible="parent.picking_type_code == 'incoming'" groups="stock.group_stock_multi_locations"/>
                 <field name="location_dest_id" options="{'no_create': True}"  column_invisible="parent.picking_type_code == 'outgoing'" groups="stock.group_stock_multi_locations"/>
                 <field name="state"/>
-                <field name="is_done" readonly="parent.state in ('draft', 'new', 'done') or is_fresh_package"/>
+                <field name="is_done" optional="hide" readonly="parent.state in ('draft', 'new', 'done') or is_fresh_package"/>
                 <button name="action_show_package_details" title="Display package content" type="object" icon="fa-list" />
             </tree>
         </field>


### PR DESCRIPTION
## Versions:
17.0+

## Steps to reproduce:
*In `Settings` app, check packages*
*In `Operation Types`, in `Internal Transfers`, check the `Move Entire Packages` box* Create an internal transfer with 2 units of `Product A`:
- Click `Mark as Todo`;
- Click `Put in Pack`;
- Validate; Create an new internal transfer with 1 unit of `Product B`;
- Add the newly created package;
- Click `Mark as Todo`.

## Issue:
It is currently unclear for the customer why there is a checkbox to validate packages picking as the box for product picking is hidden. Both should either be displayed or hidden

## Fix:
*Discussed with CRL and LASE*
Hide the packages' `Done` checkbox as it is the most confusing flow.


opw-4380897