### PR TITLE
[IMP] *: convert manual savepoints to helper

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -5,6 +5,7 @@ import base64
 import binascii
 import codecs
 import collections
+import contextlib
 import difflib
 import unicodedata
 
@@ -1360,7 +1361,7 @@ class Import(models.TransientModel):
         :rtype: dict(ids: list(int), messages: list({type, message, record}))
         """
         self.ensure_one()
-        self._cr.execute('SAVEPOINT import')
+        sp = self.env.cr.savepoint(flush=False)
 
         try:
             input_file_data, import_fields = self._convert_import_data(fields, options)
@@ -1389,23 +1390,14 @@ class Import(models.TransientModel):
 
         # If transaction aborted, RELEASE SAVEPOINT is going to raise
         # an InternalError (ROLLBACK should work, maybe). Ignore that.
-        # TODO: to handle multiple errors, create savepoint around
-        #       write and release it in case of write error (after
-        #       adding error to errors array) => can keep on trying to
-        #       import stuff, and rollback at the end if there is any
-        #       error in the results.
-        try:
-            if dryrun:
-                self._cr.execute('ROLLBACK TO SAVEPOINT import')
-                # cancel all changes done to the registry/ormcache
-                # we need to clear the cache in case any created id was added to an ormcache and would be missing afterward
-                self.pool.clear_all_caches()
-                # don't propagate to other workers since it was rollbacked
-                self.pool.reset_changes()
-            else:
-                self._cr.execute('RELEASE SAVEPOINT import')
-        except psycopg2.InternalError:
-            pass
+        with contextlib.suppress(psycopg2.InternalError):
+            sp.close(rollback=dryrun)
+        if dryrun:
+            # cancel all changes done to the registry/ormcache
+            # we need to clear the cache in case any created id was added to an ormcache and would be missing afterward
+            self.pool.clear_all_caches()
+            # don't propagate to other workers since it was rollbacked
+            self.pool.reset_changes()
 
         # Insert/Update mapping columns when import complete successfully
         if import_result['ids'] and options.get('has_headers'):

--- a/odoo/addons/base/models/res_users_deletion.py
+++ b/odoo/addons/base/models/res_users_deletion.py
@@ -60,20 +60,18 @@ class ResUsersDeletion(models.Model):
         for delete_request in batch_requests:
             user = delete_request.user_id
             user_name = user.name
+            partner = user.partner_id
             requester_name = delete_request.create_uid.name
             # Step 1: Delete User
             try:
-                self.env.cr.execute("SAVEPOINT delete_user")
-                partner = user.partner_id
-                user.unlink()
+                with self.env.cr.savepoint():
+                    user.unlink()
                 _logger.info("User #%i %r, deleted. Original request from %r.",
                              user.id, user_name, delete_request.create_uid.name)
-                self.env.cr.execute("RELEASE SAVEPOINT delete_user")
                 delete_request.state = 'done'
             except Exception as e:
                 _logger.error("User #%i %r could not be deleted. Original request from %r. Related error: %s",
-                             user.id, user_name, requester_name, e)
-                self.env.cr.execute("ROLLBACK TO SAVEPOINT delete_user")
+                              user.id, user_name, requester_name, e)
                 delete_request.state = "fail"
             # make sure we never rollback the work we've done, this can take a long time
             if auto_commit:
@@ -84,15 +82,13 @@ class ResUsersDeletion(models.Model):
             # Step 2: Delete Linked Partner
             #         Could be impossible if the partner is linked to a SO for example
             try:
-                self.env.cr.execute("SAVEPOINT delete_partner")
-                partner.unlink()
+                with self.env.cr.savepoint():
+                    partner.unlink()
                 _logger.info("Partner #%i %r, deleted. Original request from %r.",
                              partner.id, user_name, delete_request.create_uid.name)
-                self.env.cr.execute("RELEASE SAVEPOINT delete_partner")
             except Exception as e:
                 _logger.warning("Partner #%i %r could not be deleted. Original request from %r. Related error: %s",
-                             partner.id, user_name, requester_name, e)
-                self.env.cr.execute("ROLLBACK TO SAVEPOINT delete_partner")
+                                partner.id, user_name, requester_name, e)
             # make sure we never rollback the work we've done, this can take a long time
             if auto_commit:
                 self.env.cr.commit()

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2016,11 +2016,10 @@ def warmup(func, *args, **kwargs):
     self.env.invalidate_all()
     # run once to warm up the caches
     self.warm = False
-    self.cr.execute('SAVEPOINT test_warmup')
-    func(*args, **kwargs)
-    self.env.flush_all()
+    with contextlib.closing(self.cr.savepoint(flush=False)):
+        func(*args, **kwargs)
+        self.env.flush_all()
     # run once for real
-    self.cr.execute('ROLLBACK TO SAVEPOINT test_warmup')
     self.env.invalidate_all()
     self.warm = True
     func(*args, **kwargs)


### PR DESCRIPTION
Avoids inconsistencies, simplifies control flow sometimes.

Not all manual savepoints are converted:

- The implementation details of `Savepoint` can't exactly be converted.
- The test case savepoint is difficult to convert as the savepoint name / id is "leaked" for historical reasons, but also `test_mail_bounce_during_send` does exceedingly strange stuff and needs to re-create the test savepoint because it commits multiple times...
