### PR TITLE
[FIX] account: unamed payment method

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -335,8 +335,8 @@ class AccountPayment(models.Model):
         currency_id = self.currency_id.id
 
         # Compute a default label to set on the journal items.
-        liquidity_line_name = ''.join(x[1] for x in self._get_aml_default_display_name_list())
-        counterpart_line_name = ''.join(x[1] for x in self._get_aml_default_display_name_list())
+        liquidity_line_name = ''.join(x[1] for x in self._get_aml_default_display_name_list() if x[1])
+        counterpart_line_name = liquidity_line_name
 
         line_vals_list = [
             # Liquidity line.


### PR DESCRIPTION
Steps to reproduce :
- Open accounting and select the 3 dots on the top right corner of Bank in the dashboard
- Select "Configuration"
- In the Incoming Payments, for a payment method, change the name to an empty string
- Make sure that this payment method has an "Outstanding Receipts accounts"
- Open Customers/Invoices and open an invoice that is not paid
- Click on "Pay"
- Select the unamed payment method
- Click on Create Payment

Problem :
An error message appears

https://github.com/odoo/odoo/blob/9a27b53e6dacf7380dac6da5ae84f39f2812c9f7/addons/account/models/account_payment.py#L337

opw-4574452