### PR TITLE
[FIX] html_editor: infinite loop in removeFormat

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -23,6 +23,7 @@ import { ColorSelector } from "./color_selector";
 import { reactive } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { withSequence } from "@html_editor/utils/resource";
+import { isBlock } from "@html_editor/utils/blocks";
 
 const RGBA_OPACITY = 0.6;
 const HEX_OPACITY = "99";
@@ -262,7 +263,13 @@ export class ColorPlugin extends Plugin {
 
         const getFonts = (selectedNodes) => {
             return selectedNodes.flatMap((node) => {
-                let font = closestElement(node, "font") || closestElement(node, "span");
+                let font =
+                    closestElement(node, "font") ||
+                    closestElement(
+                        node,
+                        '[style*="color"], [style*="background-color"], [style*="background-image"]'
+                    ) ||
+                    closestElement(node, "span");
                 const children = font && descendants(font);
                 const hasInlineGradient = font && isColorGradient(font.style["background-image"]);
                 const isFullySelected =
@@ -275,17 +282,33 @@ export class ColorPlugin extends Plugin {
                         (mode === "backgroundColor" && !isTextGradient));
                 if (
                     font &&
-                    (font.nodeName === "FONT" || (font.nodeName === "SPAN" && font.style[mode])) &&
+                    font.nodeName !== "T" &&
+                    (font.nodeName !== "SPAN" || font.style[mode] || font.style.backgroundImage) &&
                     (isColorGradient(color) ||
                         color === "" ||
                         !hasInlineGradient ||
-                        shouldReplaceExistingGradient)
+                        shouldReplaceExistingGradient) &&
+                    !this.dependencies.split.isUnsplittable(font)
                 ) {
                     // Partially selected <font>: split it.
                     const selectedChildren = children.filter((child) =>
                         selectedNodes.includes(child)
                     );
                     if (selectedChildren.length) {
+                        if (isBlock(font)) {
+                            const colorStyles = ["color", "background-color", "background-image"];
+                            const newFont = this.document.createElement("font");
+                            for (const style of colorStyles) {
+                                const styleValue = font.style[style];
+                                if (styleValue) {
+                                    this.colorElement(newFont, styleValue, style);
+                                    font.style.removeProperty(style);
+                                }
+                            }
+                            newFont.append(...font.childNodes);
+                            font.append(newFont);
+                            font = newFont;
+                        }
                         const closestGradientEl = closestElement(
                             node,
                             'font[style*="background-image"], span[style*="background-image"]'
@@ -391,6 +414,7 @@ export class ColorPlugin extends Plugin {
             if (
                 !hasColor(font, "color") &&
                 !hasColor(font, "backgroundColor") &&
+                ["FONT", "SPAN"].includes(font.nodeName) &&
                 (!font.hasAttribute("style") || !color)
             ) {
                 for (const child of [...font.childNodes]) {

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -544,3 +544,17 @@ test("should remove background gradient and apply new background color if gradie
         contentAfter: '<p><font style="background-color: rgb(255, 0, 0);">[abcd]</font></p>',
     });
 });
+test("should not split unsplittable element when applying color", async () => {
+    await testEditor({
+        contentBefore: '<div style="color: rgb(255, 0, 0);"><p>[test]</p></div>',
+        stepFunction: setColor("rgb(0, 0, 255)", "color"),
+        contentAfter:
+            '<div style="color: rgb(255, 0, 0);"><p><font style="color: rgb(0, 0, 255);">[test]</font></p></div>',
+    });
+    await testEditor({
+        contentBefore: '<div style="color: rgb(255, 0, 0);"><p>t[es]t</p></div>',
+        stepFunction: setColor("rgb(0, 0, 255)", "color"),
+        contentAfter:
+            '<div style="color: rgb(255, 0, 0);"><p>t<font style="color: rgb(0, 0, 255);">[es]</font>t</p></div>',
+    });
+});

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -735,6 +735,49 @@ test("should remove all formats when having multiple formats (3)", async () => {
     });
 });
 
+test("should remove color from entire list item when fully selected", async () => {
+    await testEditor({
+        contentBefore: '<ul><li style="color: rgb(255, 0, 0);">[abcd]</li></ul>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: "<ul><li>[abcd]</li></ul>",
+    });
+});
+
+test("should remove color only from selected text within a list item", async () => {
+    await testEditor({
+        contentBefore: '<ul><li style="color: rgb(255, 0, 0);">a[bc]d</li></ul>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter:
+            '<ul><li><font style="color: rgb(255, 0, 0);">a</font>[bc]<font style="color: rgb(255, 0, 0);">d</font></li></ul>',
+    });
+});
+
+test("should remove color from entire heading when fully selected", async () => {
+    await testEditor({
+        contentBefore: '<ul><h1 style="color: rgb(255, 0, 0);">[abcd]</h1></ul>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: "<ul><h1>[abcd]</h1></ul>",
+    });
+});
+
+test("should remove color only from selected text within a heading", async () => {
+    await testEditor({
+        contentBefore: '<ul><h1 style="color: rgb(255, 0, 0);">a[bc]d</h1></ul>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter:
+            '<ul><h1><font style="color: rgb(255, 0, 0);">a</font>[bc]<font style="color: rgb(255, 0, 0);">d</font></h1></ul>',
+    });
+});
+
+test("should remove gradient color from span element", async () => {
+    await testEditor({
+        contentBefore:
+            '<p><span style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);">[ab]</span></p>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: "<p>[ab]</p>",
+    });
+});
+
 describe("Toolbar", () => {
     async function removeFormatClick() {
         await expectElementCount(".o-we-toolbar", 1);


### PR DESCRIPTION
**Current behavior before PR:**

- When color was applied to a block-level element, attempting to remove it caused the `removeFormat` method to enter an infinite loop.
- Removing formatting on a contenteditable false element infinite loop when removing format.

**Desired behavior after PR is merged:**

- Now, the color is correctly removed from the selected text, even when it is applied to a block-level element.
- Now, the toolbar no longer opens when the selected element is contenteditable false


task: 4575459
