### PR TITLE
[IMP] mail, portal: scroll to message support for portal chatter

### DIFF
--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -207,7 +207,7 @@ class MailController(http.Controller):
         if not request.env.user._is_internal():
             thread = request.env[message.model].search([('id', '=', message.res_id)])
             if hasattr(thread, "_get_share_url"):
-                return request.redirect(thread._get_share_url(share_token=False))
+                return request.redirect(f'{thread._get_share_url(share_token=False)}highlight_message_id={message.id}')
             raise Unauthorized()
         # @see commit c63d14a0485a553b74a8457aee158384e9ae6d3f
         # @see router.js: heuristics to discrimate a model name from an action path

--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -1,5 +1,6 @@
 import { Composer } from "@mail/core/common/composer";
 import { Thread } from "@mail/core/common/thread";
+import { useMessageHighlight } from "@mail/utils/common/hooks";
 
 import {
     Component,
@@ -32,6 +33,7 @@ export class Chatter extends Component {
             thread: undefined,
             aside: false,
         });
+        this.messageHighlight = useMessageHighlight();
         this.rootRef = useRef("root");
         this.onScrollDebounced = useThrottleForAnimation(this.onScroll);
         useChildSubEnv(this.childSubEnv);
@@ -58,7 +60,10 @@ export class Chatter extends Component {
     }
 
     get childSubEnv() {
-        return { inChatter: this.state };
+        return {
+            inChatter: this.state,
+            messageHighlight: this.messageHighlight,
+        };
     }
 
     get onCloseFullComposerRequestList() {
@@ -70,7 +75,11 @@ export class Chatter extends Component {
     }
 
     changeThread(threadModel, threadId) {
-        this.state.thread = this.store.Thread.insert({ model: threadModel, id: threadId });
+        this.state.thread = this.store.Thread.insert({
+            model: threadModel,
+            id: threadId,
+            highlightMessage: this.highlightMessage,
+        });
         if (threadId === false) {
             if (this.state.thread.messages.length === 0) {
                 this.state.thread.messages.push({

--- a/addons/portal/static/src/chatter/frontend/chatter_patch.js
+++ b/addons/portal/static/src/chatter/frontend/chatter_patch.js
@@ -1,10 +1,14 @@
 import { Chatter } from "@mail/chatter/web_portal/chatter";
 
+import { router } from "@web/core/browser/router";
 import { patch } from "@web/core/utils/patch";
 import { useRef, onWillPatch, useEffect } from "@odoo/owl";
 
 patch(Chatter.prototype, {
     setup() {
+        this.highlightMessage = router.current.highlight_message_id;
+        router.removeQueryParams("highlight_message_id");
+
         super.setup(...arguments);
         this.topRef = useRef("top");
         onWillPatch(() => {

--- a/addons/web/static/src/core/browser/router.js
+++ b/addons/web/static/src/core/browser/router.js
@@ -390,6 +390,17 @@ function makeDebouncedPush(mode) {
     };
 }
 
+/**
+ * Removes specified query parameters from the URL without triggering a reload
+ * @param {string|string[]} params - Parameter(s) to remove from URL
+ */
+function removeQueryParams(params) {
+    const url = new URL(window.location.href);
+    const paramList = Array.isArray(params) ? params : [params];
+    paramList.forEach((param) => url.searchParams.delete(param));
+    browser.history.replaceState({}, "", url.toString());
+}
+
 export const router = {
     get current() {
         return state;
@@ -403,6 +414,7 @@ export const router = {
     cancelPushes: () => browser.clearTimeout(pushTimeout),
     addLockedKey: (key) => _lockedKeys.add(key),
     hideKeyFromUrl: (key) => _hiddenKeysFromUrl.add(key),
+    removeQueryParams: removeQueryParams,
     skipLoad: false,
 };
 


### PR DESCRIPTION
**Current behavior before PR**:

Opening a copied message link does not automatically scroll to the message
for portal users, it only opens the record.

**Desired behavior after PR is merged**:

Opening the copied link now automatically scrolls to the specific message
within the record instead of just opening the record.

**task-id**:[4518058](https://www.odoo.com/odoo/project/1519/tasks/4518058)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
