### PR TITLE
[IMP] mail: force IM status

### DIFF
--- a/addons/hr_holidays/models/res_partner.py
+++ b/addons/hr_holidays/models/res_partner.py
@@ -25,6 +25,8 @@ class ResPartner(models.Model):
                     partner.im_status = 'leave_online'
                 elif partner.im_status == 'away':
                     partner.im_status = 'leave_away'
+                elif partner.im_status == 'busy':
+                    partner.im_status = 'leave_busy'
                 elif partner.im_status == 'offline':
                     partner.im_status = 'leave_offline'
 

--- a/addons/hr_holidays/models/res_users.py
+++ b/addons/hr_holidays/models/res_users.py
@@ -47,6 +47,8 @@ class ResUsers(models.Model):
                     user.im_status = 'leave_online'
                 elif user.im_status == 'away':
                     user.im_status = 'leave_away'
+                elif user.im_status == 'busy':
+                    user.im_status = 'leave_busy'
                 elif user.im_status == 'offline':
                     user.im_status = 'leave_offline'
 

--- a/addons/hr_holidays/static/src/avatar_card_popover_patch.xml
+++ b/addons/hr_holidays/static/src/avatar_card_popover_patch.xml
@@ -4,6 +4,7 @@
         <xpath expr="//span[@name='icon']" position="inside">
             <i t-elif="user.im_status === 'leave_online'" class="fa fa-fw fa-plane text-success" title="Online" role="img" aria-label="User is online"/>
             <i t-elif="user.im_status === 'leave_away'" class="fa fa-fw fa-plane text-warning" title="Idle" role="img" aria-label="User is idle"/>
+            <i t-elif="user.im_status === 'leave_busy'" class="fa fa-fw fa-plane text-danger" title="Busy" role="img" aria-label="User is busy"/>
             <i t-elif="user.im_status === 'leave_offline'" class="fa fa-fw fa-plane text-500" title="Out of office" role="img" aria-label="User is out of office"/>
         </xpath>
         <xpath expr="//span[@t-esc='user.name']" position="after">

--- a/addons/hr_holidays/static/src/avatar_card_resource_popover.xml
+++ b/addons/hr_holidays/static/src/avatar_card_resource_popover.xml
@@ -4,6 +4,7 @@
         <xpath expr="//span[@name='icon'][hasclass('o_user_im_status')]/i[hasclass('fa-question-circle')]" position="before">
             <i t-elif="record.im_status === 'leave_online'" class="fa fa-fw fa-plane text-success" title="Online" role="img" aria-label="User is online"/>
             <i t-elif="record.im_status === 'leave_away'" class="fa fa-fw fa-plane text-warning" title="Idle" role="img" aria-label="User is idle"/>
+            <i t-elif="record.im_status === 'leave_busy'" class="fa fa-fw fa-plane text-danger" title="Busy" role="img" aria-label="User is busy"/>
             <i t-elif="record.im_status === 'leave_offline'" class="fa fa-fw fa-plane text-500" title="Out of office" role="img" aria-label="User is out of office"/>
         </xpath>
         <xpath expr="//span[@name='icon'][hasclass('o_employee_presence_status')]" position="inside">

--- a/addons/hr_holidays/static/src/im_status_patch.xml
+++ b/addons/hr_holidays/static/src/im_status_patch.xml
@@ -3,7 +3,8 @@
     <t t-inherit="mail.ImStatus" t-inherit-mode="extension">
         <xpath expr="//*[@name='icon']" position="replace">
             <i t-if="persona.im_status === 'leave_online'" class="fa fa-plane text-success" title="On Leave (Online)" role="img" aria-label="User is on leave and online"/>
