### PR TITLE
[IMP] pos_loyalty: exclude loyalty points for UrbanPiper orders

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -124,7 +124,8 @@ patch(PosStore.prototype, {
      */
     async updatePrograms() {
         const order = this.get_order();
-        if (!order) {
+        // 'order.delivery_provider_id' check is used for UrbanPiper orders (as loyalty points and rewards are not allowed for UrbanPiper orders)
+        if (!order || order.delivery_provider_id) {
             return;
         }
         const changesPerProgram = {};


### PR DESCRIPTION
Before this commit:
======================
Loyalty points were awarded for all orders, including those from UrbanPiper (online orders). This allowed customers to earn loyalty points both for dine-in and online orders, leading to earning loyalty points twice. Since online food delivery platforms have their own reward systems, loyalty points should not be granted for these orders.

After this commit:
====================
Loyalty points and rewards are now excluded for UrbanPiper orders.

Task-4585821

