### PR TITLE
[FIX] point_of_sale: add html field to manifest

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -131,6 +131,7 @@
             'web/static/lib/owl/owl.js',
             'web/static/lib/owl/odoo_module.js',
             'web/static/lib/zxing-library/zxing-library.js',
+            'web/static/lib/dompurify/DOMpurify.js',
 
 
             ('include', 'point_of_sale.base_app'),
@@ -178,6 +179,8 @@
             ('remove', 'web/static/src/webclient/actions/reports/layout_assets/**/*'),
             ('remove', 'web/static/src/webclient/actions/**/*css'),
             'web/static/src/webclient/company_service.js',
+
+            'html_editor/static/src/**/*',
         ],
         'point_of_sale.base_tests': [
             "web/static/lib/hoot-dom/**/*",

--- a/addons/point_of_sale/static/src/app/html_editor/html_editor.js
+++ b/addons/point_of_sale/static/src/app/html_editor/html_editor.js
@@ -1,0 +1,13 @@
+import { HtmlField } from "@html_editor/fields/html_field";
+import { CORE_PLUGINS } from "@html_editor/plugin_sets";
+import { patch } from "@web/core/utils/patch";
+
+patch(HtmlField.prototype, {
+    getConfig() {
+        const config = super.getConfig();
+        return {
+            ...config,
+            Plugins: CORE_PLUGINS,
+        };
+    },
+});


### PR DESCRIPTION
Before this commit comment field in calendar_event_view_form_gantt_booking used in pos restaurant does not display properly html field.

Fixed by importing the html editor to the point_of_sale manifest.

task-4547369
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
