### PR TITLE
[FIX] base: Missing Python package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ ofxparse==0.21
 openpyxl==3.0.9 ; python_version < '3.12'
 openpyxl==3.1.2 ; python_version >= '3.12'
 passlib==1.7.4 # min version = 1.7.2 (Focal with security backports)
+phonenumbers==8.13.55 ; python_version >= '3.12'
 Pillow==9.0.1 ; python_version <= '3.10'
 Pillow==9.4.0 ; python_version > '3.10' and python_version < '3.12'
 Pillow==10.2.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Fixing issue [#197857: [18.0] account: missing the dependency phonenumbers](https://github.com/odoo/odoo/issues/197857)

Current behavior before PR:
The user cannot install the app _Invoicing_ on a fresh and clean Odoo Community 18 database because the module _account_peppol_ requires the Python package _phonenumbers_. It potentially affects other modules and Odoo versions as well.

Desired behavior after PR is merged:
The user can install the app _Invoicing_ because the Python package __phonenumbers__ is defined in the requirements.

**Please edit the package (and Python) version(s) if necessary and, if required, apply the fix to Odoo versions 16 and 17 in addition to 18.**



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
