### PR TITLE
[FIX] base,web: fix kanban & server actions style

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -79,10 +79,9 @@
         @include media-only(screen) {
             --ControlPanel-border-bottom: none;
         }
-    }
-
-    &.o_field_x2many_kanban .o_kanban_ghost {
-        display: none;
+        &.o_field_x2many_kanban .o_kanban_ghost {
+            display: none;
+        }
     }
 }
 

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -404,7 +404,7 @@
                             'is_modal': 1,
                             'default_model_id': model_id,
                         }"/>
-                        <p class="opacity-50 mb-1 mt-3" invisible="state != 'multi'">
+                        <p class="opacity-50 mb-1 mt-3 mt-md-n2 mt-lg-0" invisible="state != 'multi'">
                             If several actions return an action, only the last one will be executed.
                         </p>
                         <notebook invisible="state != 'code'">


### PR DESCRIPTION
Since [1] a CSS rule made ghosts kanban cards to never get displayed when the view was rendered through an x2m field.

The author (me) only wanted to get rid of the bottom spacing induced by ghosts cards in the `multi` type server actions form view.

This commit reverses the introduced diff in [1] and changes the strategy to target only what is needed.

[1]: https://github.com/odoo/odoo/commit/45a5562fc41b5a1ab2fb46ba025f191a5401c078#diff-368e56feea5bb220fcafabbf45b40131fdd3d496fe0f2643a9df5cdec61cb190R82-R86
