### PR TITLE
[FIX] point_of_sale: floating order dialog title translation

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -1551,6 +1551,12 @@ msgid ""
 msgstr ""
 
 #. module: point_of_sale
+#. odoo-javascript
+#: code:addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js:0
+msgid "Choose an order"
+msgstr ""
+
+#. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_res_company__point_of_sale_ticket_portal_url_display_mode
 #: model:ir.model.fields,help:point_of_sale.field_res_config_settings__point_of_sale_ticket_portal_url_display_mode
 msgid "Choose how the URL to the portal will be print on the receipt."

--- a/addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js
+++ b/addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js
@@ -2,6 +2,7 @@ import { Component, useRef, xml } from "@odoo/owl";
 import { useIsChildLarger, useReactivePopover } from "@point_of_sale/app/utils/hooks";
 import { useService } from "@web/core/utils/hooks";
 import { Dialog } from "@web/core/dialog/dialog";
+import { _t } from "@web/core/l10n/translation";
 
 class ListContainerPopover extends Component {
     static props = {
@@ -20,10 +21,13 @@ class ListContainerPopover extends Component {
 class ListContainerDialog extends ListContainerPopover {
     static components = { ListContainerPopover, Dialog };
     static template = xml`
-        <Dialog title="'Choose an order'" footer="false">
+        <Dialog title="title" footer="false">
             <ListContainerPopover t-props="props" t-on-click="props.close"/>
         </Dialog>
     `;
+    setup() {
+        this.title = _t("Choose an order");
+    }
 }
 export class ListContainer extends Component {
     static props = {


### PR DESCRIPTION
Before this commit:
==========
- The floating order dialog title was not translated due to the use of `title.translate` in the .js file.

After this commit:
==========
- The floating order dialog title will be translated.

task-4576073
