### PR TITLE
[FIX] project: wait modal is correctly loaded before closing it

### DIFF
--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -188,6 +188,9 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
         trigger: ".o_menu_item i.fa-history",
         run: "click",
     }, {
+        trigger: ".modal",
+        in_modal: false,
+    }, {
         content: "Close History Dialog",
         trigger: ".modal-header .btn-close",
         run: "click",


### PR DESCRIPTION
Before this commit, the 'project_task_history_tour' tour fails because the UI is blocked, surely, because the dialog displayed is closed too quickly and so the UI does not have the time to apply the changes to do in the UI.

This commit adds a trigger to make sure the tour waits the modal is displayed before executing the next step to close it.

runbot-75316
