### PR TITLE
[FIX] mail: mailbot send correct command

### DIFF
--- a/addons/mail_bot/i18n/mail_bot.pot
+++ b/addons/mail_bot/i18n/mail_bot.pot
@@ -258,8 +258,8 @@ msgstr ""
 #. odoo-python
 #: code:addons/mail_bot/models/mail_bot.py:0
 msgid ""
-"Wonderful! 😇%(new_line)sTry typing %(command_start)s:%(command_end)s to use "
-"canned responses. I've created a temporary one for you."
+"Wonderful! 😇%(new_line)sTry typing %(command_start)s::%(command_end)s to use"
+" canned responses. I've created a temporary one for you."
 msgstr ""
 
 #. module: mail_bot

--- a/addons/mail_bot/models/mail_bot.py
+++ b/addons/mail_bot/models/mail_bot.py
@@ -93,7 +93,7 @@ class MailBot(models.AbstractModel):
                 self.env.user.odoobot_failed = False
                 self.env.user.odoobot_state = "onboarding_canned"
                 return self.env._(
-                    "Wonderful! 😇%(new_line)sTry typing %(command_start)s:%(command_end)s to use "
+                    "Wonderful! 😇%(new_line)sTry typing %(command_start)s::%(command_end)s to use "
                     "canned responses. I've created a temporary one for you.",
                     **self._get_style_dict()
                 )


### PR DESCRIPTION
Before this commit, the mailbot was sending the wrong command to trigger the canned response. This commit fixes the command to be sent and updates the translations accordingly.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
