### PR TITLE
[FIX] website: fix test_ensure_correct_website_asset on multi-website

### DIFF
--- a/addons/website/tests/test_assets.py
+++ b/addons/website/tests/test_assets.py
@@ -233,7 +233,7 @@ class TestWebAssets(odoo.tests.HttpCase):
     def test_ensure_correct_website_asset(self):
         # when searching for an attachment, if the unique a wildcard, we want to ensute that we don't match a website one when seraching a no website one.
         # this test should also wheck that the clean_attachement does not erase a website_attachement after generating a base attachment
-        website_id = self.env['website'].search([], limit=1, order='id desc').id
+        website_id = self.env['website'].search([], limit=1, order='id asc').id
         unique = self.env['ir.qweb']._get_asset_bundle('web.assets_frontend').get_version('js')
         base_url = self.env['ir.asset']._get_asset_bundle_url('web.assets_frontend.min.js', '%', {})
         base_url_versioned = self.env['ir.asset']._get_asset_bundle_url('web.assets_frontend.min.js', unique, {})


### PR DESCRIPTION
To reproduce:

Testing `test_ensure_correct_website_asset` with multiple website will consistently fail as the bundle from the biggest `website_id` is used whereas it compare the bundle to default website loaded, which looks to be the one with the smallest ID.

Installing `test_themes` reproduce the issue consistently as the website with biggest and smallest ID will use different theme website with distinct bundle

After this fix:
As the website with smaller ID load by default, we use the smallest existing website_id rather than the biggest one

rb-65788
