### PR TITLE
[FIX] pos_restaurant: prevent blank screen when canceling an order

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.ActionpadWidget">
-        <div class="actionpad d-flex flex-column gap-2">
+        <div class="actionpad d-flex flex-column gap-2" t-if="currentOrder">
             <div t-if="ui.isSmall" class="d-flex gap-2">
                 <BackButton t-if="!props.showActionButton and pos.showBackButton()" onClick="() => pos.onClickBackButton()"/>
                 <SelectPartnerButton partner="props.partner"/>


### PR DESCRIPTION
Issue: A blank screen appears after canceling an order.

Steps to reproduce:

- Open a POS restaurant on **Community**
- Select a table
- Order some food
- Reopen the order
- Cancel the order

runbot Error:  113288
