### PR TITLE
[FIX] mail: message highlight improved

### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -8,6 +8,7 @@
 
     &.o-hasSelfAvatar {
         grid-template-columns: $o-mail-Message-sidebarWidth 1fr;
+        border-left: 3px solid transparent; // align with message avatar
     }
 
     .o-mail-Composer-sidebarMain {

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -71,6 +71,21 @@ $o-discuss-talkingColor: lighten($success, 10%);
     text-decoration: underline;
 }
 
+.o-rounded-bottom-2_5 {
+    border-bottom-left-radius: ($border-radius + $border-radius-lg) / 2;
+    border-bottom-right-radius: ($border-radius + $border-radius-lg) / 2;
+}
+
+.o-rounded-start-2_5 {
+    border-top-left-radius: ($border-radius + $border-radius-lg) / 2;
+    border-bottom-left-radius: ($border-radius + $border-radius-lg) / 2;
+}
+
+.o-rounded-end-2_5 {
+    border-top-right-radius: ($border-radius + $border-radius-lg) / 2;
+    border-bottom-right-radius: ($border-radius + $border-radius-lg) / 2;
+}
+
 .o-text-white {
     color: #FFF !important;
 }

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -62,6 +62,11 @@ $o-discuss-talkingColor: lighten($success, 10%);
     padding-bottom: map-get($spacers, 1) / 2;
 }
 
+.o-my-0_5 {
+    margin-top: map-get($spacers, 1) / 2;
+    margin-bottom: map-get($spacers, 1) / 2;
+}
+
 .o-hover-text-underline:hover {
     text-decoration: underline;
 }

