### PR TITLE
[IMP] pos_restaurant_appointment: Add minimal html editor in pos mode

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -146,7 +146,7 @@ export class HtmlField extends Component {
     }
 
     async getEditorContent() {
-        await this.editor.shared.media.savePendingImages();
+        await this.editor.shared.media?.savePendingImages();
         return this.editor.getElContent();
     }
 

--- a/addons/point_of_sale/static/src/app/pos_app.js
+++ b/addons/point_of_sale/static/src/app/pos_app.js
@@ -28,12 +28,6 @@ export class Chrome extends Component {
         if (odoo.use_pos_fake_tours) {
             window.pos_fake_tour = useTours();
         }
-        // prevent backspace from performing a 'back' navigation
-        document.addEventListener("keydown", (ev) => {
-            if (ev.key === "Backspace" && !ev.target.matches("input, textarea")) {
-                ev.preventDefault();
-            }
-        });
 
         if (this.pos.config.iface_big_scrollbars) {
             const body = document.getElementsByTagName("body")[0];


### PR DESCRIPTION
### Commit 1 

In the point of sale environnement we want to be able to edit html field
in a minimal way. So only core plugins are added to the html_editor.

As we have a special assets environnement for the point_of_sale we can
directly patch the main `htmlField` definition without impacting main
assets of Odoo.

So in Order to make it work we need to remove the preventDefault on
backspace key at the initialization of PoS.

Enterprise: 79703

### Commit 2

The html editor should only work with the “CORE_PLUGINS” plugin set.
But when an HTML field is used only with this Set a traceback is raised
because the “MediaPlugin” plugin is missing.

This is due to this piece of code:
```js
async getEditorContent() {
    await this.editor.shared.media.savePendingImages();
    return this.editor.getElContent();
}
```

Each time an HTML input is unfocused, this method is called and attempts
to save the pending images. The problem is that media.savePendingImages
depends on the “MediaPlugin”.

A quick fix is made in this commit by adding a question mark after media
to avoid traceback if the plugin is missing.
