### PR TITLE
[FIX] Many2one: return False if record value is empty

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3122,8 +3122,10 @@ class Many2one(_Relational):
             except MissingError:
                 # Should not happen, unless the foreign key is missing.
                 return False
-        else:
+        elif value:
             return value.id
+        else:
+            return False
 
     def convert_to_write(self, value, record):
         if type(value) in IdType:


### PR DESCRIPTION
In OCA we develop a module that assigns dynamic attributes to a product. In odoo 16.0 and prevous 14.0 the module is running smoothly with odoo. In this version convert_to_read method is introduced and it deals with use_display_name and value, it assumes value record is always has a value Aluthough use_display_name can be False or value record can be empty. In that case I retun False instead of causing the server to raise error because it assumes value has id and it is just an empty recordset.

Description of the issue/feature this PR addresses:

Current behavior before PR:

========================================================================================

2025-02-19 20:15:58,724 46176 ERROR pim_17_1 odoo.http: Exception during request handling. 
Traceback (most recent call last):
  File "/home/kobros/Workspace/odoo17/odoo/odoo/http.py", line 2206, in __call__
    response = request._serve_db()
               ^^^^^^^^^^^^^^^^^^^
  File "/home/kobros/Workspace/odoo17/odoo/odoo/http.py", line 1782, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kobros/Workspace/odoo17/odoo/odoo/service/model.py", line 133, in retrying
    result = func()
             ^^^^^^
  File "/home/kobros/Workspace/odoo17/odoo/odoo/http.py", line 1809, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kobros/Workspace/odoo17/odoo/odoo/http.py", line 2013, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kobros/Workspace/odoo17/odoo/odoo/addons/base/models/ir_http.py", line 221, in _dispatch
    result = endpoint(**request.params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kobros/Workspace/odoo17/odoo/odoo/http.py", line 757, in route_wrapper
    result = endpoint(self, *args, **params_ok)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kobros/Workspace/odoo17/odoo/addons/web/controllers/dataset.py", line 24, in call_kw
    return self._call_kw(model, method, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kobros/Workspace/odoo17/odoo/addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kobros/Workspace/odoo17/odoo/odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kobros/Workspace/odoo17/odoo/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kobros/Workspace/odoo17/odoo/addons/web/models/models.py", line 86, in web_read
    values_list: List[Dict] = self.read(fields_to_read, load=None)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kobros/Workspace/odoo17/odoo/odoo/models.py", line 3557, in read
    return self._read_format(fnames=fields, load=load)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kobros/Workspace/odoo17/odoo/odoo/models.py", line 3770, in _read_format
    vals[name] = convert(record[name], record, use_display_name)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kobros/Workspace/odoo17/odoo/odoo/fields.py", line 3110, in convert_to_read
    return value.id
           ^^^^^^^^
Attri
buteError: 'mail.thread' object has no attribute 'id'

========================================================================================

Desired behavior after PR is merged:
The method can just retun False if no condition is met.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
