### PR TITLE
[FIX] web: image field test fails on Chrome 133

### DIFF
--- a/addons/web/static/tests/views/fields/image_field_tests.js
+++ b/addons/web/static/tests/views/fields/image_field_tests.js
@@ -699,10 +699,9 @@ QUnit.module("Fields", (hooks) => {
             </form>`,
         });
 
-        const list = new DataTransfer();
-        list.items.add(new File([imageData], "fake_file.png", { type: "png" }));
-
         async function setFiles() {
+            const list = new DataTransfer();
+            list.items.add(new File([imageData], "fake_file.png", { type: "png" }));
             const fileInput = target.querySelector("input[type=file]");
             fileInput.files = list.files;
             fileInput.dispatchEvent(new Event("change"));


### PR DESCRIPTION
Following this commit [1] introduced in Chrome 133.0.6836.0, this QUnit test for ImageField was failing as it reused twice the same DataTransfer instance. The Chrome's fix now properly updates the reference to its `files` property which results into an "empty" DataTransfer object once it has been consumed.

This commit ensures a new DataTransfer instance created for each transfer (as "in real life") instead of reusing it.

[1]: https://chromium.googlesource.com/chromium/src/+/ed04b9d9336db2e4f667fe0cfcda8f2156553fd2
