### PR TITLE
[FIX] mail: fix cross tab test debug mode

### DIFF
--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -339,7 +339,7 @@ export async function start(options) {
         restoreRegistry(registry);
         const rootTarget = target;
         target = document.createElement("div");
-        target.style.width = "100%";
+        target.classList.add("o-mail-Discuss-asTabContainer");
         rootTarget.appendChild(target);
         addSwitchTabDropdownItem(rootTarget, target);
         env = await makeMockEnv({}, { makeNew: true });

--- a/addons/mail/static/tests/mail_test_helpers.scss
+++ b/addons/mail/static/tests/mail_test_helpers.scss
@@ -1,0 +1,14 @@
+.o-mail-Discuss-asTabContainer {
+    height: 100%;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    & .o_action_manager {
+        height: 100%;
+    }
+
+}


### PR DESCRIPTION
Discuss test helpers provide an `asTab` parameter to mount two main clients, simulating odoo being opened in two different tabs and a dropdown is available to switch from one view to the other.

However, height is not propagated to the parent div. As a result, discuss components are invisible, as height is not working properly.

This PR ensures the parent div is properly configured, allowing to see discuss UI.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
