### PR TITLE
[FIX] point_of_sale: rescue session payment lines dates

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -187,7 +187,7 @@ class PosOrder(models.Model):
                 'name': _('return'),
                 'pos_order_id': order.id,
                 'amount': -pos_order['amount_return'],
-                'payment_date': fields.Datetime.now(),
+                'payment_date': order.date_order,
                 'payment_method_id': cash_payment_method.id,
                 'is_change': True,
             }


### PR DESCRIPTION
When a customer pays with cash and there's a change return (e.g.: the order amount is 33, the customer pays 50, the cashier returns 17) that fact gets registered in the order payment lines. The date for those cash returns is set to the moment in which the order is synched to backend (fields.Datetime.now()).

The issue arises when that order comes from an order synched from a previous session to a rescue session. In that case, that date is going to missmatch the date of the possitive payment line, that has indeed the right original day, leading to inconsistent data when we group those payments by date.


cc @Tecnativa TT52579


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
