### PR TITLE
[REF] core: rename domain argument of name_search

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -808,7 +808,7 @@ class AccountAccount(models.Model):
         return self._get_most_frequent_accounts_for_partner(company_id, partner_id, move_type)
 
     @api.model
-    def name_search(self, name='', args=None, operator='ilike', limit=100) -> list[tuple[int, str]]:
+    def name_search(self, name='', domain=None, operator='ilike', limit=100) -> list[tuple[int, str]]:
         if (
             not name
             and (partner := self.env.context.get('partner_id'))
@@ -818,7 +818,7 @@ class AccountAccount(models.Model):
             records = self.sudo().browse(ordered_accounts)
             records.fetch(['display_name'])
             return [(record.id, record.display_name) for record in records]
-        return super().name_search(name, args, operator, limit)
+        return super().name_search(name, domain, operator, limit)
 
     @api.model
     def _search_display_name(self, operator, value):

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -324,7 +324,7 @@ class TestAllocations(TestHrHolidaysCommon):
             employee_id=self.employee.id,
             default_date_from='2024-08-18 06:00:00',
             default_date_to='2024-08-18 15:00:00'
-        ).name_search(args=[['id', '=', leave_type.id]])
+        ).name_search(domain=[['id', '=', leave_type.id]])
         self.assertEqual(result[0][1], 'Compensatory Days (9 remaining out of 9 days)')
 
     def test_allocation_hourly_leave_type(self):

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1296,7 +1296,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                                     ['virtual_remaining_leaves', '>', 0],
                                     ['allows_negative', '=', False]]
 
-        search_result = self.env['hr.leave.type'].with_context(employee_id=False).name_search(args=search_domain)
+        search_result = self.env['hr.leave.type'].with_context(employee_id=False).name_search(domain=search_domain)
         self.assertFalse(self.holidays_type_2.id in [alloc_id for (alloc_id, _) in search_result])
 
     def test_holiday_type_allocation_requirement_edit(self):

