### PR TITLE
[FIX] html_editor: preserve bullet for image only list item

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -763,7 +763,7 @@ export class ListPlugin extends Plugin {
         if (!closestLI || isBlockUnsplittable) {
             return;
         }
-        if (!closestLI.textContent) {
+        if (isEmptyBlock(closestLI)) {
             this.outdentLI(closestLI);
             return true;
         }

--- a/addons/html_editor/static/tests/list/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/list/paragraph_break.test.js
@@ -3,6 +3,9 @@ import { testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { insertText, splitBlock } from "../_helpers/user_actions";
 
+const base64Img =
+    "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
+
 describe("Selection collapsed", () => {
     describe("Ordered", () => {
         describe("Basic", () => {
@@ -78,6 +81,33 @@ describe("Selection collapsed", () => {
                             <li><br></li>
                             <li>c</li>
                             <li>[]<br></li>
+                        </ol>`),
+                });
+            });
+
+            test("should split list item containing image", async () => {
+                await testEditor({
+                    contentBefore: unformat(`
+                        <ol>
+                            <li><img src="${base64Img}">[]</li>
+                        </ol>`),
+                    stepFunction: splitBlock,
+                    contentAfter: unformat(`
+                        <ol>
+                            <li><img src="${base64Img}"></li>
+                            <li>[]<br></li>
+                        </ol>`),
+                });
+                await testEditor({
+                    contentBefore: unformat(`
+                        <ol>
+                            <li>[]<img src="${base64Img}"></li>
+                        </ol>`),
+                    stepFunction: splitBlock,
+                    contentAfter: unformat(`
+                        <ol>
+                            <li><br></li>
+                            <li>[]<img src="${base64Img}"></li>
                         </ol>`),
                 });
             });


### PR DESCRIPTION
### Steps to reproduce:

- Open the To-Do app.
- Create a list (e.g., `/list`).
- Insert an image into a list item and press `Enter`.
- Notice that the list item containing the image is outdented.

### Solution:

- In `handleSplitBlock`, the `!closestLI.textContent` check did not handle list items containing only an image. Adding an `isEmptyBlock` check ensures the bullet point is preserved.

### Description of the issue/feature this PR addresses:

- Pressing Enter in list item containing only an image removed the bullet point.

### Desired behavior after PR is merged:

- Pressing Enter in a list item with only an image preserves the bullet point and creates a new empty list item.

task-4586704

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
