### PR TITLE
[FIX] point_of_sale: display unit prices on orders and tickets

### DIFF
--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
@@ -30,8 +30,42 @@
                 <ul class="info-list d-flex flex-column">
                     <li class="price-per-unit">
                         <t t-set="discount" t-value="line.getDiscountStr()" />
-                        <t t-if="!props.basic_receipt and line.price_unit !== 0 and discount and discount !== '0'">
-                            <i class="fa fa-tag pe-1"/><t t-esc="line.allPrices.priceWithTaxBeforeDiscount"/> With a <em><t t-esc="discount" />% </em> discount
+                        <t t-if="!line.combo_parent_id">
+                            <t t-if="!props.basic_receipt">
+                                <t t-if="line.price_unit !== 0 and !line.isPartOfCombo()">
+                                    <t t-esc="formatCurrency(line.getUnitDisplayBasePrice())" />
+                                    <t t-if="line.getUnit()">
+                                        / <t t-esc="line.getUnit().name" />
+                                    </t>
+                                    <t t-if="discount and discount !== '0'">
+                                        <br/>
+                                        <i class="fa fa-tag pe-1"/><t t-esc="formatCurrency(line.getUnitDisplayPriceBeforeDiscount())" /> With a <em><t t-esc="discount" />% </em> discount
+                                    </t>
+                                </t>
+                                <t t-else="">
+                                    <t t-set="discount" t-value="line.getComboDiscount()" />
+                                    <t t-esc="formatCurrency(line.getComboTotalDisplayPrice())" />
+                                    <t t-if="line.getUnit()">
+                                        / <t t-esc="line.getUnit().name" />
+                                    </t>
+                                    <t t-if="discount and discount !== '0'">
+                                        <br/>
+                                        <i class="fa fa-tag pe-1"/>
+                                        <t t-esc="formatCurrency(line.getComboTotalPriceBeforeDiscount())" />
+                                         With a <em><t t-esc="discount" />% </em> discount
+                                    </t>
+                                </t>
+                            </t>
+                        </t>
+                        <t t-else="">
+                            <t t-if="discount and discount !== '0'">
+                                <i class="fa fa-tag pe-1"/>
+                                <t t-esc="formatCurrency(line.getUnitDisplayPriceBeforeDiscount())" />
+                                <t t-if="line.getUnit()">
+                                    / <t t-esc="line.getUnit().name" />
+                                </t>
+                                 With a <em><t t-esc="discount" />% </em> discount
+                            </t>
                         </t>
                     </li>
                     <li t-if="line.customer_note" class="customer-note w-100 rounded text-break bg-opacity-25" t-att-class="{'text-bg-warning p-2 mt-2': this.props.mode === 'display'}">

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -434,6 +434,16 @@ export class PosOrderline extends Base {
             return this.allUnitPrices.priceWithoutTaxBeforeDiscount;
         }
     }
+
+    getUnitDisplayBasePrice() {
+        const rounding = this.currency.rounding;
+
+        return roundPrecision(
+            this.getUnitDisplayPriceBeforeDiscount() * (1 - this.getDiscount() / 100),
+            rounding
+        );
+    }
+
     getBasePrice() {
         const rounding = this.currency.rounding;
 
@@ -628,6 +638,25 @@ export class PosOrderline extends Base {
         return Boolean(this.combo_parent_id || this.combo_line_ids?.length);
     }
 
+    getComboTotalDisplayPrice() {
+        if (this.config.iface_tax_included === "total") {
+            return this.getComboTotalPrice();
+        } else {
+            return this.getComboTotalPriceWithoutTax();
+        }
+    }
+
+    getComboDiscount() {
+        const rounding = this.currency.rounding;
+        const discountAmount =
+            this.getComboTotalPriceBeforeDiscount() - this.getComboTotalDisplayPrice();
+
+        return roundPrecision(
+            100 * (discountAmount / this.getComboTotalPriceBeforeDiscount()),
+            rounding
+        );
+    }
+
     getComboTotalPrice() {
         const allLines = this.getAllLinesInCombo();
         return allLines.reduce((total, line) => total + line.allUnitPrices.priceWithTax, 0);
@@ -635,6 +664,14 @@ export class PosOrderline extends Base {
     getComboTotalPriceWithoutTax() {
         const allLines = this.getAllLinesInCombo();
         return allLines.reduce((total, line) => total + line.getBasePrice() / line.qty, 0);
+    }
+
+    getComboTotalPriceBeforeDiscount() {
+        const allLines = this.getAllLinesInCombo();
+        return allLines.reduce(
+            (total, line) => total + line.getUnitDisplayPriceBeforeDiscount(),
+            0
+        );
     }
 
     getOldUnitDisplayPrice() {


### PR DESCRIPTION
## Versions:
saas-18.1+

## Issue:
Unit prices are not displayed on tickets anymore and discounts are shown on total price.

## Steps to reproduce:
*Ensure PoS `Line Discounts` are enabled*
- Open `Furniture Shop` register from `Point of Sale` app;
- Add:
  - 10 `Desk Pad`:
    - Apply 10% discount on line;
  - 10 `Office Combo` with `Desk Pad`, `Desk Combination` and `Office Chair Black`:
    - Apply 10% discount on each component line;
- Click on `Payment` button;
- Select `Cash` and validate;
- See the ticket without unit prices.

## Cause:
The display existed in 18.0 but has been removed by 
https://github.com/odoo/odoo/pull/191929/files#diff-395672f7326ee93c1b8e46731e3e0e6fb0af9d0f61e289dd5dd7a0c97a037484L23-L32
The [related ticket](https://www.odoo.com/odoo/project.task/4414057) suggests units and prices removal for combination products' components only.

opw-4579481
opw-4579816