### PR TITLE
[FIX] hr_homeworking_calendar,web: speed up calendar rendering

### DIFF
--- a/addons/hr_homeworking_calendar/static/src/calendar/common/hr_homeworking_calendar_controller.js
+++ b/addons/hr_homeworking_calendar/static/src/calendar/common/hr_homeworking_calendar_controller.js
@@ -9,6 +9,7 @@ patch(AttendeeCalendarController.prototype, {
     setup() {
         super.setup();
         this.action = useService("action");
+        this._baseRendererProps.openWorkLocationWizard = this.openWorkLocationWizard.bind(this);
     },
     async editRecord(record, context = {}, shouldFetchFormViewId = true) {
         if (record.homeworking && 'start' in record) {
@@ -66,11 +67,5 @@ patch(AttendeeCalendarController.prototype, {
                 this.model.load()
             },
         })
-    },
-    get rendererProps() {
-        return {
-            ...super.rendererProps,
-            openWorkLocationWizard: (date) => this.openWorkLocationWizard(date),
-        }
     },
 })

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -1,6 +1,6 @@
 import { getLocalYearAndWeek, is24HourFormat } from "@web/core/l10n/dates";
 import { localization } from "@web/core/l10n/localization";
-import { renderToString } from "@web/core/utils/render";
+import { renderToFragment, renderToString } from "@web/core/utils/render";
 import { getColor } from "../colors";
 import { useCalendarPopover, useClickHandler, useFullCalendar } from "../hooks";
 import { CalendarCommonPopover } from "./calendar_common_popover";
@@ -225,14 +225,12 @@ export class CalendarCommonRenderer extends Component {
         const record = this.props.model.records[event.id];
         if (record) {
             // This is needed in order to give the possibility to change the event template.
-            const injectedContentStr = renderToString(this.constructor.eventTemplate, {
+            const fragment = renderToFragment(this.constructor.eventTemplate, {
                 ...record,
                 startTime: this.getStartTime(record),
                 endTime: this.getEndTime(record),
             });
-            const domParser = new DOMParser();
-            const { children } = domParser.parseFromString(injectedContentStr, "text/html").body;
-            return { domNodes: children };
+            return { domNodes: fragment.children };
         }
         return true;
     }

--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -100,6 +100,13 @@ export class CalendarController extends Component {
         });
 
         this.searchBarToggler = useSearchBarToggler();
+
+        this._baseRendererProps = {
+            createRecord: this.createRecord.bind(this),
+            deleteRecord: this.deleteRecord.bind(this),
+            editRecord: this.editRecord.bind(this),
+            setDate: this.setDate.bind(this),
+        };
     }
 
     get currentDate() {
@@ -165,12 +172,9 @@ export class CalendarController extends Component {
 
     get rendererProps() {
         return {
+            ...this._baseRendererProps,
             model: this.model,
             isWeekendVisible: this.model.scale === "day" || this.state.isWeekendVisible,
-            createRecord: this.createRecord.bind(this),
-            deleteRecord: this.deleteRecord.bind(this),
-            editRecord: this.editRecord.bind(this),
-            setDate: this.setDate.bind(this),
         };
     }
     get containerProps() {

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -212,7 +212,6 @@ export class CalendarModel extends Model {
             // remove the filter directly, to provide a direct feedback to the user
             this.keepLast.add(Promise.resolve());
             section.filters = section.filters.filter((f) => f.recordId !== recordId);
-            this.notify();
         }
         if (info && info.writeResModel) {
             await this.orm.unlink(info.writeResModel, [recordId]);
@@ -229,7 +228,6 @@ export class CalendarModel extends Model {
         for (const filter of filters) {
             filter.active = active;
         }
-        this.notify();
         const info = this.meta.filtersInfo[fieldName];
         if (info && info.writeFieldName && info.writeResModel && info.filterFieldName) {
             const userFilter = filters.find((f) => f.type === "user");

--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.js
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.js
@@ -178,16 +178,19 @@ export class CalendarFilterPanel extends Component {
 
     onFilterInputChange(section, filter, ev) {
         this.props.model.updateFilters(section.fieldName, [filter], ev.target.checked);
+        this.render();
     }
 
     onAllFilterInputChange(section, ev) {
         this.props.model.updateFilters(section.fieldName, section.filters, ev.target.checked);
+        this.render();
     }
 
     onFilterRemoveBtnClick(section, filter, ev) {
         if (!ev.currentTarget.dataset.unlinked) {
             ev.currentTarget.dataset.unlinked = true;
             this.props.model.unlinkFilter(section.fieldName, filter.recordId);
+            this.render();
         }
     }
 }

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -19,7 +19,7 @@ import {
     mockTimeZone,
     runAllTimers,
 } from "@odoo/hoot-mock";
-import { Component, onWillRender, onWillStart, xml } from "@odoo/owl";
+import { Component, onRendered, onWillRender, onWillStart, xml } from "@odoo/owl";
 import {
     MockServer,
     contains,
@@ -39,6 +39,7 @@ import {
     patchWithCleanup,
     preloadBundle,
     serverState,
+    validateSearch,
 } from "@web/../tests/web_test_helpers";
 import {
     changeScale,
@@ -5616,4 +5617,26 @@ test(`calendar view with show_unusual_days`, async () => {
         "get_unusual_days from 2016-11-26 23:00:00 to 2017-01-07 22:59:59",
         "get_unusual_days from 2016-12-17 23:00:00 to 2016-12-24 22:59:59",
     ]);
+});
+
+test.tags("desktop");
+test(`calendar renderer is rendered once after search refresh`, async () => {
+    patchWithCleanup(CalendarRenderer.prototype, {
+        setup() {
+            super.setup();
+            onRendered(() => expect.step("rendered"));
+        },
+    });
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `
+            <calendar date_start="start" date_stop="stop">
+                <filter name="user_id"/>
+            </calendar>
+        `,
+    });
+    expect.verifySteps(["rendered"]);
+    await validateSearch();
+    expect.verifySteps(["rendered"]);
 });


### PR DESCRIPTION
This commit improves the perf of the calendar view's rendering.
In month mode with a lot of events (> 50 by day), the rendering
done by fullcalendar could be really slow (> 1s). The commit is
3-fold:

1) When editing the search view, two full calendar renderings were
done. The first one directly, because the controller is updated
with the new domain, and the second one once new data have been
fetched. However, the first one was a mistake. The props of the
renderer didn't really changed, so the renderer shouldn't be
re-rendered. However, it receives callbacks in props, and we
generated a new version of those callbacks (via .bind()) in the
rendererProps getter. So from owl's point of view, props were
always different, and the renderer was always re-rendered when the
controller was. This commit fixes that.

2) We use the `eventContent` param of fullcalendar to customize the
rendering of events. Before this commit, we called renderToString,
and then parsed the result into an Element. We optimized this by
using renderToFragment instead. With this, fc rendering went from
around 1800ms to 1300ms.

3) Using the filter right panel felt really slow: the UI was frozen
and the user didn't get a direct feedback of its action (e.g.
ticking a filter checkbox, or removing a filter). Yet, we directly
applied the change in js (e.g. the filter removal), without waiting
for the reload to be done. However, we triggered a whole calendar
view rendering (via notify()), and thus a fc rendering, which froze
the UI. This commit doesn't call notify() in those cases, but
re-renders the side panel only.

Task-4588974