### PR TITLE
[FIX] point_of_sale: prevent validating order when it's not fully paid

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -134,13 +134,7 @@ class PosOrder(models.Model):
     def _process_saved_order(self, draft):
         self.ensure_one()
         if not draft:
-            try:
-                self.action_pos_order_paid()
-            except psycopg2.DatabaseError:
-                # do not hide transactional errors, the order(s) won't be saved!
-                raise
-            except Exception as e:
-                _logger.error('Could not fully process the POS Order: %s', tools.exception_to_unicode(e))
+            self.action_pos_order_paid()
             self._create_order_picking()
             self._compute_total_cost_in_real_time()
 


### PR DESCRIPTION
Before this commit, _process_saved_order caught errors from action_pos_order_paid and logged them. This meant that even when payment processing failed, the order state could be set to "paid", leading to financial discrepancies.

Removing the try-catch block now stops order validation when payment is incomplete, ensuring orders are only marked as paid when fully confirmed.

opw-4487123

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
