### PR TITLE
[FIX] hr: prevent error while getting default departure date

### DIFF
--- a/addons/hr/wizard/hr_departure_wizard.py
+++ b/addons/hr/wizard/hr_departure_wizard.py
@@ -10,7 +10,7 @@ class HrDepartureWizard(models.TransientModel):
     def _get_default_departure_date(self):
         if len(active_ids := self.env.context.get('active_ids', [])) == 1:
             employee = self.env['hr.employee'].browse(active_ids[0])
-            departure_date = employee._get_departure_date()
+            departure_date = employee and employee._get_departure_date()
         else:
             departure_date = False
 


### PR DESCRIPTION
Currently, an exception is raised when a user attempts to archive a new employee before saving.

Steps to Reproduce:

1. Install the HR module.
2. Navigate to the Employee Module.
3. Try to archive a new employee before saving.
4. An error occurs.

Error:
`ValueError
Expected singleton: hr.employee()
`

This issue occurs when a user tries to archive a new employee before saving because the system expects a default departure date for the employee, which can't be set properly without saving the employee record first.

[1] -
https://github.com/odoo/odoo/blob/4f58eb9db55c102786010efe3c1fb74edefaf8f3/addons/hr/wizard/hr_departure_wizard.py#L13

This fix resolves the issue by first checking if the employee exists, and then proceeding to find the departure date.

sentry-6301787988

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
