### PR TITLE
[REF] web: calendar: do not hardcode avatar_128 field

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_arch_parser.js
+++ b/addons/web/static/src/views/calendar/calendar_arch_parser.js
@@ -171,21 +171,8 @@ export class CalendarArchParser {
                         if (node.hasAttribute("write_field")) {
                             filterInfo.writeFieldName = node.getAttribute("write_field");
                         }
-                        if (node.hasAttribute("filters")) {
-                            if (node.hasAttribute("color")) {
-                                filterInfo.colorFieldName = node.getAttribute("color");
-                            }
-                            if (node.hasAttribute("avatar_field") && field.relation) {
-                                if (
-                                    field.relation.includes([
-                                        "res.users",
-                                        "res.partners",
-                                        "hr.employee",
-                                    ])
-                                ) {
-                                    filterInfo.avatarFieldName = "image_128";
-                                }
-                            }
+                        if (node.hasAttribute("filters") && node.hasAttribute("color")) {
+                            filterInfo.colorFieldName = node.getAttribute("color");
                         }
                     }
 

--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.js
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.js
@@ -75,6 +75,7 @@ export class CalendarFilterPanel extends Component {
             value: result[0],
             label: result[1],
             model: resModel,
+            avatarField: section.avatar.field,
         }));
 
         if (records.length > 7) {

--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
@@ -103,8 +103,9 @@
     </t>
 
     <t t-name="web.CalendarFilterPanel.autocomplete.options">
-        <img t-if='option.value' t-attf-src="/web/image/{{option.model}}/{{option.value}}/avatar_128"
-                class="rounded me-1 o_avatar"
+        <img t-if='option.value and option.avatarField'
+            t-attf-src="/web/image/{{option.model}}/{{option.value}}/{{option.avatarField}}"
+            class="rounded me-1 o_avatar"
         />
         <t t-esc="option.label" />
     </t>

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -635,7 +635,7 @@ test(`check the avatar of the attendee in the calendar filter panel`, async () =
         type: "calendar",
         arch: `
             <calendar date_start="start" date_stop="stop">
-                <field name="attendee_ids" write_model="filter.partner" write_field="partner_id"/>
+                <field name="attendee_ids" write_model="filter.partner" write_field="partner_id" avatar_field="avatar_128"/>
             </calendar>
         `,
     });


### PR DESCRIPTION
Before this commit, the field name "avatar_128" was harcoded, in the sources of the calendar filter panel autocomplete. This commit uses the field set in the arch instead. In practice, this doesn't change anything as all calendar views in odoo with an avatar_field set it to "avatar_128".

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
