### PR TITLE
[FIX] html_editor: properly position toolbar in `rtl`

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -16,7 +16,7 @@ import {
 } from "@html_editor/utils/dom_traversal";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { Plugin } from "../plugin";
-import { DIRECTIONS, boundariesIn, endPos, leftPos, nodeSize, rightPos } from "../utils/position";
+import { DIRECTIONS, endPos, leftPos, nodeSize, rightPos } from "../utils/position";
 import {
     getAdjacentCharacter,
     normalizeCursorPosition,
@@ -190,7 +190,8 @@ export class SelectionPlugin extends Plugin {
         const selection = this.getEditableSelection();
         const containerSelector = "#wrap > *, .oe_structure > *, [contenteditable]";
         const container = selection && closestElement(selection.anchorNode, containerSelector);
-        const [anchorNode, anchorOffset, focusNode, focusOffset] = boundariesIn(container);
+        const [anchorNode, anchorOffset] = getDeepestPosition(container, 0);
+        const [focusNode, focusOffset] = getDeepestPosition(container, nodeSize(container));
         this.setSelection({ anchorNode, anchorOffset, focusNode, focusOffset });
     }
 

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -74,9 +74,9 @@ test("press 'ctrl+a' inside a banner should select all the banner content", asyn
         unformat(
             `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                     <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                    <div class="w-100 px-3 o_editable" contenteditable="true">[
-                        <p>Test1</p><p>Test2<br></p>
-                    ]</div>
+                    <div class="w-100 px-3 o_editable" contenteditable="true">
+                        <p>[Test1</p><p>Test2]<br></p>
+                    </div>
                 </div><p><br></p>`
         )
     );
@@ -96,9 +96,9 @@ test("remove all content should preserves the first paragraph tag inside the ban
         unformat(
             `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                     <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                    <div class="w-100 px-3 o_editable" contenteditable="true">[
-                        <p>Test1</p><p>Test2<br></p>
-                    ]</div>
+                    <div class="w-100 px-3 o_editable" contenteditable="true">
+                        <p>[Test1</p><p>Test2]<br></p>
+                    </div>
                 </div><p><br></p>`
         )
     );
@@ -149,7 +149,7 @@ test("Everything gets selected with ctrl+a, including a contenteditable=false as
                 <div class="w-100 px-3" contenteditable="true">
                     <p><br></p>
                 </div>
-            </div><p placeholder='Type "/" for commands' class="o-we-hint"><br></p>]`
+            </div><p placeholder='Type "/" for commands' class="o-we-hint">]<br></p>`
     );
 });
 
@@ -166,12 +166,12 @@ test("Everything gets selected with ctrl+a, including a banner", async () => {
     await insertText(editor, "Test2");
     await press(["ctrl", "a"]);
     expect(getContent(el)).toBe(
-        `[<p><br></p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+        `<p>[<br></p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                 <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
                 <div class="w-100 px-3 o_editable" contenteditable="true">
                     <p><br></p>
                 </div>
-            </div><p>Test1</p><p>Test2<br></p>]`,
+            </div><p>Test1</p><p>Test2]<br></p>`,
         { message: "should select everything" }
     );
 
@@ -187,7 +187,7 @@ test("Everything gets selected with ctrl+a, including a contenteditable=false as
     );
     await press(["ctrl", "a"]);
     expect(getContent(el)).toBe(
-        '[<div contenteditable="false">a</div><div contenteditable="false">b</div><p>cd</p>]'
+        '[<div contenteditable="false">a</div><div contenteditable="false">b</div><p>cd]</p>'
     );
 
     await press("Backspace");

--- a/addons/html_editor/static/tests/format/font_size.test.js
+++ b/addons/html_editor/static/tests/format/font_size.test.js
@@ -202,9 +202,7 @@ test("should add style to br except line-break br", async () => {
     const { editor, el } = await setupEditor("<p>[]abc<br><br></p>");
     await press(["ctrl", "a"]);
     execCommand(editor, "formatFontSize", { size: "36px" });
-    expect(getContent(el)).toBe(
-        `<p><span style="font-size: 36px;">[abc</span><br><span style="font-size: 36px;">]<br></span></p>`
-    );
+    expect(getContent(el)).toBe(`<p><span style="font-size: 36px;">[abc]</span><br><br></p>`);
 });
 
 test("should add style to br except line-break br (2)", async () => {
@@ -212,6 +210,6 @@ test("should add style to br except line-break br (2)", async () => {
     await press(["ctrl", "a"]);
     execCommand(editor, "formatFontSize", { size: "36px" });
     expect(getContent(el)).toBe(
-        `<p><span style="font-size: 36px;">[abc</span><br><span style="font-size: 36px;"><br>]<br></span></p>`
+        `<p><span style="font-size: 36px;">[abc</span><br><span style="font-size: 36px;"><br>]</span><br></p>`
     );
 });

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -507,9 +507,9 @@ describe("to blockquote", () => {
     test("setTag should work after control+a", async () => {
         const { el, editor } = await setupEditor("<p>[]abcd</p>");
         await press(["ctrl", "a"]);
-        expect(getContent(el)).toBe("[<p>abcd</p>]");
+        expect(getContent(el)).toBe("<p>[abcd]</p>");
         setTag("h1")(editor);
-        expect(getContent(el)).toBe("[<h1>abcd</h1>]");
+        expect(getContent(el)).toBe("<h1>[abcd]</h1>");
     });
 });
 


### PR DESCRIPTION
**Problem**:
When selecting all content with `Ctrl+A`, the main `o_editable`
element is selected, which has an `ltr` direction by default.
If we switch the direction while having a single `rtl` paragraph,
the toolbar appears on the left instead of above the text.

**Solution**:
When `Ctrl+A` is used (selection is on `o_editable`),
use deep position on the container edges. This simulates
the browser’s default `Ctrl+A` behavior.

**Example**:
content: `<div contenteditable=true><p>tex[]t</p></div>`
Existing Ctrl+A: `<div contenteditable=true>[<p>text</p>]</div>`
New Ctrl+A: `<div contenteditable=true><p>[text]</p></div>`
Default Ctrl+A (done by browser):
`<div contenteditable=true><p>[text]</p></div>`

**Steps to reproduce**:
1. Add some text.
2. Switch the text direction to `rtl`.
3. Press `Ctrl+A`.
4. The toolbar appears on the left instead of above the text.

opw-4557762

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
