### PR TITLE
[FIX] point_of_sale, pos_restaurant: prevent error when loading store data

### DIFF
--- a/addons/point_of_sale/data/scenarios/bakery_data.xml
+++ b/addons/point_of_sale/data/scenarios/bakery_data.xml
@@ -24,7 +24,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_wholemeal_loaf.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_breads')])]" />
 		</record>
 		<record model="product.product" id="product_tiger_white_loaf">
@@ -37,7 +37,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_tiger_white_loaf.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_breads')])]" />
 		</record>
 		<record model="product.product" id="product_butter_croissant">
@@ -50,7 +50,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_butter_croissant.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_pastries')])]" />
 		</record>
 		<record model="product.product" id="product_apple_pie">
@@ -63,7 +63,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_apple_pie.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_pastries')])]" />
 		</record>
 		<record model="product.product" id="product_cherry_pie">
@@ -76,7 +76,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_cherry_pie.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_pastries')])]" />
 		</record>
 		<record model="product.product" id="product_sourdough_loaf">
@@ -89,7 +89,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_sourdough_loaf.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_breads')])]" />
 		</record>
 		<record model="product.product" id="product_multigrain_bread">
@@ -102,7 +102,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_multigrain_bread.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_breads')])]" />
 		</record>
 		<record model="product.product" id="product_rye_bread">
@@ -115,7 +115,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_rye_bread.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_breads')])]" />
 		</record>
 		<record model="product.product" id="product_cinnamon_roll">
@@ -128,7 +128,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_cinnamon_roll.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_pastries')])]" />
 		</record>
 		<record model="product.product" id="product_pain_au_chocolat">
@@ -141,7 +141,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_pain_au_chocolat.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_pastries')])]" />
 		</record>
 		<record model="product.product" id="product_blueberry_muffin">
@@ -154,7 +154,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_blueberry_muffin.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_pastries')])]" />
 		</record>
 		<record model="product.product" id="product_bagel">
@@ -167,7 +167,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_pain_au_chocolat.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_breads')])]" />
 		</record>
 		<record model="product.product" id="product_cheese_croissant">
@@ -180,7 +180,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_cheese_croissant.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_pastries')])]" />
 		</record>
 		<record model="product.product" id="product_pecan_pie">
@@ -193,7 +193,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_pecan_pie.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_pastries')])]" />
 		</record>
 	</data>

--- a/addons/pos_restaurant/data/scenarios/restaurant_data.xml
+++ b/addons/pos_restaurant/data/scenarios/restaurant_data.xml
@@ -29,7 +29,7 @@
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-burger.png"/>
             <field name="available_in_pos" eval="True"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]" />
         </record>
 
@@ -88,7 +88,7 @@
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-cheeseburger.png"/>
             <field name="available_in_pos" eval="True"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]" />
         </record>
 
@@ -116,7 +116,7 @@
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-pizza-ma.png"/>
             <field name="available_in_pos" eval="True"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]" />
         </record>
 
@@ -221,7 +221,7 @@
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-pizza-ve.png"/>
             <field name="available_in_pos" eval="True"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]" />
         </record>
 
@@ -295,7 +295,7 @@
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-pasta-4f.png"/>
             <field name="available_in_pos" eval="True"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]" />
         </record>
 
@@ -357,7 +357,7 @@
             <field name="name">Funghi</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-pizza-fu.png"/>
         </record>
         <record id="pos_food_bolo" model="product.product">
@@ -366,7 +366,7 @@
             <field name="name">Pasta Bolognese</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-pasta.png"/>
         </record>
         <record id="pos_food_chicken" model="product.product">
@@ -375,7 +375,7 @@
             <field name="name">Chicken Curry Sandwich</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-sandwich.png"/>
         </record>
         <record id="pos_food_tuna" model="product.product">
@@ -384,7 +384,7 @@
             <field name="name">Spicy Tuna Sandwich</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-tuna.png"/>
         </record>
         <record id="pos_food_mozza" model="product.product">
@@ -393,7 +393,7 @@
             <field name="name">Mozzarella Sandwich</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-mozza.png"/>
         </record>
         <record id="pos_food_club" model="product.product">
