### PR TITLE
[FIX] mail: message reaction remove icon is X rather than trash

### DIFF
--- a/addons/mail/static/src/core/common/message_reaction_menu.scss
+++ b/addons/mail/static/src/core/common/message_reaction_menu.scss
@@ -7,15 +7,21 @@
     > .modal-body {
         padding: 0;
     }
+
+    button.oi-close {
+        aspect-ratio: 1;
+    }
 }
 
 .o-mail-MessageReactionMenu-persona:not(.o-isDeviceSmall) {
-    &:not(:hover) button.fa-trash {
+    &:not(:hover) button.oi-close {
         opacity: 0;
     }
-    &:hover button.fa-trash {
-        opacity: 100;
+    &:hover button.oi-close {
+        opacity: 50%;
+
         &:hover {
+            opacity: 100%;
             background-color: $gray-100;
         }
     }

--- a/addons/mail/static/src/core/common/message_reaction_menu.xml
+++ b/addons/mail/static/src/core/common/message_reaction_menu.xml
@@ -18,7 +18,7 @@
                         <span class="d-flex flex-grow-1 align-items-center">
                             <span class="mx-2 text-truncate fs-6" t-esc="persona.name"/>
                             <div class="flex-grow-1"/>
-                            <button t-if="persona.eq(store.self)" class="btn btn-light fa fa-trash rounded-pill bg-inherit border-0" title="Remove" t-on-click.stop="() => state.reaction.remove()"/>
+                            <button t-if="persona.eq(store.self)" class="btn btn-light oi oi-close rounded-pill bg-inherit border-0" title="Remove" t-on-click.stop="() => state.reaction.remove()"/>
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
Before this commit, icon to remove a message reaction in message reaction menu was trash rather than "X". This gave a wrong impression that this button has more implication that it really is.

This commit replaces it with a "X".

Also adapt slightly the style to have reduced visibility on item hover and full visibility when the button is hovered. This makes it more natural to click on the button.

Task-4589558

Before
![before](https://github.com/user-attachments/assets/5022f001-ddbe-4fc5-bf15-12572dd474f2)
After
![after](https://github.com/user-attachments/assets/97655803-bdb1-4187-90d6-fed7d298a6c7)
