### PR TITLE
[IMP] web: search bar: starts_with/ends_with operators

### DIFF
--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1551,7 +1551,7 @@ export class SearchModel extends EventBus {
                         type = "field";
                         title = searchItem.description;
                         for (const autocompleteValue of activeItem.autocompletValues) {
-                            values.push(autocompleteValue.label);
+                            values.push(autocompleteValue.labelForFacet || autocompleteValue.label);
                         }
                         break;
                     }
@@ -1638,14 +1638,14 @@ export class SearchModel extends EventBus {
      * of a search item of type 'field'.
      */
     _getFieldDomain(field, autocompleteValues) {
-        const domains = autocompleteValues.map(({ label, value, operator, enforceEqual }) => {
+        const domains = autocompleteValues.map(({ label, value, operator, enforceOperator }) => {
             let domain;
             if (field.filterDomain) {
                 let filterDomain = field.filterDomain;
-                if (enforceEqual) {
+                if (enforceOperator) {
                     filterDomain = field.filterDomain
-                        .replaceAll("'ilike'", "'='")
-                        .replaceAll('"ilike"', '"="');
+                        .replaceAll("'ilike'", `'${operator}'`)
+                        .replaceAll('"ilike"', `"${operator}"`);
                 }
                 domain = new Domain(filterDomain).toList({
                     self: label.trim(),

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -1667,6 +1667,8 @@ export class Model extends Array {
                 (!name ||
                     (operator === "="
                         ? record.display_name === name
+                        : operator === "=ilike"
+                        ? new RegExp(name.replaceAll("%", ".*")).test(record.display_name)
                         : record.display_name?.includes(name)))
             ) {
                 result.push(toIdDisplayName(record));

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -1777,6 +1777,102 @@ test(`quoted search term performs a name_search with operator = for subitems`, a
     expect(".o_searchview_autocomplete .o-dropdown-item.o_indent").toHaveText("First record");
 });
 
+test("Search with starting quote: search with starts_with", async () => {
+    const searchBar = await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+    });
+    await editSearch(`"yo`);
+    await keyDown("Enter");
+    await animationFrame();
+    expect(searchBar.env.searchModel._domain).toEqual([["foo", "=ilike", "yo%"]]);
+    expect(getFacetTexts()).toEqual(["Foo\nyo"]);
+});
+
+test(`Search with starting quote: search with starts_with on view defined's "filter_domain"`, async () => {
+    const searchBar = await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+        searchViewArch: `
+            <search>
+                <field string="Foo" name="foo" filter_domain="[('name', 'ilike', self)]"/>
+            </search>
+        `,
+    });
+    await editSearch(`"Second`);
+    await keyDown("Enter");
+    await animationFrame();
+    expect(searchBar.env.searchModel._domain).toEqual([["name", "=ilike", "Second%"]]);
+    expect(getFacetTexts()).toEqual(["Foo\nSecond"]);
+});
+
+test(`Search with starting quote: search with starts_with as operator for subitems`, async () => {
+    await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+        searchViewArch: `
+            <search>
+                <field string="Company" name="company"/>
+            </search>
+        `,
+    });
+    await editSearch(`"First`);
+    await click(".o_expand");
+    await animationFrame();
+    expect(".o_searchview_autocomplete .o-dropdown-item.o_indent").toHaveText("First record");
+});
+
+test("Search with ending quote: search with ends_with", async () => {
+    const searchBar = await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+    });
+    await editSearch(`yo"`);
+    await keyDown("Enter");
+    await animationFrame();
+    expect(searchBar.env.searchModel._domain).toEqual([["foo", "=ilike", "%yo"]]);
+    expect(getFacetTexts()).toEqual(["Foo\nyo"]);
+});
+
+test(`Search with ending quote: search with ends_with on view defined's "filter_domain"`, async () => {
+    const searchBar = await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+        searchViewArch: `
+            <search>
+                <field string="Foo" name="foo" filter_domain="[('name', 'ilike', self)]"/>
+            </search>
+        `,
+    });
+    await editSearch(`record"`);
+    await keyDown("Enter");
+    await animationFrame();
+    expect(searchBar.env.searchModel._domain).toEqual([["name", "=ilike", "%record"]]);
+    expect(getFacetTexts()).toEqual(["Foo\nrecord"]);
+});
+
+test(`Search with ending quote: search with ends_with as operator for subitems`, async () => {
+    await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+        searchViewArch: `
+            <search>
+                <field string="Company" name="company"/>
+            </search>
+        `,
+    });
+    await editSearch(`st record"`);
+    await click(".o_expand");
+    await animationFrame();
+    expect(".o_searchview_autocomplete .o-dropdown-item.o_indent").toHaveText("First record");
+});
+
 test("subitems have a load more item if there is more records available", async () => {
     for (let i = 0; i < 20; i++) {
         Partner._records.push({


### PR DESCRIPTION
With https://github.com/odoo/odoo/pull/173618, it was already possible to make exact search by using quotes at both ends of the query input. Here we extend that systems by allowing the use quotes at only one end:
type "Rec (Rec") in the search bar will end in a search equivalent to a search with a starts_with (resp. ends_with) operator.

Task ID: 4535560