### PR TITLE
[FIX] l10n_fr_pos_cert: replaced taxed_lst_unit_price by getTaxedlstUnitPrice()

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
@@ -16,7 +16,7 @@
                     Old unit price:
                     <span class="oldPrice">
                         <s>
-                            <t t-out="formatCurrency(line.taxed_lst_unit_price)" /> / Units
+                            <t t-out="formatCurrency(line.getTaxedlstUnitPrice())" /> / Units
                         </s>
                     </span>
                 </div>


### PR DESCRIPTION
In this commit:
===============

taxed_lst_unit_price gives an error as this method got changed by getTaxedlstUnitPrice()
so replaced taxed_lst_unit_price by getTaxedlstUnitPrice()

Runbot error:110614,110615