### PR TITLE
[FIX] web: x2many: do not reload records after edition

### DIFF
--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -403,9 +403,6 @@ export class StaticList extends DataPoint {
                 return;
             }
             await this._onUpdate();
-            if (this.orderBy.length) {
-                await this._sort();
-            }
             record._restoreActiveFields();
             record._savePoint = undefined;
         });

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -15251,4 +15251,76 @@ QUnit.module("Fields", (hooks) => {
             assert.verifySteps(["get_views", "onchange"]);
         }
     );
+
+    QUnit.test("edit o2m with default_order on a field not in view", async function (assert) {
+        serverData.models.partner.records[0].turtles = [1, 2, 3];
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="turtles">
+                        <tree default_order="turtle_int">
+                            <field name="turtle_foo"/>
+                            <field name="turtle_bar"/>
+                        </tree>
+                        <form>
+                            <field name="turtle_foo"/>
+                        </form>
+                    </field>
+                </form>`,
+            resId: 1,
+        });
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell.o_list_char")), [
+            "yop",
+            "blip",
+            "kawa",
+        ]);
+
+        await click(target.querySelectorAll(".o_data_row")[1].querySelector(".o_data_cell"));
+        await editInput(target, ".modal .o_field_widget[name=turtle_foo] input", "blip2");
+        await click(target.querySelector(".modal-footer .o_form_button_save"));
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell.o_list_char")), [
+            "yop",
+            "blip2",
+            "kawa",
+        ]);
+    });
+
+    QUnit.test("edit o2m with default_order on a field not in view (2)", async function (assert) {
+        serverData.models.partner.records[0].turtles = [1, 2, 3];
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="turtles">
+                        <tree default_order="turtle_foo,turtle_int">
+                            <field name="turtle_foo"/>
+                            <field name="turtle_bar"/>
+                        </tree>
+                        <form>
+                            <field name="turtle_foo"/>
+                        </form>
+                    </field>
+                </form>`,
+            resId: 1,
+        });
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell.o_list_char")), [
+            "blip",
+            "kawa",
+            "yop",
+        ]);
+
+        await click(target.querySelectorAll(".o_data_row")[1].querySelector(".o_data_cell"));
+        await editInput(target, ".modal .o_field_widget[name=turtle_foo] input", "kawa2");
+        await click(target.querySelector(".modal-footer .o_form_button_save"));
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell.o_list_char")), [
+            "blip",
+            "kawa2",
+            "yop",
+        ]);
+    });
 });

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -9308,10 +9308,14 @@ QUnit.module("Views", (hooks) => {
         await clickSave(target);
         assert.deepEqual(getFooValues(), ["zop", "yop", "xop", "My little Foo Value"]);
 
-        // client-side sort on edit
+        // no client-side sort after edit
         await click(target.querySelectorAll(".o_data_row")[1].querySelector(".o_data_cell"));
         await editInput(target, ".modal .o_field_widget[name=foo] input", "zzz");
         await click(target.querySelector(".modal-footer .o_form_button_save"));
+        assert.deepEqual(getFooValues(), ["zop", "zzz", "xop", "My little Foo Value"]);
+
+        // server-side sort post save
+        await clickSave(target);
         assert.deepEqual(getFooValues(), ["zzz", "zop", "xop", "My little Foo Value"]);
     });
 


### PR DESCRIPTION
Have an x2many list (non editable) or kanban, such that editing a record of the relation is done through the form view dialog. Have a default_order on the x2many view containing at least a field that isn't in the view. Before this commit, there were two issues occurring when the user clicked on "Save" (in the dialog footer) after editing a record in the dialog.

1) if the first field of the order wasn't in the view, e.g. `default_order="x"` but x wasn't in the view: there was a crash, because we tried to sort records on a field that is unknown.

2) if it wasn't the first field of the order, e.g. `default_order="x,y"` but y wasn't in the view: the changes done in the dialog were lost, so it was no possible to edit records.

Both issues had the same root cause. After the edition, we tried to sort the relation (as the order might have changed). We do that since [1], but it wasn't the main purpose of this commit. It has been done because it looked like a quick win at the time, and we thought it was a good idea.

However, functionally speaking, sorting the records after the edition isn't wanted. If I just clicked on a record, edited it, I expect the record to remain where it was after closing the dialog. So as sorting isn't necessarily wanted, and it even produces issues in some cases, this commit reverts that "feature".

[1] https://github.com/odoo/odoo/commit/17e198153ecfd9c5c32b3b22f43e2f1b8100a1c3

Closes #197867

opw-4499150 (case (2))

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
