### PR TITLE
[FIX] pos_online_payment: adjust no longer exist server_id field in POS order

### DIFF
--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -240,7 +240,7 @@ patch(PaymentScreen.prototype, {
             }
         }
 
-        await this.postPushOrderResolve([this.currentOrder.server_id]);
+        await this.postPushOrderResolve([this.currentOrder.id]);
 
         this.afterOrderValidation(true);
     },


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Steps to reproduce:
- Setup a POS
- Enable online payment (e.g Demo)
- Activate discount, promotion & loyalty in configuration
- Place an order in the POS until receipt screen

Alternatively, take look at the recording:
https://github.com/user-attachments/assets/471e06ae-45d6-4440-a287-7c2433845c26

Current behavior before PR:
Odoo will throw an error because the existing field of server_id is not exists anymore, error occurs when post processing loyalty.
![pos-online-payment-loyalty-error](https://github.com/user-attachments/assets/aec525a6-d3fe-4644-b783-c14f862ba33f)

Desired behavior after PR is merged:
This PR is expected to solve the issue by changing the old server_id with the current id field

opw-4584152

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
