### PR TITLE
[FIX] hw_posbox_homepage: clear Wi-Fi configuration

### DIFF
--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -99,7 +99,7 @@ class IotBoxOwlHomePage(Home):
 
     @http.route('/hw_posbox_homepage/wifi_clear', auth='none', type='http', cors='*')
     def clear_wifi_configuration(self):
-        helpers.unlink_file('wifi_network.txt')
+        helpers.update_conf({'wifi_ssid': '', 'wifi_password': ''})
         return json.dumps({
             'status': 'success',
             'message': 'Successfully disconnected from wifi',


### PR DESCRIPTION
The Wi-Fi disconnection method was still unlinking an old configuration file, which is now replaced by the `odoo.conf` file.
This fix replaces the file unlinking by a coniguration file update.

Task: 4592796
