### PR TITLE
[FIX] mail: guest im_status not being set

### DIFF
--- a/addons/im_livechat/static/tests/visitor_disconnection.test.js
+++ b/addons/im_livechat/static/tests/visitor_disconnection.test.js
@@ -51,6 +51,7 @@ test("Visitor going offline shows disconnection banner to operator", async () =>
     mockDate("2025-01-01 12:00:00", +1);
     pyEnv["mail.guest"].write(guestId, { im_status: "offline" });
     pyEnv["bus.bus"]._sendone(guestId, "bus.bus/im_status_updated", {
+        partner_id: false,
         guest_id: guestId,
         im_status: "offline",
     });
@@ -68,6 +69,7 @@ test("Visitor going offline shows disconnection banner to operator", async () =>
     await click(".o-mail-ChatBubble");
     await contains(".o-livechat-VisitorDisconnected", { text: `Visitor is disconnected` });
     pyEnv["bus.bus"]._sendone(guestId, "bus.bus/im_status_updated", {
+        partner_id: false,
         guest_id: guestId,
         im_status: "online",
     });

--- a/addons/mail/static/src/core/common/im_status_service.js
+++ b/addons/mail/static/src/core/common/im_status_service.js
@@ -40,7 +40,7 @@ export const imStatusService = {
                 const store = env.services["mail.store"];
                 const persona = store.Persona.get({
                     type: partner_id ? "partner" : "guest",
-                    id: partner_id ?? guest_id,
+                    id: partner_id || guest_id,
                 });
                 if (!persona) {
                     return; // Do not store unknown persona's status


### PR DESCRIPTION
Before this commit, the im_status of guests would not be set.

This is because since https://github.com/odoo/odoo/pull/177611 the partner_id sent on the im_status_updated bus notification in case of guests changed from None to False, making the null coalescing operator in js keep the partner_id instead of skipping it and taking the guest_id.

This commit fixes the issue by using the correct OR operator.
