### PR TITLE
[FIX] mail: chat bubble not cut with spreadsheet scrollbar

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.scss
+++ b/addons/mail/static/src/core/common/chat_hub.scss
@@ -4,7 +4,7 @@
     margin-right: $o-mail-ChatHub-bubblesMargin + $o-mail-ChatHub-bubblesStart;
     margin-bottom: $o-mail-ChatHub-bubblesMargin;
     margin-left: $o-mail-ChatHub-bubblesMargin;
-    z-index:  $o-mail-NavigableList-zIndex - 1;
+    z-index: $o-mail-NavigableList-zIndex - 1;
 
     &.o-liftUp {
         transform: translateY(-25px);

--- a/addons/mail/static/src/core/common/primary_variables.scss
+++ b/addons/mail/static/src/core/common/primary_variables.scss
@@ -17,7 +17,7 @@ $o-mail-LinkPreviewCard-height: 80px !default;
 
 $o-mail-Message-sidebarSmallWidth: 34px !default;
 $o-mail-Message-sidebarWidth: 42px !default;
-$o-mail-NavigableList-zIndex: 11;
+$o-mail-NavigableList-zIndex: 21;
 $o-mail-Chatter-minWidth: 530px !default;
 $o-mail-Discuss-inspector: 300px !default; // same value as INSPECTOR_WIDTH
 


### PR DESCRIPTION
Before this commit, when using spreadsheet with some chat bubbles, the chat bubbles were cut with horizontal scrollbar of spreadsheet.

Steps to reproduce:
- make a spreadsheet
- put a chat in chat bubble (e.g. from click on messaging menu)
- remove the "filters" panel of the spreadsheet

This happens because the horizontal scrollbar of spreadsheet uses a `z-index: 15` while chat bubble uses `z-index: 10`.

The `z-index` of chat bubble is relative to navigable list, and since the value was exactly slightly offset from navigable list, this commit fixes by shifting the `$o-mail-NavigableList-zIndex`. It was `11`, now it's `21`. As a result, the chat bubble `z-index` is being changed from `10` to `20`, which is greater to `15` from spreadsheet horizontal scrollbar.

Task-4547672

Before / After
<img width="106" alt="Screenshot 2025-02-17 at 17 10 28" src="https://github.com/user-attachments/assets/caf3d9f8-59d4-4b2b-9981-d2e5ed68a510" /> <img width="97" alt="Screenshot 2025-02-17 at 17 11 14" src="https://github.com/user-attachments/assets/1c9376bc-ca24-42dd-8864-eee0878fc1c7" />

