### PR TITLE
[FIX] pos, pos_sms: partner search more in pos is not working if sms gateway is not installed

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -126,7 +126,7 @@ export class PartnerList extends Component {
             const search_fields = [
                 "name",
                 "parent_name",
-                "phone_mobile_search",
+                ...this.getPhoneSearchTerms(),
                 "email",
                 "barcode",
                 "street",
@@ -148,5 +148,9 @@ export class PartnerList extends Component {
         });
 
         return result;
+    }
+
+    getPhoneSearchTerms() {
+        return ["phone", "mobile"];
     }
 }

--- a/addons/pos_sms/__manifest__.py
+++ b/addons/pos_sms/__manifest__.py
@@ -14,4 +14,5 @@
         ],
     },
     'license': 'LGPL-3',
+    'auto_install': True
 }

--- a/addons/pos_sms/static/src/overrides/partner_list.js
+++ b/addons/pos_sms/static/src/overrides/partner_list.js
@@ -1,0 +1,8 @@
+import { patch } from "@web/core/utils/patch";
+import { PartnerList } from "@point_of_sale/app/screens/partner_list/partner_list";
+
+patch(PartnerList.prototype, {
+    getPhoneSearchTerms() {
+        return ["phone_mobile_search"];
+    },
+});


### PR DESCRIPTION

Steps to reproduce the bug:
 - Install POS, then uninstall the sms gateway
 - Open a shop and then click on customers button
 - write anything in the input field then click on `Search More`

Problem:
Error is raised in the request because the `partner_list.js` screen is passing the field `phone_mobile_search` in the search_fields. The `phone_mobile_search` field is only introduced to the res.partner model in the a PhoneMixin and the inheritence is only applied in the `sms gateway module` so the field will only be available if the `sms gateway is installed`.

Possible Approaches:
- [Stable] added a function in the partner_list.js that tells if the PhoneMixin is applied and it returns false in the pos, and overriden the same function in the pos_sms bridge module that implies that both pos and sms are installed and it returns true there meaning the mixin is applied.
- [Non Stable] add the inheritence of the mixin in the pos module, but that will require module upgrade
- [Non Stable] add a whole direct dependency between the pos and the sms gateway

opw-4455381

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
