### PR TITLE
[IMP] point_of_sale: reduce the number of sync requests

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -1000,11 +1000,9 @@ export class PosOrder extends Base {
     }
     setGeneralCustomerNote(note) {
         this.general_customer_note = note || "";
-        this.setDirty();
     }
     setInternalNote(note) {
         this.internal_note = note || "";
-        this.setDirty();
     }
 
     get orderChange() {

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -180,7 +180,6 @@ export class PosOrderline extends Base {
         if (!this.product_id.to_weight && setQuantity) {
             this.setQuantityByLot();
         }
-        this.setDirty();
     }
 
     setDiscount(discount) {
@@ -194,7 +193,6 @@ export class PosOrderline extends Base {
         const disc = Math.min(Math.max(parsed_discount || 0, 0), 100);
         this.discount = disc;
         this.order_id.recomputeOrderData();
-        this.setDirty();
     }
 
     setLinePrice() {
@@ -275,8 +273,6 @@ export class PosOrderline extends Base {
                 )
             );
         }
-
-        this.setDirty();
         return true;
     }
 
@@ -398,7 +394,6 @@ export class PosOrderline extends Base {
             parsed_price || 0,
             this.models["decimal.precision"].find((dp) => dp.name === "Product Price").digits
         );
-        this.setDirty();
     }
 
     getUnitPrice() {
@@ -588,7 +583,6 @@ export class PosOrderline extends Base {
 
     setCustomerNote(note) {
         this.customer_note = note || "";
-        this.setDirty();
     }
 
     getCustomerNote() {
@@ -702,7 +696,6 @@ export class PosOrderline extends Base {
         return this.note || "";
     }
     setNote(note) {
-        this.setDirty();
         this.note = note;
     }
     setHasChange(isChange) {
@@ -735,21 +728,6 @@ export class PosOrderline extends Base {
     }
     isSelected() {
         return this.order_id?.uiState?.selected_orderline_uuid === this.uuid;
-    }
-    setDirty(processedLines = new Set()) {
-        if (processedLines.has(this)) {
-            return;
-        }
-        processedLines.add(this);
-        super.setDirty();
-        const linesToSetDirty = [
-            this.combo_parent_id,
-            ...(this.combo_parent_id?.combo_line_ids || []),
-            ...(this.combo_line_ids || []),
-        ].filter(Boolean);
-        for (const line of linesToSetDirty) {
-            line.setDirty(processedLines);
-        }
     }
 }
 

--- a/addons/point_of_sale/static/src/app/models/utils/recursive_serialization.js
+++ b/addons/point_of_sale/static/src/app/models/utils/recursive_serialization.js
@@ -56,7 +56,6 @@ const deepSerialization = (
 
         const relatedModel = field.relation;
         const targetModel = field.model;
-        const relatedCommands = record.models.commands[relatedModel];
         const modelCommands = record.models.commands[currentModel];
 
         if (DYNAMIC_MODELS.includes(relatedModel) && !serialized[relatedModel]) {
@@ -78,13 +77,10 @@ const deepSerialization = (
                         continue;
                     }
 
-                    if (
-                        typeof childRecord.id === "number" &&
-                        relatedCommands.update.has(childRecord.id)
-                    ) {
+                    if (typeof childRecord.id === "number" && childRecord._dirty) {
                         toUpdate.push(childRecord);
                         if (opts.clear) {
-                            relatedCommands.update.delete(childRecord.id);
+                            childRecord._dirty = false;
                         }
                     } else if (typeof childRecord.id !== "number") {
                         toCreate.push(childRecord);
@@ -193,6 +189,10 @@ const deepSerialization = (
     while (stack.length) {
         const [res, key, getValue] = stack.pop();
         res[key] = getValue();
+    }
+
+    if (opts.clear) {
+        record._dirty = false;
     }
 
     // Cleanup: remove empty entries from uuidMapping.

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1186,7 +1186,9 @@ export class PosStore extends WithLazyGetterTrap {
         let orders = options.orders || [...orderToCreate, ...orderToUpdate];
 
         // Filter out orders that are already being synced
-        orders = orders.filter((order) => !this.syncingOrders.has(order.id));
+        orders = orders.filter(
+            (order) => !this.syncingOrders.has(order.id) && (order.isDirty() || options.force)
+        );
 
         try {
             const orderIdsToDelete = this.getOrderIdsToDelete();

--- a/addons/point_of_sale/static/tests/unit/dirty_model.test.js
+++ b/addons/point_of_sale/static/tests/unit/dirty_model.test.js
@@ -1,0 +1,169 @@
+import { expect, test } from "@odoo/hoot";
+import { createRelatedModels } from "@point_of_sale/app/models/related_models";
+import { uuidv4 } from "@point_of_sale/utils";
+
+const getModels = () =>
+    createRelatedModels(
+        {
+            "pos.order": {
+                price: {
+                    name: "price",
+                    type: "float",
+                },
+                lines: {
+                    name: "lines",
+                    model: "pos.order",
+                    relation: "pos.order.line",
+                    type: "one2many",
+                    inverse_name: "order_id",
+                },
+                uuid: {
+                    name: "uuid",
+                    type: "char",
+                },
+            },
+            "pos.order.line": {
+                order_id: {
+                    name: "order_id",
+                    model: "pos.order.line",
+                    relation: "pos.order",
+                    type: "many2one",
+                    ondelete: "cascade",
+                },
+                quantity: {
+                    name: "quantity",
+                    type: "float",
+                },
+
+                product_id: {
+                    name: "product_id",
+                    model: "pos.order.line",
+                    relation: "pos.product",
+                    type: "many2one",
+                },
+                uuid: {
+                    name: "uuid",
+                    type: "char",
+                },
+            },
+
+            "pos.product": {
+                name: {
+                    name: "name",
+                    type: "char",
+                },
+            },
+        },
+        {},
+        {
+            dynamicModels: ["pos.order", "pos.order.line"],
+            databaseIndex: {
+                "pos.order": ["uuid"],
+                "pos.order.line": ["uuid"],
+            },
+            databaseTable: {
+                "pos.order": { key: "uuid" },
+                "pos.order.line": { key: "uuid" },
+            },
+        }
+    ).models;
+
+test("field update", () => {
+    const models = getModels();
+    const order = models["pos.order"].create({});
+    expect(order.isDirty()).toBe(true);
+    order.price = 23.5;
+    order.serialize({ orm: true, clear: true });
+    // Setting the same value must not mark the record as dirty.
+    expect(order.isDirty()).toBe(false);
+    order.price = 23.5;
+    expect(order.isDirty()).toBe(false);
+    order.price = 25;
+    expect(order.isDirty()).toBe(true);
+    order.serialize({ orm: true, clear: true });
+    expect(order.isDirty()).toBe(false);
+
+    order.update({ price: 26 });
+    expect(order.isDirty()).toBe(true);
+});
+
+test("model creation", () => {
+    const models = getModels();
+    // Models created with a numeric ID are not considered dirty by default
+    const order = models["pos.order"].create({ id: 12 });
+    expect(order.isDirty()).toBe(false);
+
+    order.price = 23.5;
+    expect(order.isDirty()).toBe(true);
+});
+
+test("load data", () => {
+    const models = getModels();
+    const sampleUUID = uuidv4();
+
+    // When loading data, the dirty flag must not be updated.
+    models.loadData({
+        "pos.order": [
+            {
+                id: 13,
+                price: 30,
+                uuid: sampleUUID,
+            },
+        ],
+    });
+
+    const order = models["pos.order"].getBy("uuid", sampleUUID);
+    expect(order.id).toBe(13);
+    expect(order.price).toBe(30);
+    expect(order.isDirty()).toBe(false);
+});
+
+test("related record update", () => {
+    const models = getModels();
+
+    const order = models["pos.order"].create({ id: 12 });
+    expect(order.isDirty()).toBe(false);
+
+    function clearOrder() {
+        order.serialize({ orm: true, clear: true });
+        expect(order.isDirty()).toBe(false);
+    }
+
+    // Add new line to the order
+    const line = models["pos.order.line"].create({
+        quantity: 1,
+        order_id: order,
+    });
+    expect(line.isDirty()).toBe(true);
+    expect(order.isDirty()).toBe(true);
+    clearOrder();
+    expect(line.isDirty()).toBe(false);
+
+    // Assign a product to the line
+    const sampleProduct = models["pos.product"].create({ name: "demo_product", id: 111 });
+    line.product_id = sampleProduct;
+    expect(line.isDirty()).toBe(true);
+    expect(order.isDirty()).toBe(true);
+    clearOrder();
+    expect(line.isDirty()).toBe(false);
+
+    // Update line quantity
+    line.quantity = 10;
+    expect(line.isDirty()).toBe(true);
+    expect(order.isDirty()).toBe(true);
+    clearOrder();
+
+    order.lines[0].quantity = 1000;
+    expect(line.isDirty()).toBe(true);
+    expect(order.isDirty()).toBe(true);
+    clearOrder();
+
+    // Delete product from line
+    sampleProduct.delete();
+    expect(order.isDirty()).toBe(true);
+    clearOrder();
+
+    line.delete();
+    expect(order.isDirty()).toBe(true);
+    expect(order.lines.length).toBe(0);
+});

--- a/addons/pos_restaurant/static/src/app/utils/devices_synchronisation.js
+++ b/addons/pos_restaurant/static/src/app/utils/devices_synchronisation.js
@@ -44,7 +44,6 @@ patch(DevicesSynchronisation.prototype, {
 
                         const line = order.lines.pop();
                         line.update({ order_id: uniqOrder });
-                        line.setDirty();
                         watcher++;
                     }
                 }

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -140,7 +140,6 @@ export class CartPage extends Component {
 
         if (lastChange) {
             line.qty = lastChange.qty;
-            line.setDirty();
         } else {
             this.selfOrder.removeLine(line);
         }
@@ -159,11 +158,8 @@ export class CartPage extends Component {
         for (const cline of this.selfOrder.currentOrder.lines) {
             if (cline.combo_parent_id?.uuid === line.uuid) {
                 this._changeQuantity(cline, increase);
-                cline.setDirty();
             }
         }
-
-        line.setDirty();
     }
 
     async changeQuantity(line, increase) {

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -353,11 +353,8 @@ export class SelfOrder extends Reactive {
         );
 
         if (lineToMerge) {
-            lineToMerge.setDirty();
             lineToMerge.qty += newLine.qty;
             newLine.delete();
-        } else {
-            newLine.setDirty();
         }
     }
     async confirmationPage(screen_mode, device, access_token = "") {


### PR DESCRIPTION
To reduce the number of sync_from_ui requests, a new mechanism has been introduced to detect changes in records. This ensures that a backend sync is triggered only when an order has been modified.

