### PR TITLE
[FIX] stock: give fallback value for origin while creating exchange return

### DIFF
--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -93,7 +93,7 @@ class StockRule(models.Model):
             procurements, rules = zip(*procurements_rules)
 
             # Get the set of procurement origin for the current domain.
-            origins = set([p.origin for p in procurements])
+            origins = set([p.origin for p in procurements if p.origin])
             # Check if a PO exists for the current domain.
             po = self.env['purchase.order'].sudo().search([dom for dom in domain], limit=1)
             company_id = procurements[0].company_id

--- a/addons/purchase_stock/tests/test_create_picking.py
+++ b/addons/purchase_stock/tests/test_create_picking.py
@@ -714,3 +714,35 @@ class TestCreatePicking(common.TestProductCommon):
 
         self.assertEqual(po.order_line.qty_received, 8)
         self.assertEqual(push_pick.partner_id, po.partner_id)
+
+    def test_create_return_exchange_with_no_picking_origin(self):
+        """ Test that we can create a return exchange with no picking origin """
+
+        self.product_id_2.seller_ids = [(0, 0, {
+            'partner_id': self.partner_id.id,
+            'price': 10,
+        })]
+        stock_picking = self.env['stock.picking'].create({
+            'location_id': self.env.ref('stock.stock_location_suppliers').id,
+            'location_dest_id': self.env.ref('stock.stock_location_stock').id,
+            'picking_type_id': self.env.ref('stock.picking_type_out').id,
+            'move_ids': [(0, 0, {
+                'name': 'outgoing_shipment_avg_move',
+                'product_id': self.product_id_2.id,
+                'product_uom_qty': 10,
+                'product_uom': self.product_id_2.uom_id.id,
+                'location_id': self.env.ref('stock.stock_location_suppliers').id,
+                'location_dest_id': self.env.ref('stock.stock_location_stock').id,
+            })]
+        })
+        stock_picking.button_validate()
+
+        stock_return_picking = self.env['stock.return.picking'].with_context(
+            active_ids=stock_picking.ids, active_id=stock_picking.ids[0], active_model='stock.picking').create({})
+
+        stock_return_picking.product_return_moves.quantity = 1.0
+        res = stock_return_picking.action_create_exchanges()
+        exchange_return_picking = self.env['stock.picking'].browse(res['res_id'])
+
+        self.assertTrue(exchange_return_picking)
+        self.assertEqual(exchange_return_picking.origin, 'Return of ' + stock_picking.name)


### PR DESCRIPTION
Currently, a traceback is occurring when the user tries to create an 
exchange return without giving the origin value in picking.

To reproduce this issue:

1) Install `purchase_stock`
2) Create a stock picking with operation type as `receipts` and don't give the `origin` value 
3) Add a product in operation that contains vendor records in the  product
4) `Validate` the product and click the `return` button to open a wizard 
5) Update the qty to return and click the `Return for Exchange` button

Error:-
```
TypeError: sequence item 0: expected str instance, bool found
```

This traceback occurs from the line below because we are getting the origin value as False from the procurements.

https://github.com/odoo/odoo/blob/949ed6f30f539dd787594511751bda0e714a5409/addons/purchase_stock/models/stock_rule.py#L119

The origin value of this procurement is directly taken from the origin value of picking. 
The above traceback occurs because the user didn't provide the origin value in picking.

We can resolve this issue by providing a fallback value of an empty string if there is no origin in picking.

sentry-6316652948

