### PR TITLE
[FIX] project: keep project menu when refreshing my tasks

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -1004,7 +1004,6 @@
         <record id="action_view_my_task" model="ir.actions.act_window">
             <field name="name">My Tasks</field>
             <field name="res_model">project.task</field>
-            <field name="path">my-tasks</field>
             <field name="view_mode">kanban,list,form,calendar,pivot,graph,activity</field>
             <field name="context">{
                 'search_default_open_tasks': 1,
@@ -1101,6 +1100,7 @@
             <field name="name">menu view My Tasks</field>
             <field name="model_id" ref="project.model_project_task"/>
             <field name="state">code</field>
+            <field name="path">my-tasks</field>
             <field name="code">
                 model._ensure_personal_stages(); action = env["ir.actions.actions"]._for_xml_id("project.action_view_my_task")
             </field>


### PR DESCRIPTION
Steps to reproduce
==================

- Open project > Tasks > My tasks
- Refresh the page
=> The project menu is missing

Cause of the issue
==================

The server action `action_server_view_my_task` calls the window action `action_view_my_task`.
The project menu has a a reference to the server action.

Currently, a path my-tasks is set on the window action.
When we reload the page, we look for actions with this path.
In this case, we find the window action.
We then look for a menu that contains this action. Since no menu contains
the window action, we won't find any.

Solution
========

We can move the path from the window action to the server action.

One downside is when we access the window action from `project.task.type.delete.wizard`.
In that case, we will lose the path, and the url will look like `/odoo/7/action-207`

With that said, the most common case is accessing the action from the
menu. This fixes the refresh in that case.

opw-4554814

