### PR TITLE
[FIX] web: use user.evalContext on invisible for searchModel

### DIFF
--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -633,7 +633,7 @@ export class SearchModel extends EventBus {
             if (enrichedSearchitem) {
                 const isInvisible =
                     "invisible" in searchItem &&
-                    evaluateExpr(searchItem.invisible, this.globalContext);
+                    evaluateExpr(searchItem.invisible, this.domainEvalContext);
                 if (!isInvisible && (!predicate || predicate(enrichedSearchitem))) {
                     searchItems.push(enrichedSearchitem);
                 }
@@ -882,7 +882,7 @@ export class SearchModel extends EventBus {
             resModel: this.resModel,
             defaultConnector: "|",
             domain,
-            context: this.domainEvalContext,
+            context: this.globalContext,
             onConfirm: (domain) => this.splitAndAddDomain(domain),
             disableConfirmButton: (domain) => domain === `[]`,
             title: _t("Add Custom Filter"),

--- a/addons/web/static/tests/search/search_model.test.js
+++ b/addons/web/static/tests/search/search_model.test.js
@@ -1045,6 +1045,34 @@ test("filter tags with invisible attribute", async () => {
     expect(filters).toEqual(["filter2"]);
 });
 
+test("field tags with invisible attribute - evalContext", async () => {
+    const model = await createSearchModel({
+        searchViewArch: `
+            <search>
+                <field name="foo" invisible="companies.active_id"/>
+                <field name="bar" invisible="companies.active_id == 2"/>
+            </search>
+        `,
+    });
+    const fields = model.getSearchItems((f) => f.type === "field").map((item) => item.fieldName);
+    expect(fields).toEqual(["bar"]);
+});
+
+test("filter tags with invisible attribute - evalContext", async () => {
+    const model = await createSearchModel({
+        searchViewArch: `
+            <search>
+                <filter name="filter1" string="Invisible ABC" domain="[]" invisible="companies.active_id"/>
+                <filter name="filter2" string="Invisible DEF" domain="[]" invisible="companies.active_id == 2"/>
+            </search>
+        `,
+    });
+    const filters = model
+        .getSearchItems((item) => ["filter", "dateFilter"].includes(item.type))
+        .map((item) => item.name);
+    expect(filters).toEqual(["filter2"]);
+});
+
 test("no search items created for search panel sections", async () => {
     const model = await createSearchModel(
         {


### PR DESCRIPTION
Since [1] it's possible to use the `user.evalContext` and the newly introduced key `companies` on the domain in the searchModel.
But it wasn't possible to use the `user.evalContext` on the invisible attribute of the filter and field tags of the searchModel.

This PR fixes this issue and allows the use of `user.evalContext` and the newly introduced key `companies` on the invisible attributes of the tags on the searchModel.

[1] : https://github.com/odoo/odoo/commit/19b450d4a222ec817eb2af6edab87044428e0d28