### PR TITLE
[FIX] pos_restaurant: prevent unsyncing of split orders in tests

### DIFF
--- a/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
@@ -43,3 +43,10 @@ export function endTour() {
 export function createFloatingOrder() {
     return { trigger: ".pos-topheader .list-plus-btn", run: "click" };
 }
+
+export function isSynced() {
+    return {
+        content: "Check if the request is proceeded",
+        trigger: ".oe_status .fa-wifi",
+    };
+}

--- a/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
@@ -67,6 +67,7 @@ registry.category("web_tour.tours").add("SplitBillScreenTour2", {
             ProductScreen.addOrderline("Coca-Cola", "1", "2.0"),
             ProductScreen.back(),
             FloorScreen.clickTable("2"),
+            Chrome.isSynced(),
             ProductScreen.clickControlButtonMore(),
             ProductScreen.clickControlButton("Split"),
 


### PR DESCRIPTION
Issue:
========
In `SplitBillScreenTour2`, navigating back and forth between **FloorScreen** and **ProductScreen** triggered a `SyncAllOrders` call.
Immediately after,  another `SyncAllOrders` call was sent from `createSplittedOrder`.

Since the first request was still in progress, the second request sometimes sent only one order to the backend.
This caused the original order to be filtered out from `syncingOrders`, leading to inconsistencies.

Fix:
=======
Step were added to check that the request is processed.

**Runbot Error**: 114938

