### PR TITLE
[FIX] hr_holidays: prevent conflict between time offs with close dates

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1146,6 +1146,8 @@ class HolidaysRequest(models.Model):
         work_days_data = employees._get_work_days_data_batch(date_from, date_to)
 
         for employee in employees:
+            date_from_tz = date_from.astimezone(timezone(employee.tz)).replace(tzinfo=None)
+            date_to_tz = date_to.astimezone(timezone(employee.tz)).replace(tzinfo=None)
             if self.request_unit_hours:
                 hour_from = self.date_from.time()
                 hour_to = self.date_to.time()
@@ -1153,12 +1155,12 @@ class HolidaysRequest(models.Model):
                 day_period = False
                 if self.request_unit_half:
                     day_period = 'morning' if self.request_date_from_period == 'am' else 'afternoon'
-                attendance_from, attendance_to = self.with_context(day_period=day_period)._get_attendances(employee, date_from.date(), date_to.date())
+                attendance_from, attendance_to = self.with_context(day_period=day_period)._get_attendances(employee, date_from_tz.date(), date_to_tz.date())
                 hour_from = float_to_time(attendance_from.hour_from)
                 hour_to = float_to_time(attendance_to.hour_to)
 
-            work_days_data[employee.id]['date_from'] = datetime.combine(date_from, hour_from)
-            work_days_data[employee.id]['date_to'] = datetime.combine(date_to, hour_to)
+            work_days_data[employee.id]['date_from'] = datetime.combine(date_from_tz, hour_from)
+            work_days_data[employee.id]['date_to'] = datetime.combine(date_to_tz, hour_to)
 
         return [{
             'name': self.name,


### PR DESCRIPTION
Prevent an overlapping error when assigning a new time off to an employee with an existing approved request that appears non-overlapping but conflicts due to timezone conversions.

For example, if an employee has an approved time off request from 2025-02-18 to 2025-02-21, created in the UTC-6 timezone, and another time off is assigned for 2025-02-17 in the same timezone, an overlapping error may occur even though the dates do not overlap.

This happens because `date_from` and `date_to` are stored in UTC [1], and when validating the new time off, the date hours are adjusted to match the beginning and end of the employee's workday [2], potentially shifting the end date to the next day.

This commit considers the employee's timezone when validating new time offs to prevent this issue and avoid errors for multiple employees with different timezones.

[1]: https://github.com/odoo/odoo/blob/4d29b6ea/addons/hr_holidays/models/hr_leave.py#L1662
[2]: https://github.com/odoo/odoo/blob/4d29b6ea/addons/hr_holidays/models/hr_leave.py#L1160-L1161

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
