### PR TITLE
[FIX] website_sale: allow adding a product to cart from any page

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_configurators.js
+++ b/addons/website_sale/static/src/js/website_sale_configurators.js
@@ -92,7 +92,7 @@ WebsiteSale.include({
             isFrontend: true,
             options: {
                 isMainProductConfigurable: !isOnProductPage,
-                showQuantity: Boolean(this.$form[0].querySelector('.css_quantity')),
+                showQuantity: Boolean(this.$form?.[0].querySelector('.css_quantity')),
             },
             save: async (mainProduct, optionalProducts, options) => {
                 this._trackProducts([mainProduct, ...optionalProducts]);
@@ -123,7 +123,7 @@ WebsiteSale.include({
             edit: false,
             isFrontend: true,
             options: {
-                showQuantity: Boolean(this.$form[0].querySelector('.css_quantity')),
+                showQuantity: Boolean(this.$form?.[0].querySelector('.css_quantity')),
             },
             save: (comboProductData, selectedComboItems, options) =>
                 this.addComboProductToCart(


### PR DESCRIPTION
## Versions:
18.0+

## Issue:
Clicking on the `Add to Cart` button displays an error message if configured on a product having variants.
The issue seems to come from the following PR: https://github.com/odoo/odoo/pull/187556

## Steps to reproduce:
Go to the `Website` app on home page in edit mode;
From the `BLOCKS`'s `Inner content` widgets add a `Add to Cart` button anywhere on the page;
Select the button to configure it;
Select a product with variants as `Product` (e.g. `Acoustic Bloc Screens`);
*Optional: choose a variant too;*
Save;
Click the added `Add to Cart` button.

## Cause:
The code tries to access an inexistant form.


opw-4573435
opw-4577757
opw-4561122
opw-4548344
opw-4567354