### PR TITLE
[FIX] discuss: add black background to inset call participant cards

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -13,7 +13,7 @@
                 >
                     <CallParticipantCard t-foreach="visibleMainCards" t-as="cardData" t-key="cardData.key"
                         cardData="cardData"
-                        className="'o-discuss-Call-mainCardStyle'"
+                        className="'o-discuss-Call-mainCardStyle p-1'"
                         minimized="minimized"
                         thread="props.thread"
                     />
@@ -36,14 +36,14 @@
             <div t-if="state.sidebar and props.thread.activeRtcSession" class="o-discuss-Call-sidebar d-flex align-items-center h-100 flex-column">
                 <CallParticipantCard t-foreach="visibleCards" t-as="cardData" t-key="cardData.key"
                     cardData="cardData"
-                    className="'o-discuss-Call-sidebarCard w-100'"
+                    className="'o-discuss-Call-sidebarCard w-100 p-1'"
                     thread="props.thread"
                 />
             </div>
             <CallParticipantCard
                 t-if="props.thread.videoCount > 0 and state.insetCard"
                 cardData="state.insetCard"
-                className="'o-discuss-Call-mainCardStyle'"
+                className="'o-discuss-Call-mainCardStyle o-bg-black'"
                 thread="props.thread"
                 inset.bind="setInset"
             />

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallParticipantCard">
-        <div class="o-discuss-CallParticipantCard position-relative cursor-pointer d-flex flex-column align-items-center justify-content-center mh-100 mw-100 p-1 rounded-1"
+        <div class="o-discuss-CallParticipantCard position-relative cursor-pointer d-flex flex-column align-items-center justify-content-center mh-100 mw-100 rounded-1"
             t-att-class="{
                 'o-isTalking': !props.minimized and isTalking,
                 'o-isInvitation opacity-50': !rtcSession,


### PR DESCRIPTION
Before this commit, inset call participant cards had no background, which would let some elements of the UI from below it to show when the video does not have a 16:9 aspect ratio.

Before (inset card mask is transparent)
<img width="198" alt="Screenshot 2025-02-19 at 15 58 56" src="https://github.com/user-attachments/assets/358a072d-d949-4e81-9ef7-7b09c2dd5c56" />

After (inset card mask is filled)
<img width="189" alt="Screenshot 2025-02-19 at 15 59 34" src="https://github.com/user-attachments/assets/df32dbc8-d042-4802-a9b4-2f3d93e97963" />
