### PR TITLE
[FIX] tests: add 'chrome' binary name in testing automation

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -948,7 +948,7 @@ class ChromeBrowser:
     def executable(self):
         system = platform.system()
         if system == 'Linux':
-            for bin_ in ['google-chrome', 'chromium', 'chromium-browser', 'google-chrome-stable']:
+            for bin_ in ['google-chrome', 'chromium', 'chromium-browser', 'google-chrome-stable', 'chrome']:
                 try:
                     return find_in_path(bin_)
                 except IOError:


### PR DESCRIPTION
As the individual testing Chrome builds downloaded from Google contains a "chrome" executable, this commit adds this name to the whitelist used to find the Chrome's path used by the automation in ChromeBrowser.
