### PR TITLE
[FIX] html_editor: banner icon and div base container misaligned

### DIFF
--- a/addons/html_editor/static/src/main/banner.scss
+++ b/addons/html_editor/static/src/main/banner.scss
@@ -1,0 +1,4 @@
+.o_editor_banner .o-paragraph:last-child {
+    // Force margin to align the text container with the icon.
+    margin-bottom: 1rem !important;
+}


### PR DESCRIPTION
**Current behavior before PR:**

When inserting a banner, div base container inside banner is not properly aligned to banner icon.


**Desired behavior after PR is merged:**

Now div base container inside banner is properly aligned to banner icon.

task-4591824




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
