### PR TITLE
[IMP] hw_drivers: show IoT box status via LED

### DIFF
--- a/addons/hw_drivers/__init__.py
+++ b/addons/hw_drivers/__init__.py
@@ -11,3 +11,4 @@ from . import http
 from . import interface
 from . import main
 from . import websocket_client
+from . import led_manager_L

--- a/addons/hw_drivers/led_manager_L.py
+++ b/addons/hw_drivers/led_manager_L.py
@@ -1,0 +1,72 @@
+import platform
+import subprocess
+import time
+from threading import Thread, Timer
+from odoo.addons.hw_drivers.tools import helpers, wifi
+
+STATUS_UPDATE_DELAY_SECONDS = 10.0
+BLINK_DELAY_SECONDS = 1.0
+
+class LedManager(Thread):
+    daemon = True
+
+    def __init__(self):
+        super().__init__()
+        self.green_led_on = None
+        self.red_led_on = None
+        self.blinking = False
+
+    def run(self):
+        self._disable_led_triggers()
+
+        while True:
+            if wifi.is_access_point() or not helpers.get_ip():
+                # RED if there is no internet
+                self._set_leds("red")
+            elif helpers.get_odoo_server_url():
+                # GREEN if there is internet and connected to DB
+                self._set_leds("green")
+            else:
+                # BLINKING GREEN there is internet but not yet paired
+                self._set_leds("blinking")
+            time.sleep(STATUS_UPDATE_DELAY_SECONDS)
+
+    def _disable_led_triggers(self):
+        subprocess.run(["sudo", "tee", "/sys/class/leds/ACT/trigger"], input="none", text=True)
+        subprocess.run(["sudo", "tee", "/sys/class/leds/PWR/trigger"], input="none", text=True)
+
+    def _set_green_led(self, value):
+        if self.green_led_on == value:
+            return
+        self.green_led_on = value
+        if helpers.raspberry_pi_model == 5:
+            # 'ACT' LED is inverted on Raspberry Pi 5
+            value = not value
+        subprocess.run(["sudo", "tee", "/sys/class/leds/ACT/brightness"], input="1" if value else "0", text=True)
+
+    def _set_red_led(self, value):
+        if self.red_led_on == value:
+            return
+        self.red_led_on = value
+        subprocess.run(["sudo", "tee", "/sys/class/leds/PWR/brightness"], input="1" if value else "0", text=True)
+
+    def _blink_green_led(self):
+        if not self.blinking:
+            return
+        self._set_green_led(not self.green_led_on)
+        Timer(BLINK_DELAY_SECONDS, self._blink_green_led).start()
+
+    def _set_leds(self, value):
+        self._set_red_led(value == "red")
+        if value == "blinking":
+            if not self.blinking:
+                self.blinking = True
+                self._blink_green_led()
+        else:
+            self.blinking = False
+            self._set_green_led(value == "green")
+
+
+if platform.system() == 'Linux':
+    led_manager = LedManager()
+    led_manager.start()

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -15,6 +15,7 @@ from OpenSSL import crypto
 import os
 from pathlib import Path
 import platform
+import re
 import requests
 import secrets
 import socket
@@ -702,3 +703,19 @@ def reset_log_level():
             'log_handler': ':WARNING',
             'log_level': 'warn',
         })
+
+
+def _get_raspberry_pi_model():
+    """Returns the Raspberry Pi model number (e.g. 4) as an integer
+    Returns 0 if the model can't be determined, or -1 if called on Windows
+
+    :rtype: int
+    """
+    if platform.system() == 'Windows':
+        return -1
+    with open('/proc/device-tree/model', 'r', encoding='utf-8') as model_file:
+        match = re.search(r'Pi (\d)', model_file.read())
+        return int(match[1]) if match else 0
+
+
+raspberry_pi_model = _get_raspberry_pi_model()


### PR DESCRIPTION
In the past, there was an `led_status.sh` service
that would turn on the status LED on the Pi as
long as the Odoo service was running. This was
removed in 9f5e558 due to it no longer working on
newer versions of the OS and causing errors during checkout.

This commit restores LED status functionality via
Python instead of a bash script, and can show more information:
- LED green -> Connected to internet and Odoo DB
- LED blinking green -> Connected to internet, waiting for DB
- LED red -> No internet connection

task-4589270

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
