### PR TITLE
[FIX] html_editor: handle empty selection in Firefox

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -386,17 +386,18 @@ export class SelectionPlugin extends Plugin {
     getSelectionData() {
         const selection = this.document.getSelection();
         const documentSelectionIsInEditable = selection && this.isSelectionInEditable(selection);
-        const documentSelection = selection
-            ? Object.freeze({
-                  anchorNode: selection.anchorNode,
-                  anchorOffset: selection.anchorOffset,
-                  focusNode: selection.focusNode,
-                  focusOffset: selection.focusOffset,
-                  commonAncestorContainer: selection.rangeCount
-                      ? selection.getRangeAt(0).commonAncestorContainer
-                      : null,
-              })
-            : null;
+        const documentSelection =
+            selection?.anchorNode && selection?.focusNode
+                ? Object.freeze({
+                      anchorNode: selection.anchorNode,
+                      anchorOffset: selection.anchorOffset,
+                      focusNode: selection.focusNode,
+                      focusOffset: selection.focusOffset,
+                      commonAncestorContainer: selection.rangeCount
+                          ? selection.getRangeAt(0).commonAncestorContainer
+                          : null,
+                  })
+                : null;
         if (documentSelectionIsInEditable) {
             this.activeSelection = this.makeActiveSelection(selection);
         } else if (!this.activeSelection.anchorNode.isConnected) {
@@ -847,8 +848,10 @@ export class SelectionPlugin extends Plugin {
         }
     }
 
-    isSelectionInEditable({ anchorNode, focusNode }) {
+    isSelectionInEditable({ anchorNode, focusNode } = {}) {
         return (
+            !!anchorNode &&
+            !!focusNode &&
             this.editable.contains(anchorNode) &&
             (focusNode === anchorNode || this.editable.contains(focusNode))
         );


### PR DESCRIPTION
**Problem**:
When the selection is empty (`anchorNode` and `focusNode` are `null`), calling `getRangeAt(0)` results in an error in Firefox.

**Solution**:
Properly check for an empty selection before accessing the range.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
