### PR TITLE
[FIX] hr_attendance: kiosk mode lang

### DIFF
--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -111,7 +111,7 @@ class HrAttendance(http.Controller):
                         'kiosk_mode': kiosk_mode,
                         'from_trial_mode': from_trial_mode,
                         'barcode_source': company.attendance_barcode_source,
-                        'lang': company.partner_id.lang,
+                        'lang': company.partner_id.lang or company.env.lang,
                         'server_version_info': version_info.get('server_version_info'),
                     },
                 }


### PR DESCRIPTION
Issue: When you try to acssess the kiosk mode for a company which has no lang set on its partner, a blocking error is raised

solve: add the env.lang as a default lang if the partner lang return false

Task: 4465594

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
