### PR TITLE
[FIX] product: set product_uom_id value in product supplier

### DIFF
--- a/addons/product/models/product_supplierinfo.py
+++ b/addons/product/models/product_supplierinfo.py
@@ -70,7 +70,8 @@ class ProductSupplierinfo(models.Model):
     @api.depends('discount', 'price')
     def _compute_price_discounted(self):
         for rec in self:
-            rec.price_discounted = rec.product_uom_id._compute_price(rec.price, rec.product_id.uom_id) * (1 - rec.discount / 100)
+            uom = rec.product_uom_id or rec.product_id.uom_id
+            rec.price_discounted = uom._compute_price(rec.price, rec.product_id.uom_id) * (1 - rec.discount / 100)
 
     @api.depends('product_id', 'product_tmpl_id', 'product_variant_count')
     def _compute_product_id(self):


### PR DESCRIPTION
Currently, a traceback will occur when the user tries to replenish 
a product that has a supplier record without UOM.

To reproduce this issue:

1) Install Purchase_stock and enable UOM from settings
2) Create a supplier record with no UOM from the product 
3) Now try to replenish the product.

Error:- 
```
ValueError: Expected singleton: uom.uom()
```

Clearly `product_uom_id` is not a required field in the `product.supplier` 
So the user can create a supplier record with no `product_uom_id` value.

This will result in the traceback mentioned above when the `_compute_price_discounted` 
method attempts to calculate the value of `price_discounted`.

https://github.com/odoo/odoo/blob/4f58eb9db55c102786010efe3c1fb74edefaf8f3/addons/product/models/product_supplierinfo.py#L71-L73

We can resolve this issue by taking the `UOM` from product if there is no uom

sentry-6307994434


