### PR TITLE
[FIX] mail: not overlapping with document button

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -1,10 +1,7 @@
 .o-mail-ChatWindow {
     width: $o-mail-ChatWindow-width;
 
-    z-index: 999; // messaging menu is dropdown (1000)
-    &.o-mobile {
-        z-index: 1001; // above messaging menu (chat window takes whole screen)
-    }
+    z-index: $zindex-dropdown + 1;
     &:not(.o-mobile) {
         --border-opacity: .15;
         aspect-ratio: 9 / 15;


### PR DESCRIPTION
When the chat windows overlap the document action buttons, the buttons are floating on top of the chatwindow.

This happens because chat window was lower than document actions, which uses `$zindex-dropdown` (`z-index: 1000`).

This commit fixes the issue by putting chat window above `$zindex-dropdown`.

before/after:
![image](https://github.com/user-attachments/assets/09f949b6-7bb2-4349-a6f2-1f9c542ba24d)
![image](https://github.com/user-attachments/assets/14c905ae-6319-4d1e-8ac0-f6d945a746ba)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
