### PR TITLE
[FIX] hw_drivers: add more logs on ghostscript printing

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
@@ -114,7 +114,18 @@ class PrinterDriver(Driver):
             f'{file_name}'
             ]
 
-        ghostscript.Ghostscript(*args)
+        _logger.debug("Printing report with ghostscript using %s", args)
+        stderr_buf = io.BytesIO()
+        stdout_buf = io.BytesIO()
+        stdout_log_level = logging.DEBUG
+        try:
+            ghostscript.Ghostscript(*args, stdout=stdout_buf, stderr=stderr_buf)
+        except Exception:
+            _logger.exception("Error while printing report, ghostscript args: %s, error buffer: %s", args, stderr_buf.getvalue())
+            stdout_log_level = logging.ERROR # some stdout value might contains relevant error information
+            raise
+        finally:
+            _logger.log(stdout_log_level, "Ghostscript stdout: %s", stdout_buf.getvalue())
 
     def print_receipt(self, data):
         receipt = b64decode(data['receipt'])


### PR DESCRIPTION
Before this commit:

Failing to print for whatever reason would yield some unhelpful error message like:
`ghostscript._gsprint.GhostscriptError: Fatal`
the error details is hidden within the stderr.

Note: in general case, any stderr is logged in the IoT logs due to ExceptionLogger, however it's not the case here (probably due to some ghostscript wrapping).

After this commit:
A more explicit error message with details regarding the error and some relevant debug information to cross compare

opw-4481596