### PR TITLE
[FIX] Purchase: move advertising button from portal

### DIFF
--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -170,7 +170,7 @@
                           </div>
 
                           <div>
-                            <button id="portal_connect_software_modal_btn" type="button" class="btn btn-primary"
+                            <button id="portal_connect_software_modal_btn" type="button" class="btn btn-primary invisible"
                             data-bs-toggle="modal" data-bs-target="#portal_connect_software_modal">
                                 Connect with your software!
                             </button>

--- a/addons/purchase_edi_ubl_bis3/__manifest__.py
+++ b/addons/purchase_edi_ubl_bis3/__manifest__.py
@@ -10,6 +10,7 @@ receiver to retrieve the PDF with only the xml file.
     'depends': ['purchase', 'account_edi_ubl_cii'],
     'data': [
         'data/bis3_templates.xml',
+        'views/portal_templates_edi_ubl_connect_software.xml',
     ],
     'installable': True,
     'auto_install': True,

--- a/addons/purchase_edi_ubl_bis3/views/portal_templates_edi_ubl_connect_software.xml
+++ b/addons/purchase_edi_ubl_bis3/views/portal_templates_edi_ubl_connect_software.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="portal_connect_software_modal" name="EDI UBL : portal connect software" inherit_id="purchase.portal_my_purchase_order" priority="35">
+        <xpath expr="//button[@id='portal_connect_software_modal_btn']" position="attributes">
+            <attribute name="class" remove="invisible" add="visible" separator=" "/>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
The text advertising the UBL functionality is in purchase rather than in the UBL module itself. This way if someone have purchase but not UBL, which is the actual case in internal, one will see a button on how to import the PO when he actually can't.

This PR makes the button in the portal PO view invisible and set it visible in an inherited view that is created once the UBL module is installed, preventing this way the message to display when it should not

opw-4465049

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
