### PR TITLE
[FIX] l10n_it_edi: test fails because date is set in name

### DIFF
--- a/addons/l10n_it_edi/tests/test_edi_export.py
+++ b/addons/l10n_it_edi/tests/test_edi_export.py
@@ -426,6 +426,7 @@ class TestItEdiExport(TestItEdi):
         self.italian_partner_a.zip = False  # invalid configuration for partner -> proforma pdf
         invoice = self.env['account.move'].with_company(self.company).create({
             'partner_id': self.italian_partner_a.id,
+            'invoice_date': '2024-03-24',
             'move_type': 'out_invoice',
             'invoice_line_ids': [
                 Command.create({


### PR DESCRIPTION
By default, if no date are specified, an invoice is dated at today.
The test enforces a name in 2024, which is why it worked before.
Now, as we're not in 2024, the test always fails.
The generated pdf does not have the same name, as it follows
the invoice name.
Let's force the date of the invoice, to force the name of the pdf.

runbot-111405




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
