### PR TITLE
[FIX] web: m2m_tags: do not forget/link to reload after edit

### DIFF
--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -89,12 +89,10 @@ export class Many2ManyTagsField extends Component {
                 onDelete: removeRecord,
                 edit: this.props.record.isInEdition,
             },
-            getEvalParams: (props) => {
-                return {
-                    evalContext: this.evalContext,
-                    readonly: props.readonly,
-                };
-            },
+            getEvalParams: (props) => ({
+                evalContext: this.evalContext,
+                readonly: props.readonly,
+            }),
         });
 
         this.openMany2xRecord = useOpenMany2XRecord({
@@ -103,17 +101,17 @@ export class Many2ManyTagsField extends Component {
                 create: false,
                 write: true,
             },
-            onRecordSaved: async (record) => {
-                await this.props.record.data[this.props.name].forget(record);
-                return saveRecord([record.resId]);
+            onRecordSaved: (record) => {
+                const records = this.props.record.data[this.props.name].records;
+                return records.find((r) => r.resId === record.resId).load();
             },
         });
 
         this.update = (recordlist) => {
             recordlist = recordlist
-                ? recordlist.filter((element) => {
-                      return !this.tags.some((record) => record.resId === element.id);
-                  })
+                ? recordlist.filter(
+                      (element) => !this.tags.some((record) => record.resId === element.id)
+                  )
                 : [];
             if (!recordlist.length) {
                 return;

--- a/addons/web/static/tests/views/fields/many2many_tags_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field.test.js
@@ -101,9 +101,7 @@ class Turtle extends models.Model {
 
 defineModels([Partner, PartnerType, Turtle]);
 
-onRpc("has_group", () => {
-    return true;
-});
+onRpc("has_group", () => true);
 
 test.tags("desktop");
 test("Many2ManyTagsField with and without color on desktop", async () => {
@@ -1937,12 +1935,12 @@ test("Many2ManyTagsField with edit_tags option", async () => {
 });
 
 test("Many2ManyTagsField with edit_tags option overrides color edition", async () => {
-    expect.assertions(4);
+    expect.assertions(9);
 
     PartnerType._views = {
         form: `<form><field name="name"/><field name="color"/></form>`,
     };
-    Partner._records[0].timmy = [12];
+    Partner._records[0].timmy = [12, 14];
 
     onRpc("get_formview_id", ({ args }) => {
         expect(args[0]).toEqual([12], {
@@ -1964,6 +1962,9 @@ test("Many2ManyTagsField with edit_tags option overrides color edition", async (
         resId: 1,
     });
 
+    expect(".o_field_widget[name=timmy] .o_badge").toHaveCount(2);
+    expect(queryAllTexts(".o_field_widget[name=timmy] .o_badge")).toEqual(["gold", "silver"]);
+
     // Click to try to open form view dialog
     expect(".o_dialog").toHaveCount(0);
     await contains(".o_tag.badge").click();
@@ -1972,6 +1973,10 @@ test("Many2ManyTagsField with edit_tags option overrides color edition", async (
     // Edit name of tag
     await fieldInput("name").edit("new");
     await clickSave();
+
+    expect(".o_field_widget[name=timmy] .o_badge").toHaveCount(2);
+    expect(queryAllTexts(".o_field_widget[name=timmy] .o_badge")).toEqual(["new", "silver"]);
+    expect(".o_form_status_indicator_buttons").not.toBeVisible();
 });
 
 test.tags("mobile");


### PR DESCRIPTION
Have a many2many_tags widget with `edit_tags` option enabled. Click on a tag to edit it, make a change in the dialog and click save. Before this commit, for the change to be reflected in the tag, we generated a forget command (3), followed by a link_to (4).

As already pointed out here [1], this hack had some drawbacks: the tag order was lost upon edition, as the edited tag was moved to the end.

There was another problem. For one2many fields whose corresponding many2one has constraint `ondelete cascade`, commands 3 are treated like commands delete (2). As a consequence, in that kind of setup, editing a tag actually deleted it.

To fix those issues, this commit simply forces a reload of the edited tag, instead using the commands 3 and 4.

[1] https://github.com/odoo/odoo/pull/165935#pullrequestreview-2068519552

Task-4567058

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
