### PR TITLE
[FIX] account: improve switch invoice error message

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -16124,7 +16124,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account/models/account_move.py:0
 #, python-format
-msgid "You cannot switch the type of a posted document."
+msgid "You cannot switch the type of a document which has been posted once."
 msgstr ""
 
 #. module: account

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3723,7 +3723,7 @@ class AccountMove(models.Model):
     def action_switch_invoice_into_refund_credit_note(self):
         for move in self:
             if move.posted_before:
-                raise ValidationError(_("You cannot switch the type of a posted document."))
+                raise ValidationError(_("You cannot switch the type of a document which has been posted once."))
             if move.move_type == 'entry':
                 raise ValidationError(_("This action isn't available for this document."))
             in_out, old_move_type = move.move_type.split('_')


### PR DESCRIPTION
- Open a posted invoice
- Reset to draft
- Action > Switch into invoice/credit note

Validation Error will raise
`You cannot switch the type of a posted document.`

However the message is misleading, because we check that the document has not
been posted at all

opw-4509455