### PR TITLE
[FIX] account: view_mode handling in error message redirect

### DIFF
--- a/addons/account/static/src/components/actionable_errors/actionable_errors.js
+++ b/addons/account/static/src/components/actionable_errors/actionable_errors.js
@@ -23,7 +23,7 @@ export class ActionableErrors extends Component {
     async handleOnClick(errorData){
         if (errorData.action?.view_mode) {
             // view_mode is not handled JS side
-            errorData.action['views'] = [[false, errorData.action.view_mode]];
+            errorData.action['views'] = errorData.action.view_mode.split(',').map(mode => [false, mode]);
             delete errorData.action['view_mode'];
         }
         this.env.model.action.doAction(errorData.action);


### PR DESCRIPTION
When we show a wizard to the user it is possible to add some warnings
and redirects to views. However currently an error message will raise
when accessing a view with more than 1 view mode

Steps to reproduce:
- Have entries already secured with hash
- Create unreconciled bank statement
- Open Secure Entries wizard (Accounting / Accounting / Secure Entries)
- Enter a future date
- Warning will raise
"There are still unreconciled bank statement lines before the selected
date. The entries from journal prefixes containing them will not be
secured: BNK1/2025 Review"
- Click on the Review Link

Traceback

```
Uncaught Promise > View types not defined kanban,list found in act_window action 855
```

This occurs because multiple view_mode are not correctly handled

opw-4571921