### PR TITLE
[IMP] website_sale, _*: improve checkout layouts 

### DIFF
--- a/addons/account_peppol/controllers/portal.py
+++ b/addons/account_peppol/controllers/portal.py
@@ -22,8 +22,8 @@ class PortalAccount(CustomerPortal):
             })
         return rendering_values
 
-    def _get_mandatory_address_fields(self, country_sudo):
-        mandatory_fields = super()._get_mandatory_address_fields(country_sudo)
+    def _get_mandatory_billing_address_fields(self, country_sudo):
+        mandatory_fields = super()._get_mandatory_billing_address_fields(country_sudo)
 
         sending_method = request.params.get('invoice_sending_method')
         if sending_method == 'peppol':

--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -133,7 +133,7 @@ class PaymentProvider(models.Model):
         string="Pending Message",
         help="The message displayed if the order pending after the payment process",
         default=lambda self: _(
-            "Your payment has been successfully processed but is waiting for approval."
+            "Your payment has been processed but is waiting for approval."
         ), translate=True)
     auth_msg = fields.Html(
         string="Authorize Message", help="The message displayed if payment is authorized",
@@ -141,7 +141,7 @@ class PaymentProvider(models.Model):
     done_msg = fields.Html(
         string="Done Message",
         help="The message displayed if the order is successfully done after the payment process",
-        default=lambda self: _("Your payment has been successfully processed."),
+        default=lambda self: _("Your payment has been processed."),
         translate=True)
     cancel_msg = fields.Html(
         string="Cancelled Message",

--- a/addons/payment/views/payment_form_templates.xml
+++ b/addons/payment/views/payment_form_templates.xml
@@ -67,7 +67,7 @@
                 <!-- === Payment tokens === -->
                 <div t-if="tokens_sudo">
                     <!-- === Header === -->
-                    <h4 id="o_payment_tokens_heading" class="fs-6 small text-uppercase fw-bolder">
+                    <h4 id="o_payment_tokens_heading">
                         Your payment methods
                     </h4>
                     <!-- === Body === -->
@@ -92,11 +92,11 @@
                      t-att-class="'collapse' if collapse_payment_methods else ''"
                 >
                     <!-- === Header === -->
-                    <h4 class="fs-6 small fw-bolder">
-                        <t t-if="not collapse_payment_methods">Choose a payment method</t>
+                    <p t-attf-class="mb-3 {{collapse_payment_methods and 'h5' or 'h4'}}">
+                        <t t-if="not collapse_payment_methods">Payment method</t>
                         <t t-else="">Other payment methods</t>
                         <t t-call="payment.availability_report_button"/>
-                    </h4>
+                    </p>
                     <!-- === Body === -->
                     <ul class="list-group">
                         <t t-foreach="payment_methods_sudo" t-as="pm_sudo">
@@ -482,15 +482,15 @@
             id="payment_availability_report"
             class="collapse"
         >
-            <h4 class="fs-6 text-uppercase fw-bolder"> Availability report </h4>
-                <h6 class="mt-3 text-uppercase fw-normal fs-6"> Payment providers </h6>
-                <t t-call="payment.availability_report_records">
-                    <t t-set="records" t-value="availability_report.get('providers')"/>
-                </t>
-                <h6 class="mt-3 text-uppercase fw-normal fs-6"> Payment methods </h6>
-                <t t-call="payment.availability_report_records">
-                    <t t-set="records" t-value="availability_report.get('payment_methods')"/>
-                </t>
+            <h5> Availability report </h5>
+            <h6 class="mt-3"> Payment providers </h6>
+            <t t-call="payment.availability_report_records">
+                <t t-set="records" t-value="availability_report.get('providers')"/>
+            </t>
+            <h6 class="mt-3"> Payment methods </h6>
+            <t t-call="payment.availability_report_records">
+                <t t-set="records" t-value="availability_report.get('payment_methods')"/>
+            </t>
         </div>
     </template>
 

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -291,7 +291,11 @@ class CustomerPortal(Controller):
         :return: The set of mandatory billing field names.
         :rtype: set
         """
-        return self._get_mandatory_address_fields(country_sudo)
+        base_fields = {'name', 'email'}
+        if not self._needs_address():
+            return base_fields
+        base_fields.add('phone')  # not required for quick checkout (event)
+        return base_fields | self._get_mandatory_address_fields(country_sudo)
 
     def _check_delivery_address(self, partner_sudo):
         """ Check that all mandatory delivery fields are filled for the given partner.
@@ -312,7 +316,15 @@ class CustomerPortal(Controller):
         :return: The set of mandatory delivery field names.
         :rtype: set
         """
-        return self._get_mandatory_address_fields(country_sudo)
+        base_fields = {'name', 'email'}
+        if not self._needs_address():
+            return base_fields
+        base_fields.add('phone')  # not required for quick checkout (event)
+        return base_fields | self._get_mandatory_address_fields(country_sudo)
+
+    def _needs_address(self):
+        """ Hook meant to be overridden in other modules. """
+        return True
 
     def _get_mandatory_address_fields(self, country_sudo):
         """ Return the set of common mandatory address fields.
@@ -321,7 +333,7 @@ class CustomerPortal(Controller):
         :return: The set of common mandatory address field names.
         :rtype: set
         """
-        field_names = {'name', 'email', 'street', 'city', 'country_id', 'phone'}
+        field_names = {'street', 'city', 'country_id'}
         if country_sudo.state_required:
             field_names.add('state_id')
         if country_sudo.zip_required:
@@ -481,6 +493,7 @@ class CustomerPortal(Controller):
         use_delivery_as_billing=False,
         callback='/my/addresses',
         required_fields=False,
+        verify_address_values=True,
         **form_data
     ):
         """ Create or update an address if there is no error else return error dict.
@@ -493,6 +506,7 @@ class CustomerPortal(Controller):
         :param str callback: The URL to redirect to in case of successful address creation/update.
         :param str required_fields: The additional required address values, as a comma-separated
                                     list of `res.partner` fields.
+        :param bool verify_address_values: Whether we want to check the given address values.
         :return: Partner record and A JSON-encoded feedback, with either the success URL or
                  an error message.
         :rtype: res.partner, dict
@@ -502,24 +516,25 @@ class CustomerPortal(Controller):
         # Parse form data into address values, and extract incompatible data as extra form data.
         address_values, extra_form_data = self._parse_form_data(form_data)
 
-        # Validate the address values and highlights the problems in the form, if any.
-        invalid_fields, missing_fields, error_messages = self._validate_address_values(
-            address_values,
-            partner_sudo,
-            address_type,
-            use_delivery_as_billing,
-            required_fields or '',
-            **extra_form_data,
-        )
-        if form_data.get("login_field"):
-            # Validate login and highlights the problems in the form, if any.
-            login = extra_form_data.get("login", "").strip()
-            self._validate_login_and_update(login, invalid_fields, missing_fields, error_messages)
-        if error_messages:
-            return partner_sudo, {
-                'invalid_fields': list(invalid_fields | missing_fields),
-                'messages': error_messages,
-            }
+        if verify_address_values:
+            # Validate the address values and highlights the problems in the form, if any.
+            invalid_fields, missing_fields, error_messages = self._validate_address_values(
+                address_values,
+                partner_sudo,
+                address_type,
+                use_delivery_as_billing,
+                required_fields or '',
+                **extra_form_data,
+            )
+            if form_data.get("login_field"):
+                # Validate login and highlights the problems in the form, if any.
+                login = extra_form_data.get("login", "").strip()
+                self._validate_login_and_update(login, invalid_fields, missing_fields, error_messages)
+            if error_messages:
+                return partner_sudo, {
+                    'invalid_fields': list(invalid_fields | missing_fields),
+                    'messages': error_messages,
+                }
 
         if not partner_sudo:  # Creation of a new address.
             self._complete_address_values(
@@ -733,6 +748,12 @@ class CustomerPortal(Controller):
                 for fname in commercial_fields:
                     if fname in required_field_set and fname not in address_values:
                         required_field_set.remove(fname)
+
+        address_fields = self._get_mandatory_address_fields(country)
+        if any(address_values.get(fname) for fname in address_fields):
+            # If the customer provided any address information, they should provide their whole
+            # address, even if the address wasn't required (e.g. the order only contains services).
+            required_field_set |= address_fields
 
         # Verify that no required field has been left empty.
         for field_name in required_field_set:

--- a/addons/portal/views/address_templates.xml
+++ b/addons/portal/views/address_templates.xml
@@ -88,46 +88,45 @@
             t-att-data-partner-id="contact.id"
         >
             <div class="card-body d-flex flex-column justify-content-between">
-                <div class="position-relative">
-                    <t
-                        t-out="contact"
-                        t-options="dict(widget='contact', fields=['name', 'address'], no_marker=True)"
-                        class="col-9"
-                    />
+                <t
+                    t-out="contact"
+                    t-options="dict(widget='contact', fields=['name', 'address'], no_marker=True)"
+                />
+                <div class="mt-3 mx-1">
                     <i
                         t-if="is_user_address"
-                        class="fa fa-id-card text-primary fs-5 position-absolute top-0 end-0"
+                        class="fa fa-id-card text-primary fs-5 position-absolute mt-1"
                         title="Your Account Address"
                     />
-                </div>
-                <div class="mt-3" t-if="can_be_edited">
-                    <t
-                        t-set="address_update_url"
-                        t-value="address_update_url or (new_address_url + '&amp;partner_id=' + str(contact.id))"
-                    />
-                    <a
-                        name="card_address_ref"
-                        t-att-href="address_update_url"
-                        class="js_edit_address btn btn-link p-0 mt-auto"
-                        role="button"
-                        title="Edit this address"
-                        aria-label="Edit this address"
-                    >
-                        <i class="fa fa-pencil me-1"/>
-                        Edit
-                    </a>
-                    <span t-if="show_removal">
-                        <span class="mx-2">|</span>
+                    <div t-if="can_be_edited" class="text-end">
+                        <t
+                            t-set="address_update_url"
+                            t-value="address_update_url or (new_address_url + '&amp;partner_id=' + str(contact.id))"
+                        />
                         <a
-                            class="btn btn-link text-danger p-0 o_remove_address"
+                            name="card_address_ref"
+                            t-att-href="address_update_url"
+                            class="js_edit_address btn btn-link fw-bold p-0 mt-auto"
                             role="button"
-                            title="Remove address"
-                            aria-label="Remove address"
-                            t-att-data-partner-id="contact.id"
+                            title="Edit this address"
+                            aria-label="Edit this address"
                         >
-                            Remove
+                            <i class="fa fa-pencil me-1"/>
+                            Edit
                         </a>
-                    </span>
+                        <span t-if="show_removal">
+                            <span class="mx-2">|</span>
+                            <a
+                                class="btn btn-link text-danger fw-bold p-0 o_remove_address"
+                                role="button"
+                                title="Remove address"
+                                aria-label="Remove address"
+                                t-att-data-partner-id="contact.id"
+                            >
+                                Remove
+                            </a>
+                        </span>
+                    </div>
                 </div>
             </div>
         </div>
@@ -147,7 +146,7 @@
             </div>
         </t>
         <div id="div_name" class="col-lg-12 mb-2">
-            <label class="col-form-label" for="o_name">Full name</label>
+            <label class="col-form-label" for="o_name">Your name</label>
             <input
                 id="o_name"
                 type="text"
@@ -265,7 +264,7 @@
         <div class="w-100"/>
         <t t-if="zip_before_city">
             <div id="div_zip" class="col-md-4 mb-2">
-                <label class="col-form-label label-optional" for="o_zip">
+                <label class="col-form-label" for="o_zip">
                     Zip Code
                 </label>
                 <input
@@ -289,7 +288,7 @@
         </div>
         <t t-if="not zip_before_city">
             <div id="div_zip" class="col-md-4 mb-2">
-                <label class="col-form-label label-optional" for="o_zip">
+                <label class="col-form-label" for="o_zip">
                     Zip Code
                 </label>
                 <input
@@ -327,7 +326,7 @@
             class="col-lg-6 mb-2"
             t-att-style="not country_states and 'display: none'"
         >
-            <label class="col-form-label" for="o_state_id">
+            <label class="col-form-label label-optional" for="o_state_id">
                 State / Province
             </label>
             <select
@@ -361,7 +360,7 @@
         <t t-if="callback">
             <input type="hidden" name="callback" t-att-value="callback"/>
         </t>
-        <input type="hidden" name="required_fields" t-att-value="'name,country_id'"/>
+        <input type="hidden" name="required_fields" t-att-value="'name,email'"/>
     </template>
 
     <template id="portal.address_footer">

--- a/addons/website_event/data/event_demo.xml
+++ b/addons/website_event/data/event_demo.xml
@@ -4,7 +4,7 @@
     <record id="event.event_0" model="event.event">
         <field name="website_published" eval="True"/>
         <field name="subtitle">Get Inspired • Stay Connected • Have Fun</field>
-        <field name="cover_properties">{"background-image": "url('/website_event/static/src/img/event_cover_0.jpg')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0.4"}</field>
+        <field name="cover_properties">{"background-image": "url('/website_event/static/src/img/event_cover_0.jpg')", "resize_class": "o_record_has_cover cover_auto", "opacity": "0.4"}</field>
         <field name="description" type="html">
             <div class="oe_structure">
                 <h5>Join us for this 3-day Event</h5>
@@ -43,7 +43,7 @@
         <field name="website_menu" eval="True"/>
         <field name="website_published" eval="True"/>
         <field name="subtitle">The Great Reno Balloon Race is the world's largest free hot-air ballooning event.</field>
-        <field name="cover_properties">{"background-image": "url('/website_event/static/src/img/event_cover_1.jpg')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0.4"}</field>
+        <field name="cover_properties">{"background-image": "url('/website_event/static/src/img/event_cover_1.jpg')", "resize_class": "o_record_has_cover cover_auto", "opacity": "0.4"}</field>
         <field name="description" type="html">
             <div class="oe_structure">
                 <h5>Join us for the greatest ballon race of all times!</h5>
@@ -62,7 +62,7 @@
     <record id="event.event_2" model="event.event">
         <field name="website_published" eval="True"/>
         <field name="subtitle">Enhance your architectural business and improve professional skills.</field>
-        <field name="cover_properties">{"background-image": "url('/website_event/static/src/img/event_cover_2.jpg')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0.4"}</field>
+        <field name="cover_properties">{"background-image": "url('/website_event/static/src/img/event_cover_2.jpg')", "resize_class": "o_record_has_cover cover_auto", "opacity": "0.4"}</field>
         <field name="description" type="html">
 <div class="oe_structure">
     <h5>Conference for Architects</h5>
@@ -104,7 +104,7 @@
     <record id="event.event_3" model="event.event">
         <field name="website_published" eval="True"/>
         <field name="subtitle">Experience live music, local food and beverages.</field>
-        <field name="cover_properties">{"background-image": "url('/website_event/static/src/img/event_cover_3.jpg')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0.4"}</field>
+        <field name="cover_properties">{"background-image": "url('/website_event/static/src/img/event_cover_3.jpg')", "resize_class": "o_record_has_cover cover_auto", "opacity": "0.4"}</field>
         <field name="description" type="html">
             <div class="oe_structure">
                 <h5>Here it is, the 12th edition of our Live Musical Festival!</h5>
@@ -122,13 +122,13 @@
     <record id="event.event_4" model="event.event">
         <field name="website_published" eval="True"/>
         <field name="subtitle">Discover how to grow a sustainable business with our experts.</field>
-        <field name="cover_properties">{"background-image": "url('/website_event/static/src/img/event_cover_4.jpg')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0.4"}</field>
+        <field name="cover_properties">{"background-image": "url('/website_event/static/src/img/event_cover_4.jpg')", "resize_class": "o_record_has_cover cover_auto", "opacity": "0.4"}</field>
     </record>
 
     <record id="event.event_5" model="event.event">
         <field name="website_published" eval="True"/>
         <field name="subtitle">Bring your outdoor field hockey season to the next level by taking the field at this 9th annual Field Hockey tournament.</field>
-        <field name="cover_properties">{"background-image": "url('/website_event/static/src/img/event_cover_5.jpg')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0.4"}</field>
+        <field name="cover_properties">{"background-image": "url('/website_event/static/src/img/event_cover_5.jpg')", "resize_class": "o_record_has_cover cover_auto", "opacity": "0.4"}</field>
         <field name="description" type="html">
             <div class="oe_structure">
                 <h5>Seasoned Hockey Fans and curious people, this tournament is for you!</h5>
@@ -153,7 +153,7 @@
         <field name="website_menu" eval="True"/>
         <field name="website_published" eval="True"/>
         <field name="subtitle">Our newest collection will be revealed online! Interact with us on our live streams!</field>
-        <field name="cover_properties">{"background-image": "url('/website_event/static/src/img/event_cover_7.jpg')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0.4"}</field>
+        <field name="cover_properties">{"background-image": "url('/website_event/static/src/img/event_cover_7.jpg')", "resize_class": "o_record_has_cover cover_auto", "opacity": "0.4"}</field>
         <field name="description" type="html">
 <div class="oe_structure">
     <h5>The finest OpenWood furnitures are coming to your house in a brand new collection</h5>

--- a/addons/website_event/models/website_snippet_filter.py
+++ b/addons/website_event/models/website_snippet_filter.py
@@ -13,32 +13,32 @@ class WebsiteSnippetFilter(models.Model):
         samples = super()._get_hardcoded_sample(model)
         if model._name == 'event.event':
             data = [{
-                'cover_properties': '{"background-image": "url(\'/website_event/static/src/img/event_cover_1.jpg\')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0.4"}',
+                'cover_properties': '{"background-image": "url(\'/website_event/static/src/img/event_cover_1.jpg\')", "resize_class": "o_record_has_cover cover_auto", "opacity": "0.4"}',
                 'name': _('Great Reno Ballon Race'),
                 'date_begin': fields.Date.today() + timedelta(days=10),
                 'date_end': fields.Date.today() + timedelta(days=11),
             }, {
-                'cover_properties': '{"background-image": "url(\'/website_event/static/src/img/event_cover_2.jpg\')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0.4"}',
+                'cover_properties': '{"background-image": "url(\'/website_event/static/src/img/event_cover_2.jpg\')", "resize_class": "o_record_has_cover cover_auto", "opacity": "0.4"}',
                 'name': _('Conference For Architects'),
                 'date_begin': fields.Date.today(),
                 'date_end': fields.Date.today() + timedelta(days=2),
             }, {
-                'cover_properties': '{"background-image": "url(\'/website_event/static/src/img/event_cover_3.jpg\')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0.4"}',
+                'cover_properties': '{"background-image": "url(\'/website_event/static/src/img/event_cover_3.jpg\')", "resize_class": "o_record_has_cover cover_auto", "opacity": "0.4"}',
                 'name': _('Live Music Festival'),
                 'date_begin': fields.Date.today() + timedelta(weeks=8),
                 'date_end': fields.Date.today() + timedelta(weeks=8, days=5),
             }, {
-                'cover_properties': '{"background-image": "url(\'/website_event/static/src/img/event_cover_5.jpg\')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0.4"}',
+                'cover_properties': '{"background-image": "url(\'/website_event/static/src/img/event_cover_5.jpg\')", "resize_class": "o_record_has_cover cover_auto", "opacity": "0.4"}',
                 'name': _('Hockey Tournament'),
                 'date_begin': fields.Date.today() + timedelta(days=7),
                 'date_end': fields.Date.today() + timedelta(days=7),
             }, {
-                'cover_properties': '{"background-image": "url(\'/website_event/static/src/img/event_cover_7.jpg\')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0.4"}',
+                'cover_properties': '{"background-image": "url(\'/website_event/static/src/img/event_cover_7.jpg\')", "resize_class": "o_record_has_cover cover_auto", "opacity": "0.4"}',
                 'name': _('OpenWood Collection Online Reveal'),
                 'date_begin': fields.Date.today() + timedelta(days=1),
                 'date_end': fields.Date.today() + timedelta(days=3),
             }, {
-                'cover_properties': '{"background-image": "url(\'/website_event/static/src/img/event_cover_4.jpg\')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0.4"}',
+                'cover_properties': '{"background-image": "url(\'/website_event/static/src/img/event_cover_4.jpg\')", "resize_class": "o_record_has_cover cover_auto", "opacity": "0.4"}',
                 'name': _('Business Workshops'),
                 'date_begin': fields.Date.today() + timedelta(days=2),
                 'date_end': fields.Date.today() + timedelta(days=4),

--- a/addons/website_event/static/src/scss/event_templates_list.scss
+++ b/addons/website_event/static/src/scss/event_templates_list.scss
@@ -76,7 +76,7 @@
         // inside the second photo will not be editable properly.
         display: block;
     }
-    .o_half_screen_height {
+    .cover_auto {
         // Set min-height to the same value as the header
         min-height: 200px !important;
     }

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -347,8 +347,7 @@
                 <div>
                     <t t-if="attendees" t-call="website_event.registration_ticket_access"/>
                     <div class="mt-4">
-                        <h5>Don't miss out!</h5>
-                        <small>Add this event to your calendar</small>
+                        <h5>Add to your calendar</h5>
                         <div id="add_to_calendar" class="o_event_add_to_calendar_btns d-flex flex-wrap gap-3 mt-2">
                             <a role="button" class="o_outlook_calendar btn btn-block bg-white" t-att-href="iCal_url">
                                 <img src="/event/static/src/img/outlook-calendar.svg" alt="Outlook" loading="lazy"/>
@@ -406,11 +405,11 @@
 </template>
 
 <template id="registration_ticket_access" name="Registration Ticket Access">
-    <div class="row mb-3 o_wevent_registration_ticket_access">
+    <div class="row mb-2 o_wevent_registration_ticket_access">
         <div class="col-12 mb-2 d-flex flex-column flex-md-row align-items-stretch align-items-md-baseline justify-content-md-start">
             <a t-if="event.address_id" class="btn btn-primary" title="Download All Tickets" target="_blank"
                 t-attf-href="/event/{{ event.id }}/my_tickets?registration_ids={{ attendees.ids }}&amp;tickets_hash={{ event._get_tickets_access_hash(attendees.ids) }}">
-                Download Tickets <i class="ms-1 fa fa-download"/>
+                Download Tickets
             </a>
             <a t-else="" class="btn btn-primary" title="Join online" target="_blank"
                 t-att-href="event.event_url or event.website_url">

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
@@ -55,14 +55,6 @@ registry.category("web_tour.tours").add('event_buy_last_ticket', {
         trigger: ".modal:contains(Attendees) button[type=submit]:contains(Go to Payment)",
         run: "click",
     },
-    ...wsTourUtils.fillAdressForm({
-        name: "test1",
-        phone: "111 111",
-        email: "test@example.com",
-        street: "street test 1",
-        city: "testCity",
-        zip: "123",
-    }),
     ...wsTourUtils.payWithTransfer(true),
     ],
 });

--- a/addons/website_event_sale/views/website_sale_templates.xml
+++ b/addons/website_event_sale/views/website_sale_templates.xml
@@ -26,24 +26,10 @@
         </xpath>
     </template>
 
-    <!-- If the sale order line concerns an event, we want to show an additional line with the event name -->
-    <template id="cart_summary_inherit_website_event_sale" inherit_id="website_sale.checkout_layout" name="Event Cart right column">
-        <xpath expr="//td[@name='website_sale_cart_summary_product_name']/h6" position="after">
-            <t t-if="line.event_id" t-call="website_sale.cart_line_description_following_lines"/>
-        </xpath>
-    </template>
-
     <template id="event_confirmation" inherit_id="website_sale.confirmation">
-        <xpath expr="//div[@id='oe_structure_website_sale_confirmation_2']" position="inside">
+        <div id="order_name" position="after">
             <t t-if="events">
-                <section class="s_title pt40 mb-3" data-snippet="s_title" data-name="Title">
-                    <div class="s_allow_columns container">
-                        <h4>
-                            We are looking forward to meeting you at the following <t t-if="len(events) == 1">event</t><t t-else="">events</t>:
-                        </h4>
-                    </div>
-                </section>
-                <section class="card mb-5" t-foreach="events" t-as="event">
+                <section class="card" t-foreach="events" t-as="event">
                     <t t-set="attendees" t-value="attendee_ids_per_event.get(event, [])"/>
                     <div class="s_nb_column_fixed s_col_no_bgcolor o_wevent_index o_wevent_sale_event">
                         <t t-set="opt_event_description_cover_top" t-value="is_view_active('website_event.opt_event_description_cover_top')"/>
@@ -76,8 +62,7 @@
                         <div class="m-3">
                             <t t-if="attendees" t-call="website_event.registration_ticket_access"/>
                             <div class="row my-3">
-                                <h5>Don't miss out!</h5>
-                                <small>Add this event to your calendar</small>
+                                <h5>Add to your calendar</h5>
                                 <div id="add_to_calendar" class="o_event_add_to_calendar_btns d-flex flex-wrap gap-3 mt-2">
                                     <a role="button" class="o_outlook_calendar btn btn-block bg-white" t-att-href="urls_per_event.get(event.id, {}).get('iCal_url', '')">
                                         <img src="/event/static/src/img/outlook-calendar.svg" alt="Outlook" loading="lazy"/>
@@ -94,7 +79,7 @@
                     </div>
                 </section>
             </t>
-        </xpath>
+        </div>
     </template>
 
 </odoo>

--- a/addons/website_event_track/models/event_event.py
+++ b/addons/website_event_track/models/event_event.py
@@ -56,6 +56,14 @@ class EventEvent(models.Model):
             event.tracks_tag_ids = event.track_ids.mapped('tag_ids').filtered(lambda tag: tag.color != 0).ids
 
     # ------------------------------------------------------------
+    # BUSINESS METHODS
+    # ------------------------------------------------------------
+
+    def _has_published_track(self):
+        self.ensure_one()
+        return bool(self.track_ids.filtered('is_published'))
+
+    # ------------------------------------------------------------
     # WEBSITE MENU MANAGEMENT
     # ------------------------------------------------------------
 

--- a/addons/website_event_track/views/event_templates.xml
+++ b/addons/website_event_track/views/event_templates.xml
@@ -4,7 +4,7 @@
 <!-- Add a shortcut to favorites / tracks after registration -->
 <template id="registration_complete" inherit_id="website_event.registration_complete">
     <xpath expr="//div[hasclass('container')]/div[last()]" position="after">
-        <div t-if="event.website_track" class="row mt-5 mb256">
+        <div t-if="event.website_track and event._has_published_track()" class="row mt-5 mb256">
             <div class="col-12">
                 <h3>Book your seats to the best talks</h3>
                 <p>Get prepared and
@@ -17,10 +17,9 @@
 
 <template id="event_confirmation_end_page_hook" inherit_id="website_event.event_confirmation_end_page_hook">
     <xpath expr="//div[hasclass('o_wevent_confirmation_end_page_hook')]" position="inside">
-        <div t-if="event.website_track" class="row mt-5 mb-3">
+        <div t-if="event.website_track and event._has_published_track()" class="row mt-4">
             <div class="col-12">
-                <h3>Book your seats to the best talks</h3>
-                <p>Get prepared and
+                <p class="mb-0">Get prepared and
                     <a class="o_translate_inline" t-att-href="'/event/%s/track' % (slug(event))">register to your favorites talks now.</a>
                 </p>
             </div>

--- a/addons/website_payment/static/tests/tours/donation.js
+++ b/addons/website_payment/static/tests/tours/donation.js
@@ -80,7 +80,7 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            trigger: ":iframe body:contains(Your payment has been successfully processed.)",
+            trigger: ":iframe body:contains(Your payment has been processed.)",
         },
         {
             content: "Verify that the amount displayed is 67",

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1158,6 +1158,11 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         return json.dumps(feedback_dict)
 
+    def _needs_address(self):
+        if cart := request.cart:
+            return cart._needs_customer_address()
+        return super()._needs_address()
+
     def _prepare_address_update(self, order_sudo, partner_id=None, address_type=None):
         """ Find the partner whose address to update and return it along with its address type.
 

--- a/addons/website_sale/data/data.xml
+++ b/addons/website_sale/data/data.xml
@@ -66,18 +66,18 @@
 
         <!-- Generic steps used to generate new specific steps -->
         <record id="website_sale.checkout_step_cart" model="website.checkout.step">
-            <field name="name">Review Order</field>
+            <field name="name">Order</field>
             <field name="sequence">0</field>
             <field name="step_href">/shop/cart</field>
             <field name="back_button_label">Back to cart</field>
         </record>
 
         <record id="website_sale.checkout_step_delivery" model="website.checkout.step">
-            <field name="name">Delivery</field>
+            <field name="name">Address</field>
             <field name="sequence">250</field>
             <field name="step_href">/shop/checkout</field>
             <field name="main_button_label">Checkout</field>
-            <field name="back_button_label">Back to delivery</field>
+            <field name="back_button_label">Back to address</field>
         </record>
 
         <record id="website_sale.checkout_step_extra" model="website.checkout.step">

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -233,6 +233,14 @@ class SaleOrder(models.Model):
             return self.env['website'].browse(website_id).get_base_url()
         return super()._get_note_url()
 
+    def _needs_customer_address(self):
+        """Return whether we need the address details of the customer (country, street, ...).
+
+        If an order only has services, unless the customer wants an invoice, their checkout can
+        be sped up by allowing them to only provide their name, email and phone numbers.
+        """
+        return not self.only_services
+
     def _update_address(self, partner_id, fnames=None):
         if not fnames:
             return

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -142,7 +142,7 @@ export function payWithDemo() {
     pay(),
     {
         content: 'eCommerce: check that the payment is successful',
-        trigger: '.oe_website_sale_tx_status:contains("Your payment has been successfully processed.")',
+        trigger: '.oe_website_sale_tx_status:contains("Your payment has been processed.")',
     }]
 }
 

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1212,7 +1212,7 @@ a.no-decoration {
         background-image: escape-svg($accordion-button-icon);
     }
 
-    #product_accordion, #wsale_products_attributes_collapse h6, #o_wsale_price_range_option h6 {
+    #product_accordion, #wsale_products_attributes_collapse h6, #o_wsale_price_range_option h6, #o_wsale_total_accordion .accordion-header {
         --accordion-active-bg: inherit;
         --accordion-active-color: var(--accordion-btn-color);
         --accordion-btn-padding-x : 0;

--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -64,7 +64,7 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         {
             // wait for the page to load, as the next check was sometimes too fast
             content: "Wait for the redirection to the cart page",
-            trigger: ":iframe h3:contains(order overview)",
+            trigger: ":iframe h4:contains(order summary)",
         },
         assertCartContains({productName: 'Product No Variant', backend: true}),
         assertCartContains({productName: 'Product Yes Variant 1 (Red)', backend: true}),

--- a/addons/website_sale/views/delivery_form_templates.xml
+++ b/addons/website_sale/views/delivery_form_templates.xml
@@ -7,7 +7,7 @@
             - selected_dm_id: The selected delivery method id.
         -->
         <form id="o_delivery_form" class="o_delivery_form mb-4">
-            <h4 class="fs-6 small fw-bolder">Choose a delivery method</h4>
+            <h5>Delivery method</h5>
             <ul t-if="delivery_methods" id="o_delivery_methods" class="list-group">
                 <t t-foreach="delivery_methods" t-as="dm">
                     <li name="o_delivery_method" class="list-group-item text-muted o_outline">

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2151,13 +2151,13 @@
                 <div class="oe_structure" id="oe_structure_website_sale_extra_info_1"/>
             </t>
 
-            <h3 class="mb-4">Extra info</h3>
+            <h4 class="mb-3">Extra info</h4>
             <section class="s_website_form" data-vcss="001" data-snippet="s_website_form">
                 <div class="container">
                     <form action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required s_website_form_no_recaptcha" data-mark="*" data-force_action="shop.sale.order" data-model_name="sale.order" data-success-mode="redirect" data-success-page="/shop/payment" hide-change-model="true">
                         <div class="s_website_form_rows s_col_no_bgcolor row">
-                            <div class="s_website_form_field col-12 py-2 mb-0" data-type="char" data-name="Field">
-                                <div class="s_col_no_resize s_col_no_bgcolor row">
+                            <div class="s_website_form_field col-12 pb-2 mb-0" data-type="char" data-name="Field">
+                                <div class="s_col_no_resize s_col_no_bgcolor">
                                     <label class="s_website_form_label col-form-label col-sm-auto" style="width: 200px" for="sale1">
                                         <span class="s_website_form_label_content">Your Reference</span>
                                     </label>
@@ -2166,8 +2166,8 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="s_website_form_field s_website_form_custom col-12 py-2 mb-0" data-type="text" data-name="Field">
-                                <div class="s_col_no_resize s_col_no_bgcolor row">
+                            <div class="s_website_form_field s_website_form_custom col-12 pb-2 mb-0" data-type="text" data-name="Field">
+                                <div class="s_col_no_resize s_col_no_bgcolor">
                                     <label class="s_website_form_label col-form-label col-sm-auto" style="width: 200px" for="sale2">
                                         <span class="s_website_form_label_content">Give us your feedback</span>
                                     </label>
@@ -2176,8 +2176,8 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="s_website_form_field s_website_form_custom col-12 py-2 mb-0" data-type="binary" data-name="Field">
-                                <div class="s_col_no_resize s_col_no_bgcolor row">
+                            <div class="s_website_form_field s_website_form_custom col-12 pb-2 mb-0" data-type="binary" data-name="Field">
+                                <div class="s_col_no_resize s_col_no_bgcolor">
                                     <label class="s_website_form_label col-form-label col-sm-auto" style="width: 200px" for="sale3">
                                         <span class="s_website_form_label_content">Upload a document</span>
                                     </label>
@@ -2255,7 +2255,7 @@
             <t t-foreach="website_sale_order.website_order_line" t-as="line">
                 <t t-set="is_combo" t-value="line.product_type == 'combo'"/>
                 <div
-                    class="o_cart_product d-flex gap-3 py-4"
+                    class="o_cart_product d-flex gap-3 pb-4"
                     t-attf-data-product-id="#{line.product_id and line.product_id.id}"
                 >
                     <div
@@ -2502,7 +2502,7 @@
                         'o_img_ratio_2_3' if is_view_active('website_sale.products_thumb_2_3') else
                         '')
             ">
-                <h3 class="mb-4">Order overview</h3>
+                <h4 class="mb-3">Order summary</h4>
                 <div t-if="abandoned_proceed or access_token" class="alert alert-info mt8 mb8" role="alert"> <!-- abandoned cart choices -->
                     <t t-if="abandoned_proceed">
                         <p>Your previous cart has already been completed.</p>
@@ -2612,7 +2612,7 @@
             <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" t-nocache="The csrf token must always be up to date."/>
             <div class="input-group w-100 my-2">
                 <input name="promo" class="form-control" type="text" placeholder="Discount code..." t-att-value="website_sale_order.pricelist_id.code or None"/>
-                <a href="#" role="button" class="btn btn-secondary a-submit ps-2">Apply</a>
+                <a href="#" role="button" class="btn btn-secondary a-submit">Apply</a>
             </div>
         </form>
         <t t-if="request.params.get('code_not_available')" name="code_not_available">
@@ -2716,7 +2716,7 @@
 
     <template id="delivery_address_row">
         <div id="delivery_address_row" class="mb-4">
-            <h4 class="small fs-6 fw-bold">Delivery address</h4>
+            <h4 class="mb-3">Delivery address</h4>
             <t t-call="website_sale.address_row">
                 <t t-set="address_type" t-value="'delivery'"/>
                 <t t-set="addresses" t-value="delivery_addresses"/>
@@ -2727,10 +2727,13 @@
 
     <template id="billing_address_row">
         <div id="billing_address_row" class="mb-3">
-            <h4 class="small fs-6 fw-bold mt-3">
-                <t groups="!account.group_delivery_invoice_address">Your address</t>
-                <t groups="account.group_delivery_invoice_address">Billing address</t>
-            </h4>
+            <p
+                t-attf-class="{{only_services and 'h4 mb-3' or 'h5'}}"
+                groups="account.group_delivery_invoice_address"
+            >
+                Billing address
+            </p>
+            <h4 groups="!account.group_delivery_invoice_address">Your address</h4>
             <t groups="account.group_delivery_invoice_address">
                 <t t-set="has_delivery" t-value="order._has_deliverable_products()"/>
                 <div t-if="has_delivery" class="form-check form-switch mt-2 mb-3">
@@ -2794,9 +2797,6 @@
 
     <!-- /shop/address route -->
     <template id="website_sale.address_form_fields" inherit_id="portal.address_form_fields" primary="True">
-        <div id="div_email" position="attributes">
-            <attribute name="t-if">not is_anonymous_cart</attribute>
-        </div>
         <t name="b2b_fields" position="attributes">
             <attribute name="t-if">display_b2b_fields</attribute>
         </t>
@@ -2808,18 +2808,10 @@
             <div class="o_customer_address_fill">
                 <div>
                     <t t-if="not is_anonymous_cart">
-                        <t t-if="use_delivery_as_billing">
-                            <h3 class="mb-3">Your address</h3>
-                        </t>
-                        <t t-elif="address_type == 'delivery'">
-                            <h3 class="mb-3">Delivery address</h3>
-                        </t>
-                        <t t-else="">
-                            <h3 class="mb-3">
-                                <t groups="!account.group_delivery_invoice_address">Your address</t>
-                                <t groups="account.group_delivery_invoice_address">Billing address</t>
-                            </h3>
-                        </t>
+                        <h4 class="mb-3">
+                            <t t-if="partner_sudo">Edit address</t>
+                            <t t-else="">New address</t>
+                        </h4>
                     </t>
                     <div
                         t-if="use_delivery_as_billing and not only_services and partner_sudo"
@@ -2844,31 +2836,19 @@
                         t-att-data-submit-url="'/shop/address/submit'"
                     >
                         <t t-if="is_anonymous_cart">
-                            <div id="div_email_public" t-attf-class="col-lg-12">
-                                <label class="col-form-label" for="o_email">Email</label>
-                                <div
-                                    t-if="website.account_on_checkout != 'disabled'"
-                                    class="align-items-center float-end"
-                                    style="margin-top: -11px"
-                                >
-                                    <span>Already have an account?</span>
+                            <div class="d-flex flex-column flex-md-row align-items-center justify-content-between mb-1">
+                                <h4 class="w-100">Details</h4>
+                                <div t-if="website.account_on_checkout != 'disabled'" class="w-100 text-end">
+                                    <span class="align-middle">Already have an account?</span>
                                     <a
                                         role="button"
                                         href='/web/login?redirect=/shop/checkout'
-                                        class="btn btn-primary"
+                                        class="btn btn-primary ms-2"
                                     >
                                         Sign in
                                     </a>
                                 </div>
-                                <input
-                                    id="o_email"
-                                    type="email"
-                                    name="email"
-                                    class="form-control"
-                                    t-att-value="partner_sudo.email"
-                                />
                             </div>
-                            <h4 class="mb-1 mt-5">Fill in your address</h4>
                         </t>
                         <div class="row">
                             <t t-call="website_sale.address_form_fields"/>
@@ -2882,32 +2862,70 @@
     <!-- Deactivatable through the website editor. -->
     <template id="address_b2b" inherit_id="website_sale.address" name="Show b2b fields" />
 
-    <!-- Called in `website_sale.payment`. -->
-    <template id="address_on_payment" name="Address on payment">
+    <template id="address_edit_button" name="Address edit button">
+        <t t-if="xmlid != 'website_sale.confirmation'">
+            <a t-if="order.partner_invoice_id.country_id" class="float-end no-decoration pe-1" href="/shop/checkout">
+                <i class="fa fa-pencil me-1"/>Edit
+            </a>
+            <a
+                t-else=""
+                class="float-end no-decoration pe-1"
+                t-attf-href="/shop/address?partner_id={{order.partner_invoice_id.id}}&amp;address_type=billing"
+            >
+                <i class="fa fa-pencil me-1"/>Want an invoice?
+            </a>
+        </t>
+    </template>
+
+    <!-- Called in `website_sale.payment` and `website_sale.confirmation`. -->
+    <template id="address_on_checkout" name="Address on payment">
         <div class="card">
             <div class="card-body" id="delivery_and_billing">
-                <a class="float-end no-decoration" href="/shop/checkout"><i class="fa fa-pencil me-1"/>Edit</a>
+                <t t-call="website_sale.address_edit_button"/>
                 <t
                     t-set="use_delivery_as_billing"
                     t-value="order.partner_invoice_id == order.partner_shipping_id and not order.pickup_location_data"
                 />
-                <div t-if="not use_delivery_as_billing and order._has_deliverable_products()" groups="account.group_delivery_invoice_address">
-                    <t t-if="order.pickup_location_data">
-                        <b>Deliver to pickup point: </b>
-                        <t t-out="order.pickup_location_data.get('name', '') + ', ' + order.pickup_location_data.get('street', '') + ' ' + order.pickup_location_data.get('zip_code', '') + ' ' + order.pickup_location_data.get('city','')"/>
-                    </t>
-                    <t t-else="">
-                        <b>Delivery: </b>
-                        <span
-                            t-out="order.partner_shipping_id"
-                            t-options="dict(widget='contact', fields=['address'], no_marker=True, separator=', ')"
-                            class="address-inline"
+                <div class="row g-0">
+                    <div
+                        t-if="not use_delivery_as_billing and order._has_deliverable_products()"
+                        t-attf-class="{{not use_delivery_as_billing and not only_services and 'col-md-6 ps-1'}}"
+                        groups="account.group_delivery_invoice_address"
+                    >
+                        <t t-if="order.pickup_location_data">
+                            <b>Deliver to pickup point</b>
+                            <div
+                                t-out="order.pickup_location_data.get('name', '')
+                                    + ', ' + order.pickup_location_data.get('street', '')
+                                    + ' ' + order.pickup_location_data.get('zip_code', '')
+                                    + ' ' + order.pickup_location_data.get('city','')
+                                "
+                            />
+                        </t>
+                        <t t-else="">
+                            <b>Delivery</b>
+                            <t
+                                t-out="order.partner_shipping_id"
+                                t-options="dict(
+                                    widget='contact',
+                                    fields=['name', 'address'],
+                                    no_marker=True,
+                                )"
+                            />
+                        </t>
+                    </div>
+                    <div t-attf-class="ps-1 {{not use_delivery_as_billing and not only_services and 'col-md-6'}}">
+                        <b t-if="use_delivery_as_billing and not only_services">Delivery &amp; Billing</b>
+                        <b t-else="">Billing</b>
+                        <t
+                            t-out="order.partner_invoice_id"
+                            t-options="dict(
+                                widget='contact',
+                                fields=['name', 'address'],
+                                no_marker=True,
+                            )"
                         />
-                    </t>
-                </div>
-                <div>
-                    <b><t t-if="use_delivery_as_billing and not only_services">Delivery &amp; </t>Billing: </b>
-                    <span t-esc="order.partner_invoice_id" t-options="dict(widget='contact', fields=['address'], no_marker=True, separator=', ')" class="address-inline"/>
+                    </div>
                 </div>
             </div>
         </div>
@@ -2937,17 +2955,19 @@
                     </div>
                 </t>
             </div>
-            <h3 class="mb-4">Confirm order</h3>
-            <div id="address_on_payment" class="mb-4">
-                <t t-call="website_sale.address_on_payment"/>
-            </div>
-            <div class="oe_structure clearfix mt-3" id="oe_structure_website_sale_payment_1"/>
+            <div class="oe_structure clearfix mb-3" id="oe_structure_website_sale_payment_1"/>
 
             <div t-if="not errors and website_sale_order.amount_total" name="website_sale_non_free_cart">
-                <div id="payment_method" class="o_not_editable mt-4">
+                <div id="payment_method" class="o_not_editable mb-3">
                     <t t-call="payment.form"/>
                 </div>
                 <t t-if="not (payment_methods_sudo or tokens_sudo)" t-set="hide_payment_button" t-value="True"/>
+            </div>
+            <h4 t-else="" class="mb-3">
+                Confirm order
+            </h4>
+            <div id="address_on_payment">
+                <t t-call="website_sale.address_on_checkout"/>
             </div>
         </t>
     </template>
@@ -2986,6 +3006,7 @@
         <t t-call="website.layout">
             <t t-set="no_footer" t-value="True if show_footer is None else not show_footer"/>
             <t t-set="show_navigation_button" t-value="True if show_navigation_button is None else show_navigation_button"/>
+            <t t-set="expand_order_summary" t-value="not show_navigation_button"/>
             <t t-set="show_wizard_checkout" t-value="True if show_wizard_checkout is None else show_wizard_checkout"/>
             <div id="wrap">
                 <div class="oe_website_sale o_website_sale_checkout container py-2">
@@ -3014,12 +3035,14 @@
                              id="o_wsale_total_accordion">
                             <div class="o_total_card sticky-lg-top">
                                 <div id="o_wsale_total_accordion_item" class="accordion-item p-lg-4 border-0">
-                                    <div class="accordion-header d-block align-items-center mb-4">
-                                        <button class="accordion-button px-0 collapsed"
-                                                data-bs-toggle="collapse"
-                                                data-bs-target="#o_wsale_accordion_item"
-                                                aria-expanded="false"
-                                                aria-controls="o_wsale_accordion_item">
+                                    <div class="accordion-header d-block align-items-center mb-2">
+                                        <button
+                                            t-attf-class="accordion-button pt-0 pb-1 px-0 {{ not expand_order_summary and 'collapsed' }}"
+                                            t-att-aria-expanded="expand_order_summary and 'True' or 'False'"
+                                            data-bs-toggle="collapse"
+                                            data-bs-target="#o_wsale_accordion_item"
+                                            aria-controls="o_wsale_accordion_item"
+                                        >
                                             <div class="d-flex flex-wrap">
                                                 <b class="w-100">Order summary</b>
                                                 <span t-out="str(website_sale_order.cart_quantity)"/>
@@ -3035,9 +3058,9 @@
                                         Your cart is empty!
                                     </div>
                                     <div id="o_wsale_accordion_item"
-                                        class="accordion-collapse collapse mb-4 mb-lg-0"
+                                        t-attf-class="accordion-collapse collapse mb-4 pt-4 mb-lg-0 {{ expand_order_summary and 'show' }}"
                                         data-bs-parent="#o_wsale_total_accordion">
-                                        <div t-att-class="len(website_sale_order.website_order_line) &gt; 3 and 'o_wsale_scrollable_table mt-n4 me-n4 pt-4 pe-4'">
+                                        <div t-att-class="len(website_sale_order.website_order_line) &gt; 3 and 'o_wsale_scrollable_table mt-n4 me-n4 pe-4'">
                                             <table t-if="website_sale_order and website_sale_order.website_order_line"
                                                 class="table accordion-body mb-0"
                                                 id="cart_products">
@@ -3092,7 +3115,7 @@
                                         </t>
                                     </div>
                                     <t t-call="website_sale.total">
-                                        <t t-set="_cart_total_classes" t-valuef="border-top pt-3"/>
+                                        <t t-set="_cart_total_classes" t-valuef="border-top pt-2"/>
                                     </t>
                                     <div t-if="show_navigation_button" class="o_cta_navigation_container position-absolute position-lg-static start-0 top-100 col-12">
                                         <t t-call="website_sale.navigation_buttons"/>
@@ -3134,49 +3157,33 @@
             <t t-set="tx_sudo" t-value="order.get_portal_last_transaction()"/>
             <div t-if="tx_sudo.state in ['pending', 'done']" class="d-flex justify-content-between align-items-center">
                 <h3>Thank you for your order.</h3>
-                <a role="button" class="d-none d-md-inline-block btn btn-primary ms-auto" href="/shop/print" target="_blank" aria-label="Print" title="Print"><i class="fa fa-print me-2"></i>Print</a>
+                <a
+                    title="Print"
+                    role="button"
+                    class="d-none d-md-inline-block btn btn-secondary ms-auto"
+                    href="/shop/print"
+                    target="_blank"
+                    aria-label="Print"
+                >
+                    <i class="fa fa-print me-2"/>Print
+                </a>
             </div>
-            <div class="mb-4">
+            <div id="order_name" class="mb-4">
                 <h5>
-                    <em>
-                        <span>Order</span>
-                        <span t-field="order.name"/>
-                        <t t-if="order.state == 'sale'">
-                            <i class="fa fa-check-circle ms-1"/>
-                        </t>
-                    </em>
+                    <span>Order</span>
+                    <span t-field="order.name"/>
                 </h5>
             </div>
             <t t-if="request.env['res.users']._get_signup_invitation_scope() == 'b2c' and request.website.is_public_user()">
                 <p class="alert alert-info mt-3" role="status">
                     <a role="button" t-att-href="order.partner_id.signup_prepare() and order.partner_id.with_context(relative_url=True)._get_signup_url()" class="btn btn-primary o_translate_inline">Sign Up</a>
-                    to follow your order.
+                    <span class="align-middle">to follow your order.</span>
                 </p>
             </t>
             <div class="oe_structure clearfix mt-3" id="oe_structure_website_sale_confirmation_1"/>
-            <h4 class="text-start mt-3">Payment Information</h4>
-            <table class="table">
-                <tbody>
-                    <tr>
-                        <td colspan="2" class="ps-0">
-                            <t t-esc="tx_sudo.provider_id.name" />
-                        </td>
-                        <td class="text-end pe-0" width="100">
-                            <strong>Total:</strong>
-                        </td>
-                        <td class="text-end pe-0" width="100">
-                            <strong t-field="tx_sudo.amount" t-options="{'widget': 'monetary', 'display_currency': order.currency_id}" />
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
             <t t-call="website_sale.payment_confirmation_status"/>
-            <div class="card mt-3">
-                <div class="card-body">
-                    <t t-set="same_shipping" t-value="bool(order.partner_shipping_id == order.partner_invoice_id or only_services)" />
-                    <div><b>Billing <t t-if="same_shipping and not only_services"> &amp; Delivery</t>: </b><span t-esc='order.partner_invoice_id' t-options="dict(widget='contact', fields=['address'], no_marker=True, separator=', ')" class="address-inline"/></div>
-                    <div t-if="not same_shipping and not only_services" groups="account.group_delivery_invoice_address"><b>Delivery: </b><span t-esc='order.partner_shipping_id' t-options="dict(widget='contact', fields=['address'], no_marker=True, separator=', ')"  class="address-inline"/></div>
-                </div>
+            <div class="mt-3">
+                <t t-call="website_sale.address_on_checkout"/>
             </div>
             <div class="oe_structure mt-3" id="oe_structure_website_sale_confirmation_2"/>
             <input t-if='website.plausible_shared_key' type='hidden' class='js_plausible_push' data-event-name='Shop' t-attf-data-event-params='{"CTA": "Order Confirmed", "amount": "#{"%3s-%3s" % (max(0, round(website_sale_order.amount_total/100)*100 - 50), round(website_sale_order.amount_total/100)*100 + 50)}"}' />
@@ -3191,10 +3198,10 @@
                     t-if="website_sale_order._has_deliverable_products()"
                     id="order_delivery"
                 >
-                    <td class="ps-0 pt-0 pb-2 border-0 text-muted" colspan="2">
+                    <td class="ps-0 pt-1 pb-2 border-0 text-muted" colspan="2">
                         Delivery
                     </td>
-                    <td class="text-end pe-0 pt-0 pb-2 border-0">
+                    <td class="text-end pe-0 pt-1 pb-2 border-0">
                         <span
                             id="message_no_dm_set"
                             t-att-class="'d-none' if website_sale_order.carrier_id else ''"
@@ -3224,8 +3231,8 @@
                     </td>
                 </tr>
                 <tr id="order_total_taxes">
-                    <td colspan="2" class="text-muted border-0 ps-0 pt-0 pb-3">Taxes</td>
-                    <td class="text-end border-0 pe-0 pt-0 pb-3">
+                    <td colspan="2" class="text-muted border-0 p-0 pe-3 pb-2">Taxes</td>
+                    <td class="text-end border-0 p-0 ps-3 pb-2">
                         <span t-field="website_sale_order.amount_tax"
                               class="monetary_field"
                               style="white-space: nowrap;"
@@ -3269,17 +3276,27 @@
     <template id="payment_confirmation_status">
         <div class="oe_website_sale_tx_status mt-3" t-att-data-order-id="order.id" t-att-data-order-tracking-info="json.dumps(order_tracking_info)">
             <t t-set="tx_sudo" t-value="order.get_portal_last_transaction()"/>
-            <div t-attf-class="card #{
-                (tx_sudo.state == 'pending' and 'bg-info') or
-                (tx_sudo.state == 'done' and order.amount_total == tx_sudo.amount and 'alert-success') or
-                (tx_sudo.state == 'done' and order.amount_total != tx_sudo.amount and 'bg-warning') or
-                (tx_sudo.state == 'authorized' and 'alert-success') or
-                'bg-danger'}">
-                <div class="card-header">
-                    <a role="button" groups="base.group_system" class="btn btn-sm btn-link text-white float-end" target="_blank" aria-label="Edit" title="Edit"
-                            t-attf-href="/odoo/action-payment.action_payment_provider/{{tx_sudo.provider_id.id}}">
-                        <i class="fa fa-pencil"></i>
-                    </a>
+            <div
+                t-attf-class="alert px-3 pb-0 pt-3 #{
+                    (tx_sudo.state == 'pending' and 'alert-info') or
+                    (tx_sudo.state == 'done' and order.amount_total == tx_sudo.amount and 'alert-success') or
+                    (tx_sudo.state == 'done' and order.amount_total != tx_sudo.amount and 'alert-warning') or
+                    (tx_sudo.state == 'authorized' and 'alert-success') or
+                    'alert-danger'}"
+                role="alert"
+            >
+                <a
+                    title="Edit"
+                    class="btn btn-sm btn-link text-dark float-end"
+                    role="button"
+                    groups="base.group_system"
+                    target="_blank"
+                    aria-label="Edit"
+                    t-attf-href="/odoo/action-payment.action_payment_provider/{{tx_sudo.provider_id.id}}"
+                >
+                    <i class="fa fa-pencil"/>
+                </a>
+                <div>
                     <t t-if="tx_sudo.state == 'pending'">
                         <t t-out="tx_sudo.provider_id.sudo().pending_msg"/>
                     </t>
@@ -3302,12 +3319,12 @@
                     </t>
                 </div>
                 <t t-if="tx_sudo.provider_code == 'custom'">
-                    <div t-if="order.reference" class="card-body">
+                    <div id="order_reference" t-if="order.reference" class="mt-2">
                         <b>Communication: </b><span t-esc='order.reference'/>
                     </div>
                     <div t-if="tx_sudo.provider_id.sudo().qr_code">
                         <t t-set="qr_code" t-value="tx_sudo.company_id.partner_id.bank_ids[:1].build_qr_code_base64(order.amount_total,tx_sudo.reference, None, tx_sudo.currency_id, tx_sudo.partner_id)"/>
-                        <div class="card-body" t-if="qr_code">
+                        <div class="mt-2" t-if="qr_code">
                             <h3>Or scan me with your banking app.</h3>
                             <img class="border border-dark rounded" t-att-src="qr_code"/>
                         </div>

--- a/addons/website_sale_collect/views/templates.xml
+++ b/addons/website_sale_collect/views/templates.xml
@@ -5,9 +5,9 @@
         id="payment_confirmation_status"
         inherit_id="website_sale.payment_confirmation_status"
     >
-        <xpath expr="(//div[hasclass('card-body')])[1]" position="replace">
+        <div id="order_reference" position="replace">
             <t t-if="tx_sudo.provider_id.custom_mode == 'on_site'">
-                <div class="card-body">
+                <div class="mt-2">
                     <div class="o_header_carrier_message">
                         <b t-out="order.carrier_id.name"/>
                         <span class="text-muted"> (In-store pickup)</span>
@@ -20,7 +20,7 @@
             <t t-else="">
                 <t>$0</t> <!-- Replaced by old content. -->
             </t>
-        </xpath>
+        </div>
     </template>
 
     <template id="product_page_click_and_collect" inherit_id="website_sale.product">

--- a/addons/website_sale_loyalty/static/tests/tours/test_apply_discount_code.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_apply_discount_code.js
@@ -20,7 +20,7 @@ registry.category("web_tour.tours").add('apply_discount_code_program_multi_rewar
         },
         tourUtils.goToCart(),
         {
-            trigger: "h3:contains(order overview)",
+            trigger: "h4:contains(order summary)",
         },
         {
             trigger: 'form[name="coupon_code"]',

--- a/addons/website_sale_mass_mailing/views/templates.xml
+++ b/addons/website_sale_mass_mailing/views/templates.xml
@@ -3,18 +3,18 @@
 
     <template
         id="website_sale_mass_mailing.newsletter"
-        inherit_id="website_sale.address"
+        inherit_id="website_sale.address_form_fields"
         name="Newsletter"
         active="False"
     >
-        <div id="div_email_public" position="after">
-            <div class="form-check mt-2">
+         <div id="div_email" position="inside">
+            <div t-if="is_anonymous_cart" class="col-lg-12 col-form-label">
                 <label>
                     <input
                         type="checkbox"
                         name="newsletter"
-                        class="form-check-input"
-                    /> Be the first to find out all the latest news, products and trends
+                        class="form-check-input label-optional"
+                    /> Subscribe to our newsletter
                 </label>
             </div>
         </div>

--- a/addons/website_sale_mondialrelay/controllers/controllers.py
+++ b/addons/website_sale_mondialrelay/controllers/controllers.py
@@ -35,7 +35,7 @@ class MondialRelay(http.Controller):
             order_sudo.partner_shipping_id = partner_shipping
 
         return {
-            'address': request.env['ir.qweb']._render('website_sale.address_on_payment', {
+            'address': request.env['ir.qweb']._render('website_sale.address_on_checkout', {
                 'order': order_sudo,
                 'only_services': order_sudo.only_services,
             }),

--- a/addons/website_sale_mondialrelay/views/templates.xml
+++ b/addons/website_sale_mondialrelay/views/templates.xml
@@ -17,12 +17,12 @@
         </div>
     </template>
 
-    <template id="website_sale_mondialrelay_address_on_payment" inherit_id="website_sale.address_on_payment">
-        <xpath expr="//span[@t-out='order.partner_shipping_id']" position="before">
+    <template id="address_on_checkout" inherit_id="website_sale.address_on_checkout">
+        <t t-out="order.partner_shipping_id" position="before">
             <t t-if="order.partner_shipping_id.is_mondialrelay" >
                 <img src="/delivery_mondialrelay/static/src/img/logo.png" title="Mondial Relay" height="20px"/>
             </t>
-        </xpath>
+        </t>
     </template>
 
 </odoo>


### PR DESCRIPTION
_* = website_sale_(collect,mass_mailing), website_event_(sale,track), payment

This commit introduces several improvements to streamline the checkout
experience:

- Dynamic Partner Creation:
  - During event ticket booking, a partner is created using the attendee's
    provided name, email, and phone number.
- UI Refinements:
  - Refactored the /shop/confirmation page for a cleaner, more visually
    appealing design.
  - Removed unnecessary text to reduce visual noise and enhance clarity.
  - Improve other UX to make it more attractive.

task-4307281

See also: https://github.com/odoo/enterprise/pull/79914