### PR TITLE
[IMP] mail, various: improve default / suggested recipients usage

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -154,6 +154,8 @@ class AccountMoveSend(models.AbstractModel):
 
     @api.model
     def _get_default_mail_partner_ids(self, move, mail_template, mail_lang):
+        # TDE FIXME: this should use standard composer / template code to be sure
+        # it is aligned with standard recipients management. Todo later
         partners = self.env['res.partner'].with_company(move.company_id)
         if mail_template.use_default_to:
             defaults = move._message_get_default_recipients()[move.id]

--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -108,7 +108,7 @@ class CalendarAttendee(models.Model):
             "use_default_to": True,
         }
 
-    def _message_get_default_recipients(self, with_cc=False):
+    def _message_get_default_recipients(self, with_cc=False, all_tos=False):
         # override: partner_id being the only stored field, we can currently
         # simplify computation, we have no other choice than relying on it
         return {

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -360,10 +360,10 @@ class EventRegistration(models.Model):
             registration_id=self.id,
         )
 
-    def _message_get_default_recipients(self, with_cc=False):
+    def _message_get_default_recipients(self, with_cc=False, all_tos=False):
         # Prioritize registration email over partner_id, which may be shared when a single
         # partner booked multiple seats
-        results = super()._message_get_default_recipients(with_cc=with_cc)
+        results = super()._message_get_default_recipients(with_cc=with_cc, all_tos=all_tos)
         for record in self:
             email_to = results[record.id]['email_to']
             if email_to:

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -26,13 +26,13 @@ from markupsafe import Markup, escape
 from requests import Session
 from werkzeug import urls
 
-from odoo import _, api, exceptions, fields, models, Command, tools
+from odoo import _, api, exceptions, fields, models, Command
 from odoo.addons.mail.tools.discuss import Store
 from odoo.addons.mail.tools.web_push import push_to_end_point, DeviceUnreachableError
 from odoo.exceptions import MissingError, AccessError
 from odoo.osv import expression
 from odoo.tools import (
-    is_html_empty, html_escape, html2plaintext, parse_contact_from_email,
+    is_html_empty, html_escape, html2plaintext,
     clean_context, split_every, Query, SQL,
     ormcache, is_list_of,
 )
@@ -2071,126 +2071,6 @@ class MailThread(models.AbstractModel):
                 # use an "OR" to avoid duplicates in returned recordset
                 found_results[res_id] |= partner
         return found_results
