### PR TITLE
[IMP] base: replace default user by default group

### DIFF
--- a/addons/account/demo/account_demo.xml
+++ b/addons/account/demo/account_demo.xml
@@ -4,6 +4,10 @@
         <record id="base.user_demo" model="res.users">
             <field name="group_ids" eval="[(3, ref('account.group_account_manager'))]"/>
         </record>
+
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('account.group_account_manager'))]"/>
+        </record>
     </data>
     <data>
         <!-- TAGS FOR RETRIEVING THE DEMO ACCOUNTS -->

--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -130,10 +130,6 @@
         <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
     </record>
 
-    <record id="base.default_user" model="res.users">
-        <field name="group_ids" eval="[(4,ref('account.group_account_manager'))]"/>
-    </record>
-
     <record id="account_move_comp_rule" model="ir.rule">
         <field name="name">Account Entry</field>
         <field name="model_id" ref="model_account_move"/>

--- a/addons/base_setup/data/base_setup_data.xml
+++ b/addons/base_setup/data/base_setup_data.xml
@@ -5,9 +5,5 @@
             <field name="key">base_setup.show_effect</field>
             <field name="value">True</field>
         </record>
-        <record model="ir.config_parameter" id="setup_default_user_rights" forcecreate="False">
-            <field name="key">base_setup.default_user_rights</field>
-            <field name="value">True</field>
-        </record>
     </data>
 </odoo>

--- a/addons/base_setup/models/res_config_settings.py
+++ b/addons/base_setup/models/res_config_settings.py
@@ -11,9 +11,6 @@ class ResConfigSettings(models.TransientModel):
     company_id = fields.Many2one('res.company', string='Company', required=True,
         default=lambda self: self.env.company)
     is_root_company = fields.Boolean(compute='_compute_is_root_company')
-    user_default_rights = fields.Boolean(
-        "Default Access Rights",
-        config_parameter='base_setup.default_user_rights')
     module_base_import = fields.Boolean("Allow users to import data from CSV/XLS/XLSX/ODS files")
     module_google_calendar = fields.Boolean(
         string='Allow the users to synchronize their calendar  with Google Calendar')
@@ -57,14 +54,29 @@ class ResConfigSettings(models.TransientModel):
             'target': 'current',
         }
 
-    def open_default_user(self):
-        action = self.env["ir.actions.actions"]._for_xml_id("base.action_res_users")
-        if self.env.ref('base.default_user', raise_if_not_found=False):
-            action['res_id'] = self.env.ref('base.default_user').id
-        else:
-            raise UserError(_("Default User Template not found."))
-        action['views'] = [[self.env.ref('base.view_users_form').id, 'form']]
-        return action
+    def open_new_user_default_groups(self):
+        default_group = self.env.ref('base.default_user_group', raise_if_not_found=False)
+        if not default_group:
+            default_group = self.env['res.groups'].create({
+                'name': _('Default access for new users'),
+                'category_id': self.env.ref('base.module_category_hidden').id,
+            })
+            self.env['ir.model.data'].create({
+                'name': 'default_user_group',
+                'module': 'base',
+                'res_id': default_group.id,
+                'model': 'res.groups',
+                'noupdate': True,
+            })
+        return {
+            'type': 'ir.actions.act_window',
+            'name': _("Edit new user default group"),
+            'view_mode': 'form',
+            'res_model': 'res.groups',
+            'res_id': default_group.id,
+            'views': [(self.env.ref('base.view_default_groups_form').id, 'form')],
+            'target': 'new',
+        }
 
     @api.model
     def _prepare_report_view_action(self, template):

--- a/addons/base_setup/models/res_users.py
+++ b/addons/base_setup/models/res_users.py
@@ -31,20 +31,3 @@ class ResUsers(models.Model):
             user = self.with_context(signup_valid=True).create(default_values)
 
         return True
-
-    def _default_groups(self):
-        """Default groups for employees
-
-        If base_setup.default_user_rights is set, only the "Employee" group is used
-        """
-        if not str2bool(self.env['ir.config_parameter'].sudo().get_param("base_setup.default_user_rights"), default=False):
-            return self.env.ref("base.group_user")
-        return super()._default_groups()
-
-    def _apply_groups_to_existing_employees(self):
-        """
-        If base_setup.default_user_rights is set, do not apply any new groups to existing employees
-        """
-        if not str2bool(self.env['ir.config_parameter'].sudo().get_param("base_setup.default_user_rights"), default=False):
-            return False
-        return super()._apply_groups_to_existing_employees()

--- a/addons/base_setup/views/res_config_settings_views.xml
+++ b/addons/base_setup/views/res_config_settings_views.xml
@@ -115,10 +115,9 @@
 
                     <block title="Permissions" id="user_default_rights">
                         <setting string="Default Access Rights" help="Set custom access rights for new users" title="By default, new users get highest access rights for all installed apps. If unchecked, new users will only have basic employee access." id="access_rights">
-                            <field name="user_default_rights"/>
-                            <div class="content-group" invisible="not user_default_rights">
+                            <div class="content-group">
                                 <div class="mt8">
-                                    <button type="object" name="open_default_user" string="Default Access Rights" icon="oi-arrow-right" class="btn-link"/>
+                                    <button type="object" name="open_new_user_default_groups" string="Default Access Rights" icon="oi-arrow-right" class="btn-link"/>
                                 </div>
                             </div>
                         </setting>

