### PR TITLE
[18.0][FIX] l10n_fr_account: fix call preserve_existing_tags_on_taxes()

### DIFF
--- a/addons/l10n_fr_account/__init__.py
+++ b/addons/l10n_fr_account/__init__.py
@@ -13,7 +13,7 @@ def _l10n_fr_post_init_hook(env):
     _setup_inalterability(env)
 
 def _preserve_tag_on_taxes(env):
-    preserve_existing_tags_on_taxes(env, 'l10n_fr')
+    preserve_existing_tags_on_taxes(env, 'l10n_fr_account')
 
 def _setup_inalterability(env):
     # enable ping for this module


### PR DESCRIPTION
When calling preserve_existing_tags_on_taxes(), the module name is passed as argument, cf https://github.com/odoo/odoo/blob/18.0/addons/account/models/chart_template.py#L38. The module name is now l10n_fr_account instead of l10n_fr (account.account.tag are now defined in l10n_fr_account, cf https://github.com/odoo/odoo/blob/18.0/addons/l10n_fr_account/data/account_chart_template_data.xml#L3).



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
