### PR TITLE
[FIX] l10n_es_edi_tbai_pos: adapt global invoicing in l10n modules

### DIFF
--- a/addons/l10n_es_edi_tbai_pos/models/pos_order.py
+++ b/addons/l10n_es_edi_tbai_pos/models/pos_order.py
@@ -90,8 +90,10 @@ class PosOrder(models.Model):
 
     def _prepare_invoice_vals(self):
         vals = super()._prepare_invoice_vals()
-
-        if self.l10n_es_tbai_is_required:
+        mapped_tbai_req = self.mapped('l10n_es_tbai_is_required')
+        if len(set(mapped_tbai_req)) > 1:
+            raise UserError(self.env._("You cannot mix orders that require TicketBAI with those that don't."))
+        if mapped_tbai_req[0]:
             vals['l10n_es_tbai_refund_reason'] = self.l10n_es_tbai_refund_reason
 
         return vals


### PR DESCRIPTION
Steps to reproduce:
--------------------------
- Install pos_restaurant and any of above localization.
- Create multiple orders.
- Try to create global invoice of those orders.

Issue:
--------
- For global invoice feature we allowed multiple orders to be consolidated and can be generated a single invoice which was not handled in l10n modules.

Cause:
---------
- We were using directly self.field_name to access some values which now can't be supported due to multiple orders in self.

Fix:
----
- We adapted the code to have consolidated invoices based on the mapped values.

Runbot Error Task:
------------------------
https://runbot.odoo.com/odoo/action-573/134660
https://runbot.odoo.com/odoo/action-573/134661

Related PR: https://github.com/odoo/enterprise/pull/79648