### PR TITLE
[IMP] hw_{drivers,posbox_homepage}: always generate HTTPS certificate

### DIFF
--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -90,10 +90,8 @@ class Manager(Thread):
         if platform.system() == 'Linux' and helpers.get_odoo_server_url():
             helpers.check_git_branch()
             helpers.generate_password()
-        is_certificate_ok, certificate_details = helpers.get_certificate_status()
-        if not is_certificate_ok and certificate_details != 'ERR_IOT_HTTPS_CHECK_NO_SERVER':
-            _logger.warning("An error happened when trying to get the HTTPS certificate: %s",
-                            certificate_details)
+
+        helpers.ensure_certificate()
 
         # We first add the IoT Box to the connected DB because IoT handlers cannot be downloaded if
         # the identifier of the Box is not found in the DB. So add the Box to the DB.
@@ -111,7 +109,7 @@ class Manager(Thread):
                 _logger.exception("Interface %s could not be started", str(interface))
 
         # Set scheduled actions
-        schedule and schedule.every().day.at("00:00").do(helpers.get_certificate_status)
+        schedule and schedule.every().day.at("00:00").do(helpers.ensure_certificate)
         schedule and schedule.every().day.at("00:00").do(helpers.reset_log_level)
 
         # Set up the websocket connection

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -139,8 +139,6 @@ class IotBoxOwlHomePage(http.Controller):
                     'ip': conf.get('addr', 'No Internet'),
                 } for conf in netifaces.ifaddresses(iface_id).get(netifaces.AF_INET, [])])
 
-        is_certificate_ok, certificate_details = helpers.get_certificate_status()
-
         devices = [{
             'name': device.device_name,
             'value': str(device.data['value']),
@@ -170,8 +168,6 @@ class IotBoxOwlHomePage(http.Controller):
             'network_interfaces': network_interfaces,
             'version': helpers.get_version(),
             'system': platform.system(),
-            'is_certificate_ok': is_certificate_ok,
-            'certificate_details': certificate_details,
             'wifi_ssid': helpers.get_conf('wifi_ssid'),
             'qr_code_wifi' : network_qr_codes['qr_wifi'],
             'qr_code_url' : network_qr_codes['qr_url'],

--- a/addons/hw_posbox_homepage/static/src/app/Homepage.js
+++ b/addons/hw_posbox_homepage/static/src/app/Homepage.js
@@ -118,22 +118,6 @@ export class Homepage extends Component {
             <div class="d-flex mb-4 flex-column align-items-center justify-content-center">
                 <h4 class="text-center m-0">IoT Box - <t t-esc="state.data.hostname" /></h4>
             </div>
-            <div t-if="!store.advanced and !state.data.is_certificate_ok and !store.base.is_access_point_up" class="alert alert-warning" role="alert">
-                <p class="m-0 fw-bold">
-                    No subscription linked to your IoT Box.
-                </p>
-                <small>
-                    Please contact your account manager to take advantage of your IoT Box's full potential.
-                </small>
-            </div>
-            <div t-if="store.advanced" t-att-class="'alert ' + (state.data.is_certificate_ok === true ? 'alert-info' : 'alert-warning')" role="alert">
-                <p class="m-0 fw-bold">HTTPS Certificate</p>
-                <small>
-                    <t t-if="state.data.is_certificate_ok === true">Status: </t>
-                    <t t-else="">Error Code: </t>
-                    <t t-esc="state.data.certificate_details" />
-                </small>
-            </div>
             <div t-if="store.base.is_access_point_up" class="alert alert-info" role="alert">
                 <p class="m-0 fw-bold">No Internet Connection</p>
                 <small>


### PR DESCRIPTION
We used to associate HTTPS certificate with IoT subscriptions. We now always generate the certificate, and let the database handle IoT subscriptions.

Task: 4585446