### PR TITLE
[FIX] point_of_sale: remove combo_ids when changing type

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -82,6 +82,13 @@ class ProductTemplate(models.Model):
             raise UserError(_("Combo products cannot contains variants or attributes"))
         return super()._onchange_type()
 
+    def write(self, vals):
+        res = super(ProductTemplate, self).write(vals)
+        for product_template in self:
+            if "detailed_type" in vals and vals.get("detailed_type") != "combo":
+                product_template.combo_ids = False
+        return res
+
 
 class ProductProduct(models.Model):
     _inherit = 'product.product'

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2259,6 +2259,10 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         product = product_form.save()
         self.assertFalse(product.taxes_id)
 
+        product_form.detailed_type = "consu"
+        product = product_form.save()
+        self.assertFalse(product.combo_ids)
+
     def test_change_is_deducted_from_cash(self):
         self.pos_config.open_ui()
         pos_session = self.pos_config.current_session_id


### PR DESCRIPTION
Currently if you change the type of a combo product to something else, the combo_ids are still saved and in the pos it will use them and open a selection popup.

Steps to reproduce:
-------------------
* Go in the products
* Select Burger Combo
* Change the type to "Goods" and save
* Open restaurant
* Select burger combo
> Observation: Selection popup for combo ids appears.

Why the fix:
------------
When changing the type of product we remove the combo_ids from the product form. Without combo_ids no popup appears.

opw-4513392