### PR TITLE
[FIX] mail: only avatar stack on folded call participant in sidebar

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -32,10 +32,11 @@
                 direction="compact ? 'v' : 'h'"
                 avatarClass="(p) => this.avatarClass(p)"
                 max="compact ? 1 : 4"
+                overlap="compact ? false : undefined"
                 personas="sessions.map((s) => s.channel_member_id?.persona).filter(p => p)"
             >
                 <t t-set-slot="avatarExtraInfo" t-slot-scope="scope">
-                    <div class="o-mail-DiscussSidebarCallParticipants-status small" t-att-class="{
+                    <div t-if="compact" class="o-mail-DiscussSidebarCallParticipants-status small" t-att-class="{
                         'position-absolute bg-inherit p-0 rounded-circle o-compact d-flex o-xsmaller text-start': compact,
                         'ms-1 d-flex align-items-center justify-content-center': !compact,
                     }">

--- a/addons/mail/static/src/discuss/core/common/avatar_stack.js
+++ b/addons/mail/static/src/discuss/core/common/avatar_stack.js
@@ -18,6 +18,7 @@ export class AvatarStack extends Component {
         direction: { type: String, optional: true, validate: (d) => ["v", "h"].includes(d) },
         avatarClass: { type: Function, optional: true },
         max: { type: Number, optional: true },
+        overlap: { type: Boolean, optional: true },
         personas: Array,
         size: { type: Number, optional: true },
         slots: { optional: true },
@@ -27,6 +28,7 @@ export class AvatarStack extends Component {
         max: 4,
         size: 24,
         direction: "h",
+        overlap: true,
     };
 
     getStyle(index) {
@@ -36,7 +38,9 @@ export class AvatarStack extends Component {
         }
         // Compute cumulative offset,
         const marginDirection = this.props.direction === "v" ? "top" : "left";
-        style += `margin-${marginDirection}: -${this.props.size / 3}px`;
+        style += `margin-${marginDirection}: ${
+            ((this.props.overlap ? -1 : 1) * this.props.size) / 3
+        }px`;
         return style;
     }
 }


### PR DESCRIPTION
Before this commit, when there's a call in a discuss conversation with many participants and the participants in sidebar are folded as an avatar stack, their short status (e.g. mute, deafen) were shown below avatar too.

This is a problem because the avatar stack is so compact that there's no room to show the short status. This looks quite off.

This commit fixes the issue by removing the short status in the avatar stack. To see the call status of participant, we can easily see it by expanding the call participants.

When the discuss sidebar is compact, however, it always show a single call participant (= most recently active participant). There's room to show the short status, so it's shown there to help see whether the most recent participant starts screen-sharing or becomes mute/deaf.

Before / After
<img width="294" alt="Screenshot 2025-02-19 at 17 41 15" src="https://github.com/user-attachments/assets/a23938ba-0cb8-4bb9-ae38-8f7638ebe5d5" /> <img width="297" alt="Screenshot 2025-02-19 at 17 40 24" src="https://github.com/user-attachments/assets/ee545083-dbde-44f3-ba64-95c4d6a8a536" />

-------

This commit also fixes a small issue with the position of "+X" in the avatar stack when sidebar is compact: the "+X" being at the very top and overlapping avatars make sense when the avatar stack is a preview of avatars and the number is more important in this view than the avatars. This is the case in non-compact sidebar mode, as we can easily expand the call participants.

In compact mode, however, the active participant is as important if not more than/as the counter. Overlapping the visibility of the single avatar is a problem. Putting the counter at the bottom, while better, hides the counter value so it has some drawbacks.

This commit fixes the issue by putting the counter next to avatar in this specific configuration of compact sidebar with call participants.

Before / After
<img width="67" alt="Screenshot 2025-02-19 at 17 41 09" src="https://github.com/user-attachments/assets/f596e896-6b37-4bc8-b4bd-e92539ebaa67" /> <img width="51" alt="Screenshot 2025-02-20 at 11 08 43" src="https://github.com/user-attachments/assets/88f34855-b02c-4653-8621-63563f0731ed" />
