### PR TITLE
[FIX] im_livechat: fix visitor offline banner

### DIFF
--- a/addons/im_livechat/static/src/core/common/thread_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_patch.js
@@ -32,7 +32,7 @@ patch(Thread.prototype, {
     },
     get showVisitorDisconnected() {
         return (
-            this.store.self.notEq(this.props.thread.livechatVisitorMember) &&
+            this.store.self.notEq(this.props.thread.livechatVisitorMember?.persona) &&
             this.props.thread.livechat_active &&
             this.props.thread.livechatVisitorMember &&
             this.state.isVisitorOffline


### PR DESCRIPTION
Before this PR, the visitor offline banner could be shown to the visitor. The condition used to determine whether the banner should be shown is incorrect (it compares channel member to persona).

At the same time, this PR cleans the thread component patch: the component relies on the `useEffect` hook to update a state based on the persona im status. The only purpose of this method is to delay the update in the UI to avoid flicker during quick disconnects.

However, a debounce is already in place in the persona model. Other places in the UI might be impacted by the same flickers, so we better increase de debounce delay directly in the model setter. It also remove the need for complex code in the component.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
