### PR TITLE
[IMP] point_of_sale: customer display configuration

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -161,6 +161,7 @@
             'point_of_sale/static/src/**/*',
             ('remove', 'point_of_sale/static/src/backend/**/*'),
             ('remove', 'point_of_sale/static/src/customer_display/**/*'),
+            'point_of_sale/static/src/customer_display/utils.js',
             # main.js boots the pos app, it is only included in the prod bundle as tests mount the app themselves
             ('remove', 'point_of_sale/static/src/app/main.js'),
             ("include", "point_of_sale.base_tests"),

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -869,7 +869,7 @@ class PosConfig(models.Model):
             'type': self.customer_display_type,
             'has_bg_img': bool(self.customer_display_bg_img),
             'company_id': self.company_id.id,
-            **({'proxy_ip': self._get_display_device_ip()} if self.customer_display_type == 'proxy' else {}),
+            **({'proxy_ip': self._get_display_device_ip()} if self.customer_display_type != 'none' else {}),
         }
 
     @api.model

--- a/addons/point_of_sale/static/src/app/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.js
@@ -15,9 +15,10 @@ import { Input } from "@point_of_sale/app/generic_components/inputs/input/input"
 import { isBarcodeScannerSupported } from "@web/core/barcode/barcode_video_scanner";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
-import { deduceUrl } from "@point_of_sale/utils";
 import { user } from "@web/core/user";
 import { OrderTabs } from "@point_of_sale/app/components/order_tabs/order_tabs";
+import { openCustomerDisplay } from "@point_of_sale/customer_display/utils";
+import { _t } from "@web/core/l10n/translation";
 
 export class Navbar extends Component {
     static template = "point_of_sale.Navbar";
@@ -97,35 +98,19 @@ export class Navbar extends Component {
                 "newWindow",
                 "width=800,height=600,left=200,top=200"
             );
-            this.notification.add("Connected");
+            this.notification.add(_t("PoS Customer Display opened in a new window"));
         }
         if (this.pos.config.customer_display_type === "remote") {
-            this.notification.add("Navigate to your POS Customer Display on the other computer");
+            this.notification.add(
+                _t("Navigate to your PoS Customer Display on the other computer")
+            );
         }
-        if (this.pos.config.customer_display_type === "proxy") {
-            this.notification.add("Connecting to the IoT Box");
-            const proxyIP = this.pos.getDisplayDeviceIP();
-            fetch(`${deduceUrl(proxyIP)}/hw_proxy/customer_facing_display`, {
-                method: "POST",
-                headers: {
-                    Accept: "application/json",
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    params: {
-                        action: "open",
-                        access_token: this.pos.config.access_token,
-                        pos_id: this.pos.config.id,
-                    },
-                }),
-            })
-                .then(() => {
-                    this.notification.add("Connection successful", { type: "success" });
-                })
-                .catch(() => {
-                    this.notification.add("Connection failed", { type: "danger" });
-                });
-        }
+        openCustomerDisplay(
+            this.pos.getDisplayDeviceIP(),
+            this.pos.config.access_token,
+            this.pos.config.id,
+            this.notification
+        );
     }
 
     get showCreateProductButton() {

--- a/addons/point_of_sale/static/src/app/pos_app.js
+++ b/addons/point_of_sale/static/src/app/pos_app.js
@@ -91,8 +91,8 @@ export class Chrome extends Component {
                 this.pos.config.access_token,
             ]);
         }
-        if (this.pos.config.customer_display_type === "proxy") {
-            const proxyIP = this.pos.getDisplayDeviceIP();
+        const proxyIP = this.pos.getDisplayDeviceIP();
+        if (proxyIP) {
             fetch(`${deduceUrl(proxyIP)}/hw_proxy/customer_facing_display`, {
                 method: "POST",
                 headers: {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -39,6 +39,7 @@ import { ClosePosPopup } from "../navbar/closing_popup/closing_popup";
 import { user } from "@web/core/user";
 import { debounce } from "@web/core/utils/timing";
 import DevicesSynchronisation from "./devices_synchronisation";
+import { openCustomerDisplay } from "@point_of_sale/customer_display/utils";
 
 const { DateTime } = luxon;
 
@@ -608,6 +609,13 @@ export class PosStore extends Reactive {
         this.markReady();
         this.showScreen(this.firstScreen);
         await this.deviceSync.readDataFromServer();
+        if (this.config.customer_display_type !== "none") {
+            openCustomerDisplay(
+                this.getDisplayDeviceIP(),
+                this.config.access_token,
+                this.config.id
+            );
+        }
     }
 
     get productListViewMode() {

--- a/addons/point_of_sale/static/src/customer_display/customer_display_data_service.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display_data_service.js
@@ -21,7 +21,7 @@ export const CustomerDisplayDataService = {
                 }
             );
         }
-        if (session.type === "proxy") {
+        if (session.proxy_ip) {
             const intervalId = setInterval(async () => {
                 try {
                     const response = await fetch(

--- a/addons/point_of_sale/static/src/customer_display/utils.js
+++ b/addons/point_of_sale/static/src/customer_display/utils.js
@@ -1,0 +1,35 @@
+import { deduceUrl } from "@point_of_sale/utils";
+import { _t } from "@web/core/l10n/translation";
+
+export function openCustomerDisplay(
+    displayDeviceIp,
+    accessToken,
+    configId,
+    notificationService = undefined
+) {
+    if (!displayDeviceIp) {
+        return;
+    }
+
+    notificationService?.add(_t("Connecting to the IoT Box"));
+    fetch(`${deduceUrl(displayDeviceIp)}/hw_proxy/customer_facing_display`, {
+        method: "POST",
+        headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            params: {
+                action: "open",
+                access_token: accessToken,
+                pos_id: configId,
+            },
+        }),
+    })
+        .then(() => {
+            notificationService?.add(_t("Connection successful"), { type: "success" });
+        })
+        .catch(() => {
+            notificationService?.add(_t("Connection failed"), { type: "danger" });
+        });
+}


### PR DESCRIPTION
To configure the RPI display as customer display we needed:

**Before this commit:**

- Go to configuration,
- Check "IoT Box" checkbox,
- Select a display,
- Go to "Configuration -> Settings",
- Scroll until "Customer Display" then select "An IoT-connected system.

**After this commit:**

- Go to configuration,
- Check "IoT Box" checkbox,
- Select a display.

**Note:** the "Customer Display" setting is now only used for a second display. That means that customer display can now be opened on both an IoT Display and a new window. The Customer Display now also opens automatically on the IoT Box display while opening PoS.

Task: 4585446
