### PR TITLE
[IMP] l10n_es: Deductibles expenses

### DIFF
--- a/addons/l10n_es/data/account_tax_data.xml
+++ b/addons/l10n_es/data/account_tax_data.xml
@@ -5222,4 +5222,22 @@
         ]"
         />
     </record>
+    <record id="account_tax_template_s_gd0" model="account.tax.template">
+        <field name="description">Gastos deducibles</field>
+        <field name="type_tax_use">none</field>
+        <field name="name">Gastos deducibles</field>
+        <field name="active">True</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_seguridad_social"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {'repartition_type': 'base'}),
+            (0,0, {'repartition_type': 'tax'}),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {'repartition_type': 'base'}),
+            (0,0, {'repartition_type': 'tax'}),
+        ]"/>
+    </record>
 </odoo>

--- a/addons/l10n_es/data/account_tax_group_data.xml
+++ b/addons/l10n_es/data/account_tax_group_data.xml
@@ -121,5 +121,9 @@
             <field name="name">Retenciones 35%</field>
             <field name="country_id" ref="base.es"/>
         </record>
+        <record id="tax_group_seguridad_social" model="account.tax.group">
+            <field name="name">Seguridad Social</field>
+            <field name="country_id" ref="base.es"/>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
A new tag is necessary to calculate deductibles expenses associated to 190 AEAT report. It isn't a percent tax, it's a new tag to can set it in move lines and calculate this box from 190 AEAT report. 
190 AEAT report (190 AEAT) isn't now included in Odoo, but it could be added in the future. Meanwhile the tax can be used in oca module `l10n_es_aeat_mod_190' or you can do a filter for this tax and fill in the report manually.

https://sede.agenciatributaria.gob.es/static_files/Sede/Disenyo_registro/DR_100_199/archivos_24/DISENOS_LOGICOS_190-2024.pdf https://sede.agenciatributaria.gob.es/static_files/Sede/Procedimiento_ayuda/GI10/Instrucciones/instr_mod190_es_es.pdf

@moduon MT-8853

@rafaelbn @etobella @pedrobaeza @jco-odoo @chklop 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
