### PR TITLE
[FIX] mail: fix last seen message non deterministic test

### DIFF
--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -447,8 +447,11 @@ class TestChannelInternals(MailCommon, HttpCase):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
+                                "avatar_128_access_token": limited_field_access_token(
+                                    self.user_admin.partner_id, "avatar_128"
+                                ),
                                 "id": self.user_admin.partner_id.id,
-                                "im_status": "offline",
+                                "im_status": self.user_admin.im_status,
                                 "name": self.user_admin.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     self.user_admin.partner_id.write_date


### PR DESCRIPTION
Before this PR, the `last_seen_message_should_send_notification_only_once` test was sometimes failing. This is due to the assertion of `im_status` being set to `offline` while the hr module overrides statuses with values such as `leave_offline`. This PR fixes the issue.

runbot-112747

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
