### PR TITLE
[IMP] {website_}event: make event cancelation easier

### DIFF
--- a/addons/event/__manifest__.py
+++ b/addons/event/__manifest__.py
@@ -55,6 +55,7 @@ Key Features
         'web.assets_backend': [
             'event/static/src/client_action/**/*',
             'event/static/src/scss/event.scss',
+            'event/static/src/event_state_selection_field/*',
             'event/static/src/icon_selection_field/icon_selection_field.js',
             'event/static/src/icon_selection_field/icon_selection_field.xml',
             'event/static/src/template_reference_field/*',

--- a/addons/event/data/event_data.xml
+++ b/addons/event/data/event_data.xml
@@ -24,12 +24,5 @@
             <field name="pipe_end" eval="True"/>
             <field name="fold" eval="True"/>
         </record>
-        <record id="event_stage_cancelled" model="event.stage">
-            <field name="name">Cancelled</field>
-            <field name="description">The event has been cancelled</field>
-            <field name="sequence">6</field>
-            <field name="pipe_end" eval="True"/>
-            <field name="fold" eval="True"/>
-        </record>
     </data>
 </odoo>

--- a/addons/event/models/event_stage.py
+++ b/addons/event/models/event_stage.py
@@ -16,12 +16,3 @@ class EventStage(models.Model):
     pipe_end = fields.Boolean(
         string='End Stage', default=False,
         help='Events will automatically be moved into this stage when they are finished. The event moved into this stage will automatically be set as green.')
-    legend_blocked = fields.Char(
-        'Red Kanban Label', default=lambda s: s.env._('Blocked'), translate=True, prefetch='legend', required=True,
-        help='Override the default value displayed for the blocked state for kanban selection.')
-    legend_done = fields.Char(
-        'Green Kanban Label', default=lambda s: s.env._('Ready for Next Stage'), translate=True, prefetch='legend', required=True,
-        help='Override the default value displayed for the done state for kanban selection.')
-    legend_normal = fields.Char(
-        'Grey Kanban Label', default=lambda s: s.env._('In Progress'), translate=True, prefetch='legend', required=True,
-        help='Override the default value displayed for the normal state for kanban selection.')

--- a/addons/event/static/src/event_state_selection_field/event_state_selection_field.js
+++ b/addons/event/static/src/event_state_selection_field/event_state_selection_field.js
@@ -1,0 +1,59 @@
+import { formatSelection } from "@web/views/fields/formatters";
+import { registry } from "@web/core/registry";
+import { StateSelectionField, stateSelectionField } from "@web/views/fields/state_selection/state_selection_field";
+import { useService } from "@web/core/utils/hooks";
+
+
+/**
+ * This widget is used to enhance the Event State Selection field UI.
+ * It extends `StateSelectionField` to provide visual feedback using icons
+ * and color classes for different states: `normal`, `done`, `blocked`, `cancel`.
+ */
+export class EventStateSelection extends StateSelectionField {
+    static template = "event.EventStateSelection";
+
+    setup() {
+        this.dialog = useService("dialog");
+        this.icons = {
+            normal: "o_status",
+            done: "o_status o_status_green",
+            blocked: "fa fa-lg fa-exclamation-circle",
+            cancel: "fa fa-lg fa-times-circle",
+        };
+        this.colorIcons = {
+            normal: "",
+            done: "text-success",
+            blocked: "o_status_blocked",
+            cancel: "text-danger",
+        };
+    }
+
+    get options() {
+        return ["normal", "done", "blocked", "cancel"].map((state) => [state, new Map(super.options).get(state)]);
+    }
+
+    get label() {
+        return formatSelection(this.currentValue, { selection: this.options });
+    }
+
+    stateIcon(value) {
+        return this.icons[value] || "";
+    }
+
+    /**
+     * @override
+     */
+    statusColor(value) {
+        return this.colorIcons[value] || "";
+    }
+}
+
+export const EventStateSelectionField = {
+    ...stateSelectionField,
+    component: EventStateSelection,
+    supportedOptions: [
+        ...stateSelectionField.supportedOptions
+    ]
+}
+
+registry.category("fields").add("event_state_selection", EventStateSelectionField);

--- a/addons/event/static/src/event_state_selection_field/event_state_selection_field.scss
+++ b/addons/event/static/src/event_state_selection_field/event_state_selection_field.scss
@@ -1,0 +1,40 @@
+.o_field_event_state_selection {
+    .o_status {
+        width: $font-size-base * 1.36;
+        height: $font-size-base * 1.36;
+        text-align: center;
+        margin-top: -0.5px;
+    }
+
+    .fa-lg {
+        font-size: 1.75em;
+        margin-top: -2.5px;
+        max-width: 20px;
+        max-height: 20px;
+    }
+
+    .o_status_blocked {
+        color: $warning;
+    }
+}
+
+.event_state_selection_menu {
+    .fa {
+        margin-top: -1.5px;
+        font-size: 1.315em;
+        vertical-align: -6%;
+        transform: translateX(-50%);
+    }
+
+    .o_status {
+        margin-top: 1px;
+        width: 14.65px;
+        height: 14.65px;
+        text-align: center;
+    }
+
+    .o_status_blocked {
+        color: $warning;
+    }
+}
+

--- a/addons/event/static/src/event_state_selection_field/event_state_selection_field.xml
+++ b/addons/event/static/src/event_state_selection_field/event_state_selection_field.xml
@@ -1,0 +1,23 @@
+<templates>
+    <t t-name="event.EventStateSelection" t-inherit="web.StateSelectionField" t-inherit-mode="primary">
+        <xpath expr="//Dropdown/button/div" position="replace">
+            <div class="d-flex align-items-center">
+                <i t-attf-class="{{ stateIcon(currentValue) }} {{ statusColor(currentValue) }} "/>
+            </div>
+        </xpath>
+        <!-- Dropdown Selection-->
+        <xpath expr="//Dropdown" position="attributes">
+            <attribute name="menuClass" separator=" + " add="' event_state_selection_menu'"></attribute>
+        </xpath>
+        <xpath expr="//CheckboxItem/span[1]" position="attributes">
+            <attribute name="t-attf-class" separator=" " add="{{ stateIcon(option[0]) }}" remove="o_status"></attribute>
+        </xpath>
+        <xpath expr="//CheckboxItem/span[2]" position="attributes">
+            <attribute name="t-attf-class">{{ statusColor(option[0]) }}</attribute>
+        </xpath>
+        <!-- Dropdown Divider -->
+        <xpath expr="//CheckboxItem" position="before">
+            <div t-if="option[0] == 'cancel'" role="separator" class="dropdown-divider"/>
+        </xpath>
+    </t>
+</templates>

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -50,11 +50,8 @@
                     </div>
                     <field name="active" invisible="1"/>
                     <field name="company_id" invisible="1"/>
-                    <field name="legend_blocked" invisible="1"/>
-                    <field name="legend_normal" invisible="1"/>
-                    <field name="legend_done" invisible="1"/>
                     <widget name="web_ribbon" text="Archived" bg_color="text-bg-danger" invisible="active"/>
-                    <field name="kanban_state" widget="state_selection" class="ms-auto float-end"/>
+                    <field name="kanban_state" widget="event_state_selection" class="ms-auto float-end"/>
                     <div class="oe_title">
                         <label for="name" string="Event Name"/>
                         <h1><field class="text-break" options="{'line_breaks': False}" widget="text" name="name" placeholder="e.g. Conference for Architects"/></h1>
@@ -106,7 +103,13 @@
                                     <field name="scheduled_date" groups="base.group_no_one"/>
                                     <field name="mail_count_done"/>
                                     <field name="mail_state" widget="event_icon_selection" string=" " nolabel="1"
-                                        options="{'error': 'fa fa-exclamation-triangle', 'sent': 'fa fa-check', 'scheduled': 'fa fa-hourglass-half', 'running': 'fa fa-cogs'}"/>
+                                        options="{
+                                            'error': 'fa fa-exclamation-triangle',
+                                            'sent': 'fa fa-check',
+                                            'scheduled': 'fa fa-hourglass-half',
+                                            'running': 'fa fa-cogs',
+                                            'cancelled': 'fa fa-times-circle'
+                                        }"/>
                                 </list>
                             </field>
                         </page>
