### PR TITLE
[FIX] google_account: change Warning to UserError

### DIFF
--- a/addons/google_account/controllers/main.py
+++ b/addons/google_account/controllers/main.py
@@ -6,6 +6,7 @@ from werkzeug.exceptions import BadRequest
 
 from odoo import http
 from odoo.http import request
+from odoo.exceptions import UserError
 
 
 class GoogleAuth(http.Controller):
@@ -30,7 +31,7 @@ class GoogleAuth(http.Controller):
             if service_field in request.env.user:
                 request.env.user[service_field]._set_auth_tokens(access_token, refresh_token, ttl)
             else:
-                raise Warning('No callback field for service <%s>' % service)
+                raise UserError('No callback field for service <%s>' % service)
             return request.redirect(url_return)
         elif kw.get('error'):
             return request.redirect("%s%s%s" % (url_return, "?error=", kw['error']))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Warning is deprecated and it should be replaced by UserError.

Current behavior before PR:
Running code that uses `google_account` generates warning.

Desired behavior after PR is merged:
No more warning should be shown in the logs.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
