### PR TITLE
[FIX] l10n_it_edi: trigger missing origin document error when either …

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -1246,7 +1246,7 @@ class AccountMove(models.Model):
                 message = _("The Origin Document Date cannot be in the future.")
                 errors['move_future_origin_document_date'] = build_error(message=message, records=moves)
         if pa_moves := self.filtered(lambda move: len(move.commercial_partner_id.l10n_it_pa_index or '') == 7):
-            if moves := pa_moves.filtered(lambda move: not move.l10n_it_origin_document_type and move.l10n_it_cig and move.l10n_it_cup):
+            if moves := pa_moves.filtered(lambda move: not move.l10n_it_origin_document_type and (move.l10n_it_cig or move.l10n_it_cup)):
                 message = _("CIG/CUP fields of partner(s) are present, please fill out Origin Document Type field in the Electronic Invoicing tab.")
                 errors['move_missing_origin_document_field'] = build_error(message=message, records=moves)
         return errors

--- a/addons/l10n_it_edi/tests/test_account_move_send.py
+++ b/addons/l10n_it_edi/tests/test_account_move_send.py
@@ -85,3 +85,46 @@ class TestItAccountMoveSend(TestItEdi, TestAccountMoveSendCommon):
         self.assertTrue(invoice2.invoice_pdf_report_id)
         self.assertTrue(invoice2.l10n_it_edi_attachment_id)
         self.assertFalse(invoice2.is_being_sent)
+
+    def test_invoice_with_cig_or_cup_or_both(self):
+            
+            self.italian_partner_a.write({'l10n_it_pa_index': '1234567'})
+            
+            invoice_valid = self.init_invoice(self.italian_partner_a)
+            invoice_cig_only = self.init_invoice(self.italian_partner_a)
+            invoice_cup_only = self.init_invoice(self.italian_partner_a)
+            invoice_cig_cup = self.init_invoice(self.italian_partner_a)
+
+            invoice_valid.write({
+                'l10n_it_cig': '1234567',
+                'l10n_it_cup': '7654321',
+                'l10n_it_origin_document_type': 'purchase_order'
+            }) 
+            
+            invoice_cig_only.write({
+                'l10n_it_cig': '1234567',
+                'l10n_it_cup': False,
+                'l10n_it_origin_document_type': False
+            }) 
+            
+            invoice_cup_only.write({
+                'l10n_it_cig': False,
+                'l10n_it_cup': '7654321',
+                'l10n_it_origin_document_type': False
+            })
+            
+            invoice_cig_cup.write({
+                'l10n_it_cig': '1234567',
+                'l10n_it_cup': '7654321',
+                'l10n_it_origin_document_type': False
+            }) 
+
+            valid = invoice_valid._l10n_it_edi_base_export_check()
+            cig = invoice_cig_only._l10n_it_edi_base_export_check()
+            cup = invoice_cup_only._l10n_it_edi_base_export_check()
+            cig_cup = invoice_cig_cup._l10n_it_edi_base_export_check()
+
+            self.assertNotIn('move_missing_origin_document_field', valid)
+            self.assertIn('move_missing_origin_document_field', cig)
+            self.assertIn('move_missing_origin_document_field', cup)
+            self.assertIn('move_missing_origin_document_field', cig_cup)


### PR DESCRIPTION
…CIG or CUP is present

**Issue:**
When only one of the CIG or CUP fields is filled in the Electronic Invoicing tab, without specifying an Origin Document, the system still allows sending the e-invoice to the tax agency, even though the data is incomplete.

**Steps to Reproduce:**
1. Install the Accounting app
2. Install the l10n_it_edi module
3. Navigate to Accounting > Customers > Invoices
4. Select or create an invoice
5. Choose a customer with a PA index
6. Open the Electronic Invoicing tab
7. Fill in either the CIG or CUP field, but leave the Origin Document Type empty
8. Click Send & Print
9. No error is displayed and the e-invoice XML can be sent

Expected Behavior: An error should be triggered, preventing the e-invoice from being sent if the Origin Document Type is missing, even when only one of CIG or CUP is present.

Actual Behavior: The system allows sending the e-invoice despite missing critical information, leading to incomplete data submission.

**Root Cause**

The existing validation only checks if both CIG and CUP are missing, but it does not account for cases where only one is filled while the Origin Document is still absent.

**Fix**
The condition has been updated to trigger an error whenever the Origin Document Type is missing, even if only one of CIG or CUP is present.

Opw-4590205

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