-            <i t-elif="persona.im_status === 'leave_away'" class="fa fa-plane o-away" title="On Leave (Idle)" role="img" aria-label="User is on leave and idle"/>
+            <i t-elif="persona.im_status === 'leave_away'" class="fa fa-plane o-yellow" title="On Leave (Idle)" role="img" aria-label="User is on leave and idle"/>
+            <i t-elif="persona.im_status === 'leave_busy'" class="fa fa-fw fa-plane text-danger" title="On Leave (Busy)" role="img" aria-label="User is on leave and busy"/>
             <i t-elif="persona.im_status === 'leave_offline'" class="fa fa-plane text-500" title="On Leave" role="img" aria-label="User is on leave"/>
             <t t-else="">$0</t>
         </xpath>

--- a/addons/hr_holidays/static/src/store_service_patch.js
+++ b/addons/hr_holidays/static/src/store_service_patch.js
@@ -4,7 +4,7 @@ import { patch } from "@web/core/utils/patch";
 /** @type {import("models").Store} */
 const storeServicePatch = {
     get onlineMemberStatuses() {
-        return super.onlineMemberStatuses + ["leave_online", "leave_away"];
+        return super.onlineMemberStatuses + ["leave_online", "leave_away", "leave_busy"];
     },
 };
 

--- a/addons/hr_homeworking/models/res_partner.py
+++ b/addons/hr_homeworking/models/res_partner.py
@@ -14,6 +14,6 @@ class ResPartner(models.Model):
             if not location_type:
                 continue
             im_status = user.partner_id.im_status
-            if im_status == "online" or im_status == "away" or im_status == "offline":
+            if im_status in ["online", "away", "busy", "offline"]:
                 user.partner_id.im_status = location_type + "_" + im_status
 

--- a/addons/hr_homeworking/models/res_users.py
+++ b/addons/hr_homeworking/models/res_users.py
@@ -34,5 +34,5 @@ class ResUsers(models.Model):
             if not location_type:
                 continue
             im_status = user.im_status
-            if im_status == "online" or im_status == "away" or im_status == "offline":
+            if im_status in ["online", "away", "busy", "offline"]:
                 user.im_status = "presence_" + location_type + "_" + im_status

--- a/addons/hr_homeworking/static/src/avatar_card_popover_patch.xml
+++ b/addons/hr_homeworking/static/src/avatar_card_popover_patch.xml
@@ -4,12 +4,15 @@
         <xpath expr="//span[@name='icon']" position="inside">
             <i t-elif="user.im_status === 'presence_home_online'" class="fa fa-fw fa-home text-success" title="At Home - Online" role="img" aria-label="At Home - Online"/>
             <i t-elif="user.im_status === 'presence_home_away'" class="fa fa-fw fa-home text-warning" title="At Home - Idle" role="img" aria-label="At Home - Idle"/>
+            <i t-elif="user.im_status === 'presence_home_busy'" class="fa fa-fw fa-home text-danger" title="At Home - Busy" role="img" aria-label="At Home - Busy"/>
             <i t-elif="user.im_status === 'presence_home_offline'" class="fa fa-fw fa-home text-body" title="At Home - Offline" role="img" aria-label="At Home - Offline"/>
             <i t-elif="user.im_status === 'presence_office_online'" class="fa fa-fw fa-building text-success" title="At Office - Online" role="img" aria-label="At Office - Online"/>
             <i t-elif="user.im_status === 'presence_office_away'" class="fa fa-fw fa-building text-warning" title="At Office - Idle" role="img" aria-label="At Office - Idle"/>
+            <i t-elif="user.im_status === 'presence_office_busy'" class="fa fa-fw fa-building text-danger" title="At Office - Busy" role="img" aria-label="At Office - Busy"/>
             <i t-elif="user.im_status === 'presence_office_offline'" class="fa fa-fw fa-building text-body" title="At Office - Offline" role="img" aria-label="At Office - Offline"/>
             <i t-elif="user.im_status === 'presence_other_online'" class="fa fa-fw fa-map-marker text-success" title="At Other - Online" role="img" aria-label="At Other - Online"/>
             <i t-elif="user.im_status === 'presence_other_away'" class="fa fa-fw fa-map-marker text-warning" title="At Other - Idle" role="img" aria-label="At Other - Idle"/>
