### PR TITLE
[FIX] mail: call participants barely visible when collapsed

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
@@ -90,7 +90,7 @@ export class DiscussSidebarCallParticipants extends Component {
      */
     avatarClass(persona) {
         return persona.currentRtcSession?.isActuallyTalking
-            ? "o-mail-DiscussSidebarCallParticipants-avatar o-isTalking shadow"
+            ? "o-mail-DiscussSidebarCallParticipants-avatar o-isTalking"
             : "";
     }
 

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -30,11 +30,14 @@
             <AvatarStack
                 t-if="!state.expanded"
                 direction="compact ? 'v' : 'h'"
+                containerClass="compact ? '' : 'cursor-pointer'"
                 avatarClass="(p) => this.avatarClass(p)"
-                max="compact ? 1 : 4"
+                max="compact ? 1 : 7"
+                size="28"
+                onClick="() => this.state.expanded = true"
                 personas="sessions.map((s) => s.channel_member_id?.persona).filter(p => p)"
             >
-                <t t-set-slot="avatarExtraInfo" t-slot-scope="scope">
+                <t t-if="compact" t-set-slot="avatarExtraInfo" t-slot-scope="scope">
                     <div class="o-mail-DiscussSidebarCallParticipants-status small" t-att-class="{
                         'position-absolute bg-inherit p-0 rounded-circle o-compact d-flex o-xsmaller text-start': compact,
                         'ms-1 d-flex align-items-center justify-content-center': !compact,
@@ -63,8 +66,8 @@
 
     <t t-name="mail.DiscussSidebarCallParticipants.participant">
         <div class="o-mail-DiscussSidebarCallParticipants-participant d-flex text-reset overflow-hidden align-items-center" t-att-class="{ 'justify-content-center bg-inherit': isCompact }">
-            <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:24px;height:24px;margin:1px">
-                <img class="o-mail-DiscussSidebarCallParticipants-avatar w-100 h-100 rounded-circle o_object_fit_cover" t-att-src="session.channel_member_id.persona.avatarUrl" t-att-class="{'o-isTalking shadow': !session.isMute and session.isTalking}" alt="Participant avatar" t-att-title="session.channel_member_id.persona.name"/>
+            <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:28px;height:28px;margin:1px">
+                <img class="o-mail-DiscussSidebarCallParticipants-avatar w-100 h-100 rounded-circle o_object_fit_cover" t-att-src="session.channel_member_id.persona.avatarUrl" t-att-class="{'o-isTalking': !session.isMute and session.isTalking}" alt="Participant avatar" t-att-title="session.channel_member_id.persona.name"/>
             </div>
             <span t-if="!isCompact" class="o-mail-DiscussSidebarCallParticipants-name mx-1 text-truncate fw-bold smaller user-select-none" t-att-title="session.channel_member_id.persona.name" t-att-class="{ 'o-isTalking': !session.isMute and session.isTalking }">
                 <t t-esc="session.channel_member_id.persona.name"/>

--- a/addons/mail/static/src/discuss/core/common/avatar_stack.js
+++ b/addons/mail/static/src/discuss/core/common/avatar_stack.js
@@ -15,28 +15,36 @@ import { Component } from "@odoo/owl";
 export class AvatarStack extends Component {
     static template = "mail.AvatarStack";
     static props = {
+        containerClass: { type: String, optional: true },
         direction: { type: String, optional: true, validate: (d) => ["v", "h"].includes(d) },
         avatarClass: { type: Function, optional: true },
         max: { type: Number, optional: true },
+        onClick: { type: Function, optional: true },
         personas: Array,
         size: { type: Number, optional: true },
         slots: { optional: true },
     };
     static defaultProps = {
         avatarClass: () => "",
+        onClick: () => {},
         max: 4,
         size: 24,
         direction: "h",
     };
 
     getStyle(index) {
-        let style = `width: ${this.props.size}px; height: ${this.props.size}px;`;
-        if (index === 0) {
-            return style;
+        const styles = [
+            "box-sizing: content-box",
+            `height: ${this.props.size}px`,
+            `padding: 1.5px`,
+            `width: ${this.props.size}px`,
+            `z-index: ${this.props.personas.length - index}`,
+        ];
+        if (index !== 0) {
+            // Compute cumulative offset,
+            const marginDirection = this.props.direction === "v" ? "top" : "left";
+            styles.push(`margin-${marginDirection}: -${this.props.size / 4.5}px`);
         }
-        // Compute cumulative offset,
-        const marginDirection = this.props.direction === "v" ? "top" : "left";
-        style += `margin-${marginDirection}: -${this.props.size / 3}px`;
-        return style;
+        return styles.join(";");
     }
 }

--- a/addons/mail/static/src/discuss/core/common/avatar_stack.xml
+++ b/addons/mail/static/src/discuss/core/common/avatar_stack.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.AvatarStack">
-        <div t-if="props.personas.length > 0" class="bg-inherit" style="margin: 1px">
+        <div t-if="props.personas.length > 0" class="bg-inherit" style="margin: 1px;" t-att-class="props.containerClass" t-on-click="props.onClick">
             <div class="d-flex bg-inherit" t-att-class="{'flex-column': props.direction === 'v'}">
-                <span t-foreach="props.personas.slice(0, props.max)" t-as="persona" t-key="persona.localId" class="position-relative bg-inherit rounded-circle">
-                    <img t-att-src="persona.avatarUrl" t-att-title="persona.name" class="rounded-circle o_object_fit_cover d-flex" t-attf-class="{{props.avatarClass(persona)}}" t-attf-style="{{getStyle(persona_index)}}"/>
+                <span t-foreach="props.personas.slice(0, props.max)" t-as="persona" t-key="persona.localId" class="bg-inherit rounded-circle" t-attf-style="{{getStyle(persona_index)}}">
+                    <img t-att-src="persona.avatarUrl" t-att-title="persona.name" class="w-100 h-100 rounded-circle o_object_fit_cover" t-attf-class="{{props.avatarClass(persona)}}"/>
                     <t t-slot="avatarExtraInfo" persona="persona"/>
                 </span>
-                <span t-if="props.personas.length > props.max" class="z-1 rounded-circle bg-secondary smaller d-flex justify-content-center align-items-center user-select-none" t-attf-style="{{getStyle(props.personas.length)}}">+<t t-esc="props.personas.length - props.max"/></span>
+                <span t-if="props.personas.length > props.max" class="rounded-circle bg-secondary smaller d-flex justify-content-center align-items-center user-select-none" t-attf-style="{{getStyle(props.personas.length)}}; font-weight: 450;">+<t t-esc="props.personas.length - props.max"/></span>
             </div>
         </div>
     </t>

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -477,6 +477,9 @@ test("expand call participants when joining a call", async () => {
         { name: "David" },
         { name: "Eric" },
         { name: "Frank" },
+        { name: "Grace" },
+        { name: "Henry" },
+        { name: "Ivy" },
     ]);
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     for (const partner of partners) {
@@ -491,14 +494,14 @@ test("expand call participants when joining a call", async () => {
     }
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-DiscussSidebarCallParticipants img", { count: 4 });
+    await contains(".o-mail-DiscussSidebarCallParticipants img", { count: 7 });
     await contains("img[title='Alice']");
     await contains("img[title='Bob']");
     await contains("img[title='Cathy']");
     await contains("img[title='David']");
     await contains(".o-mail-DiscussSidebarCallParticipants span", { text: "+2" });
     await click("[title='Join Call']");
-    await contains(".o-mail-DiscussSidebarCallParticipants img", { count: 7 });
+    await contains(".o-mail-DiscussSidebarCallParticipants img", { count: 10 });
     await contains("img[title='Alice']");
     await contains("img[title='Bob']");
     await contains("img[title='Cathy']");


### PR DESCRIPTION
The discuss side bar displays call participants in an avatar stack to avoid bloating the UI. However, this avatar stack is quite small while there is plenty of horizontal space. As a result, its difficult to know which users are currently in the call. It's possible to expand the avatar stack to have more information but the toggle is too small and its not as easy as it should be.

This PR fixes both issues:
- Avatar stack gives more space for each avatar, size is slightly increased and the stack displays more avatars.
- Its now possible to click on the stack to expand it.

Also fixes an issue where short status were shown when sidebar is in non-compact mode.


| Before | After |
| ------------- | ------------- |
|![image](https://github.com/user-attachments/assets/a6e11772-45b8-4042-9a97-d2b0cfa94e89)| ![image](https://github.com/user-attachments/assets/474d8c48-3ed8-4ba4-8933-7201577f8ffa)  |
| ![image](https://github.com/user-attachments/assets/63f68ff8-b3bd-4732-bbde-206455b47ed6)  | ![image](https://github.com/user-attachments/assets/b8d73b8d-c82e-4bf6-9290-989b47592400)  |