### PR TITLE
[FIX] point_of_sale: use pricelist tmpl rule with max `min_quantity`

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -191,7 +191,10 @@ export class ProductTemplate extends Base {
                 break;
             }
             if (rule.product_tmpl_id?.id === productTmpl.id) {
-                productTemplateRule = rule;
+                // Prefer the rule with the highest `min_quantity`
+                if (!productTemplateRule || productTemplateRule.min_quantity < rule.min_quantity) {
+                    productTemplateRule = rule;
+                }
             }
         }
 

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -518,3 +518,17 @@ registry.category("web_tour.tours").add("SortOrderlinesByCategories", {
             ]),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_pricelist_multi_items_different_qty_thresholds", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            ProductScreen.clickDisplayedProduct("tpmcapi product"),
+            ProductScreen.clickDisplayedProduct("tpmcapi product"),
+            ProductScreen.clickDisplayedProduct("tpmcapi product"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.totalIs("30"),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1689,6 +1689,38 @@ class TestUi(TestPointOfSaleHttpCommon):
             self.main_pos_config.with_user(self.pos_user).open_ui()
             self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'SearchMoreCustomer', login="pos_user")
 
+    def test_pricelist_multi_items_different_qty_thresholds(self):
+        """ Having multiple pricelist items for the same product tmpl with ascending `min_quantity`
+        values, prefer the "latest available"- that is, the one with greater `min_quantity`.
+        """
+        product = self.env['product.product'].create({
+            'name': 'tpmcapi product',
+            'list_price': 1.0,
+            'available_in_pos': True,
+            'taxes_id': False,
+        })
+        self.main_pos_config.pricelist_id.write({
+            'item_ids': [Command.create({
+                'display_applied_on': '1_product',
+                'product_tmpl_id': product.product_tmpl_id.id,
+                'compute_price': 'fixed',
+                'fixed_price': 10.0,
+                'min_quantity': 3,
+            }), Command.create({
+                'display_applied_on': '1_product',
+                'product_tmpl_id': product.product_tmpl_id.id,
+                'compute_price': 'fixed',
+                'fixed_price': 20.0,
+                'min_quantity': 2,
+            })],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(
+            f'/pos/ui?config_id={self.main_pos_config.id}',
+            'test_pricelist_multi_items_different_qty_thresholds',
+            login='pos_user'
+        )
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
**Current behavior:**
Using a pricelist with multiple items for the same product (tmpl) where each item has a different `min_quantity` threshold, the "first" available pricelist item/rule will always be applied to the order.

**Expected behavior:**
The rule with the maximum `min_quantity` value should be preferred.

**Steps to reproduce:**
1. Create a new product & pricelist, where the pricelist has 2 pricelist items for the product
* First item: `min_quantity: 2`, `fixed_price: 10`
* Second item: `min_quantity: 3`, `fixed_price: 20`

2. Open a new PoS session and select 2 of the product -> see that the price is correct per the price list rule

3. Add a 3rd product unit -> the same pricelist rule is used instead of the newly-available one

**Cause of the issue:**
Since commit: 5620a16 when the latest rule selection logic was added, there isn't consideration made for which rule should "tie-break".

**Fix:**
When looping over available product_template rules, only over-write the last rule if the current has greater `min_quantity`.

opw-4533775