### PR TITLE
[IMP] point_of_sale: search product toaster

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -431,13 +431,8 @@ export class ProductScreen extends Component {
             this.state.currentOffset = 0;
         }
         const result = await this.loadProductFromDB();
-        if (result.length > 0) {
-            this.notification.add(
-                _t('%s product(s) found for "%s".', result.length, searchProductWord),
-                3000
-            );
-        } else {
-            this.notification.add(_t('No more product found for "%s".', searchProductWord));
+        if (result.length === 0) {
+            this.notification.add(_t('No other products found for "%s".', searchProductWord), 3000);
         }
         if (this.state.previousSearchWord === searchProductWord) {
             this.state.currentOffset += result.length;


### PR DESCRIPTION
Previously, the toaster notification incorrectly displayed the number of product variants instead of actual products found. This commit removes the (useless) notification when products are found and only displays "No more product found" when no results match the search.

task-id: 4595775





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