@@ -248,7 +251,6 @@
                 <field name="stage_id" options='{"group_by_tooltip": {"description": "Description"}}'/>
                 <field name="date_begin"/>
                 <field name="date_end"/>
-                <field name="legend_done"/>
                 <templates>
                     <t t-name="card" class="p-0 row">
                         <aside class="col-4 text-bg-primary p-2 text-center d-flex flex-column justify-content-center">
@@ -280,8 +282,8 @@
                             <footer class="pt-1 p-0 m-0">
                                 <field name="activity_ids" widget="kanban_activity"/>
                                 <div class="d-flex ms-auto">
-                                    <field class="mt-1 mr4" name="kanban_state" widget="state_selection"/>
                                     <field name="user_id" widget="many2one_avatar_user"/>
+                                    <field class="ms-1 my-auto" name="kanban_state" widget="event_state_selection"/>
                                 </div>
                             </footer>
                         </main>

--- a/addons/event/views/event_mail_views.xml
+++ b/addons/event/views/event_mail_views.xml
@@ -50,7 +50,7 @@
                 <field name="scheduled_date"/>
                 <field name="mail_count_done"/>
                 <field name="mail_state" widget="event_icon_selection" string=" " nolabel="1"
-                    options="{'sent': 'fa fa-check', 'scheduled': 'fa fa-hourglass-half', 'running': 'fa fa-cogs'}"/>
+                    options="{'sent': 'fa fa-check', 'scheduled': 'fa fa-hourglass-half', 'running': 'fa fa-cogs', 'cancelled': 'fa fa-times-circle'}"/>
             </list>
         </field>
     </record>

