### PR TITLE
[FIX] google_calendar: change the AttributeError to ValidationError

### DIFF
--- a/addons/google_calendar/i18n/google_calendar.pot
+++ b/addons/google_calendar/i18n/google_calendar.pot
@@ -62,6 +62,12 @@ msgstr ""
 
 #. module: google_calendar
 #. odoo-python
+#: code:addons/google_calendar/utils/google_calendar.py:0
+msgid "An authentication token is required"
+msgstr ""
+
+#. module: google_calendar
+#. odoo-python
 #: code:addons/google_calendar/models/res_users_settings.py:0
 msgid ""
 "An error occurred while generating the token. Your authorization code may be"

--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -6,9 +6,10 @@ import requests
 import json
 import logging
 
-from odoo import fields
+from odoo import fields, _
 from odoo.addons.google_calendar.utils.google_event import GoogleEvent
 from odoo.addons.google_account.models.google_service import TIMEOUT
+from odoo.exceptions import ValidationError
 
 
 _logger = logging.getLogger(__name__)
@@ -16,7 +17,7 @@ _logger = logging.getLogger(__name__)
 def requires_auth_token(func):
     def wrapped(self, *args, **kwargs):
         if not kwargs.get('token'):
-            raise AttributeError("An authentication token is required")
+            raise ValidationError(_("An authentication token is required"))
         return func(self, *args, **kwargs)
     return wrapped
 


### PR DESCRIPTION
This error occurs when a user resets their Google Calendar account. As a result, the authentication token disappears, and if they attempt to reset the account again, an error is triggered.

Steps to reproduce:
---
- Install `google_calendar` module
- Set Google Calendar Credentials in settings.
- Go to Calendar and Sync with Google
- Users > Mitchell Admin > Calendar
- `Reset Account` > `Confirm` (keep the selections as default)
- Again `Reset Account` > `User's Existing Events: Delete from Both`

Stack Trace:
---
AttributeError: An authentication token is required


Due to an AttributeError, users are seeing an error message in the stack trace instead of a user-friendly notification.

sentry-6311340556

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
