### PR TITLE
[IMP] l10n_uy: doc number format validation

### DIFF
--- a/addons/l10n_uy/i18n/es_419.po
+++ b/addons/l10n_uy/i18n/es_419.po
@@ -17,6 +17,23 @@ msgstr ""
 
 #. module: l10n_uy
 #. odoo-python
+#: code:addons/l10n_uy/models/l10n_latam_document_type.py:0
+#, python-format
+msgid ""
+"%(document_number)s is not a valid value for %(document_type)s.\n"
+"The document number must be entered with a maximum of 2 letters for the first part and 7 numbers for the second. The following are examples of valid document numbers:\n"
+"- XX0000001\n"
+" - YY0000123\n"
+" - A0000001"
+msgstr ""
+"%(document_number)s no es un un valor válida para %(document_type)s.\n"
+"El número de documento ingresado debe tener un máximo de 2 letras para la primera parte y 7 números para la segunda. Los siguientes son ejemplos de números de documento válidos:\n"
+"- XX0000001\n"
+" - YY0000123\n"
+" - A0000001"
+
+#. module: l10n_uy
+#. odoo-python
 #: code:addons/l10n_uy/models/res_partner.py:0
 msgid "3:402.010-2 or 93:402.010-1 (CI or NIE)"
 msgstr "3:402.010-2 o 93:402.010-1 (CI o NIE)"

--- a/addons/l10n_uy/i18n/l10n_uy.pot
+++ b/addons/l10n_uy/i18n/l10n_uy.pot
@@ -17,6 +17,18 @@ msgstr ""
 
 #. module: l10n_uy
 #. odoo-python
+#: code:addons/l10n_uy/models/l10n_latam_document_type.py:0
+#, python-format
+msgid ""
+"%(document_number)s is not a valid value for %(document_type)s.\n"
+"The document number must be entered with a maximum of 2 letters for the first part and 7 numbers for the second. The following are examples of valid document numbers:\n"
+"- XX0000001\n"
+" - YY0000123\n"
+" - A0000001"
+msgstr ""
+
+#. module: l10n_uy
+#. odoo-python
 #: code:addons/l10n_uy/models/res_partner.py:0
 msgid "3:402.010-2 or 93:402.010-1 (CI or NIE)"
 msgstr ""

--- a/addons/l10n_uy/models/l10n_latam_document_type.py
+++ b/addons/l10n_uy/models/l10n_latam_document_type.py
@@ -15,14 +15,22 @@ class L10nAccountDocumentType(models.Model):
             return super()._format_document_number(document_number)
 
         if not document_number:
-            return
+            return False
+
+        if self.code == "0":
+            return document_number
 
         document_number = document_number.strip()
         number_part = re.findall(r'[\d]+', document_number)
         serie_part = re.findall(r'^[A-Za-z]+', document_number)
-
         if not serie_part or len(serie_part) > 1 or len(serie_part[0]) > 2 \
            or not number_part or len(number_part) > 1 or len(number_part[0]) > 7:
-            raise UserError(_('Please introduce a valid Document number: 2 letters and 7 digits (XX0000001)'))
-
+            raise UserError(_(
+                "%(document_number)s is not a valid value for %(document_type)s.\n"
+                "The document number must be entered with a maximum of 2 letters for the first part "
+                "and 7 numbers for the second. The following are examples of valid document numbers:\n"
+                "- XX0000001\n - YY0000123\n - A0000001",
+                document_number=document_number,
+                document_type=self.name,
+            ))
         return serie_part[0].upper() + number_part[0].zfill(7)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR is to avoid making unnecessary format validations on manual documents, as well as to improve the error message shown when the validation is done and the user had entered an invalid document number.
A use case for these changes is when the user wants to register an invoice from a foreign supplier that does not have the Uruguayan format, and at the moment of filling the “Document Number” field, an error message appears saying that it does not comply with the Uruguayan number validations.

Current behavior before PR:
Either electronic or manual document numbers format were validated against the electronic documents format.

Desired behavior after PR is merged:
Only electronic document numbers are validated to check if they have the proper format.

Steps to reproduce the error:
1) Install l10n_uy
2) Create an invoice using a manual journal.
3) Set a random document number (for example '1234')
4) Check that a pop up is raised, saying that the format is invalid.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
