### PR TITLE
[IMP] web,hr_timesheet,website_sale: simplify views' inheritance

### DIFF
--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -257,11 +257,11 @@
                     <attribute name="readonly">1</attribute>
                 </xpath>
                 <xpath expr="//field[@name='project_id']" position="attributes">
-                    <attribute name="options">{'no_create_edit': True, 'no_open': True}</attribute>
+                    <attribute name="options" add="{'no_open': True}" separator="|"/>
                     <attribute name="readonly">1</attribute>
                 </xpath>
                 <xpath expr="//field[@name='task_id']" position="attributes">
-                    <attribute name="options">{'no_create_edit': True, 'no_open': True}</attribute>
+                    <attribute name="options" add="{'no_open': True}" separator="|"/>
                     <attribute name="readonly">1</attribute>
                 </xpath>
             </field>

--- a/addons/web/static/src/core/py_js/py_interpreter.js
+++ b/addons/web/static/src/core/py_js/py_interpreter.js
@@ -242,6 +242,11 @@ function applyBinaryOp(ast, context) {
             return isIn(left, right);
         case "not in":
             return !isIn(left, right);
+        case "|":
+            if (pytypeIndex(left) === 3 && pytypeIndex(right) === 3) { // both dicts
+                return {...left, ...right};
+            }
+            return left | right;
     }
     throw new EvaluationError(`Unknown binary operator: ${ast.op}`);
 }

--- a/addons/web/static/tests/core/py_js/py_interpreter.test.js
+++ b/addons/web/static/tests/core/py_js/py_interpreter.test.js
@@ -78,6 +78,7 @@ describe("number properties", () => {
         expect(evaluateExpr("42 % 5")).toBe(2);
         expect(evaluateExpr("2 ** 3")).toBe(8);
         expect(evaluateExpr("a + b", { a: 1, b: 41 })).toBe(42);
+        expect(evaluateExpr("3 | 2 + 2")).toBe(7);
     });
 
     test("// operator", () => {
@@ -100,6 +101,8 @@ describe("boolean properties", () => {
         expect(evaluateExpr("not []")).toBe(true);
         expect(evaluateExpr("True == False or True == True")).toBe(true);
         expect(evaluateExpr("False == True and False")).toBe(false);
+        expect(evaluateExpr("False | False")).toBe(false);
+        expect(evaluateExpr("True | False and True")).toBe(true);
     });
 
     test("get value from context", () => {
@@ -309,6 +312,12 @@ describe("dicts", () => {
     test("lookup and definition", () => {
         expect(evaluateExpr("{'a': 1}['a']")).toBe(1);
         expect(evaluateExpr("{1: 2}[1]")).toBe(2);
+    });
+
+    test("dict union", () => {
+        expect(evaluateExpr("{'a': 1} | {'b': 2}")).toEqual({ a: 1, b: 2});
+        expect(evaluateExpr("{'a': 1} | {'a': 2}")).toEqual({ a: 2});
+        expect(evaluateExpr("{'a': 1, 'b': 2} | {'a': 3, 'c': 4}")).toEqual({ a: 3, b: 2, c: 4});
     });
 
     test("can get values with get method", () => {

--- a/addons/website_sale/views/sale_order_views.xml
+++ b/addons/website_sale/views/sale_order_views.xml
@@ -173,12 +173,7 @@
                     invisible="not is_abandoned_cart or cart_recovery_email_sent or state != 'draft'"/>
             </button>
             <field name="partner_id" position="attributes">
-                <attribute name="context">{
-                    'display_website': True,
-                    'res_partner_search_mode': 'customer',
-                    'show_address': 1,
-                    'show_vat': True,
-                }</attribute>
+                <attribute name="context" add="{'display_website': True}" separator="|"/>
             </field>
             <field name="team_id" position="after">
                 <field name="website_id" invisible="not website_id" groups="website.group_multi_website"/>


### PR DESCRIPTION
In XML views, it is often necessary to override a field's `context`
and/or `options`. Previously, this required replacing the entire context
dictionary, ensuring past values were retained in the new context.

This method introduced an issue:

Any changes to the parent view's behavior wouldn't apply if the child
view was active and the developer overlooked checking all relevant
xpaths.

This commit introduces support for Python's | operator to create a form
of inheritance between dictionaries.

```python
{'a': 1, 'b': 2} | {'a': 3, 'c': 4} == {'a': 3, 'b': 2, 'c': 4}
```

This approach will simplify code duplication, reduce the risk of human errors
in the codebase, and inherently increase maintainability.

See also:
- https://github.com/odoo/enterprise/pull/79826

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
