### PR TITLE
[FIX] web_editor: ZWS before banner

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -379,15 +379,16 @@ export const editorCommands = {
                 currentNode.remove();
             }
             // If the first child of editable is contenteditable false element
-            // a chromium bug prevents selecting the container. Prepend a
-            // zero-width space so it's no longer the first child.
+            // a chromium bug prevents selecting the container.
+            // Add a paragraph above it so it's no longer the first child.
             if (
                 !isNodeToInsertContentEditable &&
                 editor.editable.firstChild === nodeToInsert &&
                 nodeToInsert.nodeName === 'DIV'
             ) {
-                const zws = document.createTextNode('\u200B');
-                nodeToInsert.before(zws);
+                const p = document.createElement("p");
+                p.append(document.createElement("br"));
+                nodeToInsert.before(p);
             }
             currentNode = convertedList || nodeToInsert;
         }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insert.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insert.test.js
@@ -74,7 +74,7 @@ describe('insert HTML', () => {
                 },
                 // Inserts zws to avoid a Chromium bug preventing selection of
                 // contenteditable false element as first child.
-                contentAfter: '\u200b<div><p>content</p></div><p>[]<br></p>',
+                contentAfter: '<p><br></p><div><p>content</p></div><p>[]<br></p>',
             });
         });
         it('should not split a pre to insert another pre but just insert the text', async () => {

--- a/addons/web_editor/static/tests/banner_tests.js
+++ b/addons/web_editor/static/tests/banner_tests.js
@@ -134,7 +134,7 @@ QUnit.module(
             insertText(editor, '/banner');
             triggerEvent(editor.editable, "keydown", { key: "Enter" });
             await nextTick();
-            const p = editable.querySelectorAll('p')[1];
+            const p = editable.querySelectorAll('p')[2];
             setSelection(p, 0);
             insertText(editor, 'Test1');
             triggerEvent(editor.editable, "input", { inputType: "insertParagraph" });


### PR DESCRIPTION
Before this commit and since [1], when inserting a banner at the top of the editable, a zero-width space (ZWS) was inserted before the banner to circuvent a Chromium bug that prevents fully selecting the banner with the mouse [2].

This led to the undesirable behavior of having a text node (with a ZWS) as the first child of the editable, creating a line above the banner and allowing for text insertion at the editable's root.

This commit replaces the ZWS insertion with an empty paragraph, which can be later be moved around by the user.

[1]: a0fcba6
[2]: https://issues.chromium.org/issues/40822311

Backport of PR #195027
