### PR TITLE
[REM] web: accept only function for action macro

### DIFF
--- a/addons/web/static/src/core/macro.js
+++ b/addons/web/static/src/core/macro.js
@@ -29,25 +29,6 @@ const macroSchema = {
     onError: { type: Function, optional: true },
 };
 
-export const ACTION_HELPERS = {
-    click(el, _step) {
-        el.dispatchEvent(new MouseEvent("mouseover"));
-        el.dispatchEvent(new MouseEvent("mouseenter"));
-        el.dispatchEvent(new MouseEvent("mousedown"));
-        el.dispatchEvent(new MouseEvent("mouseup"));
-        el.click();
-        el.dispatchEvent(new MouseEvent("mouseout"));
-        el.dispatchEvent(new MouseEvent("mouseleave"));
-    },
-    text(el, step) {
-        // simulate an input (probably need to add keydown/keyup events)
-        this.click(el, step);
-        el.value = step.value;
-        el.dispatchEvent(new InputEvent("input", { bubbles: true }));
-        el.dispatchEvent(new InputEvent("change", { bubbles: true }));
-    },
-};
-
 const mutex = new Mutex();
 
 class MacroError extends Error {
@@ -116,7 +97,7 @@ export class Macro {
         if (proceedToAction) {
             this.onStep(this.currentElement, this.currentStep, this.currentIndex);
             this.clearTimer();
-            const actionResult = await this.performAction();
+            const actionResult = await this.stepAction(this.currentElement);
             if (!actionResult) {
                 // If falsy action result, it means the action worked properly.
                 // So we can proceed to the next step.
@@ -158,17 +139,15 @@ export class Macro {
     }
 
     /**
-     * Calls the `step.action` expecting no return to be successful.
+     * Must not return anything for macro to continue.
      */
-    async performAction() {
-        let actionResult;
+    async stepAction(element) {
+        const { action } = this.currentStep;
+        if (this.isComplete || !action) {
+            return;
+        }
         try {
-            const action = this.currentStep.action;
-            if (action in ACTION_HELPERS) {
-                actionResult = ACTION_HELPERS[action](this.currentElement, this.currentStep);
-            } else if (typeof action === "function") {
-                actionResult = await action(this.currentElement);
-            }
+            return await action(element);
         } catch (error) {
             this.stop(
                 new MacroError("Action", `ERROR during perform action:\n${error.message}`, {
@@ -176,7 +155,6 @@ export class Macro {
                 })
             );
         }
-        return actionResult;
     }
 
     get currentStep() {

--- a/addons/web/static/tests/core/macro.test.js
+++ b/addons/web/static/tests/core/macro.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { queryOne } from "@odoo/hoot-dom";
+import { click, edit, queryOne } from "@odoo/hoot-dom";
 import { advanceTime, animationFrame } from "@odoo/hoot-mock";
 import { Component, useState, xml } from "@odoo/owl";
 import { mountWithCleanup } from "@web/../tests/web_test_helpers";
@@ -36,7 +36,9 @@ test("simple use", async () => {
         steps: [
             {
                 trigger: "button.inc",
-                action: "click",
+                async action(trigger) {
+                    await click(trigger);
+                },
             },
         ],
     }).start(queryOne(".counter"));
@@ -57,16 +59,18 @@ test("multiple steps", async () => {
         steps: [
             {
                 trigger: "button.inc",
-                action: "click",
-            },
-            {
-                trigger: () => {
-                    return span.textContent === "1" ? span : null;
+                async action(trigger) {
+                    await click(trigger);
                 },
             },
             {
+                trigger: () => (span.textContent === "1" ? span : null),
+            },
+            {
                 trigger: "button.inc",
-                action: "click",
+                async action(trigger) {
+                    await click(trigger);
+                },
             },
         ],
     }).start(queryOne(".counter"));
@@ -105,8 +109,10 @@ test("can input values", async () => {
         steps: [
             {
                 trigger: "div.counter input",
-                action: "text",
-                value: "aaron",
+                async action(trigger) {
+                    await click(trigger);
+                    await edit("aaron", { confirm: "blur" });
+                },
             },
         ],
     }).start(queryOne(".counter"));
@@ -125,8 +131,10 @@ test("a step can have no trigger", async () => {
             { action: () => expect.step("2") },
             {
                 trigger: "div.counter input",
-                action: "text",
-                value: "aaron",
+                async action(trigger) {
+                    await click(trigger);
+                    await edit("aaron", { confirm: "blur" });
+                },
             },
             { action: () => expect.step("3") },
         ],
@@ -158,7 +166,9 @@ test("onStep function is called at each step", async () => {
             },
             {
                 trigger: "button.inc",
-                action: "click",
+                async action(trigger) {
+                    await click(trigger);
+                },
             },
         ],
     }).start(queryOne(".counter"));
@@ -177,7 +187,9 @@ test("trigger can be a function returning an htmlelement", async () => {
         steps: [
             {
                 trigger: () => queryOne("button.inc"),
-                action: "click",
+                async action(trigger) {
+                    await click(trigger);
+                },
             },
         ],
     }).start(queryOne(".counter"));
@@ -190,6 +202,7 @@ test("macro does not click on invisible element", async () => {
     await mountWithCleanup(TestComponent);
     const span = queryOne("span.value");
     const button = queryOne("button.inc");
+    button.classList.add("d-none");
     expect(span).toHaveText("0");
 
     new Macro({
@@ -197,11 +210,12 @@ test("macro does not click on invisible element", async () => {
         steps: [
             {
                 trigger: "button.inc",
-                action: "click",
+                async action(trigger) {
+                    await click(trigger);
+                },
             },
         ],
     }).start(queryOne(".counter"));
-    button.classList.add("d-none");
     await animationFrame(); // let mutation observer trigger
     await advanceTime(100);
     expect(span).toHaveText("0");


### PR DESCRIPTION
In order to simplify the macro.js API, the action of a step must be a function. The action can then call (Hoot or others) events to interact with the trigger. In any case, it is not useful to have ACTION_HELPERS in macro.js which are only used in very rare cases in the codebase.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
