### PR TITLE
[FIX] account: early payment discount access for portal users

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2527,7 +2527,7 @@ class AccountMove(models.Model):
                 or not self.invoice_date
                 or reference_date <= self.invoice_payment_term_id._get_last_discount_date(self.invoice_date)
             ) \
-            and not (payment_terms.matched_debit_ids + payment_terms.matched_credit_ids)
+            and not (payment_terms.sudo().matched_debit_ids + payment_terms.sudo().matched_credit_ids)
 
     # -------------------------------------------------------------------------
     # BUSINESS MODELS SYNCHRONIZATION


### PR DESCRIPTION
Steps to reproduce:
-------------------
- Create an invoice and set the partner to a portal user.
- Set the payment term to any payment term with an early discount option and confirm the invoice.
- Log in as the portal user and view my invoices, you will get an error message that you aren't allowed to access "Partial Reconcile" records

Cause:
-----
Since #182656, access to the payment_terms was added to the _is_eligible_for_early_payment_discount method, to allow applying the early discount for in_payment invoices.

Fix:
---
Add sudo qualifier to the payment_terms access to allow this function to be called by portal users.

opw-4535621

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
