### PR TITLE
[FIX] hr, hr_holidays, resource: fix flexible resource leave in planning gantt

### DIFF
--- a/addons/hr_calendar/models/res_partner.py
+++ b/addons/hr_calendar/models/res_partner.py
@@ -45,19 +45,19 @@ class Partner(models.Model):
             return {}
         interval_by_calendar = defaultdict()
         calendar_periods_by_employee = defaultdict(list)
-        employees_by_calendar = defaultdict(list)
+        resources_by_calendar = defaultdict(lambda: self.env['resource.resource'])
 
         # Compute employee's calendars's period and order employee by his involved calendars
         employees = sum(employees_by_partner.values(), start=self.env['hr.employee'])
         calendar_periods_by_employee = employees._get_calendar_periods(start_period, stop_period)
         for employee, calendar_periods in calendar_periods_by_employee.items():
             for (start, stop, calendar) in calendar_periods:
-                employees_by_calendar[calendar].append(employee)
+                resources_by_calendar[calendar] += employee.resource_id
 
         # Compute all work intervals per calendar
-        for calendar, employees in employees_by_calendar.items():
+        for calendar, resources in resources_by_calendar.items():
             calendar = calendar or self.env.company.resource_calendar_id # No calendar if fully flexible
-            work_intervals = calendar._work_intervals_batch(start_period, stop_period, resources=employees, tz=timezone(calendar.tz))
+            work_intervals = calendar._work_intervals_batch(start_period, stop_period, resources=resources, tz=timezone(calendar.tz))
             del work_intervals[False]
             # Merge all employees intervals to avoid to compute it multiples times
             if merge:
@@ -75,7 +75,7 @@ class Partner(models.Model):
                 if merge:
                     calendar_interval = interval_by_calendar[calendar]
                 else:
-                    calendar_interval = interval_by_calendar[calendar][employee.id]
+                    calendar_interval = interval_by_calendar[calendar][employee.resource_id.id]
                 employee_interval = employee_interval | (calendar_interval & interval)
             schedule_by_employee[employee] = employee_interval
 

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -346,4 +346,6 @@ class HrEmployee(models.Model):
         return (allocations_leaves_consumed, to_recheck_leaves_per_leave_type)
 
     def _get_hours_per_day(self, date_from):
-        return self._get_calendars(date_from)[self.id].hours_per_day
+        ''' Return 24H to handle the case of Fully Flexible (ones without a working calendar)'''
+        calendars = self._get_calendars(date_from)
+        return calendars[self.id].hours_per_day if calendars[self.id] else 24

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -560,9 +560,7 @@ class HolidaysType(models.Model):
                         datetime.combine(closest_expiration_date, time.max).replace(tzinfo=pytz.UTC),
                         resources=employee.resource_id
                     )
-                    closest_allocation_dict =\
-                        self.env['resource.calendar']._get_attendance_intervals_days_data(
-                            calendar_attendance[employee.resource_id.id])
+                    closest_allocation_dict = calendar._get_attendance_intervals_days_data(calendar_attendance[employee.resource_id.id])
                     if leave_type.request_unit in ['hour']:
                         closest_allocation_duration = closest_allocation_dict['hours']
                     else:

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -4,7 +4,7 @@
 import itertools
 
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, time
 from functools import partial
 from itertools import chain
 
@@ -367,13 +367,24 @@ class ResourceCalendar(models.Model):
             res = result_per_tz[tz]
             res_intervals = WorkIntervals(res)
             for resource in resources:
-                if resource in per_resource_result:
+                if resource and resource._is_flexible():
+                # If the resource is flexible, return the whole period from start_dt to end_dt with a dummy attendance
+                    dummy_attendance = self.env['resource.calendar.attendance']
+                    result_per_resource_id[resource.id] = WorkIntervals([(start, end, dummy_attendance)])
+                elif resource in per_resource_result:
                     resource_specific_result = [(max(bounds_per_tz[tz][0], tz.localize(val[0])), min(bounds_per_tz[tz][1], tz.localize(val[1])), val[2])
                         for val in per_resource_result[resource]]
                     result_per_resource_id[resource.id] = WorkIntervals(itertools.chain(res, resource_specific_result))
                 else:
                     result_per_resource_id[resource.id] = res_intervals
         return result_per_resource_id
+
+    def _handle_flexible_leave_interval(self, dt0, dt1, leave):
+        """Hook method to handle flexible leave intervals. Can be overridden in other modules."""
+        tz = dt0.tzinfo  # Get the timezone information from dt0
+        dt0 = datetime.combine(dt0.date(), time.min).replace(tzinfo=tz)
+        dt1 = datetime.combine(dt1.date(), time.max).replace(tzinfo=tz)
+        return dt0, dt1
 
     def _leave_intervals(self, start_dt, end_dt, resource=None, domain=None, tz=None):
         if resource is None:
@@ -431,6 +442,8 @@ class ResourceCalendar(models.Model):
                     tz_dates[(tz, end_dt)] = end
                 dt0 = string_to_datetime(leave_date_from).astimezone(tz)
                 dt1 = string_to_datetime(leave_date_to).astimezone(tz)
+                if leave_resource and leave_resource._is_flexible():
+                    dt0, dt1 = self._handle_flexible_leave_interval(dt0, dt1, leave)
                 result[resource.id].append((max(start, dt0), min(end, dt1), leave))
 
         return {r.id: Intervals(result[r.id]) for r in resources_list}
@@ -472,7 +485,7 @@ class ResourceCalendar(models.Model):
         resources_work_intervals = self._work_intervals_batch(start_dt, end_dt, resources, domain, tz)
         result = {}
         for resource in resources_list:
