### PR TITLE
[FIX] stock*: forecast availability status in multi-step delivery

### DIFF
--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -2230,3 +2230,27 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
 
         self.assertEqual(pickings[0].state, 'done')
         self.assertEqual(len(sale_order.order_line), 1)
+
+    def test_multi_step_product_forecast_availability(self):
+        """
+        Test that forecast availability(icon) widget info on the Sales Order correctly appears green
+        when enough stock is available in a 2-step/3-step delivery.
+        """
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        warehouse.delivery_steps = 'pick_ship'
+
+        # Make quantity available for the product.
+        self.env['stock.quant']._update_available_quantity(self.new_product, warehouse.lot_stock_id, 1)
+
+        so = self._get_new_sale_order(product=self.new_product, amount=1)
+        so.action_confirm()
+
+        self.assertEqual(
+            so.picking_ids.move_ids.forecast_availability, 1.0,
+            "Forecast availability should be 1.0 because 1.0 quantity is available."
+            "So forecast availability icon should appear green."
+        )
+        self.assertEqual(
+            so.order_line.free_qty_today, 1.0,
+            "Free quantity today should be 1.0, indicating the quantity is usable for this SO."
+        )

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2196,7 +2196,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         self.ensure_one()
         from_wh = self.location_id.warehouse_id
         to_wh = self.location_dest_id.warehouse_id
-        return self.picking_type_id.code == 'outgoing' or (from_wh and to_wh and from_wh != to_wh)
+        return self.picking_type_id.code in ('internal', 'outgoing') or (from_wh and to_wh and from_wh != to_wh)
 
     def _get_lang(self):
         """Determine language to use for translated description"""


### PR DESCRIPTION
*: sale_stock

Issue:
======================
The forecast availability(icon) on the sales order incorrectly appears
red even when enough stock is available for products in multi-step deliveries.

Steps to Reproduce:
======================
1. install sale_management & stock module.
2. Activate multi-step delivery in the warehouse.
3. Sell a product that has sufficient stock.
4. Ensure that enough quantities are reserved on the created picking.
5. Check the forecast availability(icon) on the sale order.

Issue:
======================
The 'is_consuming' method is not considered for internal transfer moves
during forecast availability computation. This leads to incorrectly flagging
the forecast icon as red on the Sales Order, even when sufficient stock is
available and reserved.

With this commit:
======================
This fix ensures that the forecast icon correctly reflects stock availability
by considering internal transfers in a multi-step delivery. the icon
currently appears green on the Sales Order when there is enough
stock to fulfill the demand.

task - [4555666](https://www.odoo.com/odoo/project/966/tasks/4555666)