### PR TITLE
[FIX] im_livechat: only allow one click on chat bot answer

### DIFF
--- a/addons/im_livechat/static/src/embed/common/attachment_upload_service_patch.js
+++ b/addons/im_livechat/static/src/embed/common/attachment_upload_service_patch.js
@@ -6,6 +6,7 @@ patch(AttachmentUploadService.prototype, {
     async upload(thread, composer, file, options) {
         if (thread.channel_type === "livechat" && thread.isTransient) {
             thread = await this.env.services["im_livechat.livechat"].persist();
+            thread.readyToSwapDeferred.resolve();
             composer = thread.composer;
             if (!thread) {
                 return;

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
@@ -118,19 +118,20 @@ export class Chatbot extends Record {
         } else {
             const nextStepIndex = this.steps.lastIndexOf(this.currentStep) + 1;
             this.currentStep = this.steps[nextStepIndex];
+            this.currentStep.selectedAnswer = null;
         }
     }
 
     /**
      * Simulate the typing of the chatbot.
      */
-    async _simulateTyping() {
+    async _simulateTyping(duration = Chatbot.MESSAGE_DELAY) {
         this.isTyping = true;
         await new Promise((res) =>
             setTimeout(() => {
                 this.isTyping = false;
                 res();
-            }, Chatbot.MESSAGE_DELAY)
+            }, duration)
         );
     }
 

--- a/addons/im_livechat/static/src/embed/common/message_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/message_model_patch.js
@@ -8,6 +8,7 @@ const messagePatch = {
     setup() {
         super.setup();
         this.chatbotStep = Record.one("ChatbotStep", { inverse: "message" });
+        this.disableChatbotAnswers = false;
     },
     canAddReaction(thread) {
         return (

--- a/addons/im_livechat/static/src/embed/common/message_patch.js
+++ b/addons/im_livechat/static/src/embed/common/message_patch.js
@@ -19,6 +19,10 @@ patch(Message.prototype, {
      * @param {import("@im_livechat/embed/common/chatbot/chatbot_step_model").StepAnswer} answer
      */
     answerChatbot(answer) {
+        if (this.props.message.disableChatbotAnswers) {
+            return;
+        }
+        this.props.message.disableChatbotAnswers = true;
         return this.props.message.thread.post(answer.name, {}, { selected_answer_id: answer.id });
     },
 });

--- a/addons/im_livechat/static/src/embed/common/message_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/message_patch.xml
@@ -9,11 +9,9 @@
         </xpath>
         <xpath expr="//*[hasclass('o-mail-Message-textContent')]" position="after">
             <ul class="p-0 m-0" t-if="props.message.chatbotStep?.answers and !props.message.chatbotStep.selectedAnswer">
-                <li
-                    t-foreach="props.message.chatbotStep?.answers" t-as="answer" t-key="answer.id"
-                    t-esc="answer.name" t-on-click="() => this.answerChatbot(answer)"
-                    class="btn btn-outline-primary d-block mt-2 py-2"
-                />
+                <li class="list-unstyled" t-foreach="props.message.chatbotStep?.answers" t-as="answer" t-key="answer.id">
+                    <button t-esc="answer.name" t-att-disabled="props.message.disableChatbotAnswers" t-on-click="() => this.answerChatbot(answer)" class="btn btn-outline-primary w-100 mt-2 py-2"/>
+                </li>
             </ul>
         </xpath>
         <xpath expr="//*[hasclass('o-mail-NotificationMessage')]" position="attributes">

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -4,6 +4,8 @@ import "@mail/discuss/core/common/thread_model_patch";
 
 import { patch } from "@web/core/utils/patch";
 import { _t } from "@web/core/l10n/translation";
+import { Deferred } from "@web/core/utils/concurrency";
+import { prettifyMessageContent } from "@mail/utils/common/format";
 
 /** @type {typeof Thread} */
 const threadStaticPatch = {
@@ -42,6 +44,14 @@ patch(Thread.prototype, {
                 }
             },
         });
+        /**
+         * Deferred that resolves once a newly persisted thread is ready to swap
+         * with its temporary counterpart (i.e. when the actions following the
+         * persist call are done to avoid flickering).
+         *
+         * @type {Deferred}
+         */
+        this.readyToSwapDeferred = new Deferred();
         this.chatbot = Record.one("Chatbot");
         this.livechat_active;
         this._startChatbot = Record.attr(false, {
@@ -87,13 +97,34 @@ patch(Thread.prototype, {
         return this.channel_type === "livechat" && !this.chatbot && !this.requested_by_operator;
     },
     /** @returns {Promise<import("models").Message} */
-    async post() {
+    async post(body, postData, extraData = {}) {
         if (this.channel_type === "livechat" && this.isTransient) {
+            // For smoother transition: post the temporary message and set the
+            // selected chat bot answer if any. Then, simulate the chat bot is
+            // typing (2 ** 31 - 1 is the greatest value supported by
+            // `setTimeout`).
+            if (this.chatbot && extraData.selected_answer_id) {
+                this.chatbot.currentStep.selectedAnswer = this.store["chatbot.script.answer"].get(
+                    extraData.selected_answer_id
+                );
+            }
+            const temporaryMsg = this.store["mail.message"].insert({
+                author: this.store.self,
+                body: await prettifyMessageContent(body, [], { allowEmojiLoading: false }),
+                id: this.store.getNextTemporaryId(),
+                model: "discuss.channel",
+                res_id: this.id,
+                thread: this,
+            });
+            this.messages.push(temporaryMsg);
+            this?.chatbot?._simulateTyping(2 ** 31 - 1);
             const thread = await this.store.env.services["im_livechat.livechat"].persist();
+            temporaryMsg.author = this.store.self; // Might have been created after persist.
             if (!thread) {
                 return;
             }
-            return thread.post(...arguments);
+            await thread.isLoadedDeferred;
+            return thread.post(...arguments).then(() => thread.readyToSwapDeferred.resolve());
         }
         const message = await super.post(...arguments);
         this.store.env.services["im_livechat.chatbot"].bus.trigger("MESSAGE_POST", message);
@@ -127,7 +158,7 @@ patch(Thread.prototype, {
         }
         if (
             this.chatbot.currentStep?.type === "question_selection" &&
-            !this.chatbot.currentStep.completed
+            !this.chatbot.currentStep.selectedAnswer
         ) {
             return _t("Select an option above");
         }

--- a/addons/im_livechat/static/tests/embed/chat_window.test.js
+++ b/addons/im_livechat/static/tests/embed/chat_window.test.js
@@ -42,7 +42,7 @@ test("save fold state of temporary live chats", async () => {
     await waitForSteps([]);
     await insertText(".o-mail-Composer-input", "Hello");
     await triggerHotkey("Enter");
-    await contains(".o-mail-Message", { text: "Hello" });
+    await contains(".o-mail-Thread:not([data-transient])");
     await click(".o-mail-ChatWindow-header");
     await contains(".o-mail-Message", { text: "Hello", count: 0 });
     assertChatHub({ folded: [1] });
@@ -133,7 +133,7 @@ test("can close confirm livechat with keyboard", async () => {
     await contains(".o-mail-ChatWindow");
     await insertText(".o-mail-Composer-input", "Hello");
     await triggerHotkey("Enter");
-    await contains(".o-mail-Message", { text: "Hello" });
+    await contains(".o-mail-Thread:not([data-transient])");
     await triggerHotkey("Escape");
     await contains(".o-livechat-CloseConfirmation", {
         text: "Leaving will end the livechat. Proceed leaving?",

--- a/addons/im_livechat/static/tests/embed/feedback_panel.test.js
+++ b/addons/im_livechat/static/tests/embed/feedback_panel.test.js
@@ -51,7 +51,7 @@ test("Close without feedback", async () => {
     await contains(".o-mail-ChatWindow");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message-content", { text: "Hello World!" });
+    await contains(".o-mail-Thread:not([data-transient])");
     await click("[title*='Close Chat Window']");
     await click(".o-livechat-CloseConfirmation-leave");
     await click("button", { text: "Close" });
@@ -101,7 +101,7 @@ test("Feedback with rating and comment", async () => {
     await contains(".o-mail-ChatWindow");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message-content", { text: "Hello World!" });
+    await contains(".o-mail-Thread:not([data-transient])");
     await click("[title*='Close Chat Window']");
     await click(".o-livechat-CloseConfirmation-leave");
     await waitForSteps(["/im_livechat/visitor_leave_session"]);
@@ -120,7 +120,7 @@ test("Closing folded chat window should open it with feedback", async () => {
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message-content", { text: "Hello World!" });
+    await contains(".o-mail-Thread:not([data-transient])");
     await click("[title='Fold']");
     await click(".o-mail-ChatBubble");
     await click("[title*='Close Chat Window']");
@@ -138,7 +138,7 @@ test("Start new session from feedback panel", async () => {
     await contains(".o-mail-ChatWindow", { text: "Mitchell Admin" });
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message-content", { text: "Hello World!" });
+    await contains(".o-mail-Thread:not([data-transient])");
     await click("[title*='Close Chat Window']");
     await click(".o-livechat-CloseConfirmation-leave");
     pyEnv["im_livechat.channel"].write([channelId], {

--- a/addons/im_livechat/static/tests/embed/livechat_button.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_button.test.js
@@ -35,12 +35,6 @@ test("open/close temporary channel", async () => {
 test("open/close persisted channel", async () => {
     await startServer();
     await loadDefaultEmbedConfig();
-    onRpc("/im_livechat/get_session", async (req) => {
-        const { params } = await req.json();
-        if (params.persisted) {
-            asyncStep("persisted");
-        }
-    });
     const env = await start({ authenticateAs: false });
     env.services.bus_service.subscribe("discuss.channel/new_message", () =>
         asyncStep("discuss.channel/new_message")
@@ -49,7 +43,7 @@ test("open/close persisted channel", async () => {
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "How can I help?");
     await triggerHotkey("Enter");
-    await waitForSteps(["persisted"]);
+    await contains(".o-mail-Thread:not([data-transient])");
     await contains(".o-mail-Message-content", { text: "How can I help?" });
     await waitForSteps(["discuss.channel/new_message"]);
     await click("[title*='Close Chat Window']");

--- a/addons/im_livechat/static/tests/embed/livechat_service.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service.test.js
@@ -115,6 +115,23 @@ test("Only necessary requests are made when creating a new chat", async () => {
             previous_operator_id: operatorPartnerId,
             persisted: true,
         })}`,
+        `/mail/message/post - ${JSON.stringify({
+            context: {
+                lang: "en",
+                tz: "taht",
+                uid: serverState.userId,
+                allowed_company_ids: [1],
+                temporary_id: 0.8200000000000001,
+            },
+            post_data: {
+                body: "Hello!",
+                email_add_signature: true,
+                message_type: "comment",
+                subtype_xmlid: "mail.mt_comment",
+            },
+            thread_id: threadId,
+            thread_model: "discuss.channel",
+        })}`,
         `/mail/data - ${JSON.stringify({
             fetch_params: [
                 "failures", // called because mail/core/web is loaded in test bundle
@@ -127,23 +144,6 @@ test("Only necessary requests are made when creating a new chat", async () => {
                 uid: serverState.userId,
                 allowed_company_ids: [1],
             },
-        })}`,
-        `/mail/message/post - ${JSON.stringify({
-            context: {
-                lang: "en",
-                tz: "taht",
-                uid: serverState.userId,
-                allowed_company_ids: [1],
-                temporary_id: 0.81,
-            },
-            post_data: {
-                body: "Hello!",
-                email_add_signature: true,
-                message_type: "comment",
-                subtype_xmlid: "mail.mt_comment",
-            },
-            thread_id: threadId,
-            thread_model: "discuss.channel",
         })}`,
     ]);
 });

--- a/addons/im_livechat/static/tests/embed/livechat_session.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_session.test.js
@@ -61,7 +61,7 @@ test("Fold state is saved", async () => {
     await contains(".o-mail-Thread");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message", { text: "Hello World!" });
+    await contains(".o-mail-Thread:not([data-transient])");
     assertChatHub({ opened: [1] });
     await click(".o-mail-ChatWindow-header");
     await contains(".o-mail-Thread", { count: 0 });

--- a/addons/im_livechat/static/tests/embed/transcript_sender.test.js
+++ b/addons/im_livechat/static/tests/embed/transcript_sender.test.js
@@ -29,7 +29,7 @@ test("send", async () => {
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message-content", { text: "Hello World!" });
+    await contains(".o-mail-Thread:not([data-transient])");
     await click(".o-mail-ChatWindow-command[title*='Close']");
     await click(".o-livechat-CloseConfirmation-leave");
     await contains(".form-text", { text: "Receive a copy of this conversation." });
@@ -51,7 +51,7 @@ test("send failed", async () => {
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message-content", { text: "Hello World!" });
+    await contains(".o-mail-Thread:not([data-transient])");
     await click(".o-mail-ChatWindow-command[title*='Close']");
     await click(".o-livechat-CloseConfirmation-leave");
     await insertText("input[placeholder='mail@example.com']", "odoobot@odoo.com");

--- a/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
+++ b/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
@@ -75,7 +75,6 @@ async function get_session(request) {
                 makeKwArgs({ fields: ["avatar_128", "user_livechat_username"] })
             ),
             name: channelVals["name"],
-            open_chat_window: true,
             scrollUnread: false,
             state: "open",
         });
@@ -94,7 +93,6 @@ async function get_session(request) {
     store.add(DiscussChannel.browse(channelId));
     store.add(DiscussChannel.browse(channelId), {
         isLoaded: true,
-        open_chat_window: true,
         scrollUnread: false,
     });
     return store.get_result();

--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -3,6 +3,8 @@ import { imageUrl } from "@web/core/utils/urls";
 import { rpc } from "@web/core/network/rpc";
 import { debounce } from "@web/core/utils/timing";
 
+const TRANSPARENT_AVATAR =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAQAAABpN6lAAAAAqElEQVR42u3QMQEAAAwCoNm/9GJ4CBHIjYsAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBDQ9+KgAIHd5IbMAAAAAElFTkSuQmCC";
 const { DateTime } = luxon;
 
 /**
@@ -129,6 +131,9 @@ export class Persona extends Record {
             });
         }
         if (this.type === "guest") {
+            if (this.id === -1) {
+                return TRANSPARENT_AVATAR;
+            }
             return imageUrl("mail.guest", this.id, "avatar_128", {
                 ...accessTokenParam,
                 unique: this.write_date,

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Thread">
-    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-5': env.inChatter?.aside, 'pb-4': !env.inChatter?.aside, 'px-3': !env.inChatter and !props.isInChatWindow }" t-ref="messages" tabindex="-1">
+    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-5': env.inChatter?.aside, 'pb-4': !env.inChatter?.aside, 'px-3': !env.inChatter and !props.isInChatWindow }" t-att-data-transient="props.thread.isTransient" t-ref="messages" tabindex="-1">
         <t t-if="!props.thread.isEmpty or props.thread.loadOlder or props.thread.hasLoadingFailed" name="content">
             <div class="d-flex flex-column position-relative flex-grow-1" t-att-class="{'justify-content-end': !env.inChatter and props.thread.model !== 'mail.box'}">
                 <span class="position-absolute w-100 invisible" t-att-class="props.order === 'asc' ? 'bottom-0' : 'top-0'" t-ref="present-treshold" t-att-style="`height: Min(${PRESENT_THRESHOLD}px, 100%)`"/>

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -40,7 +40,11 @@ const _escapeEntities = (function () {
  * @param validRecords {Object}
  * @param validRecords.partners {Partner}
  */
-export async function prettifyMessageContent(rawBody, validRecords = []) {
+export async function prettifyMessageContent(
+    rawBody,
+    validRecords = [],
+    { allowEmojiLoading = true } = {}
+) {
     // Suggested URL Javascript regex of http://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
     // Adapted to make http(s):// not required if (and only if) www. is given. So `should.notmatch` does not match.
     // And further extended to include Latin-1 Supplement, Latin Extended-A, Latin Extended-B and Latin Extended Additional.
@@ -54,7 +58,9 @@ export async function prettifyMessageContent(rawBody, validRecords = []) {
     // as text internally and only make html enrichment at display time but
     // the current design makes this quite hard to do.
     body = generateMentionsLinks(body, validRecords);
-    body = await _generateEmojisOnHtml(body);
+    if (allowEmojiLoading || odoo.loader.modules.get("@web/core/emoji_picker/emoji_data")) {
+        body = await _generateEmojisOnHtml(body);
+    }
     body = parseAndTransform(body, addLink);
     return body;
 }

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_continue.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_continue.js
@@ -8,7 +8,7 @@ registry.category("web_tour.tours").add("website_livechat.chatbot_continue_tour"
             trigger: messagesContain("Hello, what can I do for you?"),
         },
         {
-            trigger: ".o-livechat-root:shadow li:contains(No, thank you for your time.)",
+            trigger: ".o-livechat-root:shadow button:contains(No, thank you for your time.)",
             run: "click",
         },
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -58,7 +58,7 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 },
             },
             {
-                trigger: '.o-livechat-root:shadow li:contains("I\'d like to buy the software")',
+                trigger: '.o-livechat-root:shadow button:contains("I\'d like to buy the software")',
                 run: "click",
             },
             {
@@ -204,7 +204,7 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 trigger: messagesContain("How can I help you?"),
             },
             {
-                trigger: '.o-livechat-root:shadow li:contains("Pricing Question")',
+                trigger: '.o-livechat-root:shadow button:contains("Pricing Question")',
                 run: "click",
             },
             {
@@ -253,7 +253,8 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 run: "click",
             },
             {
-                trigger: ".o-livechat-root:shadow li:contains(I want to speak with an operator)",
+                trigger:
+                    ".o-livechat-root:shadow button:contains(I want to speak with an operator)",
                 run: "click",
             },
             {

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_forward.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_forward.js
@@ -13,7 +13,7 @@ registry.category("web_tour.tours").add("website_livechat.chatbot_forward", {
             trigger: messagesContain("Hello, what can I do for you?"),
         },
         {
-            trigger: ".o-livechat-root:shadow li:contains(Forward to operator)",
+            trigger: ".o-livechat-root:shadow button:contains(Forward to operator)",
             run: "click",
         },
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_fw_operator_matching_lang.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_fw_operator_matching_lang.js
@@ -8,7 +8,7 @@ registry.category("web_tour.tours").add("chatbot_fw_operator_matching_lang", {
             trigger: ".o-livechat-root:shadow .o-mail-Message:contains('Hello! I'm a bot!')",
         },
         {
-            trigger: ".o-livechat-root:shadow li:contains(I want to speak with an operator)",
+            trigger: ".o-livechat-root:shadow button:contains(I want to speak with an operator)",
             run: "click",
         },
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_redirect.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_redirect.js
@@ -13,7 +13,7 @@ registry.category("web_tour.tours").add("website_livechat.chatbot_redirect", {
             run: "click",
         },
         {
-            trigger: ".o-livechat-root:shadow li:contains(Go to the #chatbot-redirect anchor)",
+            trigger: ".o-livechat-root:shadow button:contains(Go to the #chatbot-redirect anchor)",
             run: "click",
         },
         {
@@ -33,7 +33,7 @@ registry.category("web_tour.tours").add("website_livechat.chatbot_redirect", {
             run: "click",
         },
         {
-            trigger: ".o-livechat-root:shadow li:contains(Go to the /chatbot-redirect page)",
+            trigger: ".o-livechat-root:shadow button:contains(Go to the /chatbot-redirect page)",
             run: "click",
         },
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_test_page_tour.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_test_page_tour.js
@@ -25,7 +25,7 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_test_page_tour
             run: "click",
         },
         {
-            trigger: '.o-livechat-root:shadow li:contains("I\'d like to buy the software")',
+            trigger: '.o-livechat-root:shadow button:contains("I\'d like to buy the software")',
             run: "click",
         },
         {
@@ -46,7 +46,7 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_test_page_tour
             },
         },
         {
-            trigger: '.o-livechat-root:shadow li:contains("Other & Documentation")',
+            trigger: '.o-livechat-root:shadow button:contains("Other & Documentation")',
             run: "click",
         },
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_trigger_selection_tour.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_trigger_selection_tour.js
@@ -6,7 +6,7 @@ const answerBothQuestions = [
             ".o-livechat-root:shadow .o-mail-Message:contains(Hello, here is a first question?)",
     },
     {
-        trigger: ".o-livechat-root:shadow li:contains(Yes to first question)",
+        trigger: ".o-livechat-root:shadow button:contains(Yes to first question)",
         run: "click",
     },
     {
@@ -14,7 +14,7 @@ const answerBothQuestions = [
             ".o-livechat-root:shadow .o-mail-Message:contains(Hello, here is a second question?)",
     },
     {
-        trigger: ".o-livechat-root:shadow li:contains(No to second question)",
+        trigger: ".o-livechat-root:shadow button:contains(No to second question)",
         run: "click",
     },
 ];

--- a/addons/website_livechat/static/tests/tours/website_livechat_question_selection_overlapping_answers.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_question_selection_overlapping_answers.js
@@ -8,7 +8,7 @@ registry.category("web_tour.tours").add("website_livechat.question_selection_ove
         },
         { trigger: ".o-livechat-root:shadow .o-mail-Message:contains(Choose an option)" },
         {
-            trigger: ".o-livechat-root:shadow li:eq(0)",
+            trigger: ".o-livechat-root:shadow li button:eq(0)",
             run: "click",
         },
         { trigger: ".o-livechat-root:shadow .o-mail-Message:contains(You selected not X)" },
@@ -18,7 +18,7 @@ registry.category("web_tour.tours").add("website_livechat.question_selection_ove
         },
         { trigger: ".o-livechat-root:shadow .o-mail-Message:contains(Choose an option)" },
         {
-            trigger: ".o-livechat-root:shadow li:eq(1)",
+            trigger: ".o-livechat-root:shadow li button:eq(1)",
             run: "click",
         },
         { trigger: ".o-livechat-root:shadow .o-mail-Message:contains(You selected X)" },
@@ -28,7 +28,7 @@ registry.category("web_tour.tours").add("website_livechat.question_selection_ove
         },
         { trigger: ".o-livechat-root:shadow .o-mail-Message:contains(Choose an option)" },
         {
-            trigger: ".o-livechat-root:shadow li:eq(2)",
+            trigger: ".o-livechat-root:shadow li button:eq(2)",
             run: "click",
         },
         { trigger: ".o-livechat-root:shadow .o-mail-Message:contains(You selected maybe X)" },


### PR DESCRIPTION
This PR fixes several issues:
- Clicking multiple times on a chat bot answer would lead to multiple
messages being posted which could impact the chat bot flow. Disable the
buttons once an answer has been selected.

- Messages could be shown in an incorrect order when answering the first
chat bot question. Ensure thread messages are properly loaded before posting
the answer.

- Chat window was flickering when persisting a temporary thread
(replacing the temporary thread with the created one). Ensure the thread
swap occurs when the created thread is fully ready, thus matching the
temporary thread visual and avoiding flickering.

task-4589418

Examples with slow 4g

| Before | After |
| ------------- | ------------- |
| ![chrome-capture-2025-2-20](https://github.com/user-attachments/assets/306e82f5-999d-421d-bfe0-3cf7958b6657)|![chrome-capture-2025-2-20 (1)](https://github.com/user-attachments/assets/e8e9d902-41df-4235-b26a-aa16c8ae0e2f) |
