### PR TITLE
[IMP]  account: Create force_create attribute in try loading

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -129,7 +129,7 @@ class AccountChartTemplate(models.AbstractModel):
     # Loading
     # --------------------------------------------------------------------------------
 
-    def try_loading(self, template_code, company, install_demo=False):
+    def try_loading(self, template_code, company, install_demo=False, force_create=True):
         """Check if the chart template can be loaded then proceeds installing it.
 
         :param template_code: code of the chart template to be loaded.
@@ -157,9 +157,9 @@ class AccountChartTemplate(models.AbstractModel):
         if template_code in {'syscohada', 'syscebnl'} and template_code != company.chart_template:
             raise UserError(_("The %s chart template shouldn't be selected directly. Instead, you should directly select the chart template related to your country.", template_code))
 
-        return self._load(template_code, company, install_demo)
+        return self._load(template_code, company, install_demo, force_create)
 
-    def _load(self, template_code, company, install_demo):
+    def _load(self, template_code, company, install_demo, force_create=True ):
         """Install this chart of accounts for the current company.
 
         :param template_code: code of the chart template to be loaded.
@@ -221,7 +221,7 @@ class AccountChartTemplate(models.AbstractModel):
             }
 
         if reload_template:
-            self._pre_reload_data(company, template_data, data)
+            self._pre_reload_data(company, template_data, data, force_create)
             install_demo = False
         data = self._pre_load_data(template_code, company, template_data, data)
         self._load_data(data)
@@ -242,7 +242,7 @@ class AccountChartTemplate(models.AbstractModel):
                 # Do not rollback installation of CoA if demo data failed
                 _logger.exception('Error while loading accounting demo data')
         for subsidiary in company.child_ids:
-            self._load(template_code, subsidiary, install_demo)
+            self._load(template_code, subsidiary, install_demo, force_create)
 
     @api.model
     def _install_demo(self, companies):
@@ -252,7 +252,7 @@ class AccountChartTemplate(models.AbstractModel):
             self.sudo()._load_data(self._get_demo_data(company))
             self._post_load_demo_data(company)
 
-    def _pre_reload_data(self, company, template_data, data):
+    def _pre_reload_data(self, company, template_data, data, force_create=True):
         """Pre-process the data in case of reloading the chart of accounts.
 
         When we reload the chart of accounts, we only want to update fields that are main
@@ -303,11 +303,19 @@ class AccountChartTemplate(models.AbstractModel):
         current_taxes = self.env['account.tax'].with_context(active_test=False).search([
             *self.env['account.tax']._check_company_domain(company),
         ])
+
+        current_fiscal_positions =  self.env['account.fiscal.position'].with_context(active_test=False).search([
+            *self.env['account.fiscal.position']._check_company_domain(company),
+        ])
         unique_tax_name_key = lambda t: (t.name, t.type_tax_use, t.tax_scope, t.company_id)
         unique_tax_name_keys = set(current_taxes.mapped(unique_tax_name_key))
         xmlid2tax = {
             xml_id.split('.')[1].split('_', maxsplit=1)[1]: self.env['account.tax'].browse(record)
             for record, xml_id in current_taxes.get_external_id().items() if xml_id.startswith('account.')
+        }
+        xmlid2fiscal_position= {
+            xml_id.split('.')[1].split('_', maxsplit=1)[1]: self.env['account.fiscal.position'].browse(record)
+            for record, xml_id in current_fiscal_positions.get_external_id().items() if xml_id.startswith('account.')
         }
         def tax_template_changed(tax, template):
             template_line_ids = [x for x in template.get('repartition_line_ids', []) if x[0] != Command.CLEAR]
@@ -324,6 +332,10 @@ class AccountChartTemplate(models.AbstractModel):
         for model_name, records in data.items():
             for xmlid, values in records.items():
                 if model_name == 'account.fiscal.position':
+                    # if xmlid is not in xmlid2fiscal_position and we do not force create so we will skip_update for that record
+                    if xmlid not in xmlid2fiscal_position and not force_create:
+                        skip_update.add((model_name, xmlid))
+                        continue
                     # Only add tax mappings containing new taxes
                     if old_tax_ids := values.pop('tax_ids', []):
                         new_tax_ids = []
@@ -340,6 +352,9 @@ class AccountChartTemplate(models.AbstractModel):
                 elif model_name == 'account.tax':
                     # Only update the tags of existing taxes
                     if xmlid not in xmlid2tax or tax_template_changed(xmlid2tax[xmlid], values):
+                        if not force_create:
+                            skip_update.add((model_name, xmlid))
+                            continue
                         if self._context.get('force_new_tax_active'):
                             values['active'] = True
                         if xmlid in xmlid2tax:
@@ -393,7 +408,7 @@ class AccountChartTemplate(models.AbstractModel):
                     # on existing accounts, only tag_ids are to be updated using default data
                     if account and 'tag_ids' in data[model_name][xmlid]:
                         data[model_name][xmlid] = {'tag_ids': data[model_name][xmlid]['tag_ids']}
-                    elif account:
+                    elif account or not force_create:
                         skip_update.add((model_name, xmlid))
 
         for skip_model, skip_xmlid in skip_update:

--- a/addons/account/tests/test_account_all_l10n.py
+++ b/addons/account/tests/test_account_all_l10n.py
@@ -18,9 +18,9 @@ def test_all_l10n(env):
 
     try_loading = type(env['account.chart.template']).try_loading
 
-    def try_loading_patch(self, template_code, company, install_demo=True):
+    def try_loading_patch(self, template_code, company, install_demo=True, force_create=True):
         self = self.with_context(l10n_check_fields_complete=True)
-        return try_loading(self, template_code, company, install_demo)
+        return try_loading(self, template_code, company, install_demo, force_create)
 
 
     # Ensure the presence of demo data, to see if they can be correctly installed

--- a/addons/l10n_ar/models/account_chart_template.py
+++ b/addons/l10n_ar/models/account_chart_template.py
@@ -18,7 +18,7 @@ class AccountChartTemplate(models.AbstractModel):
         }
         return match.get(chart_template)
 
-    def _load(self, template_code, company, install_demo):
+    def _load(self, template_code, company, install_demo,force_create=True):
         """ Set companies AFIP Responsibility and Country if AR CoA is installed, also set tax calculation rounding
         method required in order to properly validate match AFIP invoices.
 
