### PR TITLE
[IMP] website_sale: always display breadcrumb for ecom categories

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -756,6 +756,10 @@ class WebsiteSale(payment_portal.PaymentPortal):
     def _prepare_product_values(self, product, category, **kwargs):
         ProductCategory = request.env['product.public.category']
         product_markup_data = [product._to_markup_data(request.website)]
+        category = (
+            category and ProductCategory.browse(int(category)).exists()
+            or product.public_categ_ids[:1]
+        )
         if category:
             # Add breadcrumb's SEO data.
             product_markup_data.append(self._prepare_breadcrumb_markup_data(

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1892,19 +1892,24 @@
                                         <i class="oi oi-chevron-left d-lg-none me-1" role="presentation"/>All Products
                                     </a>
                                 </li>
-                                <li
-                                    t-nocache="The category does not have to be cached, as the product can be accessed via different paths."
-                                    t-if="category"
-                                    class="breadcrumb-item"
-                                >
-                                    <a
-                                        class="py-2 py-lg-0"
-                                        t-att-href="keep('%s/category/%s' % (shop_path, slug(category)))"
+                                <t t-foreach="category.parents_and_self" t-as="cat">
+                                    <li
+                                        t-nocache="The category does not have to be cached, as the product can be accessed via different paths."
+                                        class="breadcrumb-item"
                                     >
-                                        <i class="oi oi-chevron-left d-lg-none me-1" role="presentation"/><t t-out="category.name"/>
-                                    </a>
-                                </li>
-                                <li t-else="" class="o_not_editable breadcrumb-item d-lg-none">
+                                        <a
+                                            class="py-2 py-lg-0"
+                                            t-att-href="keep('%s/category/%s' % (shop_path, slug(cat)))"
+                                        >
+                                            <i
+                                                class="oi oi-chevron-left d-lg-none me-1"
+                                                role="presentation"
+                                            />
+                                            <t t-out="cat.name"/>
+                                        </a>
+                                    </li>
+                                </t>
+                                <li class="o_not_editable breadcrumb-item d-lg-none">
                                     <a class="py-2 py-lg-0" t-att-href="keep(shop_path)">
                                         <i class="oi oi-chevron-left me-1" role="presentation"/>All Products
                                     </a>


### PR DESCRIPTION
Prior to this commit:
- The breadcrumb for e-commerce categories on product page was inconsistent.
- It was only displayed based on the user’s navigation path, meaning it would sometimes be missing.
- The breadcrumb only showed categories the user had previously browsed, rather than a fixed structure.

Post this commit:
- The breadcrumb is always displayed on the product page, improving navigation and SEO.
- By default, it shows the first category (by sequence) in which the product is listed.
- If the category is child category, all parent categories up to 'All Products' are displayed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
