### PR TITLE
[FIX] pos_self_order: fix stripe kiosk payment

### DIFF
--- a/addons/pos_self_order/models/pos_payment_method.py
+++ b/addons/pos_self_order/models/pos_payment_method.py
@@ -11,6 +11,6 @@ class PosPaymentMethod(models.Model):
     @api.model
     def _load_pos_self_data_domain(self, data):
         if data['pos.config']['data'][0]['self_ordering_mode'] == 'kiosk':
-            return [('use_payment_terminal', 'in', ['adyen', 'stripe'])]
+            return [('use_payment_terminal', 'in', ['adyen', 'stripe']), ('id', 'in', data['pos.config']['data'][0]['payment_method_ids'])]
         else:
             [('id', '=', False)]

--- a/addons/pos_self_order_stripe/tests/__init__.py
+++ b/addons/pos_self_order_stripe/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_self_order_kiosk_stripe

--- a/addons/pos_self_order_stripe/tests/test_self_order_kiosk_stripe.py
+++ b/addons/pos_self_order_stripe/tests/test_self_order_kiosk_stripe.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
+from odoo.tests import Command
+
+@odoo.tests.tagged("post_install", "-at_install")
+class TestSelfOrderKioskStripe(SelfOrderCommonTest):
+    def test_self_order_kiosk_stripe(self):
+        self.pos_config.write({
+            'takeaway': True,
+            'self_ordering_takeaway': True,
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'table',
+        })
+        stripe = self.env['pos.payment.method'].create({
+            'name': 'Stripe',
+            'use_payment_terminal': 'stripe',
+        })
+
+        self.env['pos.payment.method'].create({
+            'name': 'Stripe 2',
+            'use_payment_terminal': 'stripe',
+        })
+
+        self.pos_config.write({
+            'payment_method_ids': [Command.set([stripe.id])]
+        })
+
+        res = self.pos_config.load_self_data()
+        self.assertEqual(len(res['pos.payment.method']['data']), 1, 'Only one payment method should be loaded')
+        self.assertEqual(res['pos.payment.method']['data'][0]['name'], 'Stripe', 'The loaded payment method should be Stripe')


### PR DESCRIPTION
When you have multiple payment methods that can work on the kiosk, they would all be shown on the kiosk screen.

Steps to reproduce:
-------------------
* Setup 2 Stripe payment methods
* Create a PoS kiosk
* Assign one of the methods to the kiosk
* Open the kiosk
* Create an order and go to the payment screen
> Observation: Both payment methods are shown

Why the fix:
------------
The payment methods are now filtered based on the payment methods assigned to the kiosk.

opw-4574644