### PR TITLE
[FIX] website_sale: prevent duplicate cart payments

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -4,12 +4,16 @@
 import json
 import logging
 from datetime import datetime
+
+from psycopg2.errors import LockNotAvailable
 from werkzeug.exceptions import Forbidden, NotFound
 from werkzeug.urls import url_decode, url_encode, url_parse
 
 from odoo import fields, http, SUPERUSER_ID, tools, _
+from odoo.exceptions import AccessError, MissingError, UserError, ValidationError
 from odoo.fields import Command
 from odoo.http import request
+
 from odoo.addons.base.models.ir_qweb_fields import nl2br
 from odoo.addons.http_routing.models.ir_http import slug
 from odoo.addons.payment import utils as payment_utils
@@ -17,7 +21,6 @@ from odoo.addons.payment.controllers import portal as payment_portal
 from odoo.addons.payment.controllers.post_processing import PaymentPostProcessing
 from odoo.addons.website.controllers.main import QueryURL
 from odoo.addons.website.models.ir_http import sitemap_qs2dom
-from odoo.exceptions import AccessError, MissingError, ValidationError
 from odoo.addons.portal.controllers.portal import _build_url_w_params
 from odoo.addons.website.controllers import main
 from odoo.addons.website.controllers.form import WebsiteForm
@@ -1793,6 +1796,13 @@ class PaymentPortal(payment_portal.PaymentPortal):
         if order_sudo.state == "cancel":
             raise ValidationError(_("The order has been canceled."))
 
+        try:  # prevent concurrent payments by putting a database-level lock on the SO
+            request.env.cr.execute(
+                f'SELECT 1 FROM sale_order WHERE id = {order_sudo.id} FOR NO KEY UPDATE NOWAIT'
+            )
+        except LockNotAvailable:
+            raise UserError(_("Payment is already being processed."))
+
         kwargs.update({
             'reference_prefix': None,  # Allow the reference to be computed based on the order
             'partner_id': order_sudo.partner_invoice_id.id,
@@ -1802,8 +1812,14 @@ class PaymentPortal(payment_portal.PaymentPortal):
         if not kwargs.get('amount'):
             kwargs['amount'] = order_sudo.amount_total
 
-        if tools.float_compare(kwargs['amount'], order_sudo.amount_total, precision_rounding=order_sudo.currency_id.rounding):
+        compare_amounts = order_sudo.currency_id.compare_amounts
+        if compare_amounts(kwargs['amount'], order_sudo.amount_total):
             raise ValidationError(_("The cart has been updated. Please refresh the page."))
+        amount_paid = sum(
+            tx.amount for tx in order_sudo.transaction_ids if tx.state in ('authorized', 'done')
+        )
+        if compare_amounts(amount_paid, order_sudo.amount_total) == 0:
+            raise UserError(_("The cart has already been paid. Please refresh the page."))
 
         tx_sudo = self._create_transaction(
             custom_create_values={'sale_order_ids': [Command.set([order_id])]}, **kwargs,

--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -2551,6 +2551,13 @@ msgid "Payment Transactions"
 msgstr ""
 
 #. module: website_sale
+#. odoo-python
+#: code:addons/website_sale/controllers/main.py:0
+#, python-format
+msgid "Payment is already being processed."
+msgstr ""
+
+#. module: website_sale
 #. odoo-javascript
 #: code:addons/website_sale/static/src/xml/website_sale_dashboard.xml:0
 #, python-format
@@ -3639,6 +3646,13 @@ msgstr ""
 #: model:ir.model.fields,help:website_sale.field_product_template__compare_list_price
 msgid ""
 "The amount will be displayed strikethroughed on the eCommerce product page"
+msgstr ""
+
+#. module: website_sale
+#. odoo-python
+#: code:addons/website_sale/controllers/main.py:0
+#, python-format
+msgid "The cart has already been paid. Please refresh the page."
 msgstr ""
 
 #. module: website_sale


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Have a cart ready to be paid;
2. open `/shop/payment` in two windows;
3. click "Pay now" in  one window;
4. click "Pay now" in the next window.

Issue
-----
Depending on version, installed modules & click speed, one of the following happens:
- Error: "The operation cannot be completed: Reference must be unique!"
- 500: Internal Server Error.
- Both payments get confirmed.

Cause
-----
There's no check on whether a payment is already being processed for a particular order.

This can happen in two manners:
1. The 1st one has finished, but the 2nd one is still allowed to start.
2. Clicking fast enough, both will try to transaction concurrently.

Solution
--------
1. If the `amount_total` is equal to `amount_paid`, raise an error.
2. Put a database-level lock on the Sale Order using `FOR NO KEY UPDATE` which will get released as soon as the payment transaction is committed to the database, or is rolled back due to failure.

opw-4555664
