### PR TITLE
[FIX] website_sale_loyalty: fix expired reward test

### DIFF
--- a/addons/website_sale_loyalty/tests/test_shop_loyalty_payment.py
+++ b/addons/website_sale_loyalty/tests/test_shop_loyalty_payment.py
@@ -29,7 +29,7 @@ class TestShopLoyaltyPayment(PaymentHttpCommon, TestSaleCouponCommon):
         order = self.empty_order
         program = self.program_gift_card
 
-        program.date_to = date.today()  # set program to expire after today
+        program.date_to = date.today() + timedelta(days=1)  # set program to expire after tomorrow
 
         self.env['loyalty.generate.wizard'].with_context(active_id=program.id).create({
             'coupon_qty': 1,
@@ -47,7 +47,7 @@ class TestShopLoyaltyPayment(PaymentHttpCommon, TestSaleCouponCommon):
         })
         self._apply_promo_code(order, program.coupon_ids.code)
 
-        with freeze_time(program.date_to + timedelta(days=1)):
+        with freeze_time(program.date_to + timedelta(days=2)):
             self.authenticate(self.portal_user.login, self.portal_user.login)
             with self.assertRaises(
                 JsonRpcException,


### PR DESCRIPTION
The Issue:
Before this commit, if a promo code was set to expire today and a user attempted to apply it tomorrow, an error was correctly thrown. Which is the correct behavior, However, due to what seems to be a delay caused by Runbot running all tests, the promo code sometimes gets applied the next day. This issue consistently occurs between 12 AM and 1 AM, as seen in the build error.

The Fix:
Since the original test checks a promo code one day after its expiration to see if its still applicable or not, we can adjust the expiration date to today +1 and run the test on day +2.

runbot-112678