### PR TITLE
[IMP] im_livechat, mail: view and search expertises in livechat invite

### DIFF
--- a/addons/im_livechat/i18n/im_livechat.pot
+++ b/addons/im_livechat/i18n/im_livechat.pot
@@ -699,6 +699,8 @@ msgid "Enabled only if no operator"
 msgstr ""
 
 #. module: im_livechat
+#. odoo-javascript
+#: code:addons/im_livechat/static/src/core/web/channel_invitation_patch.xml:0
 #: model:ir.actions.act_window,name:im_livechat.expertise_action
 #: model:ir.ui.menu,name:im_livechat.expertise_menu
 msgid "Expertise"
@@ -1614,6 +1616,12 @@ msgstr ""
 #. module: im_livechat
 #: model_terms:ir.ui.view,arch_db:im_livechat.discuss_channel_view_search
 msgid "Search history"
+msgstr ""
+
+#. module: im_livechat
+#. odoo-javascript
+#: code:addons/im_livechat/static/src/core/web/channel_invitation_patch.js:0
+msgid "Search people, languages or expertise"
 msgstr ""
 
 #. module: im_livechat

--- a/addons/im_livechat/static/src/core/web/channel_invitation_patch.js
+++ b/addons/im_livechat/static/src/core/web/channel_invitation_patch.js
@@ -1,0 +1,12 @@
+import { ChannelInvitation } from "@mail/discuss/core/common/channel_invitation";
+import { _t } from "@web/core/l10n/translation";
+import { patch } from "@web/core/utils/patch";
+
+patch(ChannelInvitation.prototype, {
+    get searchPlaceholder() {
+        if (this.props.thread?.channel_type === "livechat") {
+            return _t("Search people, languages or expertise");
+        }
+        return super.searchPlaceholder;
+    },
+});

--- a/addons/im_livechat/static/src/core/web/channel_invitation_patch.xml
+++ b/addons/im_livechat/static/src/core/web/channel_invitation_patch.xml
@@ -5,10 +5,21 @@
             <t t-if="props.thread?.channel_type !== 'livechat' or !selectablePartner.lang_name">$0</t>
             <div t-else="" class="d-flex flex-column flex-grow-1">
                 <t>$0</t>
-                <span class="mx-2 text-truncate text-start fs-6">
-                    <i class="fa fa-comment-o me-1" aria-label="Lang"/>
-                    <t t-esc="selectablePartner.lang_name"/>
-                </span>
+                <div class="d-flex flex-wrap align-items-center gap-1 ms-2">
+                    <span class="d-flex text-start fs-6 gap-1">
+                        <i class="fa fa-fw fa-comment-o" title="Language"/>
+                        <span class="badge rounded text-bg-primary" t-esc="selectablePartner.lang_name"/>
+                        <t t-foreach="selectablePartner.livechat_languages" t-as="language" t-key="index">
+                            <span class="badge rounded text-bg-primary" t-esc="language"/>
+                        </t>
+                    </span>
+                    <span class="d-flex text-start fs-6 gap-1">
+                        <i t-if="selectablePartner.livechat_expertise.length" class="fa fa-fw fa-graduation-cap" title="Expertise"/>
+                        <t t-foreach="selectablePartner.livechat_expertise" t-as="expertise" t-key="index">
+                            <span class="badge rounded text-bg-info bg-opacity-75 o-text-white" t-esc="expertise"/>
+                        </t>
+                    </span>
+                </div>
             </div>
         </xpath>
     </t>

--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -8372,7 +8372,7 @@ msgstr ""
 
 #. module: mail
 #. odoo-javascript
-#: code:addons/mail/static/src/discuss/core/common/channel_invitation.xml:0
+#: code:addons/mail/static/src/discuss/core/common/channel_invitation.js:0
 msgid "Search people to invite"
 msgstr ""
 

--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -4,7 +4,7 @@ from odoo import api, fields, models
 from odoo.osv import expression
 from odoo.tools import SQL
 from odoo.addons.mail.tools.discuss import Store
-
+from odoo.fields import Domain
 
 class ResPartner(models.Model):
     _inherit = "res.partner"
@@ -30,17 +30,18 @@ class ResPartner(models.Model):
         count = self._search_for_channel_invite(store, search_term, channel_id, limit)
         return {"count": count, "data": store.get_result()}
 
+    def _get_search_for_channel_invite_term_domain(self, channel_id, search_term):
+        return (
+            Domain("name", "ilike", search_term) |
+            Domain("email", "ilike", search_term)
+        )
+
     @api.readonly
     @api.model
     def _search_for_channel_invite(self, store: Store, search_term, channel_id=None, limit=30):
         domain = expression.AND(
             [
-                expression.OR(
-                    [
-                        [("name", "ilike", search_term)],
-                        [("email", "ilike", search_term)],
-                    ]
-                ),
+                self._get_search_for_channel_invite_term_domain(channel_id, search_term),
                 [('id', '!=', self.env.user.partner_id.id)],
                 [("active", "=", True)],
                 [("user_ids", "!=", False)],

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -101,6 +101,10 @@ export class ChannelInvitation extends Component {
         );
     }
 
+    get searchPlaceholder() {
+        return _t("Search people to invite");
+    }
+
     async fetchPartnersToInvite() {
         const results = await this.sequential(() =>
             this.orm.call("res.partner", "search_for_channel_invite", [

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -11,7 +11,7 @@
     <t t-name="discuss.ChannelInvitation.main">
         <div class="d-flex flex-column flex-grow-1 bg-inherit" t-att-class="{ 'o-mail-Discuss-threadActionPopover w-100': props.hasSizeConstraints, 'px-1': !props.thread }">
             <t t-if="store.self.type === 'partner'">
-                <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-white" t-att-value="searchStr" t-ref="input" placeholder="Search people to invite" t-on-input="onInput"/>
+                <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-white" t-att-value="searchStr" t-ref="input" t-att-placeholder="searchPlaceholder" t-on-input="onInput"/>
                 <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': selectablePartners.length === 0 }">
                     <div t-if="selectablePartners.length === 0" class="small text-muted mx-1 fst-italic">
                         <t t-if="props.thread">No user found that is not already a member of this channel.</t>


### PR DESCRIPTION
This commit improves the invite people popover for livechat conversations. Before this commit we would only display the user language for Odoo next to his name in the search results, we now also display the user-selected livechat languages and expertises.
This commit also expands the search to be not only on the name but also the languages and expertises

task-4523464
