### PR TITLE
[FIX] base: update user's companies on unarchiving company

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -883,7 +883,6 @@ class Users(models.Model):
 
         return frozendict(context)
 
-    @tools.ormcache('self.id')
     def _get_company_ids(self):
         # use search() instead of `self.company_ids` to avoid extra query for `active_test`
         domain = [('active', '=', True), ('user_ids', 'in', self.id)]


### PR DESCRIPTION
Issue:
When a company is unarchived, the cache for some fields are not updated.

Steps to reproduce:
- create company b
- archive company b
- access CoA
- unarchive company b
- try to access specific chart of account, error will be raised

Purpose of this PR:
when we unarchive a company we call the `_get_company_ids` method on the user to update the cache.

opw-4427576
