### PR TITLE
[FIX] website_sale: handle product description translation in cart

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -155,6 +155,16 @@ class Website(main.Website):
             'position': request.website.currency_id.position,
         }
 
+    @http.route()
+    def change_lang(self, lang, **kwargs):
+        order_sudo = request.website.sale_get_order()
+        request.env.add_to_compute(
+            order_sudo.order_line._fields['name'],
+            order_sudo.order_line.with_context(lang=lang),
+        )
+        return super().change_lang(lang, **kwargs)
+
+
 class WebsiteSale(http.Controller):
     _express_checkout_route = '/shop/express_checkout'
 


### PR DESCRIPTION
## Versions:
16.0+

## Issue:
When changing the website language from the cart page, the product description is not translated while all other elements of the page are.

## Steps to reproduce:
Install at least 2 languages available on website; From the shop, add a product (e.g. "Customizable Desk") to cart; Move to the cart and change language.

## Cause:
Description is retrieved without being recomputed with selected language.


opw-4485686