### PR TITLE
[FIX] account: Linking an employee to a related user with a bank account

### DIFF
--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -291,7 +291,7 @@ class ResPartnerBank(models.Model):
         if ('acc_number' in vals or 'partner_id' in vals) and not should_allow_changes:
             raise UserError(_("You cannot modify the account number or partner of an account that has been trusted."))
 
-        if 'allow_out_payment' in vals and not self.user_has_groups('account.group_validate_bank_account'):
+        if 'allow_out_payment' in vals and not self.user_has_groups('account.group_validate_bank_account') and not self.env.su:
             raise UserError(_("You do not have the rights to trust or un-trust accounts."))
 
         res = super().write(vals)


### PR DESCRIPTION
Steps to reproduce:

- Let's consider an employee E with a bank account BA
- Let's consider that BA has the option "Send Money" enabled
- Let's log to an internal user U without any access right in Bank
- Try to link E to any internal user

Bug:

A user error was raised: You do not have the rights to trust or untrust accounts.

opw:4553238
