### PR TITLE
[FIX] mail, web: add a main component (ChatHub) lazily (chatter bundle)

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -16,12 +16,12 @@ export class ChatHub extends Component {
     static template = "mail.ChatHub";
 
     get chatHub() {
-        return this.store.chatHub;
+        return this.store && this.store.chatHub;
     }
 
     setup() {
         super.setup();
-        this.store = useService("mail.store");
+        this.store = useService("mail.store", (s) => (this.store = s));
         this.ui = useService("ui");
         this.busMonitoring = useService("bus.monitoring_service");
         this.bubblesHover = useHover("bubbles");
@@ -37,13 +37,19 @@ export class ChatHub extends Component {
             isDragging: false,
             top: "unset",
             left: "unset",
-            bottom: `${this.chatHub.BUBBLE_OUTER}px;`,
-            right: `${this.chatHub.BUBBLE_OUTER + this.chatHub.BUBBLE_START}px;`,
+            bottom: `${this.chatHub ? this.chatHub.BUBBLE_OUTER : 10}px;`,
+            right: `${
+                this.chatHub ? this.chatHub.BUBBLE_OUTER + this.chatHub.BUBBLE_START : 25
+            }px;`,
         });
         this.onResize();
         useExternalListener(browser, "resize", this.onResize);
         useEffect(() => {
-            if (this.chatHub.folded.length && this.store.channels?.status === "not_fetched") {
+            if (
+                this.chatHub &&
+                this.chatHub.folded.length &&
+                this.store.channels?.status === "not_fetched"
+            ) {
                 this.store.channels.fetch();
             }
         });
@@ -74,7 +80,7 @@ export class ChatHub extends Component {
     }
 
     onResize() {
-        this.chatHub.onRecompute();
+        this.chatHub && this.chatHub.onRecompute();
     }
 
     resetPosition() {

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -2,8 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.ChatHub">
-    <div class="o-mail-ChatHub d-print-none" t-if="isShown or ui.isSmall">
-
+    <div class="o-mail-ChatHub d-print-none" t-if="(isShown or ui.isSmall) and store">
         <t t-set="visibleChatWindows" t-value="chatHub.compact ? chatHub.opened.filter(({ bypassCompact }) => bypassCompact) : chatHub.opened "/>
         <t t-foreach="visibleChatWindows" t-as="cw" t-key="cw.localId">
             <ChatWindow chatWindow="cw" right="chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (visibleChatWindows.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2)"/>

--- a/addons/web/static/src/core/utils/hooks.js
+++ b/addons/web/static/src/core/utils/hooks.js
@@ -1,6 +1,15 @@
 import { hasTouch, isMobileOS } from "@web/core/browser/feature_detection";
 
-import { status, useComponent, useEffect, useRef, onWillUnmount, useState, toRaw } from "@odoo/owl";
+import {
+    status,
+    useComponent,
+    useEffect,
+    useRef,
+    onWillUnmount,
+    useState,
+    toRaw,
+    onWillStart,
+} from "@odoo/owl";
 
 /**
  * This file contains various custom hooks.
@@ -113,6 +122,10 @@ export const useServiceProtectMethodHandling = {
 // -----------------------------------------------------------------------------
 // useService
 // -----------------------------------------------------------------------------
+function isServiceStateful(service) {
+    return toRaw(service) === service;
+}
+
 function _protectMethod(component, fn) {
     return function (...args) {
         if (status(component) === "destroyed") {
@@ -132,20 +145,7 @@ function _protectMethod(component, fn) {
 
 export const SERVICES_METADATA = {};
 
-/**
- * Import a service into a component
- *
- * @template {keyof import("services").ServiceFactories} K
- * @param {K} serviceName
- * @returns {import("services").ServiceFactories[K]}
- */
-export function useService(serviceName) {
-    const component = useComponent();
-    const { services } = component.env;
-    if (!(serviceName in services)) {
-        throw new Error(`Service ${serviceName} is not available`);
-    }
-    const service = services[serviceName];
+function decorateService(serviceName, service, component, { autoUseState = true } = {}) {
     if (SERVICES_METADATA[serviceName]) {
         if (service instanceof Function) {
             return _protectMethod(component, service);
@@ -158,10 +158,52 @@ export function useService(serviceName) {
             return result;
         }
     }
-    if (toRaw(service) !== service) {
+    if (!isServiceStateful(service) && autoUseState) {
         return useState(service);
     }
     return service;
+}
+
+/**
+ * Import a service into a component
+ *
+ * @template {keyof import("services").ServiceFactories} K
+ * @param {K} serviceName
+ * @param {Function} [onDelayedServiceReady] - Used to reassign services to variable
+ * @returns {import("services").ServiceFactories[K]}
+ */
+export function useService(serviceName, onDelayedServiceReady) {
+    const component = useComponent();
+    const { services } = component.env;
+    if (serviceName in services) {
+        return decorateService(serviceName, services[serviceName], component);
+    }
+    const tempState = useState({});
+    onWillStart(async () => {
+        await new Promise((resolve, reject) => {
+            setTimeout(() => {
+                if (!(serviceName in services)) {
+                    reject(
+                        new Error(
+                            `Service ${serviceName} is not available in "${component.constructor.name}".`
+                        )
+                    );
+                } else {
+                    resolve();
+                }
+            }, 0);
+        });
+        if (typeof onDelayedServiceReady === "function") {
+            const service = services[serviceName];
+            tempState.service = service;
+            const decoratedService = isServiceStateful(service)
+                ? decorateService(serviceName, service, component)
+                : decorateService(serviceName, tempState.service, component, {
+                      autoUseState: false,
+                  });
+            onDelayedServiceReady(decoratedService);
+        }
+    });
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
When we create a public root, we do:
- Create env
- Wait for services to load
- Create `MainComponentsContainer`

In a usual scenario, all the services are started in the second step above, so
when we create the MainComponentsContainer, all the services we need are already
 available. The problem with the lazy loading chatter bundle is that one of the
 services in the second step is responsible for loading that bundle. So while
 the lazy bundle is loading, new services and main components are being added to
 the registry.

The steps become like this:
- Create env
- Wait for services to start
- Start loading chatter bundle
- Lazy services (from chatter bundle) are not yet completely started
- A main component from lazy bundle is added to the registry (in this case
ChatHub) => crash
- Lazy services are completely started

Steps to reproduce:
- Install a module that has portal chatter for example sales
- Go to the portal page of a sale order
- Error: `service mail.store is not available`

This PR adds a very small delay to throw the error in the `useService()` hook 
if the service is not available to make sure that update services lazily is 
completed.