@@ -402,7 +402,7 @@
             <field name="name">Club Sandwich</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-club.png"/>
         </record>
         <record id="pos_food_maki" model="product.product">
@@ -411,7 +411,7 @@
             <field name="name">Lunch Maki 18pc</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-maki.png"/>
         </record>
         <record id="pos_food_salmon" model="product.product">
@@ -420,7 +420,7 @@
             <field name="name">Lunch Salmon 20pc</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-salmon.png"/>
         </record>
         <record id="pos_food_temaki" model="product.product">
@@ -429,7 +429,7 @@
             <field name="name">Lunch Temaki mix 3pc</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-temaki.png"/>
         </record>
         <record id="pos_food_chirashi" model="product.product">
@@ -438,7 +438,7 @@
             <field name="name">Salmon and Avocado</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-salmon-avocado.png"/>
         </record>
 
@@ -449,7 +449,7 @@
             <field name="name">Coca-Cola</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-coke.png"/>
         </record>
 
@@ -459,7 +459,7 @@
             <field name="name">Water</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-water.png"/>
         </record>
 
@@ -469,7 +469,7 @@
             <field name="name">Minute Maid</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-minute_maid.png"/>
         </record>
 
@@ -478,7 +478,7 @@
             <field name="list_price">4.70</field>
             <field name="name">Espresso</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-espresso.png"/>
         </record>
 
@@ -487,7 +487,7 @@
             <field name="list_price">4.70</field>
             <field name="name">Green Tea</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-green_tea.png"/>
         </record>
 
@@ -496,7 +496,7 @@
             <field name="list_price">3.60</field>
             <field name="name">Milkshake Banana</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-milkshake_banana.png"/>
         </record>
 
@@ -505,7 +505,7 @@
             <field name="list_price">2.20</field>
             <field name="name">Ice Tea</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-ice_tea.png"/>
         </record>
 
@@ -514,7 +514,7 @@
             <field name="list_price">2.20</field>
             <field name="name">Schweppes</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-schweppes.png"/>
         </record>
 
@@ -523,7 +523,7 @@
             <field name="list_price">2.20</field>
             <field name="name">Fanta</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-fanta.png"/>
         </record>
 
@@ -581,7 +581,7 @@
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/combo-hamb.png"/>
             <field name="combo_ids" eval="[(6, 0, [ref('drink_combo'), ref('burger_combo')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
             <field name="taxes_id" eval="[(5,)]"/>  <!-- no taxes -->
             <field name="supplier_taxes_id" eval="[(5,)]"/>


### PR DESCRIPTION
Currently a `ParseError` arises when we try to load the store data after deleting the `Food` Category in Invoicing.

Steps to reproduce:
---
- Install `Invoicing` application (without demo data).
- Invoicing > Configuration > Categories > Delete `Food`
- Now in POS try to load `Restaurant` and `Bar`

Traceback:
---
```
ValueError: External ID not found in the system: point_of_sale.product_category_food

ParseError: while parsing /home/odoo/src/odoo/saas-18.1/addons/pos_restaurant/data/scenarios/restaurant_data.xml:56, somewhere inside <record model="product.product" id="pos_food_bacon">
            <field name="name">Bacon Burger</field>
            <field name="list_price">15.50</field>
            <field name="standard_price">13.95</field>
            <field name="description_sale">200G Irish Black Angus beef, caramelized onions with paprika, chopped iceberg salad, red onions, grilled bacon, tomato sauce, pickles, barbecue sauce</field>
            <field name="type">consu</field>
            <field name="weight">0.01</field>
            <field name="uom_id" ref="uom.product_uom_unit"/>
            <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-burger.png"/>
            <field name="available_in_pos" eval="True"/>
            <field name="categ_id" ref="point_of_sale.product_category_food"/>
            <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
        </record>
```

The error occurs because the user deleted the category, and then tried to load the store data, that references the missing product category.

This commit resolves the error by providing a False value for the field if the product category is missing.

sentry-6314696040

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
