### PR TITLE
[IMP] l10n_tr_nilvera{_einvoice}: translate country names in XML

### DIFF
--- a/addons/l10n_tr_nilvera/__init__.py
+++ b/addons/l10n_tr_nilvera/__init__.py
@@ -1,1 +1,5 @@
 from . import models
+
+
+def _l10n_tr_nilvera_post_init(env):
+    env['res.lang']._activate_lang('tr_TR')

--- a/addons/l10n_tr_nilvera/__manifest__.py
+++ b/addons/l10n_tr_nilvera/__manifest__.py
@@ -11,5 +11,6 @@ Base module containing core functionalities required by other Nilvera modules.
         'views/res_config_settings_views.xml',
         'views/res_partner_views.xml',
     ],
+    'post_init_hook': '_l10n_tr_nilvera_post_init',
     'license': 'LGPL-3',
 }

--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -42,6 +42,12 @@ class AccountEdiXmlUblTr(models.AbstractModel):
         })
         return vals
 
+    def _get_country_vals(self, country):
+        # EXTENDS account.edi.xml.ubl_21
+        vals = super()._get_country_vals(country)
+        vals['name'] = country.with_context(lang='tr_TR').name
+        return vals
+
     def _get_partner_party_identification_vals_list(self, partner):
         # EXTENDS account.edi.xml.ubl_21
         vals = super()._get_partner_party_identification_vals_list(partner)


### PR DESCRIPTION
Nilvera requires the country name in the XML to be in Turkish. To achieve this, the Turkish language is now activated during installation, ensuring translated values are stored in the database and can be enforced in the XML output.

task-4504454