### PR TITLE
[FIX] project: don't replace the stage set by the user on his new project

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -467,11 +467,15 @@ class Project(models.Model):
                 # The project's company_id must be the same as the stage's company_id
                 if stage.company_id:
                     for vals in vals_list:
+                        if vals.get('stage_id'):
+                            continue
                         vals['company_id'] = stage.company_id.id
             else:
                 companies_ids = [vals.get('company_id', False) for vals in vals_list] + [False]
                 stages = self.env['project.project.stage'].search([('company_id', 'in', companies_ids)])
                 for vals in vals_list:
+                    if vals.get('stage_id'):
+                        continue
                     # Pick the stage with the lowest sequence with no company or project's company
                     stage_domain = [False] if 'company_id' not in vals else [False, vals.get('company_id')]
                     stage = stages.filtered(lambda s: s.company_id.id in stage_domain)[:1]

--- a/addons/project/tests/test_project_stage_multicompany.py
+++ b/addons/project/tests/test_project_stage_multicompany.py
@@ -126,3 +126,16 @@ class TestProjectStagesMulticompany(TestMultiCompanyProject):
             'name': 'Project company B',
         })
         self.assertEqual(project.company_id, self.company_b)
+
+    def test_create_project_in_stage(self):
+        """ Test create project inside a specific stage """
+        self.env['res.config.settings'].create({'group_project_stages': True}).execute()
+        stage = self.env['project.project.stage'].create({
+            'name': 'Stage 2',
+            'sequence': 100,
+        })
+        project = self.env['project.project'].create({
+            'name': 'Project in stage 2',
+            'stage_id': stage.id,
+        })
+        self.assertEqual(project.stage_id, stage)


### PR DESCRIPTION
Before this commit, when the user creates a project in the form and select a stage to directly put it in another stage then the first one given as default value. The stage is changed to set again the project in the default stage instead of keeping the choice made by the user.

This commit makes sure the stage chosen by the user is still kept once the project is created.

Steps to reproduce:
------------------
1. Install project
2. Go to Project > Configuration > Settings
3. Enable the Project Stage feature
4. Go to Project > Configuration > Projects
5. Click on new button to create a new project
6. Set the project name and click on the second project stage

Current Behavior:
----------------
The project goes back to the default stage instead of staying in the stage selected by the user.

Expected Behavior:
-----------------
The project should be in the stage selected.
