### PR TITLE
[FIX] l10n_dk_audit_trail: audit trail checked

### DIFF
--- a/addons/l10n_dk/models/template_dk.py
+++ b/addons/l10n_dk/models/template_dk.py
@@ -32,6 +32,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_journal_early_pay_discount_gain_account_id': 'dk_coa_2720',
                 'account_sale_tax_id': 'tax_s1',
                 'account_purchase_tax_id': 'tax_k1',
+                'check_account_audit_trail': True,
             },
         }
 

--- a/addons/l10n_dk_audit_trail/__manifest__.py
+++ b/addons/l10n_dk_audit_trail/__manifest__.py
@@ -11,6 +11,6 @@ This module is a bridge to be able to have audit trail module with Denmark
         'account_audit_trail'
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': ['l10n_dk'],
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
When installing l10n_dk_audit_trail module, the audit trail option wasn't checked by default

task-4575368




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
