### PR TITLE
[IMP] account: show counterpart_item when rule_type == 'invoice_match…

### DIFF
--- a/addons/account/views/account_reconcile_model_views.xml
+++ b/addons/account/views/account_reconcile_model_views.xml
@@ -62,7 +62,7 @@
                             <page id="counterpart_items_tab"
                                   string="Counterpart Items"
                                   name="counterpart_items"
-                                  invisible="rule_type == 'invoice_matching'">
+                                  invisible="rule_type == 'invoice_matching' and  payment_tolerance_param == 0">
                                 <group class="oe_inline">
                                     <field name="line_ids"
                                            default="{'default_model_id': self, 'default_company_id': self.company_id}"


### PR DESCRIPTION
…ing' and  payment_tolerance_param > 0

- I have modified the Counterpart Items page invisibility condition to be visible when rule_type == 'invoice_matching' and  payment_tolerance_param == 0

task-4595853

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
