### PR TITLE
[FIX] mail: keep composer when livechat has ended for operator (2)

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/discuss_patch.xml
+++ b/addons/im_livechat/static/src/core/public_web/discuss_patch.xml
@@ -2,6 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Discuss" t-inherit-mode="extension">
         <xpath expr="//Composer" position="replace">
+            <t t-if="thread?.composerDisabled and !thread?.isTransient and store.self.notEq(thread?.livechatVisitorMember?.persona)">$0</t>
             <span t-if="thread?.composerDisabled" class="bg-200 py-1 text-center fst-italic fw-bold text-muted" t-esc="thread.composerDisabledText"/>
             <t t-else="">$0</t>
         </xpath>


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/195734

PR above reintroduced composer when livechat is inactive for operators, so that they can still make leads or post a message to visitor as a last resort.

However the showing of composer was only made in chat window: the discuss app was still hiding the composer for operator on livechat end.

This commit fixes the issue in discuss app, by showing the composer to livechat operators when the livechat has ended.

Part of Task-4528331

Before
![Screenshot 2025-02-18 at 18 28 20](https://github.com/user-attachments/assets/e3760e2b-9553-48a3-82b6-ea561fc6856e)

After
![Screenshot 2025-02-18 at 18 28 06](https://github.com/user-attachments/assets/af6b73cd-3b13-4cc4-8700-8a053fbd0cc0)