+            <i t-elif="user.im_status === 'presence_other_busy'" class="fa fa-fw fa-map-marker text-danger" title="At Other - Busy" role="img" aria-label="At Other - Busy"/>
             <i t-elif="user.im_status === 'presence_other_offline'" class="fa fa-fw fa-map-marker text-body" title="At Other - Offline" role="img" aria-label="At Other - Offline"/>
         </xpath>
     </t>

--- a/addons/hr_homeworking/static/src/im_status_patch.xml
+++ b/addons/hr_homeworking/static/src/im_status_patch.xml
@@ -8,7 +8,7 @@
                     <t t-if="location == 'home' || location == 'office' || location == 'other'">
                         <t t-set="status" t-value="persona.im_status.split('_')[1]"/>
                         <t t-set="location_map" t-value="{'home': 'fa-home', 'office': 'fa-building', 'other': 'fa-map-marker'}"/>
-                        <t t-set="status_map" t-value="{'online': 'text-success', 'away': 'o-away', 'offline': 'text-body'}"/>
+                        <t t-set="status_map" t-value="{'online': 'text-success', 'away': 'o-yellow', 'busy': 'text-danger', 'offline': 'text-body'}"/>
                         <t t-set="icon" t-value="location_map[location]"/>
                         <t t-set="text" t-value="status_map[status]"/>
                         <i class="fa" t-attf-class="{{icon}} {{text}}" t-attf-title="At {{location}} - {{status}}" role="img" t-attf-aria-label=" User work at {{location}} and is {{status}}"/>
@@ -29,7 +29,7 @@
                     <t t-if="location == 'home' || location == 'office' || location == 'other'">
                         <t t-set="status" t-value="correspondent.persona.im_status.split('_')[1]"/>
                         <t t-set="location_map" t-value="{'home': 'fa-home', 'office': 'fa-building', 'other': 'fa-map-marker'}"/>
-                        <t t-set="status_map" t-value="{'online': 'text-success', 'away': 'o-away', 'offline': 'text-body'}"/>
+                        <t t-set="status_map" t-value="{'online': 'text-success', 'away': 'o-yellow', 'busy': 'text-danger', 'offline': 'text-body'}"/>
                         <t t-set="icon" t-value="location_map[location]"/>
                         <t t-set="text" t-value="status_map[status]"/>
                         <i class="fa" t-attf-class="{{icon}} {{text}}" t-attf-title="At {{location}} - {{status}}" role="img" t-attf-aria-label=" User work at {{location}} and is {{status}}"/>

--- a/addons/mail/controllers/__init__.py
+++ b/addons/mail/controllers/__init__.py
@@ -3,6 +3,7 @@
 from . import attachment
 from . import google_translate
 from . import guest
+from . import im_status
 from . import link_preview
 from . import mail
 from . import mailbox

--- a/addons/mail/controllers/im_status.py
+++ b/addons/mail/controllers/im_status.py
@@ -1,0 +1,22 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import http, _
+from odoo.http import request
+
+
+class ImStatusController(http.Controller):
+    @http.route("/mail/set_manual_im_status", methods=["POST"], type="jsonrpc", auth="user")
+    def set_manual_im_status(self, status):
+        if status not in ["online", "away", "busy", "offline"]:
+            raise ValueError(_("Unexpected IM status %(status)s", status=status))
+        user = request.env.user
+        user.manual_im_status = False if status == "online" else status
+        user._bus_send(
+            "bus.bus/im_status_updated",
+            {
+                "debounce": False,
+                "im_status": user.partner_id.im_status,
+                "partner_id": user.partner_id.id,
+            },
+            subchannel="presence",
+        )

--- a/addons/mail/static/src/core/common/im_status.scss
+++ b/addons/mail/static/src/core/common/im_status.scss
@@ -10,8 +10,4 @@
         width: 0.65rem; // matches .o-xsmaller
         height: 0.65rem;
     }
-
-    .o-away {
-        color: $yellow;
-    }
 }

