### PR TITLE
[FIX] l10n_br_website_sale: VAT missing in invoice generation test

### DIFF
--- a/addons/l10n_br_website_sale/controllers/portal.py
+++ b/addons/l10n_br_website_sale/controllers/portal.py
@@ -12,9 +12,6 @@ class CustomerPortalBr(CustomerPortal):
             country = request.env['res.country'].browse(int(request.params['country_id']))
             if request.website.sudo().company_id.country_id.code == "BR" and country.code == "BR" and "vat" not in mandatory_fields:
                 mandatory_fields += ['vat']
-            # Needed because the user could put brazil and then change to another country, we don't want the field to stay mandatory
-            elif 'vat' in mandatory_fields and country.code != 'BR':
-                mandatory_fields.remove('vat')
 
         return mandatory_fields
 


### PR DESCRIPTION
This commit fixes the runbot test failures related to invoice generation when the user is not logged in and VAT values are missing.
- Cause an issue for MX and EC country code - VAT field is removed from mandatory fields
- No need to remove the vat field manually, when the country changes the mandatory field list will be changed accordingly.


Runbot Errors: 111328, 111329

Related: https://github.com/odoo/enterprise/pull/79646

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
