### PR TITLE
[FIX] barcodes_gs1_nomenclature: restrict user to add gs1-128 encoding if no is_gs1_nomenclature

### DIFF
--- a/addons/barcodes_gs1_nomenclature/i18n/barcodes_gs1_nomenclature.pot
+++ b/addons/barcodes_gs1_nomenclature/i18n/barcodes_gs1_nomenclature.pot
@@ -88,6 +88,12 @@ msgid "GS1-128"
 msgstr ""
 
 #. module: barcodes_gs1_nomenclature
+#. odoo-python
+#: code:addons/barcodes_gs1_nomenclature/models/barcode_rule.py:0
+msgid "GS1-128 encoding is only available for GS1 nomenclature."
+msgstr ""
+
+#. module: barcodes_gs1_nomenclature
 #: model:ir.model,name:barcodes_gs1_nomenclature.model_ir_http
 msgid "HTTP Routing"
 msgstr ""

--- a/addons/barcodes_gs1_nomenclature/models/barcode_rule.py
+++ b/addons/barcodes_gs1_nomenclature/models/barcode_rule.py
@@ -67,3 +67,8 @@ class BarcodeRule(models.Model):
                     rule.name))
 
         super(BarcodeRule, (self - gs1_rules))._check_pattern()
+
+    @api.constrains('encoding')
+    def _check_gs1_encoding(self):
+        if any(rule.encoding == 'gs1-128' and not rule.is_gs1_nomenclature for rule in self):
+            raise ValidationError(_("GS1-128 encoding is only available for GS1 nomenclature."))


### PR DESCRIPTION
Currently, a traceback will occur when the user adds the gs1-128 encoding rule 
for non gs1-nomenclature record and tries to scan a barcode.

To reproduce this issue:

1) Install stock, barcode
2) In the default Nomenclature(non gs1 nomenclature) record add a barcode rule
3) Make sure the encoding should be `gs1-128` with a valid pattern 
4) Now try to scan a barcode from the barcode app

Error:- 
```
KeyError: 'gs1-128'
```

This error is occurring because we don't have any
barcode size for `gs1-128` in barcode_size dict.

https://github.com/odoo/odoo/blob/73ed7dbfbb164823d7e9f66cd3bb1d0aa0b70dbd/odoo/tools/barcode.py#L45-L52

So this leads to the above traceback when the encoding type is `gs1-128`. We can resolve this issue by adding the encode `gs1-128` with its barcode size in the `barcode_size` dict.

sentry-6308131627

