### PR TITLE
[IMP] base_automation: add on_change filter domain

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -866,6 +866,11 @@ class BaseAutomation(models.Model):
             """ Instanciate an onchange method for the given automation rule. """
             def base_automation_onchange(self):
                 automation_rule = self.env['base.automation'].browse(automation_rule_id)
+
+                if not automation_rule._filter_post(self):
+                    # Do nothing if onchange record does not satisfy the filter_domain
+                    return
+
                 result = {}
                 actions = automation_rule.sudo().action_server_ids.with_context(
                     active_model=self._name,

--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -92,10 +92,10 @@
                                 />
                                 <field name="filter_domain" widget="domain" groups="base.group_no_one"
                                     options="{'model': 'model_name', 'in_dialog': True}"
-                                    invisible="trigger in ['on_change', 'on_webhook']"
+                                    invisible="trigger in ['on_webhook']"
                                 />
                                 <label for="filter_domain" groups="!base.group_no_one"
-                                    invisible="trigger not in ['on_create', 'on_create_or_write', 'on_unlink']"
+                                    invisible="trigger not in ['on_create', 'on_create_or_write', 'on_change', 'on_unlink']"
                                 />
                                 <label for="filter_domain" groups="!base.group_no_one"
                                     string="Extra Conditions"
@@ -104,7 +104,7 @@
                                 <field name="filter_domain" nolabel="1" widget="domain"
                                     groups="!base.group_no_one"
                                     options="{'model': 'model_name', 'in_dialog': False, 'foldable': True}"
-                                    invisible="trigger not in ['on_create', 'on_create_or_write', 'on_unlink', 'on_time', 'on_time_created', 'on_time_updated']"
+                                    invisible="trigger not in ['on_create', 'on_create_or_write', 'on_change', 'on_unlink', 'on_time', 'on_time_created', 'on_time_updated']"
                                 />
                                 <field name="trigger_field_ids" string="When updating" placeholder="Select fields..."
                                     options="{'no_open': True, 'no_create': True}"

--- a/addons/test_base_automation/models/test_base_automation.py
+++ b/addons/test_base_automation/models/test_base_automation.py
@@ -44,7 +44,7 @@ class BaseAutomationLeadTest(models.Model):
         # this method computes two fields on purpose; don't split it
         for record in self:
             record.employee = record.partner_id.employee
-            if not record.priority:
+            if not record.priority or not record.create_date:
                 record.deadline = False
             else:
                 record.deadline = record.create_date + relativedelta.relativedelta(days=3)


### PR DESCRIPTION
The commit [1] removed the base.automation form view filter_domain field for the `on_change` trigger type, because its value was not taken into account.

After the current commit it is reintroduced and resultant behavior is now implemented.

Taskid: opw-4496668

[1]: https://github.com/odoo/odoo/commit/205563bd5db19b47a50f63b2e913cf978046d300