### PR TITLE
[FIX] pos_{,restaurant}: partner button not visible in mobile view

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.js
@@ -22,4 +22,8 @@ export class ActionpadWidget extends Component {
         this.pos = usePos();
         this.ui = useService("ui");
     }
+
+    get currentOrder() {
+        return this.pos.getOrder();
+    }
 }

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.js
@@ -22,9 +22,6 @@ patch(ActionpadWidget.prototype, {
             this.pos.config.module_pos_restaurant && this.pos.mainScreen.component !== TicketScreen
         );
     },
-    get currentOrder() {
-        return this.pos.getOrder();
-    },
     get hasChangesToPrint() {
         let hasChange = this.pos.getOrderChanges();
         hasChange =


### PR DESCRIPTION
Steps:
==========
- Install only the point_of_sale module.
- Open the PoS Register in mobile view.
- Click on the cart button.

Issue:
===========
- The partner button is not visible.

Cause:
===========
- The `currentOrder` getter was defined in `pos_restaurant`, making it unavailable when only `point_of_sale` is installed. Fix:
- Moved the `currentOrder` getter from `pos_restaurant` to `point_of_sale`, ensuring availability in all cases.