### PR TITLE
[FIX] web: menu_id fallback

### DIFF
--- a/addons/web/static/src/webclient/menus/menu_service.js
+++ b/addons/web/static/src/webclient/menus/menu_service.js
@@ -30,6 +30,7 @@ function makeMenus(env, menusData, fetchLoadMenus) {
         menu = typeof menu === "number" ? _getMenu(menu) : menu;
         if (menu && menu.appID !== currentAppId) {
             currentAppId = menu.appID;
+            browser.sessionStorage.setItem("menu_id", currentAppId);
             env.bus.trigger("MENUS:APP-CHANGED");
         }
     }

--- a/addons/web/static/src/webclient/webclient.js
+++ b/addons/web/static/src/webclient/webclient.js
@@ -9,6 +9,7 @@ import { NavBar } from "./navbar/navbar";
 
 import { Component, onMounted, onWillStart, useExternalListener, useState } from "@odoo/owl";
 import { router, routerBus } from "@web/core/browser/router";
+import { browser } from "@web/core/browser/browser";
 
 export class WebClient extends Component {
     static template = "web.WebClient";
@@ -87,6 +88,10 @@ export class WebClient extends Component {
             const currentController = this.actionService.currentController;
             const actionId = currentController && currentController.action.id;
             menuId = this.menuService.getAll().find((m) => m.actionID === actionId)?.appID;
+            if (!menuId) {
+                // Setting the menu based on the session storage if no other menu was found
+                menuId = Number(browser.sessionStorage.getItem("menu_id"));
+            }
             if (menuId) {
                 // Sets the menu according to the current action
                 this.menuService.setCurrentMenu(menuId);

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -214,6 +214,7 @@ describe(`new urls`, () => {
         await mountWebClient();
         expect(`.test_client_action`).toHaveCount(1);
         expect(`.o_menu_brand`).toHaveText("App1");
+        expect(browser.sessionStorage.getItem("menu_id")).toBe("1");
         expect(browser.location.href).toBe("http://example.com/odoo/action-1001", {
             message: "url did not change",
         });
@@ -229,6 +230,7 @@ describe(`new urls`, () => {
         await mountWebClient();
         expect(`.test_client_action`).toHaveText("ClientAction_Id 2");
         expect(`.o_menu_brand`).toHaveText("App2");
+        expect(browser.sessionStorage.getItem("menu_id")).toBe("2");
         expect(browser.location.href).toBe("http://example.com/odoo/action-1002", {
             message: "url now points to the default action of the menu",
         });
@@ -242,6 +244,7 @@ describe(`new urls`, () => {
         await mountWebClient();
         expect(`.test_client_action`).toHaveText("ClientAction_Id 1");
         expect(`.o_menu_brand`).toHaveText("App2");
+        expect(browser.sessionStorage.getItem("menu_id")).toBe("2");
         expect(router.current).toEqual({
             action: 1001,
             actionStack: [
@@ -255,6 +258,24 @@ describe(`new urls`, () => {
             message: "menu is removed from url",
         });
         expect.verifySteps(["pushState http://example.com/odoo/action-1001"]);
+    });
+
+    test("menu fallback", async () => {
+        class ClientAction extends Component {
+            static template = xml`<div class="o_client_action_test">Hello World</div>`;
+            static path = "test";
+            static props = ["*"];
+        }
+        actionRegistry.add("HelloWorldTest", ClientAction);
+        browser.sessionStorage.setItem("menu_id", 2);
+        redirect("/odoo/test");
+        logHistoryInteractions();
+        await mountWebClient();
+
+        expect(`.o_menu_brand`).toHaveText("App2");
+        expect.verifySteps([
+            "Update the state without updating URL, nextState: actionStack,action",
+        ]);
     });
 
     test(`initial loading with action id`, async () => {
@@ -1417,6 +1438,7 @@ describe(`new urls`, () => {
         expect.verifySteps([
             'get current_action-{"type":"ir.actions.act_window","res_model":"partner","views":[[1,"kanban"]],"context":{"lang":"en","tz":"taht","uid":7,"allowed_company_ids":[1],"active_model":"partner","active_id":1,"active_ids":[1]}}',
             'set current_action-{"type":"ir.actions.act_window","res_model":"partner","views":[[1,"kanban"]],"context":{"lang":"en","tz":"taht","uid":7,"active_model":"partner","active_id":1,"active_ids":[1]}}',
+            "get menu_id-null",
         ]);
     });
 });


### PR DESCRIPTION
[1] introduced a new URL mechanism where the menu_id isn't in the URL anymore. To find the corresponding menu on reload, the web client searches for a menu corresponding to the first application in the URL. The advantage of this, is that a clean URL without superflow is used. One of the limitations is that if the first action in the URL is not linked to a menu, the menu may disappear on reload.

This PR fixes this issue by creating a fallback to the last used menu. This is done to improve the user experience on reload. Note that this only fixes the problem on reload. If the URL is opened in a new tab, or shared, the menu will not be display.

[1] https://github.com/odoo/odoo/commit/c63d14a0485a553b74a8457aee158384e9ae6d3f

opw-198103
