### PR TITLE
[IMP] hw_drivers: refresh pairing code

### DIFF
--- a/addons/hw_drivers/connection_manager.py
+++ b/addons/hw_drivers/connection_manager.py
@@ -12,7 +12,11 @@ from odoo.addons.hw_drivers.tools import helpers, wifi
 
 _logger = logging.getLogger(__name__)
 
-PAIRING_CODE_TIMEOUT_SECONDS = 300
+# We use a timeout slightly less than the IoT proxy so
+# that there is a grace period between codes
+PAIRING_CODE_TIMEOUT_SECONDS = 580
+
+MAXIMUM_NUMBER_OF_CODES = 3
 
 
 class ConnectionManager(Thread):
@@ -20,44 +24,66 @@ class ConnectionManager(Thread):
         super(ConnectionManager, self).__init__()
         self.pairing_code = False
         self.pairing_uuid = False
+        self.pairing_code_expires = 0
+        self.pairing_code_count = 0
+        self.running = False
+        requests.packages.urllib3.disable_warnings()
 
     def run(self):
-        if platform.system() == 'Linux' and wifi.is_access_point():
-            return
+        self.running = True
+        while self.running:
+            if self._should_fetch_pairing_code():
+                if time.monotonic() > self.pairing_code_expires:
+                    self._refresh_pairing_code()
+                else:
+                    self._poll_pairing_result()
+            else:
+                self.running = False
+                self.pairing_code = False
+                self.pairing_uuid = False
+                self.pairing_code_expires = 0
+            time.sleep(10)
 
-        if not helpers.get_odoo_server_url():
-            end_time = time.monotonic() + PAIRING_CODE_TIMEOUT_SECONDS
-            while time.monotonic() < end_time:
-                self._connect_box()
-                time.sleep(10)
-            self.pairing_code = False
-            self.pairing_uuid = False
+    def _should_fetch_pairing_code(self):
+        return (
+            not helpers.get_odoo_server_url() and
+            helpers.get_ip() and
+            not (platform.system() == 'Linux' and wifi.is_access_point()) and
+            self.pairing_code_count <= MAXIMUM_NUMBER_OF_CODES
+        )
 
-    def _connect_box(self):
-        if not helpers.get_ip() or (platform.system() == 'Linux' and wifi.is_access_point()):
-            return
-
+    def _call_iot_proxy(self, pairing_code, pairing_uuid):
         data = {
             'jsonrpc': 2.0,
             'params': {
-                'pairing_code': self.pairing_code,
-                'pairing_uuid': self.pairing_uuid,
+                'pairing_code': pairing_code,
+                'pairing_uuid': pairing_uuid,
             }
         }
 
         try:
-            requests.packages.urllib3.disable_warnings()
             req = requests.post(
                 'https://iot-proxy.odoo.com/odoo-enterprise/iot/connect-box', json=data, verify=False, timeout=5
             )
-            result = req.json().get('result', {})
-            if all(key in result for key in ['pairing_code', 'pairing_uuid']):
-                self.pairing_code = result['pairing_code']
-                self.pairing_uuid = result['pairing_uuid']
-            elif all(key in result for key in ['url', 'token', 'db_uuid', 'enterprise_code']):
-                self._connect_to_server(result['url'], result['token'], result['db_uuid'], result['enterprise_code'])
+            return req.json().get('result', {})
         except Exception:
             _logger.exception('Could not reach iot-proxy.odoo.com')
+            return {}
+
+    def _poll_pairing_result(self):
+        result = self._call_iot_proxy(self.pairing_code, self.pairing_uuid)
+        
+        if all(key in result for key in ['url', 'token', 'db_uuid', 'enterprise_code']):
+            self._connect_to_server(result['url'], result['token'], result['db_uuid'], result['enterprise_code'])
+
+    def _refresh_pairing_code(self):
+        result = self._call_iot_proxy(pairing_code=None, pairing_uuid=None)
+
+        if all(key in result for key in ['pairing_code', 'pairing_uuid']):
+            self.pairing_code = result['pairing_code']
+            self.pairing_uuid = result['pairing_uuid']
+            self.pairing_code_expires = time.monotonic() + PAIRING_CODE_TIMEOUT_SECONDS
+            self.pairing_code_count += 1
 
     def _connect_to_server(self, url, token, db_uuid, enterprise_code):
         # Save DB URL and token

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -155,6 +155,7 @@ class IotBoxOwlHomePage(http.Controller):
 
         six_terminal = helpers.get_conf('six_payment_terminal') or 'Not Configured'
         network_qr_codes = wifi.generate_network_qr_codes()
