### PR TITLE
[FIX] im_livechat: allow livechat users to remove colleagues

### DIFF
--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -103,7 +103,7 @@
                                                     <main class="ps-1">
                                                         <div class="d-flex justify-content-between align-items-baseline">
                                                             <field name="name" class="fw-bold fs-5"/>
-                                                            <a class="btn p-0 opacity-75 opacity-100-hover" role="button" groups="im_livechat.im_livechat_group_manager" type="delete">
+                                                            <a class="btn p-0 opacity-75 opacity-100-hover" role="button" groups="im_livechat.im_livechat_group_user" type="delete">
                                                                 <i title="Remove operator" class="fa fa-fw fa-lg fa-close"/>
                                                             </a>
                                                         </div>


### PR DESCRIPTION
**Current behavior before PR:**

Only users with group `im_livechat_group_manager`  could remove a livechat operator.

**Desired behavior after PR is merged:**

Users with group `im_livechat_group_user` can remove colleagues.

**Task**-4510760



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
