### PR TITLE
[FIX] point_of_sale: Prevent error when updating x2many field

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -949,6 +949,8 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
                                 .filter(Boolean);
                             if (existingRecords.length) {
                                 record[field] = [["set", ...existingRecords]];
+                            } else {
+                                record[field] = [];
                             }
                         } else if (
                             params.type === "many2one" &&


### PR DESCRIPTION
Before this commit, an error occurred when loading data and updating a x2many field if no existing record was present. This was due to attempting to modify a non-existent recordset, leading to a crash.

After this commit, the update logic ensures that the x2many field is handled correctly even when no prior records exist, preventing unexpected errors.

opw-4594842

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
