### PR TITLE
[FIX] web_tour: handle out of screen on X axis

### DIFF
--- a/addons/web_tour/static/src/tour_pointer/tour_pointer.js
+++ b/addons/web_tour/static/src/tour_pointer/tour_pointer.js
@@ -95,8 +95,8 @@ export class TourPointer extends Component {
                 // Check is the pointed element is a zone
                 if (this.props.pointerState.isZone) {
                     const { anchor } = this.props.pointerState;
-                    let offsetLeft,
-                        offsetTop = 0;
+                    let offsetLeft = 0;
+                    let offsetTop = 0;
                     if (document !== anchor.ownerDocument) {
                         const iframe = [...document.querySelectorAll("iframe")].filter(
                             (e) => e.contentDocument === anchor.ownerDocument

--- a/addons/web_tour/static/src/tour_service/tour_pointer_state.js
+++ b/addons/web_tour/static/src/tour_service/tour_pointer_state.js
@@ -50,11 +50,16 @@ class Intersection {
             if (observation.isIntersecting) {
                 this._targetPosition = "in";
             } else {
+                const scrollParentElement = getScrollParent(this.currentTarget);
                 const targetBounds = this.currentTarget.getBoundingClientRect();
-                if (targetBounds.bottom < this.rootBounds.height / 2) {
-                    this._targetPosition = "out-above";
-                } else if (targetBounds.top > this.rootBounds.height / 2) {
+                if (targetBounds.bottom > scrollParentElement.clientHeight) {
                     this._targetPosition = "out-below";
+                } else if (targetBounds.top < 0) {
+                    this._targetPosition = "out-above";
+                } else if (targetBounds.left < 0) {
+                    this._targetPosition = "out-left";
+                } else if (targetBounds.right > scrollParentElement.clientWidth) {
+                    this._targetPosition = "out-right";
                 }
             }
         } else {
@@ -154,15 +159,27 @@ export function createPointerState() {
                         x += iframeOffset.x;
                         y += iframeOffset.y;
                     }
-                    floatingAnchor.style.left = `${x + width / 2}px`;
                     if (intersection.targetPosition === "out-below") {
                         tooltipPosition = "top";
                         content = _t("Scroll down to reach the next step.");
                         floatingAnchor.style.top = `${y + height - TourPointer.height}px`;
+                        floatingAnchor.style.left = `${x + width / 2}px`;
                     } else if (intersection.targetPosition === "out-above") {
                         tooltipPosition = "bottom";
                         content = _t("Scroll up to reach the next step.");
                         floatingAnchor.style.top = `${y + TourPointer.height}px`;
+                        floatingAnchor.style.left = `${x + width / 2}px`;
+                    }
+                    if (intersection.targetPosition === "out-left") {
+                        tooltipPosition = "right";
+                        content = _t("Scroll left to reach the next step.");
+                        floatingAnchor.style.top = `${y + height / 2}px`;
+                        floatingAnchor.style.left = `${x + TourPointer.width}px`;
+                    } else if (intersection.targetPosition === "out-right") {
+                        tooltipPosition = "left";
+                        content = _t("Scroll right to reach the next step.");
+                        floatingAnchor.style.top = `${y + height / 2}px`;
+                        floatingAnchor.style.left = `${x + width - TourPointer.width}px`;
                     }
                     if (!document.contains(floatingAnchor)) {
                         document.body.appendChild(floatingAnchor);

--- a/addons/web_tour/static/tests/tour_interactive.test.js
+++ b/addons/web_tour/static/tests/tour_interactive.test.js
@@ -58,18 +58,14 @@ beforeEach(() => {
             .at(0);
         return (nextTour && { name: nextTour.at(0) }) || false;
     });
-    onRpc("/web/dataset/call_kw/res.users/switch_tour_enabled", async () => {
-        return true;
-    });
-    onRpc("/web/dataset/call_kw/web_tour.tour/get_tour_json_by_name", async () => {
-        return {
-            name: "tour1",
-            steps: [
-                { trigger: "button.foo", run: "click" },
-                { trigger: "button.bar", run: "click" },
-            ],
-        };
-    });
+    onRpc("/web/dataset/call_kw/res.users/switch_tour_enabled", async () => true);
+    onRpc("/web/dataset/call_kw/web_tour.tour/get_tour_json_by_name", async () => ({
+        name: "tour1",
+        steps: [
+            { trigger: "button.foo", run: "click" },
+            { trigger: "button.bar", run: "click" },
+        ],
+    }));
 });
 
 test("points to next step", async () => {
@@ -433,13 +429,17 @@ test("scroller pointer to reach next step", async () => {
     });
 
     registry.category("web_tour.tours").add("tour_des_flandres", {
-        steps: () => [{ trigger: "button.inc", content: "Click to increment", run: "click" }],
+        steps: () => [
+            { trigger: "button.inc", content: "Click to increment", run: "click" },
+            { trigger: "button.test", run: "click" },
+        ],
     });
     class Root extends Component {
         static props = ["*"];
         static components = { Counter };
         static template = xml/*html*/ `
             <div class="scrollable-parent" style="overflow-y: scroll; height: 150px;">
+                <button class="test">Test me</button>
                 <div class="top-filler" style="height: 500px" />
                 <Counter />
                 <div class="bottom-filler" style="height: 500px" />
@@ -462,9 +462,72 @@ test("scroller pointer to reach next step", async () => {
     expect(".counter .value").toHaveText("0");
 
     await click("button.inc");
-    await animationFrame();
+    await advanceTime(1000);
 
     expect(".counter .value").toHaveText("1");
+    expect(".o_tour_pointer").toHaveCount(1);
+
+    await hover(".o_tour_pointer:empty");
+    await click(waitFor(".o_tour_pointer:contains(Scroll up to reach the next step.)"));
+    await advanceTime(1000);
+
+    await click("button.test");
+    await animationFrame();
+    expect(".o_tour_pointer").toHaveCount(0);
+});
+
+test("scroller pointer to reach next step (X axis)", async () => {
+    patchWithCleanup(Element.prototype, {
+        scrollIntoView(options) {
+            super.scrollIntoView({ ...options, behavior: "instant" });
+        },
+    });
+
+    registry.category("web_tour.tours").add("tour_des_flandres", {
+        steps: () => [
+            { trigger: "button.inc", content: "Click to increment", run: "click" },
+            { trigger: "button.test", run: "click" },
+        ],
+    });
+    class Root extends Component {
+        static props = ["*"];
+        static components = { Counter };
+        static template = xml/*html*/ `
+            <div class="scrollable-parent d-flex flex-row" style="overflow-x: scroll; width: 300px;">
+                <button class="test">Test me</button>
+                <div class="left-filler" style="min-width: 500px" />
+                <Counter />
+                <div class="right-filler" style="min-width: 500px" />
+            </div>
+        `;
+    }
+
+    await mountWithCleanup(Root);
+    await getService("tour_service").startTour("tour_des_flandres", { mode: "manual" });
+    await advanceTime(1000);
+
+    await hover(".o_tour_pointer:empty");
+    await click(waitFor(".o_tour_pointer:contains(Scroll right to reach the next step.)"));
+    await leave();
+    await advanceTime(1000);
+
+    await hover(".o_tour_pointer:empty");
+    await waitFor(".o_tour_pointer:contains(Click to increment)");
+
+    expect(".counter .value").toHaveText("0");
+
+    await click("button.inc");
+    await advanceTime(1000);
+
+    expect(".counter .value").toHaveText("1");
+    expect(".o_tour_pointer").toHaveCount(1);
+
+    await hover(".o_tour_pointer:empty");
+    await click(waitFor(".o_tour_pointer:contains(Scroll left to reach the next step.)"));
+    await advanceTime(1000);
+
+    await click("button.test");
+    await animationFrame();
     expect(".o_tour_pointer").toHaveCount(0);
 });
 


### PR DESCRIPTION
Before this commit, if an element was out of the screen on the X axis, the pointer was showing as if it was out of the screen in top.

Now, it makes the difference between X and Y axis.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
