### PR TITLE
[IMP] account: synchronized between analytic item and journal item

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5276,7 +5276,7 @@ class AccountMove(models.Model):
 
         self._check_draftable()
         # We remove all the analytics entries for this journal
-        self.mapped('line_ids.analytic_line_ids').unlink()
+        self.line_ids.analytic_line_ids.with_context(skip_analytic_sync=True).unlink()
         self.mapped('line_ids').remove_move_reconcile()
         self.state = 'draft'
 

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1183,9 +1183,11 @@ class AccountMoveLine(models.Model):
 
     def _inverse_analytic_distribution(self):
         """ Unlink and recreate analytic_lines when modifying the distribution."""
+        if self.env.context.get('skip_analytic_sync'):
+            return
         lines_to_modify = self.env['account.move.line'].browse([
             line.id for line in self if line.parent_state == "posted"
-        ])
+        ]).with_context(skip_analytic_sync=True)
         lines_to_modify.analytic_line_ids.unlink()
         lines_to_modify._create_analytic_lines()
 
@@ -3164,6 +3166,7 @@ class AccountMoveLine(models.Model):
 
         context = dict(self.env.context)
         context.pop('default_account_id', None)
+        context['skip_analytic_sync'] = True
         self.env['account.analytic.line'].with_context(context).create(analytic_line_vals)
 
     def _prepare_analytic_lines(self):
@@ -3216,6 +3219,15 @@ class AccountMoveLine(models.Model):
     def _related_analytic_distribution(self):
         """ Returns the analytic distribution set on the record which triggered the creation of this line. """
         return {}
+
+    def _update_analytic_distribution(self):
+        if self.env.context.get('skip_analytic_sync'):
+            return
+        for line in self:
+            line.with_context(skip_analytic_sync=True).analytic_distribution = {
+                analytic_line._get_distribution_key(): -analytic_line.amount / line.balance * 100
+                for analytic_line in line.analytic_line_ids
+            }
 
     # -------------------------------------------------------------------------
     # INSTALLMENTS

--- a/addons/analytic/models/analytic_line.py
+++ b/addons/analytic/models/analytic_line.py
@@ -63,9 +63,12 @@ class AnalyticPlanFields(models.AbstractModel):
             if self[fname]
         ])
 
+    def _get_distribution_key(self):
+        return ",".join(str(account_id) for account_id in self._get_analytic_accounts().ids)
+
     def _get_analytic_distribution(self):
-        account_ids = self._get_analytic_accounts().ids
-        return {} if not account_ids else {",".join(str(account_id) for account_id in account_ids): 100}
+        accounts = self._get_distribution_key()
+        return {} if not accounts else {accounts: 100}
 
     def _get_mandatory_plans(self, company, business_domain):
         return [


### PR DESCRIPTION
overrode the write and unlink functions related to the analytic_line so that it synchronize the analytic distribution in the move_line every time a change happen

before this commit whenever an analytic line is edited it is not reflected to its linked journal line's analytic distribution. so an update function is created so that the analytic distribution is updated whenever an analytic line is edited or deleted.

task-4378407

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
