### PR TITLE
[FIX] website_sale: allow document download from portal so preview

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -169,7 +169,7 @@ class SaleOrder(models.Model):
         action = super().action_preview_sale_order()
         if action['url'].startswith('/'):
             # URL should always be relative, safety check
-            action['url'] = f'/@{action["url"]}'
+            action['url'] = f'{action["url"]}'
         return action
 
     def action_recovery_email_send(self):


### PR DESCRIPTION
## Versions:
18.0+
No fix needed before as feature starts here

## Issue:
An error page show up when trying to download files from SO portal preview.

## Steps to reproduce:
- Create a new `Sale Order` for any client with any product(s);
- Click the `Send message` button in the chatter:
  - Write down any message and attach at least 1 file;
  - Send the message;
- Click on the SO's `Preview` button that will redirect you to the portal;
- **Don't reload the page**;
- Move down to the chatter;
- Hover the message containing the file(s);
- Click the three dots then `Download Files`.

## Cause:
The relative URL is created a wrong way, including an old way (<16.0) to access edition mode (even replaced by `get_client_action_url`[^1]) which we don't want here. Probably copy-pasted from https://github.com/odoo/odoo/blob/ddb03a55ac94b9fd48ae6ce138e70c0070bedd36/addons/website_sale/models/account_move.py#L23-L28 *We might want to remove it from here too but no bug declared yet (?)*

opw-4545106

[^1]: https://github.com/odoo/odoo/pull/99926