@@ -36,7 +36,7 @@ class AccountChartTemplate(models.AbstractModel):
             # the default VAT type.
             company.partner_id.l10n_latam_identification_type_id = self.env.ref('l10n_ar.it_cuit')
 
-        res = super()._load(template_code, company, install_demo)
+        res = super()._load(template_code, company, install_demo,force_create)
 
         # If Responsable Monotributista remove the default purchase tax
         if template_code in ('ar_base', 'ar_ex'):
@@ -44,7 +44,7 @@ class AccountChartTemplate(models.AbstractModel):
 
         return res
 
-    def try_loading(self, template_code, company, install_demo=False):
+    def try_loading(self, template_code, company, install_demo=False, force_create=True):
         # During company creation load template code corresponding to the AFIP Responsibility
         if not company:
             return
@@ -57,4 +57,4 @@ class AccountChartTemplate(models.AbstractModel):
                 self.env.ref('l10n_ar.res_IVARI'): 'ar_ri',
             }
             template_code = match.get(company.l10n_ar_afip_responsibility_type_id, template_code)
-        return super().try_loading(template_code, company, install_demo)
+        return super().try_loading(template_code, company, install_demo, force_create)

--- a/addons/l10n_ec_stock/models/account_chart_template.py
+++ b/addons/l10n_ec_stock/models/account_chart_template.py
@@ -5,9 +5,9 @@ from odoo import models
 class AccountChartTemplate(models.AbstractModel):
     _inherit = 'account.chart.template'
 
-    def _load(self, template_code, company, install_demo):
+    def _load(self, template_code, company, install_demo, force_create=True):
         # EXTENDS account to set up default accounts on stock locations
-        res = super()._load(template_code, company, install_demo)
+        res = super()._load(template_code, company, install_demo, force_create)
         if template_code == 'ec':
             self._l10n_ec_setup_location_accounts(company)
         return res

--- a/addons/l10n_hu_edi/models/template_hu.py
+++ b/addons/l10n_hu_edi/models/template_hu.py
@@ -5,8 +5,8 @@ from odoo.addons.account.models.chart_template import template
 class AccountChartTemplate(models.AbstractModel):
     _inherit = 'account.chart.template'
 
-    def _load(self, template_code, company, install_demo):
-        res = super()._load(template_code, company, install_demo)
+    def _load(self, template_code, company, install_demo, force_create=True):
+        res = super()._load(template_code, company, install_demo, force_create)
         if template_code == 'hu':
             company._l10n_hu_edi_configure_company()
         return res

--- a/addons/l10n_nl/migrations/3.1/end-migrate_update_taxes.py
+++ b/addons/l10n_nl/migrations/3.1/end-migrate_update_taxes.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'nl')], order="parent_path"):
-        env['account.chart.template'].try_loading('nl', company)
+        env['account.chart.template'].try_loading('nl', company, force_create=False)

--- a/addons/l10n_nl/migrations/3.4/end-migrate.py
+++ b/addons/l10n_nl/migrations/3.4/end-migrate.py
@@ -4,4 +4,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'nl')], order="parent_path"):
-        env['account.chart.template'].try_loading('nl', company)
+        env['account.chart.template'].try_loading('nl', company, force_create=False)

--- a/addons/l10n_uy/models/template_uy.py
+++ b/addons/l10n_uy/models/template_uy.py
@@ -54,10 +54,10 @@ class AccountChartTemplate(models.AbstractModel):
             },
         }
 
-    def _load(self, template_code, company, install_demo):
+    def _load(self, template_code, company, install_demo, force_create=True):
         """ Set companies rut as the company identification type  after install the chart of account,
         this one is the uruguayan vat """
-        res = super()._load(template_code, company, install_demo)
+        res = super()._load(template_code, company, install_demo, force_create)
         if template_code == 'uy':
             company.partner_id.l10n_latam_identification_type_id = self.env.ref('l10n_uy.it_rut')
         return res


### PR DESCRIPTION
The goal is that we do not need to be more accurate on what we need to update when updating the CoA so I have added force_create to be false if wo do not want to create  new accounts, new taxes, new fiscal positions in the Netherlands

task-4556250

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
