### PR TITLE
[FIX] mail: remove parent message when message is deleted

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1358,6 +1358,15 @@ class DiscussChannel(models.Model):
         )
         return Store(unknown_members).add(self, "member_count").get_result()
 
+    def _clean_empty_message(self, message):
+        super()._clean_empty_message(message)
+        message.parent_id = False
+
+    def _get_store_message_update_extra_fields(self):
+        return super()._get_store_message_update_extra_fields() + [
+            Store.One("parent_id", rename="parentMessage")
+        ]
+
     # ------------------------------------------------------------
     # COMMANDS
     # ------------------------------------------------------------

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4713,12 +4713,12 @@ class MailThread(models.AbstractModel):
             )
         elif attachment_ids is not None:  # None means "no update"
             message.attachment_ids._delete_and_notify()
-        if partner_ids:
-            msg_values.update({
-                'partner_ids': list(partner_ids or [])
-            })
+        if partner_ids is not None:
+            msg_values.update({"partner_ids": [int(pid) for pid in partner_ids] or False})
         if msg_values:
             message.write(msg_values)
+        if message._filter_empty():
+            self._clean_empty_message(message)
 
         if 'scheduled_date' in kwargs:
             # update scheduled datetime
@@ -4737,12 +4737,19 @@ class MailThread(models.AbstractModel):
             Store.Many("partner_ids", ["avatar_128", "name"], rename="recipients"),
             "pinned_at",
             "write_date",
+            *self._get_store_message_update_extra_fields()
         ]
         if body is not None:
             # sudo: mail.message.translation - discarding translations of message after editing it
             self.env["mail.message.translation"].sudo().search([("message_id", "=", message.id)]).unlink()
             res.append({"translationValue": False})
         message._bus_send_store(message, res)
+
+    def _clean_empty_message(self, message):
+        pass
+
+    def _get_store_message_update_extra_fields(self):
+        return []
 
     # ------------------------------------------------------
     # STORE

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -509,6 +509,7 @@ export class Message extends Record {
             attachment_tokens: [],
             body: "",
             message_id: this.id,
+            partner_ids: [],
             ...this.thread.rpcParams,
         });
         this.body = "";

--- a/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
+++ b/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
@@ -96,6 +96,37 @@ test("channel preview show deleted messages", async () => {
     });
 });
 
+test("deleted message should not show parent message reference and mentions", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const messageId = pyEnv["mail.message"].create({
+        body: "<p>Parent Message</p>",
+        message_type: "comment",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    pyEnv["mail.message"].create({
+        body: "<p>reply message</p>",
+        message_type: "comment",
+        model: "discuss.channel",
+        parent_id: messageId,
+        partner_ids: [serverState.partnerId],
+        res_id: channelId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-MessageInReply", { text: "Parent Message" });
+    await click("[title='Expand']", {
+        parent: [".o-mail-Message:has(.o-mail-Message-bubble.o-orange)", { text: "reply message" }],
+    });
+    await click(".o-mail-Message-moreMenu [title='Delete']");
+    await click("button", { text: "Confirm" });
+    await contains(".o-mail-Message:not(:has(.o-mail-Message-bubble.o-orange))", {
+        text: "This message has been removed",
+    });
+    await contains(".o-mail-MessageInReply", { count: 0 });
+});
+
 test("channel preview ignores transient message", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Demo" });

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -722,6 +722,10 @@ async function mail_message_update_content(request) {
         );
         msg_values.attachment_ids = attachment_ids;
     }
+    if (!body && attachment_ids.length === 0) {
+        msg_values.partner_ids = false;
+        msg_values.parent_id = false;
+    }
     MailMessage.write([message_id], msg_values);
     BusBus._sendone(
         MailMessage._bus_notification_target(message.id),
@@ -734,6 +738,7 @@ async function mail_message_update_content(request) {
                 this.env["res.partner"].browse(message.partner_ids),
                 makeKwArgs({ fields: ["avatar_128", "name"] })
             ),
+            parentMessage: mailDataHelpers.Store.one(MailMessage.browse(message.parent_id)),
         }).get_result()
     );
     return new mailDataHelpers.Store(


### PR DESCRIPTION
**Current behavior before PR:**

When a user replies to a message and then deletes it, the message body changes to 'This message has been removed.' However, the mention of the parent message remains visible.

**Desired behavior after PR is merged:**

The parent message mention is no longer shown if the message is deleted.

Task-4593293

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
