### PR TITLE
[IMP] mail: allow to mention channel without being a member

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1261,11 +1261,7 @@ class DiscussChannel(models.Model):
         """ Return 'limit'-first channels' id, name, channel_type and authorizedGroupFullName fields such that the
             name matches a 'search' string. Exclude channels of type chat (DM) and group.
         """
-        domain = expression.AND([
-                        [('name', 'ilike', search)],
-                        [('channel_type', '=', 'channel')],
-                        [('channel_partner_ids', 'in', [self.env.user.partner_id.id])]
-                    ])
+        domain = [("name", "ilike", search), ("channel_type", "=", "channel")]
         channels = self.search(domain, limit=limit)
         return [{
             'authorizedGroupFullName': channel.group_public_id.full_name,


### PR DESCRIPTION
Before this PR, only the channels the user is a member of were returned by the
mention suggestions.
This PR removes an unnecessary limitation when mentioning a channel as it's
It is already possible to mention a channel you are not a member of.
