### PR TITLE
[FIX] point_of_sale: enable barcode search for product variants

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -256,6 +256,7 @@ export class ProductTemplate extends Base {
         const variantMatch = this.product_variant_ids.some(
             (variant) =>
                 (variant.default_code && variant.default_code.toLowerCase() == searchWord) ||
+                (variant.barcode && variant.barcode.toLowerCase() == searchWord) ||
                 variant.product_template_variant_value_ids.some((vv) =>
                     vv.name.toLowerCase().includes(searchWord)
                 )

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -354,6 +354,8 @@ registry.category("web_tour.tours").add("SearchProducts", {
             ProductScreen.clickDisplayedProduct("Test CHAIR 2"),
             ProductScreen.searchProduct("clémentine"),
             ProductScreen.clickDisplayedProduct("clémentine"),
+            ProductScreen.searchProduct("2100005000000"),
+            ProductScreen.clickDisplayedProduct("Wall Shelf Unit"),
         ].flat(),
 });
 


### PR DESCRIPTION
**Problem**:
When searching for a product variant using its barcode, the product does not appear in the results.

**Solution**:
Ensure that the barcode of product variants is checked when matching products during the search.

**Steps to Reproduce**:
1. Create a product with variants.
2. Assign a barcode to a variant product.
3. Start a PoS session (ensure the variant can be sold here).
4. Use the search bar to look up the variant's barcode.
   - **Issue**: No results are found.

opw-4561663

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
