### PR TITLE
[FIX] point_of_sale: ensure product names start from the beginning in…

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
@@ -16,6 +16,7 @@
             </div>
             <div class="product-content d-flex flex-row px-2 justify-content-between rounded-bottom rounded-3 flex-shrink-1" t-att-class="{'h-100' : !props.imageUrl}">
                 <div class="overflow-hidden lh-sm product-name my-2"
+                    style="align-items: normal !important;"
                     t-att-class="{'no-image d-flex justify-content-center align-items-center text-center fs-4': !props.imageUrl}"
                     t-attf-id="article_product_{{props.productId}}"
                     t-esc="props.name" />


### PR DESCRIPTION
… search results

**Issue:**
When performing a search in the PoS search bar, products with long names are displayed in a way that hides the beginning of the name, making it difficult to identify them.

**Steps to Reproduce:**
1. Install the Point of Sales app
2. Navigate to Point of Sales > Products
3. Create a product with a name longer than six lines
4. Open the register
5. Search for the product on the search bar
6. Observe that the product name is truncated at the beginning.

Expected Behavior: The product name should always be displayed from the beginning, even when searched in the PoS search bar

Actual Behavior: When searched, the product name is cut off at the beginning, making it difficult to read

**Root Cause**

The issue occurs because align-items: center !important; is applied to a higher-level class. While this alignment works well for buttons with short names, it causes unintended truncation for product cards with long names.

**Fix**
The align-items property is explicitly overridden in the product name’s \<div\> to ensure that only the product name is affected, preventing unwanted truncation.

Opw-4561019

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
