### PR TITLE
[FIX] stock: prevent traceback on print picking operation report

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -176,8 +176,8 @@
                                                 <td class="text-end">
                                                     <span t-out="format_number(line.quantity)">3.00</span>
                                                     <span t-field="line.product_uom_id" groups="uom.group_uom">units</span>
-                                                    <span t-if="line.move_id.product_packaging_id">
-                                                        (<span t-field="line.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="line.move_id.product_packaging_id.name"/>)
+                                                    <span t-if="line.move_id.packaging_uom_id">
+                                                        (<span t-field="line.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="line.move_id.packaging_uom_id.name"/>)
                                                     </span>
                                                 </td>
                                                 <td class="text-start" t-if="from_col_exists" groups="stock.group_stock_multi_locations">


### PR DESCRIPTION
Issue Before This Commit:
============================

A traceback occurs when printing the picking operations report.

Steps to Reproduce:
=====================
1. Install the purchase_stock module.
2. Activate 'Units of Measure & Packagings'.
3. Create a new Purchase Order (PO) with multiple purchase order lines.
4. Confirm the PO and navigate to the receipt.
5. Print a 'Picking Operations' report. it will give errors like:
  - AttributeError: 'stock.move' object has no attribute 'product_packaging_id'.

With This Commit:
=====================

The issue occurred because `product_packaging_id` was removed from `stock.move` in this [PR](https://github.com/odoo/upgrade/commit/1ab23e5418c820329a618fb4c8c9f48b7862b6ec). This fix replaces it with `packaging_uom_id`, ensuring the correct field is used and preventing errors when printing the report.

task - [4583172](https://www.odoo.com/odoo/my-tasks/4583172)