--- a/addons/event/views/event_stage_views.xml
+++ b/addons/event/views/event_stage_views.xml
@@ -17,21 +17,7 @@
                             <field name="sequence"/>
                         </group>
                     </group>
-                    <group string="Stage Description and Tooltips">
-                        <p class="text-muted" colspan="2">
-                            You can define here labels that will be displayed for the state instead
-                            of the default labels in the kanban view.
-                        </p>
-                        <label for="legend_normal" string=" " class="o_status " title="Task in progress. Click to block or set as done." aria-label="Task in progress. Click to block or set as done." role="img"/>
-                        <field name="legend_normal" nolabel="1"/>
-                        <label for="legend_blocked" string=" " class="o_status o_status_red" title="Task is blocked. Click to unblock or set as done." aria-label="Task is blocked. Click to unblock or set as done." role="img"/>
-                        <field name="legend_blocked" nolabel="1"/>
-                        <label for="legend_done" string=" " class="o_status o_status_green" title="This step is done. Click to block or set in progress." aria-label="This step is done. Click to block or set in progress." role="img"/>
-                        <field name="legend_done" nolabel="1"/>
-
-                        <p class="text-muted" colspan="2">
-                            You can also add a description to help your coworkers understand the meaning and purpose of the stage.
-                        </p>
+                    <group string="Add a description that will appear as a tooltip for this stage">
                         <field name="description" placeholder="Add a description..." nolabel="1" colspan="2"/>
                     </group>
                 </sheet>

--- a/addons/test_event_full/tests/test_event_event.py
+++ b/addons/test_event_full/tests/test_event_event.py
@@ -72,6 +72,20 @@ class TestEventEvent(TestEventFullCommon):
             self.assertTrue(event.is_ongoing)
             self.assertTrue(event.event_registrations_started)
 
+    def test_event_kanban_state_on_stage_change(self):
+        """Test that kanban_state updates correctly when stage is changed."""
+        test_event_1 = self.env['event.event'].browse(self.test_event.ids)
+        test_event_2 = test_event_1.copy()
+
+        test_event_1.kanban_state = 'done'
+        test_event_2.kanban_state = 'cancel'  # Event Cancelled
+
+        new_stage = self.env['event.stage'].create({'name': 'New Stage', 'sequence': 1})
+        (test_event_1 | test_event_2).stage_id = new_stage.id  # Change event stage
+
+        self.assertEqual(test_event_1.kanban_state, 'normal', 'kanban state should reset to "normal" on stage change')
+        self.assertEqual(test_event_2.kanban_state, 'cancel', 'kanban state should not reset on stage change')
+
     @freeze_time('2021-12-01 11:00:00')
     @users('event_user')
     def test_event_seats_and_schedulers(self):

