### PR TITLE
[FIX] web: pivot: fix tests failing randomly

### DIFF
--- a/addons/web/static/tests/views/pivot_view_tests.js
+++ b/addons/web/static/tests/views/pivot_view_tests.js
@@ -1947,6 +1947,7 @@ QUnit.module("Views", (hooks) => {
         async function (assert) {
             assert.expect(2);
 
+            const downloadDef = makeDeferred();
             mockDownload(async ({ url, data }) => {
                 data = JSON.parse(await data.data.text());
                 assert.strictEqual(url, "/web/pivot/export_xlsx");
@@ -1955,6 +1956,7 @@ QUnit.module("Views", (hooks) => {
                     4,
                     "should have measure_headers in data"
                 );
+                downloadDef.resolve();
                 return Promise.resolve();
             });
 
@@ -1970,6 +1972,7 @@ QUnit.module("Views", (hooks) => {
             });
 
             await click(target.querySelector(".o_pivot_download"));
+            await downloadDef;
         }
     );
 
@@ -3616,6 +3619,7 @@ QUnit.module("Views", (hooks) => {
 
         patchDate(2016, 11, 20, 1, 0, 0);
 
+        const downloadDef = makeDeferred();
         mockDownload(async ({ url, data }) => {
             data = JSON.parse(await data.data.text());
             for (const l of data.col_group_headers) {
@@ -3635,6 +3639,7 @@ QUnit.module("Views", (hooks) => {
                 "/web/pivot/export_xlsx",
                 "should call get_file with correct parameters"
             );
+            downloadDef.resolve();
             return Promise.resolve();
         });
 
@@ -3674,6 +3679,7 @@ QUnit.module("Views", (hooks) => {
         // With the data above, the time ranges contain some records.
         // export data. Should execute 'get_file'
         await click(target.querySelector(".o_control_panel button.o_pivot_download"));
+        await downloadDef;
 
         assert.verifySteps([
             // col group headers


### PR DESCRIPTION
This commit fixes two pivot tests failing randomly by ensuring that we wait for the download to be completed before ending the test or asserting the steps.

Runbot error-134572

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
