### PR TITLE
[IMP] payment_worldline: simplify card mapping

### DIFF
--- a/addons/payment_worldline/const.py
+++ b/addons/payment_worldline/const.py
@@ -4,6 +4,11 @@
 DEFAULT_PAYMENT_METHOD_CODES = {
     # Primary payment methods.
     'card',
+    # Brand payment methods.
+    'amex',
+    'discover',
+    'mastercard',
+    'visa',
 }
 
 # Mapping of payment method codes to Worldline codes.

--- a/addons/payment_worldline/models/payment_transaction.py
+++ b/addons/payment_worldline/models/payment_transaction.py
@@ -154,17 +154,9 @@ class PaymentTransaction(models.Model):
                 worldline_code = const.PAYMENT_METHODS_MAPPING.get(self.payment_method_id.code, 0)
                 payload['cardPaymentMethodSpecificInput']['paymentProductId'] = worldline_code
             else:
-                pm_codes = self.env['payment.method'].search([
-                    ('active', 'in', [True, False]),
-                    ('primary_payment_method_id', '=', self.payment_method_id.id),
-                ]).mapped('code')
-                worldline_codes = [
-                    const.PAYMENT_METHODS_MAPPING[code] for code in pm_codes
-                    if code in const.PAYMENT_METHODS_MAPPING
-                ]
                 payload['hostedCheckoutSpecificInput']['paymentProductFilters'] = {
                     'restrictTo': {
-                        'products': worldline_codes,
+                        'groups': ['cards'],
                     },
                 }
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:** 
- simplification of card mapping for Worldline payment provider.

**Current behavior before PR:**
- 'card' Odoo PM when paying through Worldline works by mapping with card brands (VISA, Mastercard) directly.

**Desired behavior after PR is merged:** 
- 'card' Odoo PM is mapped with 'group' parameter for all card brands, which simplifies mapping.

Task - 4347430