### PR TITLE
[FIX] odoo: Display error message to internal user

### DIFF
--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -158,7 +158,7 @@ def retrying(func, env):
                         if exc.diag.table_name == rclass._table:
                             model = env[rclass._name]
                             break
-                    message = env._("The operation cannot be completed: %s", model._sql_error_to_message(exc))
+                    message = env._("The operation cannot be completed: %s", model.sudo()._sql_error_to_message(exc))
                     raise ValidationError(message) from exc
                 if not isinstance(exc, PG_CONCURRENCY_EXCEPTIONS_TO_RETRY):
                     raise


### PR DESCRIPTION
Steps to reproduce:

- Login as admin
- Go to the demo user and set Employees: “Officer: Manage all employees”
- Logout and login as demo/demo
- Go to employees
- On one employee: set Badge ID 1234 in the Settings tab
- On another set the same Badge ID

Bug:

Odoo displayed an access error because ir.mode
is only readable with Admin access rights

Expectec behavior:

Odoo should instead display: "The Badge ID must be unique, this one is already assigned to another employee."

opw:4559870