### PR TITLE
[FIX] web : visibility of translation button

### DIFF
--- a/addons/web/static/src/views/fields/translation_button.scss
+++ b/addons/web/static/src/views/fields/translation_button.scss
@@ -1,22 +1,23 @@
 
-.btn.o_field_translate {
-    position: absolute;
-    right: 5px;
-    top: 5px;
-    vertical-align: top;
-    text-align: right;
-    visibility: hidden;
-
-    &, .o_web_client.o_touch_device & {
-        padding: 0;
-    }
-}
-
 .o_field_widget {
     &:hover,
     &:focus-within {
         .btn.o_field_translate {
             visibility: visible;
+        }
+    }
+
+    .btn.o_field_translate {
+        position: absolute;
+        right: 5px;
+        top: 5px;
+        vertical-align: top;
+        text-align: right;
+        visibility: hidden;
+        text-wrap: nowrap;
+    
+        &, .o_web_client.o_touch_device & {
+            padding: 0;
         }
     }
 


### PR DESCRIPTION
In studio, the translation button is always invisible in the ir.ui.view form and more importantly studio xml editor since e5a0100d09b3c150ae90e8fc4a5e3c7cb2fe83ec.

opw-4519334

