### PR TITLE
[FIX] stock: make mtso act as mto in adjust procure method

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2256,8 +2256,8 @@ Please change the quantity done or the rounding precision of your unit of measur
                 continue
 
             move.rule_id = rule.id
-            if rule.procure_method in ['make_to_stock', 'make_to_order']:
-                move.procure_method = rule.procure_method
+            if rule.procure_method in ['mts_else_mto', 'make_to_order']:
+                move.procure_method = 'make_to_order'
             else:
                 move.procure_method = 'make_to_stock'
 


### PR DESCRIPTION
Since a72382063ee662, the mtso mechanism always create mts move in `_adjust_procure_method()`. So new move gathering manufacturing component for instance are always created in mts. Which lead to reservation sharing which is not desired in mto flows.

Task: 4374225

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
