### PR TITLE
[FIX] payment_paypal: fix payment from PoS

### DIFF
--- a/addons/payment_paypal/tests/test_paypal.py
+++ b/addons/payment_paypal/tests/test_paypal.py
@@ -23,6 +23,15 @@ class PaypalTest(PaypalCommon, PaymentHttpCommon):
             processing_values = tx._get_processing_values()
         self.assertEqual(processing_values['order_id'], self.order_id)
 
+    def test_order_payload_values_for_public_user(self):
+        """ If a payment is made with the public user we need to make sure that the
+            email address is not sent to PayPal and that we provide the country code of the company instead."""
+        tx = self._create_transaction(flow='direct', partner_id=self.public_user.id)
+        payload = tx._paypal_prepare_order_payload()
+        customer_payload = payload['payment_source']['paypal']
+        self.assertTrue('email_address' not in customer_payload)
+        self.assertEqual(customer_payload['address']['country_code'], self.company.country_id.code)
+
     @mute_logger('odoo.addons.payment_paypal.controllers.main')
     def test_complete_order_confirms_transaction(self):
         """ Test the processing of a webhook notification. """


### PR DESCRIPTION

When making a payment from the PoS, the user would always be the Public
User. This would cause the payload sent to paypal to be incorrect and
the payment to fail.
This happens because we are trying to make a payment without any user,
so this can be reproduced in other workflows. Like making a donation

Steps to reproduce:
-------------------
* Setup paypal payment provider
* Create a PoS payment method with the paypal provider
* Create a PoS order and pay with the paypal payment method
> Observation: You get an error saying that something is malformed

Alternative steps to reproduce:
--------------------------------
* Make sure you are not connected on Odoo
* Go to the `donation/pay` url
* Fill out the form and make the payment via paypal
> Observation: You get an error saying that something is malformed

Why the fix:
------------
When using the public user, we cannot provide an email address or a
country code. To fix this we make sure to not send the email address at
all when there is none available. And we send the country code of the
company instead of none.

opw-4446219