### PR TITLE
[FIX] payment: prevent deleting the default payment method

### DIFF
--- a/addons/payment/models/payment_method.py
+++ b/addons/payment/models/payment_method.py
@@ -188,6 +188,12 @@ class PaymentMethod(models.Model):
 
         return super().write(values)
 
+    @api.ondelete(at_uninstall=False)
+    def _unlink_if_not_default_payment_method(self):
+        payment_method_unknown = self.env.ref('payment.payment_method_unknown')
+        if payment_method_unknown in self:
+            raise UserError(_("You cannot delete the default payment method."))
+
     # === BUSINESS METHODS === #
 
     def _get_compatible_payment_methods(


### PR DESCRIPTION
Currently, an error occurs when opening a website cart if its `Payment method` record has been deleted. This results in preventing the user from accessing the cart.

**Steps to produce:**
- Install the `website_sale` module.
- Navigate to `Website / Configuration / eCommerce / Payment Methods`.
- Delete method `name: Payment method`.
- Add the product to the cart and then open it.
- Observe the error.

**Error:**
`ValueError: External ID not found in the system: payment.payment_method_unknown`

The error occurs because the system attempts to access id of the payment method `payment.payment_method_unknown` at [1], but it is unavailable as the user has already deleted it.

This commit adds validation to prevent deletion of the `payment_method_unknown`.

[1] - https://github.com/odoo/odoo/blob/1c896c5da71b58b382269fe6cca556f4a61e4d5d/addons/website_sale/controllers/main.py#L1714

Sentry - 6177955401

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
