### PR TITLE
[FIX] portal, web: main component container is lunched before updating services

### DIFF
--- a/addons/portal/__manifest__.py
+++ b/addons/portal/__manifest__.py
@@ -45,7 +45,7 @@ a dependency towards website editing and customization capabilities.""",
             'portal/static/src/xml/portal_security.xml',
             'portal/static/src/js/components/**/*',
             'portal/static/src/signature_form/**/*',
-            'portal/static/src/chatter/boot/boot_service.js',
+            'portal/static/src/chatter/boot/*.js',
         ],
         'web.assets_tests': [
             'portal/static/tests/**/*',

--- a/addons/portal/static/src/chatter/boot/boot_service.js
+++ b/addons/portal/static/src/chatter/boot/boot_service.js
@@ -3,8 +3,6 @@ import { loadBundle } from "@web/core/assets";
 import { registry } from "@web/core/registry";
 import { memoize } from "@web/core/utils/functions";
 
-odoo.portalChatterReady = new Deferred();
-
 const loader = {
     loadChatter: memoize(() => loadBundle("portal.assets_chatter")),
 };
@@ -12,6 +10,7 @@ export const portalChatterBootService = {
     start() {
         const chatterEl = document.querySelector(".o_portal_chatter");
         if (chatterEl) {
+            odoo.portalChatterReady = new Deferred();
             loader.loadChatter();
         }
     },

--- a/addons/portal/static/src/chatter/boot/public_root_patch.js
+++ b/addons/portal/static/src/chatter/boot/public_root_patch.js
@@ -1,0 +1,13 @@
+import { PublicRoot } from "@web/legacy/js/public/public_root";
+import { patch } from "@web/core/utils/patch";
+
+patch(PublicRoot.prototype, {
+    /**
+     * @override
+     * wait for chatter lazy loaded bundle before lunching the MainComponentsContainer
+     */
+    async createMainComponent(env) {
+        await odoo.portalChatterReady;
+        return super.createMainComponent(...arguments);
+    },
+});

--- a/addons/web/static/src/legacy/js/public/public_root.js
+++ b/addons/web/static/src/legacy/js/public/public_root.js
@@ -302,6 +302,22 @@ export const PublicRoot = publicWidget.Widget.extend({
     _onDateTimePickerError: function (ev) {
         return false;
     },
+    /**
+     * create an Owl App with the MainComponentsContainer as root component
+     *
+     * @param {OdooEnv} env
+     * @returns {Promise<App>}
+     */
+    async createMainComponent(env) {
+        return new App(MainComponentsContainer, {
+            getTemplate,
+            env,
+            dev: env.debug,
+            translateFn: _t,
+            translatableAttributes: ["data-tooltip"],
+        });
+    },
+
 });
 
 /**
@@ -318,13 +334,7 @@ export async function createPublicRoot(RootWidget) {
     Component.env = env;
     await env.services.public_component.mountComponents();
     const publicRoot = new RootWidget(null, env);
-    const app = new App(MainComponentsContainer, {
-        getTemplate,
-        env,
-        dev: env.debug,
-        translateFn: _t,
-        translatableAttributes: ["data-tooltip"],
-    });
+    const app = await publicRoot.createMainComponent(env);
     const locale = pyToJsLocale(lang) || browser.navigator.language;
     Settings.defaultLocale = locale;
     const [root] = await Promise.all([


### PR DESCRIPTION
When loading portal chatter, because the chatter bundle is lazy loading, it could happen that some components are added to the main_components registry while the services are not fully updated. In non-lazy loading scenarios, this doesn't happen because before lunching the main components, the code waits for all services to start, but with lazy loading, the services update happens again with the lazily loaded bundle, and if there are some main components in that bundle, they will be added to the MainComponentsContainer regardless of the updating services. As a result, this could lead to a main component being added randomly before or after the services are loaded.
This commit, by postponing the lunching of the MainComponentsContainer until after the lazy loading is complete, ensures that if there are other lazily loaded services, the main components will wait for them to be updated.