### PR TITLE
[FIX] html_editor: prevent crash when deleting embedded state property

### DIFF
--- a/addons/html_editor/static/src/others/embedded_component_utils.js
+++ b/addons/html_editor/static/src/others/embedded_component_utils.js
@@ -419,6 +419,11 @@ export class StateChangeManager {
      * recompute `data-embedded-props` for the next mounting operation.
      */
     changeState() {
+        if (!this.previousEmbeddedState) {
+            // If there is no previousEmbeddedState, it means that no
+            // effective change was performed, so there is nothing to commit.
+            return;
+        }
         const previousEmbeddedState = this.previousEmbeddedState;
         this.previousEmbeddedState = null;
         const previous = JSON.stringify(sortedCopy(this.state));

--- a/addons/html_editor/static/tests/embedded_components.test.js
+++ b/addons/html_editor/static/tests/embedded_components.test.js
@@ -1351,6 +1351,31 @@ describe("Embedded state", () => {
         );
     });
 
+    test("Removing a non-existing property in the embedded state should do nothing", async () => {
+        let counter;
+        patchWithCleanup(SavedCounter.prototype, {
+            setup() {
+                super.setup();
+                counter = this;
+            },
+        });
+        const { el } = await setupEditor(
+            `<p><span data-embedded="counter" data-embedded-props='{"value":1}'></span></p>`,
+            { config: getConfig([savedCounter]) }
+        );
+        expect(getContent(el)).toBe(
+            `<p><span data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true" contenteditable="false"><span class="counter">Counter:1</span></span></p>`
+        );
+        delete counter.embeddedState.notValue;
+        await animationFrame();
+        expect(getContent(el)).toBe(
+            `<p><span data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true" contenteditable="false"><span class="counter">Counter:1</span></span></p>`
+        );
+        expect(counter.embeddedState).toEqual({
+            value: 1,
+        });
+    });
+
     test("Write on `data-embedded-state` should write on the state, re-render the component and write on `data-embedded-props` and the embedded state", async () => {
         let counter;
         patchWithCleanup(OffsetCounter.prototype, {


### PR DESCRIPTION
Issue:
Deleting a non-existing property in the embeddedState of an EmbeddedComponent
would produce a traceback.

Expected:
If no embeddedState snapshot was done (previousEmbeddedState is null), it means
that no effective change was performed, and in that case `changeState` should
return early to prevent the traceback.

task-4600079
