### PR TITLE
[IMP] HR: Allow portal user selection for employee's related user

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -212,7 +212,7 @@
                                             <field name="user_id"
                                                 string="Related User"
                                                 help=""
-                                                domain="[('company_ids', 'in', company_id), ('share', '=', False)]"
+                                                domain="[('company_ids', 'in', company_id)]"
                                                 context="{'default_create_employee_id': id}"
                                                 widget="many2one_avatar_user"/>
                                             <button string="Create User"


### PR DESCRIPTION
Purpose
=======

We want to be able to share the payslips of the employees through the document app. Task-4309991 will require the Documents app to be installed alongside Payroll, and their payslips will be stored on the "My Drive" of each employee. So we need to remove the constraint of the portal user for the employee so that he can access the documents app to access his payslips.

Spec
====

Allow to select portal users as related user in the employee form view. Doing so will allow the selected portal user to access his payslips in the later task.

Task-4574706

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
