### PR TITLE
[FIX] l10n_{hu_edi,latam_invoice_document}: wrong xpath report layouts

### DIFF
--- a/addons/l10n_hu_edi/views/report_templates.xml
+++ b/addons/l10n_hu_edi/views/report_templates.xml
@@ -7,7 +7,8 @@
         </xpath>
 
         <xpath expr="//img/../.." position="after">
-            <div t-if="custom_header and company.account_fiscal_country_id.code == 'HU'">
+            <div t-attf-class="header o_company_#{company.id}_layout"
+                t-if="custom_header and company.account_fiscal_country_id.code == 'HU'">
                 <t t-call="#{custom_header}"/>
             </div>
         </xpath>

--- a/addons/l10n_latam_invoice_document/views/report_templates.xml
+++ b/addons/l10n_latam_invoice_document/views/report_templates.xml
@@ -78,8 +78,7 @@
             <attribute name="t-if">not custom_header</attribute>
         </xpath>
         <xpath expr="//img/../.." position="after">
-            <div t-attf-class="o_company_#{company.id}_layout header"
-                 t-if="custom_header and company._localization_use_documents()">
+            <div t-if="custom_header and company._localization_use_documents()">
                 <t t-call="#{custom_header}"/>
             </div>
         </xpath>


### PR DESCRIPTION
Commit 9d986db17f14c7fcc05ba30df59b07b8c37d0a9d introduced a regression that caused `l10n_latam_invoice_document` to lose its header for the striped layout.

In addition due to different position of the header img tag in the standard layout template HTML tree, `l10n_hu_edi` also required explicit base standard layout header classes in its attributes. This was caused by the xpath `//img/../..` introduced in f86238d7c872b3f025085831d50f1896168b6274 which thus unintentionally removed these classes

opw-4593505