### PR TITLE
[FIX] account_edi: Skip documents in error

### DIFF
--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -272,7 +272,11 @@ class AccountEdiDocument(models.Model):
 
         :param job_count: Limit explicitely the number of web service calls. If not provided, process all.
         '''
-        edi_documents = self.search([('state', 'in', ('to_send', 'to_cancel')), ('move_id.state', '=', 'posted')])
+        edi_documents = self.search([
+            ('state', 'in', ('to_send', 'to_cancel')),
+            ('move_id.state', '=', 'posted'),
+            ('blocking_level', '!=', 'error'),
+        ])
         nb_remaining_jobs = edi_documents._process_documents_web_services(job_count=job_count)
 
         # Mark the CRON to be triggered again asap since there is some remaining jobs to process.


### PR DESCRIPTION
The CRON has to search for documents that are not in error because they are filtered out in _process_jobs.
Without that, the documents are retrieved, not processed but the cron is triggered again and again endlessly.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
