### PR TITLE
[FIX] payment_worldline: handle 402 payment rejected response

### DIFF
--- a/addons/payment_worldline/const.py
+++ b/addons/payment_worldline/const.py
@@ -62,3 +62,11 @@ PAYMENT_STATUS_MAPPING = {
     'cancel': ('CANCELLED',),
     'declined': ('REJECTED', 'REJECTED_CAPTURE'),
 }
+
+# Mapping of response codes indicating Worldline handled the request
+# See https://apireference.connect.worldline-solutions.com/s2sapi/v1/en_US/json/response-codes.html.
+VALID_RESPONSE_CODES = {
+    200: 'Successful',
+    201: 'Created',
+    402: 'Payment Rejected',
+}

--- a/addons/payment_worldline/models/payment_provider.py
+++ b/addons/payment_worldline/models/payment_provider.py
@@ -81,7 +81,8 @@ class PaymentProvider(models.Model):
         try:
             response = requests.request(method, url, json=payload, headers=headers, timeout=10)
             try:
-                response.raise_for_status()
+                if response.status_code not in const.VALID_RESPONSE_CODES:
+                    response.raise_for_status()
             except requests.exceptions.HTTPError:
                 _logger.exception(
                     "Invalid API request at %s with data:\n%s", url, pprint.pformat(payload)


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have an expired credit card[^1];
2. have an Odoo subscription;
3. pay subscription with expired credit card.

Issue
-----
Subscription chatter shows:
> Automatic payment failed. No email sent this time.
> Error: Worldline: The communication with the API failed.
> Details:

Cause
-----
When a payment gets rejected for any reason like card expiration, Worldline returns the 402 HTTP response code[^2].
This is a nonstandard response indicating "Payment Required"[^3].

Because the 4xx HTTP status code range is reserved for client errors, we currently interpret the 402 response as a communication failure with the API instead of a rejected payment.

Solution
--------
Don't `raise_for_status` if the response belongs to one of the "expected" responses according to their API:
- 200: Successful
- 201: Created
- 402: Payment rejected

opw-4481602

[^1]: Wordline doesn't provide a way to easily test rejected payments.
[^2]: https://apireference.connect.worldline-solutions.com/s2sapi/v1/en_US/json/response-codes.html
[^3]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/402