--- a/addons/mail/static/src/core/common/im_status.xml
+++ b/addons/mail/static/src/core/common/im_status.xml
@@ -16,10 +16,11 @@
                 <t name="icon">
                     <t t-if="(!props.member or !props.member.isTyping) and persona">
                         <i t-if="persona.im_status === 'online'" class="fa fa-circle text-success" title="Online" role="img" aria-label="User is online"/>
-                        <i t-elif="persona.im_status === 'away'" class="fa fa-circle o-away" title="Idle" role="img" aria-label="User is idle"/>
+                        <i t-elif="persona.im_status === 'away'" class="fa fa-circle o-yellow" title="Idle" role="img" aria-label="User is idle"/>
+                        <i t-elif="persona.im_status === 'busy'" class="fa fa-minus-circle text-danger" title="Busy" role="img" aria-label="User is busy"/>
                         <i t-elif="persona.im_status === 'offline'" class="fa fa-circle-o text-700 opacity-75" title="Offline" role="img" aria-label="User is offline"/>
                         <i t-elif="persona.im_status === 'bot'" class="fa fa-heart text-success" title="Bot" role="img" aria-label="User is a bot"/>
-                        <i t-else="" class="fa fa-fw fa-question-circle opacity-75" title="No IM status available"/>
+                        <i t-else="" class="fa fa-question-circle opacity-75" title="No IM status available"/>
                     </t>
                     <div t-if="props.member?.isTyping" class="rounded-pill" style="padding: 1px;" t-att-class="{ 'bg-300': env.inChatBubble, 'bg-inherit': !env.inChatBubble }">
                         <div class="bg-success rounded-pill" style="padding: 3px;">

--- a/addons/mail/static/src/core/common/im_status_dropdown.js
+++ b/addons/mail/static/src/core/common/im_status_dropdown.js
@@ -1,0 +1,48 @@
+import { Component } from "@odoo/owl";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { ImStatus } from "./im_status";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { rpc } from "@web/core/network/rpc";
+
+export class ImStatusDropdown extends Component {
+    static components = { Dropdown, DropdownItem, ImStatus };
+    static props = [];
+    static template = "mail.ImStatusDropdown";
+
+    setup() {
+        this.store = useService("mail.store");
+        this.readableImStatusByCode = {
+            online: _t("Online"),
+            away: _t("Away"),
+            busy: _t("Do Not Disturb"),
+            offline: _t("Offline"),
+        };
+    }
+
+    setManualImStatus(status) {
+        rpc("/mail/set_manual_im_status", { status });
+    }
+
+    get readableImStatus() {
+        const imStatus = this.store.self.im_status || "offline";
+        for (const status in this.readableImStatusByCode) {
+            if (imStatus.includes(status)) {
+                return this.readableImStatusByCode[status];
+            }
+        }
+        return _t("Unknown Status");
+    }
+}
+
+export function imStatusItem(env) {
+    return {
+        type: "component",
+        contentComponent: ImStatusDropdown,
+        sequence: 45,
+    };
+}
+
+registry.category("user_menuitems").add("im_status", imStatusItem);

--- a/addons/mail/static/src/core/common/im_status_dropdown.xml
+++ b/addons/mail/static/src/core/common/im_status_dropdown.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.ImStatusDropdown">
+        <Dropdown>
+            <button><ImStatus persona='store.self'/> <span t-esc="readableImStatus"/></button>
+            <t t-set-slot="content">
+                <DropdownItem onSelected="() => this.setManualImStatus('online')"><i class="fa fa-circle text-success me-1" title="Online" role="img"/> Online</DropdownItem>
+                <hr class="my-1"/>
+                <DropdownItem onSelected="() => this.setManualImStatus('away')"><i class="fa fa-circle o-yellow me-1" title="Away" role="img"/> Away</DropdownItem>
+                <DropdownItem onSelected="() => this.setManualImStatus('busy')"><span><i class="fa fa-minus-circle text-danger me-1" title="Busy" role="img"/> Do Not Disturb</span></DropdownItem>
+                <DropdownItem onSelected="() => this.setManualImStatus('offline')"><i class="fa fa-circle-o text-700 opacity-75 me-1" title="Offline" role="img"/> Offline</DropdownItem>
+            </t>
+        </Dropdown>
+    </t>
+</templates>

