### PR TITLE
[FIX] web_editor: fix recognition of SVG mimetype

### DIFF
--- a/addons/web_editor/models/ir_attachment.py
+++ b/addons/web_editor/models/ir_attachment.py
@@ -30,7 +30,7 @@ class IrAttachment(models.Model):
     def _compute_image_src(self):
         for attachment in self:
             # Only add a src for supported images
-            if attachment.mimetype not in SUPPORTED_IMAGE_MIMETYPES:
+            if not attachment.mimetype or attachment.mimetype.split(';')[0] not in SUPPORTED_IMAGE_MIMETYPES:
                 attachment.image_src = False
                 continue
 

--- a/addons/web_editor/static/src/components/media_dialog/image_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/image_selector.js
@@ -329,7 +329,8 @@ export class ImageSelector extends FileSelector {
         const mediaUrl = imgEl.src;
         try {
             const response = await fetch(mediaUrl);
-            if (response.headers.get('content-type') === 'image/svg+xml') {
+            const contentType = response.headers.get("content-type");
+            if (contentType && contentType.startsWith("image/svg+xml")) {
                 let svg = await response.text();
                 const dynamicColors = {};
                 const combinedColorsRegex = new RegExp(Object.values(DEFAULT_PALETTE).join('|'), 'gi');


### PR DESCRIPTION
At some point, servers started to return `image/svg+xml; charset=utf-8` instead of `image/svg+xml` in the `content-type` header of SVG images. Because of this, dynamic SVGs were not properly handled anymore.

This commit adapts the mimetype comparisons to cope for this extra `charset` info inside the mimetype.

Steps to reproduce:
- Drop an image block inside a website page.
- Replace the image.
- Search for e.g. "city".
- Pick an undraw illustration.

=> The image was lost because its `src` became `false`.
