### PR TITLE
[IMP] hr_holidays: half-day visibility

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_model.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_model.js
@@ -28,6 +28,7 @@ export class TimeOffCalendarModel extends CalendarModel {
                 result.title = [employee, result.title].join(' ');
             }
         }
+        if (rawRecord.request_unit_half) result.request_date_from_period = rawRecord.request_date_from_period
         return result;
     }
 
@@ -97,7 +98,8 @@ export class TimeOffCalendarModel extends CalendarModel {
         if (!this.employeeId) {
             context['short_name'] = 1;
         }
-        return this.orm.searchRead(resModel, this.computeDomain(data), fieldNames, { context });
+        const fieldNamesToAdd = ["request_unit_half", "request_date_from_period"]
+        return this.orm.searchRead(resModel, this.computeDomain(data), [...fieldNames, ...fieldNamesToAdd], { context });
     }
 
     computeDomain(data) {

--- a/addons/hr_holidays/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_renderer.scss
@@ -30,5 +30,13 @@
                 --o-cw-bg: var(--mandatory-day-color);
             }
         }
+
+        .o_event_half_left {
+          clip-path: polygon(0 0, 50% 0, 50% 100%, 0% 100%);
+        }
+
+        .o_event_half_right {
+          clip-path: polygon(100% 0, 50% 0, 50% 100%, 100% 100%);
+        }
     }
 }

--- a/addons/hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
+++ b/addons/hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
@@ -79,4 +79,16 @@ export class TimeOffCalendarYearRenderer extends CalendarYearRenderer {
     getDayCellClassNames(info) {
         return [...super.getDayCellClassNames(info), ...this.mandatoryDays(info)];
     }
+
+    /**
+     * @override
+     */
+    eventClassNames({ event }) {
+        const classesToAdd = super.eventClassNames(...arguments);
+        const record = this.props.model.records[event.id];
+        if (record && record.request_date_from_period) {
+            record.request_date_from_period === "am" ? classesToAdd.push("o_event_half_left") : classesToAdd.push("o_event_half_right");
+        }
+        return classesToAdd;
+    }
 }


### PR DESCRIPTION
Problem
----------
In the time off dashboard calendar for the full year, we can't make difference between half days and full days

Objective
----------
Change the visual of the time off to cut the circle in 2 if the time off is a half day.
The up part for the afternoon ; the down part for the morning

Solution
----------
Depending on the start or the end of the time off, a new style class is added (as strike or hatch)
start >= 12h => afternoon
end <= 13h => morning

task-4583163
