### PR TITLE
[FIX] product: show full reference numbers longer than 10 digits

### DIFF
--- a/addons/product/report/product_product_templates.xml
+++ b/addons/product/report/product_product_templates.xml
@@ -116,7 +116,7 @@
                         <span t-else="" t-field="product.name"/>
                     </div>
                     <div class="o_label_left_column">
-                        <small class="text-nowrap" t-field="product.default_code"/>
+                        <small class="text-nowrap" t-field="product.default_code" style="font-size: 0.875em;"/>
                     </div>
                     <div class="text-end" style="padding: 0 4px;">
                         <strong class="o_label_price_small" t-out="pricelist._get_product_price(product, 1, pricelist.currency_id or product.currency_id)"


### PR DESCRIPTION
**Issue:**
When printing labels in Dymo format, product reference numbers longer than 10 digits are truncated, resulting in incomplete information.

**Steps to Reproduce:**
1. Install the Sales app
2. Navigate to Sales > Products
3. Select or create a product with a reference number longer than 10 digits
4. Click Print Labels > Dynamo format > Confirm
5. Notice that the reference number is cut off after 10 digits

Expected Behavior: The full reference number should be visible on the product label, regardless of length

Actual Behavior: Reference numbers longer than 10 digits are truncated, showing only the first 10 digits.

**Root Cause**

The issue arises from a override(https://github.com/odoo/odoo/commit/2b32d1431a33dea9052be3be4f9668a92cd0422e) to the font size of the <small> tag added to Bootstrap. Previously, the font size was set to 0.875em, but it has been updated to 0.8125rem. This change affects text rendering and causes a smaller number of digits to be displayed compared to previous versions.

**Fix**
To maintain consistency with Odoo 17.0, the font size of the <small> tag is explicitly overridden to ensure the same number of digits is displayed as before.

Opw-4578147
Opw-4568804

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
