### PR TITLE
[FIX]  l10n_hu_edi: remove VTSZ number unnecessary space

### DIFF
--- a/addons/l10n_hu_edi/views/report_invoice.xml
+++ b/addons/l10n_hu_edi/views/report_invoice.xml
@@ -96,8 +96,7 @@
         <xpath expr="//td[@name='account_invoice_line_name']/span" position="after">
             <div t-if="line.product_id.l10n_hu_product_code_type and line.product_id.l10n_hu_product_code">
                 <span t-if="line.product_id.l10n_hu_product_code_type == 'OTHER'">Other Product Code</span>
-                <span t-else="else" t-out="line.product_id.l10n_hu_product_code_type"/>
-                :
+                <span t-else="else" t-out="line.product_id.l10n_hu_product_code_type"/>:
                 <span t-out="line.product_id.l10n_hu_product_code"/>
             </div>
         </xpath>

--- a/doc/cla/corporate/ossys-technology.md
+++ b/doc/cla/corporate/ossys-technology.md
@@ -1,0 +1,15 @@
+Romania, 2025-02-21
+
+Ossys Technology SRL
+ agrees to the terms of the Odoo Corporate Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Attila Tatár atta@ossys.eu  https://github.com/atta-t-osh
+
+List of contributors:
+
+Attila Tatár atta@ossys.eu  https://github.com/atta-t-osh
+Csaba Barabás csaba@ossys.eu  https://github.com/Csaby33


### PR DESCRIPTION
  In the invoice report, the usual form of the VTSZ number is without spaces,
    which is easier to read.

            before eg. "VTSZ :8604000"
             after     "VTSZ:8604000"

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
