### PR TITLE
[IMP] mail, various: cleanup default recipients (overrides)

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -108,7 +108,7 @@ class CalendarAttendee(models.Model):
             "use_default_to": True,
         }
 
-    def _message_get_default_recipients(self):
+    def _message_get_default_recipients(self, with_cc=False):
         # override: partner_id being the only stored field, we can currently
         # simplify computation, we have no other choice than relying on it
         return {

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1982,7 +1982,7 @@ class CrmLead(models.Model):
             res.update(super(CrmLead, leftover)._notify_get_reply_to(default=default, author_id=author_id))
         return res
 
-    def _message_get_default_recipients(self):
+    def _message_get_default_recipients(self, with_cc=False):
         return {
             r.id: {
                 'partner_ids': [],

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1982,15 +1982,6 @@ class CrmLead(models.Model):
             res.update(super(CrmLead, leftover)._notify_get_reply_to(default=default, author_id=author_id))
         return res
 
-    def _message_get_default_recipients(self, with_cc=False):
-        return {
-            r.id: {
-                'partner_ids': [],
-                'email_to': ','.join(tools.email_normalize_all(r.email_from)) or r.email_from,
-                'email_cc': False,
-            } for r in self
-        }
-
     @api.model
     def message_new(self, msg_dict, custom_values=None):
         # remove default author when going through the mail gateway. Indeed we

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -360,10 +360,10 @@ class EventRegistration(models.Model):
             registration_id=self.id,
         )
 
-    def _message_get_default_recipients(self):
+    def _message_get_default_recipients(self, with_cc=False):
         # Prioritize registration email over partner_id, which may be shared when a single
         # partner booked multiple seats
-        results = super()._message_get_default_recipients()
+        results = super()._message_get_default_recipients(with_cc=with_cc)
         for record in self:
             email_to = results[record.id]['email_to']
             if email_to:

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -239,7 +239,7 @@ class Base(models.AbstractModel):
             email_cc_lst, email_to_lst = [], []
             # main recipients (res.partner)
             recipients_all = customers.get(record.id).filtered(lambda p: not p.is_public)
-            recipients = recipients_all.filtered(lambda p: p.email)
+            recipients = recipients_all.filtered(lambda p: p.email_normalized)
             # to computation
             to_fn = next(
                 (
@@ -269,7 +269,13 @@ class Base(models.AbstractModel):
                 # if no valid recipients nor emails, fallback on recipients even
                 # invalid to have at least some information
                 if recipients:
-                    partner_ids = recipients.ids or recipients_all.ids
+                    partner_ids = recipients.ids
+                    email_to = ''
+                elif recipients_all and len(recipients_all) == len(email_to_lst) and all(
+                    email in recipients_all.mapped('email') for email in email_to_lst
+                ):
+                    # here we just have partners with invalid emails, same as email fields
+                    partner_ids = recipients_all.ids
                     email_to = ''
                 else:
                     partner_ids = [] if email_to_lst else recipients_all.ids

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -78,7 +78,7 @@ class ResPartner(models.Model):
         partners += self
         return email_to_lst, partners
 
-    def _message_get_default_recipients(self):
+    def _message_get_default_recipients(self, with_cc=False):
         return {
             r.id:
             {

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -78,17 +78,6 @@ class ResPartner(models.Model):
         partners += self
         return email_to_lst, partners
 
-    def _message_get_default_recipients(self, with_cc=False):
-        return {
-            r.id:
-            {
-                'partner_ids': [r.id],
-                'email_to': False,
-                'email_cc': False,
-            }
-            for r in self
-        }
-
     # ------------------------------------------------------------
     # ORM
     # ------------------------------------------------------------

--- a/addons/mail/tests/test_res_partner.py
+++ b/addons/mail/tests/test_res_partner.py
@@ -444,7 +444,7 @@ class TestPartner(MailCommon):
         for partner in partners:
             with self.subTest(partner=partner.name):
                 self.assertEqual(defaults[partner.id], {
-                    'email_cc': False, 'email_to': False,
+                    'email_cc': '', 'email_to': '',
                     'partner_ids': partner.ids,
                 })
 

--- a/addons/mail/tests/test_res_partner.py
+++ b/addons/mail/tests/test_res_partner.py
@@ -13,7 +13,7 @@ from odoo.tests import Form, tagged, users
 from odoo.tools import mute_logger
 
 
-@tagged('res_partner', 'mail_tools')
+@tagged('res_partner', 'mail_tools', 'mail_thread_api')
 class TestPartner(MailCommon):
 
     @classmethod
@@ -304,7 +304,7 @@ class TestPartner(MailCommon):
                     self.assertEqual(partner.name, exp_name)
 
     @users('employee_c2')
-    def test_res_partner_find_or_create_from_emails_dupes_email_field(self):
+    def test_find_or_create_from_emails_dupes_email_field(self):
         """ Specific test for duplicates management: based on email to avoid
         creating similar partners. """
         # all same partner, same email 'test.customer@test.dupe.example.com'
@@ -433,6 +433,36 @@ class TestPartner(MailCommon):
                     self.assertIn(partner, self._new_partners)
                 self.assertEqual(partner.email, expected_email)
                 self.assertEqual(partner.name, expected_name)
+
+    def test_message_get_default_recipients(self):
+        """ Specific use case: partner should contact himself """
+        partners = self.env['res.partner'].create([
+            {'name': 'Raoulette', 'email': '"Raoulette" <raoulette@example.com>'},
+            {'name': 'Ignassette', 'email': 'wrong'}
+        ])
+        defaults = partners._message_get_default_recipients()
+        for partner in partners:
+            with self.subTest(partner=partner.name):
+                self.assertEqual(defaults[partner.id], {
+                    'email_cc': False, 'email_to': False,
+                    'partner_ids': partner.ids,
+                })
+
+    def test_message_get_suggested_recipients(self):
+        """ Specific use case: partner should contact himself """
+        partners = self.env['res.partner'].create([
+            {'name': 'Raoulette', 'email': '"Raoulette" <raoulette@example.com>'},
+            {'name': 'Ignassette', 'email': 'wrong'}
+        ])
+        for partner in partners:
+            with self.subTest(partner_name=partner.name):
+                suggested = partner._message_get_suggested_recipients()
+                self.assertEqual(suggested, [{
+                    'create_values': {},
+                    'email': partner.email_normalized,
+                    'name': partner.name,
+                    'partner_id': partner.id,
+                }])
 
     def test_log_portal_group(self):
         Users = self.env['res.users']

--- a/addons/mass_mailing/models/mailing_contact.py
+++ b/addons/mass_mailing/models/mailing_contact.py
@@ -146,7 +146,7 @@ class MailingContact(models.Model):
         contact = self.create({'name': name, 'email': email, 'list_ids': [(4, list_id)]})
         return contact.id, contact.display_name
 
-    def _message_get_default_recipients(self):
+    def _message_get_default_recipients(self, with_cc=False):
         return {
             r.id: {
                 'partner_ids': [],

--- a/addons/mass_mailing/models/mailing_contact.py
+++ b/addons/mass_mailing/models/mailing_contact.py
@@ -146,15 +146,6 @@ class MailingContact(models.Model):
         contact = self.create({'name': name, 'email': email, 'list_ids': [(4, list_id)]})
         return contact.id, contact.display_name
 
-    def _message_get_default_recipients(self, with_cc=False):
-        return {
-            r.id: {
-                'partner_ids': [],
-                'email_to': ','.join(tools.email_normalize_all(r.email)) or r.email,
-                'email_cc': False,
-            } for r in self
-        }
-
     def action_import(self):
         action = self.env["ir.actions.actions"]._for_xml_id("mass_mailing.mailing_contact_import_action")
         context = self.env.context.copy()

--- a/addons/test_mail/models/mail_test_ticket.py
+++ b/addons/test_mail/models/mail_test_ticket.py
@@ -29,7 +29,7 @@ class MailTestTicket(models.Model):
         self.ensure_one()
         return f"Ticket for {self.name} on {self.datetime.strftime('%m/%d/%Y, %H:%M:%S')}"
 
-    def _message_get_default_recipients(self):
+    def _message_get_default_recipients(self, with_cc=False):
         return {
             record.id:  {
                 'email_cc': False,
@@ -226,7 +226,7 @@ class MailTestContainer(models.Model):
     def _mail_get_partner_fields(self, introspect_fields=False):
         return ['customer_id']
 
-    def _message_get_default_recipients(self):
+    def _message_get_default_recipients(self, with_cc=False):
         return {
             record.id: {
                 'email_cc': False,

--- a/addons/test_mail/models/mail_test_ticket.py
+++ b/addons/test_mail/models/mail_test_ticket.py
@@ -29,15 +29,6 @@ class MailTestTicket(models.Model):
         self.ensure_one()
         return f"Ticket for {self.name} on {self.datetime.strftime('%m/%d/%Y, %H:%M:%S')}"
 
-    def _message_get_default_recipients(self, with_cc=False):
-        return {
-            record.id:  {
-                'email_cc': False,
-                'email_to': record.email_from if not record.customer_id.ids else False,
-                'partner_ids': record.customer_id.ids,
-            } for record in self
-        }
-
     def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
         # Activate more groups to test query counters notably (and be backward compatible for tests)
         groups = super()._notify_get_recipients_groups(
@@ -225,15 +216,6 @@ class MailTestContainer(models.Model):
 
     def _mail_get_partner_fields(self, introspect_fields=False):
         return ['customer_id']
-
-    def _message_get_default_recipients(self, with_cc=False):
-        return {
-            record.id: {
-                'email_cc': False,
-                'email_to': False,
-                'partner_ids': record.customer_id.ids,
-            } for record in self
-        }
 
     def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
         # Activate more groups to test query counters notably (and be backward compatible for tests)

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -144,7 +144,7 @@ class MailTestGatewayGroups(models.Model):
     def _mail_get_partner_fields(self, introspect_fields=False):
         return ['customer_id']
 
-    def _message_get_default_recipients(self):
+    def _message_get_default_recipients(self, with_cc=False):
         return dict(
             (record.id, {
                 'email_cc': False,

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -144,16 +144,6 @@ class MailTestGatewayGroups(models.Model):
     def _mail_get_partner_fields(self, introspect_fields=False):
         return ['customer_id']
 
-    def _message_get_default_recipients(self, with_cc=False):
-        return dict(
-            (record.id, {
-                'email_cc': False,
-                'email_to': record.email_from if not record.customer_id.ids else False,
-                'partner_ids': record.customer_id.ids,
-            })
-            for record in self
-        )
-
 
 class MailTestTrack(models.Model):
     """ This model can be used in tests when automatic subscription and simple

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -348,7 +348,7 @@ class TestAPI(MailCommon, TestRecipients):
         # test default computation of recipients
         self.env.invalidate_all()
         with self.assertQueryCount(20):
-            defaults_withcc = test_records.with_context()._message_get_default_recipients(include_cc=True)
+            defaults_withcc = test_records.with_context()._message_get_default_recipients(with_cc=True)
             defaults_withoutcc = test_records.with_context()._message_get_default_recipients()
         for record, expected in zip(test_records, [
             {
@@ -427,7 +427,7 @@ class TestAPI(MailCommon, TestRecipients):
         })
         for ticket in ticket_partner_email + ticket_partner:
             with self.subTest(ticket=ticket.name):
-                suggestions = ticket_partner_email._message_get_suggested_recipients(no_create=True)
+                suggestions = ticket._message_get_suggested_recipients(no_create=True)
                 self.assertEqual(len(suggestions), 1)
                 self.assertDictEqual(
                     suggestions[0],

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -348,8 +348,8 @@ class TestAPI(MailCommon, TestRecipients):
         # test default computation of recipients
         self.env.invalidate_all()
         with self.assertQueryCount(20):
-            defaults_withcc = test_records.with_context(mail_recipients_include_cc=True)._message_get_default_recipients()
-            defaults_withoutcc = test_records.with_context(mail_recipients_include_cc=False)._message_get_default_recipients()
+            defaults_withcc = test_records.with_context()._message_get_default_recipients(include_cc=True)
+            defaults_withoutcc = test_records.with_context()._message_get_default_recipients()
         for record, expected in zip(test_records, [
             {
                 # customer_id first for partner_ids; partner > email

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -487,7 +487,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
         test_template.write({'attachment_ids': [(5, 0)]})
 
-        with self.assertQueryCount(admin=7, employee=7):
+        with self.assertQueryCount(admin=9, employee=9):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -511,7 +511,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_mail_composer_w_template_attachments(self):
         test_record, test_template = self._create_test_records()
 
-        with self.assertQueryCount(admin=8, employee=8):
+        with self.assertQueryCount(admin=10, employee=10):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -540,7 +540,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_template.write({'attachment_ids': [(5, 0)]})
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=18, employee=18):  # tm 14/14
+        with self.assertQueryCount(admin=20, employee=20):  # tm 16/16
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -570,7 +570,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=18, employee=18):  # tm 14/14
+        with self.assertQueryCount(admin=20, employee=20):  # tm 16/16
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',

--- a/addons/test_mass_mailing/models/mailing_models.py
+++ b/addons/test_mass_mailing/models/mailing_models.py
@@ -20,18 +20,8 @@ class MailingTestCustomer(models.Model):
         for mailing in self.filtered(lambda rec: not rec.email_from and rec.customer_id):
             mailing.email_from = mailing.customer_id.email
 
-    def _message_get_default_recipients(self, with_cc=False):
-        """ Default recipient checks for 'partner_id', here the field is named
-        'customer_id'. """
-        default_recipients = super()._message_get_default_recipients()
-        for record in self:
-            if record.customer_id:
-                default_recipients[record.id] = {
-                    'email_cc': False,
-                    'email_to': False,
-                    'partner_ids': record.customer_id.ids,
-                }
-        return default_recipients
+    def _mail_get_partner_fields(self, introspect_fields=False):
+        return ['customer_id']
 
 
 class MailingTestSimple(models.Model):
@@ -69,18 +59,8 @@ class MailingTestBlacklist(models.Model):
     customer_id = fields.Many2one('res.partner', 'Customer', tracking=True)
     user_id = fields.Many2one('res.users', 'Responsible', tracking=True)
 
-    def _message_get_default_recipients(self, with_cc=False):
-        """ Default recipient checks for 'partner_id', here the field is named
-        'customer_id'. """
-        default_recipients = super()._message_get_default_recipients()
-        for record in self:
-            if record.customer_id:
-                default_recipients[record.id] = {
-                    'email_cc': False,
-                    'email_to': False,
-                    'partner_ids': record.customer_id.ids,
-                }
-        return default_recipients
+    def _mail_get_partner_fields(self, introspect_fields=False):
+        return ['customer_id']
 
 
 class MailingTestOptout(models.Model):
@@ -97,6 +77,9 @@ class MailingTestOptout(models.Model):
     customer_id = fields.Many2one('res.partner', 'Customer', tracking=True)
     user_id = fields.Many2one('res.users', 'Responsible', tracking=True)
 
+    def _mail_get_partner_fields(self, introspect_fields=False):
+        return ['customer_id']
+
     def _mailing_get_opt_out_list(self, mailing):
         res_ids = mailing._get_recipients()
         opt_out_contacts = set(self.search([
@@ -104,19 +87,6 @@ class MailingTestOptout(models.Model):
             ('opt_out', '=', True)
         ]).mapped('email_normalized'))
         return opt_out_contacts
-
-    def _message_get_default_recipients(self, with_cc=False):
-        """ Default recipient checks for 'partner_id', here the field is named
-        'customer_id'. """
-        default_recipients = super()._message_get_default_recipients()
-        for record in self:
-            if record.customer_id:
-                default_recipients[record.id] = {
-                    'email_cc': False,
-                    'email_to': False,
-                    'partner_ids': record.customer_id.ids,
-                }
-        return default_recipients
 
 
 class MailingTestPartner(models.Model):

--- a/addons/test_mass_mailing/models/mailing_models.py
+++ b/addons/test_mass_mailing/models/mailing_models.py
@@ -20,7 +20,7 @@ class MailingTestCustomer(models.Model):
         for mailing in self.filtered(lambda rec: not rec.email_from and rec.customer_id):
             mailing.email_from = mailing.customer_id.email
 
-    def _message_get_default_recipients(self):
+    def _message_get_default_recipients(self, with_cc=False):
         """ Default recipient checks for 'partner_id', here the field is named
         'customer_id'. """
         default_recipients = super()._message_get_default_recipients()
@@ -69,7 +69,7 @@ class MailingTestBlacklist(models.Model):
     customer_id = fields.Many2one('res.partner', 'Customer', tracking=True)
     user_id = fields.Many2one('res.users', 'Responsible', tracking=True)
 
-    def _message_get_default_recipients(self):
+    def _message_get_default_recipients(self, with_cc=False):
         """ Default recipient checks for 'partner_id', here the field is named
         'customer_id'. """
         default_recipients = super()._message_get_default_recipients()
@@ -105,7 +105,7 @@ class MailingTestOptout(models.Model):
         ]).mapped('email_normalized'))
         return opt_out_contacts
 
-    def _message_get_default_recipients(self):
+    def _message_get_default_recipients(self, with_cc=False):
         """ Default recipient checks for 'partner_id', here the field is named
         'customer_id'. """
         default_recipients = super()._message_get_default_recipients()

--- a/addons/test_mass_mailing/tests/test_mailing.py
+++ b/addons/test_mass_mailing/tests/test_mailing.py
@@ -11,10 +11,6 @@ from odoo.tools import mute_logger, email_normalize
 @tagged('mass_mailing')
 class TestMassMailing(TestMassMailCommon):
 
-    @classmethod
-    def setUpClass(cls):
-        super(TestMassMailing, cls).setUpClass()
-
     @users('user_marketing')
     @mute_logger('odoo.addons.mail.models.mail_thread')
     def test_mailing_gateway_reply(self):
@@ -219,39 +215,39 @@ class TestMassMailing(TestMassMailCommon):
                 self.assertMailTraces(
                     [
                         {'email': 'customer.multi.1@example.com',
-                         'email_to_mail': False,  # using recipient_ids, not email_to
+                         'email_to_mail': '',  # using recipient_ids, not email_to
                          'email_to_recipients': [[f'"{customer_mult.name}" <customer.multi.1@example.com>', f'"{customer_mult.name}" <customer.multi.2@example.com>']],
                          'failure_type': False,
                          'partner': customer_mult,
                          'trace_status': 'sent'},
                         {'email': 'test.customer.format@example.com',
-                         'email_to_mail': False,  # using recipient_ids, not email_to
+                         'email_to_mail': '',  # using recipient_ids, not email_to
                          # mail to avoids double encapsulation
                          'email_to_recipients': [[f'"{customer_fmt.name}" <test.customer.format@example.com>']],
                          'failure_type': False,
                          'partner': customer_fmt,
                          'trace_status': 'sent'},
                         {'email': 'test.customer.😊@example.com',
-                         'email_to_mail': False,  # using recipient_ids, not email_to
+                         'email_to_mail': '',  # using recipient_ids, not email_to
                          # mail to avoids double encapsulation
                          'email_to_recipients': [[f'"{customer_unic.name}" <test.customer.😊@example.com>']],
                          'failure_type': False,
                          'partner': customer_unic,
                          'trace_status': 'sent'},
                         {'email': 'test.customer.case@example.com',
-                         'email_to_mail': False,  # using recipient_ids, not email_to
+                         'email_to_mail': '',  # using recipient_ids, not email_to
                          'email_to_recipients': [[f'"{customer_case.name}" <test.customer.case@example.com>']],
                          'failure_type': False,
                          'partner': customer_case,
                          'trace_status': 'sent'},  # lower cased
                         {'email': 'test.customer.weird@example.comweirdformat',
-                         'email_to_mail': False,  # using recipient_ids, not email_to
+                         'email_to_mail': '',  # using recipient_ids, not email_to
                          'email_to_recipients': [[f'"{customer_weird.name}" <test.customer.weird@example.comweirdformat>']],
                          'failure_type': False,
                          'partner': customer_weird,
                          'trace_status': 'sent'},  # concatenates everything after domain
                         {'email': 'test.customer.weird.2@example.com',
-                         'email_to_mail': False,  # using recipient_ids, not email_to
+                         'email_to_mail': '',  # using recipient_ids, not email_to
                          'email_to_recipients': [[f'"{customer_weird_2.name}" <test.customer.weird.2@example.com>']],
                          'failure_type': False,
                          'partner': customer_weird_2,

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -473,7 +473,7 @@ class EventTrack(models.Model):
     # MESSAGING
     # ------------------------------------------------------------
 
-    def _message_get_default_recipients(self):
+    def _message_get_default_recipients(self, with_cc=False):
         return {
             track.id: {
                 'partner_ids': [],

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -7,7 +7,7 @@ from random import randint
 
 from odoo import api, fields, models, tools
 from odoo.osv import expression
-from odoo.tools.mail import is_html_empty
+from odoo.tools.mail import email_normalize, is_html_empty
 from odoo.tools.translate import _, html_translate
 
 
@@ -22,6 +22,7 @@ class EventTrack(models.Model):
         'website.published.mixin',
         'website.searchable.mixin'
     ]
+    _primary_email = 'contact_email'
 
     @api.model
     def _get_default_stage_id(self):
@@ -474,22 +475,18 @@ class EventTrack(models.Model):
     # ------------------------------------------------------------
 
     def _message_get_default_recipients(self, with_cc=False):
-        return {
-            track.id: {
-                'partner_ids': [],
-                'email_to': ','.join(tools.email_normalize_all(track.contact_email or track.partner_email)) or track.contact_email or track.partner_email,
-                'email_cc': False
-            } for track in self
-        }
+        recipients = super()._message_get_default_recipients(with_cc=with_cc)
+        for track in self.filtered(lambda t: not t.partner_id.email_normalized and not email_normalize(t.contact_email) and t.partner_email):
+            info = recipients[track.id]
+            info['email_to'] = ','.join(tools.email_normalize_all(track.partner_email)) or track.partner_email
+            info['partner_ids'] = []
+        return recipients
 
     def _message_add_suggested_recipients(self, primary_email=False):
         email_to_lst, partners = super()._message_add_suggested_recipients(primary_email)
-        if not self.partner_id:
-            #  Priority: contact information then speaker information
-            if self.contact_email:
-                email_to_lst.append(self.contact_email)
-            elif self.partner_email:
-                email_to_lst.append(self.partner_email)
+        #  Priority: contact information then speaker information
+        if not self.partner_id.email_normalized and not email_normalize(self.contact_email) and self.partner_email:
+            email_to_lst.append(self.partner_email)
         return email_to_lst, partners
 
     def _message_post_after_hook(self, message, msg_vals):

--- a/addons/website_event_track/tests/__init__.py
+++ b/addons/website_event_track/tests/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_event_menus
+from . import test_mail_features
 from . import test_track_internals
 from . import test_website_event
 from . import test_website_visitor

--- a/addons/website_event_track/tests/test_mail_features.py
+++ b/addons/website_event_track/tests/test_mail_features.py
@@ -1,0 +1,154 @@
+from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.website_event.tests.common import TestEventOnlineCommon
+from odoo.tests import tagged, users
+
+
+@tagged('post_install', '-at_install', 'mail_flow', 'mail_tools')
+class TestTrackMailFeatures(TestEventOnlineCommon, MailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.event_customer_wrongemail = cls.env['res.partner'].create({
+            'email': 'wrong',
+            'name': 'Wrong Emails',
+        })
+        cls.tracks = cls.env['event.track'].with_user(cls.user_eventmanager).create([
+            {
+                'contact_email': 'not.partner@test.example.com',
+                'event_id': cls.event_0.id,
+                'name': 'Email Ony',
+            }, {
+                'event_id': cls.event_0.id,
+                'name': 'Partner',
+                'partner_id': cls.event_customer.id,
+            }, {
+                'contact_email': '"Contact" <contact@test.example.com>',
+                'event_id': cls.event_0.id,
+                'name': 'Partner and contact',
+                'partner_id': cls.event_customer.id,
+            }, {
+                'contact_email': False,
+                'event_id': cls.event_0.id,
+                'name': 'Partner (no contact_email) and speaker email',
+                'partner_email': '"Speaker" <speaker@test.example.com>',
+                'partner_id': cls.event_customer.id,
+            }, {
+                'event_id': cls.event_0.id,
+                'name': 'Partner (wrong email) and speaker email',
+                'partner_email': '"Speaker" <speaker@test.example.com>',
+                'partner_id': cls.event_customer_wrongemail.id,
+            }, {
+                'contact_email': '"Contact" <contact@test.example.com>',
+                'event_id': cls.event_0.id,
+                'name': 'Speaker and contact emails (no partner)',
+                'partner_email': '"Speaker" <speaker@test.example.com>',
+            },
+        ])
+
+    @users('user_eventmanager')
+    def test_track_default_recipients(self):
+        """ Test track default recipients """
+        tracks = self.tracks.with_user(self.env.user)
+        defaults = tracks._message_get_default_recipients()
+        expected_all = {
+            self.tracks[0].id: {
+                'email_cc': False, 'email_to': 'not.partner@test.example.com',
+                'partner_ids': [],
+            },
+            # event with a partner, partner_email is used
+            self.tracks[1].id: {
+                'email_cc': False, 'email_to': self.event_customer.email,
+                'partner_ids': [],
+            },
+            # contact_email > partner_email (speaker info), and normalized is used only
+            self.tracks[2].id: {
+                'email_cc': False, 'email_to': 'contact@test.example.com',
+                'partner_ids': [],
+            },
+            # find at least one email (no contact_email -> partner_email)
+            self.tracks[3].id: {
+                'email_cc': False, 'email_to': 'speaker@test.example.com',
+                'partner_ids': [],
+            },
+            # FIXME wrong contact email
+            self.tracks[4].id: {
+                'email_cc': False, 'email_to': 'wrong',
+                'partner_ids': [],
+            },
+            # no partner: contact then speaker
+            self.tracks[5].id: {
+                'email_cc': False, 'email_to': 'contact@test.example.com',
+                'partner_ids': [],
+            },
+        }
+
+        for track in tracks:
+            expected = expected_all.get(track.id)
+            with self.subTest(track_name=track.name):
+                self.assertEqual(defaults[track.id], expected)
+
+    @users('user_eventmanager')
+    def test_track_suggested_recipients(self):
+        """ Test track suggested recipients """
+        tracks = self.tracks.with_user(self.env.user)
+        expected_all = [
+            [
+                {
+                    'create_values': {},
+                    'email': 'not.partner@test.example.com',
+                    'name': '',
+                    'partner_id': False,
+                },
+            ],
+            # event with a partner, use it
+            [
+                {
+                    'create_values': {},
+                    'email': self.event_customer.email_normalized,
+                    'name': self.event_customer.name,
+                    'partner_id': self.event_customer.id,
+                },
+            ],
+            # partner > contact_email (should be the same anyway)
+            [
+                {
+                    'create_values': {},
+                    'email': self.event_customer.email_normalized,
+                    'name': self.event_customer.name,
+                    'partner_id': self.event_customer.id,
+                },
+            ],
+            # FIXME partner wo email is taken
+            [
+                {
+                    'create_values': {},
+                    'email': self.event_customer.email_normalized,
+                    'name': self.event_customer.name,
+                    'partner_id': self.event_customer.id,
+                },
+            ],
+            # partner with wrong email
+            [
+                {
+                    'create_values': {},
+                    'email': self.event_customer_wrongemail.email_normalized,
+                    'name': self.event_customer_wrongemail.name,
+                    'partner_id': self.event_customer_wrongemail.id,
+                },
+            ],
+            # no partner: contact then speaker
+            [
+                {
+                    'create_values': {},
+                    'email': 'contact@test.example.com',
+                    'name': 'Contact',
+                    'partner_id': False,
+                },
+            ],
+        ]
+
+        for track, expected in zip(tracks, expected_all, strict=True):
+            suggested = track._message_get_suggested_recipients()
+            with self.subTest(track_name=track.name):
+                self.assertEqual(suggested, expected)


### PR DESCRIPTION
RATIONALE

Cleanup addon-specific code about default recipients computation. Since
base code is now smarter, most overrides can be removed to keep simple
code and ease understanding.

SPECIFICATIONS

Remove overrides that are now covered by base computation.

When necessary use '_mail_defaults_to_email' that prioritizes email
over partner (customer) when searching for default recipients.

When necessary add missing '_primary_email' definition allowing to find
the main email to contact.

Provide some fixes in default recipients computation, notably linked to
normalized emails usage and comparison instead of raw emails.

QUERIES

Simple overrides on test models are removed. This implies usage of
more complete '_message_get_default_recipients' hence some additional
queries.

LINKS

Followup of odoo/odoo#172714: improve default behavior of templates
Followup of odoo/odoo#188642 : main branch for email-like recipients

Task-4555506: Cleanup / Mergeup default / suggested recipients
