### PR TITLE
[FIX] account: compute account error

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1727,7 +1727,7 @@ class AccountTax(models.Model):
             'analytic_distribution': (
                 base_line_grouping_key['analytic_distribution']
                 if tax.analytic or not tax_rep.use_in_tax_closing
-                else {}
+                else False
             ),
             'account_id': tax_rep_data['account'].id or base_line_grouping_key['account_id'],
             'tax_ids': [Command.set(tax_rep_data['taxes'].ids)],

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -956,3 +956,25 @@ class TestAccountAccount(TestAccountMergeCommon):
             child_group,
             "group_id computation should work if company_id is not in self.env.companies"
         )
+
+    def test_compute_account(self):
+        account_sale = self.company_data['default_account_revenue'].copy()
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'account_id': account_sale.id,
+                    'product_id': self.product_a.id,
+                    'quantity': 1,
+                    'price_unit': 100,
+                })
+            ]
+        })
+
+        self.assertEqual(invoice.invoice_line_ids.account_id, account_sale)
+
+        invoice.line_ids._compute_account_id()
+
+        self.assertEqual(invoice.invoice_line_ids.account_id, self.company_data['default_account_revenue'])


### PR DESCRIPTION
When calling `account_move_line._compute_account_id` (via
`action_update_fpos_values` for example), we wrongly delete a line after
after assigning a new account here https://github.com/odoo/odoo/blob/22bdaf64ff3f2ee37cd51f0938d1bdd80f9e5ee8/addons/account/models/account_move_line.py#L599-L602

This is because we set a default value for `analytic_distribution` in
`_prepare_base_line_tax_repartition_grouping_key`, therefore we enter
in the wrong condition here https://github.com/odoo/odoo/blob/6ff943b30561f2d7415fdbdfc2246716428779be/addons/account/models/account_tax.py#L2407
because in `grouping_key`, we have `{'analytic_distribution': {}}` and in `tax_lines_mapping` we have`{'analytic_distribution': False}`

Steps:

- Have a fiscal position that map the default revenue account to another
- Create an invoice with the fiscal position created previously, add a
  product line
- Unset fiscal position, and click on 'Update Taxes and Accounts' button
-> Error: "Record does not exist or has been deleted."

opw-4512877
