### PR TITLE
[FIX] web: fixing getSelectedResIds missing fuction

### DIFF
--- a/addons/account/static/src/views/account_move_list/account_move_list_controller.js
+++ b/addons/account/static/src/views/account_move_list/account_move_list_controller.js
@@ -30,7 +30,7 @@ export class AccountMoveListController extends FileUploadListController {
     }
 
     async onDeleteSelectedRecords() {
-        const selectedResIds = await this.getSelectedResIds();
+        const selectedResIds = await this.model.root.getResIds(true);
         if (this.props.resModel !== "account.move" || !await this.account_move_service.addDeletionDialog(this, selectedResIds)) {
             return super.onDeleteSelectedRecords(...arguments);
         }

--- a/addons/data_recycle/static/src/views/data_recycle_list_view.js
+++ b/addons/data_recycle/static/src/views/data_recycle_list_view.js
@@ -7,7 +7,7 @@ export class DataRecycleListController extends DataCleaningCommonListController 
      * Validate all the records selected
      */
     async onValidateClick() {
-        const record_ids = await this.getSelectedResIds();
+        const record_ids = await this.model.root.getResIds(true);
 
         await this.orm.call('data_recycle.record', 'action_validate', [record_ids]);
         await this.model.load();

--- a/addons/stock/static/src/views/stock_orderpoint_list_controller.js
+++ b/addons/stock/static/src/views/stock_orderpoint_list_controller.js
@@ -12,7 +12,7 @@ export class StockOrderpointListController extends ListController {
     }
 
     async onClickOrder(force_to_max) {
-        const resIds = await this.getSelectedResIds();
+        const resIds = await this.model.root.getResIds(true);
         const action = await this.model.orm.call(this.props.resModel, 'action_replenish', [resIds], {
             context: this.props.context,
             force_to_max: force_to_max,
@@ -26,7 +26,7 @@ export class StockOrderpointListController extends ListController {
     }
 
     async onClickSnooze() {
-        const resIds = await this.getSelectedResIds();
+        const resIds = await this.model.root.getResIds(true);
         this.actionService.doAction('stock.action_orderpoint_snooze', {
             additionalContext: { default_orderpoint_ids: resIds },
             onClose: () => {

--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -221,7 +221,7 @@ export class DynamicList extends DataPoint {
 
     deleteRecordsWithConfirmation(dialogProps = {}, records) {
         let body = deleteConfirmationMessage;
-        if (this.model.root.isDomainSelected || this.model.root.selection.length > 1) {
+        if (this.isDomainSelected || this.selection.length > 1) {
             body = _t("Are you sure you want to delete these records?");
         }
         const defaultProps = {


### PR DESCRIPTION
In this commit: https://github.com/odoo/odoo/commit/1e4e40cf78fe8151dffdcb19df2688787084732c We removed getSelectedResIds, but this function is still needed in some overrides. This commit removes the calls to that function while keeping the same behaviour as before.

no-task

linked:https://github.com/odoo/enterprise/pull/79589