### PR TITLE
[FIX] account: align graphs from the bottom in account dashboard

### DIFF
--- a/addons/account/static/src/scss/account_journal_dashboard.scss
+++ b/addons/account/static/src/scss/account_journal_dashboard.scss
@@ -35,6 +35,12 @@
         .o_field_widget.o_field_kanban_vat_activity {
             display: block;
         }
+
+        .container-fluid {
+            flex: 1 0 auto;
+            display: flex;
+            flex-flow: column nowrap;
+        }
     }
 
     &.o_kanban_ungrouped {


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Go to Accounting dashboard
- Make sure that one journal has more action links than the other ones of the same row

**Issue:**
There is an offset between the bottom border of the kanban card and the graph that depends on the difference between the number of action links in the current card and the higher number of action links in a card on the same row.
![account_dashboard](https://github.com/user-attachments/assets/7cbd9a81-f824-48b4-b968-dcb8ff7a8be3)


**Cause:**
The view has been refactored in version 18.0 and some css has been lost in the process.

opw-4473451




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
