### PR TITLE
[FIX] l10n_ro_efactura: duplicate invoice on request timeout

### DIFF
--- a/addons/l10n_ro_efactura/i18n/l10n_ro_efactura.pot
+++ b/addons/l10n_ro_efactura/i18n/l10n_ro_efactura.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-01 09:28+0000\n"
-"PO-Revision-Date: 2024-07-01 09:28+0000\n"
+"POT-Creation-Date: 2025-02-20 14:35+0000\n"
+"PO-Revision-Date: 2025-02-20 14:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -75,6 +75,13 @@ msgstr ""
 #: code:addons/l10n_ro_efactura/models/ciusro_document.py:0
 #, python-format
 msgid "Access token is forbidden."
+msgstr ""
+
+#. module: l10n_ro_efactura
+#. odoo-python
+#: code:addons/l10n_ro_efactura/models/ciusro_document.py:0
+#, python-format
+msgid "Access token is unauthorized."
 msgstr ""
 
 #. module: l10n_ro_efactura
@@ -269,6 +276,27 @@ msgstr ""
 msgid ""
 "Error when sending the document to the SPV:\n"
 "%s"
+msgstr ""
+
+#. module: l10n_ro_efactura
+#. odoo-python
+#: code:addons/l10n_ro_efactura/models/account_move.py:0
+#, python-format
+msgid "Error when trying to download the E-Factura answer from the SPV: %s"
+msgstr ""
+
+#. module: l10n_ro_efactura
+#. odoo-python
+#: code:addons/l10n_ro_efactura/models/account_move.py:0
+#, python-format
+msgid "Error when trying to fetch the E-Factura from the SPV: %s"
+msgstr ""
+
+#. module: l10n_ro_efactura
+#. odoo-python
+#: code:addons/l10n_ro_efactura/models/account_move.py:0
+#, python-format
+msgid "Error when trying to send the E-Factura to the SPV: %s"
 msgstr ""
 
 #. module: l10n_ro_efactura

--- a/addons/l10n_ro_efactura/models/ciusro_document.py
+++ b/addons/l10n_ro_efactura/models/ciusro_document.py
@@ -29,7 +29,7 @@ def make_efactura_request(session, company, endpoint, method, params, data=None)
                'Authorization': f'Bearer {company.l10n_ro_edi_access_token}'}
 
     try:
-        response = session.request(method=method, url=url, params=params, data=data, headers=headers, timeout=10)
+        response = session.request(method=method, url=url, params=params, data=data, headers=headers, timeout=60)
     except requests.HTTPError as e:
         return {'error': str(e)}
     if response.status_code == 204:
@@ -37,6 +37,8 @@ def make_efactura_request(session, company, endpoint, method, params, data=None)
     if response.status_code == 400:
         error_json = response.json()
         return {'error': error_json['message']}
+    if response.status_code == 401:
+        return {'error': _('Access token is unauthorized.')}
     if response.status_code == 403:
         return {'error': _('Access token is forbidden.')}
     if response.status_code == 500:


### PR DESCRIPTION
The Romanian SPV servers are slow. When sending a request to them, we previously set a hard timeout limit at 10 seconds and mark the request as failed if it exceeds it.

However, recently we have found a critical issue where some users found that their invoice has been sent twice (or more) to the Romanian SPV.

After investigating, we found that what's likely to happen is that the SPV takes more than 10 seconds to send the response back when we're making a request, and since in our side we consider the request as failed and requires the user to send a new request again, we make the user send a second request on the same invoice, where the SPV actually acknowledges all of the received invoices.

After discussing with the PO, a temporary workaround for now is to increase the timeout limit to 60 seconds (1 full minute) to reduce the likelihood of this issue happening, and log error messages on the chatter if the request (either for send/fetch/download) failed, so that the user are aware when it is timeout and be more wary not to send another request right away, in case the new timeout limit are still not enough.

Other small changes in this PR:

- Handle response code 401, (which is a JSON object, invalid access token)
- Remove the "Error when sending the document to the SPV:" template in error documents (because not all error documents are for sending, some are from fetch/download)

opw-4571713