### PR TITLE
[FIX] loyalty: default product for reward in multi company

### DIFF
--- a/addons/loyalty/models/loyalty_program.py
+++ b/addons/loyalty/models/loyalty_program.py
@@ -188,7 +188,10 @@ class LoyaltyProgram(models.Model):
     def _program_type_default_values(self):
         # All values to change when program_type changes
         # NOTE: any field used in `rule_ids`, `reward_ids` and `communication_plan_ids` MUST be present in the kanban view for it to work properly.
-        first_sale_product = self.env['product.product'].search([('sale_ok', '=', True)], limit=1)
+        first_sale_product = self.env['product.product'].search([
+            '|', ('company_id', '=', False), ('company_id', '=', self.company_id.id),
+            ('sale_ok', '=', True)
+        ], limit=1)
         return {
             'coupons': {
                 'applies_on': 'current',


### PR DESCRIPTION
Steps to reproduce:
-------------------
- being in a multi-company environment;
- have one product made that is first in alphabetical order of "Internal Reference" throughout the database (e.g. [AAA]);
- make this product specific to one of the companies (set the "Company" field on the product template)
- go into a different company within the database (not the one set on this product);
- create a new discount & loyalty record, and set the "Program Type" to "Discount Code".

Issue:
------
An access rights error occurs.

Cause:
------
When creating a `promo_code` program, we use the first product that can be sold in the default reward values.

Solution:
---------
Take into account the company in the domain that retrieves the default product.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
