### PR TITLE
[FIX] mail: better message notification icon style

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -197,8 +197,8 @@
 
 <t t-name="mail.Message.notification">
     <div t-if="message.thread?.eq(props.thread) and message.notifications.length > 0" class="mx-1">
-        <span class="o-mail-Message-notification cursor-pointer" t-att-class="message.failureNotifications.length > 0 ? 'text-danger' : text-600" role="button" tabindex="0" t-on-click="onClickNotification">
-            <i t-att-class="message.notifications[0].icon" role="img" aria-label="Delivery failure"/> <span t-if="message.notifications[0].label" t-out="message.notifications[0].label"/>
+        <span class="o-mail-Message-notification cursor-pointer opacity-100-hover" t-att-class="message.failureNotifications.length > 0 ? 'text-danger opacity-75' : 'opacity-50'" role="button" tabindex="0" t-on-click="onClickNotification">
+            <i t-att-class="message.notifications[0].icon" role="img" aria-label="Delivery failure"/> <span class="fw-bold small" t-if="message.notifications[0].label" t-out="message.notifications[0].label"/>
         </span>
     </div>
 </t>


### PR DESCRIPTION
Before this commit, style of message notification icon (e.g. envelope) was not subtle enough. Intent was to use `text-600`, but due to typo this was not actually used (was `NaN` so does nothing).

Also this wasn't clear this button is clickable, due to lack of moouse hover feedback.

This commit fixes the issue by having an opacity change on mouse hover. When there's a failure, the static opacity is lower so that failed notifications are a bit more noticeable.

Also message notification with label had slightly improper style that make them less look like a button: buttons should have a bit of font weight, and also the label was too big compared to icon. This commit also fixes that issue.

Before
![before](https://github.com/user-attachments/assets/b04ac7cf-686e-4b72-81d7-5b78f2a339b7)

After
![after](https://github.com/user-attachments/assets/e1f949e3-06b0-4dc5-9f58-7cda9d4f90d7)

