### PR TITLE
[FIX] point_of_sale: prevent traceback on receipt screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
@@ -62,7 +62,7 @@ export class OrderReceipt extends Component {
     }
 
     doesAnyOrderlineHaveTaxLabel() {
-        return this.order.lines.some((line) => line.taxGroupLabels);
+        return this.order.lines?.some((line) => line.taxGroupLabels);
     }
     getPortalURL() {
         return `${this.order.session._base_url}/pos/ticket`;


### PR DESCRIPTION
- Fix for following runbot error (https://runbot.odoo.com/odoo/runbot.build.error/110971) that was causing a traceback when displaying the receipt screen.

runbot error: 110971

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
