### PR TITLE
[IMP] hw_posbox_homepage: add pairing instructions

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
@@ -390,7 +390,8 @@ class PrinterDriver(Driver):
             homepage = '\nHomepage:\nhttp://%s:8069\n\n' % ips[0]
 
         if iot_status["pairing_code"]:
-            pairing_code = '\nPairing Code:\n%s\n' % iot_status["pairing_code"]
+            pairing_code = '\nPairing Code: %s\n' % iot_status["pairing_code"]
+            pairing_code += 'Enter this code in the Odoo IoT app to pair your IoT Box.\n'
 
         commands = RECEIPT_PRINTER_COMMANDS[self.receipt_protocol]
         title = commands['title'] % b'IoTBox Status'
@@ -408,6 +409,7 @@ class PrinterDriver(Driver):
             command += f"^FT35,155 ^A0N,25 ^FDIP: {', '.join(iot_status['ips'])}^FS"
         if iot_status["pairing_code"]:
             command += f"^FT35,190 ^A0N,25 ^FDPairing code: {iot_status['pairing_code']}^FS"
+            command += "^FT35,225 ^A0N,25 ^FDEnter this code in the Odoo IoT app^FS"
         command += "^XZ"
 
         self.print_raw(command.encode())

--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/WifiDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/WifiDialog.js
@@ -15,7 +15,7 @@ export class WifiDialog extends Component {
         this.state = useState({
             scanning: true,
             waitRestart: false,
-            statusMessage: "",
+            status: "",
             availableWiFi: [],
         });
         this.form = useState({
@@ -74,7 +74,7 @@ export class WifiDialog extends Component {
             }
         } else {
             // The IoT box is no longer reachable, so we can't await the response.
-            this.state.statusMessage = `The IoT Box will now attempt to connect to ${this.form.essid}. You may close this page.`;
+            this.state.status = "connecting";
             this.state.waitRestart = false;
         }
     }
@@ -92,7 +92,7 @@ export class WifiDialog extends Component {
                 }
             } else {
                 // The IoT box is no longer reachable, so we can't await the response.
-                this.state.statusMessage = `The IoT Box Wi-Fi configuration has been cleared. You will need to connect to the IoT Box hotspot or connect an ethernet cable.`;
+                this.state.status = "disconnecting";
                 this.state.waitRestart = false;
             }
         } catch {
@@ -107,8 +107,22 @@ export class WifiDialog extends Component {
             </t>
         </LoadingFullScreen>
 
-        <div t-if="state.statusMessage" class="position-fixed top-0 start-0 bg-white vh-100 w-100 justify-content-center align-items-center d-flex always-on-top">
-            <div class="alert alert-success" t-out="state.statusMessage"/>
+        <div t-if="state.status" class="position-fixed top-0 start-0 bg-white vh-100 w-100 justify-content-center align-items-center d-flex always-on-top">
+            <div class="alert alert-success mx-4">
+                <t t-if="state.status === 'connecting'">
+                    The IoT Box will now attempt to connect to <t t-out="form.essid"/>. The next step is to find your <b>pairing code</b>:
+                    <ul>
+                        <li>You will need a screen or a compatible USB printer connected.</li>
+                        <li>In a few seconds, the pairing code should display on your screen and/or print from your printer.</li>
+                        <li>Once you have the pairing code, you can enter it on the IoT app in your database to pair your IoT Box.</li>
+                    </ul>
+                    In the event that the pairing code does not appear, it may be because the IoT Box failed to connect to the Wi-Fi network.
+                    In this case you will need to reconnect to the Wi-Fi hotspot and try again.
+                </t>
+                <t t-if="state.status === 'disconnecting'">
+                    The IoT Box Wi-Fi configuration has been cleared. You will need to connect to the IoT Box hotspot or connect an ethernet cable.
+                </t>
+            </div>
         </div>
 
         <BootstrapDialog identifier="'wifi-configuration'" btnName="'Configure'" onOpen.bind="getWiFiNetworks" onClose.bind="onClose">

--- a/addons/hw_posbox_homepage/static/src/app/status.js
+++ b/addons/hw_posbox_homepage/static/src/app/status.js
@@ -27,7 +27,7 @@ class StatusPage extends Component {
     }
 
     get accessPointSsid() {
-        return this.state.data.network_interfaces.filter(i => i.is_wifi)[0]?.ssid;
+        return this.state.data.network_interfaces.filter((i) => i.is_wifi)[0]?.ssid;
     }
 
     static template = xml`
@@ -90,6 +90,9 @@ class StatusPage extends Component {
                 <h4 class="text-center mb-3">Pairing Code</h4>
                 <hr/>
                 <h4 t-out="state.data.pairing_code" class="text-center mb-3"/>
+                <p class="text-center mb-3">
+                    Enter this code in the IoT app in your Odoo database to pair the IoT Box.
+                </p>
             </div>
             <div t-if="state.data.is_access_point_up and accessPointSsid" class="status-display-box">
                 <h4 class="text-center mb-3">No Internet Connection</h4>


### PR DESCRIPTION
Before this PR, upon connecting an IoT box to
WiFi, the user was left with a simple message
saying that the IoT box would attempt to connect
to the network. There was no context given
with the pairing code on either the screen
or status printout.

After this PR, there are additional
instructions directing the user to find their
pairing code and enter it into the IoT app on
their database.

task-4586907

![image](https://github.com/user-attachments/assets/0403cbec-3b0a-4379-ac3c-69b3cc453d2b)

![image](https://github.com/user-attachments/assets/559f8c84-9c21-43dd-9ff2-34dd6ed6dd7b)

![image](https://github.com/user-attachments/assets/b831ffd6-54cb-44fe-aa56-bb27a8825c30)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
