### PR TITLE
[FIX] web: properly handle card selection with 'space'

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -206,13 +206,13 @@ export class KanbanRenderer extends Component {
             { area: () => this.rootRef.el }
         );
 
-        useHotkey(
-            "space",
-            ({ target }) => {
-                this.handleRecordSelection(target);
-            },
-            { area: () => this.rootRef.el }
-        );
+        useHotkey("space", ({ target }) => this.onSpaceKeyPress(target), {
+            area: () => this.rootRef.el,
+        });
+
+        useHotkey("shift+space", ({ target }) => this.onSpaceKeyPress(target, true), {
+            area: () => this.rootRef.el,
+        });
 
         const arrowsOptions = { area: () => this.rootRef.el, allowRepeat: true };
         if (this.env.searchModel) {
@@ -402,12 +402,6 @@ export class KanbanRenderer extends Component {
         }));
     }
 
-    handleRecordSelection(target) {
-        if (target.closest(".o_kanban_selection_active") !== null) {
-            target.click();
-        }
-    }
-
     /**
      * @param {string} id
      * @returns {boolean}
@@ -547,6 +541,13 @@ export class KanbanRenderer extends Component {
             await this.props.list.resequence(dataGroupId, refId);
         } finally {
             this.toggleProcessing(dataGroupId, false);
+        }
+    }
+
+    onSpaceKeyPress(target, isRange) {
+        if (target.classList.contains("o_kanban_record")) {
+            const record = this.props.list.records.find((e) => e.id === target.dataset.id);
+            this.toggleSelection(record, isRange);
         }
     }
 

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -13609,3 +13609,35 @@ test("selection can be enabled by long touch with drag & drop enabled", async ()
     await contains(".o_kanban_record:nth-of-type(1)").click();
     expect(".o_record_selected").toHaveCount(1);
 });
+
+test.tags("desktop");
+test("selection can be enabled by pressing 'space' key", async () => {
+    Product._records[1].fold = true;
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+                <kanban>
+                    <templates>
+                        <t t-name="card">
+                            <field name="foo"/>
+                        </t>
+                    </templates>
+                </kanban>`,
+    });
+    expect(".o_selection_box").toHaveCount(0);
+    await press("ArrowDown");
+    await press("Space");
+    await animationFrame();
+    expect(".o_selection_box").toHaveCount(1);
+    await press("ArrowDown");
+    await press("Space");
+    await animationFrame();
+    expect(".o_record_selected").toHaveCount(2);
+    await press("ArrowDown");
+    await press("ArrowDown");
+    await keyDown("Shift");
+    await press("Space");
+    await animationFrame();
+    expect(".o_record_selected").toHaveCount(4);
+});


### PR DESCRIPTION
This commit brings a more appropriate selection behavior to Kanban view. Previously, it was only possible to select cards when already being in selection mode, which made impossible to enter selection mode from keyboard navigation.

Now, it is entirely possible to interact and select cards with keyboard navigation, by pressing 'space' when a card is focused.

The handleRecordSelection function can be disabled, as its purpose was to override the behavior in Documents to do this. Now that the behavior as been fixed globally, it is no longer useful.

task-4582340