### PR TITLE
[IMP] discuss: synchronize the state of calls across tabs

### DIFF
--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -299,9 +299,15 @@ class DiscussChannelMember(models.Model):
 
     def _rtc_join_call(self, store: Store = None, check_rtc_session_ids=None, camera=False):
         self.ensure_one()
-        check_rtc_session_ids = (check_rtc_session_ids or []) + self.rtc_session_ids.ids
+        session_domain = []
+        if self.partner_id:
+            session_domain = [("partner_id", "=", self.partner_id.id)]
+        elif self.guest_id:
+            session_domain = [("guest_id", "=", self.guest_id.id)]
+        user_sessions = self.search(session_domain).rtc_session_ids
+        check_rtc_session_ids = (check_rtc_session_ids or []) + user_sessions.ids
         self.channel_id._rtc_cancel_invitations(member_ids=self.ids)
-        self.rtc_session_ids.unlink()
+        user_sessions.unlink()
         rtc_session = self.env['discuss.channel.rtc.session'].create({'channel_member_id': self.id, 'is_camera_on': camera})
         current_rtc_sessions, outdated_rtc_sessions = self._rtc_sync_sessions(check_rtc_session_ids=check_rtc_session_ids)
         ice_servers = self.env["mail.ice.server"]._get_ice_servers()
@@ -318,7 +324,7 @@ class DiscussChannelMember(models.Model):
                 "Rtc",
                 {
                     "iceServers": ice_servers or False,
-                    "selfSession": Store.One(rtc_session),
+                    "localSession": Store.One(rtc_session),
                     "serverInfo": self._get_rtc_server_info(rtc_session, ice_servers),
                 },
             )

