### PR TITLE
[FIX] core: use proper HTTP status code

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -539,25 +539,17 @@ class IrHttp(models.AbstractModel):
             exception=exception,
             traceback=''.join(traceback.format_exception(exception)),
         )
-        if isinstance(exception, exceptions.AccessDenied):
-            code = 403
-        elif isinstance(exception, exceptions.UserError):
-            values['error_message'] = exception.args[0]
-            code = 400
-            if isinstance(exception, exceptions.AccessError):
-                code = 403
 
-        elif isinstance(exception, QWebException):
+        if isinstance(exception, QWebException):
             values.update(qweb_exception=exception)
+            exception = exception.__cause__ or exception.__context__
 
-            if isinstance(exception.__context__, exceptions.UserError):
-                code = 400
-                values['error_message'] = exception.__context__.args[0]
-                if isinstance(exception.__context__, exceptions.AccessError):
-                    code = 403
-
+        elif isinstance(exception, exceptions.UserError):
+            code = exception.http_status
+            values['error_message'] = exception.args[0]
         elif isinstance(exception, werkzeug.exceptions.HTTPException):
             code = exception.code
+            values['error_message'] = exception.description
 
         values.update(
             status_message=werkzeug.http.HTTP_STATUS_CODES.get(code, ''),
@@ -573,7 +565,12 @@ class IrHttp(models.AbstractModel):
 
     @classmethod
     def _get_error_html(cls, env, code, values):
-        return code, env['ir.ui.view']._render_template('http_routing.%s' % code, values)
+        try:
+            return code, env['ir.ui.view']._render_template('http_routing.%s' % code, values)
+        except ValueError:
+            if str(code)[0] == '4':
+                return code, env['ir.ui.view']._render_template('http_routing.4xx', values)
+            raise
 
     @classmethod
     def _handle_error(cls, exception):
@@ -608,6 +605,7 @@ class IrHttp(models.AbstractModel):
         try:
             code, html = cls._get_error_html(request.env, code, values)
         except Exception:
+            _logger.exception("Couldn't render a template for http status %s", code)
             code, html = 418, request.env['ir.ui.view']._render_template('http_routing.http_error', values)
 
         response = Response(html, status=code, content_type='text/html;charset=utf-8')

--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -537,7 +537,7 @@ class IrHttp(models.AbstractModel):
         code = 500  # default code
         values = dict(
             exception=exception,
-            traceback=traceback.format_exc(),
+            traceback=''.join(traceback.format_exception(exception)),
         )
         if isinstance(exception, exceptions.AccessDenied):
             code = 403

--- a/addons/http_routing/views/http_routing_template.xml
+++ b/addons/http_routing/views/http_routing_template.xml
@@ -62,12 +62,31 @@
         </div>
     </template>
 
-    <template id="400">
+    <template id="4xx">
         <t t-call="web.frontend_layout">
             <div id="wrap">
                 <div class="container">
                     <h1 class="mt-5">Oops! Something went wrong.</h1>
                     <p>Take a look at the error message below.</p>
+                </div>
+                <t t-if="editable or debug">
+                    <t t-call="http_routing.http_error_debug"/>
+                </t>
+                <t t-else="">
+                    <div class="container">
+                        <t t-call="http_routing.error_message"/>
+                    </div>
+                </t>
+        </div>
+        </t>
+    </template>
+
+    <template id="400">
+        <t t-call="web.frontend_layout">
+            <div id="wrap">
+                <div class="container">
+                    <h1 class="mt-5">400: Bad Request</h1>
+                    <p>The server couldn't understand the request. Take a look at the error message below.</p>
                 </div>
                 <t t-if="editable or debug">
                     <t t-call="http_routing.http_error_debug"/>
@@ -133,6 +152,44 @@
                     </section>
                 </div>
             </div>
+        </t>
+    </template>
+
+    <template id="415">
+        <t t-call="web.frontend_layout">
+            <div id="wrap">
+                <div class="container">
+                    <h1 class="mt-5">415: Unsupported Media Type</h1>
+                    <p>It looks like the URL you are accessing doesn't support the format of the request. Take a look at the error message below.</p>
+                </div>
+                <t t-if="editable or debug">
+                    <t t-call="http_routing.http_error_debug"/>
+                </t>
+                <t t-else="">
+                    <div class="container">
+                        <t t-call="http_routing.error_message"/>
+                    </div>
+                </t>
+        </div>
+        </t>
+    </template>
+
+    <template id="422">
+        <t t-call="web.frontend_layout">
+            <div id="wrap">
+                <div class="container">
+                    <h1 class="mt-5">Oops! Something went wrong.</h1>
+                    <p>Take a look at the error message below.</p>
+                </div>
+                <t t-if="editable or debug">
+                    <t t-call="http_routing.http_error_debug"/>
+                </t>
+                <t t-else="">
+                    <div class="container">
+                        <t t-call="http_routing.error_message"/>
+                    </div>
+                </t>
+        </div>
         </t>
     </template>
 

--- a/addons/mass_mailing/tests/test_mailing_controllers.py
+++ b/addons/mass_mailing/tests/test_mailing_controllers.py
@@ -135,8 +135,8 @@ class TestMailingControllers(TestMailingControllersCommon):
         # TEST: various invalid cases
         for test_user_id, test_token, error_code in [
             (self.user_marketing.id, '', 400),  # no token
-            (self.user_marketing.id, 'zboobs', 418),  # invalid token
-            (self.env.uid, hash_token, 418),  # invalid credentials
+            (self.user_marketing.id, 'zboobs', 401),  # invalid token
+            (self.env.uid, hash_token, 401),  # invalid credentials
         ]:
             with self.subTest(test_user_id=test_user_id, test_token=test_token):
                 res = self.url_open(
@@ -158,7 +158,7 @@ class TestMailingControllers(TestMailingControllersCommon):
                 f'mailing/report/unsubscribe?user_id={self.user_marketing.id}&token={hash_token}',
             )
         )
