### PR TITLE
[FIX] spreadsheet: display frozen message when needed

### DIFF
--- a/addons/spreadsheet/views/public_readonly_spreadsheet_templates.xml
+++ b/addons/spreadsheet/views/public_readonly_spreadsheet_templates.xml
@@ -14,7 +14,7 @@
             <header class="container-fluid p-0 d-flex align-items-center justify-content-between border-bottom">
                 <div t-out="spreadsheet_name" class="text-primary fw-bold ps-3"/>
                 <div class="fst-italic flex-fill ps-3">
-                    Frozen and copied on <span t-field="share.create_date"/>
+                    <t t-if="is_frozen">Frozen and copied on <span t-field="share.create_date"/></t>
                     <div class="d-inline-flex" t-if="props['downloadExcelUrl']">
                         <a class="btn btn-secondary btn-block o_download_btn" t-att-href="props['downloadExcelUrl']" title="Download"><i class="fa fa-download"/></a>
                     </div>

--- a/addons/spreadsheet_dashboard/controllers/share.py
+++ b/addons/spreadsheet_dashboard/controllers/share.py
@@ -13,6 +13,7 @@ class DashboardShareRoute(http.Controller):
             {
                 "spreadsheet_name": share.dashboard_id.name,
                 "share": share,
+                "is_frozen": True,
                 "session_info": request.env["ir.http"].session_info(),
                 "props": {
                     "dataUrl": f"/dashboard/data/{share.id}/{token}",


### PR DESCRIPTION
Steps to reproduce:

- Create a new blank spreadsheet in Documens
- Hit the Share button
- Open the sharing link in a incognito window => it says "Frozen and copied on ..." even though it's not frozen at all

See Enterprise PR

Task-4583953

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
