### PR TITLE
[FIX] web_editor: prevent using self-closing tags in editor

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -85,6 +85,7 @@ import {
     getAdjacentCharacter,
     isLinkEligibleForZwnbsp,
     isZwnbsp,
+    fixInvalidHTML,
 } from './utils/utils.js';
 import { editorCommands } from './commands/commands.js';
 import { Powerbox } from './powerbox/Powerbox.js';
@@ -894,7 +895,7 @@ export class OdooEditor extends EventTarget {
 
     resetContent(value) {
         value = value || '<p><br></p>';
-        this.editable.innerHTML = value;
+        this.editable.innerHTML = fixInvalidHTML(value);
         this.sanitize(this.editable);
         this.historyStep(true);
         // The unbreakable protection mechanism detects an anomaly and attempts

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -3315,3 +3315,20 @@ export function cleanZWS(node) {
             }
         });
 }
+
+/**
+ * Properly close common XML-like self-closing elements to avoid HTML parsing
+ * issues.
+ *
+ * @param {string} content
+ * @returns {string}
+ */
+export function fixInvalidHTML(content) {
+    if (!content) {
+        return content;
+    }
+    // TODO: improve the regex to support nodes with data-attributes containing
+    // `/` and `>` characters.
+    const regex = /<\s*(a|strong|t)[^<]*?\/\s*>/g;
+    return content.replace(regex, (match, g0) => match.replace(/\/\s*>/, `></${g0}>`));
+}


### PR DESCRIPTION
**Problem**:
When rendering editor content that includes self-closing tags, it will not be rendered properly because self-closing tags are not valid HTML in this context.

**Solution**:
Convert self-closing tags to explicitly opened and closed tags before rendering.

**Steps to Reproduce**:
1. Open an email template.
2. Edit content by adding a self-closing tag.
3. Save.
4. The content is not rendered properly.

opw-4555555

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
