### PR TITLE
[FIX] pos_sale: consider POS downpayments in amount_invoiced

### DIFF
--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -790,6 +790,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSDownPaymentAmount', login="accountman")
         self.assertEqual(sale_order.amount_to_invoice, 80.0, "Downpayment amount not considered!")
+        self.assertEqual(sale_order.amount_invoiced, 20.0, "Downpayment amount not considered!")
 
         self.assertEqual(sale_order.order_line[2].price_unit, 20)
 


### PR DESCRIPTION
Currently when invoicing a SO which has a downpayment made in Pos this downpayment is not reflected in the wizard.

Steps to reproduce:
-------------------
* Create an SO
* Open pos session and make a downpayment for the SO
* Close register
* Go back to the SO
* Deliver the items
* Select the invoice
> Observation: Amount already invoiced is at 0

Why the fix:
------------
There was a previous fix at the same place previously: https://github.com/odoo/odoo/commit/f613b87c38d208730ba2470e0a26a110c2089b66

However the wizard had changed and instead of showing `amount_to_invoice` we now show `amount_invoiced`

opw-4585413