### PR TITLE
[FIX] account: change JOIN to LEFT JOIN in account.placeholder_code SQL

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -147,8 +147,10 @@ class AccountAccount(models.Model):
         if fname == 'code':
             return self.with_company(self.env.company.root_id).sudo()._field_to_sql(alias, 'code_store', query, flush)
         if fname == 'placeholder_code':
+            # The placeholder_code is defined as the account's code in the first active company to
+            # which the account belongs.
             query.add_join(
-                'JOIN',
+                'LEFT JOIN',
                 'account_first_company',
                 SQL(
                     """(
@@ -164,21 +166,23 @@ class AccountAccount(models.Model):
                       ORDER BY rel.account_account_id, company_id
                     )""",
                     authorized_company_ids=self.env.user._get_company_ids(),
+                    to_flush=self._fields['company_ids'],
                 ),
                 SQL('account_first_company.account_id = %(account_id)s', account_id=SQL.identifier(alias, 'id')),
             )
 
-            # Can't have spaces because of how stupidly the `Model._read_group_orderby` method is written
-            # see https://github.com/odoo/odoo/blob/2a3466e8f86bc08594391658e08ba3416fb8307b/odoo/models.py#L2222
             return SQL(
-                "COALESCE("
-                "%(code_store)s->>%(active_company_root_id)s,"
-                "%(code_store)s->>%(account_first_company_root_id)s||'('||%(account_first_company_name)s||')'"
-                ")",
+                """
+                    COALESCE(
+                        %(code_store)s->>%(active_company_root_id)s,
+                        %(code_store)s->>%(account_first_company_root_id)s || ' (' || %(account_first_company_name)s || ')'
+                    )
+                """,
                 code_store=SQL.identifier(alias, 'code_store'),
-                active_company_root_id=self.env.company.root_id.id,
+                active_company_root_id=str(self.env.company.root_id.id),
                 account_first_company_name=SQL.identifier('account_first_company', 'company_name'),
                 account_first_company_root_id=SQL.identifier('account_first_company', 'root_company_id'),
+                to_flush=self._fields['code_store'],
             )
 
         return super()._field_to_sql(alias, fname, query, flush)

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -1,6 +1,6 @@
 from odoo import Command
 from odoo.addons.account.tests.common import TestAccountMergeCommon
-from odoo.tests import Form, tagged
+from odoo.tests import Form, tagged, new_test_user
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import mute_logger
 import psycopg2
@@ -622,6 +622,68 @@ class TestAccountAccount(TestAccountMergeCommon):
             move_type="out_invoice"
         )
         self.assertFalse(account.id in results_2, "Deprecated account should NOT appear in account suggestions")
+
+    def test_placeholder_code(self):
+        """ Test that the placeholder code is '{code_in_company} ({company})'
+            where `company` is the first of the user's companies that is
+            in `account.company_ids`.
+
+            Check that `_field_to_sql` gives the same value.
+        """
+        def get_placeholder_code_via_sql(account):
+            account_query = account._as_query()
+            placeholder_code_sql = account_query.select(account._field_to_sql('account_account', 'placeholder_code', account_query))
+            placeholder_code = self.env.execute_query(placeholder_code_sql)[0][0]
+            return placeholder_code
+
+        # This user cannot access company 2, so it can't access the created account.
+        user_2 = new_test_user(
+            self.env,
+            name="User that can't access company 2",
+            login='user_that_cannot_access_company_2',
+            password='user_that_cannot_access_company_2',
+            email='user_that_cannot_access_company_2@test.com',
+            groups_id=self.get_default_groups().ids,
+            company_id=self.env.company.id,
+        )
+
+        account = self.env['account.account'].create([{
+            'name': 'My account',
+            'company_ids': [Command.set(self.company_data_2['company'].ids)],
+            'code': '180001',
+        }])
+
+        self.assertEqual(account.placeholder_code, '180001 (company_2)')
+        self.assertEqual(get_placeholder_code_via_sql(account), '180001 (company_2)')
+
+        self.assertEqual(account.with_company(self.company_data_2['company']).placeholder_code, '180001')
+        self.assertEqual(get_placeholder_code_via_sql(account.with_company(self.company_data_2['company'])), '180001')
+
+        # Invalidate in order to recompute `placeholder_code` with `user_2`
+        account.invalidate_recordset(fnames=['placeholder_code'])
+        self.assertEqual(account.with_user(user_2).sudo().placeholder_code, False)
+        self.assertEqual(get_placeholder_code_via_sql(account.with_user(user_2).sudo()), None)
+
+    def test_account_accessible_by_search_in_sudo_mode(self):
+        """ Test that even if an account isn't accessible by the current user, it is returned by a search in sudo mode. """
+        account = self.env['account.account'].with_company(self.company_data_2['company']).create([{
+            'name': 'Account in Company 2',
+            'code': '180002',
+        }])
+
+        # This user can't access company 2, so it can't access the created account.
+        user_that_cannot_access_company_2 = new_test_user(
+            self.env,
+            name="User that can't access company 2",
+            login='user_that_cannot_access_company_2',
+            password='user_that_cannot_access_company_2',
+            email='user_that_cannot_access_company_2@test.com',
+            groups_id=self.get_default_groups().ids,
+            company_id=self.env.company.id,
+        )
+
+        searched_account = self.env['account.account'].with_user(user_that_cannot_access_company_2).sudo().search([('id', '=', account.id)])
+        self.assertEqual(searched_account, account)
 
     @freeze_time('2017-01-01')
     def test_account_opening_balance(self):


### PR DESCRIPTION
Bug: At the moment, searching on `account.account` does not return accounts whose `company_ids` does not contain any of the companies accessible to the current user, even in sudo mode.

Diagnosis: The default `_order` on `account.account` includes `placeholder_code`. When we call `_field_to_sql` for `placeholder_code`, we do a JOIN, which excludes any accounts for which a value could not be computed on `placeholder_code`. These are the accounts that are not accessible to the current user.

Solution: We change `_field_to_sql` for `placeholder_code` to perform a LEFT JOIN rather than a JOIN on the first account company accessible to the user. If none of the account's companies are accessible to the user, `placeholder_code` will simply be NULL.

We add tests that check this behaviour and ensure that no accounts are excluded from a `search` in `sudo` mode.

opw-4393854