### PR TITLE
[FIX] test_mail_full: missing primary attribute in the test template

### DIFF
--- a/addons/test_mail_full/views/test_portal_template.xml
+++ b/addons/test_mail_full/views/test_portal_template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <template id="test_portal_template" name="Test Portal" inherit_id="portal.portal_sidebar">
+    <template id="test_portal_template" name="Test Portal" inherit_id="portal.portal_sidebar" primary="True">
         <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
             <!-- chatter -->
             <div>


### PR DESCRIPTION
Since odoo/odoo#196778, a portal test template has been added. Missing the `primary`attribute in this template affects all the portal templates. This commit adds this attribute to the test template.

Steps to reproduce:
- Install a module that inherits `portal.mixin` such as sale and `test_mail_full`
- Go to a sale order page in the portal
- Chatter is at the top of the page