-            if resource and resource._is_flexible():
+            if resource and resource._is_fully_flexible():
                 continue
             work_intervals = [(start, stop) for start, stop, meta in resources_work_intervals[resource.id]]
             # start + flatten(intervals) + end
@@ -505,7 +518,10 @@ class ResourceCalendar(models.Model):
             # take durations in days proportionally to what is left of the interval.
             interval_hours = (stop - start).total_seconds() / 3600
             day_hours[start.date()] += interval_hours
-            day_days[start.date()] += sum(meta.mapped('duration_days')) * interval_hours / sum(meta.mapped('duration_hours'))
+            if len(self) == 1 and self.flexible_hours and self.hours_per_day:
+                day_days[start.date()] += interval_hours / self.hours_per_day
+            else:
+                day_days[start.date()] += sum(meta.mapped('duration_days')) * interval_hours / sum(meta.mapped('duration_hours'))
 
         return {
             # Round the number of days to the closest 16th of a day.

--- a/addons/resource/models/resource_mixin.py
+++ b/addons/resource/models/resource_mixin.py
@@ -79,7 +79,7 @@ class ResourceMixin(models.AbstractModel):
         return vals_list
 
     def _get_calendars(self, date_from=None):
-        return {resource.id: resource.resource_calendar_id or resource.company_id.resource_calendar_id for resource in self}
+        return { resource.id: resource.resource_calendar_id or False for resource in self }
 
     def _get_work_days_data_batch(self, from_datetime, to_datetime, compute_leaves=True, calendar=None, domain=None):
         """
@@ -150,6 +150,15 @@ class ResourceMixin(models.AbstractModel):
             mapped_resources[calendar or record.resource_calendar_id] |= record.resource_id
 
         for calendar, calendar_resources in mapped_resources.items():
+            # handle fully flexible resources by returning the length of the whole interval
+            # since we do not take into account leaves for fully flexible resources
+            if not calendar:
+                days = (to_datetime - from_datetime).days
+                hours = (to_datetime - from_datetime).total_seconds() / 3600
+                for calendar_resource in calendar_resources:
+                    result[calendar_resource.id] = {'days': days, 'hours': hours}
+                continue
+
             # compute actual hours per day
             attendances = calendar._attendance_intervals_batch(from_datetime, to_datetime, calendar_resources)
             leaves = calendar._leave_intervals_batch(from_datetime, to_datetime, calendar_resources, domain)

--- a/addons/test_resource/tests/test_performance.py
+++ b/addons/test_resource/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestResourcePerformance(TransactionCase):
             start = pytz.utc.localize(datetime.now() + relativedelta(month=1, day=1))
             stop = pytz.utc.localize(datetime.now() + relativedelta(month=12, day=31))
             start_time = time.time()
-            calendar._attendance_intervals_batch(start, stop, resources=resources)
+            calendar._attendance_intervals_batch(start, stop, resources=resources.resource_id)
             _logger.info('Attendance Intervals Batch (100): --- %s seconds ---', time.time() - start_time)
             # Before
             #INFO master test_performance: Attendance Intervals Batch (100): --- 2.0667169094085693 seconds ---

--- a/addons/test_resource/tests/test_resource.py
+++ b/addons/test_resource/tests/test_resource.py
@@ -1322,6 +1322,39 @@ class TestTimezones(TestResourceCommon):
             (datetime(2022, 9, 21, 15, 0, tzinfo=utc), datetime(2022, 9, 22, 0, 0, tzinfo=utc)),
         ])
 
+    def test_flexible_resource_leave_interval(self):
+        """
+        Test whole day off for a flexible resource.
+        The standard 8 - 17 leave should be converted to a whole day leave interval for the flexible resource.
+        """
+
+        flexible_calendar = self.env['resource.calendar'].create({
+            'name': 'Flex Calendar',
+            'tz': 'UTC',
+            'flexible_hours': True,
+        })
+        flex_resource = self.env['resource.resource'].create({
+            'name': 'Test FlexResource',
+            'calendar_id': flexible_calendar.id,
+        })
+        self.env['resource.calendar.leaves'].create({
+            'name': 'Standard Time Off',
+            'calendar_id': flexible_calendar.id,
+            'resource_id': flex_resource.id,
+            'date_from': '2025-03-07 08:00:00',
+            'date_to': '2025-03-07 17:00:00',
+        })
+
+        start_dt = datetime(2025, 3, 7, 0, 0, 0, tzinfo=utc)
+        end_dt = datetime(2025, 3, 7, 23, 59, 59, 999999, tzinfo=utc)
+
+        intervals = flexible_calendar._leave_intervals_batch(start_dt, end_dt, [flex_resource])
+        intervals_list = list(intervals[flex_resource.id])
+        self.assertEqual(len(intervals_list), 1, "There should be one leave interval")
+        interval = intervals_list[0]
+        self.assertEqual(interval[0], start_dt, "The start of the interval should be 00:00:00")
+        self.assertEqual(interval[1], end_dt, "The end of the interval should be 23:59:59.999999")
+
 class TestResource(TestResourceCommon):
 
     def test_calendars_validity_within_period(self):


### PR DESCRIPTION
Prior to this commit, flexible resources did not have their leaves reflected as gray cells in the planning gantt view. This was due to the work_intervals being ignored for the calculation of flexible resources availability.

This commit adds measures to handle the leaves for flexible resources by setting a dummy attendance (which covers the whole length of the period in gantt interval), and then injects their leaves interval.

To replicate:
1. set a timeoff to a flexible resource
2. open planning app
3. in the gantt view, the day in which the timeoff was set should be grayed.

ticket-id: 4492625
enterprise: [79532](https://github.com/odoo/enterprise/pull/79532)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