--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -1,5 +1,9 @@
-.o-mail-Message.o-card {
-    background-color: mix($gray-100, $gray-200);
+.o-mail-Message {
+    --mail-Message-highlightBorderOpacity: 1;
+
+    &.o-card {
+        background-color: mix($gray-100, $gray-200);
+    }
 }
 
 .o-mail-Message-actions {

--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -20,26 +20,35 @@
 
 .o-mail-Message-bubble {
     &.o-blue {
-        background-color: mix($gray-100, $info, 87.5%) !important;
-        border-color: lighten(mix($gray-100, $info, 87.5%), 5%) !important;
+        background-color: lighten(mix($gray-100, $info, 87.5%), 5%) !important;
+        
+        > .o-mail-Message-bubbleIn {
+            background-color: mix($gray-100, $info, 87.5%) !important;
+        }
 
-        &.o-muted {
+        &.o-muted > .o-mail-Message-bubbleIn {
             background-color: mix($gray-100, mix($gray-100, $info, 87.5%)) !important;
         }
     }
     &.o-green {
-        background-color: mix($gray-100, $success, 87.5%) !important;
-        border-color: lighten(mix($gray-100, $success, 87.5%), 5%) !important;
+        background-color: lighten(mix($gray-100, $success, 87.5%), 5%) !important;
+        
+        > .o-mail-Message-bubbleIn {
+            background-color: mix($gray-100, $success, 87.5%) !important;
+        }
 
-        &.o-muted {
+        &.o-muted > .o-mail-Message-bubbleIn {
             background-color: mix($gray-100, mix($gray-100, $success, 87.5%)) !important;
         }
     }
     &.o-orange {
-        background-color: mix($gray-100, $warning, 72.5%) !important;
-        border-color: lighten(mix($gray-100, $warning, 72.5%), 5%) !important;
+        background-color: lighten(mix($gray-100, $warning, 72.5%), 5%) !important;
+        
+        > .o-mail-Message-bubbleIn {
+            background-color: mix($gray-100, $warning, 72.5%) !important;
+        }
 
-        &.o-muted {
+        &.o-muted > .o-mail-Message-bubbleIn {
             background-color: mix($gray-100, mix($gray-100, $warning, 72.5%), 85%) !important;
         }
     }

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -200,7 +200,7 @@ export class Message extends Component {
         return {
             [this.props.className]: true,
             "o-card p-2 mt-2 border border-secondary": this.props.asCard,
-            "pt-1": !this.props.asCard,
+            "o-py-0_5": !this.props.asCard,
             "o-selfAuthored": this.message.isSelfAuthored && !this.env.messageCard,
             "o-selected": this.props.messageToReplyTo?.isSelected(
                 this.props.thread,
@@ -219,6 +219,7 @@ export class Message extends Component {
             ),
             "o-actionMenuMobileOpen": this.state.actionMenuMobileOpen,
             "o-editing": this.state.isEditing,
+            "px-3": !this.env.inChatter && !this.props.isInChatWindow,
         };
     }
 

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -1,5 +1,5 @@
 .o-mail-Message {
-    transition: background-color .2s ease-out, opacity .2s ease-out, box-shadow .2s ease-out, transform .2s ease-out, border-left-color .3s ease-out, outline .3s ease-out;
+    transition: background-color .2s ease-out, opacity .2s ease-out, box-shadow .2s ease-out, transform .2s ease-out, border-left-color .3s ease-out, outline .3s ease-out, background-image .3s ease-out;
     border-left: inset 3px transparent;
 
     &.o-card {
@@ -13,10 +13,11 @@
         background-color: rgba(lighten($o-action, 15%), .05);
         border-left-color: rgba(lighten($o-action, 15%), var(--mail-Message-highlightBorderOpacity, .5));
         box-shadow: $box-shadow-sm;
+        --border-angle: 0turn; // For animation.
 
         .o-mail-Message-bubble:not(.o-muted) {
-            outline: 1px solid rgba($o-action, .35);
-            outline-offset: -1px;
+            background-image: conic-gradient(from var(--border-angle), transparent 25%, rgba($o-action, 1));
+            animation: o-mail-Message-highlightBubbleAnimation 2s linear infinite;
         }
     }
 
@@ -26,6 +27,18 @@
         outline-offset: -1px;
     }
 }
+
+@keyframes o-mail-Message-highlightBubbleAnimation {
+    to {
+        --border-angle: 1turn;
+    }
+}
+
+@property --border-angle {
+    syntax: "<angle>";
+    inherits: true;
+    initial-value: 0turn;
+  }
 
 .o-mail-Message-date {
     opacity: 50%;
@@ -97,29 +110,44 @@
 
 .o-mail-Message-bubble {
     &.o-blue {
-        background-color: mix($o-view-background-color, $info, 87.5%) !important;
-        border-color: darken(mix($o-view-background-color, $info, 87.5%), 10%) !important;
+        background-color: darken(mix($o-view-background-color, $info, 87.5%), 10%) !important;
 
-        &.o-muted {
+        > .o-mail-Message-bubbleIn {
+            background-color: mix($o-view-background-color, $info, 87.5%) !important;
+        }
+
+        &.o-muted > .o-mail-Message-bubbleIn {
             background-color: mix($white, mix($o-view-background-color, $info, 87.5%)) !important;
         }
     }
     &.o-green {
-        background-color: mix($o-view-background-color, $success, 87.5%) !important;
-        border-color: darken(mix($o-view-background-color, $success, 87.5%), 10%) !important;
+        background-color: darken(mix($o-view-background-color, $success, 87.5%), 10%) !important;
+        
+        > .o-mail-Message-bubbleIn {
+            background-color: mix($o-view-background-color, $success, 87.5%) !important;
+        }
 
-        &.o-muted {
+        &.o-muted > .o-mail-Message-bubbleIn {
             background-color: mix($white, mix($o-view-background-color, $success, 87.5%)) !important;
         }
     }
     &.o-orange {
-        background-color: mix($o-view-background-color, $warning, 75%) !important;
-        border-color: darken(mix($o-view-background-color, $warning, 75%), 10%) !important;
+        background-color: darken(mix($o-view-background-color, $warning, 75%), 10%) !important;
+        
+        > .o-mail-Message-bubbleIn {
+            background-color: mix($o-view-background-color, $warning, 75%) !important;
+        }
 
-        &.o-muted {
+        &.o-muted > .o-mail-Message-bubbleIn {
             background-color: mix($white, mix($o-view-background-color, $warning, 75%), 85%) !important;
         }
     }
+}
+
+.o-mail-Message-bubbleIn {
+    margin: 1px;
+    width: calc(100% - 2px);
+    height: calc(100% - 2px);
 }
 
 .o-mail-ChatWindow .o-mail-Message.o-selfAuthored {

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -1,5 +1,6 @@
 .o-mail-Message {
-    transition: background-color .2s ease-out, opacity .5s ease-out, box-shadow .5s ease-out, transform .2s ease-out;
+    transition: background-color .2s ease-out, opacity .2s ease-out, box-shadow .2s ease-out, transform .2s ease-out, border-left-color .3s ease-out, outline .3s ease-out;
+    border-left: inset 3px transparent;
 
     &.o-card {
         outline: $border-width solid rgba($border-color, .35);
@@ -9,7 +10,14 @@
     }
 
     &.o-highlighted {
-        transform: translateY(-#{map-get($spacers, 3)});
+        background-color: rgba(lighten($o-action, 15%), .05);
+        border-left-color: rgba(lighten($o-action, 15%), var(--mail-Message-highlightBorderOpacity, .5));
+        box-shadow: $box-shadow-sm;
+
+        .o-mail-Message-bubble:not(.o-muted) {
+            outline: 1px solid rgba($o-action, .35);
+            outline-offset: -1px;
+        }
     }
 
     &.o-actionMenuMobileOpen {

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -68,11 +68,14 @@
                                         <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" linkPreviews="message.link_preview_ids" deletable="false"/>
                                         <t t-else="">
                                             <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block rounded-bottom-3" t-att-class="{ 'w-100': state.isEditing }">
-                                                <div t-if="message.bubbleColor" class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100 border" t-att-class="{
+                                                <div t-if="message.bubbleColor" class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100" t-att-class="{
                                                     'o-blue': message.bubbleColor === 'blue',
                                                     'o-green': message.bubbleColor === 'green',
                                                     'o-orange': message.bubbleColor === 'orange',
-                                                    }" t-attf-class="{{ isAlignedRight ? 'rounded-start-3' : 'rounded-end-3' }}"/>
+                                                    }" t-attf-class="{{ isAlignedRight ? 'rounded-start-3' : 'rounded-end-3' }}"
+                                                >
+                                                    <div class="o-mail-Message-bubbleIn o-rounded-bottom-2_5" t-attf-class="{{ isAlignedRight ? 'o-rounded-start-2_5' : 'o-rounded-end-2_5' }}"/>
+                                                </div>
                                                 <MessageInReply t-if="message.parentMessage" message="message" onClick="props.onParentMessageClick"/>
                                                 <div class="position-relative text-break o-mail-Message-body" t-att-class="{
                                                             'p-1': message.is_note,

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -61,13 +61,13 @@
                                    'flex-row-reverse': isAlignedRight,
                                    }"
                         >
-                            <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': state.isEditing, 'opacity-50': message.isPending, 'pt-1': message.is_note }">
+                            <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': state.isEditing, 'opacity-50': message.isPending, 'o-py-0_5': message.is_note }">
                                 <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': state.isEditing }">
                                     <t t-if="message.message_type === 'notification' and message.body" t-call="mail.Message.bodyAsNotification" name="bodyAsNotification"/>
                                     <t t-if="message.isEmpty or (message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or state.isEditing or message.edited))">
                                         <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" linkPreviews="message.link_preview_ids" deletable="false"/>
                                         <t t-else="">
-                                            <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
+                                            <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block rounded-bottom-3" t-att-class="{ 'w-100': state.isEditing }">
                                                 <div t-if="message.bubbleColor" class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100 border" t-att-class="{
                                                     'o-blue': message.bubbleColor === 'blue',
                                                     'o-green': message.bubbleColor === 'green',
@@ -131,7 +131,7 @@
         t-att-class="{
             'start-0': isAlignedRight,
             'mx-1': !isMobileOS,
-            'mt-1': !message.is_note,
+            'o-my-0_5': !message.is_note,
             'my-n2': message.is_note,
             'invisible': !isActive and !isMobileOS,
             'o-expanded': optionsDropdown.isOpen

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -2,11 +2,16 @@
 <templates xml:space="preserve">
     <t t-name="mail.MessageInReply">
         <div class="o-mail-MessageInReply mx-2 mt-1 p-1 pb-0">
-            <small class="o-mail-MessageInReply-core o-mail-Message-bubble o-muted border position-relative d-flex px-2 py-1 rounded-3 rounded-start-0 d-inline-flex" t-att-class="{
+            <small class="o-mail-MessageInReply-core o-muted border position-relative d-flex px-2 py-1 rounded-3 rounded-start-0 d-inline-flex" t-att-class="{
                 'o-blue': props.message.parentMessage.bubbleColor === 'blue',
                 'o-green': props.message.parentMessage.bubbleColor === 'green',
                 'o-orange': props.message.parentMessage.bubbleColor === 'orange',
             }">
+                <div class="o-mail-Message-bubble o-muted" t-att-class="{
+                    'o-blue': props.message.parentMessage.bubbleColor === 'blue',
+                    'o-green': props.message.parentMessage.bubbleColor === 'green',
+                    'o-orange': props.message.parentMessage.bubbleColor === 'orange',
+                }"/>
                 <span t-if="!props.message.parentMessage.isEmpty" class="d-inline-flex align-items-center text-muted opacity-75" t-att-class="{ 'cursor-pointer opacity-100-hover': props.onClick }" t-on-click="() => this.props.onClick?.()">
                     <img class="o-mail-MessageInReply-avatar me-2 rounded o_object_fit_cover" t-att-src="authorAvatarUrl" t-att-title="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from" alt="Avatar"/>
                     <span class="o-mail-MessageInReply-content overflow-hidden smaller">

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -482,7 +482,7 @@ export class Thread extends Component {
 
     getMessageClassName(message) {
         return !message.isNotification && this.messageHighlight?.highlightedMessageId === message.id
-            ? "o-highlighted bg-view shadow-lg pb-1"
+            ? "o-highlighted"
             : "";
     }
 

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Thread">
-    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-5': env.inChatter?.aside, 'pb-4': !env.inChatter?.aside, 'px-3': !env.inChatter and !props.isInChatWindow }" t-ref="messages" tabindex="-1">
+    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-5': env.inChatter?.aside, 'pb-4': !env.inChatter?.aside }" t-ref="messages" tabindex="-1">
         <t t-if="!props.thread.isEmpty or props.thread.loadOlder or props.thread.hasLoadingFailed" name="content">
             <div class="d-flex flex-column position-relative flex-grow-1" t-att-class="{'justify-content-end': !env.inChatter and props.thread.model !== 'mail.box'}">
                 <span class="position-absolute w-100 invisible" t-att-class="props.order === 'asc' ? 'bottom-0' : 'top-0'" t-ref="present-treshold" t-att-style="`height: Min(${PRESENT_THRESHOLD}px, 100%)`"/>

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -267,7 +267,7 @@ export function useVisible(refName, cb, { ready = true } = {}) {
  * @property {number|null} highlightedMessageId
  * @returns {MessageHighlight}
  */
-export function useMessageHighlight(duration = 2000) {
+export function useMessageHighlight(duration = 1500) {
     let timeout;
     const state = useState({
         clearHighlight() {


### PR DESCRIPTION
Previous style had the following problem:

- message content was moved up during the animation of message highlighted, which annoys immediate reading of content when scrolled to the message
- style was too soft, especially in dark theme, because there's only the shadow effect outside of translate effect, and this is dark on dark bg.

This commit solves the issue as follow:

- highlighted message is not moved at all
- bg color of highlighted message uses low opacity active color
- highlighted message has left inset border to easily spot the message at hand
- when highlighted message has bubble, the bubble outline is also colored to attract reader. Bubbles can make the highlight border hard to find, even with the left inset border, as replies to bubble also have a left-border inset.

Task-4543530

Before (white theme)
![before-white](https://github.com/user-attachments/assets/19ed2138-e32c-46cf-8d42-5ec977ab508d)
Before (dark theme)
![before-dark](https://github.com/user-attachments/assets/cf6f8cb2-f2cc-4db4-a16b-1baf6f377729)
After (white theme)
![white](https://github.com/user-attachments/assets/bbe0d27a-7600-4c58-8c57-1ec161cf24cc)
After (dark theme)
![dark](https://github.com/user-attachments/assets/fd29fc68-c50e-42c8-bd6a-24971f48a037)
