### PR TITLE
[FIX] tools: make pdf signature avid crash in 3.10

### DIFF
--- a/odoo/tools/pdf/signature.py
+++ b/odoo/tools/pdf/signature.py
@@ -12,7 +12,7 @@ try:
     from cryptography.hazmat.primitives.serialization import Encoding, load_pem_private_key
     from cryptography.hazmat.primitives.asymmetric import padding
     from cryptography.x509 import Certificate, load_pem_x509_certificate
-except ModuleNotFoundError:
+except ImportError:
     # cryptography 41.0.7 and above is supported
     hashes = None
     PrivateKeyTypes = None
@@ -45,7 +45,7 @@ class PdfSigner:
     def __init__(self, stream: io.BytesIO, company: Optional[ResCompany] = None) -> None:
         self.company = company
         if not 'clone_document_from_reader' in dir(PdfWriter):
-            _logger.warning("PDF signature is supported by Python 3.12 and above")
+            _logger.info("PDF signature is supported by Python 3.12 and above")
             return
         reader = PdfReader(stream)
         self.writer = PdfWriter()


### PR DESCRIPTION
Before this commit, when signature.py is called in python 3.10, the following error is observed. ModuleNotFoundError is catched but an ImportError is raised. In that case, the signature feature is disabled.

File "/home/odoo/src/odoo/saas-18.2/odoo/tools/pdf/signature.py", line 11, in <module>
    from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
ImportError: cannot import name 'PrivateKeyTypes' from 'cryptography.hazmat.primitives.asymmetric.types' (/home/odoo/.local/lib/python3.10/site-packages/cryptography/hazmat/primitives/asymmetric/types.py) 2025-02-19 13:38:20,377 288857 INFO test_18.1_18.2 odoo.service.server: Initiating shutdown



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