--- a/addons/calendar/data/calendar_data.xml
+++ b/addons/calendar/data/calendar_data.xml
@@ -45,5 +45,10 @@
             <field name="alarm_type">email</field>
             <field name="mail_template_id" ref="calendar.calendar_template_meeting_reminder"/>
         </record>
+
+        <record id="default_privacy" model="ir.config_parameter">
+            <field name="key">calendar.default_privacy</field>
+            <field name="value">public</field>
+        </record>
     </data>
 </odoo>

--- a/addons/calendar/models/res_users.py
+++ b/addons/calendar/models/res_users.py
@@ -49,9 +49,7 @@ class ResUsers(models.Model):
     @api.model
     def _default_user_calendar_default_privacy(self):
         """ Get the calendar default privacy from the Default User Template, set public as default. """
-        if default_user := self.env.ref('base.default_user', raise_if_not_found=False):
-            return default_user.sudo().calendar_default_privacy or 'public'
-        return 'public'
+        return self.env['ir.config_parameter'].sudo().get_param('calendar.default_privacy', 'public')
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -68,11 +66,9 @@ class ResUsers(models.Model):
     def write(self, vals):
         """ Forbid the calendar default privacy update from different users for keeping private events secured. """
         privacy_update = 'calendar_default_privacy' in vals
-        default_user = self.env.ref('base.default_user', raise_if_not_found=False)
-        if default_user and privacy_update and any(user not in [default_user, self.env.user] for user in self):
+        if privacy_update and self != self.env.user:
             raise AccessError(_("You are not allowed to change the calendar default privacy of another user due to privacy constraints."))
-        res = super().write(vals)
-        return res
+        return super().write(vals)
 
     @api.depends("res_users_settings_id.calendar_default_privacy")
     def _compute_calendar_default_privacy(self):

