### PR TITLE
[FIX] pos_restaurant: load restaurant scenario without demo

### DIFF
--- a/addons/pos_restaurant/__manifest__.py
+++ b/addons/pos_restaurant/__manifest__.py
@@ -20,12 +20,12 @@ This module adds several features to the Point of Sale that are specific to rest
     'website': 'https://www.odoo.com/app/point-of-sale-restaurant',
     'data': [
         'security/ir.model.access.csv',
+        'data/preset_data.xml',
         'views/pos_order_views.xml',
         'views/pos_restaurant_views.xml',
         'views/res_config_settings_views.xml',
     ],
     'demo': [
-        'data/preset_data.xml',
         'data/demo_data.xml',
     ],
     'installable': True,


### PR DESCRIPTION
In this commit,
The restaurant scenario loads in data instead of the demo.

related PR: https://github.com/odoo/odoo/pull/194777



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
