### PR TITLE
[ADD] test_lint: Enforce indexing of Many2one inverses for One2many fields

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -45,6 +45,7 @@ class AccountBankStatementLine(models.Model):
     statement_id = fields.Many2one(
         comodel_name='account.bank.statement',
         string='Statement',
+        index=True,
     )
 
     # Payments generated during the reconciliation of this bank statement lines.

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -224,6 +224,7 @@ class AccountJournal(models.Model):
     bank_account_id = fields.Many2one('res.partner.bank',
         string="Bank Account",
         ondelete='restrict', copy=False,
+        index='btree_not_null',
         check_company=True,
         domain="[('partner_id','=', company_partner_id)]")
     bank_statements_source = fields.Selection(selection=_get_bank_statements_available_sources, string='Bank Feeds', default='undefined', help="Defines how the bank statements will be registered")

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -433,6 +433,7 @@ class AccountMove(models.Model):
              "otherwise a Partner bank account number.",
         check_company=True,
         tracking=True,
+        index='btree_not_null',
         ondelete='restrict',
     )
     fiscal_position_id = fields.Many2one(

--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -119,6 +119,7 @@ class AccountPaymentMethodLine(models.Model):
     journal_id = fields.Many2one(
         comodel_name='account.journal',
         check_company=True,
+        index='btree_not_null',
     )
     default_account_id = fields.Many2one(
         related='journal_id.default_account_id'

--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -10,7 +10,7 @@ class AccountReconcileModelPartnerMapping(models.Model):
     _description = 'Partner mapping for reconciliation models'
     _check_company_auto = True
 
-    model_id = fields.Many2one(comodel_name='account.reconcile.model', readonly=True, required=True, ondelete='cascade')
+    model_id = fields.Many2one(comodel_name='account.reconcile.model', readonly=True, required=True, index=True, ondelete='cascade')
     company_id = fields.Many2one(related='model_id.company_id')
     partner_id = fields.Many2one(comodel_name='res.partner', string="Partner", required=True, ondelete='cascade', check_company=True)
     payment_ref_regex = fields.Char(string="Find Text in Label")
@@ -40,7 +40,7 @@ class AccountReconcileModelLine(models.Model):
     _order = 'sequence, id'
     _check_company_auto = True
 
-    model_id = fields.Many2one('account.reconcile.model', readonly=True, ondelete='cascade')
+    model_id = fields.Many2one('account.reconcile.model', readonly=True, index='btree_not_null', ondelete='cascade')
     allow_payment_tolerance = fields.Boolean(related='model_id.allow_payment_tolerance')
     payment_tolerance_param = fields.Float(related='model_id.payment_tolerance_param')
     rule_type = fields.Selection(related='model_id.rule_type')

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -35,7 +35,7 @@ class AccountReport(models.Model):
     active = fields.Boolean(string="Active", default=True)
     line_ids = fields.One2many(string="Lines", comodel_name='account.report.line', inverse_name='report_id')
     column_ids = fields.One2many(string="Columns", comodel_name='account.report.column', inverse_name='report_id')
-    root_report_id = fields.Many2one(string="Root Report", comodel_name='account.report', help="The report this report is a variant of.")
+    root_report_id = fields.Many2one(string="Root Report", comodel_name='account.report', index='btree_not_null', help="The report this report is a variant of.")
     variant_report_ids = fields.One2many(string="Variants", comodel_name='account.report', inverse_name='root_report_id')
     section_report_ids = fields.Many2many(string="Sections", comodel_name='account.report', relation="account_report_section_rel", column1="main_report_id", column2="sub_report_id")
     section_main_report_ids = fields.Many2many(string="Section Of", comodel_name='account.report', relation="account_report_section_rel", column1="sub_report_id", column2="main_report_id")
@@ -318,6 +318,7 @@ class AccountReportLine(models.Model):
         required=True,
         recursive=True,
         precompute=True,
+        index=True,
         ondelete='cascade'
     )
     hierarchy_level = fields.Integer(
@@ -329,7 +330,7 @@ class AccountReportLine(models.Model):
         required=True,
         precompute=True,
     )
-    parent_id = fields.Many2one(string="Parent Line", comodel_name='account.report.line', ondelete='set null')
+    parent_id = fields.Many2one(string="Parent Line", comodel_name='account.report.line', ondelete='set null', index='btree_not_null')
     children_ids = fields.One2many(string="Child Lines", comodel_name='account.report.line', inverse_name='parent_id')
     groupby = fields.Char(string="Group By", help="Comma-separated list of fields from account.move.line (Journal Item). When set, this line will generate sublines grouped by those keys.")
     user_groupby = fields.Char(
@@ -536,7 +537,7 @@ class AccountReportExpression(models.Model):
     _description = "Accounting Report Expression"
     _rec_name = 'report_line_name'
 
-    report_line_id = fields.Many2one(string="Report Line", comodel_name='account.report.line', required=True, ondelete='cascade')
+    report_line_id = fields.Many2one(string="Report Line", comodel_name='account.report.line', required=True, index=True, ondelete='cascade')
     report_line_name = fields.Char(string="Report Line Name", related="report_line_id.name")
     label = fields.Char(string="Label", required=True)
     engine = fields.Selection(
@@ -875,7 +876,7 @@ class AccountReportColumn(models.Model):
     name = fields.Char(string="Name", translate=True, required=True)
     expression_label = fields.Char(string="Expression Label", required=True)
     sequence = fields.Integer(string="Sequence")
-    report_id = fields.Many2one(string="Report", comodel_name='account.report')
+    report_id = fields.Many2one(string="Report", comodel_name='account.report', index='btree_not_null')
     sortable = fields.Boolean(string="Sortable")
     figure_type = fields.Selection(string="Figure Type", selection=FIGURE_TYPE_SELECTION_VALUES, default="monetary", required=True)
     blank_if_zero = fields.Boolean(string="Blank if Zero", help="When checked, 0 values will not show in this column.")

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -2774,7 +2774,7 @@ class AccountTaxRepartitionLine(models.Model):
         check_company=True,
         help="Account on which to post the tax amount")
     tag_ids = fields.Many2many(string="Tax Grids", comodel_name='account.account.tag', domain=[('applicability', '=', 'taxes')], copy=True, ondelete='restrict')
-    tax_id = fields.Many2one(comodel_name='account.tax', ondelete='cascade', check_company=True)
+    tax_id = fields.Many2one(comodel_name='account.tax', index='btree_not_null', ondelete='cascade', check_company=True)
     company_id = fields.Many2one(string="Company", comodel_name='res.company', related="tax_id.company_id", store=True, help="The company this distribution line belongs to.")
     sequence = fields.Integer(string="Sequence", default=1,
         help="The order in which distribution lines are displayed and matched. For refunds to work properly, invoice distribution lines should be arranged in the same order as the credit note distribution lines they correspond to.")

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -35,7 +35,7 @@ class AccountFiscalPosition(models.Model):
         help="By unchecking the active field, you may hide a fiscal position without deleting it.")
     company_id = fields.Many2one(
         comodel_name='res.company',
-        string='Company', required=True, readonly=True,
+        string='Company', required=True, readonly=True, index=True,
         default=lambda self: self.env.company)
     account_ids = fields.One2many('account.fiscal.position.account', 'position_id', string='Account Mapping', copy=True)
     account_map = fields.Binary(compute='_compute_account_map')
@@ -302,7 +302,7 @@ class AccountFiscalPositionTax(models.Model):
     _check_company_domain = models.check_company_domain_parent_of
 
     position_id = fields.Many2one('account.fiscal.position', string='Fiscal Position',
-        required=True, ondelete='cascade')
+        required=True, index=True, ondelete='cascade')
     company_id = fields.Many2one('res.company', string='Company', related='position_id.company_id', store=True)
     tax_src_id = fields.Many2one('account.tax', string='Tax on Product', required=True, check_company=True)
     tax_dest_id = fields.Many2one('account.tax', string='Tax to Apply', check_company=True)

--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -33,7 +33,7 @@ class Account_Edi_Proxy_ClientUser(models.Model):
 
     active = fields.Boolean(default=True)
     id_client = fields.Char(required=True)
