### PR TITLE
[FIX] l10n_id_efaktur_coretax: prevent error when downloading e-Faktur

### DIFF
--- a/addons/l10n_id_efaktur_coretax/models/account_move_line.py
+++ b/addons/l10n_id_efaktur_coretax/models/account_move_line.py
@@ -17,7 +17,7 @@ class AccountMoveLine(models.Model):
         product = self.product_id
 
         # Separate tax into the regular and luxury component
-        luxury_tax = self.tax_ids.filtered(lambda tax: tax.tax_group_id == self.env.ref(f"account.{self.company_id.id}_l10n_id_tax_group_luxury_goods"))
+        luxury_tax = self.tax_ids.filtered(lambda tax: tax.tax_group_id == self.env.ref(f"account.{self.company_id.id}_l10n_id_tax_group_luxury_goods", raise_if_not_found=False))
         regular_tax = self.tax_ids - luxury_tax
 
         line_val = {


### PR DESCRIPTION
Currently, an error occurs when downloading e-Faktur if its `Luxury Good Taxes (ID)` record has been deleted. This results in preventing the user from generating the e-Faktur.

**Steps to produce:**
- Install the `l10n_id_efaktur_coretax` module.
- Change the  current company to `ID Company`.
- Navigate to `Settings > Technical > Sequences & Identifiers > External Identifiers`.
- Delete record with `External Identifier: l10n_id_tax_group_luxury_goods`
- Create a new invoice with the customer "ID Company".
- Click **Download e-Faktur**.
- Observe the error.

**Error:**
```
ValueError
ValueError('External ID not found in the system: account.1_l10n_id_tax_group_luxury_goods') while evaluating
'action = records.download_efaktur()'
```
The error occurs because the system attempts to fetch the tax group `l10n_id_tax_group_luxury_goods` at [1], but it is unavailable as the user has already deleted it.

This commit ensures that if the tax group does not exist, the function will return `None` instead of raising an exception.

[1] - https://github.com/odoo/odoo/blob/87d68fc6562504168bd0de8a5356bdebb4559e70/addons/l10n_id_efaktur_coretax/models/account_move_line.py#L20

Sentry-6309401666

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
