### PR TITLE
[FIX] mail: reply-to composer mode is canceled on thread change

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -177,6 +177,14 @@ export class Composer extends Component {
         onWillUnmount(() => {
             this.props.composer.isFocused = false;
         });
+        useEffect(
+            (composerThread, replyToThread) => {
+                if (replyToThread && replyToThread !== composerThread) {
+                    this.props.messageToReplyTo.cancel();
+                }
+            },
+            () => [this.props.composer.thread, this.props.messageToReplyTo?.thread]
+        );
     }
 
     get pickerSettings() {


### PR DESCRIPTION
Before this commit, when starting a reply-to in composer, changing thread and posting a new message resulted in posting the message in the original thread instead.

Steps to reproduce:
- open a conversation A in Discuss app
- click on "reply" on a message
- open another conversation B in Discuss app
- compose a message then send it => the message is posted in conversation A rather than B

This happens because when changing conversation, the reply-to mode of the composer is kept. This is the case because `messageToReplyTo` is a stateful component hook of the thread viewer such as the Discuss app. This is put there because it's shared to both the `Thread` and `Composer` components, respectively to show the message being replied (reduced opacity to all other messages) and for composer to contains the reply-to message.

The cancelling of the reply-to mode was only occurring when the user manually cancel it. Changing conversation was not considered as cancelling. This commit fixes this issue.

Task-4593206