### PR TITLE
[FIX] point_of_sale: fix line with note from still being marked as changed after ordering

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -319,6 +319,8 @@ export class PosOrder extends Base {
                 if (this.last_order_preparation_change.lines[line.preparationKey]) {
                     this.last_order_preparation_change.lines[line.preparationKey]["quantity"] =
                         line.get_quantity();
+                    this.last_order_preparation_change.lines[line.preparationKey]["note"] =
+                        line.getNote();
                 } else {
                     this.last_order_preparation_change.lines[line.preparationKey] = {
                         attribute_value_ids: line.attribute_value_ids.map((a) => ({

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -59,8 +59,7 @@ export class PosOrderline extends Base {
     }
 
     get preparationKey() {
-        const note = this.getNote();
-        return `${this.uuid} - ${note}`;
+        return this.uuid;
     }
 
     get quantityStr() {

--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -50,7 +50,7 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
     for (const orderline of order.get_orderlines()) {
         const product = orderline.get_product();
         const note = orderline.getNote();
-        const lineKey = `${orderline.uuid} - ${note}`;
+        const lineKey = orderline.uuid;
         const productCategoryIds = product.parentPosCategIds.filter((id) =>
             prepaCategoryIds.has(id)
         );


### PR DESCRIPTION
Steps to Reproduce:

- Open POS restaurant.
- Select a table.
- Order some food.
- Return to the floor plan.
- Select the same table again.
- Add a kitchen note to a line.
- Click Order.
- The note update is correctly sent to the preparation display. The "order" button is still displayed and the line with the note is still marked as “changed”.

