### PR TITLE
[FIX] gamification: align timestamp precision for tests

### DIFF
--- a/addons/gamification/tests/test_challenge.py
+++ b/addons/gamification/tests/test_challenge.py
@@ -2,6 +2,7 @@
 
 import datetime
 from freezegun import freeze_time
+from datetime import timedelta
 
 from odoo.addons.gamification.tests.common import TransactionCaseGamification
 from odoo.exceptions import UserError
@@ -117,9 +118,12 @@ class test_challenge(TestGamificationCommon):
         self.assertEqual(len(goal_ids), 4)
         self.assertEqual(set(goal_ids.mapped('state')), {'inprogress'})
 
-        # Update presence for 2 users
-        self.env["mail.presence"]._update_presence(internal_last_active_recent)
-        self.env["mail.presence"]._update_presence(portal_last_active_recent)
+        # +1 second to avoid microsecond inaccuracy when comparing to write_date in _update_all
+        current_date = datetime.datetime.now() + timedelta(seconds=1)
+        with freeze_time(current_date):
+            # Update presence for 2 users
+            self.env["mail.presence"]._update_presence(internal_last_active_recent)
+            self.env["mail.presence"]._update_presence(portal_last_active_recent)
 
         # Update goal objective checked by goal definition
         all_test_users.partner_id.write({'tz': 'Europe/Paris'})


### PR DESCRIPTION
Before this commit, the test `test_20_update_all_goals_filter` would fail occasionally due to the users supposed to have recent activity being considered inactive.
https://runbot.odoo.com/odoo/runbot.build.error/116270

This happens because the method `_update_all`, in charge of updating goals for active users, would compare the goal `write_date` stored with full timestamp precision including microseconds with the users `last_presence` which is effectively stored at second-level precision. When the two values are close, the microsecond difference can cause `write_date` to appear greater than `last_presence`, preventing goal updates.

This commit fixes the issue by artificially adding one second to the `last_presence` of the users in order to guarantee it to be greater then `write_date` and thus preventing test failures due to microsecond mismatches.