### PR TITLE
[IMP] web: add a key `groups` at session_info

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -131,6 +131,7 @@ class IrHttp(models.AbstractModel):
             },
             'test_mode': config['test_enable'],
             'view_info': self.env['ir.ui.view'].get_view_info(),
+            'groups': {},
         }
         if request.session.debug:
             session_info['bundle_params']['debug'] = request.session.debug

--- a/addons/web/static/src/core/user.js
+++ b/addons/web/static/src/core/user.js
@@ -51,6 +51,7 @@ export function _makeUser(session) {
         is_admin: isAdmin,
         is_internal_user: isInternalUser,
         is_system: isSystem,
+        is_public: isPublic,
         name,
         partner_id: partnerId,
         show_effect: showEffect,
@@ -60,6 +61,7 @@ export function _makeUser(session) {
         user_settings,
         partner_write_date: writeDate,
         user_companies: userCompanies,
+        groups = {},
     } = session;
     const settings = user_settings || {};
 
@@ -103,6 +105,7 @@ export function _makeUser(session) {
     delete session.user_settings;
     delete session.partner_write_date;
     delete session.user_companies;
+    delete session.groups;
 
     // Generate caches for has_group and has_access calls
     const getGroupCacheValue = (group, context) => {
@@ -123,6 +126,15 @@ export function _makeUser(session) {
     }
     if (isSystem !== undefined) {
         groupCache.cache["base.group_system"] = Promise.resolve(isSystem);
+    }
+    if (isAdmin !== undefined) {
+        groupCache.cache["base.group_erp_manager"] = Promise.resolve(isAdmin);
+    }
+    if (isPublic !== undefined) {
+        groupCache.cache["base.group_public"] = Promise.resolve(isPublic);
+    }
+    for (const group in groups) {
+        groupCache.cache[group] = Promise.resolve(!!groups[group]);
     }
     const getAccessRightCacheValue = (model, operation, ids, context) => {
         const url = `/web/dataset/call_kw/${model}/has_access`;

--- a/addons/web/tests/test_session_info.py
+++ b/addons/web/tests/test_session_info.py
@@ -72,6 +72,7 @@ class TestSessionInfo(common.HttpCase):
             'allowed_companies': expected_allowed_companies,
             'disallowed_ancestor_companies': expected_disallowed_ancestor_companies,
         }
+        self.assertEqual(result["groups"], {})
         self.assertEqual(
             result['user_companies'],
             expected_user_companies,


### PR DESCRIPTION
This commit adds a key groups inside the `session_info` with already
computed group to avoid a delayed call on js side without any overhead
on python side.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
