### PR TITLE
[FIX] account: properly display Upload button in Kanban/List

### DIFF
--- a/addons/account/static/src/views/account_move_kanban/account_move_kanban_controller.js
+++ b/addons/account/static/src/views/account_move_kanban/account_move_kanban_controller.js
@@ -2,6 +2,7 @@ import { FileUploadKanbanController } from "../file_upload_kanban/file_upload_ka
 import { AccountFileUploader } from "@account/components/account_file_uploader/account_file_uploader";
 
 export class AccountMoveKanbanController extends FileUploadKanbanController {
+    static template = "account.AccountMoveKanbanView";
     static components = {
         ...FileUploadKanbanController.components,
         AccountFileUploader,

--- a/addons/account/static/src/views/account_move_kanban/account_move_kanban_controller.xml
+++ b/addons/account/static/src/views/account_move_kanban/account_move_kanban_controller.xml
@@ -1,6 +1,6 @@
 <templates>
 
-    <t t-name="account.AccountMoveKanbanView.Buttons" t-inherit="account.FileuploadKanbanView.Buttons" t-inherit-mode="primary">
+    <t t-name="account.AccountMoveKanbanView" t-inherit="account.FileuploadKanbanView" t-inherit-mode="primary">
         <xpath expr="//t[@t-call='account.DocumentViewUploadButton']" position="replace">
             <t t-if="showUploadButton" t-call="account.AccountViewUploadButton"/>
         </xpath>

--- a/addons/account/static/src/views/account_move_kanban/account_move_kanban_view.js
+++ b/addons/account/static/src/views/account_move_kanban/account_move_kanban_view.js
@@ -5,7 +5,6 @@ import { AccountMoveKanbanController } from "./account_move_kanban_controller";
 export const accountMoveUploadKanbanView = {
     ...fileUploadKanbanView,
     Controller: AccountMoveKanbanController,
-    buttonTemplate: "account.AccountMoveKanbanView.Buttons",
 };
 
 registry.category("views").add("account_documents_kanban", accountMoveUploadKanbanView);

--- a/addons/account/static/src/views/account_move_list/account_move_list_controller.js
+++ b/addons/account/static/src/views/account_move_list/account_move_list_controller.js
@@ -5,6 +5,7 @@ import { AccountFileUploader } from "@account/components/account_file_uploader/a
 import { useService } from "@web/core/utils/hooks";
 
 export class AccountMoveListController extends FileUploadListController {
+    static template = "account.AccountMoveListView";
     static components = {
         ...FileUploadListController.components,
         AccountFileUploader,

--- a/addons/account/static/src/views/account_move_list/account_move_list_controller.xml
+++ b/addons/account/static/src/views/account_move_list/account_move_list_controller.xml
@@ -1,6 +1,6 @@
 <templates>
 
-    <t t-name="account.AccountMoveListView.Buttons" t-inherit="account.FileuploadListView.Buttons" t-inherit-mode="primary">
+    <t t-name="account.AccountMoveListView" t-inherit="account.FileuploadListView" t-inherit-mode="primary">
         <xpath expr="//t[@t-call='account.DocumentViewUploadButton']" position="replace">
             <t t-if="showUploadButton" t-call="account.AccountViewUploadButton"/>
         </xpath>

--- a/addons/account/static/src/views/account_move_list/account_move_list_view.js
+++ b/addons/account/static/src/views/account_move_list/account_move_list_view.js
@@ -7,7 +7,6 @@ export const accountMoveUploadListView = {
     ...fileUploadListView,
     Controller: AccountMoveListController,
     Renderer: AccountMoveListRenderer,
-    buttonTemplate: "account.AccountMoveListView.Buttons",
 };
 
 registry.category("views").add("account_tree", accountMoveUploadListView);

--- a/addons/account/static/src/views/file_upload_kanban/file_upload_kanban_controller.js
+++ b/addons/account/static/src/views/file_upload_kanban/file_upload_kanban_controller.js
@@ -2,6 +2,7 @@ import { KanbanController } from "@web/views/kanban/kanban_controller";
 import { DocumentFileUploader } from "@account/components/document_file_uploader/document_file_uploader";
 
 export class FileUploadKanbanController extends KanbanController {
+    static template = "account.FileuploadKanbanView";
     static components = {
         ...KanbanController.components,
         DocumentFileUploader,

--- a/addons/account/static/src/views/file_upload_kanban/file_upload_kanban_controller.xml
+++ b/addons/account/static/src/views/file_upload_kanban/file_upload_kanban_controller.xml
@@ -1,7 +1,7 @@
 <templates>
 
-    <t t-name="account.FileuploadKanbanView.Buttons" t-inherit="web.KanbanView.Buttons" t-inherit-mode="primary">
-        <xpath expr="//div[hasclass('o_cp_buttons')]" position="inside">
+    <t t-name="account.FileuploadKanbanView" t-inherit="web.KanbanView" t-inherit-mode="primary">
+        <xpath expr="//t[@t-set-slot='control-panel-always-buttons']" position="inside">
             <t t-call="account.DocumentViewUploadButton"/>
         </xpath>
     </t>

--- a/addons/account/static/src/views/file_upload_kanban/file_upload_kanban_view.js
+++ b/addons/account/static/src/views/file_upload_kanban/file_upload_kanban_view.js
@@ -7,7 +7,6 @@ export const fileUploadKanbanView = {
     ...kanbanView,
     Controller: FileUploadKanbanController,
     Renderer: FileUploadKanbanRenderer,
-    buttonTemplate: "account.FileuploadKanbanView.Buttons",
 };
 
 registry.category("views").add("file_upload_kanban", fileUploadKanbanView);

--- a/addons/account/static/src/views/file_upload_list/file_upload_list_controller.js
+++ b/addons/account/static/src/views/file_upload_list/file_upload_list_controller.js
@@ -2,6 +2,7 @@ import { ListController } from "@web/views/list/list_controller";
 import { DocumentFileUploader } from "@account/components/document_file_uploader/document_file_uploader";
 
 export class FileUploadListController extends ListController {
+    static template = "account.FileuploadListView";
     static components = {
         ...ListController.components,
         DocumentFileUploader,

--- a/addons/account/static/src/views/file_upload_list/file_upload_list_controller.xml
+++ b/addons/account/static/src/views/file_upload_list/file_upload_list_controller.xml
@@ -1,7 +1,7 @@
 <templates>
 
-    <t t-name="account.FileuploadListView.Buttons" t-inherit="web.ListView.Buttons" t-inherit-mode="primary">
-        <xpath expr="//div[hasclass('o_list_buttons')]" position="inside">
+    <t t-name="account.FileuploadListView" t-inherit="web.ListView" t-inherit-mode="primary">
+        <xpath expr="//t[@t-set-slot='control-panel-always-buttons']" position="inside">
             <t t-call="account.DocumentViewUploadButton"/>
         </xpath>
     </t>

--- a/addons/account/static/src/views/file_upload_list/file_upload_list_view.js
+++ b/addons/account/static/src/views/file_upload_list/file_upload_list_view.js
@@ -7,7 +7,6 @@ export const fileUploadListView = {
     ...listView,
     Controller: FileUploadListController,
     Renderer: FileUploadListRenderer,
-    buttonTemplate: "account.FileuploadListView.Buttons",
 };
 
 registry.category("views").add("file_upload_list", fileUploadListView);


### PR DESCRIPTION
Before this commit, there was a disprepancy between the display of the "Upload" button in the ControlPanel in Kanban (split button) and List (ugly button creating a second line in the CP).

This commit fixes the XPath used to add this button to those views by adding it to the "control-panel-always-buttons" slot and marking it as "should always be displayed" (like the `type="always"` in the `<header>`).

Steps to reproduce (on a smartphone-like screen):
- Open Vendor Bills
- Switch to List View => The "Upload" button is displayed below the "New" one instead of being folded in a dropdown split button.

task-4590327
