### PR TITLE
[FIX] stock_delivery: display shipping weight if picking is not done

### DIFF
--- a/addons/stock_delivery/views/report_shipping.xml
+++ b/addons/stock_delivery/views/report_shipping.xml
@@ -6,10 +6,11 @@
                 <strong>Carrier</strong>
                 <div t-field="o.carrier_id"/>
             </div>
-            <div t-if="o.weight" class="col">
+            <t t-set="display_weight" t-value="o.weight if o.state == 'done' else o.shipping_weight"/>
+            <div t-if="display_weight" class="col">
                 <strong>Weight</strong>
                 <div>
-                    <span t-field="o.weight"/>
+                    <span t-out="display_weight"/>
                     <span t-field="o.weight_uom_name"/>
                 </div>
             </div>


### PR DESCRIPTION
Steps to reproduce the bug:
- Create two storable products:
    - P1, weight: 1KG
    - P2, weight: 2KG
- Create a delivery order:
    - 1 unit of P1 and P2
    - Mark it as "To Do"
    - Set the quantity to 1 for P1 and 0 for P2
    - Print the operation type

Problem:
Only product P1 appears in the report, but the total weight is 3KG instead of 1KG.

opw-4547704