--- a/addons/mail/static/src/views/web/fields/assign_user_command_hook.js
+++ b/addons/mail/static/src/views/web/fields/assign_user_command_hook.js
@@ -63,7 +63,7 @@ export function useAssignUserCommand() {
         component._pendingRpc?.abort(false);
         component._pendingRpc = orm.call(component.relation, "name_search", [], {
             name: value,
-            args: domain,
+            domain: domain,
             operator: "ilike",
             limit: 80,
             context,

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -590,14 +590,14 @@ class ProductProduct(models.Model):
         return combine(domains)
 
     @api.model
-    def name_search(self, name='', args=None, operator='ilike', limit=100):
+    def name_search(self, name='', domain=None, operator='ilike', limit=100):
         if not name:
-            return super().name_search(name, args, operator, limit)
+            return super().name_search(name, domain, operator, limit)
         # search progressively by the most specific attributes
         positive_operators = ['=', 'ilike', '=ilike', 'like', '=like']
         is_positive = operator not in expression.NEGATIVE_TERM_OPERATORS
         products = self.browse()
-        domain = args or []
+        domain = domain or []
         if operator in positive_operators:
             products = self.search_fetch(expression.AND([domain, [('default_code', '=', name)]]), ['display_name'], limit=limit) \
                 or self.search_fetch(expression.AND([domain, [('barcode', '=', name)]]), ['display_name'], limit=limit)

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -565,13 +565,13 @@ class ProductTemplate(models.Model):
         return domain
 
     @api.model
-    def name_search(self, name='', args=None, operator='ilike', limit=100):
+    def name_search(self, name='', domain=None, operator='ilike', limit=100):
         # Only use the product.product heuristics if there is a search term and the domain
         # does not specify a match on `product.template` IDs.
         self_obj = self
-        if 'search_product_product' not in self.env.context and any(term[0] == 'id' for term in (args or [])):
+        if 'search_product_product' not in self.env.context and any(term[0] == 'id' for term in (domain or [])):
             self_obj = self_obj.with_context(search_product_product=False)
-        return super(ProductTemplate, self_obj).name_search(name, args, operator, limit)
+        return super(ProductTemplate, self_obj).name_search(name, domain, operator, limit)
 
     #=== ACTION METHODS ===#
 

--- a/addons/project/models/project_tags.py
+++ b/addons/project/models/project_tags.py
@@ -62,11 +62,11 @@ class ProjectTags(models.Model):
         return [tags_by_id[id] for id in id_order if id in tags_by_id]
 
     @api.model
-    def name_search(self, name='', args=None, operator='ilike', limit=100):
+    def name_search(self, name='', domain=None, operator='ilike', limit=100):
         if limit is None:
-            return super().name_search(name, args, operator, limit)
+            return super().name_search(name, domain, operator, limit)
         tags = self.browse()
-        domain = expression.AND([self._search_display_name(operator, name), args or []])
+        domain = expression.AND([self._search_display_name(operator, name), domain or []])
         if self.env.context.get('project_id'):
             # optimisation for large projects, we look first for tags present on the last 1000 tasks of said project.
             # when not enough results are found, we complete them with a fallback on a regular search

--- a/addons/project/tests/test_project_flow.py
+++ b/addons/project/tests/test_project_flow.py
@@ -310,7 +310,7 @@ class TestProjectFlow(TestProjectCommon, MailCommon):
         })
         # Tag name_search should not raise Error if project_id is False
         task.tag_ids.with_context(project_id=task.project_id.id).name_search(
-            args=["!", ["id", "in", []]])
+            domain=["!", ["id", "in", []]])
 
     def test_copy_project_with_default_name(self):
         """ Test the new project after the duplication got the exepected name

--- a/addons/sale_service/models/sale_order_line.py
+++ b/addons/sale_service/models/sale_order_line.py
@@ -71,8 +71,8 @@ class SaleOrderLine(models.Model):
         return name_per_id
 
     @api.model
-    def name_search(self, name='', args=None, operator='ilike', limit=100):
-        domain = args or []
+    def name_search(self, name='', domain=None, operator='ilike', limit=100):
+        domain = domain or []
         # optimization for a SOL services name_search, to avoid joining on sale_order with too many lines
         if domain and ('is_service', '=', True) in domain and operator in ('like', 'ilike') and limit is not None:
             sols = self.search_fetch(

--- a/addons/spreadsheet/static/tests/global_filters/filter_value_component.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/filter_value_component.test.js
@@ -67,7 +67,7 @@ test("text filter with range", async function () {
 test("relational filter with domain", async function () {
     onRpc("partner", "name_search", ({ kwargs }) => {
         expect.step("name_search");
-        expect(kwargs.args).toEqual(["&", ["display_name", "=", "Bob"], "!", ["id", "in", []]]);
+        expect(kwargs.domain).toEqual(["&", ["display_name", "=", "Bob"], "!", ["id", "in", []]]);
     });
     const env = await makeMockEnv();
     const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
@@ -87,7 +87,7 @@ test("relational filter with domain", async function () {
 test("relational filter with a contextual domain", async function () {
     onRpc("partner", "name_search", ({ kwargs }) => {
         expect.step("name_search");
-        expect(kwargs.args).toEqual([
+        expect(kwargs.domain).toEqual([
             "&",
             ["user_ids", "in", [user.userId]],
             "!",

--- a/addons/web/models/res_users.py
+++ b/addons/web/models/res_users.py
@@ -8,9 +8,9 @@ class ResUsers(models.Model):
     _inherit = "res.users"
 
     @api.model
-    def name_search(self, name='', args=None, operator='ilike', limit=100):
+    def name_search(self, name='', domain=None, operator='ilike', limit=100):
         # if we have a search with a limit, move current user as the first result
-        user_list = super().name_search(name, args, operator, limit)
+        user_list = super().name_search(name, domain, operator, limit)
         uid = self._uid
         # index 0 is correct not Falsy in this case, use None to avoid ignoring it
         if (index := next((i for i, (user_id, _name) in enumerate(user_list) if user_id == uid), None)) is not None:
@@ -19,7 +19,7 @@ class ResUsers(models.Model):
             user_list.insert(0, user_tuple)
         elif limit is not None and len(user_list) == limit:
             # user not found and limit reached, try to find the user again
-            if user_tuple := super().name_search(name, expression.AND([args or [], [('id', '=', uid)]]), operator, limit=1):
+            if user_tuple := super().name_search(name, expression.AND([domain or [], [('id', '=', uid)]]), operator, limit=1):
                 user_list = [user_tuple[0], *user_list[:-1]]
         return user_list
 

--- a/addons/web/static/src/core/record_selectors/record_autocomplete.js
+++ b/addons/web/static/src/core/record_selectors/record_autocomplete.js
@@ -123,7 +123,7 @@ export class RecordAutocomplete extends Component {
         const domain = this.getDomain();
         return this.orm.call(this.props.resModel, "name_search", [], {
             name,
-            args: domain,
+            domain: domain,
             limit,
             context: this.props.context || {},
         });

--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -320,7 +320,7 @@ export class SearchBar extends Component {
         }
         const limitToFetch = this.state.subItemsLimits[searchItem.id] + 1;
         const options = await this.orm.call(relation, "name_search", [], {
-            args: domain,
+            domain: domain,
             operator: nameSearchOperator,
             context: { ...this.env.searchModel.globalContext, ...field.context },
             limit: limitToFetch,

--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.js
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.js
@@ -65,7 +65,7 @@ export class CalendarFilterPanel extends Component {
         const records = await this.orm.call(resModel, "name_search", [], {
             name: request,
             operator: "ilike",
-            args: domain,
+            domain: domain,
             limit: 8,
             context: {},
         });
@@ -100,7 +100,7 @@ export class CalendarFilterPanel extends Component {
         if (request.length) {
             const nameGets = await this.orm.call(resModel, "name_search", [], {
                 name: request,
-                args: domain,
+                domain: domain,
                 operator: "ilike",
                 context: {},
             });

--- a/addons/web/static/src/views/fields/many2one/many2one_field.js
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.js
@@ -300,7 +300,7 @@ export class Many2OneField extends Component {
     async search(barcode) {
         const results = await this.orm.call(this.relation, "name_search", [], {
             name: barcode,
-            args: this.getDomain(),
+            domain: this.getDomain(),
             operator: "ilike",
             limit: 2, // If one result we set directly and if more than one we use normal flow so no need to search more
             context: this.context,

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -313,7 +313,7 @@ export class Many2XAutocomplete extends Component {
         return this.orm.call(this.props.resModel, "name_search", [], {
             name: name,
             operator: "ilike",
-            args: this.props.getDomain(),
+            domain: this.props.getDomain(),
             limit: this.props.searchLimit + 1,
             context: this.props.context,
         });
@@ -418,7 +418,7 @@ export class Many2XAutocomplete extends Component {
         if (request.length) {
             const nameGets = await this.orm.call(resModel, "name_search", [], {
                 name: request,
-                args: domain,
+                domain: domain,
                 operator: "ilike",
                 limit: this.props.searchMoreLimit,
                 context,

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -1672,8 +1672,8 @@ export class Model extends Array {
      * @param {number} [limit]
      */
     name_search(name, domain, operator, limit) {
-        const kwargs = getKwArgs(arguments, "name", "args", "operator", "limit");
-        ({ name = "", args: domain = [], operator = "ilike", limit = 100 } = kwargs);
+        const kwargs = getKwArgs(arguments, "name", "domain", "operator", "limit");
+        ({ name = "", domain = [], operator = "ilike", limit = 100 } = kwargs);
 
         const actualDomain = new Domain(domain);
         /** @type {[number, string][]} */

--- a/addons/web/static/tests/core/record_selectors/multi_record_selector.test.js
+++ b/addons/web/static/tests/core/record_selectors/multi_record_selector.test.js
@@ -128,7 +128,7 @@ test("Can give domain and context props for the name search", async () => {
     expect.assertions(4);
     onRpc("partner", "name_search", ({ kwargs }) => {
         expect.step("name_search");
-        expect(kwargs.args).toEqual(["&", ["display_name", "=", "Bob"], "!", ["id", "in", [1]]]);
+        expect(kwargs.domain).toEqual(["&", ["display_name", "=", "Bob"], "!", ["id", "in", [1]]]);
         expect(kwargs.context.blip).toBe("blop");
     });
 

--- a/addons/web/static/tests/core/record_selectors/record_selector.test.js
+++ b/addons/web/static/tests/core/record_selectors/record_selector.test.js
@@ -104,7 +104,7 @@ test("Can give domain and context props for the name search", async () => {
     expect.assertions(5);
     onRpc("partner", "name_search", ({ kwargs }) => {
         expect.step("name_search");
-        expect(kwargs.args).toEqual(["&", ["display_name", "=", "Bob"], "!", ["id", "in", []]]);
+        expect(kwargs.domain).toEqual(["&", ["display_name", "=", "Bob"], "!", ["id", "in", []]]);
         expect(kwargs.context.blip).toBe("blop");
     });
     await mountRecordSelector({

--- a/addons/web/static/tests/legacy/helpers/mock_server.js
+++ b/addons/web/static/tests/legacy/helpers/mock_server.js
@@ -873,7 +873,7 @@ export class MockServer {
     mockNameSearch(model, args, kwargs) {
         const str = args && typeof args[0] === "string" ? args[0] : kwargs.name;
         const limit = kwargs.limit || 100;
-        const domain = (args && args[1]) || kwargs.args || [];
+        const domain = (args && args[1]) || kwargs.domain || [];
         const { records } = this.models[model];
         const result = [];
         for (const r of records) {

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -742,7 +742,7 @@ test("check kwargs of a rpc call with a domain", async () => {
             method: "name_search",
             args: [],
             kwargs: {
-                args: [["bool", "=", true]],
+                domain: [["bool", "=", true]],
                 context: { lang: "en", uid: 7, tz: "taht", allowed_company_ids: [1] },
                 limit: 8 + 1,
                 operator: "ilike",
@@ -1392,7 +1392,7 @@ test("edit a field", async () => {
 test("no rpc for getting display_name for facets if known", async () => {
     onRpc("/web/domain/validate", () => true);
     onRpc("name_search", ({ kwargs }) => {
-        expect.step(kwargs.args /** domain */);
+        expect.step(kwargs.domain);
     });
     onRpc(({ method }) => expect.step(method));
 

--- a/addons/web/static/tests/views/fields/many2many_tags_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field.test.js
@@ -385,7 +385,7 @@ test("Many2ManyTagsField view a domain on desktop", async () => {
     Partner._records[0].timmy = [12];
     PartnerType._records.push({ id: 99, name: "red", color: 8 });
     onRpc("name_search", (args) => {
-        expect(args.kwargs.args).toEqual([["id", "<", 50]]);
+        expect(args.kwargs.domain).toEqual([["id", "<", 50]]);
     });
 
     await mountView({
@@ -1763,7 +1763,7 @@ test("Many2ManyTagsField doesn't use virtualId for 'name_search' on desktop", as
     onRpc("name_search", ({ kwargs }) => {
         expect.step("name_search");
         // no virtualId in domain
-        expect(kwargs.args).toEqual([]);
+        expect(kwargs.domain).toEqual([]);
     });
     await mountView({
         type: "form",

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -1591,7 +1591,7 @@ test("many2one inside one2many form view, with domain", async () => {
         search: "<search></search>",
     };
     onRpc("name_search", ({ kwargs }) => {
-        expect(kwargs.args).toEqual([["id", ">", 1]]);
+        expect(kwargs.domain).toEqual([["id", ">", 1]]);
     });
     onRpc("web_search_read", ({ kwargs }) => {
         expect(kwargs.domain).toEqual([["id", ">", 1]]);
@@ -2286,7 +2286,7 @@ test("X2Many sequence list in modal", async () => {
 test("autocompletion in a many2one, in form view with a domain", async () => {
     expect.assertions(1);
     onRpc("name_search", ({ kwargs }) => {
-        expect(kwargs.args).toEqual([]);
+        expect(kwargs.domain).toEqual([]);
     });
 
     await mountView({
@@ -2302,7 +2302,7 @@ test("autocompletion in a many2one, in form view with a domain", async () => {
 test("autocompletion in a many2one, in form view with a date field", async () => {
     expect.assertions(1);
     onRpc("name_search", ({ kwargs }) => {
-        expect(kwargs.args).toEqual([["bar", "=", true]]);
+        expect(kwargs.domain).toEqual([["bar", "=", true]]);
     });
 
     await mountView({
@@ -2400,7 +2400,7 @@ test("domain and context are correctly used when doing a name_search in a m2o", 
     const DEFAULT_USER_CTX = { ...user.context, allowed_company_ids: [1] };
     serverState.userContext = { hey: "ho" };
     onRpc("product", "name_search", ({ kwargs }) => {
-        expect(kwargs.args).toEqual(["&", ["foo", "=", "bar"], ["foo", "=", "yop"]]);
+        expect(kwargs.domain).toEqual(["&", ["foo", "=", "bar"], ["foo", "=", "yop"]]);
         expect(kwargs.context).toEqual({
             ...DEFAULT_USER_CTX,
             hey: "ho",
@@ -2410,7 +2410,7 @@ test("domain and context are correctly used when doing a name_search in a m2o", 
         return [];
     });
     onRpc("partner", "name_search", ({ kwargs }) => {
-        expect(kwargs.args).toEqual([["id", "in", [12]]]);
+        expect(kwargs.domain).toEqual([["id", "in", [12]]]);
         expect(kwargs.context).toEqual({
             ...DEFAULT_USER_CTX,
             hey: "ho",
@@ -3126,7 +3126,7 @@ test("many2one: dynamic domain set in the field's definition", async () => {
         domain: "[('foo' ,'=', foo)]",
     });
     onRpc("name_search", ({ kwargs }) => {
-        expect(kwargs.args).toEqual([["foo", "=", "yop"]]);
+        expect(kwargs.domain).toEqual([["foo", "=", "yop"]]);
     });
 
     await mountView({
@@ -3154,7 +3154,7 @@ test("many2one: domain set in view and on field", async () => {
     });
     onRpc("name_search", ({ kwargs }) => {
         // should only use the domain set in the view
-        expect(kwargs.args).toEqual([["foo", "=", "blip"]]);
+        expect(kwargs.domain).toEqual([["foo", "=", "blip"]]);
     });
 
     await mountView({
@@ -3190,7 +3190,7 @@ test("many2one: domain updated by an onchange", async () => {
         };
     });
     onRpc("name_search", ({ kwargs }) => {
-        expect(kwargs.args).toEqual(domain);
+        expect(kwargs.domain).toEqual(domain);
     });
     await mountView({
         type: "form",

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -494,7 +494,7 @@ test("O2M with parented m2o and domain on parent.m2o", async () => {
             </form>`,
     };
     onRpc("name_search", ({ kwargs }) => {
-        expect(kwargs.args).toEqual([["id", "in", []]]);
+        expect(kwargs.domain).toEqual([["id", "in", []]]);
     });
     await mountView({
         type: "form",

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -8332,7 +8332,7 @@ test.tags("desktop");
 test(`action context is used when evaluating domains`, async () => {
     onRpc("name_search", ({ kwargs }) => {
         expect.step("name_search");
-        expect(kwargs.args[0]).toEqual(["id", "in", [45, 46, 47]]);
+        expect(kwargs.domain[0]).toEqual(["id", "in", [45, 46, 47]]);
     });
     await mountView({
         resModel: "partner",

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -15797,7 +15797,7 @@ test.tags("desktop");
 test(`view's context is passed down as evalContext`, async () => {
     onRpc("name_search", ({ kwargs }) => {
         expect.step(`name_search`);
-        expect(kwargs.args).toEqual([["someField", "=", "some_value"]]);
+        expect(kwargs.domain).toEqual([["someField", "=", "some_value"]]);
     });
 
     await mountView({

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2968,7 +2968,7 @@ const Many2oneUserValueWidget = SelectUserValueWidget.extend({
     async _search(needle) {
         const recTuples = await this.orm.call(this.options.model, "name_search", [], {
             name: needle,
-            args: (await this._getSearchDomain()).concat(
+            domain: (await this._getSearchDomain()).concat(
                 Object.values(this.options.domainComponents).filter(item => item !== null)
             ),
             operator: "ilike",

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -86,9 +86,9 @@ class ResCountry(models.Model):
     )
 
     @api.model
-    def name_search(self, name='', args=None, operator='ilike', limit=100):
+    def name_search(self, name='', domain=None, operator='ilike', limit=100):
         result = []
-        domain = args or []
+        domain = domain or []
         # first search by code
         if operator not in expression.NEGATIVE_TERM_OPERATORS and name and len(name) == 2:
             countries = self.search_fetch(expression.AND([domain, [('code', operator, name)]]), ['display_name'], limit=limit)
@@ -177,15 +177,15 @@ class ResCountryState(models.Model):
     )
 
     @api.model
-    def name_search(self, name='', args=None, operator='ilike', limit=100):
+    def name_search(self, name='', domain=None, operator='ilike', limit=100):
         result = []
-        domain = args or []
+        domain = domain or []
         # accepting 'in' as operator (see odoo/addons/base/tests/test_res_country.py)
         if operator == 'in':
             if limit is None:
                 limit = 100  # force a limit
             for item in name:
-                result.extend(self.name_search(item, args, operator='=', limit=limit - len(result)))
+                result.extend(self.name_search(item, domain, operator='=', limit=limit - len(result)))
                 if len(result) == limit:
                     break
             return result

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -620,8 +620,8 @@ class ResUsers(models.Model):
             raise UserError(_('Deleting the template users is not allowed. Deleting this profile will compromise critical functionalities.'))
 
     @api.model
-    def name_search(self, name='', args=None, operator='ilike', limit=100):
-        domain = args or []
+    def name_search(self, name='', domain=None, operator='ilike', limit=100):
+        domain = domain or []
         # first search only by login, then the normal search
         if (
             name and operator not in expression.NEGATIVE_TERM_OPERATORS

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -290,14 +290,14 @@ class TestPartner(TransactionCaseWithUserDemo):
         ns_res = self.env['res.partner'].name_search('Vlad', operator='ilike')
         self.assertEqual(set(i[0] for i in ns_res), set((test_partner | test_user.partner_id).ids))
 
-        ns_res = self.env['res.partner'].name_search('Vlad', args=[('user_ids.email', 'ilike', 'vlad')])
+        ns_res = self.env['res.partner'].name_search('Vlad', domain=[('user_ids.email', 'ilike', 'vlad')])
         self.assertEqual(set(i[0] for i in ns_res), set(test_user.partner_id.ids))
 
         # Check a partner may be searched when current user has no access but sudo is used
         public_user = self.env.ref('base.public_user')
         with self.assertRaises(AccessError):
             test_partner.with_user(public_user).check_access('read')
-        ns_res = self.env['res.partner'].with_user(public_user).sudo().name_search('Vlad', args=[('user_ids.email', 'ilike', 'vlad')])
+        ns_res = self.env['res.partner'].with_user(public_user).sudo().name_search('Vlad', domain=[('user_ids.email', 'ilike', 'vlad')])
         self.assertEqual(set(i[0] for i in ns_res), set(test_user.partner_id.ids))
 
     def test_partner_merge_wizard_dst_partner_id(self):

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1450,12 +1450,16 @@ class BaseModel(metaclass=MetaModel):
 
     @api.model
     @api.readonly
-    def name_search(self, name='', args=None, operator='ilike', limit=100) -> list[tuple[int, str]]:
-        """ name_search(name='', args=None, operator='ilike', limit=100)
-
-        Search for records that have a display name matching the given
+    def name_search(
+        self,
+        name: str = '',
+        domain: DomainType | None = None,
+        operator: str = 'ilike',
+        limit: int = 100,
+    ) -> list[tuple[int, str]]:
+        """Search for records that have a display name matching the given
         ``name`` pattern when compared with the given ``operator``, while also
-        matching the optional search domain (``args``).
+        matching the optional search domain (``domain``).
 
         This is used for example to provide suggestions based on a partial
         value for a relational field. Should usually behave as the reverse of
@@ -1466,15 +1470,14 @@ class BaseModel(metaclass=MetaModel):
         the resulting search.
 
         :param str name: the name pattern to match
-        :param list args: optional search domain (see :meth:`~.search` for
-                          syntax), specifying further restrictions
+        :param list domain: optional search domain (see :meth:`~.search` for
+                            syntax), specifying further restrictions
         :param str operator: domain operator for matching ``name``, such as
                              ``'like'`` or ``'='``.
         :param int limit: optional max number of records to return
-        :rtype: list
         :return: list of pairs ``(id, display_name)`` for all matching records.
         """
-        domain = Domain('display_name', operator, name) & Domain(args or [])
+        domain = Domain('display_name', operator, name) & Domain(domain or Domain.TRUE)
         records = self.search_fetch(domain, ['display_name'], limit=limit)
         return [(record.id, record.display_name) for record in records.sudo()]
 


### PR DESCRIPTION
Align the name of the `domain` argument with other search methods. It used to be just `args`.

odoo/enterprise#79577

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
