### PR TITLE
[FIX] pos_event: prevent error on installing module

### DIFF
--- a/addons/pos_event/data/event_product_data.xml
+++ b/addons/pos_event/data/event_product_data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
-        <record id="event_product.product_product_event" model="product.product">
+        <record id="event_product.product_product_event" model="product.product" forcecreate="False">
             <field name="available_in_pos">True</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_event.pos_category_event')])]"/>
         </record>


### PR DESCRIPTION
Currently a `ParseError` is arising when the user installs the `pos_event` module after deleting `Event Registration` product from the products.

Steps to reproduce:
---
- Install `event_product` application (without demo data).
- Delete `Event Registration` from products
- Now install `pos_event` module

Traceback:
---
```
Exception: Cannot update missing record 'event_product.product_product_event'

ParseError: while parsing /home/odoo/src/odoo/saas-18.1/addons/pos_event/data/event_product_data.xml:4, somewhere inside <record id="event_product.product_product_event" model="product.product">
            <field name="available_in_pos">True</field>
            <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_event.pos_category_event')])]"/>
        </record>
```

The error occurs because the user deleted the product, and then tried to install the other module.

This commit solves the above issue by using `forcecreate="False"` to bypass record creation if it violates checks.

https://github.com/odoo/odoo/blob/f5378fadf910d193cbb44a4d1c10a5a15d8b9a51/odoo/tools/convert.py#L364

sentry-5731062091

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
