### PR TITLE
[FIX] event_product, sale, sale_timesheet: prevent error on installing module

### DIFF
--- a/addons/event_product/data/event_product_data.xml
+++ b/addons/event_product/data/event_product_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="product_category_events" model="product.category">
-            <field name="parent_id" ref="product.product_category_services"/>
+            <field name="parent_id" eval="ref('product.product_category_services', raise_if_not_found=False)"/>
             <field name="name">Events</field>
         </record>
 

--- a/addons/sale/data/product_demo.xml
+++ b/addons/sale/data/product_demo.xml
@@ -186,7 +186,7 @@
 
     <record id="advance_product_0" model="product.product">
         <field name="name">Deposit</field>
-        <field name="categ_id" ref="product.product_category_services"/>
+        <field name="categ_id" eval="ref('product.product_category_services', raise_if_not_found=False)"/>
         <field name="type">service</field>
         <field name="list_price">150.0</field>
         <field name="invoice_policy">order</field>

--- a/addons/sale_timesheet/data/sale_service_data.xml
+++ b/addons/sale_timesheet/data/sale_service_data.xml
@@ -6,7 +6,7 @@
             <field name="type">service</field>
             <field name="list_price">40</field>
             <field name="uom_id" ref="uom.product_uom_hour"/>
-            <field name="categ_id" ref="product.product_category_services"/>
+            <field name="categ_id" eval="ref('product.product_category_services', raise_if_not_found=False)"/>
             <field name="service_policy">delivered_timesheet</field>
             <field name="image_1920" type="base64" file="sale_timesheet/static/img/product_product_time_product.png"/>
         </record>


### PR DESCRIPTION
Currently a `ParseError` arises when the user installs the modules after deleting the `Service` Category in Invoicing.

Steps to reproduce:
---
- Install `Invoicing` application (without demo data).
- Invoicing > Configuration > Categories > Delete `Service`
- Now installs the modules (event_product, sale, sale_timesheet)

Traceback:
---
```
ValueError: External ID not found in the system: product.product_category_services

ParseError: while parsing /home/odoo/src/odoo/saas-18.1/addons/event_product/data/event_product_data.xml:4, somewhere inside <record id="product_category_events" model="product.category">
            <field name="parent_id" ref="product.product_category_services"/>
            <field name="name">Events</field>
        </record>
```

The error occurs because the user deleted the category, and then installed the modules, that reference the missing product category.

This commit resolves the error by providing a False value for the field if the product category is missing.

sentry-6235143606

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