--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -69,7 +69,7 @@ export class Call extends Component {
     }
 
     get isActiveCall() {
-        return Boolean(this.props.thread.eq(this.rtc.state?.channel));
+        return Boolean(this.props.thread.eq(this.rtc.channel));
     }
 
     get minimized() {

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -37,7 +37,7 @@
                     <i t-if="state.sidebar" class="o-discuss-Call-sidebarToggler p-2 fs-5 cursor-pointer position-absolute oi oi-arrow-right" title="Hide sidebar" t-on-click="() => this.state.sidebar = false"/>
                     <i t-else="" class="o-discuss-Call-sidebarToggler p-2 fs-5 cursor-pointer position-absolute oi oi-arrow-left" title="Show sidebar" t-on-click="() => this.state.sidebar = true"/>
                 </t>
-                <div t-if="state.overlay or !isControllerFloating" class="o-discuss-Call-overlay d-flex justify-content-center w-100 pb-1" t-att-class="{ 'o-isFloating position-absolute bottom-0 pb-3': isControllerFloating }">
+                <div t-if="state.overlay or !isControllerFloating" class="o-discuss-Call-overlay d-flex justify-content-center w-100 pb-1" t-att-class="{ 'o-isFloating position-absolute z-2 bottom-0 pb-3': isControllerFloating }">
                     <div t-on-mousemove="onMousemoveOverlay">
                         <CallActionList thread="props.thread" compact="props.compact" fullscreen="{ isActive: state.isFullscreen, enter: () => this.enterFullScreen(), exit: () => this.exitFullScreen() }"/>
                     </div>
@@ -51,6 +51,7 @@
                     cardData="cardData"
                     className="'o-discuss-Call-sidebarCard w-100'"
                     thread="props.thread"
+                    isSidebarItem="true"
                 />
             </div>
             <CallParticipantCard

--- a/addons/mail/static/src/discuss/call/common/call_action_list.js
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.js
@@ -24,7 +24,7 @@ export class CallActionList extends Component {
     }
 
     get isOfActiveCall() {
-        return Boolean(this.props.thread.eq(this.rtc.state?.channel));
+        return Boolean(this.props.thread.eq(this.rtc.channel));
     }
 
     get isSmall() {

--- a/addons/mail/static/src/discuss/call/common/call_action_list.xml
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.xml
@@ -39,7 +39,7 @@
                     t-on-click="(ev) => this.onClickToggleAudioCall(ev, { camera: true })">
                     <i class="fa fa-video-camera fa-fw m-2" t-att-class="{ 'fa-lg': !isSmall }"/>
                 </button>
-                <t t-if="props.thread.eq(rtc.state.channel)" t-set="callText">Disconnect</t>
+                <t t-if="props.thread.eq(rtc.channel)" t-set="callText">Disconnect</t>
                 <t t-else="" t-set="callText">Join Call</t>
                 <button class="btn smaller d-flex m-1 border-0 rounded-circle shadow-none align-items-center"
                     t-att-aria-label="callText"
@@ -62,8 +62,8 @@
     </t>
 
     <t t-name="discuss.CallActionList.actionButton">
-        <button class="btn smaller d-flex m-1 border-0 rounded-circle shadow-none opacity-100 opacity-75-hover align-items-center"
-            t-att-class="{ 'p-0': isSmall, 'p-1': !isSmall }"
+        <button class="btn smaller d-flex m-1 border-0 rounded-circle shadow-none opacity-75-hover align-items-center"
+            t-att-class="{ 'p-0': isSmall, 'p-1': !isSmall, 'bg-600 opacity-75': !action.available, 'opacity-100': action.available }"
             t-att-aria-label="action.name"
             t-att-title="action.name"
             t-on-click="action.select">

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -40,8 +40,15 @@ callActionsRegistry
     })
     .add("camera-on", {
         condition: (component) => component.rtc,
-        name: (component) =>
-            component.rtc.selfSession.is_camera_on ? _t("Stop camera") : _t("Turn camera on"),
+        available: (component) => !component.rtc?.isRemote,
+        name: (component) => {
+            if (component.rtc?.isRemote) {
+                return _t("Camera is unavailable outside the call tab.");
+            }
+            return component.rtc.selfSession.is_camera_on
+                ? _t("Stop camera")
+                : _t("Turn camera on");
+        },
         isActive: (component) => component.rtc.selfSession?.is_camera_on,
         icon: "fa-video-camera",
         activeClass: "text-success",
@@ -59,10 +66,15 @@ callActionsRegistry
     })
     .add("share-screen", {
         condition: (component) => component.rtc && !isMobileOS(),
-        name: (component) =>
-            component.rtc.selfSession.is_screen_sharing_on
+        available: (component) => !component.rtc?.isRemote,
+        name: (component) => {
+            if (component.rtc?.isRemote) {
+                return _t("Screen sharing is unavailable outside the call tab.");
+            }
+            return component.rtc.selfSession.is_screen_sharing_on
                 ? _t("Stop Sharing Screen")
-                : _t("Share Screen"),
+                : _t("Share Screen");
+        },
         isActive: (component) => component.rtc.selfSession?.is_screen_sharing_on,
         icon: "fa-desktop",
         activeClass: "text-success",
@@ -71,7 +83,10 @@ callActionsRegistry
     })
     .add("blur-background", {
         condition: (component) =>
-            !isBrowserSafari() && component.rtc && component.rtc.selfSession?.is_camera_on,
+            !isBrowserSafari() &&
+            component.rtc &&
+            component.rtc.selfSession?.is_camera_on &&
+            component.rtc?.isHost,
         name: (component) =>
             component.store.settings.useBlur ? _t("Remove Blur") : _t("Blur Background"),
         isActive: (component) => component.store?.settings?.useBlur,
@@ -104,6 +119,9 @@ function transformAction(component, id, action) {
         /** Condition to display this action */
         get condition() {
             return action.condition(component);
+        },
+        get available() {
+            return action.available?.(component) ?? true;
         },
         /** Name of this action, displayed to the user */
         get name() {

--- a/addons/mail/static/src/discuss/call/common/call_context_menu.js
+++ b/addons/mail/static/src/discuss/call/common/call_context_menu.js
@@ -75,7 +75,7 @@ export class CallContextMenu extends Component {
     }
 
     async updateStats() {
-        if (this.rtc.selfSession?.eq(this.props.rtcSession)) {
+        if (this.rtc.localSession?.eq(this.props.rtcSession)) {
             if (this.rtc.sfuClient) {
                 const { uploadStats, downloadStats, ...producerStats } =
                     await this.rtc.sfuClient.getStats();
@@ -142,11 +142,6 @@ export class CallContextMenu extends Component {
 
     onChangeVolume(ev) {
         const volume = Number(ev.target.value);
-        this.store.settings.saveVolumeSetting({
-            guestId: this.props.rtcSession?.guestId,
-            partnerId: this.props.rtcSession?.partnerId,
-            volume,
-        });
-        this.props.rtcSession.volume = volume;
+        this.rtc.setVolume(this.props.rtcSession, volume);
     }
 }

--- a/addons/mail/static/src/discuss/call/common/call_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_menu.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.CallMenu">
         <div class="dropdown" t-attf-class="{{ className }}" t-ref="root">
-            <button t-if="rtc.state.channel" class="user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="buttonTitle" role="button" t-on-click="rtc.state.channel.open">
+            <button t-if="rtc.channel" class="user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="buttonTitle" role="button" t-on-click="rtc.channel.open">
                 <div class="o-discuss-CallMenu-buttonContent d-flex align-items-center o-gap-0_5 rounded-3 opacity-75 opacity-100-hover px-1">
                     <span class="position-relative small bg-inherit">
                         <i class="me-2 fa fa-fw" t-att-class="icon" />
@@ -11,7 +11,7 @@
                             <i class="o-discuss-CallMenu-animation fa fa-volume-up o-discuss-inCallIconColor bg-inherit"/>
                         </small>
                     </span>
-                    <span class="text-truncate fw-bold pe-1" t-esc="rtc.state.channel.displayName"/>
+                    <span class="text-truncate fw-bold pe-1" t-esc="rtc.channel.displayName"/>
                 </div>
             </button>
         </div>

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -21,7 +21,7 @@ import { rpc } from "@web/core/network/rpc";
 const HIDDEN_CONNECTION_STATES = new Set([undefined, "connected", "completed"]);
 
 export class CallParticipantCard extends Component {
-    static props = ["className", "cardData", "thread", "minimized?", "inset?"];
+    static props = ["className", "cardData", "thread", "minimized?", "inset?", "isSidebarItem?"];
     static components = { CallParticipantVideo };
     static template = "discuss.CallParticipantCard";
 
@@ -68,6 +68,37 @@ export class CallParticipantCard extends Component {
         );
     }
 
+    get isRemoteVideo() {
+        if (!this.rtcSession) {
+            return false;
+        }
+        return (
+            this.rtc.isRemote &&
+            (this.rtcSession.is_screen_sharing_on || this.rtcSession.is_camera_on)
+        );
+    }
+
+    get showLiveLabel() {
+        if (this.props.isSidebarItem) {
+            return false;
+        }
+        if (this.props.cardData.type === "screen") {
+            if (this.props.inset) {
+                return true;
+            } else {
+                return (
+                    !this.rtcSession.eq(this.rtcSession.channel.activeRtcSession) &&
+                    !this.props.minimized
+                );
+            }
+        }
+        return false;
+    }
+
+    get showRemoteWarning() {
+        return !this.props.minimized && !this.props.inset && this.isRemoteVideo;
+    }
+
     get rtcSession() {
         return this.props.cardData.session;
     }
@@ -77,7 +108,7 @@ export class CallParticipantCard extends Component {
     }
 
     get isOfActiveCall() {
-        return Boolean(this.rtcSession && this.rtcSession.channel?.eq(this.rtc.state.channel));
+        return Boolean(this.rtcSession && this.rtcSession.channel?.eq(this.rtc.channel));
     }
 
     get showConnectionState() {

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.scss
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.scss
@@ -33,6 +33,23 @@
 
 .o-discuss-CallParticipantCard-avatar:not(.o-minimized) {
     background-color: var(--o-discuss-CallParticipantCard-avatarBgColor, #{$o-gray-700});
+    &.o-isRemoteVideo {
+        background: linear-gradient(180deg, #144173 0%, #082647 30%, #133c68 60%, #082647 90%);
+        background-size: 200% 200%;
+        animation: gradientAnimation 5s ease-in-out infinite alternate;
+        filter: blur(2px);
+    }
+    @keyframes gradientAnimation {
+    0% {
+        background-position: 0% 50%;
+    }
+    50% {
+        background-position: 100% 50%;
+    }
+    100% {
+        background-position: 0% 100%;
+    }
+}
 }
 
 .o-discuss-CallParticipantCard-avatar img {
@@ -71,6 +88,15 @@
 
 .o-discuss-CallParticipantCard-overlay {
     margin: Min(5%, map-get($spacers, 2));
+
+    &.o-proportional-container {
+        container-type: inline-size;
+        .o-proportional-text {
+            &.o-video-text {
+                font-size: 5cqw;
+            }
+        }
+    }
 }
 
 .o-discuss-CallParticipantCard-overlayBottomName {

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -19,24 +19,27 @@
         >
             <!-- card -->
             <CallParticipantVideo t-if="hasVideo" session="rtcSession" type="props.cardData.type" inset="props.inset"/>
-            <div t-else="" class="o-discuss-CallParticipantCard-avatar d-flex align-items-center justify-content-center h-100 w-100 rounded-1" t-att-class="{ 'o-minimized': props.minimized }" draggable="false">
-                <img alt="Avatar" class="h-100 rounded-circle border-5 o_object_fit_cover" t-att-src="channelMember?.persona.avatarUrl" draggable="false" t-att-class="{
+            <div t-else="" class="o-discuss-CallParticipantCard-avatar d-flex align-items-center justify-content-center h-100 w-100 rounded-1" t-att-class="{ 'o-minimized': props.minimized, 'o-isRemoteVideo': isRemoteVideo }" draggable="false">
+                <img t-if="!showRemoteWarning" alt="Avatar" class="h-100 rounded-circle border-5 o_object_fit_cover" t-att-src="channelMember?.persona.avatarUrl" draggable="false" t-att-class="{
                     'o-isTalking': isTalking,
                     'o-isInvitation': !rtcSession,
                 }"/>
             </div>
             <t t-if="rtcSession">
                 <!-- overlay -->
-                <span class="o-discuss-CallParticipantCard-overlay z-1 position-absolute bottom-0 start-0 d-flex overflow-hidden rounded-1">
-                    <span t-if="!props.minimized and !props.inset" class="px-1 rounded-1 text-truncate smaller opacity-75 o-discuss-CallParticipantCard-overlayBottomName" t-esc="name"/>
+                <span class="o-discuss-CallParticipantCard-overlay o-discuss-CallParticipantCard-overlayBottom z-1 position-absolute bottom-0 start-0 d-flex overflow-hidden rounded-1">
+                    <span t-if="!props.minimized and !props.inset" class="px-1 rounded-1 text-truncate smaller opacity-75 w-100 o-discuss-CallParticipantCard-overlayBottomName" t-esc="name"/>
                     <small t-if="rtcSession.is_screen_sharing_on and props.minimized and !isOfActiveCall" class="user-select-none o-minimized rounded text-bg-danger d-flex align-items-center fw-bolder p-1" title="live" aria-label="live">
                         LIVE
                     </small>
                 </span>
+                <span t-if="showRemoteWarning" class="o-discuss-CallParticipantCard-overlay o-proportional-container z-1 w-50 position-absolute d-flex align-items-center justify-content-center overflow-hidden">
+                    <span class="fw-bolder p-1 rounded-1 o-video-text o-proportional-text">Video visible in the call tab</span>
+                </span>
                 <button t-if="popover.isOpen or (isContextMenuAvailable and ((!isMobileOS and rootHover.isHover) or (isMobileOS and !props.minimized)))" t-on-click="onContextMenu" class="o-discuss-CallParticipantCard-contextButton btn btn-secondary btn-sm rounded-circle position-absolute border-0 top-0 end-0 smaller p-1" title="Participant options" t-ref="contextMenuAnchor">
                     <i class="fa fa-chevron-down fa-fw"/>
                 </button>
-                <div class="o-discuss-CallParticipantCard-overlay position-absolute bottom-0 end-0 d-flex flex-row-reverse">
+                <div class="o-discuss-CallParticipantCard-overlay position-absolute bottom-0 end-0 d-flex w-25 flex-row-reverse">
                     <span t-if="hasRaisingHand" class="d-flex flex-column justify-content-center me-1 rounded-circle bg-500" t-att-class="{'o-minimized p-1': props.minimized, 'p-2': !props.minimized }" title="raising hand" aria-label="raising hand">
                         <i class="fa fa-hand-paper-o"/>
                     </span>
@@ -53,7 +56,7 @@
                     <span t-if="showConnectionState" class="d-flex flex-column justify-content-center me-1 p-2 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-title="rtcSession.connectionState">
                         <i class="fa fa-exclamation-triangle text-warning"/>
                     </span>
-                    <span t-if="rtcSession.is_screen_sharing_on and !props.minimized and !isOfActiveCall" class="user-select-none rounded text-bg-danger d-flex align-items-center me-1 fw-bolder p-1" title="live" aria-label="live">
+                    <span t-if="showLiveLabel" class="user-select-none rounded o-proportional-text text-bg-danger d-flex align-items-center py-1 px-2 fw-bolder" title="live" aria-label="live">
                         LIVE
                     </span>
                 </div>

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -2,7 +2,7 @@ import { Record } from "@mail/core/common/record";
 import { BlurManager } from "@mail/discuss/call/common/blur_manager";
 import { monitorAudio } from "@mail/utils/common/media_monitoring";
 import { rpc } from "@web/core/network/rpc";
-import { closeStream, onChange } from "@mail/utils/common/misc";
+import { assignDefined, closeStream, onChange } from "@mail/utils/common/misc";
 
 import { reactive, toRaw } from "@odoo/owl";
 
@@ -61,6 +61,18 @@ const IS_CLIENT_RTC_COMPATIBLE = Boolean(window.RTCPeerConnection && window.Medi
 const DEFAULT_ICE_SERVERS = [
     { urls: ["stun:stun1.l.google.com:19302", "stun:stun2.l.google.com:19302"] },
 ];
+export const CROSS_TAB_HOST_MESSAGE = {
+    PING: "PING", // signals that the host is still active
+    UPDATE_REMOTE: "UPDATE_REMOTE", // sent with updated state of the remote rtc sessions of the call
+    CLOSE: "CLOSE", // sent when the host ends the call
+};
+export const CROSS_TAB_CLIENT_MESSAGE = {
+    INIT: "INIT", // sent by a tab to signal its presence and receive a state update
+    REQUEST_ACTION: "REQUEST_ACTION", // request that an action be executed by the host (mute, deaf,...)
+    LEAVE: "LEAVE", // request the host to leave the call
+    UPDATE_VOLUME: "UPDATE_VOLUME", // sent by a tab to signal a volume change
+};
+const PING_INTERVAL = 30_000;
 
 /**
  * @param {Array<RTCIceServer>} iceServers
@@ -219,7 +231,37 @@ export class Rtc extends Record {
             return this.iceServers ? this.iceServers : DEFAULT_ICE_SERVERS;
         },
     });
-    selfSession = Record.one("discuss.channel.rtc.session");
+    localSession = Record.one("discuss.channel.rtc.session");
+    selfSession = Record.one("discuss.channel.rtc.session", {
+        compute() {
+            return (
+                this.localSession ||
+                this.store["discuss.channel.rtc.session"].get(this._remotelyHostedSessionId)
+            );
+        },
+    });
+    channel = Record.one("Thread", {
+        compute() {
+            if (this.state.channel) {
+                return this.state.channel;
+            }
+            if (this._remotelyHostedChannelId) {
+                return this.store.Thread.insert({
+                    model: "discuss.channel",
+                    id: this._remotelyHostedChannelId,
+                });
+            }
+        },
+        onUpdate() {
+            if (!this.channel) {
+                return;
+            }
+            this.store.Thread.getOrFetch({
+                model: "discuss.channel",
+                id: this.channel.id,
+            });
+        },
+    });
     serverInfo;
     /**
      * @type {Network}
@@ -238,6 +280,24 @@ export class Rtc extends Record {
     cleanups = [];
     /** @type {number} */
     sfuTimeout;
+    // cross tab sync
+    _broadcastChannel = new browser.BroadcastChannel("call_sync_state");
+    _remotelyHostedSessionId;
+    _remotelyHostedChannelId;
+    _crossTabTimeoutId;
+
+    /**
+     * Whether this tab serves as a remote for a call hosted on another tab.
+     */
+    get isRemote() {
+        return Boolean(this._remotelyHostedChannelId);
+    }
+    /**
+     * Whether the current tab is the host of the call.
+     */
+    get isHost() {
+        return Boolean(this.localSession);
+    }
 
     callActions = Record.attr([], {
         compute() {
@@ -302,6 +362,10 @@ export class Rtc extends Record {
         this.notification = services.notification;
         this.soundEffectsService = services["mail.sound_effects"];
         this.pttExtService = services["discuss.ptt_extension"];
+        if (this._broadcastChannel) {
+            this._broadcastChannel.onmessage = this._onBroadcastChannelMessage.bind(this);
+            this._postToTabs({ type: CROSS_TAB_CLIENT_MESSAGE.INIT });
+        }
         /**
          * @type {import("@mail/discuss/call/common/peer_to_peer").PeerToPeer}
          */
@@ -321,7 +385,7 @@ export class Rtc extends Record {
             this.linkVoiceActivationDebounce();
         });
         onChange(this.store.settings, "audioInputDeviceId", async () => {
-            if (this.selfSession) {
+            if (this.localSession) {
                 await this.resetAudioTrack({ force: true });
             }
         });
@@ -351,7 +415,7 @@ export class Rtc extends Record {
                     !this.state.channel ||
                     !this.store.settings.use_push_to_talk ||
                     !this.store.settings.isPushToTalkKey(ev) ||
-                    !this.selfSession.isTalking
+                    !this.localSession.isTalking
                 ) {
                     return;
                 }
@@ -386,21 +450,25 @@ export class Rtc extends Record {
          * connections that were established but failed or timed out.
          */
         browser.setInterval(async () => {
-            if (!this.selfSession || !this.state.channel) {
+            if (!this.localSession || !this.state.channel) {
                 return;
             }
+            this._postToTabs({
+                type: CROSS_TAB_HOST_MESSAGE.PING,
+                hostedSessionId: this.localSession.id,
+            });
             await this.ping();
-            if (!this.selfSession || !this.state.channel) {
+            if (!this.localSession || !this.state.channel) {
                 return;
             }
             this.call();
-        }, 30_000);
+        }, PING_INTERVAL);
     }
 
     setPttReleaseTimeout(duration = 200) {
         this.state.pttReleaseTimeout = browser.setTimeout(() => {
             this.setTalking(false);
-            if (!this.selfSession?.isMute) {
+            if (!this.localSession?.isMute) {
                 this.soundEffectsService.play("ptt-release");
             }
         }, Math.max(this.store.settings.voice_active_duration || 0, duration));
@@ -415,7 +483,7 @@ export class Rtc extends Record {
             return;
         }
         browser.clearTimeout(this.state.pttReleaseTimeout);
-        if (!this.selfSession.isTalking && !this.selfSession.isMute) {
+        if (!this.localSession.isTalking && !this.localSession.isMute) {
             this.soundEffectsService.play("ptt-press");
         }
         this.setTalking(true);
@@ -465,6 +533,7 @@ export class Rtc extends Record {
      * @param {import("models").Thread} [channel]
      */
     endCall(channel = this.state.channel) {
+        this._endHost();
         channel.rtcInvitingSession = undefined;
         channel.activeRtcSession = undefined;
         if (channel.eq(this.state.channel)) {
@@ -476,6 +545,10 @@ export class Rtc extends Record {
     }
 
     async deafen() {
+        if (this.isRemote) {
+            this._remoteAction({ is_deaf: true });
+            return;
+        }
         await this.setDeaf(true);
         this.soundEffectsService.play("earphone-off");
     }
@@ -502,7 +575,24 @@ export class Rtc extends Record {
         }
     }
 
+    setVolume(session, volume) {
+        session.volume = volume;
+        this.store.settings.saveVolumeSetting({
+            guestId: session?.guestId,
+            partnerId: session?.partnerId,
+            volume,
+        });
+        this._postToTabs({
+            type: CROSS_TAB_CLIENT_MESSAGE.UPDATE_VOLUME,
+            changes: { sessionId: session.id, volume },
+        });
+    }
+
     async mute() {
+        if (this.isRemote) {
+            this._remoteAction({ is_muted: true });
+            return;
+        }
         await this.setMute(true);
         this.soundEffectsService.play("mic-off");
     }
@@ -516,6 +606,11 @@ export class Rtc extends Record {
      * @param {boolean} [initialState.camera]
      */
     async toggleCall(channel, { audio = true, fullscreen, camera } = {}) {
+        if (channel.id === this._remotelyHostedChannelId) {
+            this._postToTabs({ type: CROSS_TAB_CLIENT_MESSAGE.LEAVE });
+            this.clear();
+            return;
+        }
         await Promise.resolve(() =>
             loadJS(url("/mail/static/lib/selfie_segmentation/selfie_segmentation.js")).catch(
                 () => {}
@@ -535,7 +630,7 @@ export class Rtc extends Record {
     }
 
     async toggleMicrophone() {
-        if (this.selfSession.isMute) {
+        if (this.localSession.isMute) {
             await this.unmute();
         } else {
             await this.mute();
@@ -543,11 +638,19 @@ export class Rtc extends Record {
     }
 
     async undeafen() {
+        if (this.isRemote) {
+            this._remoteAction({ is_deaf: false });
+            return;
+        }
         await this.setDeaf(false);
         this.soundEffectsService.play("earphone-on");
     }
 
     async unmute() {
+        if (this.isRemote) {
+            this._remoteAction({ is_muted: false });
+            return;
+        }
         if (this.state.audioTrack) {
             await this.setMute(false);
         } else {
@@ -591,22 +694,22 @@ export class Rtc extends Record {
     }
 
     async _initConnection() {
-        this.selfSession.connectionState = "selecting network type";
+        this.localSession.connectionState = "selecting network type";
         this.state.connectionType = CONNECTION_TYPES.P2P;
         this.network?.disconnect();
         // loading p2p in any case as we may need to receive peer-to-peer connections from users who failed to connect to the SFU.
-        this.p2pService.connect(this.selfSession.id, this.state.channel.id, {
+        this.p2pService.connect(this.localSession.id, this.state.channel.id, {
             info: this.formatInfo(),
             iceServers: this.iceServers,
         });
         this.network = new Network(this.p2pService);
         this.updateUpload();
         if (this.serverInfo) {
-            this.log(this.selfSession, "loading sfu server", {
+            this.log(this.localSession, "loading sfu server", {
                 step: "loading sfu server",
                 serverInfo: this.serverInfo,
             });
-            this.selfSession.connectionState = "loading SFU assets";
+            this.localSession.connectionState = "loading SFU assets";
             try {
                 await this._loadSfu();
                 this.state.connectionType = CONNECTION_TYPES.SERVER;
@@ -623,14 +726,14 @@ export class Rtc extends Record {
                         type: "warning",
                     }
                 );
-                this.log(this.selfSession, "failed to load sfu server", {
+                this.log(this.localSession, "failed to load sfu server", {
                     error: e,
                     important: true,
                 });
             }
             this.selfSession.connectionState = "initializing";
         } else {
-            this.log(this.selfSession, "no sfu server info, using peer-to-peer");
+            this.log(this.localSession, "no sfu server info, using peer-to-peer");
         }
         this.network.addEventListener("stateChange", this._handleSfuClientStateChange);
         this.network.addEventListener("update", this._handleNetworkUpdates);
@@ -644,6 +747,151 @@ export class Rtc extends Record {
             await this.call();
             this.updateUpload();
         }
+    }
+
+    /**
+     * Send an action to the host tab of the call
+     *
+     * @param {Object} changes
+     */
+    _remoteAction(changes) {
+        this._postToTabs({
+            type: CROSS_TAB_CLIENT_MESSAGE.REQUEST_ACTION,
+            changes,
+        });
+    }
+
+    _updateInfo() {
+        if (!this.isHost) {
+            return;
+        }
+        const info = toRaw(this.formatInfo());
+        this.network?.updateInfo(info);
+        this._updateRemoteTabs({ [this.localSession.id]: info });
+    }
+
+    _host() {
+        this._remotelyHostedChannelId = undefined;
+        this._remotelyHostedSessionId = this.localSession.id;
+        this._updateRemoteTabs({ [this.localSession.id]: toRaw(this.formatInfo()) });
+    }
+    _endHost() {
+        this._postToTabs({
+            type: CROSS_TAB_HOST_MESSAGE.CLOSE,
+            hostedSessionId: this._remotelyHostedSessionId,
+        });
+    }
+
+    _updateRemoteTabs(changes) {
+        this._postToTabs({
+            type: CROSS_TAB_HOST_MESSAGE.UPDATE_REMOTE,
+            hostedChannelId: this.state.channel.id,
+            hostedSessionId: this.localSession.id,
+            changes,
+        });
+    }
+
+    _postToTabs(message) {
+        if (!this._broadcastChannel) {
+            this.log(this.selfSession, "broadcast channel not available");
+            return;
+        }
+        try {
+            this._broadcastChannel.postMessage(message);
+        } catch (error) {
+            this.log(this.selfSession, "failed to post message to broadcast channel", { error });
+        }
+    }
+
+    _refreshCrossTabTimeout() {
+        browser.clearTimeout(this._crossTabTimeoutId);
+        this._crossTabTimeoutId = browser.setTimeout(() => {
+            this.clear();
+        }, PING_INTERVAL + 10_000);
+    }
+
+    async _onBroadcastChannelMessage({
+        data: { type, hostedChannelId, hostedSessionId, changes },
+    }) {
+        switch (type) {
+            case CROSS_TAB_HOST_MESSAGE.UPDATE_REMOTE:
+                if (this.isHost) {
+                    return;
+                }
+                this._remotelyHostedSessionId = hostedSessionId;
+                this._remotelyHostedChannelId = hostedChannelId;
+                this._refreshCrossTabTimeout();
+                this.updateSessionInfo(changes);
+                return;
+            case CROSS_TAB_HOST_MESSAGE.CLOSE: {
+                if (this._remotelyHostedSessionId !== hostedSessionId) {
+                    return;
+                }
+                this.clear();
+                return;
+            }
+            case CROSS_TAB_HOST_MESSAGE.PING: {
+                this._refreshCrossTabTimeout();
+                return;
+            }
+            case CROSS_TAB_CLIENT_MESSAGE.INIT: {
+                if (!this.isHost) {
+                    return;
+                }
+                this._updateRemoteTabs({ [this.localSession.id]: toRaw(this.formatInfo()) });
+                return;
+            }
+            case CROSS_TAB_CLIENT_MESSAGE.REQUEST_ACTION: {
+                if (!this.isHost) {
+                    return;
+                }
+                await this._localAction(changes);
+                this._updateRemoteTabs({ [this.localSession.id]: toRaw(this.formatInfo()) });
+                return;
+            }
+            case CROSS_TAB_CLIENT_MESSAGE.LEAVE: {
+                if (!this.isHost) {
+                    return;
+                }
+                await this.leaveCall(this.channel);
+                return;
+            }
+            case CROSS_TAB_CLIENT_MESSAGE.UPDATE_VOLUME: {
+                const session = this.store["discuss.channel.rtc.session"].get(changes.sessionId);
+                if (!session) {
+                    return;
+                }
+                session.volume = changes.volume;
+                return;
+            }
+        }
+    }
+
+    async _localAction(actions = {}) {
+        const promises = [];
+        for (const [key, value] of Object.entries(actions)) {
+            switch (key) {
+                case "is_muted":
+                    if (value === this.localSession.is_muted) {
+                        break;
+                    }
+                    promises.push(value ? this.mute() : this.unmute());
+                    break;
+                case "is_deaf":
+                    if (value === this.localSession.is_deaf) {
+                        break;
+                    }
+                    value ? promises.push(this.deafen()) : promises.push(this.undeafen());
+                    break;
+                case "raisingHand":
+                    if (value === Boolean(this.localSession.raisingHand)) {
+                        break;
+                    }
+                    promises.push(this.raiseHand(value));
+                    break;
+            }
+        }
+        await Promise.all(promises);
     }
 
     /**
@@ -720,33 +968,7 @@ export class Rtc extends Record {
                 }
                 return;
             case "info_change":
-                if (!payload) {
-                    return;
-                }
-                for (const [id, info] of Object.entries(payload)) {
-                    const session = this.store["discuss.channel.rtc.session"].get(Number(id));
-                    if (!session) {
-                        return;
-                    }
-                    if (
-                        this.state.channel.activeRtcSession === session &&
-                        session.is_screen_sharing_on &&
-                        !info.isScreenSharingOn
-                    ) {
-                        this.state.channel.activeRtcSession = undefined;
-                    }
-                    // `isRaisingHand` is turned into the Date `raisingHand`
-                    this.setRemoteRaiseHand(session, info.isRaisingHand);
-                    delete info.isRaisingHand;
-                    Object.assign(session, {
-                        is_muted: info.isSelfMuted,
-                        is_deaf: info.isDeaf,
-                        isTalking: info.isTalking,
-                        is_camera_on: info.isCameraOn,
-                        is_screen_sharing_on: info.isScreenSharingOn,
-                    });
-                    Object.assign(session, info);
-                }
+                this.updateSessionInfo(payload);
                 return;
             case "track":
                 {
@@ -776,8 +998,8 @@ export class Rtc extends Record {
     }
 
     async _handleSfuClientStateChange({ detail: { state, cause } }) {
-        this.log(this.selfSession, "SFU connection state changed", { state, cause });
-        this.selfSession.connectionState = state;
+        this.log(this.localSession, "SFU connection state changed", { state, cause });
+        this.localSession.connectionState = state;
         switch (state) {
             case this.SFU_CLIENT_STATE.AUTHENTICATED:
                 // if we are hot-swapping connection type, we clear the p2p as late as possible
@@ -805,7 +1027,7 @@ export class Rtc extends Record {
                         text = _t(
                             "Connection to SFU server closed by the server, falling back to peer-to-peer"
                         );
-                        this.log(this.selfSession, text, { important: true });
+                        this.log(this.localSession, text, { important: true });
                         this._downgradeConnection();
                     }
                     this.notification.add(text, {
@@ -813,6 +1035,38 @@ export class Rtc extends Record {
                     });
                 }
                 return;
+        }
+    }
+
+    updateSessionInfo(payload) {
+        if (!payload) {
+            return;
+        }
+        if (this.isHost) {
+            this._updateRemoteTabs(payload);
+        }
+        for (const [id, info] of Object.entries(payload)) {
+            const session = this.store["discuss.channel.rtc.session"].get(Number(id));
+            if (!session) {
+                return;
+            }
+            if (
+                this.channel.activeRtcSession === session &&
+                session.is_screen_sharing_on &&
+                !info.isScreenSharingOn
+            ) {
+                this.channel.activeRtcSession = undefined;
+            }
+            // `isRaisingHand` is turned into the Date `raisingHand`
+            this.setRemoteRaiseHand(session, info.isRaisingHand);
+            delete info.isRaisingHand;
+            assignDefined(session, {
+                is_muted: info.isSelfMuted ?? info.is_muted,
+                is_deaf: info.isDeaf ?? info.is_deaf,
+                isTalking: info.isTalking,
+                is_camera_on: info.isCameraOn ?? info.is_camera_on,
+                is_screen_sharing_on: info.isScreenSharingOn ?? info.is_screen_sharing_on,
+            });
         }
     }
 
@@ -855,7 +1109,7 @@ export class Rtc extends Record {
             return;
         }
         for (const session of this.state.channel.rtcSessions) {
-            if (session.eq(this.selfSession)) {
+            if (session.eq(this.localSession)) {
                 continue;
             }
             this.log(session, "init call", { step: "init call" });
@@ -872,7 +1126,7 @@ export class Rtc extends Record {
     async handleRemoteTrack({ session, track, type, active = true }) {
         session.updateStreamState(type, active);
         await this.updateStream(session, track, {
-            mute: this.selfSession.is_deaf,
+            mute: this.localSession.is_deaf,
             videoType: type,
         });
         this.updateActiveSession(session, type, { addVideo: true });
@@ -908,15 +1162,15 @@ export class Rtc extends Record {
         this.newLogs();
         this.state.updateAndBroadcastDebounce = debounce(
             async () => {
-                if (!this.selfSession) {
+                if (!this.localSession) {
                     return;
                 }
                 await rpc(
                     "/mail/rtc/session/update_and_broadcast",
                     {
-                        session_id: this.selfSession.id,
+                        session_id: this.localSession.id,
                         values: pick(
-                            this.selfSession,
+                            this.localSession,
                             "is_camera_on",
                             "is_deaf",
                             "is_muted",
@@ -939,6 +1193,7 @@ export class Rtc extends Record {
             return;
         }
         this.soundEffectsService.play("call-join");
+        this._host();
         this.cleanups.push(
             // only register the beforeunload event if there is a call as FireFox will not place
             // the pages with beforeunload listeners in the bfcache.
@@ -952,7 +1207,7 @@ export class Rtc extends Record {
 
     newLogs() {
         const date = luxon.DateTime.now().toFormat("yyyy-MM-dd-HH:mm:ss");
-        const id = `c:${this.state.channel.id}-s:${this.selfSession.id}-d:${date}`;
+        const id = `c:${this.state.channel.id}-s:${this.localSession.id}-d:${date}`;
         this.state.logs = this.state.globalLogs[id] = {};
         this.state.logs["hasTurn"] = hasTurn(this.iceServers);
     }
@@ -999,7 +1254,7 @@ export class Rtc extends Record {
             {
                 channel_id: this.state.channel.id,
                 check_rtc_session_ids: this.state.channel.rtcSessions.map((session) => session.id),
-                rtc_session_id: this.selfSession.id,
+                rtc_session_id: this.localSession.id,
             },
             { silent: true }
         );
@@ -1034,6 +1289,9 @@ export class Rtc extends Record {
                 session.isTalking = false;
             }
         }
+        this._remotelyHostedSessionId = undefined;
+        this._remotelyHostedChannelId = undefined;
+        browser.clearTimeout(this._crossTabTimeoutId);
         this.cleanups.splice(0).forEach((cleanup) => cleanup());
         browser.clearTimeout(this.sfuTimeout);
         this.sfuClient = undefined;
@@ -1053,7 +1311,7 @@ export class Rtc extends Record {
             this.blurManager = undefined;
         }
         this.update({
-            selfSession: undefined,
+            localSession: undefined,
             serverInfo: undefined,
         });
         Object.assign(this.state, {
@@ -1096,22 +1354,26 @@ export class Rtc extends Record {
      * @param {Boolean} raise
      */
     async raiseHand(raise) {
-        if (!this.selfSession || !this.state.channel) {
+        if (this.isRemote) {
+            this._remoteAction({ raisingHand: raise });
             return;
         }
-        this.selfSession.raisingHand = raise ? new Date() : undefined;
-        await this.network?.updateInfo(this.formatInfo());
+        if (!this.localSession || !this.state.channel) {
+            return;
+        }
+        this.localSession.raisingHand = raise ? new Date() : undefined;
+        await this._updateInfo();
     }
 
     /**
      * @param {boolean} isTalking
      */
     async setTalking(isTalking) {
-        if (!this.selfSession || isTalking === this.selfSession.isTalking) {
+        if (!this.localSession || isTalking === this.localSession.isTalking) {
             return;
         }
-        this.selfSession.isTalking = isTalking;
-        if (!this.selfSession.isMute) {
+        this.localSession.isTalking = isTalking;
+        if (!this.localSession.isMute) {
             this.pttExtService.notifyIsTalking(isTalking);
             await this.refreshAudioStatus();
         }
@@ -1122,6 +1384,12 @@ export class Rtc extends Record {
      * @param {boolean} [force]
      */
     async toggleVideo(type, force) {
+        if (this.isRemote) {
+            this.notification.add(_t("This action can only be done in the call tab."), {
+                type: "warning",
+            });
+            return;
+        }
         if (!this.state.channel?.id) {
             return;
         }
@@ -1141,26 +1409,26 @@ export class Rtc extends Record {
                 break;
             }
         }
-        if (this.selfSession) {
+        if (this.localSession) {
             switch (type) {
                 case "camera": {
-                    this.removeVideoFromSession(this.selfSession, {
+                    this.removeVideoFromSession(this.localSession, {
                         type: "camera",
                         cleanup: false,
                     });
                     if (this.state.cameraTrack) {
-                        this.updateStream(this.selfSession, this.state.cameraTrack);
+                        this.updateStream(this.localSession, this.state.cameraTrack);
                     }
                     break;
                 }
                 case "screen": {
                     if (!this.state.screenTrack) {
-                        this.removeVideoFromSession(this.selfSession, {
+                        this.removeVideoFromSession(this.localSession, {
                             type: "screen",
                             cleanup: false,
                         });
                     } else {
-                        this.updateStream(this.selfSession, this.state.screenTrack);
+                        this.updateStream(this.localSession, this.state.screenTrack);
                     }
                     break;
                 }
@@ -1168,7 +1436,7 @@ export class Rtc extends Record {
         }
         const updatedTrack = type === "camera" ? this.state.cameraTrack : this.state.screenTrack;
         await this.network?.updateUpload(type, updatedTrack);
-        if (!this.selfSession) {
+        if (!this.localSession) {
             return;
         }
         switch (type) {
@@ -1188,8 +1456,8 @@ export class Rtc extends Record {
     }
 
     updateAndBroadcast(data) {
-        const session = this.selfSession;
-        Object.assign(session, data);
+        this._updateRemoteTabs({ [this.localSession.id]: data });
+        assignDefined(this.localSession, data);
         this.state.updateAndBroadcastDebounce?.();
     }
 
@@ -1201,8 +1469,8 @@ export class Rtc extends Record {
         if (!this.state.audioTrack) {
             return;
         }
-        this.state.audioTrack.enabled = !this.selfSession.isMute && this.selfSession.isTalking;
-        this.network?.updateInfo(this.formatInfo());
+        this.state.audioTrack.enabled = !this.localSession.isMute && this.localSession.isTalking;
+        this._updateInfo();
     }
 
     /**
@@ -1320,7 +1588,7 @@ export class Rtc extends Record {
         if (!this.state.channel) {
             return;
         }
-        if (this.selfSession) {
+        if (this.localSession) {
             this.setMute(true);
         }
         if (force) {
@@ -1330,7 +1598,7 @@ export class Rtc extends Record {
                     audio: this.store.settings.audioConstraints,
                 });
                 audioTrack = audioStream.getAudioTracks()[0];
-                if (this.selfSession) {
+                if (this.localSession) {
                     this.setMute(false);
                 }
             } catch {
@@ -1342,7 +1610,7 @@ export class Rtc extends Record {
                 );
                 return;
             }
-            if (!this.selfSession) {
+            if (!this.localSession) {
                 // The getUserMedia promise could resolve when the call is ended
                 // in which case the track is no longer relevant.
                 audioTrack.stop();
@@ -1353,7 +1621,7 @@ export class Rtc extends Record {
                 await this.resetAudioTrack({ force: false });
                 this.setMute(true);
             });
-            audioTrack.enabled = !this.selfSession.isMute && this.selfSession.isTalking;
+            audioTrack.enabled = !this.localSession.isMute && this.localSession.isTalking;
             this.state.audioTrack = audioTrack;
             this.linkVoiceActivationDebounce();
             await this.network?.updateUpload("audio", this.state.audioTrack);
@@ -1366,11 +1634,11 @@ export class Rtc extends Record {
      */
     async linkVoiceActivation() {
         this.state.disconnectAudioMonitor?.();
-        if (!this.selfSession) {
+        if (!this.localSession) {
             return;
         }
         if (this.store.settings.use_push_to_talk || !this.state.channel || !this.state.audioTrack) {
-            this.selfSession.isTalking = false;
+            this.localSession.isTalking = false;
             await this.refreshAudioStatus();
             return;
         }
@@ -1390,7 +1658,7 @@ export class Rtc extends Record {
             this.notification.add(_t("Your browser does not support voice activation"), {
                 type: "warning",
             });
-            this.selfSession.isTalking = true;
+            this.localSession.isTalking = true;
         }
         await this.refreshAudioStatus();
     }
@@ -1401,8 +1669,8 @@ export class Rtc extends Record {
     deleteSession(id) {
         const session = this.store["discuss.channel.rtc.session"].get(id);
         if (session) {
-            if (this.selfSession && session.eq(this.selfSession)) {
-                this.log(this.selfSession, "self session deleted, ending call", {
+            if (this.localSession && session.eq(this.localSession)) {
+                this.log(this.localSession, "self session deleted, ending call", {
                     important: true,
                 });
                 this.endCall();
@@ -1413,9 +1681,9 @@ export class Rtc extends Record {
     }
 
     formatInfo() {
-        this.selfSession.is_camera_on = Boolean(this.state.cameraTrack);
-        this.selfSession.is_screen_sharing_on = Boolean(this.state.screenTrack);
-        return this.selfSession.info;
+        this.localSession.is_camera_on = Boolean(this.state.cameraTrack);
+        this.localSession.is_screen_sharing_on = Boolean(this.state.screenTrack);
+        return this.localSession.info;
     }
 
     /**
@@ -1593,7 +1861,7 @@ export const rtcService = {
         services["bus_service"].subscribe(
             "discuss.channel.rtc.session/sfu_hot_swap",
             async ({ serverInfo }) => {
-                if (!rtc.selfSession) {
+                if (!rtc.localSession) {
                     return;
                 }
                 if (rtc.serverInfo?.channelUUID === serverInfo.channelUUID) {
@@ -1606,7 +1874,7 @@ export const rtcService = {
             }
         );
         services["bus_service"].subscribe("discuss.channel.rtc.session/ended", ({ sessionId }) => {
-            if (rtc.selfSession?.id === sessionId) {
+            if (rtc.localSession?.id === sessionId) {
                 rtc.endCall();
                 services.notification.add(_t("Disconnected from the RTC call by the server"), {
                     type: "warning",
@@ -1626,7 +1894,7 @@ export const rtcService = {
                  * If this event comes from the channel of the current call, information is shared in real time
                  * through the peer to peer connection. So we do not use this less accurate broadcast.
                  */
-                if (channelId !== rtc.state.channel?.id) {
+                if (channelId !== rtc.channel?.id) {
                     rtc.store.insert(data);
                 }
             }

--- a/addons/mail/static/src/discuss/call/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/call/common/thread_actions.js
@@ -9,9 +9,7 @@ import { useService } from "@web/core/utils/hooks";
 threadActionsRegistry
     .add("call", {
         condition(component) {
-            return (
-                component.thread?.allowCalls && !component.thread?.eq(component.rtc.state.channel)
-            );
+            return component.thread?.allowCalls && !component.thread?.eq(component.rtc.channel);
         },
         icon: "fa fa-fw fa-phone",
         iconLarge: "fa fa-fw fa-lg fa-phone",

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
@@ -3,7 +3,7 @@
     <t t-name="mail.DiscussSidebarCallIndicator">
         <div t-if="props.thread.rtcSessions.length > 0" title="Ongoing call" class="o-mail-DiscussSidebarCallIndicator o-py-0_5 fa-fw rounded-circle fa fa-volume-up" t-att-class="{
             'o-discuss-inCallIconColor opacity-75': props.thread.eq(rtc.state.channel),
-            'opacity-50': !props.thread.eq(rtc.state.channel),
+            'opacity-50': !props.thread.eq(rtc.channel),
             'me-2': !store.discuss.isSidebarCompact,
         }"/>
     </t>

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -12,6 +12,10 @@ import {
     triggerEvents,
 } from "@mail/../tests/mail_test_helpers";
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
+import {
+    CROSS_TAB_HOST_MESSAGE,
+    CROSS_TAB_CLIENT_MESSAGE,
+} from "@mail/discuss/call/common/rtc_service";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { hover, queryFirst } from "@odoo/hoot-dom";
@@ -588,4 +592,44 @@ test("show call participants after stopping camera share", async () => {
     await contains("video", { count: 0 });
     // when all participant cards are shown they are minimized
     await contains(".o-discuss-Call-mainCards .o-discuss-CallParticipantCard .o-minimized");
+});
+
+test("Cross tab calls: tabs can interact with calls remotely", async () => {
+    mockGetMedia();
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const broadcastChannel = new browser.BroadcastChannel("call_sync_state");
+    const sessionId = pyEnv["discuss.channel.rtc.session"].create({
+        channel_member_id: pyEnv["discuss.channel.member"].create({
+            channel_id: channelId,
+            partner_id: pyEnv["res.partner"].create({ name: "remoteHost" }),
+        }),
+        channel_id: channelId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    expect("[title='Disconnect']").not.toBeVisible();
+    expect("[title='Mute']").not.toBeVisible();
+    expect("[title='Deafen']").not.toBeVisible();
+    broadcastChannel.postMessage({
+        type: CROSS_TAB_HOST_MESSAGE.UPDATE_REMOTE,
+        hostedChannelId: channelId,
+        hostedSessionId: sessionId,
+        changes: {
+            [sessionId]: {
+                is_muted: false,
+                is_deaf: false,
+            },
+        },
+    });
+    await contains("[title='Disconnect']");
+    await contains("[title='Deafen']");
+
+    broadcastChannel.onmessage = (event) => {
+        if (event.data.type === CROSS_TAB_CLIENT_MESSAGE.REQUEST_ACTION) {
+            asyncStep(`is_muted:${event.data.changes["is_muted"]}`);
+        }
+    };
+    await click("[title='Mute']");
+    await waitForSteps(["is_muted:true"]);
 });

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -200,7 +200,7 @@ async function channel_call_join(request) {
     })
         .add("Rtc", {
             iceServers: false,
-            selfSession: mailDataHelpers.Store.one(DiscussChannelRtcSession.browse(sessionId)),
+            localSession: mailDataHelpers.Store.one(DiscussChannelRtcSession.browse(sessionId)),
         })
         .get_result();
 }
@@ -873,7 +873,7 @@ registerRoute("/mail/thread/recipients/fields", mail_thread_recipients_fields);
 async function mail_thread_recipients_fields(request) {
     return {
         partner_fields: [],
-        primary_email_field: []
+        primary_email_field: [],
     };
 }
 

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -135,7 +135,7 @@ class TestChannelRTC(MailCommon):
                 ),
                 "Rtc": {
                     "iceServers": False,
-                    "selfSession": channel_member.rtc_session_ids.id,
+                    "localSession": channel_member.rtc_session_ids.id,
                     "serverInfo": None,
                 },
             },
@@ -1259,7 +1259,7 @@ class TestChannelRTC(MailCommon):
             ],
         ):
             current_rtc_sessions, outdated_rtc_sessions = channel_member._rtc_sync_sessions(
-                check_rtc_session_ids=[join_call_values["Rtc"]["selfSession"]] + unused_ids
+                check_rtc_session_ids=[join_call_values["Rtc"]["localSession"]] + unused_ids
             )
         self.assertEqual(channel_member.rtc_session_ids, current_rtc_sessions)
         self.assertEqual(unused_ids, outdated_rtc_sessions.ids)


### PR DESCRIPTION
This commit adds the ability to see and control calls from any tab,
with the exception of video features which cannot be shared.

This commit also limits the amount of RtcSession per user at 1. Which
means that one user can only be in one call at a time.

task-4393318