### PR TITLE
[FIX] iap: Add etisalat to generic mail providers (eim.ae)

### DIFF
--- a/addons/iap/tools/iap_tools.py
+++ b/addons/iap/tools/iap_tools.py
@@ -44,6 +44,7 @@ _MAIL_PROVIDERS = {
     'asterisk-tech.mn', 'in.com', 'aliceadsl.fr', 'lycos.com', 'topnet.tn', 'teleworm.us', 'kedgebs.com', 'supinfo.com', 'posteo.de',
     'yahoo.com ', 'op.pl', 'gmail.fr', 'grr.la', 'oci.fr', 'aselcis.com', 'optusnet.com.au', 'mailcatch.com', 'rambler.ru', 'protonmail.ch',
     'prisme.ch', 'bbox.fr', 'orbitalu.com', 'netcourrier.com', 'iinet.net.au', 'cegetel.net', 'proton.me', 'dbmail.com', 'club-internet.fr', 'outlook.jp',
+    'eim.ae',
     # Dummy entries
     'example.com',
 }


### PR DESCRIPTION
The email domain eim.ae is associated with Etisalat, a major telecommunications provider in the United Arab Emirates. Addresses ending with @eim.ae are commonly used by individuals and businesses in the UAE, similar to how @gmail.com addresses are used globally.

That's why we should not use it for detect it similar leads.

Reproduce
---
- Install crm
- Create a lead
- Add email with @eim.ae as domain
- BUG: Similar lead identified based on the email domain

opw-4506179