### PR TITLE
[FIX] iap: handle connection errors while iap jsonrpc

### DIFF
--- a/addons/iap/tools/iap_tools.py
+++ b/addons/iap/tools/iap_tools.py
@@ -137,7 +137,7 @@ def iap_jsonrpc(url, method='call', params=None, timeout=15):
             elif name == "ReadTimeout":
                 raise requests.exceptions.Timeout()
             else:
-                raise requests.exceptions.ConnectionError()
+                raise ValueError()
             e = e_class(message)
             e.data = response['error']['data']
             raise e
@@ -147,7 +147,12 @@ def iap_jsonrpc(url, method='call', params=None, timeout=15):
         raise exceptions.ValidationError(
             _('The request to the service timed out. Please contact the author of the app. The URL it tried to contact was %s', url)
         )
-    except (ValueError, requests.exceptions.ConnectionError, requests.exceptions.MissingSchema, requests.exceptions.HTTPError):
+    except (requests.exceptions.ConnectionError, requests.exceptions.MissingSchema, requests.exceptions.HTTPError):
+        _logger.warning("unable to reach endpoint at %s", url)
+        raise exceptions.ValidationError(
+            _('The url that this service requested returned an error. Please contact the author of the app. The url it tried to contact was %s', url)
+        )
+    except ValueError:
         _logger.exception("iap jsonrpc %s failed", url)
         raise exceptions.AccessError(
             _("An error occurred while reaching %s. Please contact Odoo support if this error persists.", url)


### PR DESCRIPTION
This error occurs when the `IAP` service is `unreachable` when calling the JSON-RPC in IAP.

ConnectionError: HTTPSConnectionPool(host='extract.api.odoo.com', port=443)

At [1] `ValueError` is now raised and handled connection errors separately because this can also be raised from `requests.post`

This commit will raise a `ValueError` instead of the `ConnectionError`

Link [1] :
https://github.com/odoo/odoo/blob/62ca36f5a347a230eda3cec2d31797fef0c7a13d/addons/iap/tools/iap_tools.py#L140

Sentry - 6280660773

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
