### PR TITLE
[FIX] mrp{,_subcontacting}: allow portal subcontractor to set SN

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -793,7 +793,8 @@ class MrpProduction(models.Model):
     @api.onchange('qty_producing', 'lot_producing_id')
     def _onchange_producing(self):
         productions_bypass_qty_producting = self.filtered(lambda p: p.lot_producing_id and p.product_tracking == 'lot' and p._origin and p._origin.qty_producing == p.qty_producing)
-        (self - productions_bypass_qty_producting)._set_qty_producing(False)
+        # sudo needed for portal users
+        (self - productions_bypass_qty_producting).sudo()._set_qty_producing(False)
 
     @api.onchange('lot_producing_id')
     def _onchange_lot_producing(self):


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable purchase > dropshipping
- Create a new user "BOB". Enable debug mode and set it as a portal user. Note: you can click on the wheel to change its password.
- Create a product FP tracked by SN, "BOB" as vendor and a bom of type subcontracting: 1 x COMP (tracked by SN), subcontracted by "BOB"
- On COMP, check the routes "Buy" and "Dropship Subcontractor on Order" and set a vendor price list.
- Create and confirm a purchase order for 2 units of FP for BOB
- A dropship Purchase Order is created for 2 units of COMP > confirm it
- In the Portal view, as BOB, return to the MO related to FP
- Click on the "burger" icon of the move and try to change the qty_producing or set a SN for the finished product.
#### > you trigger and access right error.

### Cause of the issue:

Changing the qty_producing or the serial number of the finished product triggers a call of the `_set_qty_producting`:
https://github.com/odoo/odoo/blob/5fb046e7278778cdbefe179d3258a7185a03a1b8/addons/mrp/models/mrp_production.py#L793-L796 During this call, the pickings linked to the MO will be fetchded to determine if the MO is waiting for components to arrive or if the reservation can already be done.
https://github.com/odoo/odoo/blob/5fb046e7278778cdbefe179d3258a7185a03a1b8/addons/mrp/models/mrp_production.py#L1223-L1224 However, the portal user does not have the access right to read this record and you are not saved by the `Stock Pickings Subcontractor`, `ir.rule` as this is a dropdhip.

### Note:
It was not possible to trigger the issue in 17.0 because prior to: https://github.com/odoo/odoo/blob/5fb046e7278778cdbefe179d3258a7185a03a1b8/addons/mrp/models/mrp_production.py#L466 The dropshipping picking was not linked to the MO and hence we didn't try to access the values of any record we didn't have access to.

opw-4485186
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
