### PR TITLE
[FIX] mass_mailing{_sms}, project_sms: avoid double tests

### DIFF
--- a/addons/mass_mailing/tests/test_mailing_ab_testing.py
+++ b/addons/mass_mailing/tests/test_mailing_ab_testing.py
@@ -11,7 +11,7 @@ from odoo import fields
 
 
 @tagged('post_install', '-at_install')
-class TestMailingABTesting(MassMailCommon):
+class TestMailingABTestingCommon(MassMailCommon):
 
     def setUp(self):
         super().setUp()
@@ -31,6 +31,8 @@ class TestMailingABTesting(MassMailCommon):
         self.ab_testing_mailing_ids = self.ab_testing_mailing_1 + self.ab_testing_mailing_2
         self.env.flush_all()
         self.env.invalidate_all()
+
+class TestMailingABTesting(TestMailingABTestingCommon):
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
     @users('user_marketing')

--- a/addons/mass_mailing_sms/tests/test_mailing_sms_ab_testing.py
+++ b/addons/mass_mailing_sms/tests/test_mailing_sms_ab_testing.py
@@ -4,12 +4,12 @@
 from datetime import datetime
 
 from odoo.addons.mass_mailing_sms.tests.common import MassSMSCommon
-from odoo.addons.mass_mailing.tests.test_mailing_ab_testing import TestMailingABTesting
+from odoo.addons.mass_mailing.tests.test_mailing_ab_testing import TestMailingABTestingCommon
 from odoo.tests import tagged
 
 
 @tagged('post_install', '-at_install')
-class TestMailingSMSABTesting(MassSMSCommon, TestMailingABTesting):
+class TestMailingSMSABTesting(MassSMSCommon, TestMailingABTestingCommon):
     def setUp(self):
         super().setUp()
         self.ab_testing_mailing_sms_1 = self.env['mailing.mailing'].create({

--- a/addons/project_sms/tests/test_project_sharing.py
+++ b/addons/project_sms/tests/test_project_sharing.py
@@ -64,9 +64,7 @@ class TestProjectSharingWithSms(TestProjectSharingCommon, SMSCommon):
         self.assertEqual(self.project_portal.stage_id, self.project_stage_with_sms)
         self.assertSMSIapSent([self.project_portal.partner_id.mobile])
 
-@tagged('post_install', '-at_install')
-class TestPostInstallProjectSharingWithSms(TestProjectSharingWithSms):
-
+    @tagged('post_install', '-at_install')
     def test_project_user_can_change_stage_with_sms_template(self):
         """ Test that users with the rights to change the stage of a task can perform this action
             when the stage has an sms template.


### PR DESCRIPTION
Until 18.0 [1], test classes should not inherit from other test classes which themselves contain tests. When this happens, the tests of the parent class are run for every class that inherits from it.

We fix occurrences of this for social marketing apps. A naive detection script is available on the pad of the related task.

[1]: 6dc96811c24ec4c97b8fbd2489aef6d4f061ac03

task-3792478
