### PR TITLE
[IMP] profiling: log url at the end during tests

### DIFF
--- a/addons/web/views/speedscope_config_wizard.xml
+++ b/addons/web/views/speedscope_config_wizard.xml
@@ -54,7 +54,7 @@
                             <label class="form-check-label" for="sql_density_profile">SQL density</label>
                         </div>
                         <div class="form-check" t-if="any(profile.traces_async for profile in profiles)">
-                            <input type="checkbox" class="form-check-input" id="frames_profile" name="frames_profile" value="True"/>
+                            <input type="checkbox" class="form-check-input" id="frames_profile" name="frames_profile" value="True" t-att-checked="not any(profile.sql for profile in profiles)"/>
                             <label class="form-check-label" for="frames_profile">Frames</label>
                         </div>
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -738,9 +738,10 @@ class BaseCase(case.TestCase):
             self.profile_session = profiler.make_session(test_method)
         if 'db' not in kwargs:
             kwargs['db'] = self.env.cr.dbname
+        http_port = config['http_port']
         return profiler.Profiler(
             description='%s uid:%s %s %s' % (test_method, self.env.user.id, 'warm' if self.warm else 'cold', description),
-            profile_session=self.profile_session,
+            profile_session=self.profile_session, base_url=f'http://{HOST}:{http_port}',
             **kwargs)
 
 
@@ -855,6 +856,7 @@ class TransactionCase(BaseCase):
         cls.addClassCleanup(cls._gc_filestore)
         cls.registry = Registry(get_db_name())
         cls.registry_start_invalidated = cls.registry.registry_invalidated
+        cls.registry.registry_invalidated = False
         cls.registry_start_sequence = cls.registry.registry_sequence
         cls.registry_cache_sequences = dict(cls.registry.cache_sequences)
 

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -527,7 +527,7 @@ class Profiler:
     Will save sql and async stack trace by default.
     """
     def __init__(self, collectors=None, db=..., profile_session=None,
-                 description=None, disable_gc=False, params=None, log=False):
+                 description=None, disable_gc=False, params=None, log=False, base_url=None):
         """
         :param db: database name to use to save results.
             Will try to define database automatically by default.
@@ -553,6 +553,7 @@ class Profiler:
         self.sub_profilers = []
         self.entry_count_limit = int(self.params.get("entry_count_limit",0)) # the limit could be set using a smarter way
         self.done = False
+        self.base_url = base_url
 
         if db is ...:
             # determine database from current thread
@@ -643,6 +644,8 @@ class Profiler:
                     cr.execute(query)
                     self.profile_id = cr.fetchone()[0]
                     _logger.info('ir_profile %s (%s) created', self.profile_id, self.profile_session)
+                    if self.base_url:
+                        _logger.info(f"Speedscope url: {self.base_url}/web/speedscope/{self.profile_id}")
         except OperationalError:
             _logger.exception("Could not save profile in database")
         finally:


### PR DESCRIPTION
When profiling during a test, this will allow to log the URL to access the speedscope output of the profiler.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
