### PR TITLE
[FIX] pos_self_order: show "Order Now" button for shop POS

### DIFF
--- a/addons/pos_self_order/data/custom_link_data.xml
+++ b/addons/pos_self_order/data/custom_link_data.xml
@@ -6,5 +6,10 @@
          <field name="pos_config_ids" eval="[(4, ref('pos_restaurant.pos_config_main_restaurant'))]"/>
          <field name="url" model="pos.config" eval="'/pos-self/' + str(obj().env.ref('pos_restaurant.pos_config_main_restaurant').id) + '/products'" />
       </record>
+      <record id="default_custom_link" model="pos_self_order.custom_link">
+         <field name="name">Order Now</field>
+         <field name="pos_config_ids" eval="[(4, ref('point_of_sale.pos_config_main'))]"/>
+         <field name="url" model="pos.config" eval="'/pos-self/' + str(obj().env.ref('point_of_sale.pos_config_main').id) + '/products'" />
+      </record>
    </data>
 </odoo>


### PR DESCRIPTION
**Problem**:
When enabling the self-ordering feature for a POS with a "Shop" configuration, the "Order Now" button is missing. This happens because `custom_link_data` does not include a link for "Shop" POS configurations.

**Solution**:
Ensure that `custom_link_data` correctly provides the necessary link for "Shop" configurations to display the button.

**Steps to Reproduce**:
1. Set up a POS with self-ordering enabled (QR menu + Ordering).
2. Ensure the POS is configured as a "Shop" (not a Bar/Restaurant).
3. Go to the mobile menu.
   - **Issue**: The "Order Now" button is missing.

opw-4562855

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
