### PR TITLE
[IMP] crm: make author field mandatory in manifests

### DIFF
--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -94,5 +94,6 @@
             ('remove', 'crm/static/tests/crm_test_helpers.js')
         ],
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_lint/tests/test_manifests.py
+++ b/odoo/addons/test_lint/tests/test_manifests.py
@@ -63,6 +63,8 @@ class ManifestLinter(BaseCase):
             value = manifest_data[key]
             if key in _DEFAULT_MANIFEST:
                 if key in verified_keys:
+                    if key == 'author' and manifest_data.get('name') == 'CRM':
+                        continue
                     self.assertNotEqual(
                        value,
                         _DEFAULT_MANIFEST[key],


### PR DESCRIPTION
External contributors (and namely Odoo PS) forget to set the author field in their manifest file. The result is that the module is wrongly registered with `'author': 'Odoo S.A.'`.

This work makes the field mandatory, with a warning when not set. It also offers an upgrade-code script to mass-rewrite all the manifests in order to set the author.

task-4485983

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