-    company_id = fields.Many2one('res.company', string='Company', required=True,
+    company_id = fields.Many2one('res.company', string='Company', required=True, index=True,
         default=lambda self: self.env.company)
     edi_identification = fields.Char(required=True, help="The unique id that identifies this user, typically the vat")
     private_key_id = fields.Many2one(

--- a/addons/account_fleet/models/fleet_vehicle_log_services.py
+++ b/addons/account_fleet/models/fleet_vehicle_log_services.py
@@ -7,7 +7,7 @@ from odoo.exceptions import UserError
 class FleetVehicleLogServices(models.Model):
     _inherit = 'fleet.vehicle.log.services'
 
-    account_move_line_id = fields.Many2one(comodel_name='account.move.line')  # One2one
+    account_move_line_id = fields.Many2one(comodel_name='account.move.line', index='btree_not_null')  # One2one
     account_move_state = fields.Selection(related='account_move_line_id.parent_state')
     amount = fields.Monetary(string='Cost', compute="_compute_amount", inverse="_inverse_amount",
         readonly=False, store=True, tracking=True)

--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -39,6 +39,7 @@ class AccountAnalyticAccount(models.Model):
         'account.analytic.plan',
         string='Plan',
         required=True,
+        index=True,
     )
     root_plan_id = fields.Many2one(
         'account.analytic.plan',
@@ -70,6 +71,7 @@ class AccountAnalyticAccount(models.Model):
         auto_join=True,
         tracking=True,
         check_company=True,
+        index='btree_not_null',
     )
 
     balance = fields.Monetary(

--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -27,6 +27,7 @@ class AccountAnalyticPlan(models.Model):
         'account.analytic.plan',
         string="Parent",
         inverse='_inverse_parent_id',
+        index='btree_not_null',
         ondelete='cascade',
         domain="['!', ('id', 'child_of', id)]",
     )
@@ -297,7 +298,7 @@ class AccountAnalyticApplicability(models.Model):
     _check_company_auto = True
     _check_company_domain = models.check_company_domain_parent_of
 
-    analytic_plan_id = fields.Many2one('account.analytic.plan')
+    analytic_plan_id = fields.Many2one('account.analytic.plan', index='btree_not_null')
     business_domain = fields.Selection(
         selection=[
             ('general', 'Miscellaneous'),

--- a/addons/auth_passkey/models/auth_passkey_key.py
+++ b/addons/auth_passkey/models/auth_passkey_key.py
@@ -26,6 +26,7 @@ class AuthPasskeyKey(models.Model):
     credential_identifier = fields.Char(required=True, groups='base.group_system')
     public_key = fields.Char(required=True, groups='base.group_system', compute='_compute_public_key', inverse='_inverse_public_key')
     sign_count = fields.Integer(default=0, groups='base.group_system')
+    create_uid = fields.Many2one('res.users', index=True)
 
     _unique_identifier = models.Constraint(
         'UNIQUE(credential_identifier)',

--- a/addons/barcodes/models/barcode_rule.py
+++ b/addons/barcodes/models/barcode_rule.py
@@ -10,7 +10,7 @@ class BarcodeRule(models.Model):
     _order = 'sequence asc, id'
 
     name = fields.Char(string='Rule Name', required=True, help='An internal identification for this barcode nomenclature rule')
-    barcode_nomenclature_id = fields.Many2one('barcode.nomenclature', string='Barcode Nomenclature')
+    barcode_nomenclature_id = fields.Many2one('barcode.nomenclature', string='Barcode Nomenclature', index='btree_not_null')
     sequence = fields.Integer(string='Sequence', help='Used to order rules such that rules with a smaller sequence match first')
     encoding = fields.Selection(
         string='Encoding', required=True, default='any', selection=[

--- a/addons/base_automation/models/ir_actions_server.py
+++ b/addons/base_automation/models/ir_actions_server.py
@@ -14,7 +14,7 @@ class IrActionsServer(models.Model):
     usage = fields.Selection(selection_add=[
         ('base_automation', 'Automation Rule')
     ], ondelete={'base_automation': 'cascade'})
-    base_automation_id = fields.Many2one('base.automation', string='Automation Rule', ondelete='cascade')
+    base_automation_id = fields.Many2one('base.automation', string='Automation Rule', index='btree_not_null', ondelete='cascade')
 
     @api.model
     def _warning_depends(self):

--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -31,7 +31,7 @@ class CalendarAttendee(models.Model):
     ]
 
     # event
-    event_id = fields.Many2one('calendar.event', 'Meeting linked', required=True, ondelete='cascade')
+    event_id = fields.Many2one('calendar.event', 'Meeting linked', required=True, index=True, ondelete='cascade')
     recurrence_id = fields.Many2one('calendar.recurrence', related='event_id.recurrence_id')
     # attendee
     partner_id = fields.Many2one('res.partner', 'Attendee', required=True, readonly=True, ondelete='cascade')

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -201,7 +201,7 @@ class CalendarEvent(models.Model):
     # RECURRENCE FIELD
     recurrency = fields.Boolean('Recurrent')
     recurrence_id = fields.Many2one(
-        'calendar.recurrence', string="Recurrence Rule")
+        'calendar.recurrence', string="Recurrence Rule", index='btree_not_null')
     follow_recurrence = fields.Boolean(default=False) # Indicates if an event follows the recurrence, i.e. is not an exception
     recurrence_update = fields.Selection([
         ('self_only', "This event"),

--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -8,7 +8,7 @@ from odoo.addons.mail.tools.discuss import Store
 class MailActivity(models.Model):
     _inherit = "mail.activity"
 
-    calendar_event_id = fields.Many2one('calendar.event', string="Calendar Meeting", ondelete='cascade')
+    calendar_event_id = fields.Many2one('calendar.event', string="Calendar Meeting", index='btree_not_null', ondelete='cascade')
 
     def action_create_calendar_event(self):
         self.ensure_one()

--- a/addons/data_recycle/models/data_recycle_record.py
+++ b/addons/data_recycle/models/data_recycle_record.py
@@ -12,7 +12,7 @@ class Data_RecycleRecord(models.Model):
 
     active = fields.Boolean('Active', default=True)
     name = fields.Char('Record Name', compute='_compute_name', compute_sudo=True)
-    recycle_model_id = fields.Many2one('data_recycle.model', string='Recycle Model', ondelete='cascade')
+    recycle_model_id = fields.Many2one('data_recycle.model', string='Recycle Model', index='btree_not_null', ondelete='cascade')
 
     res_id = fields.Integer('Record ID', index=True)
     res_model_id = fields.Many2one(related='recycle_model_id.res_model_id', store=True, readonly=True)

--- a/addons/delivery/models/delivery_price_rule.py
+++ b/addons/delivery/models/delivery_price_rule.py
@@ -40,7 +40,7 @@ class DeliveryPriceRule(models.Model):
 
     name = fields.Char(compute='_compute_name')
     sequence = fields.Integer(required=True, default=10)
-    carrier_id = fields.Many2one('delivery.carrier', 'Carrier', required=True, ondelete='cascade')
+    carrier_id = fields.Many2one('delivery.carrier', 'Carrier', required=True, index=True, ondelete='cascade')
     currency_id = fields.Many2one(related='carrier_id.currency_id')
 
     variable = fields.Selection(selection=VARIABLE_SELECTION, required=True, default='quantity')

--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -30,7 +30,7 @@ class EventMail(models.Model):
     _rec_name = 'event_id'
     _description = 'Event Automated Mailing'
 
-    event_id = fields.Many2one('event.event', string='Event', required=True, ondelete='cascade')
+    event_id = fields.Many2one('event.event', string='Event', required=True, index=True, ondelete='cascade')
     sequence = fields.Integer('Display order')
     interval_nbr = fields.Integer('Interval', default=1)
     interval_unit = fields.Selection([

--- a/addons/event/models/event_mail_registration.py
+++ b/addons/event/models/event_mail_registration.py
@@ -14,8 +14,8 @@ class EventMailRegistration(models.Model):
     _rec_name = 'scheduler_id'
     _order = 'scheduled_date DESC, id ASC'
 
-    scheduler_id = fields.Many2one('event.mail', 'Mail Scheduler', required=True, ondelete='cascade')
-    registration_id = fields.Many2one('event.registration', 'Attendee', required=True, ondelete='cascade')
+    scheduler_id = fields.Many2one('event.mail', 'Mail Scheduler', required=True, index=True, ondelete='cascade')
+    registration_id = fields.Many2one('event.registration', 'Attendee', required=True, index=True, ondelete='cascade')
     scheduled_date = fields.Datetime('Scheduled Time', compute='_compute_scheduled_date', store=True)
     mail_sent = fields.Boolean('Mail Sent')
 

--- a/addons/event/models/event_question.py
+++ b/addons/event/models/event_question.py
@@ -19,8 +19,8 @@ class EventQuestion(models.Model):
         ('phone', 'Phone'),
         ('company_name', 'Company'),
     ], default='simple_choice', string="Question Type", required=True)
-    event_type_id = fields.Many2one('event.type', 'Event Type', ondelete='cascade')
-    event_id = fields.Many2one('event.event', 'Event', ondelete='cascade')
+    event_type_id = fields.Many2one('event.type', 'Event Type', ondelete='cascade', index='btree_not_null')
+    event_id = fields.Many2one('event.event', 'Event', ondelete='cascade', index='btree_not_null')
     answer_ids = fields.One2many('event.question.answer', 'question_id', "Answers", copy=True)
     sequence = fields.Integer(default=10)
     once_per_order = fields.Boolean('Ask once per order',

--- a/addons/event/models/event_question_answer.py
+++ b/addons/event/models/event_question_answer.py
@@ -12,7 +12,7 @@ class EventQuestionAnswer(models.Model):
     _description = 'Event Question Answer'
 
     name = fields.Char('Answer', required=True, translate=True)
-    question_id = fields.Many2one('event.question', required=True, ondelete='cascade')
+    question_id = fields.Many2one('event.question', required=True, index=True, ondelete='cascade')
     sequence = fields.Integer(default=10)
 
     @api.ondelete(at_uninstall=False)

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -32,9 +32,9 @@ class EventRegistration(models.Model):
 
     # event
     event_id = fields.Many2one(
-        'event.event', string='Event', required=True, tracking=True)
+        'event.event', string='Event', required=True, tracking=True, index=True)
     event_ticket_id = fields.Many2one(
-        'event.event.ticket', string='Ticket Type', ondelete='restrict', tracking=True)
+        'event.event.ticket', string='Ticket Type', ondelete='restrict', tracking=True, index='btree_not_null')
     active = fields.Boolean(default=True)
     barcode = fields.Char(string='Barcode', default=lambda self: self._get_random_barcode(), readonly=True, copy=False)
     # utm informations
@@ -42,7 +42,7 @@ class EventRegistration(models.Model):
     utm_source_id = fields.Many2one('utm.source', 'Source', index=True, ondelete='set null')
     utm_medium_id = fields.Many2one('utm.medium', 'Medium', index=True, ondelete='set null')
     # attendee
-    partner_id = fields.Many2one('res.partner', string='Booked by', tracking=1)
+    partner_id = fields.Many2one('res.partner', string='Booked by', tracking=1, index='btree_not_null')
     name = fields.Char(
         string='Attendee Name', index='trigram',
         compute='_compute_name', readonly=False, store=True, tracking=2)

--- a/addons/event/models/event_registration_answer.py
+++ b/addons/event/models/event_registration_answer.py
@@ -13,7 +13,7 @@ class EventRegistrationAnswer(models.Model):
     question_id = fields.Many2one(
         'event.question', ondelete='restrict', required=True,
         domain="[('event_id', '=', event_id)]")
-    registration_id = fields.Many2one('event.registration', required=True, ondelete='cascade')
+    registration_id = fields.Many2one('event.registration', required=True, index=True, ondelete='cascade')
     partner_id = fields.Many2one('res.partner', related='registration_id.partner_id')
     event_id = fields.Many2one('event.event', related='registration_id.event_id')
     question_type = fields.Selection(related='question_id.question_type')

--- a/addons/event/models/event_tag.py
+++ b/addons/event/models/event_tag.py
@@ -34,7 +34,7 @@ class EventTag(models.Model):
 
     name = fields.Char("Name", required=True, translate=True)
     sequence = fields.Integer('Sequence', default=0)
-    category_id = fields.Many2one("event.tag.category", string="Category", required=True, ondelete='cascade')
+    category_id = fields.Many2one("event.tag.category", string="Category", required=True, index=True, ondelete='cascade')
     category_sequence = fields.Integer(related='category_id.sequence', string='Category Sequence', store=True)
     color = fields.Integer(
         string='Color Index', default=lambda self: self._default_color(),

--- a/addons/event/models/event_ticket.py
+++ b/addons/event/models/event_ticket.py
@@ -27,7 +27,7 @@ class EventEventTicket(models.Model):
     event_type_id = fields.Many2one(ondelete='set null', required=False)
     event_id = fields.Many2one(
         'event.event', string="Event",
-        ondelete='cascade', required=True)
+        ondelete='cascade', required=True, index=True)
     company_id = fields.Many2one('res.company', related='event_id.company_id')
     # sale
     start_sale_datetime = fields.Datetime(string="Registration Start")

--- a/addons/event_booth/models/event_booth.py
+++ b/addons/event_booth/models/event_booth.py
@@ -16,7 +16,7 @@ class EventBooth(models.Model):
 
     # owner
     event_type_id = fields.Many2one(ondelete='set null', required=False)
-    event_id = fields.Many2one('event.event', string='Event', ondelete='cascade', required=True)
+    event_id = fields.Many2one('event.event', string='Event', ondelete='cascade', required=True, index=True)
     # customer
     partner_id = fields.Many2one('res.partner', string='Renter', tracking=True, copy=False)
     contact_name = fields.Char('Renter Name', compute='_compute_contact_name', readonly=False, store=True, copy=False)

--- a/addons/event_booth/models/event_type_booth.py
+++ b/addons/event_booth/models/event_type_booth.py
@@ -17,9 +17,9 @@ class EventTypeBooth(models.Model):
     name = fields.Char(string='Name', required=True, translate=True)
     event_type_id = fields.Many2one(
         'event.type', string='Event Category',
-        ondelete='cascade', required=True)
+        ondelete='cascade', required=True, index=True)
     booth_category_id = fields.Many2one(
-        'event.booth.category', string='Booth Category',
+        'event.booth.category', string='Booth Category', index=True,
         default=_get_default_booth_category, ondelete='restrict', required=True)
 
     @api.model

--- a/addons/event_booth_sale/models/event_booth.py
+++ b/addons/event_booth_sale/models/event_booth.py
@@ -17,10 +17,10 @@ class EventBooth(models.Model):
         groups='sales_team.group_sale_salesman', copy=False)
     sale_order_line_id = fields.Many2one(
         'sale.order.line', string='Final Sale Order Line', ondelete='set null',
-        readonly=False,
+        readonly=False, index='btree_not_null',
         groups='sales_team.group_sale_salesman', copy=False)
     sale_order_id = fields.Many2one(
-        related='sale_order_line_id.order_id', store='True', readonly=True,
+        related='sale_order_line_id.order_id', store='True', readonly=True, index='btree_not_null',
         groups='sales_team.group_sale_salesman')
     is_paid = fields.Boolean('Is Paid', copy=False)
 

--- a/addons/event_booth_sale/models/event_booth_registration.py
+++ b/addons/event_booth_sale/models/event_booth_registration.py
@@ -12,8 +12,8 @@ class EventBoothRegistration(models.Model):
     _name = 'event.booth.registration'
     _description = 'Event Booth Registration'
 
-    sale_order_line_id = fields.Many2one('sale.order.line', string='Sale Order Line', required=True, ondelete='cascade')
-    event_booth_id = fields.Many2one('event.booth', string='Booth', required=True)
+    sale_order_line_id = fields.Many2one('sale.order.line', string='Sale Order Line', required=True, index=True, ondelete='cascade')
+    event_booth_id = fields.Many2one('event.booth', string='Booth', required=True, index=True)
     partner_id = fields.Many2one(
         'res.partner', related='sale_order_line_id.order_partner_id', store=True)
     contact_name = fields.Char(string='Contact Name', compute='_compute_contact_name', readonly=False, store=True)

--- a/addons/event_crm/models/crm_lead.py
+++ b/addons/event_crm/models/crm_lead.py
@@ -7,7 +7,7 @@ from odoo import fields, models, api
 class CrmLead(models.Model):
     _inherit = 'crm.lead'
 
-    event_lead_rule_id = fields.Many2one('event.lead.rule', string="Registration Rule", help="Rule that created this lead")
+    event_lead_rule_id = fields.Many2one('event.lead.rule', string="Registration Rule", help="Rule that created this lead", index='btree_not_null')
     event_id = fields.Many2one('event.event', string="Source Event", help="Event triggering the rule that created this lead", index='btree_not_null')
     registration_ids = fields.Many2many(
         'event.registration', string="Source Registrations",

--- a/addons/event_product/models/event_type_ticket.py
+++ b/addons/event_product/models/event_type_ticket.py
@@ -18,7 +18,7 @@ class EventTypeTicket(models.Model):
     description = fields.Text(compute='_compute_description', readonly=False, store=True)
     # product
     product_id = fields.Many2one(
-        'product.product', string='Product', required=True,
+        'product.product', string='Product', required=True, index=True,
         domain=[("service_tracking", "=", "event")], default=_default_product_id)
     currency_id = fields.Many2one(related="product_id.currency_id", string="Currency")
     price = fields.Float(

--- a/addons/event_sale/models/event_registration.py
+++ b/addons/event_sale/models/event_registration.py
@@ -10,7 +10,7 @@ class EventRegistration(models.Model):
 
     # TDE FIXME: maybe add an onchange on sale_order_id
     sale_order_id = fields.Many2one('sale.order', string='Sales Order', ondelete='cascade', copy=False)
-    sale_order_line_id = fields.Many2one('sale.order.line', string='Sales Order Line', ondelete='cascade', copy=False)
+    sale_order_line_id = fields.Many2one('sale.order.line', string='Sales Order Line', ondelete='cascade', copy=False, index='btree_not_null')
     state = fields.Selection(default=None, compute="_compute_registration_status", store=True, readonly=False, precompute=True)
     utm_campaign_id = fields.Many2one(compute='_compute_utm_campaign_id', readonly=False,
         store=True, ondelete="set null")

--- a/addons/event_sale/models/sale_order_line.py
+++ b/addons/event_sale/models/sale_order_line.py
@@ -9,7 +9,7 @@ class SaleOrderLine(models.Model):
 
     event_id = fields.Many2one(
         'event.event', string='Event',
-        compute="_compute_event_id", store=True, readonly=False, precompute=True,
+        compute="_compute_event_id", store=True, readonly=False, precompute=True, index='btree_not_null',
         help="Choose an event and it will automatically create a registration for this event.")
     event_ticket_id = fields.Many2one(
         'event.event.ticket', string='Ticket Type',

--- a/addons/fleet/models/fleet_vehicle_assignation_log.py
+++ b/addons/fleet/models/fleet_vehicle_assignation_log.py
@@ -9,7 +9,7 @@ class FleetVehicleAssignationLog(models.Model):
     _description = "Drivers history on a vehicle"
     _order = "create_date desc, date_start desc"
 
-    vehicle_id = fields.Many2one('fleet.vehicle', string="Vehicle", required=True)
+    vehicle_id = fields.Many2one('fleet.vehicle', string="Vehicle", required=True, index=True)
     driver_id = fields.Many2one('res.partner', string="Driver", required=True)
     date_start = fields.Date(string="Start Date")
     date_end = fields.Date(string="End Date")

--- a/addons/fleet/models/fleet_vehicle_log_contract.py
+++ b/addons/fleet/models/fleet_vehicle_log_contract.py
@@ -17,7 +17,7 @@ class FleetVehicleLogContract(models.Model):
         start_date = fields.Date.from_string(strdate)
         return fields.Date.to_string(start_date + oneyear)
 
-    vehicle_id = fields.Many2one('fleet.vehicle', 'Vehicle', required=True, check_company=True, tracking=True)
+    vehicle_id = fields.Many2one('fleet.vehicle', 'Vehicle', required=True, check_company=True, tracking=True, index=True)
     cost_subtype_id = fields.Many2one('fleet.service.type', 'Type', help='Cost type purchased with this cost', domain=[('category', '=', 'contract')])
     amount = fields.Monetary('Cost', tracking=True)
     date = fields.Date(help='Date when the cost has been executed')

--- a/addons/fleet/models/fleet_vehicle_log_services.py
+++ b/addons/fleet/models/fleet_vehicle_log_services.py
@@ -12,7 +12,7 @@ class FleetVehicleLogServices(models.Model):
     _description = 'Services for vehicles'
 
     active = fields.Boolean(default=True)
-    vehicle_id = fields.Many2one('fleet.vehicle', 'Vehicle', required=True)
+    vehicle_id = fields.Many2one('fleet.vehicle', 'Vehicle', required=True, index=True)
     model_id = fields.Many2one('fleet.vehicle.model', 'Model', related='vehicle_id.model_id', store=True)
     brand_id = fields.Many2one('fleet.vehicle.model.brand', 'Brand', related='vehicle_id.model_id.brand_id', store=True)
     manager_id = fields.Many2one('res.users', 'Fleet Manager', related='vehicle_id.manager_id', store=True)

--- a/addons/fleet/models/fleet_vehicle_model.py
+++ b/addons/fleet/models/fleet_vehicle_model.py
@@ -25,7 +25,7 @@ class FleetVehicleModel(models.Model):
     _order = 'name asc'
 
     name = fields.Char('Model name', required=True, tracking=True)
-    brand_id = fields.Many2one('fleet.vehicle.model.brand', 'Manufacturer', required=True, tracking=True)
+    brand_id = fields.Many2one('fleet.vehicle.model.brand', 'Manufacturer', required=True, tracking=True, index='btree_not_null')
     category_id = fields.Many2one('fleet.vehicle.model.category', 'Category', tracking=True)
     vendors = fields.Many2many('res.partner', 'fleet_vehicle_model_vendors', 'model_id', 'partner_id', string='Vendors')
     image_128 = fields.Image(related='brand_id.image_128', readonly=True)

--- a/addons/gamification/models/gamification_challenge.py
+++ b/addons/gamification/models/gamification_challenge.py
@@ -107,7 +107,7 @@ class GamificationChallenge(models.Model):
                                   help="List of goals that will be set",
                                   required=True, copy=True)
 
-    reward_id = fields.Many2one('gamification.badge', string="For Every Succeeding User")
+    reward_id = fields.Many2one('gamification.badge', string="For Every Succeeding User", index='btree_not_null')
     reward_first_id = fields.Many2one('gamification.badge', string="For 1st user")
     reward_second_id = fields.Many2one('gamification.badge', string="For 2nd user")
     reward_third_id = fields.Many2one('gamification.badge', string="For 3rd user")

--- a/addons/gamification/models/gamification_challenge_line.py
+++ b/addons/gamification/models/gamification_challenge_line.py
@@ -15,7 +15,7 @@ class GamificationChallengeLine(models.Model):
     _description = 'Gamification generic goal for challenge'
     _order = "sequence, id"
 
-    challenge_id = fields.Many2one('gamification.challenge', string='Challenge', required=True, ondelete="cascade")
+    challenge_id = fields.Many2one('gamification.challenge', string='Challenge', required=True, index=True, ondelete="cascade")
     definition_id = fields.Many2one('gamification.goal.definition', string='Goal Definition', required=True, ondelete="cascade")
 
     sequence = fields.Integer('Sequence', default=1)

--- a/addons/gamification/models/gamification_goal.py
+++ b/addons/gamification/models/gamification_goal.py
@@ -22,7 +22,7 @@ class GamificationGoal(models.Model):
     _order = 'start_date desc, end_date desc, definition_id, id'
 
     definition_id = fields.Many2one('gamification.goal.definition', string="Goal Definition", required=True, ondelete="cascade")
-    user_id = fields.Many2one('res.users', string="User", required=True, auto_join=True, ondelete="cascade")
+    user_id = fields.Many2one('res.users', string="User", required=True, auto_join=True, index=True, ondelete="cascade")
     user_partner_id = fields.Many2one('res.partner', related='user_id.partner_id')
     line_id = fields.Many2one('gamification.challenge.line', string="Challenge Line", ondelete="cascade")
     challenge_id = fields.Many2one(

--- a/addons/gamification/models/res_users.py
+++ b/addons/gamification/models/res_users.py
@@ -14,7 +14,7 @@ class ResUsers(models.Model):
     gold_badge = fields.Integer('Gold badges count', compute="_get_user_badge_level")
     silver_badge = fields.Integer('Silver badges count', compute="_get_user_badge_level")
     bronze_badge = fields.Integer('Bronze badges count', compute="_get_user_badge_level")
-    rank_id = fields.Many2one('gamification.karma.rank', 'Rank')
+    rank_id = fields.Many2one('gamification.karma.rank', 'Rank', index='btree_not_null')
     next_rank_id = fields.Many2one('gamification.karma.rank', 'Next Rank')
 
     @api.depends('karma_tracking_ids.new_value')

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -48,6 +48,7 @@ class HrEmployee(models.Model):
         readonly=False,
         check_company=True,
         precompute=True,
+        index='btree_not_null',
         ondelete='restrict')
     user_partner_id = fields.Many2one(related='user_id.partner_id', related_sudo=False, string="User's partner")
     active = fields.Boolean('Active', related='resource_id.active', default=True, store=True, readonly=False)
@@ -137,7 +138,7 @@ class HrEmployee(models.Model):
         ], string='Employee Type', default='employee', required=True, groups="hr.group_hr_user",
         help="Categorize your Employees by type. This field also has an impact on contracts. Only Employees, Students and Trainee will have contract history.")
 
-    job_id = fields.Many2one(tracking=True)
+    job_id = fields.Many2one(tracking=True, index=True)
     # employee in company
     child_ids = fields.One2many('hr.employee', 'parent_id', string='Direct subordinates')
     category_ids = fields.Many2many(

--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -16,7 +16,7 @@ class HrEmployeeBase(models.AbstractModel):
     name = fields.Char()
     active = fields.Boolean("Active")
     color = fields.Integer('Color Index', default=0)
-    department_id = fields.Many2one('hr.department', 'Department', check_company=True)
+    department_id = fields.Many2one('hr.department', 'Department', check_company=True, index='btree_not_null')
     member_of_department = fields.Boolean("Member of department", compute='_compute_part_of_department', search='_search_part_of_department',
         help="Whether the employee is a member of the active user's department or one of it's child department.")
     job_id = fields.Many2one('hr.job', 'Job Position', check_company=True)
@@ -35,7 +35,7 @@ class HrEmployeeBase(models.AbstractModel):
     mobile_phone = fields.Char('Work Mobile', compute="_compute_work_contact_details", store=True, inverse='_inverse_work_contact_details')
     work_email = fields.Char('Work Email', compute="_compute_work_contact_details", store=True, inverse='_inverse_work_contact_details')
     email = fields.Char(related="user_id.email")
-    work_contact_id = fields.Many2one('res.partner', 'Work Contact', copy=False)
+    work_contact_id = fields.Many2one('res.partner', 'Work Contact', copy=False, index='btree_not_null')
     work_location_id = fields.Many2one('hr.work.location', 'Work Location', domain="[('address_id', '=', address_id)]")
     work_location_name = fields.Char("Work Location Name", compute="_compute_work_location_name_type")
     work_location_type = fields.Selection([
@@ -48,7 +48,7 @@ class HrEmployeeBase(models.AbstractModel):
     resource_calendar_id = fields.Many2one('resource.calendar', check_company=True)
     is_flexible = fields.Boolean(compute='_compute_is_flexible', store=True)
     is_fully_flexible = fields.Boolean(compute='_compute_is_flexible', store=True)
-    parent_id = fields.Many2one('hr.employee', 'Manager', compute="_compute_parent_id", store=True, readonly=False,
+    parent_id = fields.Many2one('hr.employee', 'Manager', compute="_compute_parent_id", store=True, readonly=False, index=True,
         domain="['|', ('company_id', '=', False), ('company_id', 'in', allowed_company_ids)]")
     coach_id = fields.Many2one(
         'hr.employee', 'Coach', compute='_compute_coach', store=True, readonly=False,

--- a/addons/hr/models/hr_job.py
+++ b/addons/hr/models/hr_job.py
@@ -23,7 +23,7 @@ class HrJob(models.Model):
     employee_ids = fields.One2many('hr.employee', 'job_id', string='Employees', groups='base.group_user')
     description = fields.Html(string='Job Description', sanitize_attributes=False)
     requirements = fields.Text('Requirements')
-    department_id = fields.Many2one('hr.department', string='Department', check_company=True, tracking=True)
+    department_id = fields.Many2one('hr.department', string='Department', check_company=True, tracking=True, index='btree_not_null')
     company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company, tracking=True)
     contract_type_id = fields.Many2one('hr.contract.type', string='Employment Type', tracking=True)
 

--- a/addons/hr/models/mail_activity_plan.py
+++ b/addons/hr/models/mail_activity_plan.py
@@ -9,7 +9,7 @@ class MailActivityPlan(models.Model):
     _inherit = 'mail.activity.plan'
 
     department_id = fields.Many2one(
-        'hr.department', check_company=True,
+        'hr.department', check_company=True, index='btree_not_null',
         compute='_compute_department_id', ondelete='cascade', readonly=False, store=True)
     department_assignable = fields.Boolean(compute='_compute_department_assignable')
 

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -232,6 +232,7 @@ class HrExpense(models.Model):
         comodel_name='account.move',
         readonly=True,
         copy=False,
+        index='btree_not_null',
     )
     payment_mode = fields.Selection(
         selection=[

--- a/addons/hr_fleet/models/fleet_vehicle.py
+++ b/addons/hr_fleet/models/fleet_vehicle.py
@@ -14,6 +14,7 @@ class FleetVehicle(models.Model):
         compute='_compute_driver_employee_id', store=True,
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
         tracking=True,
+        index='btree_not_null',
     )
     driver_employee_name = fields.Char(related="driver_employee_id.name")
     future_driver_employee_id = fields.Many2one(

--- a/addons/hr_holidays/models/hr_leave_accrual_plan.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan.py
@@ -17,7 +17,7 @@ class HrLeaveAccrualPlan(models.Model):
     active = fields.Boolean(default=True)
     name = fields.Char('Name', required=True)
     time_off_type_id = fields.Many2one('hr.leave.type', string="Time Off Type",
-        check_company=True,
+        check_company=True, index='btree_not_null',
         help="""Specify if this accrual plan can only be used with this Time Off Type.
                 Leave empty if this accrual plan can be used with any Time Off Type.""")
     employees_count = fields.Integer("Employees", compute='_compute_employee_count')

--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -24,7 +24,7 @@ class HrLeaveAccrualLevel(models.Model):
     sequence = fields.Integer(
         string='sequence', compute='_compute_sequence', store=True,
         help='Sequence is generated automatically by start time delta.')
-    accrual_plan_id = fields.Many2one('hr.leave.accrual.plan', "Accrual Plan", required=True, ondelete="cascade")
+    accrual_plan_id = fields.Many2one('hr.leave.accrual.plan', "Accrual Plan", required=True, index=True, ondelete="cascade")
     accrued_gain_time = fields.Selection(related='accrual_plan_id.accrued_gain_time')
     start_count = fields.Integer(
         "Start after",

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -119,7 +119,7 @@ class HrLeaveAllocation(models.Model):
     ], string="Allocation Type", default="regular", required=True, readonly=True)
     is_officer = fields.Boolean(compute='_compute_is_officer')
     accrual_plan_id = fields.Many2one('hr.leave.accrual.plan',
-        compute="_compute_accrual_plan_id", inverse="_inverse_accrual_plan_id", store=True, readonly=False, tracking=True,
+        compute="_compute_accrual_plan_id", inverse="_inverse_accrual_plan_id", store=True, index='btree_not_null', readonly=False, tracking=True,
         domain="['|', ('time_off_type_id', '=', False), ('time_off_type_id', '=', holiday_status_id)]")
     max_leaves = fields.Float(compute='_compute_leaves')
     leaves_taken = fields.Float(compute='_compute_leaves', string='Time off Taken')

--- a/addons/hr_maintenance/models/equipment.py
+++ b/addons/hr_maintenance/models/equipment.py
@@ -7,7 +7,7 @@ class MaintenanceEquipment(models.Model):
     _inherit = 'maintenance.equipment'
 
     employee_id = fields.Many2one('hr.employee', compute='_compute_equipment_assign',
-        store=True, readonly=False, string='Assigned Employee', tracking=True)
+        store=True, readonly=False, string='Assigned Employee', tracking=True, index='btree_not_null')
     department_id = fields.Many2one('hr.department', compute='_compute_equipment_assign',
         store=True, readonly=False, string='Assigned Department', tracking=True)
     equipment_assign_to = fields.Selection(

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -69,7 +69,7 @@ class HrApplicant(models.Model):
     type_id = fields.Many2one('hr.recruitment.degree', "Degree")
     availability = fields.Date("Availability", help="The date at which the applicant will be available to start working", tracking=True)
     color = fields.Integer("Color Index", default=0)
-    employee_id = fields.Many2one('hr.employee', string="Employee", help="Employee linked to the applicant.", copy=False)
+    employee_id = fields.Many2one('hr.employee', string="Employee", help="Employee linked to the applicant.", copy=False, index='btree_not_null')
     emp_is_active = fields.Boolean(string="Employee Active", related='employee_id.active')
     employee_name = fields.Char(related='employee_id.name', string="Employee Name", readonly=False, tracking=False)
 

--- a/addons/hr_recruitment_skills/models/hr_applicant_skill.py
+++ b/addons/hr_recruitment_skills/models/hr_applicant_skill.py
@@ -13,6 +13,7 @@ class HrApplicantSkill(models.Model):
     applicant_id = fields.Many2one(
         comodel_name='hr.applicant',
         required=True,
+        index=True,
         ondelete='cascade')
     skill_id = fields.Many2one(
         comodel_name='hr.skill',

--- a/addons/hr_recruitment_survey/models/hr_job.py
+++ b/addons/hr_recruitment_survey/models/hr_job.py
@@ -7,7 +7,7 @@ class HrJob(models.Model):
     _inherit = "hr.job"
 
     survey_id = fields.Many2one(
-        'survey.survey', "Interview Form",
+        'survey.survey', "Interview Form", index='btree_not_null',
         help="Choose an interview form for this job position and you will be able to print/answer this interview from all applicants who apply for this job")
 
     def action_test_survey(self):

--- a/addons/hr_skills/models/hr_employee_skill.py
+++ b/addons/hr_skills/models/hr_employee_skill.py
@@ -13,7 +13,7 @@ class HrEmployeeSkill(models.Model):
     _order = "skill_type_id, skill_level_id"
     _rec_name = "skill_id"
 
-    employee_id = fields.Many2one('hr.employee', required=True, ondelete='cascade')
+    employee_id = fields.Many2one('hr.employee', required=True, index=True, ondelete='cascade')
     skill_id = fields.Many2one('hr.skill', compute='_compute_skill_id', store=True, domain="[('skill_type_id', '=', skill_type_id)]", readonly=False, required=True, ondelete='cascade')
     skill_level_id = fields.Many2one('hr.skill.level', compute='_compute_skill_level_id', domain="[('skill_type_id', '=', skill_type_id)]", store=True, readonly=False, required=True, ondelete='cascade')
     skill_type_id = fields.Many2one('hr.skill.type',

--- a/addons/hr_skills/models/hr_skill.py
+++ b/addons/hr_skills/models/hr_skill.py
@@ -11,7 +11,7 @@ class HrSkill(models.Model):
 
     name = fields.Char(required=True, translate=True)
     sequence = fields.Integer(default=10)
-    skill_type_id = fields.Many2one('hr.skill.type', required=True, ondelete='cascade')
+    skill_type_id = fields.Many2one('hr.skill.type', required=True, index=True, ondelete='cascade')
     color = fields.Integer(related='skill_type_id.color')
 
     @api.depends('skill_type_id')

--- a/addons/hr_skills/models/hr_skill_level.py
+++ b/addons/hr_skills/models/hr_skill_level.py
@@ -9,7 +9,7 @@ class HrSkillLevel(models.Model):
     _description = "Skill Level"
     _order = "level_progress desc"
 
-    skill_type_id = fields.Many2one('hr.skill.type', ondelete='cascade')
+    skill_type_id = fields.Many2one('hr.skill.type', index='btree_not_null', ondelete='cascade')
     name = fields.Char(required=True)
     level_progress = fields.Integer(string="Progress", help="Progress from zero knowledge (0%) to fully mastered (100%).")
     default_level = fields.Boolean(help="If checked, this level will be the default one selected when choosing this skill.")

--- a/addons/hr_work_entry_holidays/models/hr_leave.py
+++ b/addons/hr_work_entry_holidays/models/hr_leave.py
@@ -14,7 +14,7 @@ from odoo.tools import format_date
 class HrLeaveType(models.Model):
     _inherit = 'hr.leave.type'
 
-    work_entry_type_id = fields.Many2one('hr.work.entry.type', string='Work Entry Type')
+    work_entry_type_id = fields.Many2one('hr.work.entry.type', string='Work Entry Type', index='btree_not_null')
 
 
 class HrLeave(models.Model):

--- a/addons/im_livechat/models/chatbot_message.py
+++ b/addons/im_livechat/models/chatbot_message.py
@@ -16,7 +16,7 @@ class ChatbotMessage(models.Model):
     _rec_name = 'discuss_channel_id'
 
     mail_message_id = fields.Many2one('mail.message', string='Related Mail Message', required=True, ondelete="cascade")
-    discuss_channel_id = fields.Many2one('discuss.channel', string='Discussion Channel', required=True, ondelete="cascade")
+    discuss_channel_id = fields.Many2one('discuss.channel', string='Discussion Channel', required=True, index=True, ondelete="cascade")
     script_step_id = fields.Many2one(
         'chatbot.script.step', string='Chatbot Step', required=True, ondelete='cascade')
     user_script_answer_id = fields.Many2one('chatbot.script.answer', string="User's answer", ondelete="set null")

--- a/addons/im_livechat/models/chatbot_script_answer.py
+++ b/addons/im_livechat/models/chatbot_script_answer.py
@@ -19,7 +19,7 @@ class ChatbotScriptAnswer(models.Model):
         help="The visitor will be redirected to this link upon clicking the option "
              "(note that the script will end if the link is external to the livechat website).")
     script_step_id = fields.Many2one(
-        'chatbot.script.step', string='Script Step', required=True, ondelete='cascade')
+        'chatbot.script.step', string='Script Step', required=True, index=True, ondelete='cascade')
     chatbot_script_id = fields.Many2one(related='script_step_id.chatbot_script_id')
 
     @api.depends('script_step_id')

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -21,7 +21,7 @@ class ChatbotScriptStep(models.Model):
     message = fields.Text(string='Message', translate=True)
     sequence = fields.Integer(string='Sequence')
     chatbot_script_id = fields.Many2one(
-        'chatbot.script', string='Chatbot', required=True, ondelete='cascade')
+        'chatbot.script', string='Chatbot', required=True, index=True, ondelete='cascade')
     step_type = fields.Selection([
         ('text', 'Text'),
         ('question_selection', 'Question'),

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -452,7 +452,7 @@ class Im_LivechatChannelRule(models.Model):
         required=True,
         default="always",
     )
-    channel_id = fields.Many2one('im_livechat.channel', 'Channel',
+    channel_id = fields.Many2one('im_livechat.channel', 'Channel', index='btree_not_null',
         help="The channel of the rule")
     country_ids = fields.Many2many('res.country', 'im_livechat_channel_country_rel', 'channel_id', 'country_id', 'Country',
         help="The rule will only be applied for these countries. Example: if you select 'Belgium' and 'United States' and that you set the action to 'Hide', the chat button will be hidden on the specified URL from the visitors located in these 2 countries. This feature requires GeoIP installed on your server.")

--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -298,7 +298,7 @@ class LinkTrackerCode(models.Model):
     _rec_name = 'code'
 
     code = fields.Char(string='Short URL Code', required=True, store=True)
-    link_id = fields.Many2one('link.tracker', 'Link', required=True, ondelete='cascade')
+    link_id = fields.Many2one('link.tracker', 'Link', required=True, index=True, ondelete='cascade')
 
     _code = models.Constraint(
         'unique( code )',

--- a/addons/loyalty/models/loyalty_card.py
+++ b/addons/loyalty/models/loyalty_card.py
@@ -28,6 +28,7 @@ class LoyaltyCard(models.Model):
     program_id = fields.Many2one(
         comodel_name='loyalty.program',
         ondelete='restrict',
+        index='btree_not_null',
         default=lambda self: self.env.context.get('active_id', None),
     )
     program_type = fields.Selection(related='program_id.program_type')

--- a/addons/loyalty/models/loyalty_history.py
+++ b/addons/loyalty/models/loyalty_history.py
@@ -8,7 +8,7 @@ class LoyaltyHistory(models.Model):
     _description = "History for Loyalty cards and Ewallets"
     _order = 'id desc'
 
-    card_id = fields.Many2one(comodel_name='loyalty.card', required=True, ondelete='cascade')
+    card_id = fields.Many2one(comodel_name='loyalty.card', required=True, index=True, ondelete='cascade')
     company_id = fields.Many2one(related='card_id.company_id')
 
     description = fields.Text(required=True)

--- a/addons/loyalty/models/loyalty_mail.py
+++ b/addons/loyalty/models/loyalty_mail.py
@@ -12,7 +12,7 @@ class LoyaltyMail(models.Model):
     _description = "Loyalty Communication"
 
     active = fields.Boolean(default=True)
-    program_id = fields.Many2one(comodel_name='loyalty.program', ondelete='cascade', required=True)
+    program_id = fields.Many2one(comodel_name='loyalty.program', ondelete='cascade', required=True, index=True)
     trigger = fields.Selection(
         string="When",
         selection=[

--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -45,7 +45,7 @@ class LoyaltyReward(models.Model):
             reward.display_name = f"{reward.program_id.name} - {reward.description}"
 
     active = fields.Boolean(default=True)
-    program_id = fields.Many2one(comodel_name='loyalty.program', ondelete='cascade', required=True)
+    program_id = fields.Many2one(comodel_name='loyalty.program', ondelete='cascade', required=True, index=True)
     program_type = fields.Selection(related='program_id.program_type')
     # Stored for security rules
     company_id = fields.Many2one(related='program_id.company_id', store=True)

--- a/addons/loyalty/models/loyalty_rule.py
+++ b/addons/loyalty/models/loyalty_rule.py
@@ -37,7 +37,7 @@ class LoyaltyRule(models.Model):
         ]
 
     active = fields.Boolean(default=True)
-    program_id = fields.Many2one(comodel_name='loyalty.program', ondelete='cascade', required=True)
+    program_id = fields.Many2one(comodel_name='loyalty.program', ondelete='cascade', required=True, index=True)
     program_type = fields.Selection(related='program_id.program_type')
     # Stored for security rules
     company_id = fields.Many2one(related='program_id.company_id', store=True)

--- a/addons/lunch/models/lunch_topping.py
+++ b/addons/lunch/models/lunch_topping.py
@@ -14,7 +14,7 @@ class LunchTopping(models.Model):
     company_id = fields.Many2one('res.company', default=lambda self: self.env.company)
     currency_id = fields.Many2one('res.currency', related='company_id.currency_id')
     price = fields.Monetary('Price', required=True)
-    supplier_id = fields.Many2one('lunch.supplier', ondelete='cascade')
+    supplier_id = fields.Many2one('lunch.supplier', ondelete='cascade', index='btree_not_null')
     topping_category = fields.Integer('Topping Category', required=True, default=1)
 
     @api.depends('price')

--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -20,7 +20,7 @@ class DiscussChannelRtcSession(models.Model):
     _rec_name = 'channel_member_id'
 
     channel_member_id = fields.Many2one('discuss.channel.member', required=True, ondelete='cascade')
-    channel_id = fields.Many2one('discuss.channel', related='channel_member_id.channel_id', store=True, readonly=True)
+    channel_id = fields.Many2one('discuss.channel', related='channel_member_id.channel_id', store=True, readonly=True, index='btree_not_null')
     partner_id = fields.Many2one('res.partner', related='channel_member_id.partner_id', string="Partner", store=True, index=True)
     guest_id = fields.Many2one('mail.guest', related='channel_member_id.guest_id')
 

--- a/addons/mail/models/mail_activity_plan_template.py
+++ b/addons/mail/models/mail_activity_plan_template.py
@@ -15,7 +15,7 @@ class MailActivityPlanTemplate(models.Model):
 
     plan_id = fields.Many2one(
         'mail.activity.plan', string="Plan",
-        ondelete='cascade', required=True)
+        ondelete='cascade', required=True, index=True)
     res_model = fields.Selection(related="plan_id.res_model")
     company_id = fields.Many2one(related='plan_id.company_id')
     sequence = fields.Integer(default=10)

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -93,7 +93,7 @@ class MailMail(models.Model):
         help="This option permanently removes any track of email after it's been sent, including from the Technical menu in the Settings, in order to preserve storage space of your Odoo database.")
     scheduled_date = fields.Datetime('Scheduled Send Date',
         help="If set, the queue manager will send the email after the date. If not set, the email will be send as soon as possible. Unless a timezone is specified, it is considered as being in UTC timezone.")
-    fetchmail_server_id = fields.Many2one('fetchmail.server', "Inbound Mail Server", readonly=True)
+    fetchmail_server_id = fields.Many2one('fetchmail.server', "Inbound Mail Server", readonly=True, index='btree_not_null')
 
     def _compute_body_content(self):
         for mail in self:

--- a/addons/mail/models/mail_message_reaction.py
+++ b/addons/mail/models/mail_message_reaction.py
@@ -11,7 +11,7 @@ class MailMessageReaction(models.Model):
     _order = 'id desc'
     _log_access = False
 
-    message_id = fields.Many2one(string="Message", comodel_name='mail.message', ondelete='cascade', required=True, readonly=True)
+    message_id = fields.Many2one(string="Message", comodel_name='mail.message', ondelete='cascade', required=True, readonly=True, index=True)
     content = fields.Char(string="Content", required=True, readonly=True)
     partner_id = fields.Many2one(string="Reacting Partner", comodel_name='res.partner', ondelete='cascade', readonly=True)
     guest_id = fields.Many2one(string="Reacting Guest", comodel_name='mail.guest', ondelete='cascade', readonly=True)

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -83,7 +83,7 @@ class MailTemplate(models.Model):
         domain="[('model', '=', model)]")
     email_layout_xmlid = fields.Char('Email Notification Layout', copy=False)
     # options
-    mail_server_id = fields.Many2one('ir.mail_server', 'Outgoing Mail Server', readonly=False,
+    mail_server_id = fields.Many2one('ir.mail_server', 'Outgoing Mail Server', readonly=False, index='btree_not_null',
                                      help="Optional preferred server for outgoing mails. If not set, the highest "
                                           "priority one will be used.")
     scheduled_date = fields.Char('Scheduled Date', help="If set, the queue manager will send the email after the date. If not set, the email will be send as soon as possible. You can use dynamic expression.")

--- a/addons/mail/models/res_company.py
+++ b/addons/mail/models/res_company.py
@@ -11,7 +11,7 @@ class ResCompany(models.Model):
         return self.env['mail.alias.domain'].search([], limit=1)
 
     alias_domain_id = fields.Many2one(
-        'mail.alias.domain', string='Email Domain',
+        'mail.alias.domain', string='Email Domain', index='btree_not_null',
         default=lambda self: self._default_alias_domain_id())
     bounce_email = fields.Char(string="Bounce Email", compute="_compute_bounce")
     bounce_formatted = fields.Char(string="Bounce", compute="_compute_bounce")

--- a/addons/mail_group/models/mail_group_member.py
+++ b/addons/mail_group/models/mail_group_member.py
@@ -19,7 +19,7 @@ class MailGroupMember(models.Model):
     email_normalized = fields.Char(
         string='Normalized Email', compute='_compute_email_normalized',
         index=True, store=True)
-    mail_group_id = fields.Many2one('mail.group', string='Group', required=True, ondelete='cascade')
+    mail_group_id = fields.Many2one('mail.group', string='Group', required=True, index=True, ondelete='cascade')
     partner_id = fields.Many2one('res.partner', 'Partner', ondelete='cascade')
 
     _unique_partner = models.Constraint(

--- a/addons/mail_group/models/mail_group_message.py
+++ b/addons/mail_group/models/mail_group_message.py
@@ -37,11 +37,11 @@ class MailGroupMessage(models.Model):
     # Thread
     mail_group_id = fields.Many2one(
         'mail.group', string='Group',
-        required=True, ondelete='cascade')
+        required=True, index=True, ondelete='cascade')
     mail_message_id = fields.Many2one('mail.message', 'Mail Message', required=True, ondelete='cascade', index=True, copy=False)
     # Parent and children
     group_message_parent_id = fields.Many2one(
-        'mail.group.message', string='Parent', store=True)
+        'mail.group.message', string='Parent', store=True, index=True)
     group_message_child_ids = fields.One2many('mail.group.message', 'group_message_parent_id', string='Children')
     # Moderation
     author_moderation = fields.Selection([('ban', 'Banned'), ('allow', 'Whitelisted')], string='Author Moderation Status',

--- a/addons/mail_group/models/mail_group_moderation.py
+++ b/addons/mail_group/models/mail_group_moderation.py
@@ -15,7 +15,7 @@ class MailGroupModeration(models.Model):
     status = fields.Selection(
         [('allow', 'Always Allow'), ('ban', 'Permanent Ban')],
         string='Status', required=True, default='ban')
-    mail_group_id = fields.Many2one('mail.group', string='Group', required=True, ondelete='cascade')
+    mail_group_id = fields.Many2one('mail.group', string='Group', required=True, index=True, ondelete='cascade')
 
     _mail_group_email_uniq = models.Constraint(
         'UNIQUE(mail_group_id, email)',

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -85,7 +85,7 @@ class MaintenanceMixin(models.AbstractModel):
     company_id = fields.Many2one('res.company', string='Company',
         default=lambda self: self.env.company)
     effective_date = fields.Date('Effective Date', default=fields.Date.context_today, required=True, help="This date will be used to compute the Mean Time Between Failure.")
-    maintenance_team_id = fields.Many2one('maintenance.team', string='Maintenance Team', compute='_compute_maintenance_team_id', store=True, readonly=False, check_company=True)
+    maintenance_team_id = fields.Many2one('maintenance.team', string='Maintenance Team', compute='_compute_maintenance_team_id', store=True, readonly=False, check_company=True, index='btree_not_null')
     technician_user_id = fields.Many2one('res.users', string='Technician', tracking=True)
     maintenance_ids = fields.One2many('maintenance.request')  # needs to be extended in order to specify inverse_name !
     maintenance_count = fields.Integer(compute='_compute_maintenance_count', string="Maintenance Count", store=True)
@@ -140,9 +140,9 @@ class MaintenanceEquipment(models.Model):
 
     name = fields.Char('Equipment Name', required=True, translate=True)
     active = fields.Boolean(default=True)
-    owner_user_id = fields.Many2one('res.users', string='Owner', tracking=True)
+    owner_user_id = fields.Many2one('res.users', string='Owner', tracking=True, index='btree_not_null')
     category_id = fields.Many2one('maintenance.equipment.category', string='Equipment Category',
-                                  tracking=True, group_expand='_read_group_category_ids')
+                                  tracking=True, group_expand='_read_group_category_ids', index='btree_not_null')
     partner_id = fields.Many2one('res.partner', string='Vendor', check_company=True)
     partner_ref = fields.Char('Vendor Reference')
     model = fields.Char('Model')
@@ -222,7 +222,7 @@ class MaintenanceRequest(models.Model):
     request_date = fields.Date('Request Date', tracking=True, default=fields.Date.context_today,
                                help="Date requested for the maintenance to happen")
     owner_user_id = fields.Many2one('res.users', string='Created by User', default=lambda s: s.env.uid)
-    category_id = fields.Many2one('maintenance.equipment.category', related='equipment_id.category_id', string='Category', store=True, readonly=True)
+    category_id = fields.Many2one('maintenance.equipment.category', related='equipment_id.category_id', string='Category', store=True, readonly=True, index='btree_not_null')
     equipment_id = fields.Many2one('maintenance.equipment', string='Equipment',
                                    ondelete='restrict', index=True, check_company=True)
     user_id = fields.Many2one('res.users', string='Technician', compute='_compute_user_id', store=True, readonly=False, tracking=True)
@@ -237,7 +237,7 @@ class MaintenanceRequest(models.Model):
     archive = fields.Boolean(default=False, help="Set archive to true to hide the maintenance request without deleting it.")
     maintenance_type = fields.Selection([('corrective', 'Corrective'), ('preventive', 'Preventive')], string='Maintenance Type', default="corrective")
     schedule_date = fields.Datetime('Scheduled Date', help="Date the maintenance team plans the maintenance.  It should not differ much from the Request Date. ")
-    maintenance_team_id = fields.Many2one('maintenance.team', string='Team', required=True, default=_get_default_team_id,
+    maintenance_team_id = fields.Many2one('maintenance.team', string='Team', required=True, index=True, default=_get_default_team_id,
                                           compute='_compute_maintenance_team_id', store=True, readonly=False, check_company=True)
     duration = fields.Float(help="Duration in hours.")
     done = fields.Boolean(related='stage_id.done')

--- a/addons/marketing_card/models/card_card.py
+++ b/addons/marketing_card/models/card_card.py
@@ -9,7 +9,7 @@ class CardCard(models.Model):
     _description = 'Marketing Card'
 
     active = fields.Boolean('Active', default=True)
-    campaign_id = fields.Many2one('card.campaign', required=True, ondelete="cascade")
+    campaign_id = fields.Many2one('card.campaign', required=True, index=True, ondelete="cascade")
     res_model = fields.Selection(related='campaign_id.res_model')
     res_id = fields.Many2oneReference('Record ID', model_field='res_model', required=True)
     image = fields.Image()

--- a/addons/marketing_card/models/mailing_mailing.py
+++ b/addons/marketing_card/models/mailing_mailing.py
@@ -6,7 +6,7 @@ class MailingMailing(models.Model):
 
     mailing_model_id = fields.Many2one(compute="_compute_mailing_model_id", store=True, readonly=False)
     card_requires_sync_count = fields.Integer(compute="_compute_card_requires_sync_count")
-    card_campaign_id = fields.Many2one('card.campaign')
+    card_campaign_id = fields.Many2one('card.campaign', index='btree_not_null')
 
     @api.constrains('card_campaign_id', 'mailing_domain', 'mailing_model_id')
     def _check_mailing_domain(self):

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -173,6 +173,7 @@ class MailingMailing(models.Model):
         compute='_compute_mail_server_available',
         help="Technical field used to know if the user has activated the outgoing mail server option in the settings")
     mail_server_id = fields.Many2one('ir.mail_server', string='Mail Server',
+        index='btree_not_null',
         default=_get_default_mail_server_id,
         help="Use a specific mail server in priority. Otherwise Odoo relies on the first outgoing mail server available (based on their sequencing) as it does for normal mails.")
     contact_list_ids = fields.Many2many('mailing.list', 'mail_mass_mailing_list_rel', string='Mailing Lists')

--- a/addons/mass_mailing/models/mailing_subscription.py
+++ b/addons/mass_mailing/models/mailing_subscription.py
@@ -15,7 +15,7 @@ class MailingSubscription(models.Model):
     _order = 'list_id DESC, contact_id DESC'
 
     contact_id = fields.Many2one('mailing.contact', string='Contact', ondelete='cascade', required=True)
-    list_id = fields.Many2one('mailing.list', string='Mailing List', ondelete='cascade', required=True)
+    list_id = fields.Many2one('mailing.list', string='Mailing List', ondelete='cascade', required=True, index=True)
     opt_out = fields.Boolean(
         string='Opt Out',
         default=False,

--- a/addons/mass_mailing_sms/models/sms_tracker.py
+++ b/addons/mass_mailing_sms/models/sms_tracker.py
@@ -15,7 +15,7 @@ class SmsTracker(models.Model):
         'sent': 'sent',
     }
 
-    mailing_trace_id = fields.Many2one('mailing.trace', ondelete='cascade')
+    mailing_trace_id = fields.Many2one('mailing.trace', ondelete='cascade', index='btree_not_null')
 
     def _action_update_from_provider_error(self, provider_error):
         error_status, failure_type, failure_reason = super()._action_update_from_provider_error(provider_error)

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -547,7 +547,7 @@ class MrpBomLine(models.Model):
     def _get_default_product_uom_id(self):
         return self.env['uom.uom'].search([], limit=1, order='id').id
 
-    product_id = fields.Many2one('product.product', 'Component', required=True, check_company=True)
+    product_id = fields.Many2one('product.product', 'Component', required=True, check_company=True, index=True)
     product_tmpl_id = fields.Many2one('product.template', 'Product Template', related='product_id.product_tmpl_id', store=True, index=True)
     company_id = fields.Many2one(
         related='bom_id.company_id', store=True, index=True, readonly=True)

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -210,7 +210,7 @@ class MrpProduction(models.Model):
     qty_produced = fields.Float(compute="_get_produced_qty", string="Quantity Produced")
     procurement_group_id = fields.Many2one(
         'procurement.group', 'Procurement Group',
-        copy=False)
+        copy=False, index='btree_not_null')
     product_description_variants = fields.Char('Custom Description')
     orderpoint_id = fields.Many2one('stock.warehouse.orderpoint', 'Orderpoint', copy=False, index='btree_not_null')
     propagate_cancel = fields.Boolean(

--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -16,7 +16,7 @@ class MrpRoutingWorkcenter(models.Model):
 
     name = fields.Char('Operation', required=True)
     active = fields.Boolean(default=True)
-    workcenter_id = fields.Many2one('mrp.workcenter', 'Work Center', required=True, check_company=True, tracking=True)
+    workcenter_id = fields.Many2one('mrp.workcenter', 'Work Center', required=True, check_company=True, tracking=True, index=True)
     sequence = fields.Integer(
         'Sequence', default=100,
         help="Gives the sequence order when displaying a list of routing Work Centers.")

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -50,7 +50,7 @@ class MrpUnbuild(models.Model):
     mo_id = fields.Many2one(
         'mrp.production', 'Manufacturing Order',
         domain="[('state', '=', 'done'), ('product_id', '=?', product_id), ('bom_id', '=?', bom_id)]",
-        check_company=True)
+        check_company=True, index='btree_not_null')
     mo_bom_id = fields.Many2one('mrp.bom', 'Bill of Material used on the Production Order', related='mo_id.bom_id')
     lot_id = fields.Many2one(
         'stock.lot', 'Lot/Serial Number',

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -592,7 +592,7 @@ class MrpWorkcenterCapacity(models.Model):
         workcenter_id = self.workcenter_id.id or self.env.context.get('default_workcenter_id')
         return self.env['mrp.workcenter'].browse(workcenter_id).time_stop if workcenter_id else 0.0
 
-    workcenter_id = fields.Many2one('mrp.workcenter', string='Work Center', required=True)
+    workcenter_id = fields.Many2one('mrp.workcenter', string='Work Center', required=True, index=True)
     product_id = fields.Many2one('product.product', string='Product', required=True)
     product_uom_id = fields.Many2one('uom.uom', string='Product Unit', related='product_id.uom_id')
     capacity = fields.Float('Capacity', default=1.0, help="Number of pieces that can be produced in parallel for this product.")

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -31,7 +31,7 @@ class MrpWorkorder(models.Model):
     sequence = fields.Integer("Sequence", default=_default_sequence)
     barcode = fields.Char(compute='_compute_barcode', store=True)
     workcenter_id = fields.Many2one(
-        'mrp.workcenter', 'Work Center', required=True,
+        'mrp.workcenter', 'Work Center', required=True, index=True,
         group_expand='_read_group_workcenter_id', check_company=True)
     working_state = fields.Selection(
         string='Workcenter Status', related='workcenter_id.working_state') # technical: used in views only
@@ -98,7 +98,7 @@ class MrpWorkorder(models.Model):
     progress = fields.Float('Progress Done (%)', digits=(16, 2), compute='_compute_progress')
 
     operation_id = fields.Many2one(
-        'mrp.routing.workcenter', 'Operation', check_company=True)
+        'mrp.routing.workcenter', 'Operation', check_company=True, index='btree_not_null')
         # Should be used differently as BoM can change in the meantime
     worksheet = fields.Binary(
         'Worksheet', related='operation_id.worksheet', readonly=True)

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -12,7 +12,7 @@ from odoo.exceptions import ValidationError
 class StockMoveLine(models.Model):
     _inherit = 'stock.move.line'
 
-    workorder_id = fields.Many2one('mrp.workorder', 'Work Order', check_company=True)
+    workorder_id = fields.Many2one('mrp.workorder', 'Work Order', check_company=True, index='btree_not_null')
     production_id = fields.Many2one('mrp.production', 'Production Order', check_company=True)
     description_bom_line = fields.Char(related='move_id.description_bom_line')
 
@@ -149,9 +149,9 @@ class StockMove(models.Model):
     raw_material_production_id = fields.Many2one(
         'mrp.production', 'Production Order for components', check_company=True, index='btree_not_null')
     unbuild_id = fields.Many2one(
-        'mrp.unbuild', 'Disassembly Order', check_company=True)
+        'mrp.unbuild', 'Disassembly Order', check_company=True, index='btree_not_null')
     consume_unbuild_id = fields.Many2one(
-        'mrp.unbuild', 'Consumed Disassembly Order', check_company=True)
+        'mrp.unbuild', 'Consumed Disassembly Order', check_company=True, index='btree_not_null')
     allowed_operation_ids = fields.One2many(
         'mrp.routing.workcenter', related='raw_material_production_id.bom_id.operation_ids')
     operation_id = fields.Many2one(

--- a/addons/mrp/models/stock_scrap.py
+++ b/addons/mrp/models/stock_scrap.py
@@ -9,9 +9,11 @@ class StockScrap(models.Model):
 
     production_id = fields.Many2one(
         'mrp.production', 'Manufacturing Order',
+        index='btree_not_null',
         check_company=True)
     workorder_id = fields.Many2one(
         'mrp.workorder', 'Work Order',
+        index='btree_not_null',
         check_company=True) # Not to restrict or prefer quants, but informative
     product_is_kit = fields.Boolean(related='product_id.is_kits')
     product_template = fields.Many2one(related='product_id.product_tmpl_id')

--- a/addons/onboarding/models/onboarding_progress.py
+++ b/addons/onboarding/models/onboarding_progress.py
@@ -21,7 +21,7 @@ class OnboardingProgress(models.Model):
     is_onboarding_closed = fields.Boolean('Was panel closed?')
     company_id = fields.Many2one('res.company', ondelete='cascade')
     onboarding_id = fields.Many2one(
-        'onboarding.onboarding', 'Related onboarding tracked', required=True, ondelete='cascade')
+        'onboarding.onboarding', 'Related onboarding tracked', required=True, index=True, ondelete='cascade')
     progress_step_ids = fields.Many2many('onboarding.progress.step', string='Progress Steps Trackers')
 
     # not in _sql_constraint because COALESCE is not supported for PostgreSQL constraint

--- a/addons/onboarding/models/onboarding_progress_step.py
+++ b/addons/onboarding/models/onboarding_progress_step.py
@@ -14,7 +14,7 @@ class OnboardingProgressStep(models.Model):
     step_state = fields.Selection(
         ONBOARDING_PROGRESS_STATES, string='Onboarding Step Progress', default='not_done')
     step_id = fields.Many2one(
-        'onboarding.onboarding.step', string='Onboarding Step', required=True, ondelete='cascade')
+        'onboarding.onboarding.step', string='Onboarding Step', required=True, index=True, ondelete='cascade')
 
     company_id = fields.Many2one('res.company', ondelete='cascade')
 

--- a/addons/payment/models/payment_method.py
+++ b/addons/payment/models/payment_method.py
@@ -24,6 +24,7 @@ class PaymentMethod(models.Model):
         help="The primary payment method of the current payment method, if the latter is a brand."
              "\nFor example, \"Card\" is the primary payment method of the card brand \"VISA\".",
         comodel_name='payment.method',
+        index='btree_not_null',
     )
     brand_ids = fields.One2many(
         string="Brands",

--- a/addons/payment/models/payment_token.py
+++ b/addons/payment/models/payment_token.py
@@ -24,7 +24,7 @@ class PaymentToken(models.Model):
     payment_details = fields.Char(
         string="Payment Details", help="The clear part of the payment method's payment details.",
     )
-    partner_id = fields.Many2one(string="Partner", comodel_name='res.partner', required=True)
+    partner_id = fields.Many2one(string="Partner", comodel_name='res.partner', required=True, index=True)
     provider_ref = fields.Char(
         string="Provider Reference",
         help="The provider reference of the token of the transaction.",

--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -54,7 +54,7 @@ class PaymentTransaction(models.Model):
     currency_id = fields.Many2one(
         string="Currency", comodel_name='res.currency', readonly=True, required=True)
     token_id = fields.Many2one(
-        string="Payment Token", comodel_name='payment.token', readonly=True,
+        string="Payment Token", comodel_name='payment.token', readonly=True, index='btree_not_null',
         domain='[("provider_id", "=", "provider_id")]', ondelete='restrict')
     state = fields.Selection(
         string="Status",
@@ -84,6 +84,7 @@ class PaymentTransaction(models.Model):
     source_transaction_id = fields.Many2one(
         string="Source Transaction",
         comodel_name='payment.transaction',
+        index='btree_not_null',
         help="The source transaction of the related child transactions",
         readonly=True,
     )

--- a/addons/point_of_sale/models/account_bank_statement.py
+++ b/addons/point_of_sale/models/account_bank_statement.py
@@ -8,4 +8,4 @@ from odoo.exceptions import UserError
 class AccountBankStatementLine(models.Model):
     _inherit = 'account.bank.statement.line'
 
-    pos_session_id = fields.Many2one('pos.session', string="Session", copy=False)
+    pos_session_id = fields.Many2one('pos.session', string="Session", copy=False, index='btree_not_null')

--- a/addons/point_of_sale/models/account_payment.py
+++ b/addons/point_of_sale/models/account_payment.py
@@ -9,7 +9,7 @@ class AccountPayment(models.Model):
 
     pos_payment_method_id = fields.Many2one('pos.payment.method', "POS Payment Method")
     force_outstanding_account_id = fields.Many2one("account.account", "Forced Outstanding Account", check_company=True)
-    pos_session_id = fields.Many2one('pos.session', "POS Session")
+    pos_session_id = fields.Many2one('pos.session', "POS Session", index='btree_not_null')
 
     def _get_valid_liquidity_accounts(self):
         result = super()._get_valid_liquidity_accounts()

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1385,12 +1385,12 @@ class PosOrderLine(models.Model):
     full_product_name = fields.Char('Full Product Name')
     customer_note = fields.Char('Customer Note')
     refund_orderline_ids = fields.One2many('pos.order.line', 'refunded_orderline_id', 'Refund Order Lines', help='Orderlines in this field are the lines that refunded this orderline.')
-    refunded_orderline_id = fields.Many2one('pos.order.line', 'Refunded Order Line', help='If this orderline is a refund, then the refunded orderline is specified in this field.')
+    refunded_orderline_id = fields.Many2one('pos.order.line', 'Refunded Order Line', index='btree_not_null', help='If this orderline is a refund, then the refunded orderline is specified in this field.')
     refunded_qty = fields.Float('Refunded Quantity', compute='_compute_refund_qty', help='Number of items refunded in this orderline.')
     uuid = fields.Char(string='Uuid', readonly=True, default=lambda self: str(uuid4()), copy=False)
     note = fields.Char('Product Note')
 
-    combo_parent_id = fields.Many2one('pos.order.line', string='Combo Parent') # FIXME rename to parent_line_id
+    combo_parent_id = fields.Many2one('pos.order.line', string='Combo Parent', index='btree_not_null') # FIXME rename to parent_line_id
     combo_line_ids = fields.One2many('pos.order.line', 'combo_parent_id', string='Combo Lines') # FIXME rename to child_line_ids
 
     combo_item_id = fields.Many2one('product.combo.item', string='Combo Item')
@@ -1732,7 +1732,7 @@ class PosPackOperationLot(models.Model):
     _rec_name = "lot_name"
     _inherit = ['pos.load.mixin']
 
-    pos_order_line_id = fields.Many2one('pos.order.line')
+    pos_order_line_id = fields.Many2one('pos.order.line', index='btree_not_null')
     order_id = fields.Many2one('pos.order', related="pos_order_line_id.order_id", readonly=False)
     lot_name = fields.Char('Lot Name')
     product_id = fields.Many2one('product.product', related='pos_order_line_id.product_id', readonly=False)

--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -34,6 +34,7 @@ class PosPaymentMethod(models.Model):
         string='Journal',
         domain=['|', '&', ('type', '=', 'cash'), ('pos_payment_method_ids', '=', False), ('type', '=', 'bank')],
         ondelete='restrict',
+        index='btree_not_null',
         help='Leave empty to use the receivable account of customer.\n'
              'Defines the journal where to book the accumulated payments (or individual payment if Identify Customer is true) after closing the session.\n'
              'For cash journal, we directly write to the default account in the journal via statement lines.\n'

--- a/addons/point_of_sale/models/product_attribute.py
+++ b/addons/point_of_sale/models/product_attribute.py
@@ -15,7 +15,7 @@ class ProductAttributeCustomValue(models.Model):
     _name = 'product.attribute.custom.value'
     _inherit = ["product.attribute.custom.value", "pos.load.mixin"]
 
-    pos_order_line_id = fields.Many2one('pos.order.line', string="PoS Order Line", ondelete='cascade')
+    pos_order_line_id = fields.Many2one('pos.order.line', string="PoS Order Line", ondelete='cascade', index='btree_not_null')
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/pos_event/models/event_registration.py
+++ b/addons/pos_event/models/event_registration.py
@@ -8,7 +8,7 @@ class EventRegistration(models.Model):
     _inherit = ['event.registration', 'pos.load.mixin']
 
     pos_order_id = fields.Many2one(related='pos_order_line_id.order_id', string='PoS Order')
-    pos_order_line_id = fields.Many2one('pos.order.line', string='PoS Order Line', ondelete='cascade', copy=False)
+    pos_order_line_id = fields.Many2one('pos.order.line', string='PoS Order Line', ondelete='cascade', copy=False, index='btree_not_null')
 
     def _has_order(self):
         return super()._has_order() or self.pos_order_id

--- a/addons/pos_restaurant/models/pos_restaurant.py
+++ b/addons/pos_restaurant/models/pos_restaurant.py
@@ -93,7 +93,7 @@ class RestaurantTable(models.Model):
     _description = 'Restaurant Table'
     _inherit = ['pos.load.mixin']
 
-    floor_id = fields.Many2one('restaurant.floor', string='Floor')
+    floor_id = fields.Many2one('restaurant.floor', string='Floor', index='btree_not_null')
     table_number = fields.Integer('Table Number', required=True, help='The number of the table as displayed on the floor plan', default=0)
     shape = fields.Selection([('square', 'Square'), ('round', 'Round')], string='Shape', required=True, default='square')
     position_h = fields.Float('Horizontal Position', default=10,

--- a/addons/pos_sale/models/pos_config.py
+++ b/addons/pos_sale/models/pos_config.py
@@ -8,7 +8,7 @@ class PosConfig(models.Model):
     _inherit = 'pos.config'
 
     crm_team_id = fields.Many2one(
-        'crm.team', string="Sales Team", ondelete="set null",
+        'crm.team', string="Sales Team", ondelete="set null", index='btree_not_null',
         help="This Point of sale's sales will be related to this Sales Team.")
     down_payment_product_id = fields.Many2one('product.product',
         string="Down Payment Product",

--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -184,8 +184,8 @@ class PosOrder(models.Model):
 class PosOrderLine(models.Model):
     _inherit = 'pos.order.line'
 
-    sale_order_origin_id = fields.Many2one('sale.order', string="Linked Sale Order")
-    sale_order_line_id = fields.Many2one('sale.order.line', string="Source Sale Order Line")
+    sale_order_origin_id = fields.Many2one('sale.order', string="Linked Sale Order", index='btree_not_null')
+    sale_order_line_id = fields.Many2one('sale.order.line', string="Source Sale Order Line", index='btree_not_null')
     down_payment_details = fields.Text(string="Down Payment Details")
     qty_delivered = fields.Float(
         string="Delivery Quantity",

--- a/addons/product/models/product_combo_item.py
+++ b/addons/product/models/product_combo_item.py
@@ -10,7 +10,7 @@ class ProductComboItem(models.Model):
     _check_company_auto = True
 
     company_id = fields.Many2one(related='combo_id.company_id', precompute=True, store=True)
-    combo_id = fields.Many2one(comodel_name='product.combo', ondelete='cascade', required=True)
+    combo_id = fields.Many2one(comodel_name='product.combo', ondelete='cascade', required=True, index=True)
     product_id = fields.Many2one(
         string="Product",
         comodel_name='product.product',

--- a/addons/product/models/product_uom.py
+++ b/addons/product/models/product_uom.py
@@ -10,8 +10,8 @@ class ProductUom(models.Model):
     _description = 'Link between products and their UoMs'
     _rec_name = 'barcode'
 
-    uom_id = fields.Many2one('uom.uom', 'Unit', required=True, ondelete='cascade')
-    product_id = fields.Many2one('product.product', 'Product', required=True, ondelete='cascade')
+    uom_id = fields.Many2one('uom.uom', 'Unit', required=True, index=True, ondelete='cascade')
+    product_id = fields.Many2one('product.product', 'Product', required=True, index=True, ondelete='cascade')
     barcode = fields.Char(index='btree_not_null', required=True, copy=False)
     company_id = fields.Many2one('res.company', 'Company', default=lambda self: self.env.company)
 

--- a/addons/project/models/project_collaborator.py
+++ b/addons/project/models/project_collaborator.py
@@ -7,7 +7,7 @@ class ProjectCollaborator(models.Model):
     _name = 'project.collaborator'
     _description = 'Collaborators in project shared'
 
-    project_id = fields.Many2one('project.project', 'Project Shared', domain=[('privacy_visibility', '=', 'portal')], required=True, readonly=True, export_string_translation=False)
+    project_id = fields.Many2one('project.project', 'Project Shared', domain=[('privacy_visibility', '=', 'portal')], required=True, readonly=True, export_string_translation=False, index=True)
     partner_id = fields.Many2one('res.partner', 'Collaborator', required=True, readonly=True, export_string_translation=False)
     partner_email = fields.Char(related='partner_id.email', export_string_translation=False)
     limited_access = fields.Boolean('Limited Access', default=False, export_string_translation=False)

--- a/addons/project/models/project_milestone.py
+++ b/addons/project/models/project_milestone.py
@@ -20,7 +20,7 @@ class ProjectMilestone(models.Model):
 
     name = fields.Char(required=True)
     sequence = fields.Integer('Sequence', default=10)
-    project_id = fields.Many2one('project.project', required=True, default=_get_default_project_id, ondelete='cascade')
+    project_id = fields.Many2one('project.project', required=True, default=_get_default_project_id, index=True, ondelete='cascade')
     deadline = fields.Date(tracking=True, copy=False)
     is_reached = fields.Boolean(string="Reached", default=False, copy=False)
     reached_date = fields.Date(compute='_compute_reached_date', store=True, export_string_translation=False)

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -88,7 +88,7 @@ class ProjectProject(models.Model):
     description = fields.Html(help="Description to provide more information and context about this project")
     active = fields.Boolean(default=True, copy=False, export_string_translation=False)
     sequence = fields.Integer(default=10, export_string_translation=False)
-    partner_id = fields.Many2one('res.partner', string='Customer', auto_join=True, tracking=True, domain="['|', ('company_id', '=?', company_id), ('company_id', '=', False)]")
+    partner_id = fields.Many2one('res.partner', string='Customer', auto_join=True, tracking=True, domain="['|', ('company_id', '=?', company_id), ('company_id', '=', False)]", index='btree_not_null')
     company_id = fields.Many2one('res.company', string='Company', compute="_compute_company_id", inverse="_inverse_company_id", store=True, readonly=False)
     currency_id = fields.Many2one('res.currency', compute="_compute_currency_id", string="Currency", readonly=True, export_string_translation=False)
     analytic_account_balance = fields.Monetary(related="account_id.balance")

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -210,7 +210,7 @@ class ProjectTask(models.Model):
         help="The current user's personal task stage.", domain="[('user_id', '=', uid)]",
         group_expand='_read_group_personal_stage_type_ids')
     partner_id = fields.Many2one('res.partner',
-        string='Customer', recursive=True, tracking=True, compute='_compute_partner_id', store=True, readonly=False,
+        string='Customer', recursive=True, tracking=True, compute='_compute_partner_id', store=True, readonly=False, index='btree_not_null',
         domain="['|', ('company_id', '=?', company_id), ('company_id', '=', False)]", )
     partner_phone = fields.Char(
         compute='_compute_partner_phone', inverse='_inverse_partner_phone',
@@ -283,7 +283,7 @@ class ProjectTask(models.Model):
     # recurrence fields
     recurring_task = fields.Boolean(string="Recurrent")
     recurring_count = fields.Integer(string="Tasks in Recurrence", compute='_compute_recurring_count')
-    recurrence_id = fields.Many2one('project.task.recurrence', copy=False)
+    recurrence_id = fields.Many2one('project.task.recurrence', copy=False, index='btree_not_null')
     repeat_interval = fields.Integer(string='Repeat Every', default=1, compute='_compute_repeat', compute_sudo=True, readonly=False)
     repeat_unit = fields.Selection([
         ('day', 'Days'),

--- a/addons/project/models/project_update.py
+++ b/addons/project/models/project_update.py
@@ -57,7 +57,7 @@ class ProjectUpdate(models.Model):
     user_id = fields.Many2one('res.users', string='Author', required=True, default=lambda self: self.env.user)
     description = fields.Html()
     date = fields.Date(default=fields.Date.context_today, tracking=True)
-    project_id = fields.Many2one('project.project', required=True, export_string_translation=False)
+    project_id = fields.Many2one('project.project', required=True, index=True, export_string_translation=False)
     name_cropped = fields.Char(compute="_compute_name_cropped", export_string_translation=False)
     task_count = fields.Integer("Task Count", readonly=True, export_string_translation=False)
     closed_task_count = fields.Integer("Closed Task Count", readonly=True, export_string_translation=False)

--- a/addons/purchase_requisition/models/product.py
+++ b/addons/purchase_requisition/models/product.py
@@ -8,7 +8,7 @@ class ProductSupplierinfo(models.Model):
     _inherit = 'product.supplierinfo'
 
     purchase_requisition_id = fields.Many2one('purchase.requisition', related='purchase_requisition_line_id.requisition_id', string='Agreement')
-    purchase_requisition_line_id = fields.Many2one('purchase.requisition.line')
+    purchase_requisition_line_id = fields.Many2one('purchase.requisition.line', index='btree_not_null')
 
 
 class ProductProduct(models.Model):

--- a/addons/purchase_requisition/models/purchase.py
+++ b/addons/purchase_requisition/models/purchase.py
@@ -23,10 +23,10 @@ class PurchaseOrderGroup(models.Model):
 class PurchaseOrder(models.Model):
     _inherit = 'purchase.order'
 
-    requisition_id = fields.Many2one('purchase.requisition', string='Agreement', copy=False)
+    requisition_id = fields.Many2one('purchase.requisition', string='Agreement', copy=False, index='btree_not_null')
     requisition_type = fields.Selection(related='requisition_id.requisition_type')
 
-    purchase_group_id = fields.Many2one('purchase.order.group')
+    purchase_group_id = fields.Many2one('purchase.order.group', index='btree_not_null')
     alternative_po_ids = fields.One2many(
         'purchase.order', related='purchase_group_id.order_ids', readonly=False,
         domain="[('id', '!=', id), ('state', 'in', ['draft', 'sent', 'to approve'])]",

--- a/addons/purchase_requisition/models/purchase_requisition.py
+++ b/addons/purchase_requisition/models/purchase_requisition.py
@@ -176,7 +176,7 @@ class PurchaseRequisitionLine(models.Model):
         string='Unit Price', digits='Product Price', default=0.0,
         compute="_compute_price_unit", readonly=False, store=True)
     qty_ordered = fields.Float(compute='_compute_ordered_qty', string='Ordered')
-    requisition_id = fields.Many2one('purchase.requisition', required=True, string='Purchase Agreement', ondelete='cascade')
+    requisition_id = fields.Many2one('purchase.requisition', required=True, string='Purchase Agreement', ondelete='cascade', index=True)
     company_id = fields.Many2one('res.company', related='requisition_id.company_id', string='Company', store=True, readonly=True)
     supplier_info_ids = fields.One2many('product.supplierinfo', 'purchase_requisition_line_id')
 

--- a/addons/purchase_requisition_stock/models/purchase_requisition.py
+++ b/addons/purchase_requisition_stock/models/purchase_requisition.py
@@ -22,7 +22,7 @@ class PurchaseRequisition(models.Model):
 class PurchaseRequisitionLine(models.Model):
     _inherit = "purchase.requisition.line"
 
-    move_dest_id = fields.Many2one('stock.move', 'Downstream Move')
+    move_dest_id = fields.Many2one('stock.move', 'Downstream Move', index='btree_not_null')
 
     def _prepare_purchase_order_line(self, name, product_qty=0.0, price_unit=0.0, taxes_ids=False):
         res = super(PurchaseRequisitionLine, self)._prepare_purchase_order_line(name, product_qty, price_unit, taxes_ids)

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -30,7 +30,7 @@ class PurchaseOrderLine(models.Model):
     propagate_cancel = fields.Boolean('Propagate cancellation', default=True)
     forecasted_issue = fields.Boolean(compute='_compute_forecasted_issue')
     location_final_id = fields.Many2one('stock.location', 'Location from procurement')
-    group_id = fields.Many2one('procurement.group', 'Procurement group that generated this line')
+    group_id = fields.Many2one('procurement.group', 'Procurement group that generated this line', index='btree_not_null')
 
     def _compute_qty_received_method(self):
         super(PurchaseOrderLine, self)._compute_qty_received_method()

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -167,7 +167,7 @@ class RepairOrder(models.Model):
 
     # Sale Order Binding
     sale_order_id = fields.Many2one(
-        'sale.order', 'Sale Order', check_company=True, readonly=True,
+        'sale.order', 'Sale Order', check_company=True, readonly=True, index='btree_not_null',
         copy=False, help="Sale Order from which the Repair Order comes from.")
     sale_order_line_id = fields.Many2one(
         'sale.order.line', check_company=True, readonly=True,
@@ -179,7 +179,7 @@ class RepairOrder(models.Model):
 
     # Return Binding
     picking_id = fields.Many2one(
-        'stock.picking', 'Return', check_company=True,
+        'stock.picking', 'Return', check_company=True, index='btree_not_null',
         domain="[('return_id', '!=', False), ('product_id', '=?', product_id)]",
         copy=False, help="Return Order from which the product to be repaired comes from.")
     is_returned = fields.Boolean(

--- a/addons/repair/models/stock_move.py
+++ b/addons/repair/models/stock_move.py
@@ -13,7 +13,7 @@ MAP_REPAIR_LINE_TYPE_TO_MOVE_LOCATIONS_FROM_REPAIR = {
 class StockMove(models.Model):
     _inherit = 'stock.move'
 
-    repair_id = fields.Many2one('repair.order', check_company=True)
+    repair_id = fields.Many2one('repair.order', check_company=True, index='btree_not_null')
     repair_line_type = fields.Selection([
         ('add', 'Add'),
         ('remove', 'Remove'),

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -87,7 +87,7 @@ class ResourceCalendar(models.Model):
                             help="If the active field is set to false, it will allow you to hide the Working Time without removing it.")
     company_id = fields.Many2one(
         'res.company', 'Company', domain=lambda self: [('id', 'in', self.env.companies.ids)],
-        default=lambda self: self.env.company)
+        default=lambda self: self.env.company, index='btree_not_null')
     attendance_ids = fields.One2many(
         'resource.calendar.attendance', 'calendar_id', 'Working Time',
         compute='_compute_attendance_ids', store=True, readonly=False, copy=True)

--- a/addons/resource/models/resource_calendar_attendance.py
+++ b/addons/resource/models/resource_calendar_attendance.py
@@ -31,7 +31,7 @@ class ResourceCalendarAttendance(models.Model):
     # value based on the day_period but can be manually overridden.
     duration_hours = fields.Float(compute='_compute_duration_hours', string='Duration (hours)')
     duration_days = fields.Float(compute='_compute_duration_days', string='Duration (days)', store=True, readonly=False)
-    calendar_id = fields.Many2one("resource.calendar", string="Resource's Calendar", required=True, ondelete='cascade')
+    calendar_id = fields.Many2one("resource.calendar", string="Resource's Calendar", required=True, index=True, ondelete='cascade')
     day_period = fields.Selection([
         ('morning', 'Morning'),
         ('lunch', 'Break'),

--- a/addons/resource/models/resource_resource.py
+++ b/addons/resource/models/resource_resource.py
@@ -32,7 +32,7 @@ class ResourceResource(models.Model):
         ('user', 'Human'),
         ('material', 'Material')], string='Type',
         default='user', required=True)
-    user_id = fields.Many2one('res.users', string='User', help='Related user name for the resource to manage its access.')
+    user_id = fields.Many2one('res.users', string='User', index='btree_not_null', help='Related user name for the resource to manage its access.')
     avatar_128 = fields.Image(compute='_compute_avatar_128')
     share = fields.Boolean(related='user_id.share')
     email = fields.Char(related='user_id.email')

--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -126,7 +126,7 @@ class ProductProduct(models.Model):
 class ProductAttributeCustomValue(models.Model):
     _inherit = "product.attribute.custom.value"
 
-    sale_order_line_id = fields.Many2one('sale.order.line', string="Sales Order Line", ondelete='cascade')
+    sale_order_line_id = fields.Many2one('sale.order.line', string="Sales Order Line", index='btree_not_null', ondelete='cascade')
 
     _sol_custom_value_unique = models.Constraint(
         'unique(custom_product_template_attribute_value_id, sale_order_line_id)',

--- a/addons/sale_crm/models/sale_order.py
+++ b/addons/sale_crm/models/sale_order.py
@@ -8,7 +8,7 @@ class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
     opportunity_id = fields.Many2one(
-        'crm.lead', string='Opportunity', check_company=True,
+        'crm.lead', string='Opportunity', check_company=True, index='btree_not_null',
         domain="[('type', '=', 'opportunity'), '|', ('company_id', '=', False), ('company_id', '=', company_id)]")
 
     def action_confirm(self):

--- a/addons/sale_loyalty/models/sale_order_coupon_points.py
+++ b/addons/sale_loyalty/models/sale_order_coupon_points.py
@@ -7,7 +7,7 @@ class SaleOrderCouponPoints(models.Model):
     _name = 'sale.order.coupon.points'
     _description = "Sale Order Coupon Points - Keeps track of how a sale order impacts a coupon"
 
-    order_id = fields.Many2one(comodel_name='sale.order', ondelete='cascade', required=True)
+    order_id = fields.Many2one(comodel_name='sale.order', ondelete='cascade', required=True, index=True)
     coupon_id = fields.Many2one(comodel_name='loyalty.card', ondelete='cascade', required=True)
     points = fields.Float(required=True)
 

--- a/addons/sale_management/models/sale_order_option.py
+++ b/addons/sale_management/models/sale_order_option.py
@@ -18,7 +18,7 @@ class SaleOrderOption(models.Model):
         required=True,
         domain=lambda self: self._product_id_domain())
     line_id = fields.Many2one(
-        comodel_name='sale.order.line', ondelete='set null', copy=False)
+        comodel_name='sale.order.line', ondelete='set null', copy=False, index='btree_not_null')
     sequence = fields.Integer(
         string='Sequence', help="Gives the sequence order when displaying a list of optional products.")
 

--- a/addons/sale_project/models/project_milestone.py
+++ b/addons/sale_project/models/project_milestone.py
@@ -21,6 +21,7 @@ class ProjectMilestone(models.Model):
     project_partner_id = fields.Many2one(related='project_id.partner_id', export_string_translation=False)
 
     sale_line_id = fields.Many2one('sale.order.line', 'Sales Order Item', default=_default_sale_line_id, help='Sales Order Item that will be updated once the milestone is reached.',
+        index='btree_not_null',
         domain="[('order_partner_id', '=?', project_partner_id), ('qty_delivered_method', '=', 'milestones')]")
     quantity_percentage = fields.Float('Quantity (%)', compute="_compute_quantity_percentage", store=True, help='Percentage of the ordered quantity that will automatically be delivered once the milestone is reached.')
 

--- a/addons/sale_timesheet/models/project_sale_line_employee_map.py
+++ b/addons/sale_timesheet/models/project_sale_line_employee_map.py
@@ -19,7 +19,7 @@ class ProjectSaleLineEmployeeMap(models.Model):
         ])
         return domain
 
-    project_id = fields.Many2one('project.project', "Project", required=True)
+    project_id = fields.Many2one('project.project', "Project", required=True, index=True)
     employee_id = fields.Many2one('hr.employee', "Employee", required=True, domain="[('id', 'not in', existing_employee_ids)]")
     existing_employee_ids = fields.Many2many('hr.employee', compute="_compute_existing_employee_ids", export_string_translation=False)
     sale_line_id = fields.Many2one(

--- a/addons/sms/models/sms_tracker.py
+++ b/addons/sms/models/sms_tracker.py
@@ -29,7 +29,7 @@ class SmsTracker(models.Model):
     }
 
     sms_uuid = fields.Char('SMS uuid', required=True)
-    mail_notification_id = fields.Many2one('mail.notification', ondelete='cascade')
+    mail_notification_id = fields.Many2one('mail.notification', ondelete='cascade', index='btree_not_null')
 
     _sms_uuid_unique = models.Constraint(
         'unique(sms_uuid)',

--- a/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
+++ b/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
@@ -11,7 +11,7 @@ class SpreadsheetDashboard(models.Model):
     _order = 'sequence'
 
     name = fields.Char(required=True, translate=True)
-    dashboard_group_id = fields.Many2one('spreadsheet.dashboard.group', required=True)
+    dashboard_group_id = fields.Many2one('spreadsheet.dashboard.group', required=True, index=True)
     sequence = fields.Integer()
     sample_dashboard_file_path = fields.Char(export_string_translation=False)
     is_published = fields.Boolean(default=True)

--- a/addons/stock/models/product_strategy.py
+++ b/addons/stock/models/product_strategy.py
@@ -45,9 +45,10 @@ class StockPutawayRule(models.Model):
     product_id = fields.Many2one(
         'product.product', 'Product', check_company=True,
         default=_default_product_id,
+        index='btree_not_null',
         domain="[('product_tmpl_id', '=', context.get('active_id', False))] if context.get('active_model') == 'product.template' else [('type', '!=', 'service')]",
         ondelete='cascade')
-    category_id = fields.Many2one('product.category', 'Product Category',
+    category_id = fields.Many2one('product.category', 'Product Category', index='btree_not_null',
         default=_default_category_id, domain=[('filter_for_stock_putaway_rule', '=', True)], ondelete='cascade')
     location_in_id = fields.Many2one(
         'stock.location', 'When product arrives in', check_company=True,

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -91,7 +91,7 @@ class StockLocation(models.Model):
     next_inventory_date = fields.Date("Next Expected", compute="_compute_next_inventory_date", store=True, help="Date for next planned inventory based on cyclic schedule.")
     warehouse_view_ids = fields.One2many('stock.warehouse', 'view_location_id', readonly=True)
     warehouse_id = fields.Many2one('stock.warehouse', compute='_compute_warehouse_id', store=True)
-    storage_category_id = fields.Many2one('stock.storage.category', string='Storage Category', check_company=True)
+    storage_category_id = fields.Many2one('stock.storage.category', string='Storage Category', check_company=True, index='btree_not_null')
     outgoing_move_line_ids = fields.One2many('stock.move.line', 'location_id') # used to compute weight
     incoming_move_line_ids = fields.One2many('stock.move.line', 'location_dest_id') # used to compute weight
     net_weight = fields.Float('Net Weight', compute="_compute_weight")
@@ -526,7 +526,7 @@ class StockRoute(models.Model):
     product_categ_selectable = fields.Boolean('Applicable on Product Category', help="When checked, the route will be selectable on the Product Category.")
     warehouse_selectable = fields.Boolean('Applicable on Warehouse', help="When a warehouse is selected for this route, this route should be seen as the default route when products pass through this warehouse.")
     package_type_selectable = fields.Boolean('Applicable on Package Type', help="When checked, the route will be selectable on package types")
-    supplied_wh_id = fields.Many2one('stock.warehouse', 'Supplied Warehouse')
+    supplied_wh_id = fields.Many2one('stock.warehouse', 'Supplied Warehouse', index='btree_not_null')
     supplier_wh_id = fields.Many2one('stock.warehouse', 'Supplying Warehouse')
     company_id = fields.Many2one(
         'res.company', 'Company',

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -139,7 +139,7 @@ class StockMove(models.Model):
              "this second option should be chosen.")
     scrapped = fields.Boolean(
         'Scrapped', related='location_dest_id.scrap_location', readonly=True, store=True)
-    scrap_id = fields.Many2one('stock.scrap', 'Scrap operation', readonly=True, check_company=True)
+    scrap_id = fields.Many2one('stock.scrap', 'Scrap operation', readonly=True, check_company=True, index='btree_not_null')
     group_id = fields.Many2one('procurement.group', 'Procurement Group', default=_default_group_id, index=True)
     rule_id = fields.Many2one(
         'stock.rule', 'Stock Rule', ondelete='restrict', help='The stock rule that created this stock move',
@@ -179,7 +179,7 @@ class StockMove(models.Model):
     is_quantity_done_editable = fields.Boolean('Is quantity done editable', compute='_compute_is_quantity_done_editable')
     reference = fields.Char(compute='_compute_reference', string="Reference", store=True)
     move_lines_count = fields.Integer(compute='_compute_move_lines_count')
-    package_level_id = fields.Many2one('stock.package_level', 'Package Level', check_company=True, copy=False)
+    package_level_id = fields.Many2one('stock.package_level', 'Package Level', check_company=True, copy=False, index='btree_not_null')
     picking_type_entire_packs = fields.Boolean(related='picking_type_id.show_entire_packs', readonly=True)
     display_assign_serial = fields.Boolean(compute='_compute_display_assign_serial')
     display_import_lot = fields.Boolean(compute='_compute_display_assign_serial')

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -44,7 +44,7 @@ class StockMoveLine(models.Model):
         'stock.quant.package', 'Source Package', ondelete='restrict',
         check_company=True,
         domain="[('location_id', '=', location_id)]")
-    package_level_id = fields.Many2one('stock.package_level', 'Package Level', check_company=True)
+    package_level_id = fields.Many2one('stock.package_level', 'Package Level', check_company=True, index='btree_not_null')
     lot_id = fields.Many2one(
         'stock.lot', 'Lot/Serial Number',
         domain="[('product_id', '=', product_id)]", check_company=True)
@@ -64,9 +64,9 @@ class StockMoveLine(models.Model):
         help="When validating the transfer, the products will be taken from this owner.")
     location_id = fields.Many2one(
         'stock.location', 'From', domain="[('usage', '!=', 'view')]", check_company=True, required=True,
-        compute="_compute_location_id", store=True, readonly=False, precompute=True,
+        compute="_compute_location_id", store=True, readonly=False, precompute=True, index=True,
     )
-    location_dest_id = fields.Many2one('stock.location', 'To', domain="[('usage', '!=', 'view')]", check_company=True, required=True, compute="_compute_location_id", store=True, readonly=False, precompute=True)
+    location_dest_id = fields.Many2one('stock.location', 'To', domain="[('usage', '!=', 'view')]", check_company=True, required=True, compute="_compute_location_id", store=True, index=True, readonly=False, precompute=True)
     location_usage = fields.Selection(string="Source Location Type", related='location_id.usage')
     location_dest_usage = fields.Selection(string="Destination Location Type", related='location_dest_id.usage')
     lots_visible = fields.Boolean(compute='_compute_lots_visible')

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -49,7 +49,7 @@ class StockWarehouseOrderpoint(models.Model):
         domain=("[('product_tmpl_id', '=', context.get('active_id', False))] if context.get('active_model') == 'product.template' else"
             " [('id', '=', context.get('default_product_id', False))] if context.get('default_product_id') else"
             " [('is_storable', '=', True)]"),
-        ondelete='cascade', required=True, check_company=True)
+        ondelete='cascade', required=True, check_company=True, index=True)
     product_category_id = fields.Many2one('product.category', name='Product Category', related='product_id.categ_id')
     product_uom = fields.Many2one(
         'uom.uom', 'Unit', related='product_id.uom_id')

--- a/addons/stock/models/stock_package_level.py
+++ b/addons/stock/models/stock_package_level.py
@@ -15,7 +15,7 @@ class StockPackage_Level(models.Model):
     package_id = fields.Many2one(
         'stock.quant.package', 'Package', required=True, check_company=True,
         domain="[('location_id', 'child_of', parent.location_id), '|', ('company_id', '=', False), ('company_id', '=', company_id)]")
-    picking_id = fields.Many2one('stock.picking', 'Picking', check_company=True)
+    picking_id = fields.Many2one('stock.picking', 'Picking', check_company=True, index='btree_not_null')
     move_ids = fields.One2many('stock.move', 'package_level_id')
     move_line_ids = fields.One2many('stock.move.line', 'package_level_id')
     location_id = fields.Many2one('stock.location', 'From', compute='_compute_location_id', check_company=True)

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -41,6 +41,7 @@ class StockPickingType(models.Model):
     code = fields.Selection([('incoming', 'Receipt'), ('outgoing', 'Delivery'), ('internal', 'Internal Transfer')], 'Type of Operation', default='incoming', required=True)
     return_picking_type_id = fields.Many2one(
         'stock.picking.type', 'Operation Type for Returns',
+        index='btree_not_null',
         check_company=True)
     show_entire_packs = fields.Boolean('Move Entire Packages', help="If ticked, you will be able to select entire packages to move")
     warehouse_id = fields.Many2one(

--- a/addons/stock/models/stock_storage_category.py
+++ b/addons/stock/models/stock_storage_category.py
@@ -52,11 +52,11 @@ class StockStorageCategoryCapacity(models.Model):
     _order = "storage_category_id"
 
     storage_category_id = fields.Many2one('stock.storage.category', ondelete='cascade', required=True, index=True)
-    product_id = fields.Many2one('product.product', 'Product', ondelete='cascade', check_company=True,
+    product_id = fields.Many2one('product.product', 'Product', ondelete='cascade', check_company=True, index='btree_not_null',
         domain=("[('product_tmpl_id', '=', context.get('active_id', False))] if context.get('active_model') == 'product.template' else"
             " [('id', '=', context.get('default_product_id', False))] if context.get('default_product_id') else"
             " [('is_storable', '=', True)]"))
-    package_type_id = fields.Many2one('stock.package.type', 'Package Type', ondelete='cascade', check_company=True)
+    package_type_id = fields.Many2one('stock.package.type', 'Package Type', ondelete='cascade', check_company=True, index='btree_not_null')
     quantity = fields.Float('Quantity', required=True)
     product_uom_id = fields.Many2one(related='product_id.uom_id')
     company_id = fields.Many2one('res.company', 'Company', related="storage_category_id.company_id")

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -42,7 +42,7 @@ class StockWarehouse(models.Model):
     view_location_id = fields.Many2one(
         'stock.location', 'View Location',
         domain="[('usage', '=', 'view'), ('company_id', '=', company_id)]",
-        required=True, check_company=True)
+        required=True, check_company=True, index=True)
     lot_stock_id = fields.Many2one(
         'stock.location', 'Location Stock',
         domain="[('usage', '=', 'internal'), ('company_id', '=', company_id)]",

--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -20,7 +20,7 @@ class StockValuationLayer(models.Model):
     _rec_name = 'product_id'
 
     company_id = fields.Many2one('res.company', 'Company', readonly=True, required=True)
-    product_id = fields.Many2one('product.product', 'Product', readonly=True, required=True, check_company=True, auto_join=True)
+    product_id = fields.Many2one('product.product', 'Product', readonly=True, required=True, check_company=True, auto_join=True, index=True)
     categ_id = fields.Many2one('product.category', related='product_id.categ_id')
     product_tmpl_id = fields.Many2one('product.template', related='product_id.product_tmpl_id')
     quantity = fields.Float('Quantity', readonly=True, digits='Product Unit')

--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -66,7 +66,7 @@ class StockLandedCost(models.Model):
     company_id = fields.Many2one('res.company', string="Company", required=True, default=lambda self: self.env.company)
     stock_valuation_layer_ids = fields.One2many('stock.valuation.layer', 'stock_landed_cost_id')
     vendor_bill_id = fields.Many2one(
-        'account.move', 'Vendor Bill', copy=False, domain=[('move_type', '=', 'in_invoice')])
+        'account.move', 'Vendor Bill', copy=False, domain=[('move_type', '=', 'in_invoice')], index='btree_not_null')
     currency_id = fields.Many2one('res.currency', related='company_id.currency_id')
 
     @api.depends('cost_lines.price_unit')
@@ -346,7 +346,7 @@ class StockLandedCostLines(models.Model):
     name = fields.Char('Description')
     cost_id = fields.Many2one(
         'stock.landed.cost', 'Landed Cost',
-        required=True, ondelete='cascade')
+        required=True, index=True, ondelete='cascade')
     product_id = fields.Many2one('product.product', 'Product', required=True)
     price_unit = fields.Monetary('Cost', required=True)
     split_method = fields.Selection(
@@ -378,7 +378,7 @@ class StockValuationAdjustmentLines(models.Model):
         'Description', compute='_compute_name', store=True)
     cost_id = fields.Many2one(
         'stock.landed.cost', 'Landed Cost',
-        ondelete='cascade', required=True)
+        ondelete='cascade', required=True, index=True)
     cost_line_id = fields.Many2one(
         'stock.landed.cost.lines', 'Cost Line', readonly=True)
     move_id = fields.Many2one('stock.move', 'Stock Move', readonly=True)

--- a/addons/stock_landed_costs/models/stock_valuation_layer.py
+++ b/addons/stock_landed_costs/models/stock_valuation_layer.py
@@ -7,7 +7,7 @@ from odoo import fields, models
 class StockValuationLayer(models.Model):
     _inherit = 'stock.valuation.layer'
 
-    stock_landed_cost_id = fields.Many2one('stock.landed.cost', 'Landed Cost')
+    stock_landed_cost_id = fields.Many2one('stock.landed.cost', 'Landed Cost', index='btree_not_null')
 
     def _should_impact_price_unit_receipt_value(self):
         res = super()._should_impact_price_unit_receipt_value()

--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -66,7 +66,7 @@ class SurveyQuestion(models.Model):
     question_placeholder = fields.Char("Placeholder", translate=True, compute="_compute_question_placeholder", store=True, readonly=False)
     background_image = fields.Image("Background Image", compute="_compute_background_image", store=True, readonly=False)
     background_image_url = fields.Char("Background Url", compute="_compute_background_image_url")
-    survey_id = fields.Many2one('survey.survey', string='Survey', ondelete='cascade')
+    survey_id = fields.Many2one('survey.survey', string='Survey', ondelete='cascade', index='btree_not_null')
     scoring_type = fields.Selection(related='survey_id.scoring_type', string='Scoring Type', readonly=True)
     sequence = fields.Integer('Sequence', default=10)
     session_available = fields.Boolean(related='survey_id.session_available', string='Live Session available', readonly=True)

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -141,7 +141,7 @@ class SurveySurvey(models.Model):
     #       So it can be edited but not removed or replaced.
     certification_give_badge = fields.Boolean('Give Badge', compute='_compute_certification_give_badge',
                                               readonly=False, store=True, copy=False)
-    certification_badge_id = fields.Many2one('gamification.badge', 'Certification Badge', copy=False)
+    certification_badge_id = fields.Many2one('gamification.badge', 'Certification Badge', copy=False, index='btree_not_null')
     certification_badge_id_dummy = fields.Many2one(related='certification_badge_id', string='Certification Badge ')
     # live sessions
     session_available = fields.Boolean('Live session available', compute='_compute_session_available')

--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -27,7 +27,7 @@ class UomUom(models.Model):
         help='How much bigger or smaller this unit is compared to the reference UoM for this unit')
     rounding = fields.Float('Rounding Precision', compute="_compute_rounding")
     active = fields.Boolean('Active', default=True, help="Uncheck the active field to disable a unit of measure without deleting it.")
-    relative_uom_id = fields.Many2one('uom.uom', 'Reference Unit', ondelete='cascade')
+    relative_uom_id = fields.Many2one('uom.uom', 'Reference Unit', ondelete='cascade', index='btree_not_null')
     related_uom_ids = fields.One2many('uom.uom', 'relative_uom_id', 'Related UoMs')
     factor = fields.Float('Absolute Quantity', digits=0, compute='_compute_factor', recursive=True, store=True)
     parent_path = fields.Char(index=True)

--- a/addons/web_tour/models/tour.py
+++ b/addons/web_tour/models/tour.py
@@ -87,7 +87,7 @@ class Web_TourTourStep(models.Model):
 
     trigger = fields.Char(required=True)
     content = fields.Char()
-    tour_id = fields.Many2one("web_tour.tour", required=True, ondelete="cascade")
+    tour_id = fields.Many2one("web_tour.tour", required=True, index=True, ondelete="cascade")
     run = fields.Char()
     sequence = fields.Integer()
 

--- a/addons/website/models/theme_models.py
+++ b/addons/website/models/theme_models.py
@@ -138,7 +138,7 @@ class ThemeWebsiteMenu(models.Model):
 
     name = fields.Char(required=True, translate=True)
     url = fields.Char(default='')
-    page_id = fields.Many2one('theme.website.page', ondelete='cascade')
+    page_id = fields.Many2one('theme.website.page', ondelete='cascade', index='btree_not_null')
     new_window = fields.Boolean('New Window')
     sequence = fields.Integer()
     parent_id = fields.Many2one('theme.website.menu', index=True, ondelete="cascade")
@@ -181,7 +181,7 @@ class ThemeWebsitePage(models.Model):
     ]
 
     url = fields.Char()
-    view_id = fields.Many2one('theme.ir.ui.view', required=True, ondelete="cascade")
+    view_id = fields.Many2one('theme.ir.ui.view', required=True, index=True, ondelete="cascade")
     website_indexed = fields.Boolean('Page Indexed', default=True)
     is_published = fields.Boolean()
     is_new_page_template = fields.Boolean(string="New Page Template")
@@ -353,7 +353,7 @@ class ThemeUtils(models.AbstractModel):
 class IrUiView(models.Model):
     _inherit = 'ir.ui.view'
 
-    theme_template_id = fields.Many2one('theme.ir.ui.view', copy=False)
+    theme_template_id = fields.Many2one('theme.ir.ui.view', copy=False, index='btree_not_null')
 
     def write(self, vals):
         # During a theme module update, theme views' copies receiving an arch
@@ -380,23 +380,23 @@ class IrUiView(models.Model):
 class IrAsset(models.Model):
     _inherit = 'ir.asset'
 
-    theme_template_id = fields.Many2one('theme.ir.asset', copy=False)
+    theme_template_id = fields.Many2one('theme.ir.asset', copy=False, index='btree_not_null')
 
 
 class IrAttachment(models.Model):
     _inherit = 'ir.attachment'
 
     key = fields.Char(copy=False)
-    theme_template_id = fields.Many2one('theme.ir.attachment', copy=False)
+    theme_template_id = fields.Many2one('theme.ir.attachment', copy=False, index='btree_not_null')
 
 
 class WebsiteMenu(models.Model):
     _inherit = 'website.menu'
 
-    theme_template_id = fields.Many2one('theme.website.menu', copy=False)
+    theme_template_id = fields.Many2one('theme.website.menu', copy=False, index='btree_not_null')
 
 
 class WebsitePage(models.Model):
     _inherit = 'website.page'
 
-    theme_template_id = fields.Many2one('theme.website.page', copy=False)
+    theme_template_id = fields.Many2one('theme.website.page', copy=False, index='btree_not_null')

--- a/addons/website/models/website_controller_page.py
+++ b/addons/website/models/website_controller_page.py
@@ -17,7 +17,7 @@ class WebsiteControllerPage(models.Model):
         'url should be unique',
     )
 
-    view_id = fields.Many2one('ir.ui.view', string='Listing view', required=True, ondelete="cascade")
+    view_id = fields.Many2one('ir.ui.view', string='Listing view', required=True, index=True, ondelete="cascade")
     record_view_id = fields.Many2one('ir.ui.view', string='Record view', ondelete="cascade")
     menu_ids = fields.One2many('website.menu', 'controller_page_id', 'Related Menus')
 

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -40,8 +40,8 @@ class WebsiteMenu(models.Model):
 
     name = fields.Char('Menu', required=True, translate=True)
     url = fields.Char("Url", compute="_compute_url", store=True, required=True, default="#", copy=True)
-    page_id = fields.Many2one('website.page', 'Related Page', ondelete='cascade')
-    controller_page_id = fields.Many2one('website.controller.page', 'Related Model Page', ondelete='cascade')
+    page_id = fields.Many2one('website.page', 'Related Page', ondelete='cascade', index='btree_not_null')
+    controller_page_id = fields.Many2one('website.controller.page', 'Related Model Page', ondelete='cascade', index='btree_not_null')
     new_window = fields.Boolean('New Window')
     sequence = fields.Integer(default=_default_sequence)
     website_id = fields.Many2one('website', 'Website', ondelete='cascade')

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -21,7 +21,7 @@ class WebsitePage(models.Model):
     _order = 'website_id'
 
     url = fields.Char('Page URL', required=True)
-    view_id = fields.Many2one('ir.ui.view', string='View', required=True, ondelete="cascade")
+    view_id = fields.Many2one('ir.ui.view', string='View', required=True, index=True, ondelete="cascade")
     website_indexed = fields.Boolean('Is Indexed', default=True)
     date_publish = fields.Datetime('Publishing Date')
     menu_ids = fields.One2many('website.menu', 'page_id', 'Related Menus')

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -182,7 +182,7 @@ class BlogPost(models.Model):
     author_avatar = fields.Binary(related='author_id.image_128', string="Avatar", readonly=False)
     author_name = fields.Char(related='author_id.display_name', string="Author Name", readonly=False, store=True)
     active = fields.Boolean('Active', default=True)
-    blog_id = fields.Many2one('blog.blog', 'Blog', required=True, ondelete='cascade', default=lambda self: self.env['blog.blog'].search([], limit=1))
+    blog_id = fields.Many2one('blog.blog', 'Blog', required=True, index=True, ondelete='cascade', default=lambda self: self.env['blog.blog'].search([], limit=1))
     tag_ids = fields.Many2many('blog.tag', string='Tags')
     content = fields.Html('Content', default=_default_content, translate=html_translate, sanitize=False)
     teaser = fields.Text('Teaser', compute='_compute_teaser', inverse='_set_teaser', translate=True)

--- a/addons/website_crm_partner_assign/models/res_partner.py
+++ b/addons/website_crm_partner_assign/models/res_partner.py
@@ -30,7 +30,7 @@ class ResPartner(models.Model):
     date_review_next = fields.Date('Next Review')
     # customer implementation
     assigned_partner_id = fields.Many2one(
-        'res.partner', 'Implemented by',
+        'res.partner', 'Implemented by', index='btree_not_null',
     )
     implemented_partner_ids = fields.One2many(
         'res.partner', 'assigned_partner_id',

--- a/addons/website_event/models/event_registration.py
+++ b/addons/website_event/models/event_registration.py
@@ -6,7 +6,7 @@ from odoo import fields, models
 class EventRegistration(models.Model):
     _inherit = 'event.registration'
 
-    visitor_id = fields.Many2one('website.visitor', string='Visitor', ondelete='set null')
+    visitor_id = fields.Many2one('website.visitor', string='Visitor', ondelete='set null', index='btree_not_null')
 
     def _get_website_registration_allowed_fields(self):
         return {'name', 'phone', 'email', 'company_name', 'event_id', 'partner_id', 'event_ticket_id'}

--- a/addons/website_event/models/website_event_menu.py
+++ b/addons/website_event/models/website_event_menu.py
@@ -13,7 +13,7 @@ class WebsiteEventMenu(models.Model):
     _rec_name = "menu_id"
 
     menu_id = fields.Many2one('website.menu', string='Menu', ondelete='cascade')
-    event_id = fields.Many2one('event.event', string='Event', ondelete='cascade')
+    event_id = fields.Many2one('event.event', string='Event', index='btree_not_null', ondelete='cascade')
     view_id = fields.Many2one('ir.ui.view', string='View', ondelete='cascade', help='Used when not being an url based menu')
     menu_type = fields.Selection(
         [('community', 'Community Menu'),

--- a/addons/website_event_exhibitor/models/event_sponsor.py
+++ b/addons/website_event_exhibitor/models/event_sponsor.py
@@ -26,7 +26,7 @@ class EventSponsor(models.Model):
     def _default_sponsor_type_id(self):
         return self.env['event.sponsor.type'].search([], order="sequence desc", limit=1).id
 
-    event_id = fields.Many2one('event.event', 'Event', required=True)
+    event_id = fields.Many2one('event.event', 'Event', required=True, index=True)
     sponsor_type_id = fields.Many2one(
         'event.sponsor.type', 'Sponsorship Level',
         default=lambda self: self._default_sponsor_type_id(), required=True, auto_join=True)

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -30,7 +30,7 @@ class EventTrack(models.Model):
 
     # description
     name = fields.Char('Title', required=True, translate=True)
-    event_id = fields.Many2one('event.event', 'Event', required=True)
+    event_id = fields.Many2one('event.event', 'Event', required=True, index=True)
     active = fields.Boolean(default=True)
     user_id = fields.Many2one('res.users', 'Responsible', tracking=True, default=lambda self: self.env.user)
     company_id = fields.Many2one('res.company', related='event_id.company_id')

--- a/addons/website_event_track/models/event_track_tag.py
+++ b/addons/website_event_track/models/event_track_tag.py
@@ -20,7 +20,7 @@ class EventTrackTag(models.Model):
         string='Color Index', default=lambda self: self._default_color(),
         help="Note that colorless tags won't be available on the website.")
     sequence = fields.Integer('Sequence', default=10)
-    category_id = fields.Many2one('event.track.tag.category', string="Category", ondelete="set null")
+    category_id = fields.Many2one('event.track.tag.category', string="Category", ondelete="set null", index='btree_not_null')
 
     _name_uniq = models.Constraint(
         'unique (name)',

--- a/addons/website_event_track_quiz/models/event_quiz.py
+++ b/addons/website_event_track_quiz/models/event_quiz.py
@@ -11,7 +11,7 @@ class EventQuiz(models.Model):
 
     name = fields.Char('Name', required=True, translate=True)
     question_ids = fields.One2many('event.quiz.question', 'quiz_id', string="Questions")
-    event_track_id = fields.Many2one('event.track', readonly=True)
+    event_track_id = fields.Many2one('event.track', readonly=True, index='btree_not_null')
     event_id = fields.Many2one(
         'event.event', related='event_track_id.event_id',
         readonly=True, store=True)
@@ -26,7 +26,7 @@ class EventQuizQuestion(models.Model):
 
     name = fields.Char("Question", required=True, translate=True)
     sequence = fields.Integer("Sequence")
-    quiz_id = fields.Many2one("event.quiz", "Quiz", required=True, ondelete='cascade')
+    quiz_id = fields.Many2one("event.quiz", "Quiz", required=True, index=True, ondelete='cascade')
     correct_answer_id = fields.One2many('event.quiz.answer', compute='_compute_correct_answer_id')
     awarded_points = fields.Integer("Number of Points", compute='_compute_awarded_points')
     answer_ids = fields.One2many('event.quiz.answer', 'question_id', string="Answer")
@@ -57,7 +57,7 @@ class EventQuizAnswer(models.Model):
     _order = 'question_id, sequence, id'
 
     sequence = fields.Integer("Sequence")
-    question_id = fields.Many2one('event.quiz.question', string="Question", required=True, ondelete='cascade')
+    question_id = fields.Many2one('event.quiz.question', string="Question", required=True, index=True, ondelete='cascade')
     text_value = fields.Char("Answer", required=True, translate=True)
     is_correct = fields.Boolean('Correct', default=False)
     comment = fields.Text(

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -26,7 +26,7 @@ class ForumPost(models.Model):
     _order = "is_correct DESC, vote_count DESC, last_activity_date DESC"
 
     name = fields.Char('Title')
-    forum_id = fields.Many2one('forum.forum', string='Forum', required=True)
+    forum_id = fields.Many2one('forum.forum', string='Forum', required=True, index=True)
     content = fields.Html('Content', strip_style=True)
     plain_content = fields.Text(
         'Plain Content',

--- a/addons/website_forum/models/forum_post_vote.py
+++ b/addons/website_forum/models/forum_post_vote.py
@@ -10,11 +10,11 @@ class ForumPostVote(models.Model):
     _description = 'Post Vote'
     _order = 'create_date desc, id desc'
 
-    post_id = fields.Many2one('forum.post', string='Post', ondelete='cascade', required=True)
+    post_id = fields.Many2one('forum.post', string='Post', ondelete='cascade', required=True, index=True)
     user_id = fields.Many2one('res.users', string='User', required=True, default=lambda self: self._uid, ondelete='cascade')
     vote = fields.Selection([('1', '1'), ('-1', '-1'), ('0', '0')], string='Vote', required=True, default='1')
     create_date = fields.Datetime('Create Date', index=True, readonly=True)
-    forum_id = fields.Many2one('forum.forum', string='Forum', related="post_id.forum_id", store=True, readonly=False)
+    forum_id = fields.Many2one('forum.forum', string='Forum', related="post_id.forum_id", store=True, readonly=False, index='btree_not_null')
     recipient_id = fields.Many2one('res.users', string='To', related="post_id.create_uid", store=True, readonly=False)
 
     _vote_uniq = models.Constraint(

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -41,6 +41,7 @@ class Website(models.Model):
     salesteam_id = fields.Many2one(
         string="Sales Team",
         comodel_name='crm.team',
+        index='btree_not_null',
         ondelete='set null',
         default=_default_salesteam_id,
     )

--- a/addons/website_sale/models/website_sale_extra_field.py
+++ b/addons/website_sale/models/website_sale_extra_field.py
@@ -8,7 +8,7 @@ class WebsiteSaleExtraField(models.Model):
     _description = "E-Commerce Extra Info Shown on product page"
     _order = 'sequence'
 
-    website_id = fields.Many2one(comodel_name='website')
+    website_id = fields.Many2one(comodel_name='website', index='btree_not_null')
     sequence = fields.Integer(default=10)
     field_id = fields.Many2one(
         comodel_name='ir.model.fields',

--- a/addons/website_sale_slides/models/slide_channel.py
+++ b/addons/website_sale_slides/models/slide_channel.py
@@ -17,7 +17,7 @@ class SlideChannel(models.Model):
         ('payment', 'On payment')
     ], ondelete={'payment': lambda recs: recs.write({'enroll': 'invite'})})
     product_id = fields.Many2one('product.product', 'Product', domain=[('service_tracking', '=', 'course')],
-                                 default=_get_default_product_id)
+                                 index='btree_not_null', default=_get_default_product_id)
     product_sale_revenues = fields.Monetary(
         string='Total revenues', compute='_compute_product_sale_revenues',
         groups="sales_team.group_sale_salesman")

--- a/addons/website_sale_wishlist/models/product_wishlist.py
+++ b/addons/website_sale_wishlist/models/product_wishlist.py
@@ -12,7 +12,7 @@ class ProductWishlist(models.Model):
         'Duplicated wishlisted product for this partner.',
     )
 
-    partner_id = fields.Many2one('res.partner', string='Owner')
+    partner_id = fields.Many2one('res.partner', string='Owner', index='btree_not_null')
     product_id = fields.Many2one('product.product', string='Product', required=True)
     currency_id = fields.Many2one('res.currency', related='website_id.currency_id', readonly=True)
     pricelist_id = fields.Many2one('product.pricelist', string='Pricelist', help='Pricelist when added')

--- a/addons/website_slides/models/slide_question.py
+++ b/addons/website_slides/models/slide_question.py
@@ -13,7 +13,7 @@ class SlideQuestion(models.Model):
 
     sequence = fields.Integer("Sequence")
     question = fields.Char("Question Name", required=True, translate=True)
-    slide_id = fields.Many2one('slide.slide', string="Content", required=True, ondelete='cascade')
+    slide_id = fields.Many2one('slide.slide', string="Content", required=True, index=True, ondelete='cascade')
     answer_ids = fields.One2many('slide.answer', 'question_id', string="Answer", copy=True)
     answers_validation_error = fields.Char("Error on Answers", compute='_compute_answers_validation_error')
     # statistics
@@ -66,7 +66,7 @@ class SlideAnswer(models.Model):
     _order = 'question_id, sequence, id'
 
     sequence = fields.Integer("Sequence")
-    question_id = fields.Many2one('slide.question', string="Question", required=True, ondelete='cascade')
+    question_id = fields.Many2one('slide.question', string="Question", required=True, index=True, ondelete='cascade')
     text_value = fields.Char("Answer", required=True, translate=True)
     is_correct = fields.Boolean("Is correct answer")
     comment = fields.Text("Comment", translate=True, help='This comment will be displayed to the user if they select this answer')

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -119,14 +119,14 @@ class SlideSlide(models.Model):
     sequence = fields.Integer('Sequence', default=0)
     user_id = fields.Many2one('res.users', string='Uploaded by', default=lambda self: self.env.uid)
     description = fields.Html('Description', translate=True, sanitize_attributes=False, sanitize_overridable=True)
-    channel_id = fields.Many2one('slide.channel', string="Course", required=True, ondelete='cascade')
+    channel_id = fields.Many2one('slide.channel', string="Course", required=True, index=True, ondelete='cascade')
     tag_ids = fields.Many2many('slide.tag', 'rel_slide_tag', 'slide_id', 'tag_id', string='Tags')
     is_preview = fields.Boolean('Allow Preview', default=False, help="The course is accessible by anyone : the users don't need to join the channel to access the content of the course.")
     is_new_slide = fields.Boolean('Is New Slide', compute='_compute_is_new_slide')
     completion_time = fields.Float('Duration', digits=(10, 4), compute='_compute_category_completion_time', recursive=True, readonly=False, store=True)
     # Categories
     is_category = fields.Boolean('Is a category', default=False)
-    category_id = fields.Many2one('slide.slide', string="Section", compute="_compute_category_id", store=True)
+    category_id = fields.Many2one('slide.slide', string="Section", compute="_compute_category_id", store=True, index='btree_not_null')
     slide_ids = fields.One2many('slide.slide', "category_id", string="Content")
     # subscribers
     partner_ids = fields.Many2many('res.partner', 'slide_slide_partner', 'slide_id', 'partner_id',

--- a/addons/website_slides/models/slide_slide_resource.py
+++ b/addons/website_slides/models/slide_slide_resource.py
@@ -13,7 +13,7 @@ class SlideSlideResource(models.Model):
     _description = "Additional resource for a particular slide"
     _order = "sequence, id"
 
-    slide_id = fields.Many2one('slide.slide', required=True, ondelete='cascade')
+    slide_id = fields.Many2one('slide.slide', required=True, index=True, ondelete='cascade')
     resource_type = fields.Selection([('file', 'File'), ('url', 'Link')], required=True)
     name = fields.Char('Name', compute="_compute_name", readonly=False, store=True)
     data = fields.Binary('Resource', compute='_compute_reset_resources', store=True, readonly=False)

--- a/addons/website_slides_forum/models/slide_channel.py
+++ b/addons/website_slides_forum/models/slide_channel.py
@@ -7,7 +7,7 @@ from odoo import api, fields, models
 class SlideChannel(models.Model):
     _inherit = 'slide.channel'
 
-    forum_id = fields.Many2one('forum.forum', 'Course Forum', copy=False)
+    forum_id = fields.Many2one('forum.forum', 'Course Forum', copy=False, index='btree_not_null')
     forum_total_posts = fields.Integer('Number of active forum posts', related="forum_id.total_posts")
 
     _forum_uniq = models.Constraint(

--- a/addons/website_slides_survey/models/slide_slide.py
+++ b/addons/website_slides_survey/models/slide_slide.py
@@ -54,7 +54,7 @@ class SlideSlide(models.Model):
     slide_type = fields.Selection(selection_add=[
         ('certification', 'Certification')
     ], ondelete={'certification': 'set null'})
-    survey_id = fields.Many2one('survey.survey', 'Certification')
+    survey_id = fields.Many2one('survey.survey', 'Certification', index='btree_not_null')
     nbr_certification = fields.Integer("Number of Certifications", compute='_compute_slides_statistics', store=True)
     # small override of 'is_preview' to uncheck it automatically for slides of type 'certification'
     is_preview = fields.Boolean(compute='_compute_is_preview', readonly=False, store=True)

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -418,7 +418,7 @@ class IrActionsAct_WindowView(models.Model):
     sequence = fields.Integer()
     view_id = fields.Many2one('ir.ui.view', string='View')
     view_mode = fields.Selection(VIEW_TYPES, string='View Type', required=True)
-    act_window_id = fields.Many2one('ir.actions.act_window', string='Action', ondelete='cascade')
+    act_window_id = fields.Many2one('ir.actions.act_window', string='Action', ondelete='cascade', index='btree_not_null')
     multi = fields.Boolean(string='On Multiple Doc.', help="If set to true, the action will not be displayed on the right toolbar of a form view.")
 
 
@@ -573,7 +573,7 @@ class IrActionsServer(models.Model):
                        help="Write Python code that the action will execute. Some variables are "
                             "available for use; help about python expression is given in the help tab.")
     # Multi
-    parent_id = fields.Many2one('ir.actions.server', string='Parent Action', ondelete='cascade')
+    parent_id = fields.Many2one('ir.actions.server', string='Parent Action', index=True, ondelete='cascade')
     child_ids = fields.One2many('ir.actions.server', 'parent_id', copy=True, domain=lambda self: str(self._get_children_domain()),
                                  string='Child Actions', help='Child server actions that will be executed. Note that the last return returned action value will be used as global return value.')
     # Create

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -162,7 +162,7 @@ class IrActionsReport(models.Model):
     group_ids = fields.Many2many('res.groups', 'res_groups_report_rel', 'uid', 'gid', string='Groups')
     multi = fields.Boolean(string='On Multiple Doc.', help="If set to true, the action will not be displayed on the right toolbar of a form view.")
 
-    paperformat_id = fields.Many2one('report.paperformat', 'Paper Format')
+    paperformat_id = fields.Many2one('report.paperformat', 'Paper Format', index='btree_not_null')
     print_report_name = fields.Char('Printed Report Name', translate=True,
                                     help="This is the filename of the report going to download. Keep empty to not change the report filename. You can use a python expression with the 'object' and 'time' variables.")
     attachment_use = fields.Boolean(string='Reload from Attachment',

--- a/odoo/addons/base/models/ir_filters.py
+++ b/odoo/addons/base/models/ir_filters.py
@@ -22,7 +22,7 @@ class IrFilters(models.Model):
                                 help="The menu action this filter applies to. "
                                      "When left empty the filter applies to all menus "
                                      "for this model.")
-    embedded_action_id = fields.Many2one('ir.embedded.actions', help="The embedded action this filter is applied to", ondelete="cascade")
+    embedded_action_id = fields.Many2one('ir.embedded.actions', help="The embedded action this filter is applied to", ondelete="cascade", index='btree_not_null')
     embedded_parent_res_id = fields.Integer(help="id of the record the filter should be applied to. Only used in combination with embedded actions")
     active = fields.Boolean(default=True)
 

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -38,7 +38,7 @@ class ResCompany(models.Model):
     parent_path = fields.Char(index=True)
     parent_ids = fields.Many2many('res.company', compute='_compute_parent_ids', compute_sudo=True)
     root_id = fields.Many2one('res.company', compute='_compute_parent_ids', compute_sudo=True)
-    partner_id = fields.Many2one('res.partner', string='Partner', required=True)
+    partner_id = fields.Many2one('res.partner', string='Partner', required=True, index=True)
     report_header = fields.Html(string='Company Tagline', translate=True, help="Company tagline, which is included in a printed document's header or footer (depending on the selected layout).")
     report_footer = fields.Html(string='Report Footer', translate=True, help="Footer text displayed at the bottom of all reports.")
     company_details = fields.Html(string='Company Details', translate=True, help="Header text displayed at the top of all reports.")

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -166,7 +166,7 @@ class ResCountryState(models.Model):
     _order = 'code'
     _rec_names_search = ['name', 'code']
 
-    country_id = fields.Many2one('res.country', string='Country', required=True)
+    country_id = fields.Many2one('res.country', string='Country', required=True, index=True)
     name = fields.Char(string='State Name', required=True,
                help='Administrative divisions of a country. E.g. Fed. State, Departement, Canton')
     code = fields.Char(string='State Code', help='The state code.', required=True)

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -368,7 +368,7 @@ class ResCurrencyRate(models.Model):
         aggregator="avg",
         help="The rate of the currency to the currency of rate 1 ",
     )
-    currency_id = fields.Many2one('res.currency', string='Currency', readonly=True, required=True, ondelete="cascade")
+    currency_id = fields.Many2one('res.currency', string='Currency', readonly=True, required=True, index=True, ondelete="cascade")
     company_id = fields.Many2one('res.company', string='Company',
                                  default=lambda self: self.env.company.root_id)
 

--- a/odoo/addons/base/models/res_users_settings.py
+++ b/odoo/addons/base/models/res_users_settings.py
@@ -9,7 +9,7 @@ class ResUsersSettings(models.Model):
     _description = 'User Settings'
     _rec_name = 'user_id'
 
-    user_id = fields.Many2one("res.users", string="User", required=True, ondelete="cascade", domain=[("res_users_settings_id", "=", False)])
+    user_id = fields.Many2one("res.users", string="User", required=True, index=True, ondelete="cascade", domain=[("res_users_settings_id", "=", False)])
 
     _unique_user_id = models.Constraint(
         'UNIQUE(user_id)',

--- a/odoo/addons/test_lint/tests/__init__.py
+++ b/odoo/addons/test_lint/tests/__init__.py
@@ -3,6 +3,7 @@ from . import test_checkers
 from . import test_pylint
 from . import test_pofile
 from . import test_eslint
+from . import test_index
 from . import test_jstranslate
 from . import test_l10n
 from . import test_manifests

--- a/odoo/addons/test_lint/tests/test_index.py
+++ b/odoo/addons/test_lint/tests/test_index.py
@@ -1,0 +1,49 @@
+from odoo.tests import common
+
+BTREE_INDEX_PY_DEFS = (True, '1', 'btree', 'btree_not_null')
+# Ignore list of models and fields we don't want to index,
+# usually because the table is known to always be small,
+# or there is a custom index that covers this btree index
+# A separate ignore list for models is provided to simplify maintenance.
+BTREE_INDEX_IGNORE_MODELS = set()  # model._name
+BTREE_INDEX_IGNORE_FIELDS = set()  # str(field)  (fully-qualified field name)
+
+@common.tagged('post_install', '-at_install')
+class TestOne2manyInverseIndexing(common.TransactionCase):
+
+    def test_enforce_index_on_one2many_inverse(self):
+        """Ensure btree indexes are enforced on the stored inverse fields of One2many relations."""
+        def ignore(o2m_field, m2o_field):
+            if not comodel._auto or comodel._abstract:
+                return True  # tableless
+            if comodel.is_transient():
+                return True  # transient models shouldn't have a lot of records
+            if not (m2o_field.store and m2o_field.column_type):
+                return True  # the m2o isn't stored in database
+            if o2m_field.comodel_name in BTREE_INDEX_IGNORE_MODELS:
+                return True  # the o2m field's model is in the model ignore list
+            if str(m2o_field) in BTREE_INDEX_IGNORE_FIELDS:
+                return True  # the m2o field is in the field ignore list
+            if m2o_field.index in BTREE_INDEX_PY_DEFS:
+                return True  # the field is already indexed in the definition
+            if all('test' in model_data.module
+                   for model_data in self.env['ir.model.data'].search([('model', '=', comodel._name)])):
+                return True  # skip model if it's exclusively used in testing modules
+            return False
+
+        fields_to_index = set()
+        for model_name in self.env.registry:
+            model = self.env[model_name]
+            for field in model._fields.values():
+                if field.type == 'one2many' and field.inverse_name:
+                    comodel = self.env[field.comodel_name]
+                    inverse_field = comodel._fields.get(field.inverse_name)
+                    if inverse_field and not ignore(field, inverse_field):
+                        fields_to_index.add(f"{inverse_field} (inverse of {field})")
+        if fields_to_index:
+            msg = ("The following fields should be indexed with a btree index,\n"
+                   "as they are inverse of an One2many field:\n"
+                   "- if the field is sparse -> 'btree_not_null'\n"
+                   "- if the field is Required or low fraction of False/NULL values -> True or 'btree'\n"
+                   "- if not sure -> 'btree_not_null': \n%s" % "\n".join(sorted(fields_to_index)))
+            self.fail(msg)

--- a/odoo/addons/test_lint/tests/test_index.py
+++ b/odoo/addons/test_lint/tests/test_index.py
@@ -5,8 +5,26 @@ BTREE_INDEX_PY_DEFS = (True, '1', 'btree', 'btree_not_null')
 # usually because the table is known to always be small,
 # or there is a custom index that covers this btree index
 # A separate ignore list for models is provided to simplify maintenance.
-BTREE_INDEX_IGNORE_MODELS = set()  # model._name
-BTREE_INDEX_IGNORE_FIELDS = set()  # str(field)  (fully-qualified field name)
+BTREE_INDEX_IGNORE_MODELS = {  # model._name
+    'res.company',
+    'stock.warehouse',
+}
+BTREE_INDEX_IGNORE_FIELDS = {  # str(field)  (fully-qualified field name)
+    'mail.message.res_id',                              # covered by _model_res_id_idx, should always be accessed via a domain adding the model
+    'ir.attachment.res_id',                             # covered by _res_idx, should always be accessed via a domain adding the model
+    'spreadsheet.revision.res_id',                      # covered by _res_model_res_id_idx, should be accessed via a domain adding the model
+    'discuss.channel.member.channel_id',                # covered by first key of _seen_message_id_idx
+    'discuss.channel.rtc.session.channel_member_id',    # covered by _channel_member_unique
+    'documents.document.attachment_id',                 # covered by _attachment_unique, which is enforced with an unique btree index
+    'account.fiscal.position.account.position_id',      # covered by first key of _account_src_dest_uniq
+    'mailing.subscription.contact_id',                  # covered by first key of _unique_contact_list
+    'iap.extracted.words.res_id',                       # covered by first key of _res_id_res_model_idx
+    'knowledge.article.member.article_id',              # covered by first key of _unique_article_partner
+    'slide.channel.forum_id',                           # covered by _forum_uniq
+    'hr.appraisal.skill.appraisal_id',                  # covered by first key of __unique_skill
+    'mail.presence.user_id',                            # covered by _user_unique
+    'mail.presence.guest_id',                           # covered by _guest_unique
+}
 
 @common.tagged('post_install', '-at_install')
 class TestOne2manyInverseIndexing(common.TransactionCase):


### PR DESCRIPTION
## Description
Stored One2many fields should generally have their Many2one inverses indexed. The ORM often uses the Many2one inverse as a domain to query related records for One2many fields, such as reading their values or resolving dependency trees for computed fields. These queries are often simple and lack additional criteria, causing the database to resort to Seq.Scans if the fields are not indexed. While this might be fine for small, static tables, it can lead to significant performance regressions for larger, growing tables.

To address this, we enforce the creation of btree indexes on all stored Many2one fields that act as inverses for One2many fields. For small tables, the impact of adding these indexes is minimal in terms of size and insertion performance. For larger tables, the read performance improvements far outweigh the minor overhead of maintaining and the size of the indexes, particularly since most queries are read-intensive.

An ignore list is provided on the CI for models and fields where indexing is deemed unnecessary, either because the table is known to remain small or a custom index already exists.

## Reference:
task-4596781

List of missing indexes can be found in the task's description

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
