### PR TITLE
[FIX] discuss: prevent incorrect display of the call connection warning

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -86,7 +86,7 @@ export class CallParticipantCard extends Component {
         ) {
             return false;
         }
-        if (this.rtc.connectionType === CONNECTION_TYPES.SERVER) {
+        if (this.rtc.state.connectionType === CONNECTION_TYPES.SERVER) {
             return this.rtcSession.eq(this.rtc?.selfSession);
         } else {
             return this.rtcSession.notEq(this.rtc?.selfSession);


### PR DESCRIPTION
Before this commit, the condition for displaying the call warning was using `rtc.connectionType` instead of `rtc.state.connectionType`, which resulted in the warning being shown in the wrong situations.

