### PR TITLE
[FIX] l10n_din5008: fix external_layout_din5008 template footer size

### DIFF
--- a/addons/l10n_din5008/static/src/scss/report_din5008.scss
+++ b/addons/l10n_din5008/static/src/scss/report_din5008.scss
@@ -98,7 +98,6 @@
         .company_details {
             margin-top: 4.23mm;
             width: 100%;
-            font-size: 0.8em;
             table {
                 border-top: solid 1px;
                 table-layout: fixed;
@@ -107,7 +106,10 @@
                     vertical-align: baseline;
                     padding-right: 3mm;
                     li {
-                        font-size: 0.7em;
+                        font-size: 0.8em;
+                        p {
+                            line-height: 1.3em;
+                        }
                     }
                     &:last-child {
                         padding-right: initial;


### PR DESCRIPTION
**Issue:**

-  When selecting the `DIN 5008 (external_layout_din5008)` layout in the report layout and printing the report, the footer font size appears too small.

![before_fix](https://github.com/user-attachments/assets/603725a6-065b-43bf-948c-009476833a3b)


**Solution:**

- After the PR [#100723](https://github.com/odoo/odoo/pull/100723), the table layout was stabilized, but it introduced a very small `font-size (0.7em)`. A subsequent change by `malb` applied a font-size to the `.company_details` class, but this is no longer sufficient due to the presence of `<p>` tags in the footer.

To resolve this - 
- remove the general font-size directive
- add a new one in li
- add a limited line-height to the `<p>` tag to reduce the vertical size of the footer, given we are boosting the font size.


![after_fix](https://github.com/user-attachments/assets/b7c033f3-7c84-488a-b8c9-bb6198be59dd)

opw-4506533