+        odoo_server_url = helpers.get_odoo_server_url()
 
         return json.dumps({
             'db_uuid': helpers.get_conf('db_uuid'),
@@ -163,8 +164,9 @@ class IotBoxOwlHomePage(http.Controller):
             'ip': helpers.get_ip(),
             'mac': helpers.get_mac_address(),
             'devices': grouped_devices,
-            'server_status': helpers.get_odoo_server_url() or 'Not Configured',
+            'server_status': odoo_server_url or 'Not Configured',
             'pairing_code': connection_manager.pairing_code,
+            'pairing_code_expired': not connection_manager.running and not odoo_server_url,
             'six_terminal': six_terminal,
             'is_access_point_up': platform.system() == 'Linux' and wifi.is_access_point(),
             'network_interfaces': network_interfaces,

--- a/addons/hw_posbox_homepage/static/src/app/Homepage.js
+++ b/addons/hw_posbox_homepage/static/src/app/Homepage.js
@@ -60,7 +60,7 @@ export class Homepage extends Component {
         );
         if (wifiInterface) {
             return this.state.data.is_access_point_up
-                ? "No internet connection - click on \"Configure\""
+                ? 'No internet connection - click on "Configure"'
                 : `Wi-Fi: ${wifiInterface.ssid}`;
         }
         return "Not Connected";
@@ -162,7 +162,8 @@ export class Homepage extends Component {
 					<ServerDialog />
 				</t>
 			</SingleData>
-            <SingleData t-if="state.data.pairing_code and !this.store.base.is_access_point_up" name="'Pairing Code'" value="state.data.pairing_code" icon="'fa-code'"/>
+            <SingleData t-if="state.data.pairing_code and !this.store.base.is_access_point_up" name="'Pairing Code'" value="state.data.pairing_code + ' - Enter this code in the IoT app in your Odoo database'" icon="'fa-code'"/>
+            <SingleData t-if="state.data.pairing_code_expired" name="'Pairing Code'" value="'Code has expired - restart the IoT Box to generate a new one'" icon="'fa-code'"/>
             <SingleData  t-if="store.advanced and !store.base.is_access_point_up" name="'Six terminal'" value="state.data.six_terminal" icon="'fa-money'">
                 <t t-set-slot="button">
                     <SixDialog />

--- a/addons/hw_posbox_homepage/static/src/app/status.js
+++ b/addons/hw_posbox_homepage/static/src/app/status.js
@@ -86,12 +86,17 @@ class StatusPage extends Component {
             </div>
         </div>
         <div class="status-display-boxes">
-            <div t-if="state.data.pairing_code and !state.data.is_access_point_up" class="status-display-box">
+            <div t-if="(state.data.pairing_code || state.data.pairing_code_expired) and !state.data.is_access_point_up" class="status-display-box">
                 <h4 class="text-center mb-3">Pairing Code</h4>
                 <hr/>
-                <h4 t-out="state.data.pairing_code" class="text-center mb-3"/>
-                <p class="text-center mb-3">
-                    Enter this code in the IoT app in your Odoo database to pair the IoT Box.
+                <t t-if="state.data.pairing_code">
+                    <h4 t-out="state.data.pairing_code" class="text-center mb-3"/>
+                    <p class="text-center mb-3">
+                        Enter this code in the IoT app in your Odoo database to pair the IoT Box.
+                    </p>
+                </t>
+                <p t-else="" class="text-center mb-3">
+                    The pairing code has expired. Please restart your IoT Box to generate a new one.
                 </p>
             </div>
             <div t-if="state.data.is_access_point_up and accessPointSsid" class="status-display-box">


### PR DESCRIPTION
Before this commit, a pairing code is fetched once
upon startup, displayed for 5 minutes, and then
cleared.

After this commit, the code timeout is extended to
10 minutes, and will be refreshed 2 times
automatically.

task-4586979

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
