### PR TITLE
[IMP] mail, various: improve performance of recipients computation

### DIFF
--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -114,12 +114,11 @@ class Base(models.AbstractModel):
           customers to contact;
         """
         partner_fields = self._mail_get_partner_fields(introspect_fields=introspect_fields)
-        pids = {pid for record in self for fn in partner_fields for pid in record[fn].ids}
-        Partner = self.env['res.partner'].with_prefetch(pids)
+        all_pids = {pid for record in self for fn in partner_fields for pid in record[fn].ids}
         records_partners = {}
         for record in self:
             pids = tools.unique(pid for fn in partner_fields for pid in record[fn].ids)
-            records_partners[record.id] = Partner.browse(pids)
+            records_partners[record.id] = self.env['res.partner'].browse(pids).with_prefetch(all_pids)
         return records_partners
 
     @api.model

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -250,9 +250,9 @@ class Base(models.AbstractModel):
         primary_emails = self._mail_get_primary_email()
         for record in self:
             email_cc_lst, email_to_lst = [], []
-            # main recipients (res.partner)
+            # main recipients (res.partner) (filter twice, otherwise prefetch is lost /shrug)
             recipients_all = customers.get(record.id).filtered(lambda p: not p.is_public)
-            recipients = recipients_all.filtered(lambda p: p.email_normalized)
+            recipients = customers.get(record.id).filtered(lambda p: not p.is_public and p.email_normalized)
             # to computation
             email_to = primary_emails[record.id]
             if not email_to:

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -201,9 +201,9 @@ class ResPartner(models.Model):
                 }
                 for name in names if name not in partners.mapped('email') and name not in (ban_emails or [])
             ]
-            # create partners once
+            # create partners once, avoid current user being followers of those
             if tocreate_vals_list:
-                partners += self.create(tocreate_vals_list)
+                partners += self.with_context(mail_create_nosubscribe=True).create(tocreate_vals_list)
 
         # sort partners (already ordered based on search)
         if sort_key:

--- a/addons/membership/models/partner.py
+++ b/addons/membership/models/partner.py
@@ -47,6 +47,13 @@ class ResPartner(models.Model):
     def _compute_membership_state(self):
         today = fields.Date.today()
         for partner in self:
+            if not partner.member_lines and not partner.associate_member:
+                partner.membership_start = partner.membership_start or False
+                partner.membership_stop = partner.membership_stop or False
+                partner.membership_cancel = partner.membership_cancel or False
+                partner.membership_state = partner.membership_state or (partner.free_member and 'free') or 'none'
+                continue
+
             partner.membership_start = self.env['membership.membership_line'].search([
                 ('partner', 'in', (partner.associate_member or partner).ids), ('date_cancel', '=', False)
             ], limit=1, order='date_from').date_from

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -21,6 +21,19 @@ class MailPerformanceThread(models.Model):
             record.value_pc = float(record.value) / 100
 
 
+class MailPerformanceThreadRecipients(models.Model):
+    _name = 'mail.performance.thread.recipients'
+    _description = 'Performance: mail.thread, for recipients'
+    _inherit = ['mail.thread']
+    _primary_email = 'email_from'
+
+    name = fields.Char()
+    value = fields.Integer()
+    email_from = fields.Char('Email From')
+    partner_id = fields.Many2one('res.partner', string='Customer')
+    user_id = fields.Many2one('res.users', 'Responsible', tracking=1)
+
+
 class MailPerformanceTracking(models.Model):
     _name = 'mail.performance.tracking'
     _description = 'Performance: multi tracking'

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -1,5 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_mail_performance_thread,access_mail_performance_thread,model_mail_performance_thread,base.group_user,1,1,1,1
+access_mail_performance_thread_recipients,access_mail_performance_thread_recipients,model_mail_performance_thread_recipients,base.group_user,1,1,1,1
 access_mail_performance_tracking_user,mail.performance.tracking,model_mail_performance_tracking,base.group_user,1,1,1,1
 access_mail_test_access_portal,mail.access.portal.portal,model_mail_test_access,base.group_portal,1,1,0,0
 access_mail_test_access_public,mail.access.portal.public,model_mail_test_access,base.group_public,1,0,0,0

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -919,7 +919,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_default_recipients_batch(self):
         records = self.test_records_recipients.with_env(self.env)
-        with self.assertQueryCount(employee=8):
+        with self.assertQueryCount(employee=6):
             defaults = records._message_get_default_recipients()
         self.assertDictEqual(defaults, {
             records[0].id: {
@@ -963,7 +963,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_suggested_recipients_batch(self):
         records = self.test_records_recipients.with_env(self.env)
-        with self.assertQueryCount(employee=44):  # tm: 25
+        with self.assertQueryCount(employee=42):  # tm: 23
             _recipients = records._message_get_suggested_recipients_batch(no_create=False)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -948,7 +948,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_suggested_recipients(self):
         record = self.test_records_recipients[0].with_env(self.env)
-        with self.assertQueryCount(employee=26):  # tm: 16
+        with self.assertQueryCount(employee=24):  # tm: 14
             recipients = record._message_get_suggested_recipients(no_create=False)
         new_partner = self.env['res.partner'].search([('email_normalized', '=', 'only.email.1@test.example.com')])
         self.assertEqual(len(new_partner), 1)
@@ -963,7 +963,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_suggested_recipients_batch(self):
         records = self.test_records_recipients.with_env(self.env)
-        with self.assertQueryCount(employee=40):  # tm: 21
+        with self.assertQueryCount(employee=38):  # tm: 19
             _recipients = records._message_get_suggested_recipients_batch(no_create=False)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
@@ -1074,7 +1074,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_partner_find_from_emails(self):
         """ Test '_partner_find_from_emails', notably to check batch optimization """
         records = self.test_records_recipients.with_user(self.env.user)
-        with self.assertQueryCount(employee=40):  # tm: 20
+        with self.assertQueryCount(employee=38):  # tm: 18
             partners = records._partner_find_from_emails(
                 {record: [record.email_from, record.partner_id.email, record.user_id.email] for record in records},
                 avoid_alias=True,

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -487,7 +487,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
         test_template.write({'attachment_ids': [(5, 0)]})
 
-        with self.assertQueryCount(admin=34, employee=34):  # tm: 22/22
+        with self.assertQueryCount(admin=29, employee=29):  # tm: 22/22
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -948,7 +948,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_suggested_recipients(self):
         record = self.test_records_recipients[0].with_env(self.env)
-        with self.assertQueryCount(employee=24):  # tm: 14
+        with self.assertQueryCount(employee=21):  # tm: 14
             recipients = record._message_get_suggested_recipients(no_create=False)
         new_partner = self.env['res.partner'].search([('email_normalized', '=', 'only.email.1@test.example.com')])
         self.assertEqual(len(new_partner), 1)
@@ -963,7 +963,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_suggested_recipients_batch(self):
         records = self.test_records_recipients.with_env(self.env)
-        with self.assertQueryCount(employee=38):  # tm: 19
+        with self.assertQueryCount(employee=26):  # tm: 19
             _recipients = records._message_get_suggested_recipients_batch(no_create=False)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
@@ -1074,7 +1074,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_partner_find_from_emails(self):
         """ Test '_partner_find_from_emails', notably to check batch optimization """
         records = self.test_records_recipients.with_user(self.env.user)
-        with self.assertQueryCount(employee=38):  # tm: 18
+        with self.assertQueryCount(employee=26):  # tm: 18
             partners = records._partner_find_from_emails(
                 {record: [record.email_from, record.partner_id.email, record.user_id.email] for record in records},
                 avoid_alias=True,

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -919,7 +919,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_default_recipients_batch(self):
         records = self.test_records_recipients.with_env(self.env)
-        with self.assertQueryCount(employee=6):
+        with self.assertQueryCount(employee=4):
             defaults = records._message_get_default_recipients()
         self.assertDictEqual(defaults, {
             records[0].id: {
@@ -963,7 +963,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_suggested_recipients_batch(self):
         records = self.test_records_recipients.with_env(self.env)
-        with self.assertQueryCount(employee=42):  # tm: 23
+        with self.assertQueryCount(employee=40):  # tm: 21
             _recipients = records._message_get_suggested_recipients_batch(no_create=False)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -419,7 +419,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, _test_template = self._create_test_records()
         customer = self.env['res.partner'].browse(self.customer.ids)
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
-        with self.assertQueryCount(admin=20, employee=20):  # tm 14/14
+        with self.assertQueryCount(admin=20, employee=20):  # tm 19/19
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -487,8 +487,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
         test_template.write({'attachment_ids': [(5, 0)]})
 
-        # TDE FIXME: from 9 to 34 due to suggested recipients -> to optimize
-        with self.assertQueryCount(admin=34, employee=34):
+        with self.assertQueryCount(admin=34, employee=34):  # tm: 22/22
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -502,9 +501,12 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         # notifications
         message = test_record.message_ids[0]
         self.assertFalse(message.attachment_ids)
+        new_partner = self.env['res.partner'].sudo().search([('email', '=', 'nopartner.test@example.com')])
+        self.assertTrue(new_partner)
+        self.assertEqual(message.notified_partner_ids, self.user_test.partner_id + self.customer + new_partner)
 
         # remove created partner to ensure tests are the same each run
-        self.env['res.partner'].sudo().search([('email', '=', 'nopartner.test@example.com')]).unlink()
+        new_partner.unlink()
 
     @users('admin', 'employee')
     @warmup
@@ -512,8 +514,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_mail_composer_w_template_attachments(self):
         test_record, test_template = self._create_test_records()
 
-        # TDE FIXME: from 10 to 35 due to suggested recipients -> to optimize
-        with self.assertQueryCount(admin=35, employee=35):
+        with self.assertQueryCount(admin=35, employee=35):  # tm: 23/23
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -541,9 +542,8 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
         test_template.write({'attachment_ids': [(5, 0)]})
 
-        # TDE FIXME: from 20 to 49 due to suggested recipients -> to optimize
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=49, employee=49):  # tm 16/16
+        with self.assertQueryCount(admin=49, employee=49):  # tm 36/36
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -572,9 +572,8 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_mail_composer_w_template_form_attachments(self):
         test_record, test_template = self._create_test_records()
 
-        # TDE FIXME: from 20 to 49 due to suggested recipients -> to optimize
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=49, employee=49):  # tm 16/16
+        with self.assertQueryCount(admin=49, employee=49):  # tm 36/36
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -612,7 +611,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         # use another user already pre-defined with the email notification type,
         # so the ormcache is preserved.
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(admin=40, employee=39):
+        with self.assertQueryCount(admin=39, employee=38):
             record.write({
                 'user_id': self.user_test_email.id,
             })
@@ -814,6 +813,23 @@ class TestMailAPIPerformance(BaseMailPerformance):
             cls.env.ref('test_mail.st_mail_test_container_child_full').id
         ])
 
+        cls.test_records_recipients = cls.env['mail.performance.thread.recipients'].create([
+            {
+                'email_from': 'only.email.1@test.example.com',
+            }, {
+                'email_from': 'only.email.2@test.example.com',
+            }, {
+                'email_from': 'both.1@test.example.com',
+                'partner_id': cls.partners[0].id,
+            }, {
+                'email_from': 'trice.1@test.example.com',
+                'partner_id': cls.partners[1].id,
+                'user_id': cls.user_admin.id,
+            }, {
+                'partner_id': cls.partners[2].id,
+            },
+        ])
+
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     @users('admin', 'employee')
     @warmup
@@ -888,6 +904,67 @@ class TestMailAPIPerformance(BaseMailPerformance):
         self.assertIn(mails[-2].id, unlinked_mails, 'Mail: mails with invalid recipient are also to be unlinked')
         self.assertEqual(mails[-1].state, 'exception')
         self.assertIn(mails[-1].id, unlinked_mails, 'Mail: mails with invalid recipient are also to be unlinked')
+
+    @users('employee')
+    @warmup
+    def test_message_get_default_recipients(self):
+        record = self.test_records_recipients[0].with_env(self.env)
+        with self.assertQueryCount(employee=1):
+            defaults = record._message_get_default_recipients()
+        self.assertDictEqual(defaults, {record.id: {
+            'email_cc': '', 'email_to': 'only.email.1@test.example.com', 'partner_ids': [],
+        }})
+
+    @users('employee')
+    @warmup
+    def test_message_get_default_recipients_batch(self):
+        records = self.test_records_recipients.with_env(self.env)
+        with self.assertQueryCount(employee=8):
+            defaults = records._message_get_default_recipients()
+        self.assertDictEqual(defaults, {
+            records[0].id: {
+                'email_cc': '',
+                'email_to': 'only.email.1@test.example.com',
+                'partner_ids': []},
+            records[1].id: {
+                'email_cc': '',
+                'email_to': 'only.email.2@test.example.com',
+                'partner_ids': []},
+            records[2].id: {
+                'email_cc': '',
+                'email_to': '',
+                'partner_ids': self.partners[0].ids},
+            records[3].id: {
+                'email_cc': '',
+                'email_to': '',
+                'partner_ids': self.partners[1].ids},
+            records[4].id: {
+                'email_cc': '',
+                'email_to': '',
+                'partner_ids': self.partners[2].ids},
+        })
+
+    @users('employee')
+    @warmup
+    def test_message_get_suggested_recipients(self):
+        record = self.test_records_recipients[0].with_env(self.env)
+        with self.assertQueryCount(employee=26):  # tm: 16
+            recipients = record._message_get_suggested_recipients(no_create=False)
+        new_partner = self.env['res.partner'].search([('email_normalized', '=', 'only.email.1@test.example.com')])
+        self.assertEqual(len(new_partner), 1)
+        self.assertDictEqual(recipients[0], {
+            'email': 'only.email.1@test.example.com',
+            'name': 'only.email.1@test.example.com',
+            'partner_id': new_partner.id,
+            'create_values': {},
+        })
+
+    @users('employee')
+    @warmup
+    def test_message_get_suggested_recipients_batch(self):
+        records = self.test_records_recipients.with_env(self.env)
+        with self.assertQueryCount(employee=44):  # tm: 25
+            _recipients = records._message_get_suggested_recipients_batch(no_create=False)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     @users('admin', 'employee')
@@ -991,6 +1068,29 @@ class TestMailAPIPerformance(BaseMailPerformance):
             )
 
         self.assertEqual(rec1.message_partner_ids, self.env.user.partner_id | self.user_portal.partner_id | self.partners)
+
+    @users('employee')
+    @warmup
+    def test_partner_find_from_emails(self):
+        """ Test '_partner_find_from_emails', notably to check batch optimization """
+        records = self.test_records_recipients.with_user(self.env.user)
+        with self.assertQueryCount(employee=40):  # tm: 20
+            partners = records._partner_find_from_emails(
+                {record: [record.email_from, record.partner_id.email, record.user_id.email] for record in records},
+                avoid_alias=True,
+                no_create=False,
+            )
+        new_p1 = self.env['res.partner'].search([('email_normalized', '=', 'only.email.1@test.example.com')])
+        new_p2 = self.env['res.partner'].search([('email_normalized', '=', 'only.email.2@test.example.com')])
+        new_p3 = self.env['res.partner'].search([('email_normalized', '=', 'both.1@test.example.com')])
+        new_p4 = self.env['res.partner'].search([('email_normalized', '=', 'trice.1@test.example.com')])
+        self.assertDictEqual(partners, {
+            records[0].id: new_p1,
+            records[1].id: new_p2,
+            records[2].id: new_p3 + self.partners[0],
+            records[3].id: new_p4 + self.partners[1] + self.partner_admin,
+            records[4].id: self.partners[2],
+        })
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     @users('admin', 'employee')


### PR DESCRIPTION
Since odoo/odoo#198095 templates enable suggested recipients fetch when
computing recipients automatically. This made some query counters
higher than before, hence adding some performance tests.

After check, using suggested recipients actually creates partners for
additional recipients. This was not the case with default recipients.
Additional queries come from creating partners notably.

Some performance tests are added then profiled. Some performance
improvements are done in this PR to lessen number of irrelevant queries.
Those are related to: prefetching, partner creation. Some other fiximps
may come in a near future, notably with company_check on properties
fields (under investigation).

See sub commits for more details.

Task-4599142