### PR TITLE
[IMP] mail: smooth jump to present / message in discuss

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -7,7 +7,7 @@ import { FollowerList } from "@mail/core/web/follower_list";
 import { isDragSourceExternalFile } from "@mail/utils/common/misc";
 import { useAttachmentUploader } from "@mail/core/common/attachment_uploader_hook";
 import { useCustomDropzone } from "@web/core/dropzone/dropzone_hook";
-import { useHover, useMessageHighlight } from "@mail/utils/common/hooks";
+import { useHover, useMessageScrolling } from "@mail/utils/common/hooks";
 import { MailAttachmentDropzone } from "@mail/core/common/mail_attachment_dropzone";
 import { RecipientsInput } from "@mail/core/web/recipients_input";
 import { SearchMessageInput } from "@mail/core/common/search_message_input";
@@ -79,7 +79,7 @@ Object.assign(Chatter.defaultProps, {
  */
 patch(Chatter.prototype, {
     setup() {
-        this.messageHighlight = useMessageHighlight();
+        this.messageHighlight = useMessageScrolling();
         super.setup(...arguments);
         this.orm = useService("orm");
         this.keepLastSuggestedRecipientsUpdate = new KeepLast();

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -5,7 +5,7 @@ import { AutoresizeInput } from "@mail/core/common/autoresize_input";
 import { CountryFlag } from "@mail/core/common/country_flag";
 import { useThreadActions } from "@mail/core/common/thread_actions";
 import { ThreadIcon } from "@mail/core/common/thread_icon";
-import { useHover, useMessageHighlight } from "@mail/utils/common/hooks";
+import { useHover, useMessageScrolling } from "@mail/utils/common/hooks";
 import { isEventHandled } from "@web/core/utils/misc";
 
 import { Component, toRaw, useChildSubEnv, useRef, useState, useSubEnv } from "@odoo/owl";
@@ -44,7 +44,7 @@ export class ChatWindow extends Component {
         super.setup();
         useSubEnv({ inChatWindow: true });
         this.store = useService("mail.store");
-        this.messageHighlight = useMessageHighlight();
+        this.messageHighlight = useMessageScrolling();
         this.state = useState({
             actionsMenuOpened: false,
             jumpThreadPresent: 0,

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -8,13 +8,13 @@
                 <span class="position-absolute w-100 invisible" t-att-class="props.order === 'asc' ? 'bottom-0' : 'top-0'" t-ref="present-treshold" t-att-style="`height: Min(${PRESENT_THRESHOLD}px, 100%)`"/>
                 <t t-set="currentDay" t-value="0"/>
                 <t t-if="props.order === 'asc'">
-                    <t t-if="props.thread.loadOlder and !props.thread.isTransient and !props.thread.hasLoadingFailed" t-call="mail.Thread.loadOlder"/>
+                    <t t-if="showLoadOlder" t-call="mail.Thread.loadOlder"/>
                     <t t-elif="props.thread.hasLoadingFailed" t-call="mail.Thread.loadingError"/>
                     <t t-elif="showStartMessage" t-call="mail.Thread.startMessage"/>
                 </t>
                 <span t-else="" class="pt-1" t-ref="load-newer"/>
                 <t t-set="messages" t-value="orderedMessages"/>
-                <t t-if="state.mountedAndLoaded" t-foreach="messages" t-as="msg" t-key="msg.id">
+                <t t-foreach="messages" t-as="msg" t-key="msg.id">
                     <t t-set="prevMsg" t-value="messages[msg_index -1]"/>
                     <t t-if="msg.dateDay !== currentDay and props.showDates">
                         <DateSection date="msg.dateDay" className="'pt-2 px-2'"/>
@@ -42,7 +42,7 @@
                 </t>
                 <span t-if="props.order === 'asc'" class="pt-1" t-ref="load-newer"/>
                 <t t-else="">
-                    <t t-if="props.thread.loadOlder and !props.thread.isTransient and !props.thread.hasLoadingFailed" t-call="mail.Thread.loadOlder"/>
+                    <t t-if="showLoadOlder" t-call="mail.Thread.loadOlder"/>
                     <t t-if="props.thread.hasLoadingFailed" t-call="mail.Thread.loadingError"/>
                 </t>
             </div>
@@ -74,7 +74,7 @@
 </t>
 
 <t t-name="mail.Thread.loadOlder">
-    <button class="btn btn-link" t-on-click="onClickLoadOlder" t-ref="load-older">Load More</button>
+    <button class="btn btn-link" t-att-class="{ 'opacity-0': !mountedAndLoaded }" t-on-click="onClickLoadOlder" t-ref="load-older">Load More</button>
 </t>
 
 <t t-name="mail.Thread.loadingError">

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -209,6 +209,12 @@ export class Thread extends Record {
      * Content should be fetched and inserted in a controlled way.
      */
     messages = fields.Many("mail.message");
+    /**
+     * Phantom messages is a snapshot of `messages` while the thread is being loaded.
+     * In other words: when thread is not loaded or loading, phantom messages are the
+     * messages before thread loading.
+     */
+    phantomMessages = fields.Many("mail.message");
     /** @type {string} */
     modelName;
     /** @type {string} */
@@ -656,7 +662,9 @@ export class Thread extends Record {
         this.isLoaded = false;
         this.scrollTop = undefined;
         try {
+            this.phantomMessages = this.messages;
             this.messages = await this.fetchMessages({ around: messageId });
+            this.phantomMessages = [];
         } catch {
             this.isLoaded = true;
             return;

--- a/addons/mail/static/src/core/public_web/discuss.js
+++ b/addons/mail/static/src/core/public_web/discuss.js
@@ -6,7 +6,7 @@ import { Thread } from "@mail/core/common/thread";
 import { useThreadActions } from "@mail/core/common/thread_actions";
 import { ThreadIcon } from "@mail/core/common/thread_icon";
 import { DiscussSidebar } from "@mail/core/public_web/discuss_sidebar";
-import { useMessageHighlight } from "@mail/utils/common/hooks";
+import { useMessageScrolling } from "@mail/utils/common/hooks";
 
 import { Component, useRef, useState, useExternalListener, useEffect, useSubEnv } from "@odoo/owl";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
@@ -38,7 +38,7 @@ export class Discuss extends Component {
     setup() {
         super.setup();
         this.store = useService("mail.store");
-        this.messageHighlight = useMessageHighlight();
+        this.messageHighlight = useMessageScrolling();
         this.contentRef = useRef("content");
         this.root = useRef("root");
         this.state = useState({ jumpThreadPresent: 0 });


### PR DESCRIPTION
Before this commit, jump to present and to message in a discuss conversation was visually unappealing.

This comes from:
- jump to present scrolling is instantaneous, instead of smooth.
- jump to message scroll direction is always from top, when the frequent use-case is jump to older message thus should scroll to top.
- message list is empty while the thread is loading, so the slower the connection the most visually unappealing it was.

This commit improves scrolling experience with jump to present and jump to message as follow:

- jump to present uses a smooth scroll effect similarly to jump to message
- jump to message scroll direction is based on whether the message is older or newer to loaded set of messages.
- message list stay visually in place while thread is loading.

Task-4589532

Before
![before](https://github.com/user-attachments/assets/68b195a5-8496-4b7f-b273-7209e18837a7)

After
![after](https://github.com/user-attachments/assets/07dc84d0-3735-4887-8f9b-17c282b126fd)

