### PR TITLE
[FIX] pos_restaurant: remove extra step from PosResTicketScreenTour

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -26,7 +26,6 @@ registry.category("web_tour.tours").add("PosResTicketScreenTour", {
             Chrome.clickMenuOption("Orders"),
             TicketScreen.deleteOrder("-0001"),
             Dialog.confirm(),
-            TicketScreen.clickDiscard(),
             Chrome.clickPlanButton(),
             FloorScreen.isShown(),
             FloorScreen.clickTable("5"),


### PR DESCRIPTION
Following this commit:
====
- Extra step was removed.

runbot Error: 114352
