### PR TITLE
[FIX] mail,im_livechat: fix composerDisabledText

### DIFF
--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -61,8 +61,9 @@ patch(Thread.prototype, {
     },
 
     get composerDisabledText() {
-        return this.channel_type === "livechat" && this.livechat_active === false
-            ? _t("This livechat conversation has ended")
-            : null;
+        if (this.channel_type === "livechat" && this.livechat_active === false) {
+            return _t("This livechat conversation has ended");
+        };
+        return "";
     },
 });


### PR DESCRIPTION
Patch in im_livechat is returning `null` instead of `""`.