--- a/addons/test_event_full/tests/test_event_security.py
+++ b/addons/test_event_full/tests/test_event_security.py
@@ -55,7 +55,7 @@ class TestEventSecurity(TestEventFullCommon):
     def test_event_access_event_registration(self):
         # Event: read ok
         event = self.test_event.with_user(self.env.user)
-        event.read(['name', 'user_id', 'kanban_state_label'])
+        event.read(['name', 'user_id', 'kanban_state'])
 
         # Event: read only
         with self.assertRaises(AccessError):
@@ -77,7 +77,7 @@ class TestEventSecurity(TestEventFullCommon):
     def test_event_access_event_user(self):
         # Event
         event = self.test_event.with_user(self.env.user)
-        event.read(['name', 'user_id', 'kanban_state_label'])
+        event.read(['name', 'user_id', 'kanban_state'])
         event.write({'name': 'New name'})
         self.env['event.event'].create({
             'name': 'Event',

--- a/addons/website_event/static/src/scss/event_templates_list.scss
+++ b/addons/website_event/static/src/scss/event_templates_list.scss
@@ -46,6 +46,18 @@
             padding: ($spacer * .5) $card-spacer-x;
             transform: translateY(-50%);
         }
+        .o_wevent_badge_event_list {
+            @include o-position-absolute($top: 0, $left: 0);
+            @include border-end-radius(0);
+            padding: ($spacer * .5) $card-spacer-x;
+            transform: translateX(-100%);
+
+            @include media-breakpoint-down(sm) {
+                margin-top: 1rem;
+                border-radius: 10rem;
+                transform: none;
+            }
+        }
     }
     .o_wevent_sidebar_title {
         margin: 0 0 ($spacer * 1.5) 0;

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -309,8 +309,9 @@
     <div t-if="event_ids and original_search" class="col-12 alert alert-warning mt8">
         No results found for '<span t-out="original_search"/>'. Showing results for '<span t-out="searches['search']"/>'.
     </div>
-    <!-- List -->
+    <!-- View -->
     <div t-foreach="event_ids" t-as="event" t-attf-class=" #{opt_event_size}">
+        <t t-set="event_tag_ids" t-value="event.tag_ids.filtered(lambda tag: tag.category_id.website_id == website or not tag.category_id.website_id)"/>
         <a t-cache="(event, event.is_participating) if not editable and event.website_published else None" t-attf-href="/event/#{ slug(event) }/#{(not event.menu_id) and 'register'}" class="text-decoration-none text-reset " t-att-data-publish="event.website_published and 'on' or 'off'">
             <article t-attf-class="h-100 #{opt_events_list_cards and 'card'}" itemscope="itemscope" itemtype="http://schema.org/Event">
                 <div t-attf-class="h-100 #{opt_events_list_columns and 'd-flex flex-wrap flex-column' or 'row mx-0'}">
@@ -338,7 +339,10 @@
                                 </div>
                                 <!-- Not open -->
                                 <span t-if="not event.event_registrations_open and (not opt_events_list_cards or not opt_events_list_columns)" class="position-absolute bottom-0 px-3 py-2 w-100 text-bg-light">
-                                    <t t-if="not event.event_registrations_started">
+                                    <t t-if="event.kanban_state == 'cancel'">
+                                        Cancelled
+                                    </t>
+                                    <t t-elif="not event.event_registrations_started">
                                         Registrations not yet open
                                     </t>
                                     <t t-elif="event.event_registrations_sold_out">
@@ -359,40 +363,78 @@
                             </t>
                         </div>
                     </header>
-                    
+
                     <!-- Body -->
-                    <main t-attf-class="card-body position-relative d-flex flex-column justify-content-between gap-2 #{opt_events_list_columns and 'col-12 py-3' or 'col-8 col-lg-9 px-4'} #{not opt_events_list_cards and opt_events_list_columns and 'bg-transparent px-0'} #{not opt_events_list_cards and not opt_events_list_columns and 'bg-transparent py-0'}">
+                    <main t-attf-class="card-body position-relative d-flex justify-content-between gap-2 #{opt_events_list_columns and 'flex-column col-12 py-3' or 'justify-content-between align-items-center col-8 col-lg-9 px-4'} #{not opt_events_list_cards and opt_events_list_columns and 'bg-transparent px-0'} #{not opt_events_list_cards and not opt_events_list_columns and 'bg-transparent py-0'}">
+                        <!-- Event Details -->
                         <div id="event_details">
-                            <div class="d-flex flex-wrap gap-1 small">
-                                <t t-foreach="event.tag_ids.filtered(lambda tag: tag.category_id.website_id == website or not tag.category_id.website_id)" t-as="tag">
-                                    <span t-if="tag.color"
-                                        t-attf-class="badge #{'o_color_%s' % tag.color if tag.color else 'text-bg-light'}">
+                            <!-- Tags (Grid View) -->
+                            <div t-if="opt_events_list_columns" class="d-flex flex-wrap gap-1 small">
+                                <t t-foreach="event_tag_ids" t-as="tag">
+                                    <span t-if="tag.color" t-attf-class="badge #{'o_color_%s' % tag.color}">
                                         <t t-out="tag.name"/>
                                     </span>
                                 </t>
                             </div>
                             <!-- Title -->
-                            <h5 t-attf-class="card-title my-2 #{(not event.website_published) and 'text-danger'}">
+                            <h5 t-attf-class="card-title my-2 #{not event.website_published and 'text-danger'} #{not opt_events_list_columns and not event.event_registrations_open and 'text-muted'}">
                                 <span t-field="event.name" itemprop="name"/>
                             </h5>
-                            <!-- Start Date & Time -->
-                            <!-- TODO remove t-out one in master -->
-                            <small t-if="False" class="o_not_editable opacity-75" itemprop="description" t-out="event.subtitle">
-                            </small>
-                            <small class="opacity-75" itemprop="description" t-field="event.subtitle"/>
+                            <div t-if="not opt_events_list_columns" class="d-inline-flex flex-wrap gap-3">
+                                <!-- Location (List View) -->
+                                <div class="d-flex align-items-center">
+                                    <i class="fa fa-map-marker me-2 text-muted" title="Location"/>
+                                    <small class="o_not_editable fw-bold text-muted" itemprop="location"
+                                        t-out="event.address_id"
+                                        t-options="{'widget': 'contact', 'fields': ['city', 'country_id'], 'null_text': 'Online event', 'no_marker': 'true'}"/>
+                                </div>
+                                <!-- Tags (List View) -->
+                                <div class="d-flex flex-wrap gap-1 small">
+                                    <t t-foreach="event_tag_ids" t-as="tag">
+                                        <span t-if="tag.color" t-attf-class="badge d-flex align-items-center #{'o_color_%s' % tag.color}">
+                                            <t t-out="tag.name"/>
+                                        </span>
+                                    </t>
+                                </div>
+                            </div>
+                            <!-- Subtitle (Grid View) -->
+                            <small t-if="opt_events_list_columns" class="opacity-75" itemprop="description" t-field="event.subtitle"/>
                         </div>
-                        <!-- Location -->
-                        <small class="o_not_editable fw-bold" itemprop="location" t-out="event.address_id" t-options="{'widget': 'contact', 'fields': ['city', 'country_id'], 'null_text': 'Online event'}"/>
+                        <!-- Location (Grid View) -->
+                        <small t-if="opt_events_list_columns" class="o_not_editable fw-bold" itemprop="location" t-out="event.address_id" t-options="{'widget': 'contact', 'fields': ['city', 'country_id'], 'null_text': 'Online event'}"/>
+                        <!-- CTA (List View) -->
+                        <div t-if="not opt_events_list_columns" t-attf-class="d-none #{opt_index_sidebar and 'd-xl-block' or 'd-lg-block'}">
+                            <div class="d-flex flex-column gap-1 align-items-end text-center">
+                                <t t-if="not event.event_registrations_open">
+                                    <small class="text-muted fw-bold w-100">
+                                        <t t-if="event.kanban_state == 'cancel'">Cancelled</t>
+                                        <t t-elif="not event.event_registrations_started and not event.event_registrations_sold_out">Registrations not open</t>
+                                        <t t-elif="event.event_registrations_sold_out">Sold Out</t>
+                                        <t t-else="">Registrations Closed</t>
+                                    </small>
+                                    <button type="button" class="btn btn-light mt-auto">
+                                        Event Info <i class="fa fa-chevron-right"/>
+                                    </button>
+                                </t>
+                                <t t-else="">
+                                    <button type="button" class="btn btn-primary mt-auto">
+                                        Get Tickets <i class="fa fa-chevron-right"/>
+                                    </button>
+                                </t>
+                            </div>
+                        </div>
                     </main>
-                    
-                    <!-- Footer -->
+                    <!-- Footer (Grid View) -->
                     <footer t-if="not event.event_registrations_open and opt_events_list_columns and opt_events_list_cards"
                         t-att-class="'small align-self-end w-100 %s %s' % (
                             opt_events_list_cards and 'card-footer' or (not opt_events_list_columns and 'py-2 mt-2') or 'py-2',
                             opt_events_list_cards and 'border-top' or 'px-2',
                         )">
                         <span t-if="not event.event_registrations_open">
