### PR TITLE
[FIX] base: prevent security email after module upgrade

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -429,9 +429,9 @@ class Users(models.Model):
           AND password !~ '^\$[^$]+\$[^$]+\$.'
         """)
         if self.env.cr.rowcount:
-            Users = self.sudo()
+            ctx = self._crypt_context()
             for uid, pw in cr.fetchall():
-                Users.browse(uid).password = pw
+                self._set_encrypted_password(uid, ctx.hash(pw))
 
     def _set_password(self):
         ctx = self._crypt_context()


### PR DESCRIPTION
saas_worker's `synchronize_metabase` will occasionally write an empty string as a password via SQL for users that have oauth via odoo.com. When a user upgrades a module that depends on base, this will then re-initialize the `res.users` model and in turn, hash all the plaintext passwords in the database. This currently sends a security email to the affected users which we want to avoid as it causes confusion.

This commit fixes this behavior by using `_set_encrypted_password` instead of the `write` method.

opw-4487479