### PR TITLE
[FIX] account: don't copy payment's `invoice_ids` field

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -144,6 +144,7 @@ class AccountPayment(models.Model):
         relation='account_move__account_payment',
         column1='payment_id',
         column2='invoice_id',
+        copy=False,
     )
     reconciled_invoice_ids = fields.Many2many('account.move', string="Reconciled Invoices",
         compute='_compute_stat_buttons_from_reconciliation',


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have an unpaid invoice;
2. create a payment using the "Pay" button;
3. go the the payment;
4. duplicate payment.

Issue
-----
Duplicate payment is linked to the same invoice, with no way to change this.

Cause
-----
The `invoice_ids` field was added to `account.payment` in commit 01b87f1230bea. Before it, it relied on the reconciliation mechanism to link payments to invoices.

Solution
--------
Add `copy=false` to the field declaration, to prevent it from getting duplicated, and let other flows handle linking it to the desired invoice.

opw-4555499