### PR TITLE
[FIX] point_of_sale: remove check delay to open the popup

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -12,7 +12,6 @@ import { registry } from "@web/core/registry";
 import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
 
 registry.category("web_tour.tours").add("TicketScreenTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),


### PR DESCRIPTION
Following this commit:
- Check delay was removed so that confirm popup can be executed
default check delay is 200 which is more than already given

runbot Error: 111974
