### PR TITLE
[FIX] purchase_stock: merge moves disrespect `date_deadline`

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -24,7 +24,7 @@ class StockMove(models.Model):
 
     @api.model
     def _prepare_merge_negative_moves_excluded_distinct_fields(self):
-        excluded_fields = super()._prepare_merge_negative_moves_excluded_distinct_fields() + ['created_purchase_line_id']
+        excluded_fields = super()._prepare_merge_negative_moves_excluded_distinct_fields() + ['created_purchase_line_id', 'date_deadline']
         if self.env['ir.config_parameter'].sudo().get_param('purchase_stock.merge_different_procurement'):
             excluded_fields += ['procure_method']
         return excluded_fields


### PR DESCRIPTION
**Current behavior:**
Having some purchase order created via replenishment/orderpoint, chaing the quantity of POL does not properly impact the quantity of a picking beyond the first in a multi-step-reception chain.

**Expected behavior:**
Changing the quantity of an order line should impact all pickings in a multi-step-reception chain.

**Steps to reproduce:**
1. Make some product with MTO + Buy routes

2. Create an out move for 10 of that product

3. Trigger the replenishment

4. Before confirming the auto-generated purchase order, change the POL quantity

5. Confirm the purchase, look up all the transfers for this product to see that we have an extra internal picking (failure to merge)

**Cause of the issue:**
When confirming the out move / delivery, an internal picking `Input -> Stock` is also created- when we confirm the auto-created purchase order, the 2nd picking in the multi-step reception chain should merge with it.

But, because the initial internal picking does not have a `date_deadline` because it has no top-level document (SO/PO), they can not be merged.

**Fix:**
Ignore `date_deadline` when trying to merge a negative quantity move.

opw-4457768