### PR TITLE
[FIX] l10n_in_ewaybill: active ewaybill feature for demo company

### DIFF
--- a/addons/l10n_in_ewaybill/demo/demo_company.xml
+++ b/addons/l10n_in_ewaybill/demo/demo_company.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="base.demo_company_in" model="res.company">
+        <field name="l10n_in_ewaybill_feature">True</field>
         <field name="l10n_in_ewaybill_username">iap_odoo</field>
         <field name="l10n_in_ewaybill_password">odoo</field>
     </record>


### PR DESCRIPTION
Before this commit:
When installing `l10n_in_ewaybill` with `-i` while starting the server or installing the module from apps, issue the demo data is loaded but the ewaybill feature is not active

After this commit:
Ewaybill feature will be activated for demo company because it's quite useful for internal purposes specially for developers, testers to ease out the process

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