-                            <t t-if="not event.event_registrations_started">
+                            <t t-if="event.kanban_state == 'cancel'">
+                                Cancelled
+                            </t>
+                            <t t-elif="not event.event_registrations_started">
                                 Registrations not yet open
                             </t>
                             <t t-elif="event.event_registrations_sold_out">
@@ -418,8 +460,8 @@
 <template id="opt_events_list_cards" inherit_id="website_event.events_list" active="True" name="'Cards' Design"/>
 
 <template id="opt_events_list_categories" inherit_id="website_event.events_list" active="False" name="Show Templates">
-    <xpath expr="//main/div[@id='event_details']" position="after">
-        <span t-if="event.event_type_id" t-attf-href="/event?type=#{event.event_type_id.id}" t-attf-class="badge text-bg-secondary o_wevent_badge #{opt_events_list_columns and 'o_wevent_badge_event' or 'position-absolute bottom-0 end-0 end-sm-0 start-sm-0'} #{not opt_events_list_columns and opt_events_list_cards and 'me-sm-3 mb-sm-3'}" t-field="event.event_type_id"/>
+    <xpath expr="//main/div[@id='event_details']" position="inside">
+        <span t-if="event.event_type_id" t-attf-href="/event?type=#{event.event_type_id.id}" t-attf-class="badge text-bg-secondary o_wevent_badge #{opt_events_list_columns and 'o_wevent_badge_event' or 'o_wevent_badge_event_list'} #{not opt_events_list_columns and opt_events_list_cards and 'me-sm-3 mb-sm-3'}" t-field="event.event_type_id"/>
     </xpath>
 </template>
 

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -185,8 +185,12 @@
         Registration failed! Suspicious activity detected by Google reCaptcha.
     </div>
     <t t-if="not event.event_registrations_open">
