### PR TITLE
[FIX] core: prefetching of secondary new records

### DIFF
--- a/odoo/addons/test_performance/tests/test_performance.py
+++ b/odoo/addons/test_performance/tests/test_performance.py
@@ -486,6 +486,26 @@ class TestPerformance(SavepointCaseWithUserDemo):
         result = list(zip(result_name, result_value, result_value_pc))
         self.assertEqual(result, [('1', 1, 0.01), ('2', 42, 0.42), ('3', 3, 0.03)])
 
+    def test_prefetch_new(self):
+        model = self.env['test_performance.base']
+        records = model.create([
+            {'name': str(i), 'line_ids': [Command.create({'value': i})]} for i in [1, 2, 3]
+        ])
+        self.env.flush_all()
+        self.env.invalidate_all()
+
+        # make a new recordset corresponding to those records, and access it
+        new_record = model.new({'line_ids': [Command.create({'value': 4})]})
+        new_records_ids = [model.new(origin=record).id for record in records]
+        new_records_ids.append(new_record.id)
+        new_records = model.browse(new_records_ids)
+
+        # fetch 'line_ids' on all records (2 queries), fetch 'value' on all lines (1 query)
+        with self.assertQueryCount(3):
+            for record in new_records:
+                for line in record.line_ids:
+                    line.value
+
     def expected_read_group(self):
         groups = defaultdict(list)
         all_records = self.env['test_performance.base'].search([])


### PR DESCRIPTION
Consider a recordset of new records, and a loop like
```py
for record in records:
    for line in record.line_ids:
        line.value
```
The implementation of `record.line_ids` does not actually prefetch all `records`.  It actually fetches the field on the records' origin (their corresponding real records), but only assigns the current new record in cache.  As the prefetching relies on the cached values of `line_ids`, the prefetching mechanism is actually broken on `line`.

The fix consists in assigning all the records to prefetch in this case. This does not add unexpected prefetching, since the origin records are prefetched as one batch anyway.