-
-    def _message_add_suggested_recipients(self, primary_email=False):
-        self.ensure_one()
-        email_to_lst, partners = [], self.env['res.partner']
-
-        # add responsible
-        user_field = self._fields.get('user_id')
-        if user_field and user_field.type == 'many2one' and user_field.comodel_name == 'res.users':
-            # SUPERUSER because of a read on res.users that would crash otherwise
-            partners += self.sudo().user_id.partner_id
-
-        # add customers
-        partners += self._mail_get_partners()[self.id].filtered(lambda p: not p.is_public)
-
-        # add email
-        if not primary_email:
-            email_fname = self._mail_get_primary_email_field()
-            if email_fname and self[email_fname]:
-                email_to_lst.append(self[email_fname])
-        else:
-            email_to_lst.append(primary_email)
-
-        return email_to_lst, partners
-
-    def _message_get_suggested_recipients(self, reply_discussion=False, reply_message=None,
-                                          no_create=True, primary_email=False, additional_partners=None):
-        """ Get suggested recipients, contextualized depending on discussion.
-
-        :param bool reply_discussion: consider user replies to the discussion.
-          Last relevant message is fetched and used to search for additional
-          'To' and 'Cc' to propose;
-        :param bool reply_message: specific message user is replying-to. Bypasses
-          'reply_discussion';
-        :param bool no_create: do not create partners when emails are not linked
-          to existing partners, see '_partner_find_from_emails';
-        :param bool primary_email: new primary_email that isn't stored inside DB;
-        :param bool additional_partners: partners that needs to be added to the suggested recipients;
-
-        :returns: list of dictionaries (per suggested recipient) containing:
-            * create_values:         dict: data to populate new partner, if not found
-            * email:                 str: email of recipient
-            * name:                  str: name of the recipient
-            * partner_id:            int: recipient partner id
-        """
-        def email_key(email):
-            return email_normalize(email, strict=False) or email.strip()
-
-        self.ensure_one()
-        email_to_lst, partners = self._message_add_suggested_recipients(primary_email)
-        partners += additional_partners or self.env['res.partner']
-
-        # find last relevant message
-        if reply_discussion:
-            messages = self.message_ids.sorted(
-                lambda msg: (
-                    msg.message_type == 'email',              # incoming email = probably customer
-                    msg.message_type == 'comment',            # user input > other input
-                    msg.date, msg.id,                         # newer first
-                ), reverse=True,
-            )
-            reply_message = next(
-                (msg for msg in messages if msg.message_type in ('comment', 'email')),
-                self.env['mail.message']
-            )
-        # fetch answer-based recipients as well as author
-        if reply_message:
-            # direct recipients, and author if not archived / root
-            partners += (reply_message.partner_ids | reply_message.author_id).filtered(lambda p: p.active)
-            # To and Cc emails (mainly for incoming email), and email_from if not linked to hereabove author
-            email_to_lst += [reply_message.incoming_email_to or '', reply_message.incoming_email_cc or '', reply_message.email_from or '']
-            from_normalized = email_normalize(reply_message.email_from)
-            if from_normalized and from_normalized != reply_message.author_id.email_normalized:
-                email_to_lst.append(reply_message.email_from)
-        # flatten emails, as some inputs are stringified list of emails (e.g. Cc, To)
-        email_to_lst = [
-            e for email_input in email_to_lst
-            for e in email_split_and_format(email_input)
-            if e and e.strip()
-        ]
-
-        # organize and deduplicate partners, exclude followers, keep ordering
-        followers = self.message_partner_ids
-        # sanitize email inputs, exclude followers and aliases, add some banned emails, keep ordering, then link to partners
-        skip_emails_normalized = (followers | partners).mapped('email_normalized') + (followers | partners).mapped('email')
-        skip_emails_normalized += [self.env.ref('base.partner_root').email_normalized]  # never propose odoobot
-        if email_to_lst:
-            skip_emails_normalized.extend(
-                self.env['mail.alias'].sudo().search(
-                    [('alias_full_name', 'in', [email_key(e) for e in email_to_lst])]
-                ).mapped('alias_full_name')
-            )
-        email_to_lst = [e for e in email_to_lst if email_key(e) not in skip_emails_normalized]
-        partners += self._partner_find_from_emails_single(email_to_lst, no_create=no_create)
-
-        # final filtering
-        partners = self.env['res.partner'].browse(tools.misc.unique(
-            p.id for p in partners if p not in followers
-        ))
-        email_to_lst = list(tools.misc.unique(
-            e for e in email_to_lst
-            if email_key(e) not in (partners.mapped('email_normalized') + partners.mapped('email'))
-        ))
-        # fetch model-related additional information
-        emails_normalized_info = self._get_customer_information() if email_to_lst else {}
-
-        recipients = [{
-            'email': partner.email_normalized,
-            'name': partner.name,
-            'partner_id': partner.id,
-            'create_values': {},
-        } for partner in partners]
-        for email_input in email_to_lst:
-            name, email_normalized = parse_contact_from_email(email_input)
-            recipients.append({
-                'email': email_normalized,
-                'name': emails_normalized_info.get(email_normalized, {}).pop('name', False) or name,
-                'partner_id': False,
-                'create_values': emails_normalized_info.get(email_normalized, {}),
-            })
-        return recipients
 
     def _mail_find_user_for_gateway(self, email_value, alias=None):
         """ Utility method to find user from email address that can create documents

--- a/addons/mail/models/mail_thread_cc.py
+++ b/addons/mail/models/mail_thread_cc.py
@@ -43,8 +43,9 @@ class MailThreadCc(models.AbstractModel):
         cc_values.update(update_vals)
         return super().message_update(msg_dict, cc_values)
 
-    def _message_add_suggested_recipients(self, primary_email=False):
-        email_to_lst, partners = super()._message_add_suggested_recipients(primary_email)
-        if self.email_cc:
-            email_to_lst.append(self.email_cc)
-        return email_to_lst, partners
+    def _message_add_suggested_recipients(self, force_primary_email=False):
+        suggested = super()._message_add_suggested_recipients(force_primary_email=force_primary_email)
+        for record in self:
+            if record.email_cc:
+                suggested[record.id]['email_to_lst'].append(record.email_cc)
+        return suggested

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -73,11 +73,6 @@ class ResPartner(models.Model):
     def _mail_get_partners(self, introspect_fields=False):
         return dict((partner.id, partner) for partner in self)
 
-    def _message_add_suggested_recipients(self, primary_email=False):
-        email_to_lst, partners = super()._message_add_suggested_recipients(primary_email)
-        partners += self
-        return email_to_lst, partners
-
     # ------------------------------------------------------------
     # ORM
     # ------------------------------------------------------------

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -1385,6 +1385,8 @@ class MailComposeMessage(models.TransientModel):
         template_values = self.template_id._generate_template(
             res_ids,
             template_fields,
+            # monorecord comment mode -> ok to use suggested instead of defaults
+            recipients_allow_suggested=self.composition_mode == 'comment' and not self.composition_batch and self.message_type == 'comment',
             find_or_create_partners=find_or_create_partners,
         )
 
@@ -1553,6 +1555,8 @@ class MailComposeMessage(models.TransientModel):
                 self[composer_fname] = self.template_id._generate_template(
                     rendering_res_ids,
                     {template_fname},
+                    # monorecord comment -> ok to use suggested recipients
+                    recipients_allow_suggested=self.message_type == 'comment',
                 )[rendering_res_ids[0]][template_fname]
             else:
                 self[composer_fname] = self.template_id[template_fname]

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -939,28 +939,52 @@ class TestNoThread(MailCommon, TestRecipients):
             'subject': 'Subject {{ object.name }}',
             'use_default_to': True,
         })
-
-    @users('employee')
-    def test_mail_composer_with_template(self):
-        """ This test simulates scenarios where a required method called `_process_attachments_for_post` is missing,
-        in such case composer should fallback to the method implementation in mail.thread. """
-        record = self.env['mail.test.nothread'].sudo().create({
-            'name': 'Test Model Missing Method',
-        })
-        attachment = self.env['ir.attachment'].create({
+        cls.test_attachment = cls.env['ir.attachment'].with_user(cls.user_employee).create({
             'name': 'Test Attachment',
             'datas': base64.b64encode(b'This is test attachment content'),
-            'res_model': 'mail.test.nothread',
-            'res_id': record.id,
+            'res_model': cls.test_record_nothread._name,
+            'res_id': cls.test_record_nothread.id,
             'mimetype': 'text/plain',
         })
+
+    @users('employee')
+    def test_mail_composer_comment_with_template(self):
+        """ This test simulates using a template, opening a composer and posting
+        a message to a non-thread record, which transforms into a user notification.
+        Check recipients computation works in non-thread mode. """
+        record = self.test_record_nothread.with_env(self.env)
+        template = self.test_template.with_env(self.env)
+        mail_compose_message = self.env['mail.compose.message'].create({
+            'attachment_ids': [(6, 0, [self.test_attachment.id])],
+            'composition_mode': 'comment',
+            'model': record._name,
+            'template_id': template.id,
+            'res_ids': record.ids,
+        })
+        with self.mock_mail_gateway():
+            _mail, message = mail_compose_message._action_send_mail()
+        self.assertMailNotifications(
+            message,
+            [{
+                'content': f'Hello {record.name}',
+                # not mail.thread -> automatically transformed using message_notify
+                'message_type': 'user_notification',
+                'notif': [{'partner': self.partner_1, 'type': 'email',}],
+            }],
+        )
+
+    @users('employee')
+    def test_mail_composer_mail_with_template(self):
+        """ This test simulates scenarios where a required method called `_process_attachments_for_post` is missing,
+        in such case composer should fallback to the method implementation in mail.thread. """
+        record = self.test_record_nothread.with_env(self.env)
         template = self.test_template.with_env(self.env)
         mail_compose_message = self.env['mail.compose.message'].create({
             'composition_mode': 'mass_mail',
             'model': 'mail.test.nothread',
             'template_id': template.id,
             'res_ids': record.ids,
-            'attachment_ids': [(6, 0, [attachment.id])]
+            'attachment_ids': [(6, 0, [self.test_attachment.id])]
         })
         with self.mock_mail_gateway():
             mail_compose_message.action_send_mail()

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -487,7 +487,8 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
         test_template.write({'attachment_ids': [(5, 0)]})
 
-        with self.assertQueryCount(admin=9, employee=9):
+        # TDE FIXME: from 9 to 34 due to suggested recipients -> to optimize
+        with self.assertQueryCount(admin=34, employee=34):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -511,7 +512,8 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_mail_composer_w_template_attachments(self):
         test_record, test_template = self._create_test_records()
 
-        with self.assertQueryCount(admin=10, employee=10):
+        # TDE FIXME: from 10 to 35 due to suggested recipients -> to optimize
+        with self.assertQueryCount(admin=35, employee=35):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -539,8 +541,9 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
         test_template.write({'attachment_ids': [(5, 0)]})
 
+        # TDE FIXME: from 20 to 49 due to suggested recipients -> to optimize
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=20, employee=20):  # tm 16/16
+        with self.assertQueryCount(admin=49, employee=49):  # tm 16/16
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -569,8 +572,9 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_mail_composer_w_template_form_attachments(self):
         test_record, test_template = self._create_test_records()
 
+        # TDE FIXME: from 20 to 49 due to suggested recipients -> to optimize
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=20, employee=20):  # tm 16/16
+        with self.assertQueryCount(admin=49, employee=49):  # tm 16/16
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',

--- a/addons/website_event_track/tests/test_mail_features.py
+++ b/addons/website_event_track/tests/test_mail_features.py
@@ -163,7 +163,8 @@ class TestTrackMailFeatures(TestEventOnlineCommon, MailCommon):
             ],
         ]
 
+        suggested_all = tracks._message_get_suggested_recipients_batch()
         for track, expected in zip(tracks, expected_all, strict=True):
-            suggested = track._message_get_suggested_recipients()
+            suggested = suggested_all[track.id]
             with self.subTest(track_name=track.name):
                 self.assertEqual(suggested, expected)

--- a/addons/website_event_track/tests/test_mail_features.py
+++ b/addons/website_event_track/tests/test_mail_features.py
@@ -73,7 +73,7 @@ class TestTrackMailFeatures(TestEventOnlineCommon, MailCommon):
             },
             # wrong email -> fallback on valid speaker email
             self.tracks[4].id: {
-                'email_cc': '', 'email_to': 'speaker@test.example.com',
+                'email_cc': '', 'email_to': '"Speaker" <speaker@test.example.com>',
                 'partner_ids': [],
             },
             # no partner: contact then speaker
@@ -131,6 +131,11 @@ class TestTrackMailFeatures(TestEventOnlineCommon, MailCommon):
                     'email': self.event_customer.email_normalized,
                     'name': self.event_customer.name,
                     'partner_id': self.event_customer.id,
+                }, {
+                    'create_values': {},
+                    'email': 'speaker@test.example.com',
+                    'name': 'Speaker',
+                    'partner_id': False,
                 },
             ],
             # partner with wrong email: add speaker as fallback

--- a/addons/website_sale/tests/test_website_sale_mail.py
+++ b/addons/website_sale/tests/test_website_sale_mail.py
@@ -11,7 +11,7 @@ from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
 
 
-@tagged('post_install', '-at_install')
+@tagged('post_install', '-at_install', 'mail_thread')
 class TestWebsiteSaleMail(HttpCase):
 
     def test_01_shop_mail_tour(self):
@@ -48,13 +48,13 @@ class TestWebsiteSaleMail(HttpCase):
             self.start_tour("/", 'shop_mail', login="admin")
             new_mail = self.env['mail.mail'].search([('create_date', '>=', start_time),
                                                      ('body_html', 'ilike', 'https://my-test-domain.com')],
-                                                    order='create_date DESC', limit=1)
+                                                    order='create_date DESC', limit=None)
             self.assertTrue(new_mail)
             self.assertIn('Your', new_mail.body_html)
-            self.assertIn('Order', new_mail.body_html)
+            self.assertIn('order', new_mail.body_html)
 
 
-@tagged('post_install', '-at_install')
+@tagged('post_install', '-at_install', 'mail_thread')
 class TestWebsiteSaleMails(MailCommon, WebsiteSaleCommon):
 
     def test_salesman_assignation(self):


### PR DESCRIPTION
SPECIFICATIONS

Similar to '_mail_get_partners' being based on '_mail_get_partner_fields',
define a helper to fetch primary email of records. It allows inheritance
in some cases where directly field access is not possible.

Use it in default recipients computation so that overrides are taken into
account. This is going to be used notably in salary offer model which has
linked models (applicant, employee), without or without partner, but no email
field per se.

Make suggested recipients computation being based on default recipients with
some additional being added. This allows to remove some duplicated computation.

Make suggested recipients computation available as a base method, to be used
notably in templates on non-thread models. Also make it batch-enabled as it
is currently running on a singleton recordset. This allows its usage in batch
flows, like composers, templates, ... This requires some rewriting and code
move in order to benefit from batch searches and prefetchs.

Update tests and addon code accordingly.

This has some impact on query counters. This will be fixed in upcoming
PR, to allow testing and feedback on 18.2. Optimizing the code can be
done in a few days.

Todo in master: rework those methods to have a cleaner API and single
return type.

LINKS

Direct followup of odoo/odoo#198173: cleanup default recipients computation

Followup of odoo/odoo#172714: improve default behavior of templates
Followup of odoo/odoo#188642 : main branch for email-like recipients

Task-4555506: Cleanup / Mergeup default / suggested recipients