### PR TITLE
[FIX] mail: recipient list overflow when screen size is increased

### DIFF
--- a/addons/mail/static/src/core/web/base_recipients_list.js
+++ b/addons/mail/static/src/core/web/base_recipients_list.js
@@ -1,12 +1,10 @@
 import { _t } from "@web/core/l10n/translation";
 import { escape } from "@web/core/utils/strings";
-import { formatList } from "@web/core/l10n/utils";
 import { markup, Component } from "@odoo/owl";
 import { usePopover } from "@web/core/popover/popover_hook";
 
 import { RecipientList } from "@mail/core/web/recipient_list";
 import { Thread } from "@mail/core/common/thread_model";
-
 
 export class BaseRecipientsList extends Component {
     static template = "mail.BaseRecipientsList";
@@ -19,19 +17,23 @@ export class BaseRecipientsList extends Component {
 
     /** @returns {Markup} */
     getRecipientListToHTML() {
-        const recipients = this.props.thread.recipients.slice(0, 5).map((
-            { partner }) => {
-                return `<span class="text-muted" title="${escape(
-                    partner.email || _t("no email address")
-                )}">${escape(partner.name)}</span>`;
-            });
+        const recipients = this.props.thread.recipients.slice(0, 5).map(({ partner }) => {
+            return `<span class="text-muted" title="${escape(
+                partner.email || _t("no email address")
+            )}"> ${escape(partner.name)}</span>`;
+        });
+        return markup(recipients);
+    }
+
+    getRecipientCount() {
         if (this.props.thread.recipients.length > 5) {
-            recipients.push(escape(
-                _t("%(recipientCount)s more", {
-                    recipientCount: this.props.thread.recipients.length - 5}))
+            return escape(
+                _t(" out of %(recipientCount)s", {
+                    recipientCount: this.props.thread.recipients.length,
+                })
             );
         }
-        return markup(formatList(recipients));
+        return "";
     }
 
     /** @param {Event} ev */
@@ -40,7 +42,7 @@ export class BaseRecipientsList extends Component {
             return this.recipientsPopover.close();
         }
         this.recipientsPopover.open(ev.target, {
-            thread: this.props.thread
+            thread: this.props.thread,
         });
     }
 };

--- a/addons/mail/static/src/core/web/base_recipients_list.xml
+++ b/addons/mail/static/src/core/web/base_recipients_list.xml
@@ -2,10 +2,15 @@
 <templates>
     <t t-name="mail.BaseRecipientsList">
         <t t-if="props.thread.recipients.length > 0">
-            <t t-out="getRecipientListToHTML()"/>
-            <button class="o-mail-BaseRecipientsList-caret btn btn-link badge rounded-pill border-0 p-1" title="Show all recipients" t-on-click="onClickRecipientList">
-                <i class="fa fa-caret-down"/>
-            </button>
+            <div class="d-flex">
+                <span class="d-flex overflow-hidden">
+                    <span t-out="getRecipientListToHTML()" class="ps-1 text-truncate"/>
+                    <span t-out="getRecipientCount()" class="ps-1"/>
+                </span>
+                <button class="o-mail-BaseRecipientsList-caret btn btn-link badge rounded-pill border-0 p-1" title="Show all recipients" t-on-click="onClickRecipientList">
+                    <i class="fa fa-caret-down"/>
+                </button>
+            </div>
         </t>
     </t>
 </templates>

--- a/addons/mail/static/src/core/web/mail_composer_bcc_list.js
+++ b/addons/mail/static/src/core/web/mail_composer_bcc_list.js
@@ -1,5 +1,4 @@
 import { MailComposerBccPopover } from "@mail/core/web/mail_composer_bcc_list_popover";
-import { formatList } from "@web/core/l10n/utils";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
@@ -27,17 +26,22 @@ export class MailComposerBccList extends Component {
             elements.push(`
                 <span class="text-muted" title="${escape(
                     partner.email_normalized || _t("no email address")
-                )}">${escape(partner.name)}</span>
+                )}"> ${escape(partner.name)}</span>
             `);
         }
+        return markup(elements);
+    }
+
+    getRecipientCount() {
+        const records = this.getRecords();
         if (records.length > this.limit) {
-            elements.push(escape(
-                _t("%(recipientCount)s more", {
-                    recipientCount: records.length - this.limit
-                }))
+            return escape(
+                _t(" out of %(recipientCount)s", {
+                    recipientCount: records.length,
+                })
             );
         }
-        return markup(formatList(elements));
+        return "";
     }
 
     /** @returns {Array[Record]} */
@@ -71,7 +75,7 @@ export const mailComposerBccList = {
     relatedFields: (fieldInfo) => {
         return [
             { name: "name", type: "char" },
-            { name: "email_normalized", type: "char" }
+            { name: "email_normalized", type: "char" },
         ];
     },
 };

--- a/addons/mail/static/src/core/web/mail_composer_bcc_list.xml
+++ b/addons/mail/static/src/core/web/mail_composer_bcc_list.xml
@@ -2,10 +2,15 @@
 <templates>
     <t t-name="mail.MailComposerBccList">
         <t t-if="hasRecipients()">
-            <t t-out="getRecipientListToHTML()"/>
-            <button class="btn btn-link badge rounded-pill border-0 p-1" title="Show all recipients" t-if="hasMoreRecipients()" t-on-click="onClickRecipientList">
-                <i class="fa fa-caret-down"/>
-            </button>
+            <div class="d-flex">
+                <span class="d-flex overflow-hidden">
+                    <span t-out="getRecipientListToHTML()" class="ps-1 text-truncate"/>
+                    <span t-out="getRecipientCount()" class="ps-1"/>
+                </span>
+                <button class="btn btn-link badge rounded-pill border-0 p-1" title="Show all recipients" t-if="hasMoreRecipients()" t-on-click="onClickRecipientList">
+                    <i class="fa fa-caret-down"/>
+                </button>
+            </div>
         </t>
     </t>
 </templates>


### PR DESCRIPTION
Purpose of this commit:
When the recipient list exceeds 5, the text 'X more recipients' is displayed. However, when the screen is zoomed, the list overflows, making the 'Show all recipients' button inaccessible. This issue occurred because the recipient list and the 'X other recipients' text were treated as a single string, preventing overflow. This commit splits the string into two parts: the recipient list, which will overflow, and the recipient count, which remains visible when the list is large.

saas-17.4: https://github.com/odoo/odoo/pull/191880

task-4417552





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
