### PR TITLE
[FIX] auth_totp_mail: avoid double tests

### DIFF
--- a/addons/auth_totp_mail/tests/test_notify_security_update_totp.py
+++ b/addons/auth_totp_mail/tests/test_notify_security_update_totp.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.mail.tests.test_res_users import TestNotifySecurityUpdate
-from odoo.tests import users
+from odoo.addons.mail.tests.common import MailCommon
+from odoo.tests import tagged, users
 
 
-class TestNotifySecurityUpdateTotp(TestNotifySecurityUpdate):
+@tagged('-at_install', 'post_install', 'mail_tools', 'res_users')
+class TestNotifySecurityUpdateTotp(MailCommon):
     @users('employee')
     def test_security_update_totp_enabled_disabled(self):
         recipients = [self.env.user.email_formatted]


### PR DESCRIPTION
Until 18.0 [1], test classes should not inherit from other test classes which themselves contain tests. When this happens, the tests of the parent class are run for every class that inherits from it.

We fix occurrences of this for social marketing apps. A naive detection script is available on the pad of the related task.

[1]: 6dc96811c24ec4c97b8fbd2489aef6d4f061ac03

task-3792478
