### PR TITLE
[FIX] sale_project_stock: make a stock user can validate stock picking

### DIFF
--- a/addons/sale_project_stock/models/stock_picking.py
+++ b/addons/sale_project_stock/models/stock_picking.py
@@ -14,7 +14,7 @@ class StockPicking(models.Model):
 
         for picking in self:
             project = picking.project_id
-            sale_order = project.reinvoiced_sale_order_id
+            sale_order = project.sudo().reinvoiced_sale_order_id
             if not (sale_order and picking.picking_type_id.analytic_costs):
                 continue
             reinvoicable_stock_moves = picking.move_ids.filtered(lambda m: m.product_id.expense_policy in {'sales_price', 'cost'})
@@ -58,5 +58,5 @@ class StockPicking(models.Model):
                 # Create the sale lines in batch
                 sale_line_values_to_create.append(stock_move._sale_prepare_sale_line_values(sale_order, price, last_sequence))
                 last_sequence += 1
-            self.env['sale.order.line'].with_context(skip_procurement=True).create(sale_line_values_to_create)
+            self.env['sale.order.line'].with_context(skip_procurement=True).sudo().create(sale_line_values_to_create)
         return res

--- a/addons/sale_project_stock/tests/test_reinvoice.py
+++ b/addons/sale_project_stock/tests/test_reinvoice.py
@@ -59,8 +59,8 @@ class TestReInvoice(TestStockCommon):
                 'product_uom_qty': 5,
             },
         ])
-        self.picking_out.action_confirm()
-        self.picking_out.button_validate()
+        self.picking_out.with_user(self.user_stock_user).action_confirm()
+        self.picking_out.with_user(self.user_stock_user).button_validate()
 
         self.assertEqual(len(self.sale_order.order_line), 2, 'There should be 2 lines on the SO')
         new_sale_order_line1 = self.sale_order.order_line.filtered(lambda sol: sol.product_id == self.reinvoicable_product_at_cost)


### PR DESCRIPTION
Before this commit, when the user validates a stock picking and that user does not have access  to sales app, he will get a traceback if `sale_project_stock` module is installed because the `reinvoiced_sale_order_id` field of the project linked to the picking and that field required the user to have sale access to access to it.

This commit adds a sudo to generate eventual SOLs to reinvoice the stock move when the user without any access to Sales validates the stock picking.

Steps to reproduce the issue:
----------------------------

1. Create a sales order with a storable product
2. and Service product that creates a task in the Field service project
3. After confirming this SO, a task is created => assign Demo to this task and demo doesn't have Sales access right
4. Login as demo, trying to validate the delivery from this task

opw-4590044