### PR TITLE
[FIX] marketing_card: ui/ux improvements

### DIFF
--- a/addons/marketing_card/__manifest__.py
+++ b/addons/marketing_card/__manifest__.py
@@ -24,6 +24,9 @@
         'web.assets_backend': [
             'marketing_card/static/src/scss/*',
         ],
+        'web_editor.backend_assets_wysiwyg': [
+            'marketing_card/static/src/scss/mass_mailing.scss'
+        ],
     },
     'application': True,
     'installable': True,

--- a/addons/marketing_card/i18n/marketing_card.pot
+++ b/addons/marketing_card/i18n/marketing_card.pot
@@ -870,7 +870,7 @@ msgstr ""
 
 #. module: marketing_card
 #: model:ir.model.fields,field_description:marketing_card.field_card_campaign__reward_message
-msgid "Thanks to You Message"
+msgid "Thank You Message"
 msgstr ""
 
 #. module: marketing_card
@@ -942,6 +942,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:marketing_card.template_4
 #: model_terms:ir.ui.view,arch_db:marketing_card.template_5
 msgid "button text"
+msgstr ""
+
+#. module: marketing_card
+#: model_terms:ir.ui.view,arch_db:marketing_card.card_campaign_view_form
+msgid "e.g. \"Thanks for sharing, here is your reward!\""
 msgstr ""
 
 #. module: marketing_card

--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -49,7 +49,7 @@ class CardCampaign(models.Model):
 
     user_id = fields.Many2one('res.users', string='Responsible', default=lambda self: self.env.user, domain="[('share', '=', False)]")
 
-    reward_message = fields.Html(string='Thanks to You Message')
+    reward_message = fields.Html(string='Thank You Message')
     reward_target_url = fields.Char(string='Reward Link')
     request_title = fields.Char('Request', default=lambda self: _('Help us share the news'))
     request_description = fields.Text('Request Description')
@@ -374,8 +374,8 @@ class CardCampaign(models.Model):
         """Helper to get the right value for dynamic fields."""
         self.ensure_one()
         result = {
-            'image1': images[0] if (images := self.content_image1_path and record.mapped(self.content_image1_path)) else False,
-            'image2': images[0] if (images := self.content_image2_path and record.mapped(self.content_image2_path)) else False,
+            'image1': images[0] if (images := self.content_image1_path and self.content_image1_path in record and record.mapped(self.content_image1_path)) else False,
+            'image2': images[0] if (images := self.content_image2_path and self.content_image2_path in record and record.mapped(self.content_image2_path)) else False,
         }
         campaign_text_element_fields = (
             ('header', 'content_header', 'content_header_dyn', 'content_header_path'),

--- a/addons/marketing_card/static/src/scss/mass_mailing.scss
+++ b/addons/marketing_card/static/src/scss/mass_mailing.scss
@@ -1,0 +1,8 @@
+body.o_mass_mailing_iframe_body_fullscreen {
+    display: grid;
+    align-items: center;
+}
+
+body.o_mass_mailing_iframe_body_with_snippets_sidebar {
+    background: $gray-200;
+}

--- a/addons/marketing_card/views/card_campaign_views.xml
+++ b/addons/marketing_card/views/card_campaign_views.xml
@@ -78,7 +78,7 @@
                     </group>
                     <group>
                         <field name="user_id" widget="many2one_avatar"/>
-                        <field name="tag_ids" widget="many2many_tags"  options="{'color_field': 'color'}"/>
+                        <field name="tag_ids" widget="many2many_tags"  options="{'color_field': 'color', 'no_create_edit': True}"/>
                     </group>
                 </group>
                 <notebook>
@@ -138,7 +138,7 @@
                             </group>
                             <group>
                                 <field name="reward_target_url" placeholder='e.g. "https://www.mycompany.com/reward"'/>
-                                <field name="reward_message" placeholder="Thanks for sharing, here is your reward!"/>
+                                <field name="reward_message" placeholder='e.g. "Thanks for sharing, here is your reward!"'/>
                             </group>
                         </group>
                     </page>

--- a/addons/marketing_card/views/mailing_mailing_views.xml
+++ b/addons/marketing_card/views/mailing_mailing_views.xml
@@ -15,6 +15,9 @@
                     confirm-title="Confirm Cards Update" confirm-label="Update Cards">Update <field name="card_requires_sync_count"/> Cards</button>
                 </header>
             </xpath>
+            <xpath expr="//header//button[@name='action_set_favorite']" position="attributes">
+                <attribute name="invisible" separator=" or " add="card_campaign_id"/>
+            </xpath>
             <xpath expr="//field[@name='mailing_model_id']" position="attributes">
                 <attribute name="readonly" separator=" or " add="card_campaign_id"/>
             </xpath>

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -118,7 +118,7 @@
                 <field class="text-break" name="sms_subject" string="Title" placeholder="e.g. Black Friday SMS coupon" invisible="mailing_type != 'sms'" readonly="state in ('sending', 'done')" required="mailing_type == 'sms'"/>
             </xpath>
             <xpath expr="//button[@name='action_set_favorite']" position="attributes">
-                <attribute name="invisible">mailing_type != 'mail' or favorite</attribute>
+                <attribute name="invisible" separator=" or " add="mailing_type != 'mail'"/>
             </xpath>
             <xpath expr="//button[@name='action_remove_favorite']" position="attributes">
                 <attribute name="invisible">mailing_type != 'mail' or not favorite</attribute>


### PR DESCRIPTION
**Before this PR:**
- In a fullscreen mode, mail preview was visible only on the top half of the screen.
- Traceback when changing name of the image.
- 'Create and edit' option when creating a new tag.

**After this PR:**
- String of `reward_message` will be changed to 'Thank You Message'.
- Only 'Create' option will displayed while creating a new tag.
- Mail preview will be visible in the center of the screen.
- 'Add to Templates' in mass_mailing preview will no longer be visible.

Task-4387904

