### PR TITLE
[FIX] mail: command palette mentioned and recent chat no duplicate

### DIFF
--- a/addons/mail/static/src/discuss/core/web/discuss_command_palette_patch.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_command_palette_patch.js
@@ -30,7 +30,11 @@ patch(DiscussCommandPalette.prototype, {
                 }
             }
             const limitedRecent = recentChannels
-                .filter((channel) => !mentionedSet.has(channel))
+                .filter(
+                    (channel) =>
+                        !mentionedSet.has(channel) &&
+                        !mentionedSet.has(channel.correspondent?.persona)
+                )
                 .slice(0, CATEGORY_LIMIT);
             for (const channel of limitedRecent) {
                 this.commands.push(this.makeDiscussCommand(channel, DISCUSS_RECENT));

--- a/addons/mail/static/tests/discuss/core/web/command_palette.test.js
+++ b/addons/mail/static/tests/discuss/core/web/command_palette.test.js
@@ -131,3 +131,28 @@ test("only partners with dedicated users will be displayed in command palette", 
     await contains(".o_command_name", { text: "Create Chat" });
     await contains(".o_command_name", { text: "Portal", count: 0 });
 });
+
+test("hide conversations in recent if they have mentions", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: serverState.odoobotId }),
+        ],
+        channel_type: "chat",
+    });
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        model: "discuss.channel",
+        res_id: channelId,
+        body: "@OdooBot",
+    });
+    await start();
+    triggerHotkey("control+k");
+    await insertText(".o_command_palette_search input", "@", { replace: true });
+    await contains(".o_command_category span.fw-bold", { text: "Mentions" });
+    await contains(".o_command_palette .o_command_category .o_command_name", {
+        text: "OdooBot",
+        count: 1,
+    });
+});


### PR DESCRIPTION
Before this commit, a conversation that was both recent and contained mentions could be displayed twice in the discuss command palette. This was the case with DM chats.

An item should be present only once in the command palette, and if a conversation has both mentions and is recent, it should be present only in the most important category "mentions".

The problem occurs because duplicate mentioned and recent conversations are tracked on mentioned channels, using either the conversation or the persona of correspondent for DM chat. The check on mentioned persona was mistakenly omitted, thus a DM chat could be present in mentions and recents.

This commit fixes the issue by properly checking whether the persona of DM chat was already in "mentions", so that it's not elligible in the "recent" category if that's the case.

task-4510209

Before
<img width="658" alt="Screenshot 2025-02-24 at 14 07 44" src="https://github.com/user-attachments/assets/fab6e6bb-fead-4c31-9fd4-4a2a3a4e895f" />

After
<img width="661" alt="Screenshot 2025-02-24 at 14 07 52" src="https://github.com/user-attachments/assets/cf70035a-42b0-47df-96a3-1a95580d18a2" />

