### PR TITLE
[IMP] core: avoid savepoint() in tools.sql

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -495,7 +495,7 @@ def load_modules(
             _logger.error("Some modules have inconsistent states, some dependencies may be missing: %s", sorted(module_list))
 
         # STEP 3.6: apply remaining constraints in case of an upgrade
-        registry.finalize_constraints()
+        registry.finalize_constraints(cr)
 
         # STEP 4: Finish and cleanup installations
         if registry.updated_modules:

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1098,9 +1098,19 @@ class Field(typing.Generic[T]):
             # _init_column may delay computations in post-init phase
             @model.pool.post_init
             def add_not_null():
-                # flush values before adding NOT NULL constraint
-                model.flush_model([self.name])
-                model.pool.post_constraint(apply_required, model, self.name)
+                # At the time this function is called, the model's _fields may have been reset, although
+                # the model's class is still the same. Retrieve the field to see whether the NOT NULL
+                # constraint still applies.
+                field = model._fields[self.name]
+                if not field.required or not field.store:
+                    return
+                # Flush values before adding NOT NULL constraint.
+                model.flush_model([field.name])
+                model.pool.post_constraint(
+                    model.env.cr,
+                    lambda cr: sql.set_not_null(cr, model._table, field.name),
+                    key=f"add_not_null:{model._table}:{field.name}",
+                )
 
         elif not self.required and has_notnull:
             sql.drop_not_null(model._cr, model._table, self.name)
@@ -1617,15 +1627,6 @@ class Field(typing.Generic[T]):
     def determine_group_expand(self, records, values, domain):
         """ Return a domain representing a condition on ``self``. """
         return determine(self.group_expand, records, values, domain)
-
-def apply_required(model, field_name):
-    """ Set a NOT NULL constraint on the given field, if necessary. """
-    # At the time this function is called, the model's _fields may have been reset, although
-    # the model's class is still the same. Retrieve the field to see whether the NOT NULL
-    # constraint still applies
-    field = model._fields[field_name]
-    if field.store and field.required:
-        sql.set_not_null(model.env.cr, model._table, field_name)
 
 
 # forward-reference to models because we have this last cyclic dependency

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -204,7 +204,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
         else:
             self._assertion_report = None
         self._ordinary_tables: set[str] | None = None  # cached names of regular tables
-        self._constraint_queue: deque[tuple] = deque()  # queue of functions to call on finalization of constraints
+        self._constraint_queue: dict[typing.Any, Callable[[BaseCursor], None]] = {}  # queue of functions to call on finalization of constraints
         self.__caches: dict[str, LRU] = {cache_name: LRU(cache_size) for cache_name, cache_size in _REGISTRY_CACHES.items()}
 
         # update context during loading modules
@@ -563,38 +563,40 @@ class Registry(Mapping[str, type["BaseModel"]]):
             self._is_modifying_relations[field] = result
             return result
 
-    def post_init(self, func, *args, **kwargs):
+    def post_init(self, func: Callable, *args, **kwargs) -> None:
         """ Register a function to call at the end of :meth:`~.init_models`. """
         self._post_init_queue.append(partial(func, *args, **kwargs))
 
-    def post_constraint(self, func, *args, **kwargs):
+    def post_constraint(self, cr: BaseCursor, func: Callable[[BaseCursor], None], key) -> None:
         """ Call the given function, and delay it if it fails during an upgrade. """
         try:
-            if (func, args, kwargs) not in self._constraint_queue:
+            if key not in self._constraint_queue:
                 # Module A may try to apply a constraint and fail but another module B inheriting
                 # from Module A may try to reapply the same constraint and succeed, however the
                 # constraint would already be in the _constraint_queue and would be executed again
                 # at the end of the registry cycle, this would fail (already-existing constraint)
                 # and generate an error, therefore a constraint should only be applied if it's
                 # not already marked as "to be applied".
-                func(*args, **kwargs)
+                with cr.savepoint(flush=False):
+                    func(cr)
         except Exception as e:
             if self._is_install:
                 _schema.error(*e.args)
             else:
                 _schema.info(*e.args)
-                self._constraint_queue.append((func, args, kwargs))
+                self._constraint_queue[key] = func
 
-    def finalize_constraints(self) -> None:
+    def finalize_constraints(self, cr: Cursor) -> None:
         """ Call the delayed functions from above. """
-        while self._constraint_queue:
-            func, args, kwargs = self._constraint_queue.popleft()
+        for func in self._constraint_queue.values():
             try:
-                func(*args, **kwargs)
+                with cr.savepoint(flush=False):
+                    func(cr)
             except Exception as e:
                 # warn only, this is not a deployment showstopper, and
                 # can sometimes be a transient error
                 _schema.warning(*e.args)
+        self._constraint_queue.clear()
 
     def init_models(self, cr: Cursor, model_names: Iterable[str], context: dict[str, typing.Any], install: bool = True):
         """ Initialize a list of models (given by their name). Call methods
@@ -706,9 +708,10 @@ class Registry(Mapping[str, type["BaseModel"]]):
                     method = 'btree'
                     where = f'{column_expression} IS NOT NULL' if index == 'btree_not_null' else ''
                 try:
-                    sql.create_index(cr, indexname, tablename, [expression], method, where)
+                    with cr.savepoint(flush=False):
+                        sql.create_index(cr, indexname, tablename, [expression], method, where)
                 except psycopg2.OperationalError:
-                    _schema.error("Unable to add index for %s", self)
+                    _schema.error("Unable to add index %r for %s", indexname, self)
 
             elif not index and tablename == existing.get(indexname):
                 _schema.info("Keep unexpected index %s on table %s", indexname, tablename)

--- a/odoo/orm/table_objects.py
+++ b/odoo/orm/table_objects.py
@@ -117,7 +117,8 @@ class Constraint(TableObject):
             # constraint exists but its definition may have changed
             sql.drop_constraint(cr, model._table, conname)
 
-        model.pool.post_constraint(sql.add_constraint, cr, model._table, conname, definition)
+        model.pool.post_constraint(
+            cr, lambda cr: sql.add_constraint(cr, model._table, conname, definition), conname)
 
 
 class Index(TableObject):
@@ -165,15 +166,14 @@ class Index(TableObject):
             definition_clause = self._index_definition(model.pool)
         else:
             definition_clause = self._index_definition
-        model.pool.post_constraint(
-            sql.add_index,
+        model.pool.post_constraint(cr, lambda cr: sql.add_index(
             cr,
             conname,
             model._table,
             comment=definition,
             definition=definition_clause,
             unique=self.unique,
-        )
+        ), conname)
 
 
 class UniqueIndex(Index):

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -413,12 +413,8 @@ def set_not_null(cr, tablename, columnname):
         "ALTER TABLE %s ALTER COLUMN %s SET NOT NULL",
         SQL.identifier(tablename), SQL.identifier(columnname),
     )
-    try:
-        with cr.savepoint(flush=False):
-            cr.execute(query, log_exceptions=False)
-            _schema.debug("Table %r: column %r: added constraint NOT NULL", tablename, columnname)
-    except Exception:
-        raise Exception("Table %r: unable to set NOT NULL on column %r", tablename, columnname)
+    cr.execute(query, log_exceptions=False)
+    _schema.debug("Table %r: column %r: added constraint NOT NULL", tablename, columnname)
 
 
 def drop_not_null(cr, tablename, columnname):
@@ -452,26 +448,18 @@ def add_constraint(cr, tablename, constraintname, definition):
         "COMMENT ON CONSTRAINT %s ON %s IS %s",
         SQL.identifier(constraintname), SQL.identifier(tablename), definition,
     )
-    try:
-        with cr.savepoint(flush=False):
-            cr.execute(query1, log_exceptions=False)
-            cr.execute(query2, log_exceptions=False)
-            _schema.debug("Table %r: added constraint %r as %s", tablename, constraintname, definition)
-    except Exception:
-        raise Exception("Table %r: unable to add constraint %r as %s", tablename, constraintname, definition)
+    cr.execute(query1, log_exceptions=False)
+    cr.execute(query2, log_exceptions=False)
+    _schema.debug("Table %r: added constraint %r as %s", tablename, constraintname, definition)
 
 
 def drop_constraint(cr, tablename, constraintname):
-    """ drop the given constraint. """
-    try:
-        with cr.savepoint(flush=False):
-            cr.execute(SQL(
-                "ALTER TABLE %s DROP CONSTRAINT %s",
-                SQL.identifier(tablename), SQL.identifier(constraintname),
-            ))
-            _schema.debug("Table %r: dropped constraint %r", tablename, constraintname)
-    except Exception:
-        _schema.warning("Table %r: unable to drop constraint %r!", tablename, constraintname)
+    """ Drop the given constraint. """
+    cr.execute(SQL(
+        "ALTER TABLE %s DROP CONSTRAINT %s",
+        SQL.identifier(tablename), SQL.identifier(constraintname),
+    ))
+    _schema.debug("Table %r: dropped constraint %r", tablename, constraintname)
 
 
 def add_foreign_key(cr, tablename1, columnname1, tablename2, columnname2, ondelete):
@@ -609,11 +597,10 @@ def add_index(cr, indexname, tablename, definition, *, unique: bool, comment='')
         "COMMENT ON INDEX %s IS %s",
         SQL.identifier(indexname), comment,
     ) if comment else None
-    with cr.savepoint(flush=False):
-        cr.execute(query, log_exceptions=False)
-        if query_comment:
-            cr.execute(query_comment, log_exceptions=False)
-        _schema.debug("Table %r: created index %r (%s)", tablename, indexname, definition.code)
+    cr.execute(query, log_exceptions=False)
+    if query_comment:
+        cr.execute(query_comment, log_exceptions=False)
+    _schema.debug("Table %r: created index %r (%s)", tablename, indexname, definition.code)
 
 
 def create_unique_index(cr, indexname, tablename, expressions):


### PR DESCRIPTION
Align how functions in methods in `tools/sql.py` work: the caller is responsible of managing the state of the transaction, therefore we stop creating savepoints at every call to some functions.

We refactor the callers to create the necessary savepoints. This is mostly done by using `Registry.post_constraint` which tries to apply the constraint, and on failure, retries at the end of the installation.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
