### PR TITLE
[FIX] spreadsheet: fix inconsistent day of week

### DIFF
--- a/addons/spreadsheet/static/src/@types/pivot.d.ts
+++ b/addons/spreadsheet/static/src/@types/pivot.d.ts
@@ -78,5 +78,6 @@ declare module "@spreadsheet" {
     export interface PivotModelServices {
         serverData: ServerData;
         orm: ORM;
+        getters: OdooGetters;
     }
 }

--- a/addons/spreadsheet/static/src/pivot/odoo_pivot.js
+++ b/addons/spreadsheet/static/src/pivot/odoo_pivot.js
@@ -194,6 +194,7 @@ export class OdooPivot {
             {
                 orm: this.odooDataProvider.orm,
                 serverData: this.odooDataProvider.serverData,
+                getters: this.getters,
             }
         );
         return { model, definition };

--- a/addons/spreadsheet/static/src/pivot/pivot_model.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_model.js
@@ -45,6 +45,11 @@ export class OdooPivotModel extends PivotModel {
          * @type {import("@spreadsheet/data_sources/server_data").ServerData}
          */
         this.serverData = services.serverData;
+
+        /**
+         * @type {import("@spreadsheet").OdooGetters}
+         */
+        this.getters = services.getters;
     }
 
     /**
@@ -153,7 +158,7 @@ export class OdooPivotModel extends PivotModel {
         const undef = _t("None");
         if (isDateOrDatetimeField(field)) {
             const adapter = pivotTimeAdapter(granularity);
-            return adapter.toValueAndFormat(value).value;
+            return adapter.toValueAndFormat(value, this.getters.getLocale()).value;
         }
         if (field.relation) {
             if (value === false) {
@@ -367,7 +372,12 @@ export class OdooPivotModel extends PivotModel {
             const groupBy = this._normalize(gb);
             const { field, granularity } = this.parseGroupField(gb);
             if (isDateOrDatetimeField(field)) {
-                return pivotTimeAdapter(granularity).normalizeServerValue(groupBy, field, group);
+                return pivotTimeAdapter(granularity).normalizeServerValue(
+                    groupBy,
+                    field,
+                    group,
+                    this.getters.getLocale()
+                );
             }
             return this._sanitizeValue(group[groupBy]);
         });

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -9,6 +9,7 @@ import {
     makeServerError,
     onRpc,
     patchTranslations,
+    patchWithCleanup,
     serverState,
 } from "@web/../tests/web_test_helpers";
 import { Deferred } from "@web/core/utils/concurrency";
@@ -32,6 +33,7 @@ import { createSpreadsheetWithPivot } from "@spreadsheet/../tests/helpers/pivot"
 import { CommandResult } from "@spreadsheet/o_spreadsheet/cancelled_reason";
 
 import { user } from "@web/core/user";
+import { localization } from "@web/core/l10n/localization";
 
 import { Model } from "@odoo/o-spreadsheet";
 import { THIS_YEAR_GLOBAL_FILTER } from "@spreadsheet/../tests/helpers/global_filter";
@@ -1131,6 +1133,84 @@ test("PIVOT day are correctly formatted at evaluation", async function () {
     expect(getEvaluatedCell(model, "B3").format).toBe("#,##0.00");
     expect(getEvaluatedCell(model, "B3").value).toBe(10);
     expect(getEvaluatedCell(model, "B3").formattedValue).toBe("10.00");
+});
+
+test("PIVOT day_of_week with same user and spreadsheet week start", async function () {
+    const { model, pivotId } = await createSpreadsheetWithPivot({
+        arch: /* xml */ `
+            <pivot>
+                <field name="date" interval="day" type="row"/>
+                <field name="probability" type="measure"/>
+            </pivot>`,
+        mockRPC: function (route, { method, kwargs }) {
+            if (method === "read_group" && kwargs.groupby?.includes("date:day_of_week")) {
+                return [
+                    {
+                        "date:day_of_week": 2, // 2 days after the user week start (Monday + 2 = Wednesday)
+                        __domain: [["date.day_of_week", "=", 2]],
+                        __count: 1,
+                        probability_avg_id: 11,
+                    },
+                ];
+            }
+        },
+    });
+    patchWithCleanup(localization, {
+        weekStart: 1, // Monday
+    });
+    model.dispatch("UPDATE_LOCALE", {
+        locale: {
+            ...model.getters.getLocale(),
+            weekStart: 1, // Monday
+        },
+    });
+    updatePivot(model, pivotId, {
+        rows: [{ fieldName: "date", granularity: "day_of_week" }],
+    });
+    setCellContent(model, "B1", '=PIVOT.HEADER(1, "date:day_of_week", 3)');
+    setCellContent(model, "B2", '=PIVOT.VALUE(1, "probability:avg", "date:day_of_week", 3)');
+    await animationFrame();
+    expect(getEvaluatedCell(model, "B1").value).toBe("Wednesday");
+    expect(getEvaluatedCell(model, "B2").value).toBe(11);
+});
+
+test("PIVOT day_of_week with user week start and spreadsheet week start different", async function () {
+    const { model, pivotId } = await createSpreadsheetWithPivot({
+        arch: /* xml */ `
+            <pivot>
+                <field name="date" interval="day" type="row"/>
+                <field name="probability" type="measure"/>
+            </pivot>`,
+        mockRPC: function (route, { method, kwargs }) {
+            if (method === "read_group" && kwargs.groupby?.includes("date:day_of_week")) {
+                return [
+                    {
+                        "date:day_of_week": 1, // 2 days after the user week start (Tuesday + 1 = Wednesday)
+                        __domain: [["date.day_of_week", "=", 1]],
+                        __count: 1,
+                        probability_avg_id: 11,
+                    },
+                ];
+            }
+        },
+    });
+    patchWithCleanup(localization, {
+        weekStart: 2, // Tuesday
+    });
+    model.dispatch("UPDATE_LOCALE", {
+        locale: {
+            ...model.getters.getLocale(),
+            weekStart: 6, // Saturday
+        },
+    });
+    updatePivot(model, pivotId, {
+        rows: [{ fieldName: "date", granularity: "day_of_week" }],
+    });
+    setCellContent(model, "B1", '=PIVOT.HEADER(1, "date:day_of_week", 5)');
+    setCellContent(model, "B2", '=PIVOT.VALUE(1, "probability:avg", "date:day_of_week", 5)');
+    await animationFrame();
+    expect(getEvaluatedCell(model, "B1").value).toBe("Wednesday");
+    expect(getEvaluatedCell(model, "B2").value).toBe(11);
 });
 
 test("PIVOT iso_week_number are correctly formatted at evaluation", async function () {

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -120,7 +120,7 @@ const READ_GROUP_NUMBER_GRANULARITY = [
 
 const DATE_FORMAT = {
     day: (date) => date.toFormat("yyyy-MM-dd"),
-    day_of_week: (date) => date.weekday,
+    day_of_week: (date) => date.weekday % 7, // number of days after the first day of the week (assumed to be Sunday)
     day_of_month: (date) => date.day,
     day_of_year: (date) => date.ordinal,
     week: (date) => `W${date.toFormat("WW kkkk")}`,

--- a/addons/web/static/tests/legacy/helpers/mock_server.js
+++ b/addons/web/static/tests/legacy/helpers/mock_server.js
@@ -1132,7 +1132,7 @@ export class MockServer {
                     case "day":
                         return date.toFormat("yyyy-MM-dd");
                     case "day_of_week":
-                        return date.weekday;
+                        return date.weekday % 7; // number of days after the first day of the week (assumed to be Sunday)
                     case "day_of_month":
                         return date.day;
                     case "day_of_year":
@@ -1170,7 +1170,7 @@ export class MockServer {
                     case "day":
                         return date.toFormat("yyyy-MM-dd");
                     case "day_of_week":
-                        return date.weekday;
+                        return date.weekday % 7; // number of days after the first day of the week (assumed to be Sunday)
                     case "day_of_month":
                         return date.day;
                     case "day_of_year":

--- a/addons/web/static/tests/legacy/mock_server_tests.js
+++ b/addons/web/static/tests/legacy/mock_server_tests.js
@@ -604,6 +604,68 @@ QUnit.module("MockServer", (hooks) => {
         }
     );
 
+    QUnit.test("performRPC: read_group datetime:day_of_week", async function (assert) {
+        data.models.bar.records = [
+            { foo: 11, datetime: "2025-02-17" }, // Monday
+            { foo: 22, datetime: "2025-02-18" }, // Tuesday
+            { foo: 33, datetime: "2025-02-19" }, // Wednesday
+            { foo: 44, datetime: "2025-02-20" }, // Thursday
+            { foo: 55, datetime: "2025-02-21" }, // Friday
+            { foo: 66, datetime: "2025-02-22" }, // Saturday
+            { foo: 77, datetime: "2025-02-23" }, // Sunday
+        ];
+        const server = new MockServer(data, {});
+        const response = await server.performRPC("", {
+            model: "bar",
+            method: "read_group",
+            args: [[]],
+            kwargs: {
+                fields: ["foo:max"],
+                domain: [],
+                groupby: ["datetime:day_of_week"],
+            },
+        });
+        assert.deepEqual(
+            response.map((x) => x["datetime:day_of_week"]),
+            [0, 1, 2, 3, 4, 5, 6]
+        );
+        assert.deepEqual(
+            response.map((x) => x.foo),
+            [77, 11, 22, 33, 44, 55, 66]
+        );
+    });
+
+    QUnit.test("performRPC: read_group date:day_of_week", async function (assert) {
+        data.models.bar.records = [
+            { foo: 11, date: "2025-02-17" }, // Monday
+            { foo: 22, date: "2025-02-18" }, // Tuesday
+            { foo: 33, date: "2025-02-19" }, // Wednesday
+            { foo: 44, date: "2025-02-20" }, // Thursday
+            { foo: 55, date: "2025-02-21" }, // Friday
+            { foo: 66, date: "2025-02-22" }, // Saturday
+            { foo: 77, date: "2025-02-23" }, // Sunday
+        ];
+        const server = new MockServer(data, {});
+        const response = await server.performRPC("", {
+            model: "bar",
+            method: "read_group",
+            args: [[]],
+            kwargs: {
+                fields: ["foo:max"],
+                domain: [],
+                groupby: ["date:day_of_week"],
+            },
+        });
+        assert.deepEqual(
+            response.map((x) => x["date:day_of_week"]),
+            [0, 1, 2, 3, 4, 5, 6]
+        );
+        assert.deepEqual(
+            response.map((x) => x.foo),
+            [77, 11, 22, 33, 44, 55, 66]
+        );
+    });
+
     QUnit.test("performRPC: read_group, group by datetime", async function (assert) {
         const server = new MockServer(data, {});
         let result = await server.performRPC("", {

--- a/addons/web/static/tests/mock_server/mock_server.test.js
+++ b/addons/web/static/tests/mock_server/mock_server.test.js
@@ -962,6 +962,32 @@ test("performRPC: read_group, group by datetime with number granularity", async 
     }
 });
 
+test("performRPC: read_group day_of_week", async () => {
+    Bar._records = [
+        { foo: 11, datetime: "2025-02-17 13:00:00" }, // Monday
+        { foo: 22, datetime: "2025-02-18 13:00:00" }, // Tuesday
+        { foo: 33, datetime: "2025-02-19 13:00:00" }, // Wednesday
+        { foo: 44, datetime: "2025-02-20 13:00:00" }, // Thursday
+        { foo: 55, datetime: "2025-02-21 13:00:00" }, // Friday
+        { foo: 66, datetime: "2025-02-22 13:00:00" }, // Saturday
+        { foo: 77, datetime: "2025-02-23 13:00:00" }, // Sunday
+    ];
+    await makeMockServer();
+
+    const response = await ormRequest({
+        model: "bar",
+        method: "read_group",
+        kwargs: {
+            fields: ["foo:max"],
+            domain: [],
+            groupby: ["datetime:day_of_week"],
+        },
+    });
+
+    expect(response.map((x) => x["datetime:day_of_week"])).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    expect(response.map((x) => x.foo)).toEqual([77, 11, 22, 33, 44, 55, 66]);
+});
+
 test("performRPC: read_group, group by m2m", async () => {
     await makeMockServer();
 


### PR DESCRIPTION
Steps to reproduce:

- change your language to French (or any language which doesn't the week on Sundays)
- insert a pivot into a spreadsheet
- insert the dynamic version with =PIVOT(1)
- change the row groups to "Day of week"
- right click on any pivot value and "See records"

=> the day of week displayed in spreadsheet doesn't match the records.

Task: 4591993

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
