### PR TITLE
[FIX] pos_hr: removed the isUserLoggedIn check from isAdmin in pos_store

### DIFF
--- a/addons/pos_hr/static/src/overrides/models/pos_store.js
+++ b/addons/pos_hr/static/src/overrides/models/pos_store.js
@@ -23,7 +23,7 @@ patch(PosStore.prototype, {
     },
     get employeeIsAdmin() {
         const cashier = this.get_cashier();
-        return cashier._role === "manager" || cashier.user_id?.id === this.user.id;
+        return cashier._role === "manager";
     },
     checkPreviousLoggedCashier() {
         if (this.config.module_pos_hr) {

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -132,8 +132,14 @@ registry.category("web_tour.tours").add("CashierCannotClose", {
             Dialog.confirm("Open Register"),
             Chrome.clickMenuButton(),
             {
-                trigger: negate(".close-button"),
+                trigger: negate(`span.dropdown-item:contains("Close Register")`),
             },
             PosHr.cashierNameIs("Test Employee 3"),
+            PosHr.clickCashierName(),
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+            Chrome.clickMenuButton(),
+            {
+                trigger: negate(`span.dropdown-item:contains("Close Register")`),
+            },
         ].flat(),
 });


### PR DESCRIPTION
Steps to reproduce the bug:
- Install point of sales app, employees app
- Make a shop and enable multiple employees per session option
- Add another user as a basic right user for any shop
- Open a shop session (the one rights are set up for)
- Log out of the current user and log in with the other user account
- Open the session
- The current logged-in user can close the session despite having basic rights

Problem:
The close session in the XML was having a condition of pos.employeeIsAdmin, and the employeeIsAdmin flag was checking if the user is having advanced rights on the shop or it is the logged-in Odoo user. So if you are the logged-in user, you will always have the close register option regardless of the access rights you have for a specific shop.

opw-4575692

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
