### PR TITLE
[IMP] sale_project: link project directly to sales order

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -125,7 +125,7 @@ class ProjectProject(models.Model):
             project.sale_order_line_count = len(sale_order_lines)
 
             # Use sudo to avoid AccessErrors when the SOLs belong to different companies.
-            project.sale_order_count = len(sale_order_lines.sudo().order_id)
+            project.sale_order_count = len(sale_order_lines.sudo().order_id or project.reinvoiced_sale_order_id)
 
     def _compute_invoice_count(self):
         data = self.env['account.move.line']._read_group(

--- a/addons/sale_project/models/project_task.py
+++ b/addons/sale_project/models/project_task.py
@@ -55,7 +55,7 @@ class ProjectTask(models.Model):
             return search_on_comodel
         return sales_orders
 
-    @api.depends('sale_line_id', 'project_id', 'allow_billable')
+    @api.depends('sale_line_id', 'project_id', 'allow_billable', 'project_id.reinvoiced_sale_order_id')
     def _compute_sale_order_id(self):
         for task in self:
             if not task.allow_billable:
@@ -64,6 +64,7 @@ class ProjectTask(models.Model):
             sale_order = (
                 task.sale_line_id.order_id
                 or task.project_id.sale_order_id
+                or task.project_id.reinvoiced_sale_order_id
                 or task.sale_order_id
             )
             if sale_order and not task.partner_id:

--- a/addons/sale_project/tests/test_child_tasks.py
+++ b/addons/sale_project/tests/test_child_tasks.py
@@ -31,6 +31,7 @@ class TestNestedTaskUpdate(TransactionCase):
         sale_order.action_confirm()
 
         cls.project = cls.order_line.project_id
+        cls.project.reinvoiced_sale_order_id = False
         cls.project.sale_line_id = False
         cls.user = new_test_user(cls.env, login='mla')
 

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -118,7 +118,7 @@
                 </group>
             </xpath>
             <xpath expr="//page[@name='settings']//field[@name='privacy_visibility']" position="after">
-                <field name="reinvoiced_sale_order_id" invisible="not allow_billable or not partner_id or is_template"/>
+                <field name="reinvoiced_sale_order_id" invisible="not allow_billable or not partner_id or is_template"  context="{'default_partner_id': partner_id}"/>
                 <label for="sale_line_id" invisible="not allow_billable or not partner_id or is_template"/>
                 <div 
                     class="o_row" 


### PR DESCRIPTION
Some clients prefer to create projects manually without linking them to specific products in the sales order.In this commit, we’ve added a direct link from the project to the sales order, making project management easier.

task-4380854