### PR TITLE
[FIX] spreadsheet: Fix clickable cell of pivot with positional arg

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_model.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_model.js
@@ -335,7 +335,7 @@ export class SpreadsheetPivotModel extends PivotModel {
     /**
      * Get the label of the last group by of the domain
      *
-     * @param {string[]} domain Domain of the formula
+     * @param {any[]} domain Domain of the formula
      */
     getPivotHeaderValue(domain) {
         const groupFieldString = domain[domain.length - 2];
@@ -344,8 +344,7 @@ export class SpreadsheetPivotModel extends PivotModel {
             const { cols, rows } = this._getColsRowsValuesFromDomain(domain);
             return this._isCol(field) ? cols[cols.length - 1] : rows[rows.length - 1];
         }
-        const groupValueString = domain[domain.length - 1];
-        return groupValueString;
+        return domain[domain.length - 1];
     }
 
     /**

--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
@@ -295,9 +295,12 @@ export default class PivotUIPlugin extends spreadsheet.UIPlugin {
                                 break;
                             }
                         }
+                        // A group by value of "none"
+                        if (value === false) break;
                         if (JSON.stringify(currentValue) !== `[${value}]`) {
                             transformedValue = [value];
                         }
+
                         break;
                     case "text":
                         if (currentValue !== value) {


### PR DESCRIPTION
How to reproduce:
- Create a dashboard with pivot grouped such that some group values are empty (E.g. CRM lead > group by 'lost reason')
- Add a pivot.header formula where you point towards the positional field (e.g. `=ODOO.PIVOT.HEADER(1,"#lost_reason_id",1)` )
- Add a relational filter that points on the 'lost reason' model
- Go back to the dashboard app to visualize it and click on the modified cell

-> crash

The pivot ui plugin did not properly account for that scenario as it was expecting a string as an output of `getPivotHeaderValue`. However, the later had changed its return type since we handle both balues and stringified values as arguments in the formula.

Task-4582602

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
