### PR TITLE
[IMP] phone_validation, project: make_identifier for indexes

### DIFF
--- a/addons/phone_validation/models/mail_thread_phone.py
+++ b/addons/phone_validation/models/mail_thread_phone.py
@@ -6,7 +6,7 @@ import re
 from odoo import api, fields, models, _
 from odoo.exceptions import AccessError, UserError
 from odoo.osv import expression
-from odoo.tools import create_index
+from odoo.tools import create_index, make_identifier
 
 PHONE_REGEX_PATTERN = r'[\s\\./\(\)\-]'
 
@@ -57,14 +57,14 @@ class MailThreadPhone(models.AbstractModel):
             regex_expression = rf"regexp_replace(({fname}::text), '{PHONE_REGEX_PATTERN}'::text, ''::text, 'g'::text)"
             # The btree index covers operators '=' and '=like' with a known prefix
             create_index(self.env.cr,
-                         indexname=f'{self._table}_{fname}_partial_tgm',
+                         indexname=make_identifier(f'{self._table}_{fname}_partial_tgm'),
                          tablename=self._table,
                          expressions=[regex_expression],
                          where=f'{fname} IS NOT NULL')
             if self.env.registry.has_trigram:
                 # The trigram index covers operators 'like', 'ilike' and '=like' starting with a wildcard
                 create_index(self.env.cr,
-                             indexname=f'{self._table}_{fname}_partial_gin_idx',
+                             indexname=make_identifier(f'{self._table}_{fname}_partial_gin_idx'),
                              tablename=self._table,
                              method='gin',
                              expressions=[regex_expression + ' gin_trgm_ops'],

--- a/addons/project/__init__.py
+++ b/addons/project/__init__.py
@@ -6,7 +6,7 @@ from . import models
 from . import report
 from . import wizard
 
-from odoo.tools.sql import create_index
+from odoo.tools.sql import create_index, make_identifier
 
 
 def _check_exists_collaborators_for_project_sharing(env):
@@ -27,7 +27,7 @@ def _project_post_init(env):
     project_task_stage_field_id = env['ir.model.fields']._get_ids('project.task').get('stage_id')
     create_index(
         env.cr,
-        'mail_tracking_value_mail_message_id_old_value_integer_task_stage',
+        make_identifier('mail_tracking_value_mail_message_id_old_value_integer_task_stage'),
         env['mail.tracking.value']._table,
         ['mail_message_id', 'old_value_integer'],
         where=f'field_id={project_task_stage_field_id}'


### PR DESCRIPTION
When creating indexes, we must ensure that the name of the index is not too long, otherwise it is truncated by the database. We have the function `make_identifier` for this.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
