### PR TITLE
[FIX] website_sale: address saving issue in checkout

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1114,7 +1114,10 @@ class WebsiteSale(payment_portal.PaymentPortal):
             # Unsubscribe the public partner if the cart was previously anonymous.
             order_sudo.message_unsubscribe(order_sudo.website_id.partner_id.ids)
 
-        if is_new_address or order_sudo.only_services:
+        is_extra_step_active = request.website.viewref('website_sale.extra_info').active
+        if is_extra_step_active:
+            callback = callback or 'shop/extra_info'
+        elif is_new_address or order_sudo.only_services:
             callback = callback or '/shop/checkout?try_skip_step=true'
         else:
             callback = callback or '/shop/checkout'

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2280,9 +2280,21 @@
                     <t t-elif="not hide_payment_button" t-call="payment.submit_button"/>
                 </t>
                 <t t-else="">
+                    <!-- No need to set href for address template as save address result will redirect
+                    to proper place if all values are properly filled -->
+                    <t
+                        t-if="xmlid == 'website_sale.address'"
+                        t-set="main_button_href"
+                        t-value="False"
+                    />
+                    <t
+                        t-else=""
+                        t-set="main_button_href"
+                        t-value="step_specific_values['main_button_href']"
+                    />
                     <a role="button" name="website_sale_main_button"
                         t-attf-class="#{_cta_classes} btn btn-primary #{not website_sale_order._is_cart_ready() and 'disabled'} #{_form_send_navigation and 'order-lg-3 w-100 w-lg-auto ms-lg-auto' or 'w-100'}"
-                        t-att-href="step_specific_values['main_button_href']">
+                        t-att-href="main_button_href">
                         <t t-out="step_specific_values['main_button']"/>
                         <i class="fa fa-angle-right ms-2 fw-light"/>
                     </a>


### PR DESCRIPTION
Issue:
Since we are using checkout layout in address form and removed of save address
button in PR https://github.com/odoo/odoo/pull/197621 and save address on click of confirm button in checkout layout
but because of href on confirm button it reload page even address contains wrong
values making it difficult for customer to create new address.

Fix:
Remove href from confirm button for address template and redirect user on result
of save address method result.