### PR TITLE
[IMP] pos_loyalty: highlight action button when reward is available

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -10,7 +10,7 @@
                 class="buttonClass"
                 setter="(orderline, note) => orderline.setNote(note)" />
         </t>
-        <button class="btn btn-light btn-lg flex-shrink-0 ms-auto" t-if="!props.showRemainingButtons and !ui.isSmall and props.onClickMore" t-on-click="props.onClickMore">
+        <button class="more-btn btn btn-light btn-lg flex-shrink-0 ms-auto" t-if="!props.showRemainingButtons and !ui.isSmall and props.onClickMore" t-on-click="props.onClickMore">
             Actions
         </button>
         <!-- All these buttons will only be displayed in a dialog -->

--- a/addons/pos_loyalty/static/src/overrides/components/control_buttons/control_buttons.xml
+++ b/addons/pos_loyalty/static/src/overrides/components/control_buttons/control_buttons.xml
@@ -38,5 +38,8 @@
                 </button>
             </t>
         </xpath>
+        <xpath expr="//button[hasclass('more-btn')]" position="attributes">
+            <attribute name="t-attf-class">{{ getPotentialRewards().length ? 'active text-action' : '' }}</attribute>
+        </xpath>
     </t>
 </templates>


### PR DESCRIPTION
In this commit:
===
- When a reward is available, the More action button is visually highlighted .

