### PR TITLE
[FIX] account: fix typo in _search_placeholder_code

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -406,11 +406,11 @@ class AccountAccount(models.Model):
                     record.placeholder_code = f'{code} ({company.name})'
 
     def _search_placeholder_code(self, operator, value):
-        if operator != '=like':
+        if operator != '=ilike':
             raise NotImplementedError
         query = Query(self.env, 'account_account')
         placeholder_code_sql = self.env['account.account']._field_to_sql('account_account', 'placeholder_code', query)
-        query.add_where(SQL("%s LIKE %s", placeholder_code_sql, value))
+        query.add_where(SQL("%s ILIKE %s", placeholder_code_sql, value))
         return [('id', 'in', query)]
 
     @api.depends_context('company')
@@ -422,7 +422,7 @@ class AccountAccount(models.Model):
     def _search_account_root(self, operator, value):
         if operator in ['=', 'child_of']:
             root = self.env['account.root'].browse(value)
-            return [('placeholder_code', '=like', root.name + ('' if operator == '=' and not root.parent_id else '%'))]
+            return [('placeholder_code', '=ilike', root.name + ('' if operator == '=' and not root.parent_id else '%'))]
         raise NotImplementedError
 
     def _search_panel_domain_image(self, field_name, domain, set_count=False, limit=False):


### PR DESCRIPTION


Current behavior before PR:
- After this [fix](https://github.com/odoo/odoo/commit/56d5c9f4861b3509043660c97a702bfe0e636e3f) , any type searching is not possible for `placeholder_code` field.
- For every filter applied, it just return `invalid domain error`.
- this is because ` _search_placeholder_code` uses `=like` operator, but this makes it, unsearchable from frontend, as filters supports `ilike` and its related operators.

![before fix](https://github.com/user-attachments/assets/cb75acc9-ee06-4061-8a71-7a5c69693c63)

Desired behavior after PR is merged:
- This PR fixes this issue, by changing the operator from `=like` -> `=ilike`
- `placeholder_code` field can now be searched for filters like `starts with` and `ends with` .
![after fix typo](https://github.com/user-attachments/assets/9764784c-110f-4e50-a7a5-66364c7e400b)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
