### PR TITLE
[FIX] stock: prevent error while printing report

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -8492,6 +8492,15 @@ msgstr ""
 
 #. module: stock
 #. odoo-python
+#: code:addons/stock/models/stock_picking.py:0
+#, python-format
+msgid ""
+"The Picking Operations report has been deleted so you cannot print at this "
+"time unless the report is restored."
+msgstr ""
+
+#. module: stock
+#. odoo-python
 #: code:addons/stock/models/stock_quant.py:0
 #, python-format
 msgid ""

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -907,8 +907,11 @@ class Picking(models.Model):
         return super(Picking, self).unlink()
 
     def do_print_picking(self):
+        picking_operations_report = self.env.ref('stock.action_report_picking',raise_if_not_found=False)
+        if not picking_operations_report:
+            raise UserError(_("The Picking Operations report has been deleted so you cannot print at this time unless the report is restored."))
         self.write({'printed': True})
-        return self.env.ref('stock.action_report_picking').report_action(self)
+        return picking_operations_report.report_action(self)
 
     def should_print_delivery_address(self):
         self.ensure_one()


### PR DESCRIPTION
This error occurs when user deletes the Picking Operations action.

Steps to Reproduce :

- Install the `Stock` module.
- Navigate to Settings > Technical > Actions.
- Search for `Picking Operations` in the list of actions.
- Delete the `Picking Operations` action.
- Go to Inventory > Operations and open any `Receipt`.
- Click on the `Print` button.

ValueError: External ID not found in the system: stock.action_report_picking

This error occurs when the system attempts to access the Picking Operations action, but it has been deleted.

To resolve this issue, restrict the deletion of the `Picking Operations` report from the `ir actions`, to ensure that users cannot delete it (except during the module uninstallation), and also raise a user error for already existing DBs where `Picking Operations` has been deleted.

Sentry - 6302556324

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