--- a/addons/calendar/tests/test_access_rights.py
+++ b/addons/calendar/tests/test_access_rights.py
@@ -304,8 +304,6 @@ class TestAccessRights(TransactionCase):
         default privacy from the 'res.users' related field without throwing any error.
         Updates from others users are blocked during write (except for Default User Template from admins).
         """
-        default_user = self.env.ref('base.default_user', raise_if_not_found=False)
-
         for privacy in ['public', 'private', 'confidential']:
             # Update normal user and administrator 'calendar_default_privacy' simulating their own update.
             self.john.with_user(self.john).write({'calendar_default_privacy': privacy})
@@ -313,11 +311,10 @@ class TestAccessRights(TransactionCase):
             self.assertEqual(self.john.calendar_default_privacy, privacy, 'Normal user must be able to update its calendar default privacy.')
             self.assertEqual(self.admin_system_user.calendar_default_privacy, privacy, 'Admin must be able to update its calendar default privacy.')
 
-            # Update the Default User Template's 'calendar_default_privacy' as an administrator.
-            default_user.with_user(self.admin_system_user).write({'calendar_default_privacy': privacy})
-            self.assertEqual(default_user.calendar_default_privacy, privacy, 'Admin must be able to update the Default User Template calendar privacy.')
+            # Update the Default 'calendar.default_privacy' as an administrator.
+            self.env['ir.config_parameter'].sudo().set_param("calendar.default_privacy", privacy)
 
-            # All calendar default privacy updates (except for Default user Template) must be blocked during write.
+            # All calendar default privacy updates must be blocked during write.
             with self.assertRaises(AccessError):
                 self.john.with_user(self.admin_system_user).write({'calendar_default_privacy': privacy})
             with self.assertRaises(AccessError):

--- a/addons/calendar/tests/test_res_users.py
+++ b/addons/calendar/tests/test_res_users.py
@@ -19,7 +19,6 @@ class TestResUsers(TransactionCase):
             return self.env['res.users'].create(vals)
 
         # Get Default User Template and define expected outputs for each privacy update test.
-        default_user = self.env.ref('base.default_user', raise_if_not_found=False)
         privacy_and_output = [
             (False, 'public'),
             ('public', 'public'),
@@ -27,9 +26,9 @@ class TestResUsers(TransactionCase):
             ('confidential', 'confidential')
         ]
         for (privacy, expected_output) in privacy_and_output:
-            # Update privacy of Default User Template (required field).
+            # Update default privacy.
             if privacy:
-                default_user.write({'calendar_default_privacy': privacy})
+                self.env['ir.config_parameter'].set_param("calendar.default_privacy", privacy)
 
             # If Calendar Default Privacy isn't defined in vals: get the privacy from Default User Template.
             username = 'test_%s_%s' % (str(privacy), expected_output)

--- a/addons/event/data/event_demo.xml
+++ b/addons/event/data/event_demo.xml
@@ -4,6 +4,10 @@
         <record id="base.user_demo" model="res.users">
             <field name="group_ids" eval="[(3, ref('event.group_event_manager'))]"/>
         </record>
+
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('event.group_event_manager'))]"/>
+        </record>
     </data>
 
     <!-- Event -->

--- a/addons/event/security/event_security.xml
+++ b/addons/event/security/event_security.xml
@@ -27,10 +27,6 @@
     </data>
 
     <data noupdate="1">
-        <record id="base.default_user" model="res.users">
-            <field name="group_ids" eval="[(4,ref('event.group_event_manager'))]"/>
-        </record>
-
         <!-- Multi - Company Rules -->
         <record model="ir.rule" id="event_event_company_rule">
             <field name="name">Event: multi-company</field>

--- a/addons/fleet/data/fleet_demo.xml
+++ b/addons/fleet/data/fleet_demo.xml
@@ -7,6 +7,10 @@
         ]"/>
     </record>
 
+    <record id="base.default_user_group" model="res.groups">
+        <field name="implied_ids" eval="[(4, ref('fleet.fleet_group_manager'))]"/>
+    </record>
+
         <record id="fleet_vehicle_state_ordered" model="fleet.vehicle.state">
             <field name="name">Ordered</field>
             <field name="sequence">6</field>

--- a/addons/fleet/security/fleet_security.xml
+++ b/addons/fleet/security/fleet_security.xml
@@ -17,9 +17,6 @@
         </record>
 
     <data noupdate="1">
-        <record id="base.default_user" model="res.users">
-            <field name="group_ids" eval="[(4,ref('fleet.fleet_group_manager'))]"/>
-        </record>
         <record id="fleet_rule_contract_visibility_manager" model="ir.rule">
             <field name="name">Administrator has all rights on vehicle's contracts</field>
             <field name="model_id" ref="model_fleet_vehicle_log_contract"/>

--- a/addons/hr/data/hr_demo.xml
+++ b/addons/hr/data/hr_demo.xml
@@ -7,6 +7,10 @@
                 (3, ref('hr.group_hr_manager'))]"/>
         </record>
 
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('hr.group_hr_manager'))]"/>
+        </record>
+
         <!-- Resource Calendar -->
         <record id="resource_calendar_std_20h" model="resource.calendar">
             <field name="name">Standard 20 hours/week</field>

--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -21,10 +21,6 @@
     </record>
 
 <data noupdate="1">
-    <record id="base.default_user" model="res.users">
-        <field name="group_ids" eval="[(4,ref('group_hr_manager'))]"/>
-    </record>
-
     <record id="hr_employee_comp_rule" model="ir.rule">
         <field name="name">Employee multi company rule</field>
         <field name="model_id" ref="model_hr_employee"/>

--- a/addons/hr_attendance/data/hr_attendance_demo.xml
+++ b/addons/hr_attendance/data/hr_attendance_demo.xml
@@ -5,6 +5,10 @@
             <field name="group_ids" eval="[(3, ref('hr_attendance.group_hr_attendance_manager'))]"/>
         </record>
 
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_manager'))]"/>
+        </record>
+
         <record id="hr.employee_al" model="hr.employee">
             <field name="barcode">123</field>
         </record>

--- a/addons/hr_attendance/security/hr_attendance_security.xml
+++ b/addons/hr_attendance/security/hr_attendance_security.xml
@@ -27,10 +27,6 @@
         <field name="implied_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_officer'))]"/>
     </record>
 
-    <record id="base.default_user" model="res.users">
-        <field name="group_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_manager'))]"/>
-    </record>
-
     <data noupdate="1">
 
         <!-- Attendances -->

--- a/addons/hr_contract/data/hr_contract_demo.xml
+++ b/addons/hr_contract/data/hr_contract_demo.xml
@@ -14,6 +14,10 @@
                 (3, ref('hr_contract.group_hr_contract_manager')),
                 (3, ref('hr_contract.group_hr_contract_employee_manager'))]"/>
         </record>
+
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('hr_contract.group_hr_contract_manager'))]"/>
+        </record>
     </data>
 
     <record id="hr_contract_admin" model="hr.contract">

--- a/addons/hr_contract/security/security.xml
+++ b/addons/hr_contract/security/security.xml
@@ -19,10 +19,6 @@
             <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         </record>
 
-        <record id="base.default_user" model="res.users">
-            <field name="group_ids" eval="[(4,ref('hr_contract.group_hr_contract_manager'))]"/>
-        </record>
-
         <record id="ir_rule_hr_contract_history_multi_company" model="ir.rule">
             <field name="name">HR Contract History: Multi Company</field>
             <field name="model_id" ref="model_hr_contract_history"/>

--- a/addons/hr_expense/data/hr_expense_demo.xml
+++ b/addons/hr_expense/data/hr_expense_demo.xml
@@ -9,6 +9,10 @@
             ]"/>
         </record>
 
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('hr_expense.group_hr_expense_manager'))]"/>
+        </record>
+
         <record id="hr.employee_mit" model="hr.employee">
             <field name="private_email">douglas.fletcher51@example.com</field>
             <field name="private_phone">(132)-553-7242</field>

--- a/addons/hr_expense/security/hr_expense_security.xml
+++ b/addons/hr_expense/security/hr_expense_security.xml
@@ -23,8 +23,4 @@
         <field name="implied_ids" eval="[(4, ref('hr_expense.group_hr_expense_user'))]"/>
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
     </record>
-
-    <record id="base.default_user" model="res.users">
-        <field name="group_ids" eval="[(4,ref('hr_expense.group_hr_expense_manager'))]"/>
-    </record>
 </odoo>

--- a/addons/hr_holidays/data/hr_holidays_demo.xml
+++ b/addons/hr_holidays/data/hr_holidays_demo.xml
@@ -9,6 +9,10 @@
             (3, ref('hr_holidays.group_hr_holidays_manager'))]"/>
     </record>
 
+    <record id="base.default_user_group" model="res.groups">
+        <field name="implied_ids" eval="[(4, ref('hr_holidays.group_hr_holidays_manager'))]"/>
+    </record>
+
     <!--Time Off Type-->
     <record id="hr_holiday_status_dv" model="hr.leave.type">
         <field name="name">Parental Leaves</field>

--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -26,10 +26,6 @@
 
     <data noupdate="1">
 
-    <record id="base.default_user" model="res.users">
-        <field name="group_ids" eval="[(4,ref('hr_holidays.group_hr_holidays_manager'))]"/>
-    </record>
-
     <record id="hr_leave_rule_employee" model="ir.rule">
         <field name="name">Time Off base.group_user read</field>
         <field name="model_id" ref="model_hr_leave"/>

--- a/addons/hr_recruitment/data/hr_recruitment_demo.xml
+++ b/addons/hr_recruitment/data/hr_recruitment_demo.xml
@@ -8,6 +8,10 @@
         ]"/>
     </record>
 
+    <record id="base.default_user_group" model="res.groups">
+        <field name="implied_ids" eval="[(4, ref('hr_recruitment.group_hr_recruitment_manager'))]"/>
+    </record>
+
     <!--Manage the job_id to get in hr.applicant-->
     <record id="hr.job_developer" model="hr.job">
         <field name="no_of_recruitment">4</field>

--- a/addons/hr_recruitment/security/hr_recruitment_security.xml
+++ b/addons/hr_recruitment/security/hr_recruitment_security.xml
@@ -32,10 +32,6 @@
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
     </record>
 
-    <record id="base.default_user" model="res.users">
-        <field name="group_ids" eval="[(4,ref('hr_recruitment.group_hr_recruitment_manager'))]"/>
-    </record>
-
     <record id="group_applicant_cv_display" model="res.groups">
         <field name="name">Display CV on application form</field>
         <field name="category_id" ref="base.module_category_hidden"/>

--- a/addons/hr_timesheet/data/hr_timesheet_demo.xml
+++ b/addons/hr_timesheet/data/hr_timesheet_demo.xml
@@ -6,6 +6,10 @@
                 (3, ref('project.group_project_manager')),
                 (3, ref('hr_timesheet.group_timesheet_manager'))]"/>
         </record>
+
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('hr_timesheet.group_timesheet_manager'))]"/>
+        </record>
     </data>
 
     <!-- Projects -->

--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -26,10 +26,6 @@
             <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         </record>
 
-        <record id="base.default_user" model="res.users">
-            <field name="group_ids" eval="[(4,ref('group_timesheet_manager'))]"/>
-        </record>
-
         <record id="timesheet_line_rule_portal_user" model="ir.rule">
             <field name="name">account.analytic.line.timesheet.portal.user</field>
             <field name="model_id" ref="analytic.model_account_analytic_line"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_channel.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_channel.xml
@@ -4,6 +4,10 @@
         <record id="base.user_demo" model="res.users">
             <field name="group_ids" eval="[(3, ref('im_livechat.im_livechat_group_manager'))]"/>
         </record>
+
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('im_livechat.im_livechat_group_manager'))]"/>
+        </record>
     </data>
     <data>
         <record id="im_livechat_channel_rule_demo" model="im_livechat.channel.rule">

--- a/addons/im_livechat/security/im_livechat_channel_security.xml
+++ b/addons/im_livechat/security/im_livechat_channel_security.xml
@@ -39,9 +39,5 @@
             <field name="perm_write" eval="False"/>
             <field name="perm_unlink" eval="False"/>
         </record>
-
-        <record id="base.default_user" model="res.users">
-            <field name="group_ids" eval="[(4,ref('im_livechat.im_livechat_group_manager'))]"/>
-        </record>
     </data>
 </odoo>

--- a/addons/lunch/data/lunch_demo.xml
+++ b/addons/lunch/data/lunch_demo.xml
@@ -93,6 +93,10 @@
             <field name="group_ids" eval="[(3, ref('lunch.group_lunch_manager'))]"/>
         </record>
 
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('lunch.group_lunch_manager'))]"/>
+        </record>
+
         <record model="lunch.product.category" id="categ_pasta">
             <field name="name">Pasta</field>
         </record>

--- a/addons/lunch/security/lunch_security.xml
+++ b/addons/lunch/security/lunch_security.xml
@@ -61,10 +61,6 @@
             <field name="groups" eval="[(4, ref('lunch.group_lunch_manager'))]"/>
         </record>
 
-        <record id="base.default_user" model="res.users">
-            <field name="group_ids" eval="[(4,ref('lunch.group_lunch_manager'))]"/>
-        </record>
-
         <record id="ir_rule_lunch_supplier_multi_company" model="ir.rule">
             <field name="name">Lunch supplier: Multi Company</field>
             <field name="model_id" ref="model_lunch_supplier"/>

--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -30,7 +30,6 @@
         'data/mailing_list_contact.xml',
         'data/mailing_subscription_optout.xml',
         'data/mailing_subscription.xml',
-        'data/res_users_data.xml',
         'data/mass_mailing_tour.xml',
         'wizard/mail_compose_message_views.xml',
         'wizard/mailing_contact_import_views.xml',
@@ -90,6 +89,7 @@
         'demo/mailing_subscription.xml',
         'demo/mailing_mailing.xml',
         'demo/mailing_trace.xml',
+        'demo/res_users.xml',
     ],
     'application': True,
     'assets': {

--- a/addons/mass_mailing/data/res_users_data.xml
+++ b/addons/mass_mailing/data/res_users_data.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <data noupdate="1">
-        <record id="base.default_user" model="res.users">
-            <field name="group_ids" eval="[(4,ref('mass_mailing.group_mass_mailing_user'))]"/>
-        </record>
-    </data>
-</odoo>

--- a/addons/mass_mailing/demo/res_users.xml
+++ b/addons/mass_mailing/demo/res_users.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4,ref('mass_mailing.group_mass_mailing_user'))]"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -6,6 +6,10 @@
             <field eval="[(3, ref('group_mrp_manager')), (4, ref('group_mrp_user'))]" name="group_ids"/>
         </record>
 
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
+        </record>
+
         <!-- Groups -->
         <record model="res.groups" id="base.group_user">
             <field name="implied_ids" eval="[(4, ref('mrp.group_mrp_routings'))]"/>

--- a/addons/mrp/security/mrp_security.xml
+++ b/addons/mrp/security/mrp_security.xml
@@ -47,9 +47,6 @@
 
 </data>
 <data noupdate="1">
-    <record id="base.default_user" model="res.users">
-        <field name="group_ids" eval="[(4,ref('mrp.group_mrp_manager'))]"/>
-    </record>
 <!-- Multi -->
     <record model="ir.rule" id="mrp_production_rule">
         <field name="name">mrp_production multi-company</field>

--- a/addons/payment_paypal/tests/test_paypal.py
+++ b/addons/payment_paypal/tests/test_paypal.py
@@ -26,7 +26,7 @@ class PaypalTest(PaypalCommon, PaymentHttpCommon):
     def test_order_payload_values_for_public_user(self):
         """ If a payment is made with the public user we need to make sure that the
             email address is not sent to PayPal and that we provide the country code of the company instead."""
-        tx = self._create_transaction(flow='direct', partner_id=self.public_user.id)
+        tx = self._create_transaction(flow='direct', partner_id=self.public_user.partner_id.id)
         payload = tx._paypal_prepare_order_payload()
         customer_payload = payload['payment_source']['paypal']
         self.assertTrue('email_address' not in customer_payload)

--- a/addons/point_of_sale/data/orders_demo.xml
+++ b/addons/point_of_sale/data/orders_demo.xml
@@ -2,6 +2,10 @@
 <odoo>
     <data noupdate="1">
 
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('point_of_sale.group_pos_manager'))]"/>
+        </record>
+
         <!-- Closed Session 2 -->
 
         <record id="pos_closed_session_1" model="pos.session" forcecreate="False" context="{'onboarding_creation': True}">

--- a/addons/point_of_sale/security/point_of_sale_security.xml
+++ b/addons/point_of_sale/security/point_of_sale_security.xml
@@ -83,9 +83,5 @@
         <field name="groups" eval="[(4, ref('group_pos_user'))]"/>
         <field name="domain_force">[('move_id.pos_order_ids', '!=', False)]</field>
     </record>
-
-        <record id="base.default_user" model="res.users">
-            <field name="group_ids" eval="[(4,ref('point_of_sale.group_pos_manager'))]"/>
-        </record>
     </data>
 </odoo>

--- a/addons/product/data/product_demo.xml
+++ b/addons/product/data/product_demo.xml
@@ -6,6 +6,10 @@
             <field name="implied_ids" eval="[(4, ref('product.group_product_variant'))]"/>
         </record>
 
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('product.group_product_manager'))]"/>
+        </record>
+
         <!-- Expensable products -->
         <record id="expense_product" model="product.product">
             <field name="name">Restaurant Expenses</field>

--- a/addons/product/security/product_security.xml
+++ b/addons/product/security/product_security.xml
@@ -18,10 +18,6 @@
         <field name="category_id" ref="base.module_category_usability"/>
     </record>
 
-    <record id="base.default_user" model="res.users">
-        <field name="group_ids" eval="[Command.link(ref('group_product_manager'))]"/>
-    </record>
-
 <data noupdate="1">
 
     <record id="product_comp_rule" model="ir.rule">

--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -7,6 +7,10 @@
             <field name="group_ids" eval="[(3, ref('project.group_project_manager'))]"/>
         </record>
 
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('project.group_project_manager'))]"/>
+        </record>
+
         <!-- Groups : Add milestones feature by default -->
         <record id="base.group_user" model="res.groups">
             <field name="implied_ids" eval="[Command.link(ref('group_project_milestone'))]"/>

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -48,9 +48,6 @@
     </record>
 
 <data noupdate="1">
-    <record id="base.default_user" model="res.users">
-        <field name="group_ids" eval="[(4,ref('project.group_project_manager'))]"/>
-    </record>
 
     <record model="ir.rule" id="project_comp_rule">
         <field name="name">Project: multi-company</field>

--- a/addons/purchase/data/purchase_demo.xml
+++ b/addons/purchase/data/purchase_demo.xml
@@ -6,6 +6,10 @@
             <field name="group_ids" eval="[(3, ref('purchase.group_purchase_manager'))]"/>
         </record>
 
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('purchase.group_purchase_manager'))]"/>
+        </record>
+
         <record id="base.res_partner_1" model="res.partner">
             <field name="receipt_reminder_email">True</field>
         </record>

--- a/addons/purchase/security/purchase_security.xml
+++ b/addons/purchase/security/purchase_security.xml
@@ -36,10 +36,6 @@
         <field name="implied_ids" eval="[(4, ref('purchase.group_send_reminder'))]"/>
     </record>
 
-    <record id="base.default_user" model="res.users">
-        <field name="group_ids" eval="[(4,ref('purchase.group_purchase_manager'))]"/>
-    </record>
-
     <record model="ir.rule" id="purchase_order_comp_rule">
         <field name="name">Purchase Order multi-company</field>
         <field name="model_id" ref="model_purchase_order"/>

--- a/addons/sales_team/data/crm_team_demo.xml
+++ b/addons/sales_team/data/crm_team_demo.xml
@@ -8,6 +8,10 @@
                 (4, ref('sales_team.group_sale_salesman'))]"/>
         </record>
 
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('sales_team.group_sale_manager'))]"/>
+        </record>
+
         <record model="crm.team" id="team_sales_department">
             <field name="name">Sales</field>
         </record>

--- a/addons/sales_team/security/sales_team_security.xml
+++ b/addons/sales_team/security/sales_team_security.xml
@@ -41,9 +41,5 @@
             <field name="model_id" ref="model_crm_team"/>
             <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
-
-        <record id="base.default_user" model="res.users">
-            <field name="group_ids" eval="[(4,ref('sales_team.group_sale_manager'))]"/>
-        </record>
     </data>
 </odoo>

--- a/addons/stock/data/stock_demo.xml
+++ b/addons/stock/data/stock_demo.xml
@@ -5,6 +5,11 @@
         <record id="base.user_demo" model="res.users">
             <field eval="[(3, ref('group_stock_manager')), (4, ref('group_stock_user'))]" name="group_ids"/>
         </record>
+
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('stock.group_stock_manager'))]"/>
+        </record>
+
          <record id="lot_product_27" model="stock.lot">
             <field name="name">0000000000029</field>
             <field name="product_id" ref="product.product_product_27"/>

--- a/addons/stock/security/stock_security.xml
+++ b/addons/stock/security/stock_security.xml
@@ -75,10 +75,6 @@
     </record>
 </data>
 <data noupdate="1">
-    <record id="base.default_user" model="res.users">
-        <field name="group_ids" eval="[(4,ref('stock.group_stock_manager'))]"/>
-    </record>
-
 <!-- multi -->
     <record model="ir.rule" id="stock_picking_rule">
         <field name="name">stock_picking multi-company</field>

--- a/addons/survey/data/res_users_demo.xml
+++ b/addons/survey/data/res_users_demo.xml
@@ -4,5 +4,9 @@
         <record id="base.user_demo" model="res.users">
             <field name="group_ids" eval="[(4, ref('survey.group_survey_user'))]"/>
         </record>
+
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('survey.group_survey_user'))]"/>
+        </record>
     </data>
 </odoo>

--- a/addons/survey/security/survey_security.xml
+++ b/addons/survey/security/survey_security.xml
@@ -20,10 +20,6 @@
             <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         </record>
 
-        <record id="base.default_user" model="res.users">
-            <field name="group_ids" eval="[(4, ref('group_survey_user'))]"/>
-        </record>
-
         <!-- SURVEY: SURVEY, PAGE, STAGE, QUESTION, LABEL -->
         <record id="survey_survey_rule_survey_manager" model="ir.rule">
             <field name="name">Survey: manager: all</field>

--- a/addons/web/static/src/webclient/res_user_group_ids_field/res_user_group_ids_field.js
+++ b/addons/web/static/src/webclient/res_user_group_ids_field/res_user_group_ids_field.js
@@ -9,7 +9,8 @@ import { FormRenderer } from "@web/views/form/form_renderer";
 import { Component } from "@odoo/owl";
 
 /**
- * This widget is only used for the 'group_ids' field of the 'res.users' form view,
+ * This widget is only used for the 'group_ids' field of the 'res.users'
+ * form view or the 'implied_ids' field of the 'res.groups' form view,
  * in order to vizualize and configure access rights.
  */
 export class ResUserGroupIdsField extends Component {
@@ -50,7 +51,7 @@ export class ResUserGroupIdsField extends Component {
 
     get values() {
         const values = {};
-        const ids = this.props.record.data.group_ids.currentIds;
+        const ids = this.props.record.data[this.props.name].currentIds;
         for (const category of this.categories) {
             values[this.getFieldName(category)] =
                 category.groups.find((g) => ids.includes(g[0]))?.[0] || false;

--- a/addons/website/data/website_demo.xml
+++ b/addons/website/data/website_demo.xml
@@ -620,6 +620,10 @@
     </data>
 
     <data noupdate="1">
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('website.group_website_designer'))]"/>
+        </record>
+
         <record id="website2" model="website">
             <field name="name">My Website 2</field>
             <field name="sequence">20</field>

--- a/addons/website/security/website_security.xml
+++ b/addons/website/security/website_security.xml
@@ -13,20 +13,9 @@
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         <field name="implied_ids" eval="[(4, ref('group_website_restricted_editor')), (4, ref('base.group_sanitize_override'))]"/>
         <field name="category_id" ref="base.module_category_website_website"/>
-    </record>
-
-    <record id="base.default_user" model="res.users">
-        <field name="group_ids" eval="[(4, ref('group_website_designer'))]"/>
-    </record>
-    <!-- FIXME: groups on existing users should probably be updated when implied_ids is, or existing users don't get the relevant implied groups on module installation... -->
-    <record id="base.user_admin" model="res.users">
-        <field name="group_ids" eval="[(4, ref('website.group_website_designer'))]"/>
-    </record>
-
-    <!-- NOTE: this group implication is needed so that any admin user can do the website onboarding
-        after website app installation. -->
-    <record id="base.group_system" model="res.groups">
-        <field name="implied_ids" eval="[(4, ref('website.group_website_designer'))]"/>
+        <!-- NOTE: this group implication is needed so that any admin user can do the website onboarding
+            after website app installation. -->
+        <field name="implied_by_ids" eval="[(4, ref('base.group_system'))]"/>
     </record>
 
     <data noupdate="1">

--- a/addons/website_slides/data/res_users_demo.xml
+++ b/addons/website_slides/data/res_users_demo.xml
@@ -8,5 +8,9 @@
         <record id="website_slides.group_website_slides_manager" model="res.groups">
             <field name="user_ids" eval="[(4, ref('base.user_admin')), (4, ref('base.user_root'))]"/>
         </record>
+
+        <record id="base.default_user_group" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('website_slides.group_website_slides_manager'))]"/>
+        </record>
     </data>
 </odoo>

--- a/addons/website_slides/security/website_slides_security.xml
+++ b/addons/website_slides/security/website_slides_security.xml
@@ -17,10 +17,6 @@
             <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         </record>
 
-        <record id="base.default_user" model="res.users">
-            <field name="group_ids" eval="[(4,ref('group_website_slides_manager'))]"/>
-        </record>
-
         <data noupdate="1">
         <!-- CHANNEL -->
         <record id="rule_slide_channel_global" model="ir.rule">

--- a/odoo/addons/base/data/res_users_data.xml
+++ b/odoo/addons/base/data/res_users_data.xml
@@ -25,13 +25,6 @@
             <field name="user_id" ref="base.user_admin"/>
         </record>
 
-        <!-- Default user with full access rights for newly created users -->
-        <record id="default_user" model="res.users">
-            <field name="name">Default User Template</field>
-            <field name="login">default</field>
-            <field name="active" eval="False"/>
-        </record>
-
         <record id="public_user" model="res.users">
             <field name="name">Public user</field>
             <field name="login">public</field>

--- a/odoo/addons/base/models/res_users_view.py
+++ b/odoo/addons/base/models/res_users_view.py
@@ -10,6 +10,13 @@ class ResGroups(models.Model):
     visible = fields.Boolean(related='category_id.visible', readonly=True)
     color = fields.Integer(string='Color Index')
 
+    # Field used for the widget to define the default group.
+
+    view_group_hierarchy = fields.Json(string='Technical field for default group setting', compute='_compute_view_group_hierarchy')
+
+    def _compute_view_group_hierarchy(self):
+        self.view_group_hierarchy = self._get_view_group_hierarchy()
+
     @api.model
     @tools.ormcache()
     def _get_view_group_hierarchy(self):

--- a/odoo/addons/base/security/base_groups.xml
+++ b/odoo/addons/base/security/base_groups.xml
@@ -53,14 +53,6 @@
             <field name="user_ids" eval="[Command.link(ref('base.user_root'))]"/>
             <field name="implied_by_ids" eval="[Command.link(ref('base.group_system'))]"/>
         </record>
-
-        <record id="default_user" model="res.users">
-            <field name="group_ids" eval="[
-                Command.link(ref('base.group_user')),
-                Command.link(ref('base.group_partner_manager')),
-                Command.link(ref('base.group_allow_export'))]"/>
-        </record>
-
         <!--
             A group dedicated to the portal users, making groups
             restrictions more convenient.
@@ -98,5 +90,12 @@
             <field name="value" ref="template_portal_user_id"/>
         </record>
 
+    </data>
+
+    <data noupdate="1">
+        <record id="default_user_group" model="res.groups">
+            <field name="name">Default access for new users</field>
+            <field name="category_id" ref="base.module_category_hidden"/>
+        </record>
     </data>
 </odoo>

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -296,22 +296,25 @@ class TestUsers2(UsersCommonCase):
                 "Setting a valid email as login should update the partner's email"
             )
 
-    def test_reified_groups(self):
+    def test_default_groups(self):
         """ The groups handler doesn't use the "real" view with pseudo-fields
         during installation, so it always works (because it uses the normal
         group_ids field).
         """
+        default_group = self.env.ref('base.default_user_group')
+        test_group = self.env['res.groups'].create({'name': 'test_group'})
+        default_group.implied_ids = test_group
+
         # use the specific views which has the pseudo-fields
         f = Form(self.env['res.users'], view='base.view_users_form')
         f.name = "bob"
         f.login = "bob"
         user = f.save()
 
-        self.assertIn(self.env.ref('base.group_user'), user.group_ids)
+        group_user = self.env.ref('base.group_user')
 
-        # all template user groups are copied
-        default_user = self.env.ref('base.default_user')
-        self.assertEqual(default_user.group_ids, user.group_ids)
+        self.assertIn(group_user, user.group_ids)
+        self.assertEqual(default_group.implied_ids + group_user, user.group_ids)
 
     def test_selection_groups(self):
         # create 3 groups that should be in a selection

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -151,6 +151,21 @@
         </record>
         <menuitem action="action_res_groups" id="menu_action_res_groups" parent="base.menu_users" groups="base.group_no_one" sequence="3"/>
 
+        <record id="view_default_groups_form" model="ir.ui.view">
+            <field name="name">res.groups default groups form</field>
+            <field name="model">res.groups</field>
+            <field name="priority">100</field>
+            <field name="arch" type="xml">
+                <form string="Groups">
+                  <sheet>
+                    <group>
+                        <field name="implied_ids" widget="res_user_group_ids" nolabel="1" colspan="2"/>
+                    </group>
+                  </sheet>
+                </form>
+            </field>
+        </record>
+
         <!-- res.users -->
         <record id="view_users_simple_form" model="ir.ui.view">
             <field name="name">res.users.simplified.form</field>

--- a/odoo/addons/test_convert/tests/test_env.py
+++ b/odoo/addons/test_convert/tests/test_env.py
@@ -39,14 +39,14 @@ class TestEnv(common.TransactionCase):
                     model="test_convert.usered",
                     id="test_convert.testing"
                 ),
-                uid="base.default_user"
+                uid="base.user_admin"
             )
         )
 
         r = self.env.ref('test_convert.testing')
         self.assertEqual(r.name, 'a')
-        self.assertEqual(r.create_uid, self.env.ref('base.default_user'))
-        self.assertEqual(r.user_id, self.env.ref('base.default_user'))
+        self.assertEqual(r.create_uid, self.env.ref('base.user_admin'))
+        self.assertEqual(r.user_id, self.env.ref('base.user_admin'))
 
     def test_uid_data_function(self):
         self.importer(
@@ -56,14 +56,14 @@ class TestEnv(common.TransactionCase):
                     name="create",
                     eval="[[{'name': 'b'}]]",
                 ),
-                uid="base.default_user"
+                uid="base.user_admin"
             )
         )
 
         r = self.env['test_convert.usered'].search([])
         self.assertEqual(r.name, 'b')
-        self.assertEqual(r.create_uid, self.env.ref('base.default_user'))
-        self.assertEqual(r.user_id, self.env.ref('base.default_user'))
+        self.assertEqual(r.create_uid, self.env.ref('base.user_admin'))
+        self.assertEqual(r.user_id, self.env.ref('base.user_admin'))
 
     def test_uid_record(self):
         self.importer(
@@ -72,7 +72,7 @@ class TestEnv(common.TransactionCase):
                     field('c', name="name"),
                     model="test_convert.usered",
                     id="test_convert.testing",
-                    uid="base.default_user"
+                    uid="base.user_admin"
                 ),
                 uid="base.user_root"
             )
@@ -80,8 +80,8 @@ class TestEnv(common.TransactionCase):
 
         r = self.env.ref('test_convert.testing')
         self.assertEqual(r.name, 'c')
-        self.assertEqual(r.create_uid, self.env.ref('base.default_user'))
-        self.assertEqual(r.user_id, self.env.ref('base.default_user'))
+        self.assertEqual(r.create_uid, self.env.ref('base.user_admin'))
+        self.assertEqual(r.user_id, self.env.ref('base.user_admin'))
 
 
     def test_uid_function(self):
@@ -90,7 +90,7 @@ class TestEnv(common.TransactionCase):
                 function(
                     model="test_convert.usered",
                     name="create",
-                    uid="base.default_user",
+                    uid="base.user_admin",
                     eval="[[{'name': 'd'}]]"
                 ),
                 uid="base.user_root"
@@ -98,8 +98,8 @@ class TestEnv(common.TransactionCase):
         )
         r = self.env['test_convert.usered'].search([])
         self.assertEqual(r.name, 'd')
-        self.assertEqual(r.create_uid, self.env.ref('base.default_user'))
-        self.assertEqual(r.user_id, self.env.ref('base.default_user'))
+        self.assertEqual(r.create_uid, self.env.ref('base.user_admin'))
+        self.assertEqual(r.user_id, self.env.ref('base.user_admin'))
 
     def test_context_data_function(self):
         self.env.user.tz = 'UTC'

--- a/odoo/addons/test_http/tests/test_static.py
+++ b/odoo/addons/test_http/tests/test_static.py
@@ -277,10 +277,10 @@ class TestHttpStatic(TestHttpStaticCommon):
 
     def test_static16_public_access_rights(self):
         self.authenticate(None, None)
-        default_user = self.env.ref('base.default_user')
+        user_template = self.env.ref('base.template_portal_user_id')
 
         with self.subTest('model access rights'):
-            res = self.url_open(f'/web/content/res.users/{default_user.id}/image_128')
+            res = self.url_open(f'/web/content/res.users/{user_template.id}/image_128')
             self.assertEqual(res.status_code, 404)
 
         with self.subTest('attachment + field access rights'):


### PR DESCRIPTION
[IMP] base: replace default user by a default groups

The default user was a strange use case and was confusing. Its
configuration using the users view but only the groups (and the
default_privacy calendar) was used as the default value.

The configuration is therefore directly focused on access and
therefore groups.

Another change is made: Changing this default value no longer affects
all users. Before, if you changed (voluntarily or not) the default user,
it would change all internal users). Therefore, adding a new addon often
added the manager level to all users. Now, only the administrator who
adds an addon will receive the manager role.

task: 4341594
