### PR TITLE
[FIX] purchase: stop write same `partner_id`

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -1251,9 +1251,6 @@ class PurchaseOrder(models.Model):
             partner_values['receipt_reminder_email'] = vals.pop('receipt_reminder_email')
         if 'reminder_date_before_receipt' in vals:
             partner_values['reminder_date_before_receipt'] = vals.pop('reminder_date_before_receipt')
-        # ignore costly re-write (because `_compute_price_unit_and_date_planned_and_name`)
-        if all(vals.get('partner_id') == po.partner_id.id != False for po in self):
-            del vals['partner_id']
         return vals, partner_values
 
     def _is_readonly(self):

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -1251,6 +1251,9 @@ class PurchaseOrder(models.Model):
             partner_values['receipt_reminder_email'] = vals.pop('receipt_reminder_email')
         if 'reminder_date_before_receipt' in vals:
             partner_values['reminder_date_before_receipt'] = vals.pop('reminder_date_before_receipt')
+        # ignore costly re-write (because `_compute_price_unit_and_date_planned_and_name`)
+        if all(vals.get('partner_id') == po.partner_id.id != False for po in self):
+            del vals['partner_id']
         return vals, partner_values
 
     def _is_readonly(self):

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -322,9 +322,6 @@ class PurchaseOrderLine(models.Model):
                 uom_id=line.product_uom,
                 params=params)
 
-            if seller or not line.date_planned:
-                line.date_planned = line._get_date_planned(seller).strftime(DEFAULT_SERVER_DATETIME_FORMAT)
-
             # If not seller, use the standard price. It needs a proper currency conversion.
             if not seller:
                 line.discount = 0
@@ -356,6 +353,9 @@ class PurchaseOrderLine(models.Model):
                 price_unit = float_round(price_unit, precision_digits=max(line.currency_id.decimal_places, self.env['decimal.precision'].precision_get('Product Price')))
                 line.price_unit = seller.product_uom._compute_price(price_unit, line.product_uom)
                 line.discount = seller.discount or 0.0
+
+            if seller or not line.date_planned:
+                line.date_planned = line._get_date_planned(seller).strftime(DEFAULT_SERVER_DATETIME_FORMAT)
 
             # record product names to avoid resetting custom descriptions
             default_names = []

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -946,3 +946,24 @@ class TestPurchase(AccountTestInvoicingCommon):
         self.assertEqual(po.amount_untaxed, 15.0)
         po.company_id = company_a.id
         self.assertEqual(po.amount_untaxed, 10.0)
+
+    def test_write_on_partner_and_price_unit(self):
+        """
+        """
+        product = self.product_a
+        product.seller_ids = [Command.create({
+            'partner_id': self.partner_a,
+            'price': 55.0,
+        })]
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': product.id,
+                'product_qty': 1,
+            })],
+        })
+        purchase_order.write({
+            'partner_id': self.partner_a,
+            'order_line': [Command.update(purchase_order.order_line.id, {'price_unit': 33.0})],
+        })
+        self.assertEqual(purchase_order.order_line.price_unit, 33.0)


### PR DESCRIPTION
**Current behavior:**
For a `PurchaseOrder` record, writing on the `partner_id` and a field of an `order_line` which is computed by
`_compute_price_unit_and_date_planned_and_name` will cause the new value of the order line write to be overwritten.

E.g., writing on `partner_id` and
`purchase.order.line.price_unit`

**Expected behavior:**
The freshly written value in cache for the order line field should be protected from re-writes.

**Steps to reproduce:**
1. Create a product with a supplierinfo (vendor)

2. Create a new purchase order with the vendor as the partner and an order line for the product -> Save

3. Export the purchase order to xlsx, add the fields: `partner_id`, `order_line/external ID`, `order_line.price_unit`

4. Open the exported xlsx file and change the price unit value

5. Import the file -> see that the price unit on the order line did not update

**Cause of the issue:**
The new price unit gets updated in cache, but prior to the entire `write` sequence finishing, we will process pending recomputations where, seeing that `PurchaseOrder.partner_id` was updated, `_compute_price_unit_and_date_planned_and_name` will be called.

Even though `price_unit` is protected, if any of the other fields which are computed by this method are not, then it won't matter.

**Fix:**
A simple solution for *this specific* instance of over-using a compute method is to just not over-write `partner_id` if it's equivalent to the present value on the record.

If `partner_id` is overwritten for real it seems fine to let everything be recomputed.

opw-4574816