### PR TITLE
[IMP] orm: consistent day mapping for read_group 'day_of_week'

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_time_adapters.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_time_adapters.js
@@ -4,7 +4,6 @@ import { registries, helpers, constants } from "@odoo/o-spreadsheet";
 import { deserializeDate } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
-import { localization } from "@web/core/l10n/localization";
 
 const { pivotTimeAdapterRegistry } = registries;
 const { formatValue, toNumber, toJsDate, toString } = helpers;
@@ -181,10 +180,7 @@ const odooYearAdapter = {
 
 const odooDayOfWeekAdapter = {
     normalizeServerValue(groupBy, field, readGroupResult, locale) {
-        const weekStart = localization.weekStart; // 1 = Monday, 7 = Sunday
-        const dayOffset = Number(readGroupResult[groupBy]); // offset from the first day of the week
-        const fromSundayIsZero = (dayOffset + weekStart) % 7;
-        const fromLocaleIsZero = (7 - locale.weekStart + fromSundayIsZero) % 7;
+        const fromLocaleIsZero = (7 - locale.weekStart + Number(readGroupResult[groupBy])) % 7;
         return fromLocaleIsZero + 1; // 1-based
     },
     increment(normalizedValue, step) {

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -1133,8 +1133,8 @@ test("PIVOT day_of_week with same user and spreadsheet week start", async functi
             if (method === "formatted_read_group" && kwargs.groupby?.includes("date:day_of_week")) {
                 return [
                     {
-                        "date:day_of_week": 2, // 2 days after the user week start (Monday + 2 = Wednesday)
-                        __domain: [["date.day_of_week", "=", 2]],
+                        "date:day_of_week": 3, // Wednesday
+                        __domain: [["date.day_of_week", "=", 3]],
                         __count: 1,
                         "probability:avg": 11,
                     },
@@ -1172,8 +1172,8 @@ test("PIVOT day_of_week with user week start and spreadsheet week start differen
             if (method === "formatted_read_group" && kwargs.groupby?.includes("date:day_of_week")) {
                 return [
                     {
-                        "date:day_of_week": 1, // 2 days after the user week start (Tuesday + 1 = Wednesday)
-                        __domain: [["date.day_of_week", "=", 1]],
+                        "date:day_of_week": 3, // Wednesday
+                        __domain: [["date.day_of_week", "=", 3]],
                         __count: 1,
                         "probability:avg": 11,
                     },

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -300,6 +300,9 @@ class Base(models.AbstractModel):
                 or a string `'field:granularity'`. Right now, the only supported granularities
                 are `'day'`, `'week'`, `'month'`, `'quarter'` or `'year'`, and they only make sense for
                 date/datetime fields.
+                Additionally integer date parts are also supported:
+                `'year_number'`, `'quarter_number'`, `'month_number'`, `'iso_week_number'`, `'day_of_year'`, `'day_of_month'`,
+                'day_of_week', 'hour_number', 'minute_number' and 'second_number'.
         :param list aggregates: list of aggregates specification.
                 Each element is `'field:agg'` (aggregate field with aggregation function `'agg'`).
                 The possible aggregation functions are the ones provided by

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -118,7 +118,7 @@ const READ_GROUP_NUMBER_GRANULARITY = [
 
 const DATE_FORMAT = {
     day: (date) => date.toFormat("yyyy-MM-dd"),
-    day_of_week: (date) => date.weekday % 7, // number of days after the first day of the week (assumed to be Sunday)
+    day_of_week: (date) => date.weekday % 7, // (0 = Sunday, 6 = Saturday)
     day_of_month: (date) => date.day,
     day_of_year: (date) => date.ordinal,
     week: (date) => `W${date.toFormat("WW kkkk")}`,

--- a/addons/web/static/tests/legacy/helpers/mock_server.js
+++ b/addons/web/static/tests/legacy/helpers/mock_server.js
@@ -1100,7 +1100,7 @@ export class MockServer {
                     case "hour_number":
                         return date.hour;
                     case "day_of_week":
-                        return date.weekday % 7; // number of days after the first day of the week (assumed to be Sunday)
+                        return date.weekday % 7; // (0 = Sunday, 6 = Saturday)
                     case "day_of_month":
                         return date.day;
                     case "day_of_year":

--- a/odoo/orm/fields_temporal.py
+++ b/odoo/orm/fields_temporal.py
@@ -47,26 +47,7 @@ class BaseDate(Field[T | typing.Literal[False]], typing.Generic[T]):
         if property_name not in READ_GROUP_NUMBER_GRANULARITY:
             raise ValueError(f'Error when processing the granularity {property_name} is not supported. Only {", ".join(READ_GROUP_NUMBER_GRANULARITY.keys())} are supported')
         granularity = READ_GROUP_NUMBER_GRANULARITY[property_name]
-        if property_name == 'day_of_week':
-            """
-            formula: ((7 - first_week_day) + day_in_SQL)  % 0-based first day of week
-
-                           | week starts on
-                       SQL | mon   sun   sat
-                           |  1  |  7  |  6   <-- first_week_day (in odoo)
-                      -----|-----------------
-                mon     1  |  0  |  1  |  2
-                tue     2  |  1  |  2  |  3
-                wed     3  |  2  |  3  |  4
-                thu     4  |  3  |  4  |  5
-                fri     5  |  4  |  5  |  6
-                sat     6  |  5  |  6  |  0
-                sun     7  |  6  |  0  |  1
-            """
-            first_week_day = int(get_lang(model.env, timezone).week_start)
-            sql_expr = SQL("mod(7 - %s + date_part(%s, %s)::int, 7)", first_week_day, granularity, sql_expr)
-        else:
-            sql_expr = SQL('date_part(%s, %s)', granularity, sql_expr)
+        sql_expr = SQL('date_part(%s, %s)', granularity, sql_expr)
         return sql_expr
 
 


### PR DESCRIPTION
Previously, `read_group` with the granularity 'day_of_week' returned a day offset relative to the user's week start. For example, a group value of 2 would represent Tuesday if the user's week starts on Sunday, but Wednesday if it starts on Monday.

This behavior was impractical, as the group value alone was meaningless without knowing the user's week start. It required an additional RPC to fetch the user's settings, preventing `read_group` from being used standalone.

With this commit, `read_group` now returns a fixed mapping where days are consistently numbered from 0 to 6 (0 = Sunday, 6 = Saturday), which is what PostgreSQL returns.

The user’s language still determines the order of the grouped results. A user in FR (week starts on Monday) will see: Monday, Tuesday, ... A user in US (week starts on Sunday) will see: Sunday, Monday, ...

Task:

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
