### PR TITLE
[FIX] calendar: prevent mail defender from cancelling meetings

### DIFF
--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -30,12 +30,6 @@
 
     </p>
     <div style="text-align: center; padding: 16px 0px 16px 0px;">
-        <a t-attf-href="/calendar/meeting/accept?token={{object.access_token}}&amp;id={{object.event_id.id}}"
-            style="padding: 5px 10px; color: #FFFFFF; text-decoration: none; background-color: #875A7B; border: 1px solid #875A7B; border-radius: 3px">
-            Accept</a>
-        <a t-attf-href="/calendar/meeting/decline?token={{object.access_token}}&amp;id={{object.event_id.id}}"
-            style="padding: 5px 10px; color: #FFFFFF; text-decoration: none; background-color: #875A7B; border: 1px solid #875A7B; border-radius: 3px">
-            Decline</a>
         <a t-attf-href="/calendar/meeting/view?token={{object.access_token}}&amp;id={{object.event_id.id}}"
             style="padding: 5px 10px; color: #FFFFFF; text-decoration: none; background-color: #875A7B; border: 1px solid #875A7B; border-radius: 3px"
             >View</a>
@@ -161,12 +155,6 @@
         </t>
     </p>
     <div style="text-align: center; padding: 16px 0px 16px 0px;">
-        <a t-attf-href="/calendar/meeting/accept?token={{ object.access_token }}&amp;id={{ object.event_id.id }}"
-            style="padding: 5px 10px; color: #FFFFFF; text-decoration: none; background-color: #875A7B; border: 1px solid #875A7B; border-radius: 3px">
-            Accept</a>
-        <a t-attf-href="/calendar/meeting/decline?token={{ object.access_token }}&amp;id={{ object.event_id.id }}"
-            style="padding: 5px 10px; color: #FFFFFF; text-decoration: none; background-color: #875A7B; border: 1px solid #875A7B; border-radius: 3px">
-            Decline</a>
         <a t-attf-href="/calendar/meeting/view?token={{ object.access_token }}&amp;id={{ object.event_id.id }}"
             style="padding: 5px 10px; color: #FFFFFF; text-decoration: none; background-color: #875A7B; border: 1px solid #875A7B; border-radius: 3px">
             View</a>

--- a/addons/calendar/views/calendar_templates.xml
+++ b/addons/calendar/views/calendar_templates.xml
@@ -17,8 +17,20 @@
                         <h2>Calendar Invitation <small><t t-esc="event.name"/></small></h2>
                     </div>
                     <div class="card-body">
-                        <div class="clearfix mb16" t-if="attendee.state != 'needsAction'">
-                            <span class="float-end badge text-bg-info">
+                        <div class="clearfix mb16 d-flex justify-content-between align-content-center flex-grow-0">
+                            <div class="col d-flex">
+                                <form t-if="attendee.state != 'accepted'" method="POST" action="/calendar/meeting/accept" class="me-1 d-inline-block">
+                                    <input t-foreach="request.httprequest.args.items()" t-as="request_arg" t-if="request_arg[0] != 'confirm_needed'"
+                                           type="hidden" t-att-name="request_arg[0]" t-att-value="request_arg[1]"/>
+                                    <button type="submit" role="button" class="btn btn-primary btn-block">Accept</button>
+                                </form>
+                                <form t-if="attendee.state != 'declined'" method="POST" action="/calendar/meeting/decline" class="ms-1 d-inline-block">
+                                    <input t-foreach="request.httprequest.args.items()" t-as="request_arg" t-if="request_arg[0] != 'confirm_needed'"
+                                           type="hidden" t-att-name="request_arg[0]" t-att-value="request_arg[1]"/>
+                                    <button type="submit" role="button" class="btn btn-danger btn-block">Decline</button>
+                                </form>
+                            </div>
+                            <span class="float-end badge text-bg-info align-self-center" t-if="attendee.state != 'needsAction'">
                                 <t t-if="attendee.state == 'accepted'">Yes I'm going.</t>
                                 <t t-if="attendee.state == 'declined'">No I'm not going.</t>
                                 <t t-if="attendee.state == 'tentative'">Tentative</t>


### PR DESCRIPTION
Mails are sent to users containing an acceptation and cancellation link that accepts GET requests but performs an action on visit

Some mail defender software analyzes urls in links by actually visiting the URL. This leads to both actions being triggered without user input.

Instead we now send buttons with a neutralizing parameter in the mail. Recipients may then visit the url and click a form button to "accept" or "decline".

As these are post requests, the email bots should avoid clicking them.

task-4555579
