### PR TITLE
[IMP] hr_holidays: adapt default leave type in case of hours

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -80,10 +80,12 @@ class HrLeave(models.Model):
 
         lt = self.env['hr.leave.type']
         if self.env.context.get('holiday_status_display_name', True) and 'holiday_status_id' in fields_list and not defaults.get('holiday_status_id'):
-            lt = self.env['hr.leave.type'].search(['|', ('requires_allocation', '=', 'no'), ('has_valid_allocation', '=', True)], limit=1, order='sequence')
+            domain = ['|', ('requires_allocation', '=', 'no'), ('has_valid_allocation', '=', True)]
+            if defaults.get('request_unit_hours'):
+                domain.append(('request_unit', '=', 'hour'))
+            lt = self.env['hr.leave.type'].search(domain, limit=1, order='sequence')
             if lt:
                 defaults['holiday_status_id'] = lt.id
-                defaults['request_unit_custom'] = False
 
         if 'request_date_from' in fields_list and 'request_date_from' not in defaults:
             defaults['request_date_from'] = fields.Date.today()

--- a/addons/hr_holidays/static/src/views/calendar/calendar_model.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_model.js
@@ -48,6 +48,14 @@ export class TimeOffCalendarModel extends CalendarModel {
             // "YYYY-MM-DD".length == 10
             return str.length > 10 ? deserializeDateTime(str) : deserializeDate(str);
         }
+        if (["week", "day"].includes(this.scale)) {
+            context["default_request_unit_hours"] = true;
+            const hour_from = deserialize(context['default_date_from']??this.date);
+            const hour_to = deserialize(context['default_date_to']??this.date);
+            context['default_request_hour_from'] = hour_from.hour + hour_from.minute / 60;
+            context['default_request_hour_to'] = hour_to.hour + hour_to.minute / 60;
+        }
+
         if ("default_date_from" in context) {
             context["default_date_from"] = serializeDateTime(
                 deserialize(context["default_date_from"]).set({ hours: 7 })


### PR DESCRIPTION
- when you take timeoff from dashboard using the week or day view and define some hours in the sameday. the leave should adapt to have a right type and add custom hours

Task: 4587199

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
