### PR TITLE
[FIX] hr_work_entry_holidays: prevent error on installing module

### DIFF
--- a/addons/hr_work_entry_holidays/data/hr_payroll_holidays_data.xml
+++ b/addons/hr_work_entry_holidays/data/hr_payroll_holidays_data.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data noupdate="0">
+    <data noupdate="1">
 
-        <record id="hr_holidays.holiday_status_comp" model="hr.leave.type">
+        <record id="hr_holidays.holiday_status_comp" model="hr.leave.type" forcecreate="False">
             <field name="work_entry_type_id" ref="hr_work_entry_contract.work_entry_type_compensatory"></field>
         </record>
 
-        <record id="hr_holidays.holiday_status_unpaid" model="hr.leave.type">
+        <record id="hr_holidays.holiday_status_unpaid" model="hr.leave.type" forcecreate="False">
             <field name="work_entry_type_id" ref="hr_work_entry_contract.work_entry_type_unpaid_leave"></field>
         </record>
 
-        <record id="hr_holidays.holiday_status_sl" model="hr.leave.type">
+        <record id="hr_holidays.holiday_status_sl" model="hr.leave.type" forcecreate="False">
             <field name="work_entry_type_id" ref="hr_work_entry_contract.work_entry_type_sick_leave"></field>
         </record>
 
-        <record id="hr_holidays.holiday_status_cl" model="hr.leave.type">
+        <record id="hr_holidays.holiday_status_cl" model="hr.leave.type" forcecreate="False">
             <field name="work_entry_type_id" ref="hr_work_entry_contract.work_entry_type_legal_leave"></field>
         </record>
     </data>


### PR DESCRIPTION
Currently a `ParseError` arises when the user installs the `hr_work_entry_holidays` module after deleting all `Time Off Types` in the `Time Off` Configuration.

Steps to reproduce:
---
- Install `hr_holidays` module (without demo data)
- Time Off > Configuration > `Time Off Types` > Delete all
- Now install `hr_work_entry_holidays` module

Traceback:
---
```
Exception: Cannot update missing record 'hr_holidays.holiday_status_comp'

ParseError: while parsing /home/odoo/src/odoo/saas-18.1/addons/hr_work_entry_holidays/data/hr_payroll_holidays_data.xml:5, somewhere inside <record id="hr_holidays.holiday_status_comp" model="hr.leave.type">
            <field name="work_entry_type_id" ref="hr_work_entry_contract.work_entry_type_compensatory"/>
        </record>
```

The error occurs because the user deleted all `Time Off Types` and then installed the `hr_work_entry_holidays` module. which requires particular records.

This commit solves the above issue by using `noupdate="1"` and `forcecreate="False"` to bypass record creation if it violates checks.

https://github.com/odoo/odoo/blob/b794f0f332f473deb2c04eba60baf4761db3b508/odoo/tools/convert.py#L364-L366

sentry-5731062091

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
