### PR TITLE
[FIX] mail, web: move bot im_status to mail mock server

### DIFF
--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -1,6 +1,12 @@
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 
-import { fields, getKwArgs, makeKwArgs, webModels } from "@web/../tests/web_test_helpers";
+import {
+    fields,
+    getKwArgs,
+    makeKwArgs,
+    webModels,
+    serverState,
+} from "@web/../tests/web_test_helpers";
 import { DEFAULT_MAIL_SEARCH_ID, DEFAULT_MAIL_VIEW_ID } from "./constants";
 
 /** @typedef {import("@web/../tests/web_test_helpers").ModelRecord} ModelRecord */
@@ -158,6 +164,9 @@ export class ResPartner extends webModels.ResPartner {
     }
 
     compute_im_status(partner) {
+        if (partner.id === serverState.odoobotId) {
+            return "bot";
+        }
         return partner.im_status;
     }
     /**

--- a/addons/web/static/tests/_framework/mock_server/mock_models/res_partner.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_models/res_partner.js
@@ -24,7 +24,6 @@ export class ResPartner extends ServerModel {
         {
             id: serverState.odoobotId,
             active: false,
-            im_status: "bot",
             name: "OdooBot",
         },
     ];


### PR DESCRIPTION
Before this commit, the mock server records in the `web` module would contain the `im_status` field for OdooBot. This would cause tests to fail as the field is defined in the `mail` module.
This commit fixes the issue by removing the `im_status` field in the `web` module and add the `im_status` for the OdooBot in the `mail` mock server.

rb-116442