### PR TITLE
[FIX] point_of_sale: fix splitting order from multiple devices

### DIFF
--- a/addons/point_of_sale/static/src/app/store/devices_synchronisation.js
+++ b/addons/point_of_sale/static/src/app/store/devices_synchronisation.js
@@ -143,7 +143,7 @@ export default class DevicesSynchronisation {
     processDeletedRecords(deletedRecords) {
         for (const [model, ids] of Object.entries(deletedRecords)) {
             const records = this.models[model].readMany(ids);
-            this.models[model].deleteMany(records, { silent: true });
+            this.models[model].deleteMany(records.filter(Boolean), { silent: true });
         }
     }
 


### PR DESCRIPTION
Steps to reproduce:
===================
- Open the restaurant registry from 2 devices A and B
- From device A, open a table, add a product, go back to floor plan
- From device B, choose the same table, click split, choose the product added from device A, and click on pay.

Reason:
=======
We are trying to delete the same record 'pos.order.line' twice, i.e. we're calling `processDeletedRecords` twice with the same record id [1], so it succeds the first time, and it removes the record from the frontend cache, but when trying to process the deletion the second time, it fails since the record doesn't exist in the cache anymore [2], and hence, the `record` object is `undefined` in the second call to `delete_` with the same record id, causing the traceback [3].

The reason we're calling `processDeletedRecords` twice with the same record id is because `sync_from_ui` is issuing 2 sync events at the same time [4], since it's been passed 2 orders when splitting [5].

Fix:
====
Since it's an urgent bug, this fix just skips deleting the record if it doesn't exist, without "fixing" the root cause of syncing event being issued twice.

[1]: https://github.com/odoo/odoo/blob/2d0ed96675541a88d9132bd01d33730f72c79d1d/addons/point_of_sale/static/src/app/store/devices_synchronisation.js#L116
[2]: https://github.com/odoo/odoo/blob/eca835a10d027b936890ff6ccc9e02660edfdfd5/addons/point_of_sale/static/src/app/models/related_models.js#L691
[3]: https://github.com/odoo/odoo/blob/eca835a10d027b936890ff6ccc9e02660edfdfd5/addons/point_of_sale/static/src/app/models/related_models.js#L664-L665
[4]: https://github.com/odoo/odoo/blob/eca835a10d027b936890ff6ccc9e02660edfdfd5/addons/point_of_sale/models/pos_order.py#L1043-L1046
[5]: https://github.com/odoo/odoo/blob/0faf168bbcbc66daeb58999a6222cd2c6d41134c/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js#L167

opw-4562134
