### PR TITLE
[REF] web: remove unused form's styles and function

### DIFF
--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.js
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.js
@@ -281,20 +281,6 @@ export class StatusBarField extends Component {
         return classNames.join(" ");
     }
 
-    /**
-     * @param {StatusBarItem} item
-     * TODO: unused, remove in master
-     */
-    getItemAriaLabel(item) {
-        if (item.isSelected) {
-            return _t("Current state is %s", item.label);
-        }
-        if (this.props.isDisabled) {
-            return _t("Unselected state is %s", item.label);
-        }
-        return _t("Not active state, click to change it to %s", item.label);
-    }
-
     getSortedItems() {
         const before = [];
         const after = [];

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -61,15 +61,6 @@
     }
 
     // Utility classes
-    .oe_form_box_info {
-        @include o-webclient-padding($top: 5px, $bottom: 5px);
-        > p {
-            margin: auto;
-        }
-    }
-    .oe_text_center {
-        text-align: center;
-    }
     .oe_inline, .o_field_widget.oe_inline > * {
         width: auto!important;
     }
@@ -318,21 +309,6 @@
             &:not(.modal .o_form_statusbar) {
                 background-color: $body-bg;
                 box-shadow: 0 0.3rem 0.25rem -0.25rem rgba(0, 0, 0, 0.075);
-            }
-        }
-
-        > .o_statusbar_status {
-            display: flex;
-            align-items: center;
-            align-content: space-around;
-
-            > .o_arrow_button {
-                font-weight: $font-weight-bold;
-
-                // Last element at the right should respect overall padding
-                &:first-of-type {
-                    padding-right: $o-horizontal-padding;
-                }
             }
         }
 


### PR DESCRIPTION
The selector `.o_form_statusbar > .o_statusbar_status` doesn't match any elements: `.o_statusbar_status` isn't a *direct* descending child.

`getItemAriaLabel()` is marked as deprecated and unused.

`.oe_text_center` and `.oe_form_box_info` are unused.
