### PR TITLE
[FIX] l10n_be: Display negative tax report values in muted text

### DIFF
--- a/addons/l10n_be/data/account_tax_report_data.xml
+++ b/addons/l10n_be/data/account_tax_report_data.xml
@@ -214,7 +214,6 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">c81.balance_unbound</field>
-                                        <field name="subformula">if_above(EUR(0))</field>
                                     </record>
                                 </field>
                             </record>
@@ -248,7 +247,6 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">c82.balance_unbound</field>
-                                        <field name="subformula">if_above(EUR(0))</field>
                                     </record>
                                 </field>
                             </record>
@@ -282,7 +280,6 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">c83.balance_unbound</field>
-                                        <field name="subformula">if_above(EUR(0))</field>
                                     </record>
                                 </field>
                             </record>
@@ -338,7 +335,6 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">c86.balance_unbound</field>
-                                        <field name="subformula">if_above(EUR(0))</field>
                                     </record>
                                 </field>
                             </record>
@@ -372,7 +368,6 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">c87.balance_unbound</field>
-                                        <field name="subformula">if_above(EUR(0))</field>
                                     </record>
                                 </field>
                             </record>
@@ -406,7 +401,6 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">c88.balance_unbound</field>
-                                        <field name="subformula">if_above(EUR(0))</field>
                                     </record>
                                 </field>
                             </record>


### PR DESCRIPTION
In Belgium, certain tax grids (e.g., 81, 82) in the VAT report force negative amounts to 0, as the amounts are carried over to the next period. However, this behavior confuses users, especially VAT experts, as they see 0 instead of the actual negative amount.

To improve clarity:
- Negative values are now displayed instead of being forced to 0.
- The carryover mechanism remains unchanged, and the explanatory infobullet is still displayed.

Task-4589150

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
