### PR TITLE
[REF] web: manage errors in macro

### DIFF
--- a/addons/web/static/src/core/macro.js
+++ b/addons/web/static/src/core/macro.js
@@ -11,30 +11,23 @@ const macroSchema = {
     steps: {
         type: Array,
         element: {
-            initialDelay: { type: Function, optional: true },
-            action: { type: Function },
-            trigger: { type: [Function, String], optional: true },
-            timeout: { type: Number, optional: true },
+            type: Object,
+            shape: {
+                action: { type: [Function, String], optional: true },
+                initialDelay: { type: Function, optional: true },
+                timeout: { type: Number, optional: true },
+                trigger: { type: [Function, String], optional: true },
+                value: { type: [String, Number], optional: true },
+            },
+            validate: (step) => {
+                return step.action || step.trigger;
+            },
         },
     },
     onComplete: { type: Function, optional: true },
     onStep: { type: Function, optional: true },
     onError: { type: Function, optional: true },
-    onTimeout: { type: Function, optional: true },
 };
-
-/**
- * @typedef MacroStep
- * @property {string} [trigger]
- * - An action returning a "truthy" value means that the step isn't successful.
- * - Current step index won't be incremented.
- * @property {string | (el: Element, step: MacroStep) => undefined | string} [action]
- * @property {*} [*] - any payload to the step.
- *
- * @typedef MacroDescriptor
- * @property {() => Element | undefined} trigger
- * @property {() => {}} action
- */
 
 export const ACTION_HELPERS = {
     click(el, _step) {
@@ -57,7 +50,12 @@ export const ACTION_HELPERS = {
 
 const mutex = new Mutex();
 
-class TimeoutError extends Error {}
+class MacroError extends Error {
+    constructor(type, message, options) {
+        super(message, options);
+        this.type = type;
+    }
+}
 
 export class Macro {
     currentIndex = 0;
@@ -75,6 +73,11 @@ export class Macro {
         this.name = this.name || "anonymous";
         this.onComplete = this.onComplete || (() => {});
         this.onStep = this.onStep || (() => {});
+        this.onError =
+            this.onError ||
+            ((e) => {
+                console.error(e);
+            });
         this.stepElFound = new Array(this.steps.length).fill(false);
         this.stepHasStarted = new Array(this.steps.length).fill(false);
         this.observer = new MacroMutationObserver(() => this.debounceAdvance("mutation"));
@@ -111,13 +114,16 @@ export class Macro {
             proceedToAction = this.findTrigger();
         }
         if (proceedToAction) {
-            this.safeCall(this.onStep, this.currentElement, this.currentStep);
+            this.onStep(this.currentElement, this.currentStep, this.currentIndex);
             this.clearTimer();
             const actionResult = await this.performAction();
             if (!actionResult) {
                 // If falsy action result, it means the action worked properly.
                 // So we can proceed to the next step.
-                this.increment();
+                this.currentIndex++;
+                if (this.currentIndex >= this.steps.length) {
+                    this.stop();
+                }
                 this.debounceAdvance("next");
             }
         }
@@ -128,13 +134,13 @@ export class Macro {
      * @returns {boolean}
      */
     findTrigger() {
+        const { trigger } = this.currentStep;
         if (this.isComplete) {
             return;
         }
-        const trigger = this.currentStep.trigger;
         try {
             if (typeof trigger === "function") {
-                this.currentElement = this.safeCall(trigger);
+                this.currentElement = trigger();
             } else if (typeof trigger === "string") {
                 const triggerEl = document.querySelector(trigger);
                 this.currentElement = isVisible(triggerEl) && triggerEl;
@@ -142,7 +148,11 @@ export class Macro {
                 throw new Error(`Trigger can only be string or function.`);
             }
         } catch (error) {
-            this.stop(`Error when trying to find trigger: ${error.message}`);
+            this.stop(
+                new MacroError("Trigger", `ERROR during find trigger:\n${error.message}`, {
+                    cause: error,
+                })
+            );
         }
         return !!this.currentElement;
     }
@@ -157,10 +167,14 @@ export class Macro {
             if (action in ACTION_HELPERS) {
                 actionResult = ACTION_HELPERS[action](this.currentElement, this.currentStep);
             } else if (typeof action === "function") {
-                actionResult = await this.safeCall(action, this.currentElement);
+                actionResult = await action(this.currentElement);
             }
         } catch (error) {
-            this.stop(`ERROR IN ACTION: ${error.message}`);
+            this.stop(
+                new MacroError("Action", `ERROR during perform action:\n${error.message}`, {
+                    cause: error,
+                })
+            );
         }
         return actionResult;
     }
@@ -177,24 +191,6 @@ export class Macro {
         this.stepElFound[this.currentIndex] = value;
     }
 
-    increment() {
-        this.currentIndex++;
-        if (this.currentIndex >= this.steps.length) {
-            this.stop();
-        }
-    }
-
-    safeCall(fn, ...args) {
-        if (this.isComplete) {
-            return;
-        }
-        try {
-            return fn(...args);
-        } catch (e) {
-            this.stop(e);
-        }
-    }
-
     /**
      * Timer for findTrigger only (not for doing action)
      */
@@ -203,7 +199,12 @@ export class Macro {
         const timeout = this.currentStep.timeout || this.timeout;
         if (timeout > 0) {
             this.timer = browser.setTimeout(() => {
-                this.stop(new TimeoutError(timeout));
+                this.stop(
+                    new MacroError(
+                        "Timeout",
+                        `TIMEOUT step failed to complete within ${timeout} ms.`
+                    )
+                );
             }, timeout);
         }
     }
@@ -259,19 +260,7 @@ export class Macro {
         if (!this.calledBack) {
             this.calledBack = true;
             if (error) {
-                if (error instanceof TimeoutError) {
-                    if (typeof this.onTimeout === "function") {
-                        this.onTimeout(error.message, this.currentStep, this.currentIndex);
-                    } else {
-                        console.error("Step timeout");
-                    }
-                } else {
-                    if (typeof this.onError === "function") {
-                        this.onError(error, this.currentStep, this.currentIndex);
-                    } else {
-                        console.error(error);
-                    }
-                }
+                this.onError(error, this.currentStep, this.currentIndex);
             } else if (this.currentIndex === this.steps.length) {
                 mutex.getUnlockedDef().then(() => {
                     this.onComplete();

--- a/addons/web/static/tests/core/macro.test.js
+++ b/addons/web/static/tests/core/macro.test.js
@@ -147,13 +147,16 @@ test("onStep function is called at each step", async () => {
 
     new Macro({
         name: "test",
-        onStep: (el, step) => {
-            expect.step(step.info);
+        onStep: (el, step, index) => {
+            expect.step(index);
         },
         steps: [
-            { info: "1" },
             {
-                info: "2",
+                action: () => {
+                    console.log("brol");
+                },
+            },
+            {
                 trigger: "button.inc",
                 action: "click",
             },
@@ -161,7 +164,7 @@ test("onStep function is called at each step", async () => {
     }).start(queryOne(".counter"));
     await waitForStep(true);
     expect(span).toHaveText("1");
-    expect.verifySteps(["1", "2"]);
+    expect.verifySteps([0, 1]);
 });
 
 test("trigger can be a function returning an htmlelement", async () => {

--- a/addons/web_tour/static/tests/tour_automatic.test.js
+++ b/addons/web_tour/static/tests/tour_automatic.test.js
@@ -147,7 +147,8 @@ test("a failing tour logs the step that failed in run", async () => {
         `log: [2/2] Tour tour2 → Step .button1`,
         [
             "error: FAILED: [2/2] Tour tour2 → Step .button1.",
-            "ERROR IN ACTION: Cannot read properties of null (reading 'click')",
+            `ERROR during perform action:
+Cannot read properties of null (reading 'click')`,
         ].join("\n"),
     ];
     expect.verifySteps(expectedError);
@@ -197,7 +198,7 @@ test("a failing tour with disabled element", async () => {
         `error: FAILED: [2/3] Tour tour3 → Step .button1.
 Element has been found.
 BUT: Element is not enabled. TIP: You can use :enable to wait the element is enabled before doing action on it.
-TIMEOUT: The step failed to complete within 10000 ms.`,
+TIMEOUT step failed to complete within 10000 ms.`,
     ];
     expect.verifySteps(expectedError);
 });
@@ -295,7 +296,7 @@ test("a failing tour logs the step that failed", async () => {
         "log: [5/9] Tour tour1 → Step content (trigger: .wrong_selector)",
         `error: FAILED: [5/9] Tour tour1 → Step content (trigger: .wrong_selector).
 Element (.wrong_selector) has not been found.
-TIMEOUT: The step failed to complete within 111 ms.`,
+TIMEOUT step failed to complete within 111 ms.`,
         `runbot: {"content":"content","trigger":".button1","run":"click"},{"content":"content","trigger":".button2","run":"click"},{"content":"content","trigger":".button3","run":"click"},FAILED:[5/9]Tourtour1→Stepcontent(trigger:.wrong_selector){"content":"content","trigger":".wrong_selector","run":"click","timeout":111},{"content":"content","trigger":".button4","run":"click"},{"content":"content","trigger":".button5","run":"click"},{"content":"content","trigger":".button6","run":"click"},`,
     ]);
 });
@@ -399,7 +400,7 @@ test("automatic tour with invisible element", async () => {
         `error: FAILED: [2/3] Tour tour_de_wallonie → Step .button1.
 Element has been found.
 BUT: Element is not visible. TIP: You can use :not(:visible) to force the search for an invisible element.
-TIMEOUT: The step failed to complete within 10000 ms.`,
+TIMEOUT step failed to complete within 10000 ms.`,
     ]);
 });
 
@@ -578,7 +579,7 @@ test("check not possible to click below modal", async () => {
         `error: FAILED: [2/2] Tour tour_check_modal → Step .button1.
 Element has been found.
 BUT: It is not allowed to do action on an element that's below a modal.
-TIMEOUT: The step failed to complete within 10000 ms.`,
+TIMEOUT step failed to complete within 10000 ms.`,
     ]);
 });
 
@@ -620,7 +621,8 @@ test("a tour where hoot trigger failed", async () => {
     await waitForStep();
     expect.verifySteps([
         `error: FAILED: [2/2] Tour tour_hoot_failed → Step content (trigger: .button1:brol(:machin)).
-SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '.button1:brol(:machin)' is not a valid selector.`,
+ERROR during find trigger:
+Failed to execute 'querySelectorAll' on 'Element': '.button1:brol(:machin)' is not a valid selector.`,
     ]);
 });
 
@@ -680,7 +682,8 @@ test("check for undeterminisms", async () => {
     await advanceTime(10000);
     expect.verifySteps([
         `error: FAILED: [2/3] Tour tour_und → Step .button1.
-ERROR IN ACTION: Element has been found.
+ERROR during perform action:
+Element has been found.
 UNDETERMINISM: two differents elements have been found in 3000ms for trigger .button1`,
     ]);
 });


### PR DESCRIPTION
In this commit, we simplify the macro API by removing onTimeout() and keeping only onError(). Timeout is ultimately just one type of error that can happen in macro.js.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
