### PR TITLE
[FIX] point_of_sale: add extra step in ReceiptScreenTour

### DIFF
--- a/addons/point_of_sale/static/tests/tours/ReceiptScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ReceiptScreen.tour.js
@@ -52,6 +52,9 @@ registry.category("web_tour.tours").add("ReceiptScreenTour", {
             ReceiptScreen.totalAmountContains("72.0"),
             ReceiptScreen.setEmail("test@receiptscreen.com"),
             ReceiptScreen.clickSend(),
+            {
+                trigger: `.receipt-screen .send .fa-spin`,
+            },
             ReceiptScreen.emailIsSuccessful(),
             ReceiptScreen.clickNextOrder(),
 


### PR DESCRIPTION
Issue
===============
In ReceiptScreenTour, an email is sent as part of a tour step. After clicking the "Send" button, the tour immediately checks for a success notice. However, due to occasional delays (e.g., a loading spinner appears while the email is being sent and Sending in progress notice appers), the success notice may not be available immediately, causing the tour to fail.
This issue occurs occasionally and unpredictably, causing the tour to fail.

Fix
====
Added an extra step in the tour to allow time for the email to be sent before checking for the success notice.

Runbot error-76147,115253,115483

