### PR TITLE
[FIX] mail: improved UI of collapse/expand call participants button

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.scss
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.scss
@@ -3,6 +3,20 @@
     outline-offset: -2px;
 }
 
+.o-mail-DiscussSidebarCallParticipants-expandBtn {
+    aspect-ratio: 1;
+    transform: translateY(50%);
+    opacity: 50%;
+
+    .o-mail-DiscussSidebarCallParticipants:hover & {
+        opacity: 100%;
+    }
+
+    &:hover {
+        background-color: $gray-300;
+    }
+}
+
 .o-mail-DiscussSidebarCallParticipants-name {
     color: $black;
     opacity: 60%;

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -24,8 +24,8 @@
             'rounded-3': props.compact === undefined,
             'opacity-75': props.thread.notEq(rtc.state.channel) and compact,
         }">
-            <button class="btn btn-link p-1 m-n1 align-self-start" t-if="!compact" t-on-click="() => state.expanded = !state.expanded">
-                <i class="oi o-xxsmaller text-muted me-1" t-att-class="{'oi-chevron-right': !state.expanded, 'oi-chevron-down': state.expanded}" t-att-title="title"/>
+            <button class="o-mail-DiscussSidebarCallParticipants-expandBtn btn btn-link p-1 my-n1 ms-n1 me-0 align-self-start d-flex rounded-circle" t-if="!compact" t-on-click="() => state.expanded = !state.expanded">
+                <i class="oi o-xxsmaller text-muted text-dark" t-att-class="{'oi-chevron-right': !state.expanded, 'oi-chevron-down': state.expanded}" t-att-title="title"/>
             </button>
             <AvatarStack
                 t-if="!state.expanded"


### PR DESCRIPTION
Before this commit, the button to collapse/expand participants in the discuss sidebar was not easy to spot.

The button has low impact on UI, which makes sense because the most important elements are the call participants. However, the lack of style change on mouse hovering doesn't help noticing its presence.

This commit improves by changing its visibility slightly on mouse-hovering the call participants. A background effect is also added when mouse-hovering precisely this button, so that it's very obvious that this is a clickable button.

![dark](https://github.com/user-attachments/assets/88e8c3be-a711-487f-8bb3-b8848215161d)
![white](https://github.com/user-attachments/assets/7f8bf526-ec77-44e0-9b31-00e8a875fe6d)
