### PR TITLE
[FIX] hr_holidays: hr.leave by company or by department not visible

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -700,10 +700,14 @@
             'search_default_active_time_off': 4,
             'hide_employee_name': 1,
             'holiday_status_name_get': False}</field>
-        <field name="domain">['|', ('employee_id.company_id', 'in', allowed_company_ids),
+        <field name="domain">['|', '|', '|', '|', ('employee_id.company_id', 'in', allowed_company_ids),
                                     '&amp;', ('multi_employee', '=', True),
                                     '&amp;', ('state', 'in', ['draft', 'confirm', 'validate1']),
-                                    ('employee_ids.company_id', 'in', allowed_company_ids)]</field>
+                                    ('employee_ids.company_id', 'in', allowed_company_ids),
+                                    '&amp;', ('holiday_type', '=', 'company'),
+                                    ('mode_company_id', 'in', allowed_company_ids),
+                                    ('holiday_type', '=', 'department'),
+                                    ('holiday_type', '=', 'category')]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Meet the time off dashboard.


### PR DESCRIPTION
Steps to reproduce:

- Create a time off request R with the mode "By company" or "By department"
- Save R without confirming it
- Go back to the list view
- Remove all the filters

Bug:

R is not displayed

opw:4448582