### PR TITLE
[IMP] base_automation: sync fields with domain

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -27,6 +27,33 @@ DOMAIN_FIELDS_RE = re.compile(r"""
     [^,]*?[()[\]]           # anything except a comma followed by a closing bracket or another opening bracket
 """, re.VERBOSE)
 
+
+def _get_domain_fields(env, model, domain):
+    IrModelFields = env["ir.model.fields"]
+    if not domain:
+        return IrModelFields
+    fields = IrModelFields
+    # wondering why we use a regex instead of safe_eval?
+    # because this method is called on a compute method hence could be triggered
+    # from an onchange call (i.e. a manually crafted malicious one)
+    # see: https://github.com/odoo/odoo/pull/189772#issuecomment-2548804283
+    for match in DOMAIN_FIELDS_RE.finditer(domain):
+        if field := match.groupdict().get('field'):
+            fields |= IrModelFields._get(model, field)
+    return fields
+
+
+def _domain_fields_differences(automation, domain1, domain2):
+    IrModelFields = automation.env["ir.model.fields"]
+    if not automation.model_id:
+        return IrModelFields, IrModelFields
+    d1_fields = _get_domain_fields(automation.env, automation.model_id.model, domain1)
+    d2_fields = _get_domain_fields(automation.env, automation.model_id.model, domain2)
+    in_d1_only_fields = d1_fields - d2_fields
+    in_d2_only_fields = d2_fields - d1_fields
+    return in_d1_only_fields, in_d2_only_fields
+
+
 DATE_RANGE = {
     'minutes': relativedelta(minutes=1),
     'hour': relativedelta(hours=1),
@@ -193,6 +220,7 @@ class BaseAutomation(models.Model):
         readonly=False, store=True,
         help="If present, this condition must be satisfied before the update of the record. "
              "Not checked on record creation.")
+    previous_domain = fields.Char(store=False, default=lambda self: self.filter_domain)
     filter_domain = fields.Char(
         string='Apply on',
         help="If present, this condition must be satisfied before executing the automation rule.",
@@ -364,19 +392,30 @@ class BaseAutomation(models.Model):
         to_reset = self.filtered(lambda a: a.trigger != 'on_change')
         to_reset.on_change_field_ids = False
         for automation in (self - to_reset):
-            automation.on_change_field_ids |= automation._get_filter_domain_fields()
+            automation._onchange_domain()
 
     @api.depends('model_id', 'trigger', 'filter_domain')
     def _compute_trigger_field_ids(self):
         for automation in self:
             if automation.trigger == "on_create_or_write":
-                automation.trigger_field_ids |= automation._get_filter_domain_fields()
+                automation._onchange_domain()
                 continue
             automation._onchange_trigger()
 
     @api.depends('model_id')
     def _compute_trigger(self):
         self.trigger = False
+
+    @api.onchange("filter_domain")
+    def _onchange_domain(self):
+        removed_fields, added_fields = _domain_fields_differences(self, self.previous_domain, self.filter_domain)
+        if self.trigger == "on_change":
+            self.on_change_field_ids = self.on_change_field_ids.filtered(lambda f: f._origin.id not in removed_fields.ids)
+            self.on_change_field_ids |= added_fields
+        if self.trigger == "on_create_or_write":
+            self.trigger_field_ids = self.trigger_field_ids.filtered(lambda f: f._origin.id not in removed_fields.ids)
+            self.trigger_field_ids |= added_fields
+        self.previous_domain = self.filter_domain
 
     @api.onchange('trigger')
     def _onchange_trigger(self):
@@ -386,7 +425,6 @@ class BaseAutomation(models.Model):
             else False
         )
         self.trigger_field_ids = field
-
 
     @api.onchange('trigger', 'action_server_ids')
     def _onchange_trigger_or_actions(self):
@@ -476,26 +514,11 @@ class BaseAutomation(models.Model):
             'domain': [('path', '=', "base_automation(%s)" % self.id)],
         }
 
-    def _get_filter_domain_fields(self):
-        self.ensure_one()
-        if not self.filter_domain or not self.model_id:
-            return self.env['ir.model.fields']
-        model = self.model_id.model
-        fields = self.env["ir.model.fields"]
-        # wondering why we use a regex instead of safe_eval?
-        # because this method is called on a compute method hence could be triggered
-        # from an onchange call (i.e. a manually crafted malicious one)
-        # see: https://github.com/odoo/odoo/pull/189772#issuecomment-2548804283
-        for match in DOMAIN_FIELDS_RE.finditer(self.filter_domain):
-            if field := match.groupdict().get('field'):
-                fields |= self.env["ir.model.fields"]._get(model, field)
-        return fields
-
     def _get_trigger_specific_field(self):
         self.ensure_one()
         match self.trigger:
             case 'on_create_or_write':
-                return self._get_filter_domain_fields()
+                return _get_domain_fields(self.env, self.model_id.model, self.filter_domain)
             case 'on_stage_set':
                 domain = [('ttype', '=', 'many2one'), ('name', 'in', ['stage_id', 'x_studio_stage_id'])]
             case 'on_tag_set':

--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -90,6 +90,7 @@
                                             'on_time_updated'
                                         ]"
                                 />
+                                <field name="previous_domain" invisible="1"/>
                                 <field name="filter_domain" widget="domain" groups="base.group_no_one"
                                     options="{'model': 'model_name', 'in_dialog': True}"
                                     invisible="trigger in ['on_change', 'on_webhook']"

--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -1173,18 +1173,20 @@ class TestCompute(common.TransactionCase):
         self.assertEqual(automation.on_change_field_ids.ids, [])
 
         # Change the trigger fields will not change the domain
-        automation_form.trigger_field_ids.set(
+        automation_form.trigger_field_ids.add(
             self.env.ref('test_base_automation.field_base_automation_lead_test__tag_ids')
         )
         automation = automation_form.save()
         self.assertEqual(automation.filter_pre_domain, False)
         self.assertEqual(automation.filter_domain, repr([('priority', '=', True), ('employee', '=', False)]))
-        self.assertEqual(automation.trigger_field_ids.ids, [
+        self.assertItemsEqual(automation.trigger_field_ids.ids, [
+            self.env.ref('test_base_automation.field_base_automation_lead_test__priority').id,
+            self.env.ref('test_base_automation.field_base_automation_lead_test__employee').id,
             self.env.ref('test_base_automation.field_base_automation_lead_test__tag_ids').id
         ])
         self.assertEqual(automation.on_change_field_ids.ids, [])
 
-        # Erase the domain will not change the trigger fields
+        # Erase the domain will remove corresponding fields from the trigger fields
         automation_form.filter_domain = False
         automation = automation_form.save()
         self.assertEqual(automation.filter_pre_domain, False)


### PR DESCRIPTION
Before this commit, modifying the filter_domain of a base_automation
record was appending the domain's fields to the "When updating" trigger
fields. But when the domain removed a field, it was not removed from
the trigger fields.

This commit fixes that by adding a non stored field 'previous_domain' in
order to compare the current domain with the previous one, hence keeping
successfully track of the added/removed fields from the domain.

Task id: opw-4493054