### PR TITLE
[REV] resource: revert duration days of working schedules

### DIFF
--- a/addons/resource/models/resource_calendar_attendance.py
+++ b/addons/resource/models/resource_calendar_attendance.py
@@ -73,7 +73,7 @@ class ResourceCalendarAttendance(models.Model):
         for attendance in self:
             attendance.duration_hours = (attendance.hour_to - attendance.hour_from) if attendance.day_period != 'lunch' else 0
 
-    @api.depends('day_period', 'duration_hours', 'calendar_id.hours_per_day')
+    @api.depends('day_period', 'duration_hours')
     def _compute_duration_days(self):
         for attendance in self:
             if attendance.day_period == 'lunch':


### PR DESCRIPTION
Revert of commit ca1fa38815070325e3b998efcc0ec0d663b2f3b8 

The fix introduced the impossibility of manually editing the duration days of attendances due to a depends cycle.
The duration days of attendance should be manually editable.
