### PR TITLE
[FIX] pos_loyalty: update rewards after scanning partner barcode

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/product_screen/product_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/product_screen/product_screen.js
@@ -26,4 +26,8 @@ patch(ProductScreen.prototype, {
         await super._barcodeGS1Action(code);
         this.pos.updateRewards();
     },
+    async _barcodePartnerAction(code) {
+        await super._barcodePartnerAction(code);
+        this.pos.updateRewards();
+    },
 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Steps to reproduce:
- Create a POS
- Enable discount, promo & loyalty
- Create a customer, set the PoS barcode information
- Create an eWallet for a customer
- Scan the barcode in POS
- Partner is set but then no eWallet could be applied

Current behavior before PR:
Cannot use eWallet payment after scanning partner barcode

Desired behavior after PR is merged:
Will be able to use eWallet payment after scanning partner barcode

task: opw-4572313

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
