### PR TITLE
[IMP] l10n_sa_edi: Add PDF 3-b Compliance and attach EDI document to Generated Invoices

### DIFF
--- a/addons/account/data/mail_template_data.xml
+++ b/addons/account/data/mail_template_data.xml
@@ -55,7 +55,7 @@
 </div>
             </field>
             <field name="report_template" ref="account_invoices"/>
-            <field name="report_name">Invoice_{{ (object.name or '').replace('/','_') }}{{ object.state == 'draft' and '_draft' or '' }}</field>
+            <field name="report_name">{{ object._get_report_mail_attachment_filename() }}</field>
             <field name="lang">{{ object.partner_id.lang }}</field>
             <field name="auto_delete" eval="True"/>
         </record>

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3983,6 +3983,20 @@ class AccountMove(models.Model):
     def _get_report_base_filename(self):
         return self._get_move_display_name()
 
+    def _get_report_attachment_filename(self):
+        self.ensure_one()
+        if self.state == 'posted':
+            name = self.name or _('INV')
+        else:
+            name = self._get_report_base_filename()
+        return f"{name.replace('/', '_')}.pdf"
+
+    def _get_report_mail_attachment_filename(self):
+        self.ensure_one()
+        invoice_name = (self.name or '').replace('/', '_')
+        post_suffix = _('_draft') if self.state == 'draft' else ''
+        return _('Invoice_%(name)s%(post)s', name=invoice_name, post=post_suffix)
+
     # -------------------------------------------------------------------------
     # CRON
     # -------------------------------------------------------------------------

--- a/addons/account/views/account_report.xml
+++ b/addons/account/views/account_report.xml
@@ -8,8 +8,8 @@
             <field name="report_type">qweb-pdf</field>
             <field name="report_name">account.report_invoice_with_payments</field>
             <field name="report_file">account.report_invoice_with_payments</field>
-            <field name="print_report_name">(object._get_report_base_filename())</field>
-            <field name="attachment">(object.state == 'posted') and ((object.name or 'INV').replace('/','_')+'.pdf')</field>
+            <field name="print_report_name">object._get_report_base_filename()</field>
+            <field name="attachment">object._get_report_attachment_filename()</field>
             <field name="binding_model_id" ref="model_account_move"/>
             <field name="binding_type">report</field>
             <field name="groups_id" eval="[(4, ref('account.group_account_invoice')),
@@ -34,8 +34,8 @@
             <field name="report_type">qweb-pdf</field>
             <field name="report_name">account.report_invoice</field>
             <field name="report_file">account.report_invoice</field>
-            <field name="print_report_name">(object._get_report_base_filename())</field>
-            <field name="attachment">(object.state == 'posted') and ((object.name or 'INV').replace('/','_')+'.pdf')</field>
+            <field name="print_report_name">object._get_report_base_filename()</field>
+            <field name="attachment">object._get_report_attachment_filename()</field>
             <field name="binding_model_id" ref="model_account_move"/>
             <field name="binding_type">report</field>
         </record>

--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -147,9 +147,13 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
             Seller Vat Number (BT-31), Date (BT-2), Time (KSA-25), Invoice Number (BT-1)
         """
         vat = invoice.company_id.partner_id.commercial_partner_id.vat
-        invoice_number = re.sub("[^a-zA-Z0-9 -]", "-", invoice.name)
+        invoice_number = re.sub(r'[^a-zA-Z0-9 -]+', '-', invoice.name)
         invoice_date = fields.Datetime.context_timestamp(self.with_context(tz='Asia/Riyadh'), invoice.l10n_sa_confirmation_datetime)
-        return '%s_%s_%s.xml' % (vat, invoice_date.strftime('%Y%m%dT%H%M%S'), invoice_number)
+        file_name = f"{vat}_{invoice_date.strftime('%Y%m%dT%H%M%S')}_{invoice_number}"
+        file_format = self.env.context.get('l10n_sa_file_format', 'xml')
+        if file_format:
+            file_name = f'{file_name}.{file_format}'
+        return file_name
 
     def _l10n_sa_get_invoice_transaction_code(self, invoice):
         """


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

As per ZATCA, 

`For electronic invoices generated in PDF/A-3 format: while the PDF content will be the representation of the XML invoice in a human readable format, the XML invoice itself will still be added as an attachment as specified in ISO 19005-3 titled "Document management - Electronic document file format for long -term preservation - Part 3: Use of ISO 32000-1 with support for embedded files (PDF/A-3)", and contain the compliant XML invoice as an embedded object.`

Current behavior before PR:
- Generated Saudi Localization PDF Invoice had not embedded attached EDI XML documents
- Generated Saudi Localization PDF Invoice was not PDF-A Compliant
- Generated Saudi Localization PDF Invoice file name did not adhere to ZATCA business rules of the following:
`Seller Vat Number (BT-31), Date (BT-2), Time (KSA-25), Invoice Number (BT-1)`

Desired behavior after PR is merged:
- Generated Saudi Localization PDF Invoice has the XML  EDI documents embedded as an attachment
- Generated Saudi Localization PDF Invoice is PDF-A Compliant
- Generated Saudi Localization PDF Invoice is named as per the ZATCA business rules

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

opw-4528551
