### PR TITLE
[FIX] mail: edit chatter message save with Ctrl-Enter

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -95,13 +95,11 @@ export class Composer extends Component {
         this.isMobileOS = isMobileOS();
         this.isIosPwa = isIOS() && isDisplayStandalone();
         this.composerActions = useComposerActions();
-        this.OR_PRESS_SEND_KEYBIND = markup(
-            _t("or press %(send_keybind)s", {
-                send_keybind: this.sendKeybinds
-                    .map((key) => `<samp>${escape(key)}</samp>`)
-                    .join(" + "),
-            })
-        );
+        this.OR_PRESS_SEND_KEYBIND = _t("or press %(send_keybind)s", {
+            send_keybind: markup(
+                this.sendKeybinds.map((key) => `<samp>${escape(key)}</samp>`).join(" + ")
+            ),
+        });
         this.store = useService("mail.store");
         this.attachmentUploader = useAttachmentUploader(
             this.thread ?? this.props.composer.message.thread,
@@ -283,7 +281,7 @@ export class Composer extends Component {
                 "%(open_samp)sEscape%(close_samp)s %(open_em)sto %(open_cancel)scancel%(close_cancel)s%(close_em)s, %(open_samp)sEnter%(close_samp)s %(open_em)sto %(open_save)ssave%(close_save)s%(close_em)s"
             );
             return markup(
-                sprintf(escape(this.props.mode === "extended" ? translation1 : translation2), {
+                sprintf(escape(this.env.inChatter ? translation1 : translation2), {
                     open_samp: "<samp>",
                     close_samp: "</samp>",
                     open_em: "<em>",
@@ -309,7 +307,7 @@ export class Composer extends Component {
     }
 
     get sendKeybinds() {
-        return this.props.mode === "extended" ? [_t("CTRL"), _t("Enter")] : [_t("Enter")];
+        return this.env.inChatter ? [_t("CTRL"), _t("Enter")] : [_t("Enter")];
     }
 
     get showComposerAvatar() {
@@ -484,7 +482,7 @@ export class Composer extends Component {
                     ev.preventDefault();
                     return;
                 }
-                const shouldPost = this.props.mode === "extended" ? ev.ctrlKey : !ev.shiftKey;
+                const shouldPost = this.env.inChatter ? ev.ctrlKey : !ev.shiftKey;
                 if (!shouldPost) {
                     return;
                 }

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -14,7 +14,7 @@ import {
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
-import { leave, press, queryFirst } from "@odoo/hoot-dom";
+import { animationFrame, leave, press, queryFirst } from "@odoo/hoot-dom";
 import { Deferred, mockDate, tick } from "@odoo/hoot-mock";
 import {
     asyncStep,
@@ -130,6 +130,16 @@ test("Can edit message comment in chatter", async () => {
     await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
     await click(".o-mail-Message a", { text: "save" });
     await contains(".o-mail-Message-content", { text: "edited message (edited)" });
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await contains(".o-mail-Message:contains('Escape to cancel, CTRL-Enter to save')");
+    await insertText(".o-mail-Message .o-mail-Composer-input", "edited again", { replace: true });
+    await press("Enter");
+    await animationFrame();
+    await contains(".o-mail-Message .o-mail-Composer-input"); // still editing message
+    await contains(".o-mail-Message .o-mail-Composer-input", { value: "edited again\n" });
+    await triggerHotkey("control+Enter"); // somehow press doesn't work :(
+    await contains(".o-mail-Message-content", { text: "edited again (edited)" });
 });
 
 test("Can edit message comment in chatter (mobile)", async () => {


### PR DESCRIPTION
Before this commit, editing a message was always saving it with `Enter`, including in Chatter. This is a unintentional regression of https://github.com/odoo/odoo/pull/186084 that made improvements to composer.

Sending messages in chatter uses `Ctrl-Enter`, and `Enter` is used to make new lines. In discuss channels, this is the opposite: `Enter` to send a message, and `Shift-Enter` to make new lines.

This difference looks strange, but it makes actually sense: `Enter` is the fastest for quick chat messages, whereas `Ctrl-Enter` is more appropriate when making long formatted message, which is generally the case in chatter.

The editing of message in chatter should also use `Ctrl-Enter`, for consistency with posting a new message and also chatter messages are still long when editing them. This commit fixes this issue.

Task-4593105

Before
<img width="854" alt="Screenshot 2025-02-20 at 16 40 22" src="https://github.com/user-attachments/assets/9e9153a5-f67d-492b-9cac-ff74150f2873" />
After
<img width="841" alt="Screenshot 2025-02-20 at 16 40 00" src="https://github.com/user-attachments/assets/e879d0d9-223b-45df-8111-517b02f30377" />
