### PR TITLE
[FIX] web: add gray background on section lines in reports

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report_tables.scss
+++ b/addons/web/static/src/webclient/actions/reports/report_tables.scss
@@ -10,6 +10,10 @@ table.table {
         text-align: left;
         vertical-align: middle;
     }
+
+    tr.o_line_section td {
+        background-color: rgba($gray-300, .5);
+    }
 }
 
 div#total {
@@ -139,15 +143,11 @@ div#total {
                 border-right: $border-width solid $gray-400;
             }
 
-            &.o_line_section td,
-            &.o_line_note td,
-            &.is-subtotal td {
+            tr.o_line_section td,
+            tr.o_line_note td,
+            tr.is-subtotal td {
                 border-top: $border-width solid $gray-700;
                 border-bottom: $border-width solid $gray-700;
-            }
-
-            &.o_line_section td {
-                background-color: rgba($gray-200, .5);
             }
 
             td.o_price_total, .o_taxes td {


### PR DESCRIPTION
### Steps to reproduce:
- Go to Sale, create a quotation with section lines
- Confirm and send
- The generated PDF have section lines that are only bold (no background color)
- In v17.0 sections lines were gray

### Cause:
It was removed during a refactoring.
Section lines with the "boxed" template were still supposed to be gray, but the code was `&.o_line_section td` inside of a `tbody` element, so the `&` referenced `tbody` and not `tr` on which the class `o_line_section` is added: https://github.com/odoo/odoo/blob/ddb03a55ac94b9fd48ae6ce138e70c0070bedd36/addons/account/views/report_invoice.xml#L131

### Solution:
Replace `&` by `tr` and move the change of background color to all tables, so affecting all reports.

###Before / After:

"Light" template
![Light](https://github.com/user-attachments/assets/8ed4ae95-a807-4654-b20a-60160db62435)
![Light_fixed](https://github.com/user-attachments/assets/a83c88ba-593b-4c3c-9f3f-63b21deaca33)


"DIN5008" template
![DIN](https://github.com/user-attachments/assets/87189140-cf56-4b15-81aa-4cd2f38d133a)
![DIN_fixed](https://github.com/user-attachments/assets/b47473de-1dae-45b2-ad4a-8f4023730510)


opw-4572732