### PR TITLE
[FIX] project: enable task dependencies feature should not reset task state

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -166,7 +166,7 @@ class Project(models.Model):
     date_start = fields.Date(string='Start Date')
     date = fields.Date(string='Expiration Date', index=True, tracking=True,
         help="Date on which this project ends. The timeframe defined on the project is taken into account when viewing its planning.")
-    allow_task_dependencies = fields.Boolean('Task Dependencies', default=lambda self: self.env.user.has_group('project.group_project_task_dependencies'))
+    allow_task_dependencies = fields.Boolean('Task Dependencies', default=lambda self: self.env.user.has_group('project.group_project_task_dependencies'), inverse='_inverse_allow_task_dependencies')
     allow_milestones = fields.Boolean('Milestones', default=lambda self: self.env.user.has_group('project.group_project_milestone'))
     tag_ids = fields.Many2many('project.tags', relation='project_project_project_tags_rel', string='Tags')
     task_properties_definition = fields.PropertiesDefinition('Task Properties')
@@ -381,6 +381,35 @@ class Project(models.Model):
                 project.access_instruction_message = _('Grant employees access to your project or tasks by adding them as followers. Employees automatically get access to the tasks they are assigned to.')
             else:
                 project.access_instruction_message = ''
+
+    def _inverse_allow_task_dependencies(self):
+        """ Reset state for waiting tasks in the project if the feature is disabled
+            or recompute the tasks with dependencies if the project has the feature enabled again
+        """
+        project_with_task_dependencies_feature = self.filtered('allow_task_dependencies')
+        projects_without_task_dependencies_feature = self - project_with_task_dependencies_feature
+        ProjectTask = self.env['project.task']
+        if (
+            project_with_task_dependencies_feature
+            and (
+                open_tasks_with_dependencies := ProjectTask.search([
+                    ('project_id', 'in', project_with_task_dependencies_feature.ids),
+                    ('depend_on_ids.state', 'in', ProjectTask.OPEN_STATES),
+                    ('state', 'in', ProjectTask.OPEN_STATES),
+                ])
+            )
+        ):
+            open_tasks_with_dependencies.state = '04_waiting_normal'
+        if (
+            projects_without_task_dependencies_feature
+            and (
+                waiting_tasks := ProjectTask.search([
+                    ('project_id', 'in', projects_without_task_dependencies_feature.ids),
+                    ('state', '=', '04_waiting_normal'),
+                ])
+            )
+        ):
+            waiting_tasks.state = '01_in_progress'
 
     # TODO: Remove in master
     @api.onchange('date_start', 'date')

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -297,7 +297,7 @@ class Task(models.Model):
         for task in self:
             task.analytic_account_id = task.project_id.analytic_account_id
 
-    @api.depends('stage_id', 'depend_on_ids.state', 'project_id.allow_task_dependencies')
+    @api.depends('stage_id', 'depend_on_ids.state')
     def _compute_state(self):
         for task in self:
             dependent_open_tasks = []

--- a/addons/project/tests/test_task_state.py
+++ b/addons/project/tests/test_task_state.py
@@ -155,3 +155,46 @@ class TestTaskState(TestProjectCommon):
 
         self.assertEqual(self.task_1.state, '04_waiting_normal')
         self.assertEqual(task_1_copy.state, '04_waiting_normal')
+
+    def test_state_dont_reset_when_enabling_task_dependencies(self):
+        self.task_1.state = "03_approved"
+        self.task_2.state = "02_changes_requested"
+        self.env['res.config.settings'].create({'group_project_task_dependencies': True}).execute()
+        self.assertEqual(self.task_1.state, "03_approved")
+        self.assertEqual(self.task_2.state, "02_changes_requested")
+
+    def test_recompute_state_when_task_dependencies_feature_changes(self):
+        """ Test task state is correctly computed when the task dependencies feature changes
+
+            Test Case:
+            ---------
+            1. Enable the task dependencies feature globally.
+            2. Add Task 2 in the dependencies of task 1.
+            3. Check task 1 as the right state ("Waiting" state expected).
+            4. Disable the task dependencies feature on the project linked to the both tasks.
+            5. Check the state of task 1 is correctly reset.
+            6. Enable again the task dependencies feature on the project.
+            7. Check task 1 state is `Waiting` state as before.
+            8. Mark as done task 2
+            9. Task 1 state should now be reset since all the tasks in dependencies are done
+               (in that case only task 2 is in the dependencies).
+            10. Change the state of task 1 to set it to `Approved` state.
+            11. Disable the task dependencies feature on the project
+            12. Check the state of task 1 did not change
+            13. Enable again the task dependencies on the project.
+            14. Check the state of task 1 did not change.
+        """
+        self.env['res.config.settings'].create({'group_project_task_dependencies': True}).execute()
+        self.task_1.depend_on_ids = self.task_2
+        self.assertEqual(self.task_1.state, '04_waiting_normal')
+        self.project_goats.allow_task_dependencies = False
+        self.assertEqual(self.task_1.state, '01_in_progress')
+        self.project_goats.allow_task_dependencies = True
+        self.assertEqual(self.task_1.state, '04_waiting_normal')
+        self.task_2.state = '1_done'
+        self.assertEqual(self.task_1.state, '01_in_progress')
+        self.task_1.state = '03_approved'
+        self.project_goats.allow_task_dependencies = False
+        self.assertEqual(self.task_1.state, '03_approved')
+        self.project_goats.allow_task_dependencies = True
+        self.assertEqual(self.task_1.state, '03_approved')


### PR DESCRIPTION
Before this commit, when the user enables the task dependencies feature globally, all basic projects (that is, non fsm ones) will get the feature. By doing that, the open tasks state will be recomputed to set `Waiting` state on tasks with blocking tasks linked to them. The problem is the compute method of the task state will also reset the state instead of keeping the one set on those open tasks when there is no blocking task linked.

This commit makes sure the compute method of task state field is no longer called when the task dependencies feature changes. Instead, a inverse method is added on allow_task_dependencies field on `project.project` model to correctly update the state of the tasks linked to the project in which the task dependencies feature changed.

Steps to reproduce the issue:
----------------------------

0. install project
1. Create a project
2. Create some tasks inside that project and changes the state to some tasks
3. Enable the task dependencies feature in `Project > Configuration > Settings` menu.
4. Go back to the tasks kanban view of that project.

Current Behavior:
----------------

The state of those tasks is reset to `In progress` (if those tasks did not have a state equals to `Done` or `Canceled`).

Expected Behavior:
-----------------

The state of those tasks should not be altered since no dependencies are added in those tasks yet.

task-4487922
