### PR TITLE
[FIX] web: emoji picker search with 1 char

### DIFF
--- a/addons/mail/static/tests/emoji/emoji_tests.js
+++ b/addons/mail/static/tests/emoji/emoji_tests.js
@@ -18,6 +18,8 @@ QUnit.test("search emoji from keywords", async () => {
     await click("button[aria-label='Emojis']");
     await insertText("input[placeholder='Search for an emoji']", "mexican");
     await contains(".o-Emoji", { text: "🌮" });
+    await insertText("input[placeholder='Search for an emoji']", "9", { replace: true });
+    await contains(":nth-child(1 of .o-Emoji)", { text: "9️⃣" });
 });
 
 QUnit.test("search emoji from keywords should be case insensitive", async () => {

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -296,7 +296,7 @@ export class EmojiPicker extends Component {
     }
 
     getEmojis() {
-        if (this.searchTerm.length > 1) {
+        if (this.searchTerm.length > 0) {
             return fuzzyLookup(this.searchTerm, this.emojis, (emoji) =>
                 [emoji.name, ...emoji.keywords, ...emoji.emoticons, ...emoji.shortcodes].join(" ")
             );


### PR DESCRIPTION
Before this commit, searching emoji required at least 2 chars. There is no reason to not allow 1 char, especially when searching some emoji that are best found with a single char, e.g. "9️⃣" with "9".