+        <!-- Cancelled -->
+        <div t-if="event.kanban_state == 'cancel'" class="alert alert-danger mb-3 small text-center" role="status">
+            <b>Cancelled</b>
+        </div>
         <!-- Delayed registration time -->
-        <div t-if="not event.event_registrations_started and not event.event_registrations_sold_out" class="alert alert-info mb-3 small" role="status">
+        <div t-elif="not event.event_registrations_started and not event.event_registrations_sold_out" class="alert alert-info mb-3 small" role="status">
             Registrations will open on
             <b t-out="event.start_sale_datetime" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'MMMM dd, y'}"/>, at
             <b t-out="event.start_sale_datetime" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'h:mm a'}"/>


### PR DESCRIPTION
Purpose:
========
- Make it easier to cancel events.
- Make sure we do not send reminders for events that are over/canceled as otherwise attendees may show up.

Specs:
======
- Add new event kanban_state `Cancel`
- Change the color of 'Blocked' state to orange and disable the state configuration (Same as Projects/Task)
- On Cancelled Event :
  - Event should still appear on `/event`  with a 'Cancelled' banner in grid view
and cancelled label in list view
  - Registration on these event should be disabled
  - When setting an event kanban_state to  'Cancelled' , open a confirmation modal.
- Scheduled communications should not be triggered if the event is in a done/ended stage or state is cancelled
- Improve list view in `/event` page

Task-4197048
