### PR TITLE
[FIX] stock: access error on replenishment

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -716,3 +716,7 @@ class StockWarehouseOrderpoint(models.Model):
 
     def _get_orderpoint_locations(self):
         return self.env['stock.location'].search([('replenish_location', '=', True)])
+
+    @api.model
+    def get_visibility_days(self):
+        return self.env['ir.config_parameter'].sudo().get_param('stock.visibility_days', 0)

--- a/addons/stock/static/src/views/search/stock_orderpoint_search_panel.js
+++ b/addons/stock/static/src/views/search/stock_orderpoint_search_panel.js
@@ -17,7 +17,7 @@ export class StockOrderpointSearchPanel extends SearchPanel {
     }
 
     async getVisibilityParameter() {
-        let res = await this.orm.call("ir.config_parameter", "get_param", ["stock.visibility_days", 0]);
+        let res = await this.orm.call("stock.warehouse.orderpoint", "get_visibility_days", []);
         this.globalVisibilityDays.value = Math.abs(parseInt(res)) || 0;
     }
 


### PR DESCRIPTION
odoo/odoo#192897 introduced a new bug when trying to access the replenishment view without administrator rights due to a call to `ir.config.parameter` method `get_param` without sudo rights.

opw-4583651


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
