### PR TITLE
[IMP] captcha: enable on registration and password reset

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -41,6 +41,8 @@ class AuthSignupHome(Home):
 
         if 'error' not in qcontext and request.httprequest.method == 'POST':
             try:
+                if not request.env['ir.http']._verify_request_recaptcha_token('signup'):
+                    raise UserError(_("Suspicious activity detected by Google reCaptcha."))
                 self.do_signup(qcontext)
                 # Send an account creation confirmation email
                 User = request.env['res.users']
@@ -79,6 +81,8 @@ class AuthSignupHome(Home):
 
         if 'error' not in qcontext and request.httprequest.method == 'POST':
             try:
+                if not request.env['ir.http']._verify_request_recaptcha_token('password_reset'):
+                    raise UserError(_("Suspicious activity detected by Google reCaptcha."))
                 if qcontext.get('token'):
                     self.do_signup(qcontext)
                     return self.web_login(*args, **kw)

--- a/addons/auth_signup/i18n/auth_signup.pot
+++ b/addons/auth_signup/i18n/auth_signup.pot
@@ -658,6 +658,14 @@ msgid "Status"
 msgstr ""
 
 #. module: auth_signup
+#. odoo-python
+#: code:addons/auth_signup/controllers/main.py:0
+#: code:addons/auth_signup/controllers/main.py:0
+#, python-format
+msgid "Suspicious activity detected by Google reCaptcha."
+msgstr ""
+
+#. module: auth_signup
 #: model:ir.model.fields,field_description:auth_signup.field_res_config_settings__auth_signup_template_user_id
 msgid "Template user for new users created through signup"
 msgstr ""

--- a/addons/auth_signup/static/src/js/reset_password.js
+++ b/addons/auth_signup/static/src/js/reset_password.js
@@ -18,6 +18,9 @@ odoo.define("auth_signup.reset_password", function (require) {
          */
         _onSubmit: function () {
             var $btn = this.$('.oe_login_buttons > button[type="submit"]');
+            if ($btn.prop("disabled")) {
+                return;
+            }
             $btn.attr("disabled", "disabled");
             $btn.prepend('<i class="fa fa-refresh fa-spin"/> ');
         },

--- a/addons/auth_signup/static/src/js/signup.js
+++ b/addons/auth_signup/static/src/js/signup.js
@@ -18,6 +18,9 @@ publicWidget.registry.SignUpForm = publicWidget.Widget.extend({
      */
     _onSubmit: function () {
         var $btn = this.$('.oe_login_buttons > button[type="submit"]');
+        if ($btn.prop("disabled")) {
+            return;
+        }
         $btn.attr('disabled', 'disabled');
         $btn.prepend('<i class="fa fa-refresh fa-spin"/> ');
     },

--- a/addons/google_recaptcha/__manifest__.py
+++ b/addons/google_recaptcha/__manifest__.py
@@ -16,6 +16,7 @@
         'web.assets_frontend': [
             'google_recaptcha/static/src/scss/recaptcha.scss',
             'google_recaptcha/static/src/js/recaptcha.js',
+            'google_recaptcha/static/src/js/signup.js',
             # TODO remove next line in master, it was kept here as part of a
             # stable fix in stable but is unused in the current codebase.
             'google_recaptcha/static/src/xml/recaptcha.xml',

--- a/addons/google_recaptcha/static/src/js/signup.js
+++ b/addons/google_recaptcha/static/src/js/signup.js
@@ -1,0 +1,45 @@
+odoo.define('google_recaptcha.signup', function (require) {
+    'use strict';
+
+    const publicWidget = require('web.public.widget');
+    const { ReCaptcha } = require('google_recaptcha.ReCaptchaV3');
+
+    const CaptchaFunctionality = {
+        events: {
+            submit: "_onSubmit",
+        },
+
+        init() {
+            this._super(...arguments);
+            this._recaptcha = new ReCaptcha();
+        },
+
+        async willStart() {
+            return this._recaptcha.loadLibs();
+        },
+
+        _onSubmit(ev) {
+            if (this._recaptcha._publicKey && !this.$el.find("input[name='recaptcha_token_response']").length) {
+                ev.preventDefault();
+                this._recaptcha.getToken(this.tokenName).then((tokenCaptcha) => {
+                    this.$el.append(
+                        `<input name="recaptcha_token_response" type="hidden" value="${tokenCaptcha.token}"/>`,
+                    );
+                    this.$el.submit();
+                });
+            }
+        },
+    };
+
+    publicWidget.registry.SignupCaptcha = publicWidget.Widget.extend({
+        ...CaptchaFunctionality,
+        selector: ".oe_signup_form",
+        tokenName: "signup",
+    });
+
+    publicWidget.registry.ResetPasswordCaptcha = publicWidget.Widget.extend({
+        ...CaptchaFunctionality,
+        selector: ".oe_reset_password_form",
+        tokenName: "password_reset",
+    });
+});

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -269,3 +269,7 @@ class IrHttp(models.AbstractModel):
     @classmethod
     def _is_allowed_cookie(cls, cookie_type):
         return True
+
+    @api.model
+    def _verify_request_recaptcha_token(self, action):
+        return True


### PR DESCRIPTION
Before this commit, Odoo instances were being spammed by requests that caused emails to be sent out. Primarily in the signup and forgot password feature. This is the backwards compatibile commit for the master commit located at #185648.

Task-3626220