--- a/addons/mail/static/src/core/common/im_status_service.js
+++ b/addons/mail/static/src/core/common/im_status_service.js
@@ -40,7 +40,7 @@ export const imStatusService = {
         bus_service.addEventListener("connect", () => updateBusPresence(), { once: true });
         bus_service.subscribe(
             "bus.bus/im_status_updated",
-            async ({ presence_status, im_status, partner_id, guest_id }) => {
+            async ({ presence_status, im_status, partner_id, guest_id, debounce = true }) => {
                 const store = env.services["mail.store"];
                 const persona = store.Persona.get({
                     type: partner_id ? "partner" : "guest",
@@ -49,7 +49,11 @@ export const imStatusService = {
                 if (!persona) {
                     return; // Do not store unknown persona's status
                 }
-                persona.debouncedSetImStatus(im_status);
+                if (debounce) {
+                    persona.debouncedSetImStatus(im_status);
+                } else {
+                    persona.updateImStatus(im_status);
+                }
                 if (persona.notEq(store.self)) {
                     return;
                 }

--- a/addons/mail/static/src/discuss/core/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/store_service_patch.js
@@ -22,7 +22,7 @@ const storeServicePatch = {
         );
     },
     get onlineMemberStatuses() {
-        return ["away", "bot", "online"];
+        return ["away", "bot", "busy", "online"];
     },
     /**
      * @param {Object} param0

--- a/addons/mail/static/src/discuss/core/web/user_menu_patch.js
+++ b/addons/mail/static/src/discuss/core/web/user_menu_patch.js
@@ -1,0 +1,13 @@
+import { ImStatus } from "@mail/core/common/im_status";
+import { useService } from "@web/core/utils/hooks";
+import { patch } from "@web/core/utils/patch";
+import { UserMenu } from "@web/webclient/user_menu/user_menu";
+
+Object.assign(UserMenu.components, { ImStatus });
+
+patch(UserMenu.prototype, {
+    setup() {
+        super.setup();
+        this.store = useService("mail.store");
+    },
+});

--- a/addons/mail/static/src/discuss/core/web/user_menu_patch.scss
+++ b/addons/mail/static/src/discuss/core/web/user_menu_patch.scss
@@ -1,0 +1,4 @@
+.o-web-UserMenu-imStatus {
+    bottom: -2px;
+    right: -2px;
+}

--- a/addons/mail/static/src/discuss/core/web/user_menu_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/user_menu_patch.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">  
+    <t t-inherit="web.UserMenu" t-inherit-mode="extension">
+        <xpath expr="//img[hasclass('o_user_avatar')]" position="replace">
+            <div class="position-relative d-flex flex-shrink-0 bg-inherit">
+                <t>$0</t>
+                <ImStatus className="'o-web-UserMenu-imStatus position-absolute'" persona="store.self" size="'md'"/>
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.scss
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.scss
@@ -20,7 +20,6 @@
 }
 
 .o-discuss-GifPicker-noFavoritesIcon {
-    color: $yellow;
     filter: grayscale(0.25);
 }
 

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
@@ -76,7 +76,7 @@
                             <i class="fa fa-spin fa-circle-o-notch"/>
                         </div>
                         <div t-elif="showFavorite and state.evenGif.gifs.size === 0 and state.oddGif.gifs.size === 0" class="d-flex flex-column h-100 align-items-center justify-content-center text-center text-muted gap-2">
-                            <i class="o-discuss-GifPicker-noFavoritesIcon fa fa-star fs-1"/>
+                            <i class="o-discuss-GifPicker-noFavoritesIcon o-yellow fa fa-star fs-1"/>
                             <span class="fs-5">So uhh... maybe go favorite some GIFs?</span>
                         </div>
                     </t>

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -12,6 +12,7 @@
                         <span t-if="user.im_status" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center bg-inherit">
                             <i t-if="user.im_status === 'online'" class="fa fa-fw fa-circle text-success" title="Online" role="img" aria-label="User is online"/>
                             <i t-elif="user.im_status === 'away'" class="fa fa-fw fa-circle text-warning" title="Idle" role="img" aria-label="User is idle"/>
+                            <i t-elif="user.im_status === 'busy'" class="fa fa-fw fa-minus-circle text-danger" title="Busy" role="img" aria-label="User is busy"/>
                             <i t-elif="user.im_status === 'offline'" class="fa fa-fw fa-circle-o text-700" title="Offline" role="img" aria-label="User is offline"/>
                             <i t-elif="user.im_status === 'bot'" class="fa fa-fw fa-heart text-success" title="Bot" role="img" aria-label="User is a bot"/>
                             <i t-elif="!user.im_status" class="fa fa-fw fa-question-circle" title="No IM status available"/>

--- a/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
+++ b/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
@@ -8,6 +8,7 @@
             <span t-if="record.user_id" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center o_user_im_status bg-inherit">
                 <i t-if="record.im_status === 'online'" class="fa fa-fw fa-circle text-success" title="Online" role="img" aria-label="User is online"/>
                 <i t-elif="record.im_status === 'away'" class="fa fa-fw fa-circle text-warning" title="Idle" role="img" aria-label="User is idle"/>
+                <i t-elif="record.im_status === 'busy'" class="fa fa-fw fa-minus-circle text-danger" title="Busy" role="img" aria-label="User is busy"/>
                 <i t-elif="record.im_status === 'offline'" class="fa fa-fw fa-circle-o text-700" title="Offline" role="img" aria-label="User is offline"/>
                 <i t-elif="record.im_status === 'bot'" class="fa fa-fw fa-heart text-success" title="Bot" role="img" aria-label="User is a bot"/>
                 <i t-elif="!record.im_status" class="fa fa-fw fa-question-circle" title="No IM status available"/>

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -14,12 +14,16 @@ from odoo.tests.common import users, tagged, HttpCase, warmup
 @tagged('post_install', '-at_install')
 class TestDiscussFullPerformance(HttpCase, MailCommon):
     # Queries for _query_count_init_store (in order):
+    #   1: search res_partner (odooot ref exists)
     #   1: search res_groups (internalUserGroupId ref exists)
-    #   5: odoobot format:
-    #       - search res_partner (ref exists)
+    #   8: odoobot format:
     #       - fetch res_partner (_read_format)
     #       - search res_users (_compute_im_status)
+    #       - search presence (_compute_im_status)
+    #       - fetch presence (_compute_im_status)
     #       - _get_on_leave_ids (_compute_im_status hr_holidays override)
+    #       - search employee (_compute_im_status hr_homeworking override)
+    #       - fetch employee (_compute_im_status hr_homeworking override)
     #       - fetch res_users (_read_format)
     #   5: settings:
     #       - search res_users_settings (_find_or_create_for_user)
@@ -27,11 +31,10 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search res_users_settings_volumes (_format_settings)
     #       - search res_lang_res_users_settings_rel (_format_settings)
     #       - search im_livechat_expertise_res_users_settings_rel (_format_settings)
-    #   1: fetch res_partner (self_partner _read_format)
     #   2: hasCannedResponses
     #       - fetch res_groups_users_rel
     #       - search mail_canned_response
-    _query_count_init_store = 14
+    _query_count_init_store = 17
     # Queries for _query_count_init_messaging (in order):
     #   1: insert res_device_log
     #   3: _search_is_member (for current user, first occurence _search_is_member for chathub given channel ids)
@@ -395,6 +398,8 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "active": True,
                     "avatar_128_access_token": partner_0._get_avatar_128_access_token(),
                     "id": self.users[0].partner_id.id,
+                    "im_status": 'online',
+                    "im_status_access_token": self.users[0].partner_id._get_im_status_access_token(),
                     "main_user_id": self.users[0].id,
                     "name": "Ernest Employee",
                     "write_date": fields.Datetime.to_string(self.users[0].partner_id.write_date),

--- a/addons/web/static/src/webclient/navbar/navbar.variables.scss
+++ b/addons/web/static/src/webclient/navbar/navbar.variables.scss
@@ -39,7 +39,7 @@ $o-navbar-badge-text-shadow: 1px 1px 0 rgba($o-black, .3) !default;
     height: calc(var(--o-navbar-height) - #{$o-navbar-padding-v * 2});
     border-radius: $o-navbar-entry-border-radius;
     user-select: none;
-    background: transparent;
+    background-color: inherit;
     font-size: $o-navbar-entry-font-size;
 
     @include o-hover-text-color(

--- a/addons/web/static/src/webclient/navbar/navbar.xml
+++ b/addons/web/static/src/webclient/navbar/navbar.xml
@@ -31,7 +31,7 @@
         </t>
 
         <!-- Systray -->
-        <div class="o_menu_systray d-flex flex-shrink-0 ms-auto" role="menu">
+        <div class="o_menu_systray d-flex flex-shrink-0 ms-auto bg-inherit" role="menu">
           <t t-foreach="systrayItems" t-as="item" t-key="item.key">
             <!-- This ensures the correct order of the systray items -->
             <div t-att-data-index="item.index"/>

--- a/addons/web/static/src/webclient/user_menu/user_menu.xml
+++ b/addons/web/static/src/webclient/user_menu/user_menu.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.UserMenu">
-        <div class="o_user_menu d-none d-md-block pe-0">
+        <div class="o_user_menu d-none d-md-block pe-0 bg-inherit">
             <DropdownGroup group="'web-navbar-group'">
                 <Dropdown>
                     <button class="py-1 py-lg-0">
@@ -17,6 +17,7 @@
                     <t t-set-slot="content">
                         <t t-foreach="getElements()" t-as="element" t-key="element_index">
                             <t t-if="!element.hide">
+                                <t t-if="element.type === 'component'" t-component="element.contentComponent"/>
                                 <DropdownItem
                                     t-if="element.type == 'item' || element.type == 'switch'"
                                     attrs="{ href: element.href, 'data-menu': element.id }"

--- a/addons/web/static/tests/webclient/user_menu.test.js
+++ b/addons/web/static/tests/webclient/user_menu.test.js
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { click, queryAllAttributes, queryAllProperties, queryAllTexts } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
+import { Component, xml } from "@odoo/owl";
 import {
     clearRegistry,
     contains,
@@ -162,4 +163,19 @@ test("click on odoo account item", async () => {
     expect(".o-dropdown--menu .dropdown-item").toHaveText("My Odoo.com Account");
     await contains(".o-dropdown--menu .dropdown-item").click();
     expect.verifySteps(["/web/session/account", "open https://account-url.com"]);
+});
+
+test("can use component as registry item", async () => {
+    class ExampleComponent extends Component {
+        static template = xml`<span class='component-class'>Example Component</span>`;
+        static props = ["*"];
+    }
+    userMenuRegistry.add("component-item", () => ({
+        type: "component",
+        contentComponent: ExampleComponent,
+        sequence: 10,
+    }));
+    await mountWithCleanup(UserMenu);
+    await contains("button.dropdown-toggle").click();
+    expect(".o-dropdown--menu span.component-class").toHaveText("Example Component");
 });

--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -43,8 +43,8 @@ class TestPerfSessionInfo(common.HttpCase):
 
         # cold fields cache - warm ormcache:
         # - Only web: 5
-        # - All modules: 26
-        with self.assertQueryCount(26):
+        # - All modules: 31
+        with self.assertQueryCount(31):
             self.url_open(
                 "/web/session/get_session_info",
                 data=json.dumps({'jsonrpc': "2.0", 'method': "call", 'id': str(uuid4())}),


### PR DESCRIPTION
This commit introduces the possibility for the user to force their IM status.
Their choice will take precedence over the IM status calculated through inactivity time.
A new IM status "busy" is also introduced. A busy user will receive no notifications and reject all incoming calls.

task-3208257
