### PR TITLE
[FIX] website_sale: display multicheckbox attribute filters on mobile

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -685,7 +685,7 @@
                                         <div t-if="a.display_type == 'color'" class="pt-1 pb-3">
                                             <t t-call="website_sale.o_wsale_offcanvas_color_attribute"/>
                                         </div>
-                                        <div t-elif="a.display_type in ('radio', 'pills', 'select')"
+                                        <div t-elif="a.display_type in ('radio', 'pills', 'select', 'multi')"
                                              class="list-group list-group-flush">
                                             <div t-foreach="a.value_ids" t-as="v" class="list-group-item border-0 ps-0 pb-0">
                                                 <div class="form-check mb-1">


### PR DESCRIPTION
## Versions:
17.0+

## Issue:
Multi-checkboxes attributes are displayed as filters in the shop view but are not displayed in mobile view.

## Steps to reproduce:
1. Create a `Multi-checkbox (option)` attribute called "Extra" via `Sales / Configuration / Products / Attributes`;
2. Add 1 attribute value;
3. Go to any product available on the shop (e.g. Acoustic Bloc Screens);
4. Via its `Attributes & Variants` tab, add the newly created attributes and select the value;
5. Go to the shop via the `Website` app;
    - *In normal web view, the filter is available on the left*
6. Change view to mobile mode and open the filters;
7. Open the "Extra filter and see no filter under it.

## Cause:
Mobile displayed filters are restricted to avoid color attributes but didn't expand to allow multi-checkboxes.


opw-4383970