### PR TITLE
[FIX] point_of_sale: runbot error 135227

### DIFF
--- a/addons/point_of_sale/static/tests/tours/Chrome.tour.js
+++ b/addons/point_of_sale/static/tests/tours/Chrome.tour.js
@@ -62,6 +62,7 @@ odoo.define('point_of_sale.tour.Chrome', function (require) {
     PaymentScreen.do.clickPaymentMethod('Cash');
     PaymentScreen.do.pressNumpad('2 0');
     PaymentScreen.check.remainingIs('0.0');
+    PaymentScreen.check.changeIs('18.0');
     PaymentScreen.check.validateButtonIsHighlighted(true);
     PaymentScreen.do.clickValidate();
     ReceiptScreen.check.totalAmountContains('2.0');


### PR DESCRIPTION
- The total amount of the order is 2.0.
- The payment being made is 20.
- Note that there is delay between handling of keypress in pos.
- So when pressing they keys "2" and "0" for the amount 20, the first key is registered first then the system rerenders highlighting the validate button because the payment amount is already enough.
- This means that before the callback of pressing 0 is called, the order can be validated which is what happens.
- The fix is to wait for the payment screen to show the "change" amount before validating the order.
