### PR TITLE
[IMP] hw_drivers: print new pairing codes

### DIFF
--- a/addons/hw_drivers/connection_manager.py
+++ b/addons/hw_drivers/connection_manager.py
@@ -7,7 +7,7 @@ import requests
 from threading import Thread
 import time
 
-from odoo.addons.hw_drivers.main import manager
+from odoo.addons.hw_drivers.main import manager, iot_devices
 from odoo.addons.hw_drivers.tools import helpers, wifi
 
 _logger = logging.getLogger(__name__)
@@ -24,21 +24,19 @@ class ConnectionManager(Thread):
         super(ConnectionManager, self).__init__()
         self.pairing_code = False
         self.pairing_uuid = False
+        self.pairing_code_expired = False
         self.pairing_code_expires = 0
         self.pairing_code_count = 0
-        self.running = False
         requests.packages.urllib3.disable_warnings()
 
     def run(self):
-        self.running = True
-        while self.running:
+        while not self.pairing_code_expired:
             if self._should_fetch_pairing_code():
                 if time.monotonic() > self.pairing_code_expires:
                     self._refresh_pairing_code()
                 else:
                     self._poll_pairing_result()
             else:
-                self.running = False
                 self.pairing_code = False
                 self.pairing_uuid = False
                 self.pairing_code_expires = 0
@@ -48,8 +46,7 @@ class ConnectionManager(Thread):
         return (
             not helpers.get_odoo_server_url() and
             helpers.get_ip() and
-            not (platform.system() == 'Linux' and wifi.is_access_point()) and
-            self.pairing_code_count <= MAXIMUM_NUMBER_OF_CODES
+            not (platform.system() == 'Linux' and wifi.is_access_point())
         )
 
     def _call_iot_proxy(self, pairing_code, pairing_uuid):
@@ -77,6 +74,11 @@ class ConnectionManager(Thread):
             self._connect_to_server(result['url'], result['token'], result['db_uuid'], result['enterprise_code'])
 
     def _refresh_pairing_code(self):
+        if self.pairing_code_count == MAXIMUM_NUMBER_OF_CODES:
+            self.pairing_code_expired = True
+            self.pairing_code = False
+            return
+
         result = self._call_iot_proxy(pairing_code=None, pairing_uuid=None)
 
         if all(key in result for key in ['pairing_code', 'pairing_uuid']):
@@ -84,6 +86,7 @@ class ConnectionManager(Thread):
             self.pairing_uuid = result['pairing_uuid']
             self.pairing_code_expires = time.monotonic() + PAIRING_CODE_TIMEOUT_SECONDS
             self.pairing_code_count += 1
+            self._try_print_pairing_code()
 
     def _connect_to_server(self, url, token, db_uuid, enterprise_code):
         # Save DB URL and token
@@ -92,6 +95,11 @@ class ConnectionManager(Thread):
         manager.send_all_devices()
         # Restart to checkout the git branch, get a certificate, load the IoT handlers...
         helpers.odoo_restart(2)
+
+    def _try_print_pairing_code(self):
+        printers = [device for device in iot_devices.values() if device.device_type == 'printer' and device.connected_by_usb and device.device_subtype in ['receipt_printer', 'label_printer']]
+        for printer in printers:
+            printer.print_status()
 
 
 connection_manager = ConnectionManager()

--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
@@ -90,14 +90,12 @@ class PrinterDriver(Driver):
 
         if any(cmd in device['device-id'] for cmd in ['CMD:STAR;', 'CMD:ESC/POS;']):
             self.device_subtype = "receipt_printer"
-            if self.connected_by_usb:
-                self.print_status_receipt()
         elif any(cmd in device['device-id'] for cmd in ['COMMAND SET:ZPL;', 'CMD:ESCLABEL;']):
             self.device_subtype = "label_printer"
-            if self.connected_by_usb:
-                self.print_status_zpl()
         else:
             self.device_subtype = "office_printer"
+
+        self.print_status()
 
     @classmethod
     def supported(cls, device):
@@ -366,6 +364,14 @@ class PrinterDriver(Driver):
 
         return { "mac": mac, "pairing_code": pairing_code, "ssid": ssid, "ips": ips }
 
+    def print_status(self):
+        if not self.connected_by_usb:
+            return
+        if self.device_subtype == "receipt_printer":
+            self.print_status_receipt()
+        if self.device_subtype == "label_printer":
+            self.print_status_zpl()
+
     def print_status_receipt(self):
         """Prints the status ticket of the IoTBox on the current printer."""
         wlan = ''
@@ -375,7 +381,9 @@ class PrinterDriver(Driver):
         pairing_code = ''
 
         iot_status = self._get_iot_status()
-        wlan = '\nWireless network:\n%s\n\n' % iot_status["ssid"]
+
+        if iot_status['ssid']:
+            wlan = '\nWireless network:\n%s\n\n' % iot_status["ssid"]
 
         ips = iot_status["ips"]
         if len(ips) == 0:

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -166,7 +166,7 @@ class IotBoxOwlHomePage(http.Controller):
             'devices': grouped_devices,
             'server_status': odoo_server_url or 'Not Configured',
             'pairing_code': connection_manager.pairing_code,
-            'pairing_code_expired': not connection_manager.running and not odoo_server_url,
+            'pairing_code_expired': connection_manager.pairing_code_expired and not odoo_server_url,
             'six_terminal': six_terminal,
             'is_access_point_up': platform.system() == 'Linux' and wifi.is_access_point(),
             'network_interfaces': network_interfaces,


### PR DESCRIPTION
Before this commit, the IoT box would print its
status only when the printer driver was started.
If there was no pairing code at this point (e.g.
you haven't connected to WiFi yet) the only way
to get it to print would be to restart the IoT
box.

After this commit, as well as printing the pairing
code upon start-up, every time a pairing code is
generated the status will be printed if any USB
printers are connected.

This also means when the pairing code is
refreshed, a new status ticket will be printed
automatically.

task-4599187

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
