### PR TITLE
[FIX] l10n_in: Limit GSTN check to single state

### DIFF
--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -42,7 +42,7 @@ class ResPartner(models.Model):
                         "As per GSTN the country should be other than India, so it's recommended to"
                     )
                 else:
-                    state_id = self.env['res.country.state'].search([('l10n_in_tin', '=', partner.vat[:2])])
+                    state_id = self.env['res.country.state'].search([('l10n_in_tin', '=', partner.vat[:2])], limit=1)
                     if state_id and state_id != partner.state_id:
                         partner.l10n_in_gst_state_warning = _(
                             "As per GSTN the state should be %s, so it's recommended to", state_id.name


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

When computing l10n_in's `res_partner.l10n_in_gst_state_warning` field, we [search](https://github.com/odoo/odoo/blob/f1fb0527f1b29e4b464e13718d6d0edb3b32a114/addons/l10n_in/models/res_partner.py#L45) for a res_country_state whose `l10n_in_tin` is the same as the one encoded in the partner's `vat`; if none is found we warn the user.

Since the res_country_state's [`l10n_in_tin`](https://github.com/odoo/odoo/blob/f1fb0527f1b29e4b464e13718d6d0edb3b32a114/addons/l10n_in/models/res_country_state.py#L10) is not unique though, it is legal for the customer to have multiple res.country.state entries with the same l10n_in_tin (typically one standard plus one custom state):
```sql
> SELECT ARRAY_AGG(id),ARRAY_AGG(country_id),ARRAY_AGG(name),ARRAY_AGG(code),l10n_in_tin FROM res_country_state WHERE l10n_in_tin IS NOT NULL GROUP BY l10n_in_tin HAVING COUNT(*)>1
+-------------+------------+------------------------+--------------+-------------+
| array_agg   | array_agg  | array_agg              | array_agg    | l10n_in_tin |
|-------------+------------+------------------------+--------------+-------------|
| [1741, 589] | [104, 104] | ['HARYANA', 'Haryana'] | ['06', 'HR'] | 06          |
+-------------+------------+------------------------+--------------+-------------+
```

If our search passes more than one results to `state_id.name` though, Odoo fails with a ValueError:
```
 Traceback (most recent call last):
   File "/tmp/tmpdugmps2c/migrations/base/tests/test_mock_crawl.py", line 256, in crawl_menu
    self.mock_action(action_vals)
   File "/tmp/tmpdugmps2c/migrations/base/tests/test_mock_crawl.py", line 269, in mock_action
    return self.mock_act_window(action)
   File "/tmp/tmpdugmps2c/migrations/base/tests/test_mock_crawl.py", line 429, in mock_act_window
    mock_method(model, view, fields_list, domain, group_by)
   File "/tmp/tmpdugmps2c/migrations/base/tests/test_mock_crawl.py", line 457, in mock_view_form
    [data] = record.read(fields_list)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 3801, in read
    return self._read_format(fnames=fields, load=load)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 4032, in _read_format
    vals[name] = convert(record[name], record, use_display_name)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 6999, in __getitem__
    return self._fields[key].__get__(self)
   File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 1291, in __get__
    self.compute_value(recs)
   File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 1473, in compute_value
    records._compute_field_value(self)
   File "/home/odoo/src/odoo/18.0/addons/mail/models/mail_thread.py", line 429, in _compute_field_value
    return super()._compute_field_value(field)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 5238, in _compute_field_value
    fields.determine(field.compute, self)
   File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 113, in determine
    return needle(records, *args)
   File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 710, in _compute_related
    record[self.name] = self._process_related(value[self.related_field.name], record.env)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 6999, in __getitem__
    return self._fields[key].__get__(self)
   File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 1291, in __get__
    self.compute_value(recs)
   File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 1473, in compute_value
    records._compute_field_value(self)
   File "/home/odoo/src/odoo/18.0/addons/mail/models/mail_thread.py", line 429, in _compute_field_value
    return super()._compute_field_value(field)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 5238, in _compute_field_value
    fields.determine(field.compute, self)
   File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 110, in determine
    return needle(*args)
   File "/home/odoo/src/odoo/18.0/addons/l10n_in/models/res_partner.py", line 48, in _compute_l10n_in_gst_state_warning
    "As per GSTN the state should be %s, so it's recommended to", state_id.name
   File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 1232, in __get__
    record.ensure_one()
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 6212, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
 ValueError: Expected singleton: res.country.state(1741, 589)
```


**Desired behavior after PR is merged:**
We can avoid this by explicitly limiting the search to a single result.

TBG: https://upgrade.odoo.com/web#cids=1&menu_id=107&action=178&model=upgrade.request.traceback.group&view_type=form&id=1804


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
