### PR TITLE
[IMP] web: search panel: expand hierarchy up to depth

### DIFF
--- a/addons/web/static/src/search/search_arch_parser.js
+++ b/addons/web/static/src/search/search_arch_parser.js
@@ -165,14 +165,14 @@ export class SearchArchParser {
                     }
                     preField.defaultAutocompleteValue.label = option[1];
                 } else if (fieldType === "many2one") {
-                    this.labels.push((orm) => {
-                        return orm
+                    this.labels.push((orm) =>
+                        orm
                             .call(relation, "read", [value, ["display_name"]], { context })
                             .then((results) => {
                                 preField.defaultAutocompleteValue.label =
                                     results[0]["display_name"];
-                            });
-                    });
+                            })
+                    );
                 }
             }
         } else {
@@ -355,6 +355,7 @@ export class SearchArchParser {
                 section.activeValueId = this.searchPanelDefaults[attrs.name];
                 section.icon = section.icon || "fa-folder";
                 section.hierarchize = evaluateBooleanExpr(attrs.hierarchize || "1");
+                section.depth = attrs.depth ? parseInt(attrs.depth) : 0;
                 section.values.set(false, {
                     childrenIds: [],
                     display_name: ALL.toString(),

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -196,7 +196,7 @@ export class SearchModel extends EventBus {
     async load(config) {
         const { resModel } = config;
         if (!resModel) {
-            throw Error(`SearchPanel config should have a "resModel" key`);
+            throw Error(`SearchModel config should have a "resModel" key`);
         }
         this.resModel = resModel;
 

--- a/addons/web/static/tests/search/search_model.test.js
+++ b/addons/web/static/tests/search/search_model.test.js
@@ -495,6 +495,7 @@ test("parsing a searchpanel field select one", async () => {
             activeValueId: false,
             color: null,
             description: "res.company",
+            depth: 0,
             empty: false,
             enableCounters: false,
             expand: false,

--- a/addons/web/static/tests/search/search_panel_desktop.test.js
+++ b/addons/web/static/tests/search/search_panel_desktop.test.js
@@ -819,9 +819,6 @@ test("concurrency: single category", async () => {
     const compPromise = mountWithSearch(TestComponent, {
         resModel: "partner",
         searchViewId: false,
-        context: {
-            searchpanel_default_company_id: [5],
-        },
     });
 
     // Case 1: search panel is awaited to build the query with search defaults

--- a/addons/web/static/tests/search/search_panel_desktop.test.js
+++ b/addons/web/static/tests/search/search_panel_desktop.test.js
@@ -3007,3 +3007,70 @@ test("hide search panel if there is no records", async () => {
     expect(`.o_search_panel_sidebar`).toHaveCount(1);
     expect(`.o_search_panel`).toHaveCount(0);
 });
+
+test("many2one: select one, hierarchize and depth", async () => {
+    Company._records = [
+        { id: 1, name: "L0" },
+        { id: 2, name: "L1", parent_id: 1 },
+        { id: 3, name: "L2", parent_id: 2 },
+        { id: 4, name: "L3_1", parent_id: 3 },
+        { id: 5, name: "L3_2", parent_id: 3 },
+        { id: 6, name: "L_4_1", parent_id: 4 },
+        { id: 7, name: "L_4_2", parent_id: 5 },
+    ];
+    Partner._records[0].company_id = 6;
+    Partner._records[1].company_id = 7;
+    Partner._views = {
+        search: /* xml */ `
+            <search>
+                <searchpanel>
+                    <field name="company_id" depth="3"/>
+                </searchpanel>
+            </search>
+        `,
+    };
+
+    await mountWithSearch(TestComponent, {
+        resModel: "partner",
+        searchViewId: false,
+    });
+    expect(`.o_search_panel_field .o_search_panel_category_value`).toHaveCount(6);
+    expect(`.o_toggle_fold > i`).toHaveCount(5);
+
+    await contains(`.o_search_panel_category_value header:contains(L3_2)`).click();
+    expect(`.o_search_panel_field .o_search_panel_category_value`).toHaveCount(7);
+    expect(`.o_toggle_fold > i`).toHaveCount(5);
+});
+
+test("many2one: select one, hierarchize and depth and search_default", async () => {
+    Company._records = [
+        { id: 1, name: "L0" },
+        { id: 2, name: "L1", parent_id: 1 },
+        { id: 3, name: "L2", parent_id: 2 },
+        { id: 4, name: "L3_1", parent_id: 3 },
+        { id: 5, name: "L3_2", parent_id: 3 },
+        { id: 6, name: "L_4_1", parent_id: 4 },
+        { id: 7, name: "L_4_2", parent_id: 5 },
+    ];
+    Partner._records[0].company_id = 6;
+    Partner._records[1].company_id = 7;
+    Partner._views = {
+        search: /* xml */ `
+            <search>
+                <searchpanel>
+                    <field name="company_id" depth="2"/>
+                </searchpanel>
+            </search>
+        `,
+    };
+
+    await mountWithSearch(TestComponent, {
+        resModel: "partner",
+        searchViewId: false,
+        context: {
+            searchpanel_default_company_id: 6,
+        },
+    });
+    expect(`.o_search_panel_field .o_search_panel_category_value`).toHaveCount(7);
+    expect(`.o_toggle_fold > i`).toHaveCount(5);
+});


### PR DESCRIPTION
For search panel fields of type  "category", a new parameter "depth" is introduced. If the category is hierarchized, it will be expanded by default up to the given depth. 

Task ID: 4579118
