### PR TITLE
[FIX] l10n_ch: prevent stopping pdf generation if in draft

### DIFF
--- a/addons/l10n_ch/tests/test_ch_qr_code.py
+++ b/addons/l10n_ch/tests/test_ch_qr_code.py
@@ -86,6 +86,30 @@ class TestSwissQRCode(AccountTestInvoicingCommon):
         self.ch_qr_invoice.company_id.partner_id.country_id = self.env.ref('base.fr')
         self.ch_qr_invoice._generate_qr_code()
 
+    def test_swiss_qr_code_generation_draft_invoice(self):
+        """
+        When an invoice is in draft, it should be printable without the QR-code (the reference needed but the qr is not yet computed)
+        To approximate the initial flow action > print invoice, we make sure that the QR code is not generated.
+        If it is not, it won't be an issue further in the flow
+        """
+        move = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'partner_bank_id': self.swiss_qr_iban.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'quantity': 1,
+                    'price_unit': 100,
+                    'tax_ids': [],
+                })
+            ]
+        })
+        self._assign_partner_address(move.company_id.partner_id)
+        self._assign_partner_address(move.partner_id)
+        move.qr_code_method = 'ch_qr'
+
+        self.assertIsNone(move._generate_qr_code(), "QR-code should not be generated.")
+
     def test_ch_qr_code_detection(self):
         """ Checks Swiss QR-code auto-detection when no specific QR-method
         is given to the invoice.


### PR DESCRIPTION
Steps to reproduce:
- enable qr code
- create an invoice with a swiss client
- try to print it

Issue:
An error is raised

Cause:
There is no reference for a Swiss invoice in draft. If there is no reference, it is not possible to print the qr code in Switzerland.

Solution:
We prevent QR code generation whenever the invoice is in draft.

opw-4585574

