### PR TITLE
[FIX] point_of_sale, account: changed archival/delete constraint for pos journal

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -800,11 +800,6 @@ class AccountJournal(models.Model):
             res += [(journal.id, name)]
         return res
 
-    def action_archive(self):
-        if self.env['account.payment.method.line'].search_count([('journal_id', 'in', self.ids)], limit=1):
-            raise ValidationError(_("This journal is associated with a payment method. You cannot archive it"))
-        return super().action_archive()
-
     def action_configure_bank_journal(self):
         """ This function is called by the "configure" button of bank journals,
         visible on dashboard if no bank statement source has been defined yet

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -182,8 +182,8 @@ class TestAccountJournal(AccountTestInvoicingCommon):
             'payment_method_id': check_method.id,
             'journal_id': journal.id
             })
-        with self.assertRaises(ValidationError):
-            journal.action_archive()
+        journal.action_archive()
+        self.assertFalse(journal.active)
 
     def test_archive_multiple_journals(self):
         journals = self.env['account.journal'].create([{

--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -7648,3 +7648,11 @@ msgstr ""
 #, python-format
 msgid "were duplicates of existing orders"
 msgstr ""
+
+#. module: point_of_sale
+#. odoo-python
+#: code:addons/point_of_sale/models/account_journal.py:0
+#, python-format
+msgid ""
+"This journal is associated with payment method %s that is being used by order %s in the active pos session %s"
+msgstr ""

--- a/addons/point_of_sale/tests/test_pos_setup.py
+++ b/addons/point_of_sale/tests/test_pos_setup.py
@@ -4,6 +4,7 @@
 from odoo import tools
 import odoo
 from odoo.addons.point_of_sale.tests.common import TestPoSCommon
+from odoo.exceptions import ValidationError
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestPoSSetup(TestPoSCommon):
@@ -74,3 +75,39 @@ class TestPoSSetup(TestPoSCommon):
         self.assertEqual(tax_group_7_10.name, 'Tax 7+10%')
         self.assertEqual(tax_group_7_10.amount_type, 'group')
         self.assertEqual(sorted(tax_group_7_10.children_tax_ids.ids), sorted((tax7 | tax10).ids))
+
+    def test_archive_used_journal(self):
+        journal = self.cash_pm1.journal_id
+        payment_method = self.env['pos.payment.method'].create({'name': 'Lets Pay for Tests', 'journal_id': journal.id})
+        self.basic_config.write({'payment_method_ids': [payment_method.id]})
+        journal.write({'pos_payment_method_ids': [payment_method.id]})
+        session = self.env['pos.session'].create(
+            {
+                'name': 'lets sell some tests',
+                'config_id': self.basic_config.id,
+                'user_id': self.env.user.id,
+                'state': 'opened'
+            }
+        )
+        order = self.env['pos.order'].create(
+            {
+                'name': 'MIX',
+                'amount_tax': 0,
+                'amount_total': 0,
+                'amount_paid': 0,
+                'amount_return': 0,
+                'company_id': self.company.id,
+                'pricelist_id': self.currency_pricelist.id,
+                'session_id': session.id
+            }
+        )
+        self.env['pos.payment'].create(
+            {
+                'amount': 100,
+                'payment_date': '2025-01-01',
+                'payment_method_id': payment_method.id,
+                'pos_order_id': order.id
+            }
+        )
+        with self.assertRaises(ValidationError):
+            journal.action_archive()


### PR DESCRIPTION

Steps to reproduce the bug:
- Create a cash or bank account journal
- Archive it (you will have an error, because it is associated with a payment method)
- Delete it (it will be deleted normally)

Problem:
The problem is because of added constraint on the archival of account journal, that wasn't added to the deletion as well. The constraint on the archival was too strict after discussion with accounting team, it should be reverted and a new constraint will be added from the pos side.
Now, the journal can't be archived nor deleted if it has at least one payment with payment method for that journal in an active session, because the journal items are written when the session is closed only. So, if the journal is archived with some active payments before closing the session, the journal entries are lost because it fails to write them in archived journal.
The constraint is added to both archival and deletion to prevent the possibility of deletion while we can't archive.

Testing:
A performance testing was held on the new constraint, and based on the profiling the execution time was 0.00 seconds, and the pos.payments test passed successfully.

Commits that added the constraint:
d430231
5722d52

Tickets that required that constraint:
opw-4070620

-------------------------------------------

opw-4554961
opw-4438601

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
