### PR TITLE
[IMP] mail: return focus back to thread after using quick reactions

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -132,7 +132,7 @@
                     </div>
                 </div>
                 <SearchMessageResult t-if="messageSearch.searching or messageSearch.searched" thread="state.thread"  messageSearch="messageSearch" onClickJump.bind="closeSearch"/>
-                <Thread t-else="" thread="state.thread" t-key="state.thread.localId" order="'desc'" scrollRef="rootRef" jumpPresent="state.jumpThreadPresent"/>
+                <Thread t-else="" messageEdition="messageEdition" thread="state.thread" t-key="state.thread.localId" order="'desc'" scrollRef="rootRef" jumpPresent="state.jumpThreadPresent"/>
             </t>
         </div>
     </div>

--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -1,5 +1,6 @@
 import { Composer } from "@mail/core/common/composer";
 import { Thread } from "@mail/core/common/thread";
+import { useMessageEdition } from "@mail/utils/common/hooks";
 
 import {
     Component,
@@ -34,6 +35,7 @@ export class Chatter extends Component {
         });
         this.rootRef = useRef("root");
         this.onScrollDebounced = useThrottleForAnimation(this.onScroll);
+        this.messageEdition = useMessageEdition();
         useChildSubEnv(this.childSubEnv);
 
         onMounted(this._onMounted);

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -473,7 +473,7 @@ export class Composer extends Component {
                 if (this.props.messageEdition && composer.text === "") {
                     const messageToEdit = composer.thread.lastEditableMessageOfSelf;
                     if (messageToEdit) {
-                        this.props.messageEdition.editingMessage = messageToEdit;
+                        this.props.messageEdition.enterEditMode(messageToEdit);
                     }
                 }
                 break;

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -35,7 +35,7 @@ import { usePopover } from "@web/core/popover/popover_hook";
 import { useService } from "@web/core/utils/hooks";
 import { setElementContent } from "@web/core/utils/html";
 import { url } from "@web/core/utils/urls";
-import { messageActionsRegistry, useMessageActions } from "./message_actions";
+import { useMessageActions } from "./message_actions";
 import { cookie } from "@web/core/browser/cookie";
 import { rpc } from "@web/core/network/rpc";
 import { escape } from "@web/core/utils/strings";
@@ -134,9 +134,7 @@ export class Message extends Component {
         });
         useEffect(
             (editingMessage) => {
-                if (this.props.message.eq(editingMessage)) {
-                    messageActionsRegistry.get("edit").onClick(this);
-                }
+                this.state.isEditing = this.props.message.eq(editingMessage);
             },
             () => [this.props.messageEdition?.editingMessage]
         );
@@ -432,10 +430,7 @@ export class Message extends Component {
     }
 
     exitEditMode() {
-        const message = toRaw(this.props.message);
-        this.props.messageEdition?.exitEditMode();
-        message.composer = undefined;
-        this.state.isEditing = false;
+        this.props.messageEdition.exitEditMode();
     }
 
     onClickNotification(ev) {

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -85,7 +85,7 @@
                                                             'flex-grow-1': state.isEditing,
                                                             }" t-ref="body">
                                                     <i t-if="message.isEmpty" class="text-muted opacity-75" t-esc="message.inlineBody"/>
-                                                    <Composer t-elif="state.isEditing" autofocus="true" composer="message.composer" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="'compact'" sidebar="false"/>
+                                                    <Composer t-elif="props.message.eq(props.messageEdition?.editingMessage)" autofocus="true" composer="message.composer" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="'compact'" sidebar="false"/>
                                                     <t t-else="">
                                                         <em t-if="message.subject and !message.isSubjectSimilarToThreadName and !message.isSubjectDefault" class="d-block text-muted smaller">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>
                                                         <div class="overflow-x-auto" t-if="message.message_type and message.message_type.includes('email')" t-ref="shadowBody"/>

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -7,7 +7,6 @@ import { useService } from "@web/core/utils/hooks";
 import { discussComponentRegistry } from "./discuss_component_registry";
 import { Deferred } from "@web/core/utils/concurrency";
 import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
-import { convertBrToLineBreak } from "@mail/utils/common/format";
 import { QuickReactionMenu } from "@mail/core/common/quick_reaction_menu";
 
 const { DateTime } = luxon;
@@ -93,18 +92,8 @@ messageActionsRegistry
         icon: "fa fa-pencil",
         title: _t("Edit"),
         onClick: (component) => {
-            const message = toRaw(component.props.message);
-            const text = convertBrToLineBreak(message.body);
-            message.composer = {
-                mentionedPartners: message.recipients,
-                text,
-                selection: {
-                    start: text.length,
-                    end: text.length,
-                    direction: "none",
-                },
-            };
-            component.state.isEditing = true;
+            component.props.messageEdition.enterEditMode(component.props.message);
+            component.optionsDropdown.close();
         },
         sequence: 80,
     })

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -111,6 +111,13 @@ export class Message extends Record {
         },
     });
     threadAsNewest = Record.one("Thread");
