### PR TITLE
[FIX] mrp: test_wrokcenter_oee crash on specific hours

### DIFF
--- a/addons/mrp/tests/test_oee.py
+++ b/addons/mrp/tests/test_oee.py
@@ -21,6 +21,7 @@ class TestOee(TestMrpCommon):
     def test_wrokcenter_oee(self):
         """  Test case workcenter oee. """
         day = datetime.date(datetime.today())
+        self.workcenter_1.resource_calendar_id.leave_ids.unlink()
         # Make the test work the weekend. It will fails due to workcenter working hours.
         if day.weekday() in (5, 6):
             day -= timedelta(days=2)


### PR DESCRIPTION
It's due to other module creating leaves on the 40h/week calendar. Since it's set on the workorder. During the productivity loss creation the duration could cost for 0 minutes if it's during the leave of a workcenter

opw-moc

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
