### PR TITLE
[IMP] website: add autoplay option for carousel

### DIFF
--- a/addons/website/static/src/interactions/carousel/carousel_bootstrap_upgrade_fix.js
+++ b/addons/website/static/src/interactions/carousel/carousel_bootstrap_upgrade_fix.js
@@ -30,30 +30,11 @@ export class CarouselBootstrapUpgradeFix extends Interaction {
             }),
         },
     };
-    OLD_AUTO_SLIDING_SNIPPETS = ["s_image_gallery"];
     carouselOptions = undefined;
 
     setup() {
         this.sliding = false;
         this.hasInterval = ![undefined, "false", "0"].includes(this.el.dataset.bsInterval);
-        if (!this.hasInterval && this.el.dataset.bsRide) {
-            // A bsInterval of 0 (or false or undefined) is intended to not
-            // auto-slide. With current Bootstrap version, a value of 0 will
-            // mean auto-slide without any delay (very fast). To prevent this,
-            // we remove the bsRide.
-            delete this.el.dataset.bsRide;
-        } else if (this.hasInterval && !this.el.dataset.bsRide) {
-            // Re-add bsRide on carousels that don't have it but still have
-            // a bsInterval. E.g. s_image_gallery must auto-slide on load,
-            // while others only auto-slide on mouseleave.
-            //
-            // In the case of s_image_gallery that has a bsRide = "true"
-            // instead of "carousel", it's better not to change the behavior and
-            // let the user update the snippet manually to avoid making changes
-            // that they don't expect.
-            const snippetName = this.el.closest("[data-snippet]")?.dataset.snippet;
-            this.el.dataset.bsRide = this.OLD_AUTO_SLIDING_SNIPPETS.includes(snippetName) ? "carousel" : "true";
-        }
     }
 
     async willStart() {

--- a/addons/website/static/src/interactions/carousel/carousel_slider.js
+++ b/addons/website/static/src/interactions/carousel/carousel_slider.js
@@ -22,8 +22,23 @@ export class CarouselSlider extends Interaction {
     };
     carouselOptions = undefined;
 
+    static OLD_AUTO_SLIDING_SNIPPETS = ["s_image_gallery"];
     setup() {
         this.maxHeight = undefined;
+        this.hasInterval = ![undefined, "false", "0"].includes(this.el.dataset.bsInterval);
+        if (!this.hasInterval || !this.el.dataset.bsRide) {
+            // If bsInterval is 0, false or undefined, it means no auto slide
+            window.Carousel.getOrCreateInstance(this.el, { ride: false, pause: true });
+            this.el.dataset.bsRide = "noAutoSlide";
+        } else if (this.hasInterval && this.el.dataset.bsRide === "noAutoSlide") {
+            // Restore auto-slide if explicitly enabled, except for legacy snippets
+            const snippetName = this.el.closest("[data-snippet]")?.dataset.snippet;
+            this.el.dataset.bsRide = this.constructor.OLD_AUTO_SLIDING_SNIPPETS.includes(
+                snippetName
+            )
+                ? "carousel"
+                : "true";
+        }
     }
 
     start() {

--- a/addons/website/static/tests/interactions/carousel/carousel_bootstrap_upgrade_fix.edit.test.js
+++ b/addons/website/static/tests/interactions/carousel/carousel_bootstrap_upgrade_fix.edit.test.js
@@ -53,5 +53,4 @@ test("[EDIT] carousel_bootstrap_upgrade_fix prevents ride", async () => {
     const carouselBS = window.Carousel.getInstance(carouselEl);
     expect(carouselBS._config.ride).toBe(false);
     expect(carouselBS._config.pause).toBe(true);
-    expect(carouselEl).toHaveAttribute("data-bs-ride", "carousel");
 });

--- a/addons/website/static/tests/interactions/carousel/carousel_bootstrap_upgrade_fix.test.js
+++ b/addons/website/static/tests/interactions/carousel/carousel_bootstrap_upgrade_fix.test.js
@@ -49,7 +49,6 @@ test("carousel_bootstrap_upgrade_fix is tagged while sliding", async () => {
     expect(core.interactions).toHaveLength(1);
 
     const carouselEl = queryOne(".carousel");
-    expect(carouselEl).toHaveAttribute("data-bs-ride", "carousel");
     expect(carouselEl).toHaveAttribute("data-bs-interval", "5000");
     expect(carouselEl).not.toHaveClass("o_carousel_sliding");
 

--- a/addons/website/static/tests/interactions/carousel/carousel_slider.edit.test.js
+++ b/addons/website/static/tests/interactions/carousel/carousel_slider.edit.test.js
@@ -53,7 +53,7 @@ test("[EDIT] carousel_slider prevents ride", async () => {
     core.stopInteractions();
 
     expect(core.interactions).toHaveLength(0);
-    expect(carouselEl).toHaveAttribute("data-bs-ride", "ride");
+    expect(carouselEl).toHaveAttribute("data-bs-ride", "noAutoSlide");
 });
 
 test("[EDIT] carousel_slider updates min height on content_changed", async () => {

--- a/addons/website/static/tests/tours/carousel_content_removal.js
+++ b/addons/website/static/tests/tours/carousel_content_removal.js
@@ -110,3 +110,36 @@ registerWebsitePreviewTour(
         checkSlides(3, 1),
     ]
 );
+
+registerWebsitePreviewTour("snippet_carousel_autoplay", {
+    url: "/",
+    edition: true,
+}, () => [
+    ...insertSnippet({id: "s_carousel", name: "Carousel", groupName: "Intro"}),
+    ...clickOnSnippet(".carousel .carousel-item.active"),
+    {
+        content: "Decrease the interval between slides",
+        trigger: "we-input[data-attribute-name='bsInterval'] input",
+        run: 'edit 3',
+    },
+    {
+        content: "Save the interval between slides",
+        trigger: "we-input[data-attribute-name='bsInterval']",
+        run: 'click',
+    },
+    {
+        content: "Enable the autoplay option",
+        trigger: ".autoplay we-checkbox",
+        run: 'click',
+    },
+    ...clickOnSave(),
+    {
+        content: "Check if the first slide is active and wait for 3s",
+        trigger: `${carouselInnerSelector} > div.active:nth-child(1)`,
+        run: () => new Promise(resolve => setTimeout(resolve, 3000)),
+    },
+    {
+        content: "Check if the second slide is active",
+        trigger: `${carouselInnerSelector} > div.active:nth-child(2)`,
+    },
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -733,6 +733,9 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_snippet_carousel(self):
         self.start_tour('/', 'snippet_carousel', login='admin')
 
+    def test_snippet_carousel_autoplay(self):
+        self.start_tour("/", "snippet_carousel_autoplay", login="admin")
+
     def test_media_iframe_video(self):
         self.start_tour("/", "website_media_iframe_video", login="admin")
 

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -679,14 +679,13 @@
             <we-button data-select-class="s_carousel_indicators_hidden">Hidden</we-button>
         </we-select>
         <we-select string="Transition">
-            <we-button data-select-class="slide">Slide</we-button>
-            <we-button data-select-class="carousel-fade slide">Fade</we-button>
-            <we-divider/>
-            <we-button data-select-class="">None</we-button>
+            <we-button data-select-class="slide" data-name="slide_opt">Slide</we-button>
+            <we-button data-select-class="carousel-fade slide" data-name="fade_opt">Fade</we-button>
+            <we-button data-select-class="" data-name="none_opt">None</we-button>
         </we-select>
-        <we-input string="Speed"
-                  data-select-data-attribute="0s" data-attribute-name="bsInterval"
-                  data-unit="s" data-save-unit="ms" data-step="0.1"/>
+        <we-input string="Speed" class="o_we_sublevel_1" data-select-data-attribute="0s" data-attribute-name="bsInterval"
+                  data-unit="s" data-save-unit="ms" data-step="0.1" data-dependencies="slide_opt, fade_opt"/>
+        <we-checkbox string="Autoplay" class="autoplay o_we_sublevel_1" data-attribute-name="bsRide" data-select-data-attribute="carousel" data-dependencies="slide_opt, fade_opt"/>
     </div>
 </template>
 


### PR DESCRIPTION
This PR adds an autoplay option to the carousel snippet. 

users can enable or disable the autoplay functionality through an option.
If autoplay is enabled, sliding starts automatically when the page loads.
If autoplay is disabled, sliding starts on hover or click.

task-4578024