-        self.assertEqual(res.status_code, 418)
+        self.assertEqual(res.status_code, 401)
         self.assertTrue(self.env['ir.config_parameter'].sudo().get_param('mass_mailing.mass_mailing_reports'))
 
         # TEST: finally valid call
@@ -592,10 +592,10 @@ class TestMailingControllers(TestMailingControllersCommon):
         # TEST: various invalid cases
         for test_mid, test_doc_id, test_email, test_token, error_code in [
             (test_mailing.id, doc_id, email_normalized, '', 400),  # no token
-            (test_mailing.id, doc_id, email_normalized, 'zboobs', 418),  # wrong token
-            (test_mailing.id, self.env.user.partner_id.id, email_normalized, hash_token, 418),  # mismatch
-            (test_mailing.id, doc_id, 'not.email@example.com', hash_token, 418),  # mismatch
-            (shadow_mailing.id, doc_id, email_normalized, hash_token, 418),  # valid credentials but wrong mailing_id
+            (test_mailing.id, doc_id, email_normalized, 'zboobs', 401),  # wrong token
+            (test_mailing.id, self.env.user.partner_id.id, email_normalized, hash_token, 401),  # mismatch
+            (test_mailing.id, doc_id, 'not.email@example.com', hash_token, 401),  # mismatch
+            (shadow_mailing.id, doc_id, email_normalized, hash_token, 401),  # valid credentials but wrong mailing_id
             (0, doc_id, email_normalized, hash_token, 400),  # valid credentials but missing mailing_id
         ]:
             with self.subTest(test_mid=test_mid, test_email=test_email, test_doc_id=test_doc_id, test_token=test_token):

--- a/addons/test_website/data/test_website_data.xml
+++ b/addons/test_website/data/test_website_data.xml
@@ -77,9 +77,9 @@
                         <div class="row">
                             <ul class="list-group http_error col-6">
                                 <li class="list-group-item list-group-item-primary"><h2>http Errors</h2></li>
-                                <li class="list-group-item"><a href="/test_user_error_http">http UserError (400)</a></li>
-                                <li class="list-group-item"><a href="/test_validation_error_http">http ValidationError (400)</a></li>
-                                <li class="list-group-item"><a href="/test_missing_error_http">http MissingError (400)</a></li>
+                                <li class="list-group-item"><a href="/test_user_error_http">http UserError (422)</a></li>
+                                <li class="list-group-item"><a href="/test_validation_error_http">http ValidationError (422)</a></li>
+                                <li class="list-group-item"><a href="/test_missing_error_http">http MissingError (404)</a></li>
                                 <li class="list-group-item"><a href="/test_access_error_http">http AccessError (403)</a></li>
                                 <li class="list-group-item"><a href="/test_access_denied_http">http AccessDenied (403)</a></li>
                                 <li class="list-group-item"><a href="/test_internal_error_http">http InternalServerError (500)</a></li>

