### PR TITLE
[FIX] hr_timesheet : Recompute allocated hour for task

### DIFF
--- a/addons/hr_timesheet/tests/test_project_task_quick_create.py
+++ b/addons/hr_timesheet/tests/test_project_task_quick_create.py
@@ -2,9 +2,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.hr_timesheet.tests.test_timesheet import TestCommonTimesheet
-from odoo.tests import Form
+from odoo.tests import Form, tagged
 
-
+@tagged('-at_install', 'post_install')
 class TestProjectTaskQuickCreate(TestCommonTimesheet):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
In this PR https://github.com/odoo/enterprise/pull/78465 the test is failing because it is not taking the  override into account as it is not a post_install.

opw-4192775