### PR TITLE
[FIX] mrp: add confirmation on cancel

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -45,7 +45,7 @@
                     <header>
                         <button name="button_plan" type="object" string="Plan"/>
                         <button name="action_assign"  type="object" string="Check availability"/>
-                        <button name="action_cancel" type="object" string="Cancel"/>
+                        <button name="action_cancel" type="object" string="Cancel" confirm="Are you sure you want to cancel these manufacturing orders?"/>
                     </header>
                     <field name="company_id" column_invisible="True"/>
                     <field name="priority" optional="show" widget="priority" nolabel="1"/>


### PR DESCRIPTION
It's not possible to reset to draft a canceled MO. Until it's possible we add a confirm dialog before cancel

opw-4294693

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
