### PR TITLE
[IMP] pos_self_order: shorten url

### DIFF
--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -4,7 +4,7 @@
     'version': '1.0',
     "summary": "Addon for the POS App that allows customers to view the menu on their smartphone.",
     "category": "Sales/Point Of Sale",
-    "depends": ["pos_restaurant", "http_routing"],
+    "depends": ["pos_restaurant", "http_routing", "link_tracker"],
     "auto_install": ["pos_restaurant"],
     "data": [
         "security/ir.model.access.csv",

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -232,7 +232,11 @@ class PosConfig(models.Model):
 
     def _get_self_order_url(self, table_id: Optional[int] = None) -> str:
         self.ensure_one()
-        return url_quote(self.get_base_url() + self._get_self_order_route(table_id))
+        long_url = self.get_base_url() + self._get_self_order_route(table_id)
+        return self.env['link.tracker'].search_or_create([{
+            'url': long_url,
+            'title': f"Self Order {self.name}" if not table_id else f"Self Order {self.name} - Table id {table_id}",
+        }]).short_url
 
     def preview_self_order_app(self):
         self.ensure_one()


### PR DESCRIPTION

    In this commit we add the `link_tracker` module as a dependency in
    `pos_self_order` in order to create shorter links for the table ordering
    feature.

    Task: 4575936

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
