### PR TITLE
[FIX] base: fixed traceback during compute of parent ids

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -35,7 +35,7 @@ class Company(models.Model):
     child_ids = fields.One2many('res.company', 'parent_id', string='Branches')
     all_child_ids = fields.One2many('res.company', 'parent_id', context={'active_test': False})
     parent_path = fields.Char(index=True, unaccent=False)
-    parent_ids = fields.Many2many('res.company', compute='_compute_parent_ids', compute_sudo=True)
+    parent_ids = fields.Many2many('res.company', compute='_compute_parent_ids', compute_sudo=True, context={'active_test': False})
     root_id = fields.Many2one('res.company', compute='_compute_parent_ids', compute_sudo=True)
     partner_id = fields.Many2one('res.partner', string='Partner', required=True)
     report_header = fields.Html(string='Company Tagline', translate=True, help="Company tagline, which is included in a printed document's header or footer (depending on the selected layout).")


### PR DESCRIPTION
Step to reproduce:
1. Multiple company
2. one of the company is archived
3. tax account_tax_template_s_iva0_g_i was added in 17.0 Init hook will load the data from account.tax-es_common.csv (_l10n_es_edi_facturae_post_init_hook) when upgrading from 16.0 and fail because account_tax_template_s_iva0_g_i does not exists yet and it's get parent_ids empty record set for archived company https://github.com/odoo/odoo/commit/3757daca84dc080a276c04f310262a3ddf340a0f

so we got traceback from this line:

https://github.com/odoo/odoo/blob/5f60dd1af3a10ea04b2ff4efe84b50328692613b/addons/account/models/chart_template.py#L1131

The context is lost so `parent_ids` is computed without active_test=False so non active records are excluded.

issues generated during upgrade

```
 File "/home/odoo/src/odoo/18.0/addons/l10n_es_edi_facturae/models/account_chart_template.py", line 12, in _get_es_facturae_account_tax
    taxes = {
  File "/home/odoo/src/odoo/18.0/addons/l10n_es_edi_facturae/models/account_chart_template.py", line 15, in <dictcomp>
    if self.env['account.chart.template'].ref(key, raise_if_not_found=False)
  File "/home/odoo/src/odoo/18.0/addons/account/models/chart_template.py", line 1131, in ref
    or self.env.ref(f"account.{self.env.company.parent_ids[0].id}_{xmlid}", raise_if_not_found)
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 7003, in __getitem__
    return self.browse((self._ids[key],))
IndexError: tuple index out of range
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
