### PR TITLE
[FIX] l10n_mx_edi: cancel payment when move is canceled

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5333,6 +5333,7 @@ class AccountMove(models.Model):
         if any(move.state != 'draft' for move in self):
             raise UserError(_("Only draft journal entries can be cancelled."))
 
+        self.payment_ids.state = "canceled"
         self.write({'auto_post': 'no', 'state': 'cancel'})
 
     def action_toggle_block_payment(self):

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -105,6 +105,10 @@ class TestAccountPayment(AccountTestInvoicingCommon):
             expected_liquidity_line,
         ])
 
+        # Cancel the move.
+        payment.move_id.button_cancel()
+        self.assertRecordValues(payment, [{'state': 'canceled'}])
+
     def test_payment_move_sync_update_journal_custom_accounts(self):
         """The objective is to edit the journal of a payment in order to check if the accounts are updated."""
 


### PR DESCRIPTION
Since Odoo 18.0, account.payment no longer inherits from account.move. As a result, canceling a payment with `_l10n_mx_edi_cfdi_move_post_cancel` does not automatically cancel the associated payment record.

Steps to reproduce:
- Ensure the Mexican localization is installed and properly configured.
- Generate an invoice and sign it with the government (CFDI).
- Create and sign a payment for the invoice.
- Cancel the payment from the CFDI table.

Current behavior:
- Odoo cancels the move, but the related payment remains posted.

Expected behavior:
- The payment should also be canceled when the move is canceled.

This fix ensures that the associated payment is canceled correctly.

opw-4528910
