### PR TITLE
[IMP] core: validate company-dependent many2one to prevent MissingError

### DIFF
--- a/odoo/addons/base/tests/test_orm.py
+++ b/odoo/addons/base/tests/test_orm.py
@@ -321,36 +321,31 @@ class TestInherits(TransactionCase):
 
 @tagged('post_install', '-at_install')
 class TestCompanyDependent(TransactionCase):
-    def test_orm_ondelete_cascade(self):
+    def test_orm_ondelete_restrict(self):
         # model_A
         #  | field_a                           company dependent many2one is
         #  | company dependent many2one        stored as jsonb and doesn't
-        #  v                                   have db ON DELETE action
+        #  | (ondelete='restrict')             have db ON DELETE action
+        #  v
         # model_B
         #  | field_b                           if a row for model_B is deleted
         #  | many2one (ondelete='cascade')     because of ON DELETE CASCADE,
         #  v                                   model_A will reference a deleted
-        # model_C                              row and have MissingError
-        #  | field_c
-        #  | many2one (ondelete='cascade')     this test asks you to move the
-        #  v                                   ON DELETE CASCADE logic to ORM
-        # model_D                              and remove ondelete='cascade'
+        # model_C                              row and logically be NULL when read
         #
-        # Note:
-        # the test doesn't force developers to remove ondelete='cascade' for
-        # model_C if model_C is not referenced by another company dependent
-        # many2one field. But usually it is needed, unless you can accept
-        # the value of field_b to be an empty recordset of model_C
-        #
+        #                                      this test asks you to move the
+        #                                      ON DELETE CASCADE logic of model_B
+        #                                      to ORM and remove ondelete='cascade'
+
         for model in self.env.registry.values():
             for field in model._fields.values():
-                if field.company_dependent and field.type == 'many2one':
+                if field.company_dependent and field.type == 'many2one' and field.ondelete.lower() == 'restrict':
                     for comodel_field in self.env[field.comodel_name]._fields.values():
                         self.assertFalse(
                             comodel_field.type == 'many2one' and comodel_field.ondelete == 'cascade',
                             (f'when a row for {comodel_field.comodel_name} is deleted, a row for {comodel_field.model_name} '
-                             f'may also be deleted for sake of on delete cascade field {comodel_field}, which may '
-                             f'cause MissingError for a company dependent many2one field {field} in the future. '
+                             f'may also be deleted for sake of on delete cascade field {comodel_field}, which will '
+                             f'bypass the ORM ondelete="restrict" check for a company dependent many2one field {field}. '
                              f'Please override the unlink method of {comodel_field.comodel_name} and do the ORM on '
                              f'delete cascade logic and remove/override the ondelete="cascade" of {comodel_field}')
                         )

--- a/odoo/tools/query.py
+++ b/odoo/tools/query.py
@@ -77,7 +77,8 @@ class Query:
         # memoized result
         self._ids: tuple[int, ...] | None = None
 
-    def make_alias(self, alias: str, link: str) -> str:
+    @staticmethod
+    def make_alias(alias: str, link: str) -> str:
         """ Return an alias based on ``alias`` and ``link``. """
         return _generate_table_alias(alias, link)
 


### PR DESCRIPTION
When using JSONB for company-dependent many2one fields, references to non-existing records in the comodel can lead to MissingError. This commit introduces validation during fetch and comparison by taking advantage of index-only scan to ensure that referenced records exist.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