+    threadAsInEdition = Record.one("Thread", {
+        compute() {
+            if (this.composer) {
+                return this.thread;
+            }
+        },
+    });
     /** @type {DateTime} */
     scheduledDatetime = Record.attr(undefined, { type: "datetime" });
     onlyEmojis = Record.attr(false, {

--- a/addons/mail/static/src/core/common/quick_reaction_menu.js
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.js
@@ -34,7 +34,21 @@ export class QuickReactionMenu extends Component {
                 popoverClass: "o-mail-QuickReactionMenu-pickerPopover",
             }
         );
-        this.dropdown = useState(useDropdownState());
+        this.dropdown = useState(
+            useDropdownState({
+                onClose: () => {
+                    const currentThread = this.env.getCurrentThread();
+                    if (!currentThread || currentThread.notEq(this.props.message.thread)) {
+                        return;
+                    }
+                    if (currentThread.messageInEdition) {
+                        currentThread.messageInEdition.composer.autofocus++;
+                    } else {
+                        currentThread.composer.autofocus++;
+                    }
+                },
+            })
+        );
         this.frequentEmojiService = useService("web.frequent.emoji");
         this.state = useState({ emojiLoaded: Boolean(loader.loaded) });
         if (!loader.loaded) {

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -1,7 +1,7 @@
 import { DateSection } from "@mail/core/common/date_section";
 import { Message } from "@mail/core/common/message";
 import { Record } from "@mail/core/common/record";
-import { useVisible } from "@mail/utils/common/hooks";
+import { useMessageEdition, useVisible } from "@mail/utils/common/hooks";
 
 import {
     Component,
@@ -81,6 +81,7 @@ export class Thread extends Component {
             scrollTop: null,
         });
         this.lastJumpPresent = this.props.jumpPresent;
+        this.messageEdition = this.props.messageEdition ?? useMessageEdition();
         this.orm = useService("orm");
         /** @type {ReturnType<import('@mail/utils/common/hooks').useMessageHighlight>|null} */
         this.messageHighlight = this.env.messageHighlight
@@ -348,6 +349,7 @@ export class Thread extends Component {
         });
         useEffect(this.applyScroll);
         useChildSubEnv({
+            getCurrentThread: () => this.props.thread,
             onImageLoaded: this.applyScroll,
         });
         const observer = new ResizeObserver(() => {

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -33,7 +33,7 @@
                         squashed="isSquashed(msg, prevMsg)"
                         onParentMessageClick.bind="() => msg.parentMessage and env.messageHighlight?.highlightMessage(msg.parentMessage, props.thread)"
                         thread="props.thread"
-                        messageEdition="props.messageEdition"
+                        messageEdition="messageEdition"
                         isFirstMessage="msg_first"
                         hasActions="props.messageActions and !msg.eq(props.thread.from_message_id)"
                         showDates="props.showDates"

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -189,6 +189,7 @@ export class Thread extends Record {
     mainAttachment = Record.one("ir.attachment");
     message_needaction_counter = 0;
     message_needaction_counter_bus_id = 0;
+    messageInEdition = Record.one("mail.message", { inverse: "threadAsInEdition" });
     /**
      * Contains continuous sequence of messages to show in message list.
      * Messages are ordered from older to most recent.

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -2,6 +2,7 @@ import {
     click,
     contains,
     defineMailModels,
+    focus,
     hover,
     insertText,
     onRpcBefore,
@@ -55,6 +56,40 @@ test("Start edition on click edit", async () => {
     await contains(".o-mail-Message .o-mail-Composer-input", { value: "Hello world" });
     await click("a[role='button']", { text: "cancel" });
     await contains(".o-mail-Message .o-mail-Composer-input", { count: 0 });
+});
+
+test("Can only edit one message at a time", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    pyEnv["mail.message"].create([
+        {
+            author_id: serverState.partnerId,
+            body: "Hello!",
+            model: "discuss.channel",
+            res_id: channelId,
+            message_type: "comment",
+        },
+        {
+            author_id: serverState.partnerId,
+            body: "Goodbye!",
+            model: "discuss.channel",
+            res_id: channelId,
+            message_type: "comment",
+        },
+    ]);
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Expand']", { parent: [".o-mail-Message", { text: "Goodbye!" }] });
+    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await contains(".o-mail-Composer-input", { value: "Goodbye!" });
+    await click("[title='Expand']", { parent: [".o-mail-Message", { text: "Hello!" }] });
+    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await contains(".o-mail-Message .o-mail-Composer-input", { count: 1 });
+    await contains(".o-mail-Composer-input", { value: "Hello!" });
+    await focus(".o-mail-Composer-input", { value: "" });
+    await press("ArrowUp");
+    await contains(".o-mail-Message .o-mail-Composer-input", { count: 1 });
+    await contains(".o-mail-Composer-input", { value: "Goodbye!" });
 });
 
 test("Edit message (mobile)", async () => {
@@ -557,6 +592,7 @@ test("Can open emoji picker after edit mode", async () => {
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
     await click(".o-mail-Message a", { text: "save" });
+    await contains(".o-mail-Message", { text: "Hello world" });
     await click("[title='Add a Reaction']");
     await click(".o-mail-QuickReactionMenu [title='Toggle Emoji Picker']");
     await contains(".o-EmojiPicker");

--- a/addons/mail/static/tests/quick_reaction_menu/quick_reaction_menu.test.js
+++ b/addons/mail/static/tests/quick_reaction_menu/quick_reaction_menu.test.js
@@ -96,7 +96,7 @@ test("navigate quick reaction menu using arrow keys", async () => {
     }
     await contains(".o-mail-QuickReactionMenu-emojiPicker:focus");
     await press("ArrowLeft");
-    for (const emoji of QuickReactionMenu.DEFAULT_EMOJIS.reverse()) {
+    for (const emoji of [...QuickReactionMenu.DEFAULT_EMOJIS].reverse()) {
         await contains(".o-mail-QuickReactionMenu-emoji:focus", { text: emoji });
         await press("ArrowLeft");
     }
@@ -122,4 +122,41 @@ test("can quick search emoji from quick reaction", async () => {
     await animationFrame();
     await press("Enter");
     await contains(".o-mail-MessageReaction", { text: "🥦1" });
+});
+
+test.tags("focus required");
+test("return focus to thread composer on close", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await insertText(".o-mail-Composer-input", "Hello world!");
+    await press("Enter");
+    await contains(".o-mail-Composer-input:focus");
+    await click("[title='Add a Reaction']");
+    await contains(".o-mail-QuickReactionMenu-emoji:focus", { text: "👍" });
+    await press("Enter");
+    await contains(".o-mail-MessageReaction", { text: "👍1" });
+    await contains(".o-mail-Composer-input:focus");
+});
+
+test.tags("focus required");
+test("return focus to message edition composer on close", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await insertText(".o-mail-Composer-input", "Hello world!");
+    await press("Enter");
+    await contains(".o-mail-Composer-input", { value: "" });
+    await insertText(".o-mail-Composer-input", "Goodbye world!!");
+    await press("Enter");
+    await click("[title='Expand']");
+    await click("[title='Edit']");
+    await contains(".o-mail-Message .o-mail-Composer-input:focus");
+    await click("[title='Add a Reaction']");
+    await contains(".o-mail-QuickReactionMenu-emoji:focus", { text: "👍" });
+    await press("Enter");
+    await contains(".o-mail-MessageReaction", { text: "👍1" });
+    await contains(".o-mail-Message .o-mail-Composer-input:focus");
 });

--- a/addons/web/static/src/core/navigation/navigation.js
+++ b/addons/web/static/src/core/navigation/navigation.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "@odoo/owl";
+import { onWillUnmount, useEffect, useRef } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { scrollTo } from "@web/core/utils/scrolling";
 import { debounce, throttleForAnimation } from "@web/core/utils/timing";
@@ -61,7 +61,7 @@ class NavigationItem {
     }
 }
 
-class Navigator {
+export class Navigator {
     /**
      * @param {*} containerRef
      * @param {NavigationOptions} options
@@ -297,6 +297,7 @@ export function useNavigation(containerRef, options = {}) {
         },
         () => [containerRef.el]
     );
+    onWillUnmount(() => navigator.disable());
 
     return {
         enable: () => navigator.enable(),

--- a/addons/web/static/tests/core/navigation_hook.test.js
+++ b/addons/web/static/tests/core/navigation_hook.test.js
@@ -1,10 +1,15 @@
 import { Component, xml } from "@odoo/owl";
-import { useNavigation } from "@web/core/navigation/navigation";
+import { Navigator, useNavigation } from "@web/core/navigation/navigation";
 import { useAutofocus } from "@web/core/utils/hooks";
-import { describe, expect, test } from "@odoo/hoot";
+import { describe, destroy, expect, test } from "@odoo/hoot";
 import { hover, press } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
-import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import {
+    asyncStep,
+    mountWithCleanup,
+    patchWithCleanup,
+    waitForSteps,
+} from "@web/../tests/web_test_helpers";
 
 class BasicHookParent extends Component {
     static props = [];
@@ -186,4 +191,21 @@ test("hovering an item makes it active but doesn't focus", async () => {
     await animationFrame();
     expect(".four").toBeFocused();
     expect(".four").toHaveClass("focus");
+});
+
+test("navigation disabled when component is destroyed", async () => {
+    patchWithCleanup(Navigator.prototype, {
+        enable() {
+            asyncStep("enable");
+            super.enable();
+        },
+        disable() {
+            asyncStep("disable");
+            super.disable();
+        },
+    });
+    const component = await mountWithCleanup(BasicHookParent);
+    await waitForSteps(["enable"]);
+    destroy(component);
+    await waitForSteps(["disable"]);
 });


### PR DESCRIPTION
Previously, closing the quick reaction menu did not return focus to the thread, which was inconvenient—especially in chat windows where pressing Escape is commonly used to close them.

This update ensures that focus is restored to the message composer if one is being edited; otherwise, it returns to the thread composer. This improves usability, allowing users to react to messages without disrupting their workflow.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
