### PR TITLE
[FIX] mail: non deterministic public page tour

### DIFF
--- a/addons/mail/static/src/discuss/core/public/discuss_client_action_patch.js
+++ b/addons/mail/static/src/discuss/core/public/discuss_client_action_patch.js
@@ -2,14 +2,12 @@ import { DiscussClientAction } from "@mail/core/public_web/discuss_client_action
 import { WelcomePage } from "@mail/discuss/core/public/welcome_page";
 import { useState } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
-import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 
 DiscussClientAction.components = { ...DiscussClientAction.components, WelcomePage };
 patch(DiscussClientAction.prototype, {
     setup() {
         super.setup(...arguments);
-        this.store = useService("mail.store");
         this.publicState = useState({
             welcome: this.store.shouldDisplayWelcomeViewInitially,
         });


### PR DESCRIPTION
Before this PR, the `discuss_channel_as_guest_tour` would sometimes fail. Discuss is displayed once the thread is restored. However, one patch removes the `useState` from the store of the component, which leads to the `hasRestoredThread` flag not being observed. If `restoreDiscussThread` is too slow to execute, no render occur, no thread is displayed. This PR fixes the issue.

runbot-106455

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
