### PR TITLE
[FIX] web_editor: link popover position

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -85,6 +85,7 @@ export class LinkPopoverWidget {
             tooltips.push(Tooltip.getOrCreateInstance(el));
         }
         let popoverShown = true;
+        const editable = this.wysiwyg.odooEditor.editable;
         this.$target.popover({
             html: true,
             content: this.$el,
@@ -96,7 +97,7 @@ export class LinkPopoverWidget {
             // 4. ..except if it the click was on a button of the popover content
             // 5. Close when the user click somewhere on the page (not being the link or the popover content)
             trigger: 'manual',
-            boundary: 'viewport',
+            boundary: editable,
             container: this.container,
         })
         .on('show.bs.popover.link_popover', () => {


### PR DESCRIPTION
**Current behavior before PR:**

- In mass mailing, when the link popover opens, clicking on a link that is available near the edge of the mailing template beside the sidebar would sometimes cause the popover to appear behind the sidebar.

**Desired behavior after PR is merged:**

- Clicking on a link near the edge of the mailing template now ensures that the link popover does not appear behind the sidebar.

task-4237091
