### PR TITLE
[FIX] mrp: display right component colors for confirmed MOs

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -398,8 +398,8 @@
                                     <!-- Button are used in state draft to doesn't have the name of the column "Reserved"-->
                                     <field name="forecast_availability" column_invisible="parent.state in ['done', 'cancel']" string="Forecast" widget="forecast_widget" optional="hide"/>
                                     <field name="quantity" string="Quantity"
-                                        decoration-success="not is_done and (quantity - should_consume_qty == 0)"
-                                        decoration-warning="not is_done and (quantity - should_consume_qty &gt; 0.0001)"
+                                        decoration-success="not is_done and (quantity - (should_consume_qty if parent.qty_producing else product_uom_qty) == 0)"
+                                        decoration-warning="not is_done and (quantity - (should_consume_qty if parent.qty_producing else product_uom_qty) &gt; 0.0001)"
                                         column_invisible="parent.state == 'draft'"
                                         readonly="has_tracking != 'none'"
                                         force_save="1" widget="mrp_consumed"/>


### PR DESCRIPTION
Follow-up to #190162

Steps to reproduce:
- Create a new Manufacturing Order
- Set a product that is in stock as component with a quantity of 1
- Confirm the Manufacturing Order

Issue:
The component will be displayed in yellow (i.e. overconsumption), as the condition checks always on `should_consume_qty`, which is the quantity that should be used for that amount of `qty_producing`. But that quantity will *always* be 0 for confirmed MOs, as the `qty_producing` will be 0 at the time.

Instead, while the MO isn't started yet, we can simply compare to the demand to see if there's enough reservation.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