--- a/addons/test_website/static/tests/tours/error_views.js
+++ b/addons/test_website/static/tests/tours/error_views.js
@@ -155,26 +155,15 @@ registry.category("web_tour.tours").add('test_error_website', {
         },
     },
     {
-        trigger: 'h1:contains("Something went wrong.")',
-    },
-    {
-        content: "http missing error page has title and message",
-        trigger: 'div.container pre:contains("This is a missing http test")',
+        trigger: 'h1:contains("Error 404")',
         run: function () {
                 window.location.href = window.location.origin + '/test_missing_error_http?debug=1';
         },
     },
     {
-        trigger: 'h1:contains("Something went wrong.")',
-    },
-    {
-        content: "http missing error page debug has title and message open",
-        trigger: 'div#error_main.collapse.show pre:contains("This is a missing http test")',
-    }, {
-        content: "http missing error page debug has traceback closed",
-        trigger: 'body:has(div#error_traceback.collapse:not(.show) pre#exception_traceback)',
+        trigger: 'h1:contains("Error 404")',
         run: function () {
-            window.location.href = window.location.origin + '/test_access_denied_http?debug=0';
+            window.location.href = window.location.origin + '/test_access_denied_http?debug=1';
         },
     },
     {

--- a/addons/test_website/static/tests/tours/error_views.js
+++ b/addons/test_website/static/tests/tours/error_views.js
@@ -182,7 +182,8 @@ registry.category("web_tour.tours").add('test_error_website', {
     },
     {
         content: "http error 403 page has title but no message",
-        trigger: 'div#wrap:not(:has(pre:contains("This is an access denied http test"))', //See ir_http.py handle_exception, the exception is replaced so there is no message !
+        // See http.py _transactionning, the exception is replaced so there is no message !
+        trigger: 'div#wrap:not(:has(pre:contains("Traceback"))',
         run: function () {
             window.location.href = window.location.origin + '/test_access_denied_http?debug=1';
         },
@@ -192,9 +193,6 @@ registry.category("web_tour.tours").add('test_error_website', {
     },
     {
         content: "http 403 error page debug has title but no message",
-        trigger: 'div#debug_infos:not(:has(#error_main))',
-    }, {
-        content: "http 403 error page debug has traceback open",
-        trigger: 'body:has(div#error_traceback.collapse.show pre#exception_traceback)',
+        trigger: 'div#wrap:not(:has(pre:contains("Traceback"))',
     },
 ]});

--- a/odoo/addons/test_http/controllers.py
+++ b/odoo/addons/test_http/controllers.py
@@ -134,7 +134,7 @@ class TestHttp(http.Controller):
     @http.route('/test_http/<model("test_http.galaxy"):galaxy>/<model("test_http.stargate"):gate>', auth='user', readonly=True)
     def stargate(self, galaxy, gate):
         if not gate.exists():
-            raise UserError("The goa'uld destroyed the gate")
+            raise UserError("The goauld destroyed the gate")
 
         return http.request.render('test_http.tmpl_stargate', {
             'gate': gate

--- a/odoo/addons/test_http/tests/test_captcha.py
+++ b/odoo/addons/test_http/tests/test_captcha.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from http import HTTPStatus
 from unittest.mock import patch
 
 from odoo import http
@@ -30,7 +31,8 @@ class TestCaptcha(HttpCase):
     def test_post_invalid(self):
         with self.patch_captcha_valid(False):
             res = self.url_open('/web/login', data={'csrf_token': http.Request.csrf_token(self), 'login': '_', 'password': '_'})
-            self.assertEqual(res.status_code, 400)
+            self.assertEqual(res.status_code, HTTPStatus.UNPROCESSABLE_ENTITY)
+            self.assertIn("CAPTCHA test", res.text)
 
     def test_get_valid(self):
         res = self.url_open('/web/login')

--- a/odoo/addons/test_http/tests/test_echo_reply.py
+++ b/odoo/addons/test_http/tests/test_echo_reply.py
@@ -1,10 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
+from http import HTTPStatus
 
 from odoo.http import Request
-from odoo.tests import tagged
-from odoo.tests.common import new_test_user
+from odoo.tests import Like, new_test_user, tagged
 from odoo.tools import mute_logger
 from odoo.addons.test_http.controllers import CT_JSON
 
@@ -74,7 +74,12 @@ class TestHttpEchoReplyJsonNoDB(TestHttpBase):
     @mute_logger('odoo.http')
     def test_echojson2_http_post_nodb(self):
         res = self.nodb_url_open('/test_http/echo-json', data={'race': 'Asgard'})  # POST
-        self.assertIn("Bad Request", res.text)
+        self.assertEqual(res.text, Like("""
+            ...Request inferred type is compatible with...http...but...
+            /test_http/echo-json...is type=...json...
+        """))
+        self.assertEqual(res.status_code, HTTPStatus.UNSUPPORTED_MEDIA_TYPE)
+        self.assertEqual(res.headers.get('Accept'), "application/json, application/json-rpc")
 
     def test_echojson3_bad_json(self):
         payload = 'some non json garbage'
@@ -174,7 +179,12 @@ class TestHttpEchoReplyJsonWithDB(TestHttpBase):
     @mute_logger('odoo.http')
     def test_echojson2_http_post_db(self):
         res = self.db_url_open('/test_http/echo-json', data={'race': 'Asgard'})  # POST
-        self.assertIn("Bad Request", res.text)
+        self.assertEqual(res.text, Like("""
+            ...Request inferred type is compatible with...http...but...
+            /test_http/echo-json...is type=...json...
+        """))
+        self.assertEqual(res.status_code, HTTPStatus.UNSUPPORTED_MEDIA_TYPE)
+        self.assertEqual(res.headers.get('Accept'), "application/json, application/json-rpc")
 
     def test_echojson3_context_db(self):
         payload = json.dumps({

--- a/odoo/addons/test_http/tests/test_error.py
+++ b/odoo/addons/test_http/tests/test_error.py
@@ -16,7 +16,7 @@ class TestHttpErrorHttp(TestHttpBase):
 
         with self.subTest('Decorator/UserError'):
             res = self.nodb_url_open('/test_http/hide_errors/decorator?error=UserError')
-            self.assertEqual(res.status_code, 400, "UserError are not configured to be hidden, they should be kept as-is.")
+            self.assertEqual(res.status_code, 422, "UserError are not configured to be hidden, they should be kept as-is.")
             self.assertIn("Walter is AFK", res.text, "The real UserError message should be kept")
 
         with self.subTest('Context-Manager/AccessError'):
@@ -26,7 +26,7 @@ class TestHttpErrorHttp(TestHttpBase):
 
         with self.subTest('Context-Manager/UserError'):
             res = self.nodb_url_open('/test_http/hide_errors/context-manager?error=UserError')
-            self.assertEqual(res.status_code, 400, "UserError are not configured to be hidden, they should be kept as-is.")
+            self.assertEqual(res.status_code, 422, "UserError are not configured to be hidden, they should be kept as-is.")
             self.assertIn("Walter is AFK", res.text, "The real UserError message should be kept")
 
 

--- a/odoo/addons/test_http/tests/test_models.py
+++ b/odoo/addons/test_http/tests/test_models.py
@@ -44,7 +44,7 @@ class TestHttpModels(TestHttpBase):
     @mute_logger('odoo.http')
     def test_models1_galaxy_ko(self):
         res = self.url_open("/test_http/404")  # unknown galaxy
-        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.status_code, HTTPStatus.UNPROCESSABLE_ENTITY)
         self.assertIn('The Ancients did not settle there.', res.text)
 
     def test_models2_stargate_ok(self):
@@ -69,9 +69,9 @@ class TestHttpModels(TestHttpBase):
         milky_way = self.env.ref('test_http.milky_way')
         with self.assertLogs("odoo.http", level="WARNING") as logs:
             res = self.url_open(f'/test_http/{milky_way.id}/9999')  # unknown gate
-        self.assertEqual(res.status_code, 400)
-        self.assertIn(markupsafe.escape("The goa'uld destroyed the gate"), res.text)
-        self.assertEqual(logs.output, ["WARNING:odoo.http:The goa'uld destroyed the gate"])
+        self.assertEqual(res.status_code, HTTPStatus.UNPROCESSABLE_ENTITY)
+        self.assertIn(markupsafe.escape("The goauld destroyed the gate"), res.text)
+        self.assertEqual(logs.output, ["WARNING:odoo.http:The goauld destroyed the gate"])
 
     def test_models4_stargate_setname(self):
         milky_way = self.env.ref('test_http.milky_way')

--- a/odoo/exceptions.py
+++ b/odoo/exceptions.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 """The Odoo Exceptions module defines a few core exception types.
 
 Those types are understood by the RPC layer.
@@ -16,8 +14,9 @@ class UserError(Exception):
     """Generic error managed by the client.
 
     Typically when the user tries to do something that has no sense given the current
-    state of a record. Semantically comparable to the generic 400 HTTP status codes.
+    state of a record.
     """
+    http_status = 422  # Unprocessable Entity
 
     def __init__(self, message):
         """
@@ -52,6 +51,7 @@ class AccessDenied(UserError):
 
         When you try to log with a wrong password.
     """
+    http_status = 403  # Forbidden
 
     def __init__(self, message="Access Denied"):
         super().__init__(message)
@@ -85,6 +85,7 @@ class AccessError(UserError):
 
         When you try to read a record that you are not allowed to.
     """
+    http_status = 403  # Forbidden
 
 
 class CacheMiss(KeyError):
@@ -106,6 +107,7 @@ class MissingError(UserError):
 
         When you try to write on a deleted record.
     """
+    http_status = 404  # Not Found
 
 
 class LockError(UserError):
@@ -115,6 +117,7 @@ class LockError(UserError):
 
         Code tried to lock records, but could not succeed.
     """
+    http_status = 409  # Conflict
 
 
 class ValidationError(UserError):

--- a/odoo/exceptions.py
+++ b/odoo/exceptions.py
@@ -46,7 +46,7 @@ class AccessDenied(UserError):
 
     .. note::
 
-        No traceback.
+        Traceback only visible in the logs.
 
     .. admonition:: Example
 
@@ -55,10 +55,28 @@ class AccessDenied(UserError):
 
     def __init__(self, message="Access Denied"):
         super().__init__(message)
+        self.suppress_traceback()  # must be called in `except`s too
+
+    def suppress_traceback(self):
+        """
+        Remove the traceback, cause and context of the exception, hiding
+        where the exception occured but keeping the exception message.
+
+        This method must be called in all situations where we are about
+        to print this exception to the users.
+
+        It is OK to leave the traceback (thus to *not* call this method)
+        if the exception is only logged in the logs, as they are only
+        accessible by the system administrators.
+        """
         self.with_traceback(None)
-        self.__cause__ = None
         self.traceback = ('', '', '')
 
+        # During handling of the above exception, another exception occurred
+        self.__context__ = None
+
+        # The above exception was the direct cause of the following exception
+        self.__cause__ = None
 
 class AccessError(UserError):
     """Access rights error.

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -2025,6 +2025,8 @@ class Request:
                     ):
                         raise  # bubble up to werkzeug.debug.DebuggedApplication
                     if not hasattr(exc, 'error_response'):
+                        if isinstance(exc, AccessDenied):
+                            exc.suppress_traceback()
                         exc.error_response = self.registry['ir.http']._handle_error(exc)
                     raise
 
@@ -2472,6 +2474,8 @@ class Application:
 
                 # Ensure there is always a WSGI handler attached to the exception.
                 if not hasattr(exc, 'error_response'):
+                    if isinstance(exc, AccessDenied):
+                        exc.suppress_traceback()
                     exc.error_response = request.dispatcher.handle_error(exc)
 
                 return exc.error_response(environ, start_response)

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -182,8 +182,11 @@ import werkzeug.security
 import werkzeug.wrappers
 import werkzeug.wsgi
 from werkzeug.urls import URL, url_parse, url_encode, url_quote
-from werkzeug.exceptions import (HTTPException, BadRequest, Forbidden,
-                                 NotFound, InternalServerError)
+from werkzeug.exceptions import (
+    default_exceptions as werkzeug_default_exceptions,
+    HTTPException, NotFound, UnsupportedMediaType, UnprocessableEntity,
+    InternalServerError
+)
 try:
     from werkzeug.middleware.proxy_fix import ProxyFix as ProxyFix_
     ProxyFix = functools.partial(ProxyFix_, x_for=1, x_proto=1, x_host=1)
@@ -247,9 +250,6 @@ DEFAULT_MAX_CONTENT_LENGTH = 128 * 1024 * 1024  # 128MiB
 if geoip2:
     GEOIP_EMPTY_COUNTRY = geoip2.models.Country({})
     GEOIP_EMPTY_CITY = geoip2.models.City({})
-
-# The request mimetypes that transport JSON in their body.
-JSON_MIMETYPES = ('application/json', 'application/json-rpc')
 
 MISSING_CSRF_WARNING = """\
 No CSRF validation token provided for path %r
@@ -1872,7 +1872,13 @@ class Request:
                 for disp in _dispatchers.values()
                 if disp.is_compatible_with(self)
             ]
-            raise BadRequest(f"Request inferred type is compatible with {compatible_dispatchers} but {routing['routes'][0]!r} is type={routing['type']!r}.")
+            e = (f"Request inferred type is compatible with {compatible_dispatchers} "
+                 f"but {routing['routes'][0]!r} is type={routing['type']!r}.")
+            # werkzeug doesn't let us add headers to UnsupportedMediaType
+            # so use the following (ugly) to still achieve what we want
+            res = UnsupportedMediaType(e).get_response()
+            res.headers['Accept'] = ', '.join(dispatcher_cls.mimetypes)
+            raise UnsupportedMediaType(response=res)
         self.dispatcher = dispatcher_cls(self)
 
     # =====================================================
@@ -2039,6 +2045,7 @@ _dispatchers = {}
 
 class Dispatcher(ABC):
     routing_type: str
+    mimetypes: collections.abc.Collection[str] = ()
 
     @classmethod
     def __init_subclass__(cls):
@@ -2116,6 +2123,8 @@ class Dispatcher(ABC):
 class HttpDispatcher(Dispatcher):
     routing_type = 'http'
 
+    mimetypes = ('application/x-www-form-urlencoded', 'multipart/form-data', '*/*')
+
     @classmethod
     def is_compatible_with(cls, request):
         return True
@@ -2170,15 +2179,21 @@ class HttpDispatcher(Dispatcher):
                 response.set_cookie('session_id', session.sid, max_age=get_session_max_inactivity(self.env), httponly=True)
             return response
 
-        return (exc if isinstance(exc, HTTPException)
-           else Forbidden(exc.args[0]) if isinstance(exc, (AccessDenied, AccessError))
-           else BadRequest(exc.args[0]) if isinstance(exc, UserError)
-           else InternalServerError()  # hide the real error
-        )
+        if isinstance(exc, HTTPException):
+            return exc
+
+        if isinstance(exc, UserError):
+            try:
+                return werkzeug_default_exceptions[exc.http_status](exc.args[0])
+            except (KeyError, AttributeError):
+                return UnprocessableEntity(exc.args[0])
+
+        return InternalServerError()
 
 
 class JsonRPCDispatcher(Dispatcher):
     routing_type = 'jsonrpc'
+    mimetypes = ('application/json', 'application/json-rpc')
 
     def __init__(self, request):
         super().__init__(request)
@@ -2187,7 +2202,7 @@ class JsonRPCDispatcher(Dispatcher):
 
     @classmethod
     def is_compatible_with(cls, request):
-        return request.httprequest.mimetype in JSON_MIMETYPES
+        return request.httprequest.mimetype in cls.mimetypes
 
     def dispatch(self, endpoint, args):
         """


### PR DESCRIPTION
Historically Odoo always returned 400 as the default "4xx" http status code for when the customer screwed up. But 400 is actually reserved for when the http request is malformed[^1], i.e. there was an error while parsing the headers or the body (according strickly to Content-Type).

The default go-to error for when the request is syntaxically valid but otherwise garbage is 422 - Unprocessable Entity[^2].

Used the opportunity to visit some other places where we used 400 and to use a http error that is better indicated.

[^1]: https://httpwg.org/specs/rfc9110.html#status.400
[^2]: https://httpwg.org/specs/rfc9110.html#status.422

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
