### PR TITLE
[FIX] website_sale: fixing redirection of extra info

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1116,7 +1116,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         is_extra_step_active = request.website.viewref('website_sale.extra_info').active
         if is_extra_step_active:
-            callback = callback or 'shop/extra_info'
+            callback = callback or '/shop/extra_info'
         elif is_new_address or order_sudo.only_services:
             callback = callback or '/shop/checkout?try_skip_step=true'
         else:


### PR DESCRIPTION
Instead of redirecting to /shop/shop/extra_info which throws a 404, we now redirect to the existing extra info page on /shop/extra_info

Correction of typo from https://github.com/odoo/odoo/pull/198071

