### PR TITLE
[FIX]: error when pasting images in knowledge article

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -66,6 +66,7 @@ export class HtmlField extends Component {
         this.codeViewRef = useRef("codeView");
         this.iframeRef = useRef("iframe");
         this.codeViewButtonRef = useRef("codeViewButton");
+        this.userService = useService('user');
 
         if (this.props.dynamicPlaceholder) {
             this.dynamicPlaceholder = useDynamicPlaceholder();
@@ -403,7 +404,12 @@ export class HtmlField extends Component {
                 if (urgent && status(this) !== 'destroyed') {
                     await this.updateValue();
                 }
-                await savePendingImagesPromise;
+                try {
+                    await savePendingImagesPromise;
+                } catch (error) {
+                    await this.userService.hasGroup('base.group_portal') ? null : (() => { throw error; })();
+                    // Portal users don't have rights to create attachments. Silently keep base64.
+                }
                 const codeViewEl = this._getCodeViewEl();
                 if (codeViewEl) {
                     codeViewEl.value = this.wysiwyg.getValue();


### PR DESCRIPTION
Stop access error for portal users when saving or editing Knowledge articles with pasted images

Steps to Reproduce:
1: Invite a portal user to edit Knowledge articles.
2: As a portal user, attempt to paste an image into the editor.
OR
An internal user pastes an image into the editor. When the portal user tries to access or edit the article, an error occurs due to insufficient rights.

opw-4246752



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
