### PR TITLE
[IMP] point_of_sale: customer display configuration

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -177,6 +177,7 @@
             'point_of_sale/static/src/**/*',
             ('remove', 'point_of_sale/static/src/backend/**/*'),
             ('remove', 'point_of_sale/static/src/customer_display/**/*'),
+            'point_of_sale/static/src/customer_display/utils.js',
             # main.js boots the pos app, it is only included in the prod bundle as tests mount the app themselves
             ('remove', 'point_of_sale/static/src/app/main.js'),
             ("include", "point_of_sale.base_tests"),

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -812,7 +812,7 @@ class PosConfig(models.Model):
             'type': self.customer_display_type,
             'has_bg_img': bool(self.customer_display_bg_img),
             'company_id': self.company_id.id,
-            **({'proxy_ip': self._get_display_device_ip()} if self.customer_display_type == 'proxy' else {}),
+            **({'proxy_ip': self._get_display_device_ip()} if self.customer_display_type == 'proxy' or self.iface_display_id else {}),
         }
 
     @api.model

--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -15,12 +15,12 @@ import { isBarcodeScannerSupported } from "@web/core/barcode/barcode_video_scann
 import { barcodeService } from "@barcodes/barcode_service";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
-import { deduceUrl } from "@point_of_sale/utils";
 import { user } from "@web/core/user";
 import { OrderTabs } from "@point_of_sale/app/components/order_tabs/order_tabs";
 import { PresetSlotsPopup } from "@point_of_sale/app/components/popups/preset_slots_popup/preset_slots_popup";
 import { makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
 import { _t } from "@web/core/l10n/translation";
+import { openCustomerDisplay } from "@point_of_sale/customer_display/utils";
 
 const { DateTime } = luxon;
 
@@ -136,34 +136,15 @@ export class Navbar extends Component {
                 "newWindow",
                 "width=800,height=600,left=200,top=200"
             );
-            this.notification.add("Connected");
+            this.notification.add(_t("PoS Customer Display opened in a new window"));
         }
         if (this.pos.config.customer_display_type === "remote") {
-            this.notification.add("Navigate to your POS Customer Display on the other computer");
+            this.notification.add(_t("Navigate to your PoS Customer Display on the other computer"));
         }
-        if (this.pos.config.customer_display_type === "proxy") {
-            this.notification.add("Connecting to the IoT Box");
-            const proxyIP = this.pos.getDisplayDeviceIP();
-            fetch(`${deduceUrl(proxyIP)}/hw_proxy/customer_facing_display`, {
-                method: "POST",
-                headers: {
-                    Accept: "application/json",
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    params: {
-                        action: "open",
-                        access_token: this.pos.config.access_token,
-                        pos_id: this.pos.config.id,
-                    },
-                }),
-            })
-                .then(() => {
-                    this.notification.add("Connection successful", { type: "success" });
-                })
-                .catch(() => {
-                    this.notification.add("Connection failed", { type: "danger" });
-                });
+        if (this.pos.config.iface_display_id) {
+            openCustomerDisplay(
+                this.pos.getDisplayDeviceIP(), this.pos.config.access_token, this.pos.config.id, this.notification,
+            );
         }
     }
 

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -38,6 +38,7 @@ import { unaccent } from "@web/core/utils/strings";
 import { WithLazyGetterTrap } from "@point_of_sale/lazy_getter";
 import { debounce } from "@web/core/utils/timing";
 import DevicesSynchronisation from "../utils/devices_synchronisation";
+import { openCustomerDisplay } from "@point_of_sale/customer_display/utils";
 
 const { DateTime } = luxon;
 
@@ -547,6 +548,7 @@ export class PosStore extends WithLazyGetterTrap {
 
         await this.deviceSync.readDataFromServer();
         this.markReady();
+        openCustomerDisplay(this.getDisplayDeviceIP(), this.config.access_token, this.config.id);
         this.showScreen(this.firstScreen);
     }
 

--- a/addons/point_of_sale/static/src/customer_display/customer_display_adapter.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display_adapter.js
@@ -29,7 +29,7 @@ export class CustomerDisplayPosAdapter {
             ]);
         }
 
-        if (pos.config.customer_display_type === "proxy") {
+        if (pos.config.iface_display_id) {
             const proxyIP = pos.getDisplayDeviceIP();
             fetch(`${deduceUrl(proxyIP)}/hw_proxy/customer_facing_display`, {
                 method: "POST",

--- a/addons/point_of_sale/static/src/customer_display/customer_display_data_service.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display_data_service.js
@@ -21,7 +21,7 @@ export const CustomerDisplayDataService = {
                 }
             );
         }
-        if (session.type === "proxy") {
+        if (session.iface_display_id) {
             const intervalId = setInterval(async () => {
                 try {
                     const response = await fetch(

--- a/addons/point_of_sale/static/src/customer_display/utils.js
+++ b/addons/point_of_sale/static/src/customer_display/utils.js
@@ -1,0 +1,27 @@
+import { deduceUrl } from "@point_of_sale/utils";
+import { _t } from "@web/core/l10n/translation";
+
+
+export function openCustomerDisplay(displayDeviceIp, accessToken, configId, notificationService = undefined) {
+    notificationService?.add(_t("Connecting to the IoT Box"));
+    fetch(`${deduceUrl(displayDeviceIp)}/hw_proxy/customer_facing_display`, {
+        method: "POST",
+        headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            params: {
+                action: "open",
+                access_token: accessToken,
+                pos_id: configId,
+            },
+        }),
+    })
+        .then(() => {
+            notificationService?.add(_t("Connection successful"), { type: "success" });
+        })
+        .catch(() => {
+            notificationService?.add(_t("Connection failed"), { type: "danger" });
+        });
+}


### PR DESCRIPTION
To configure the RPI display as customer display we needed to:

**Before this commit:**

- Go to configuration,
- Check "IoT Box" checkbox,
- Select a display,
- Go to "Configuration -> Settings",
- Scroll until "Customer Display" then select "An IoT-connected system.

**After this commit:**

- Go to configuration,
- Check "IoT Box" checkbox,
- Select a display.

**Note:** the "Customer Display" setting is now only used for a second display. That means that customer display can now be opened on both an IoT Display and a new window.

Task: 4585446