### PR TITLE
[FIX] point_of_sale: order time zone in a POS session

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -1,6 +1,6 @@
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
-import { formatDate, parseDateTime } from "@web/core/l10n/dates";
+import { formatDateTime, parseDateTime } from "@web/core/l10n/dates";
 import { parseFloat } from "@web/views/fields/parsers";
 import { _t } from "@web/core/l10n/translation";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
@@ -11,6 +11,7 @@ import { Orderline } from "@point_of_sale/app/components/orderline/orderline";
 import { CenteredIcon } from "@point_of_sale/app/components/centered_icon/centered_icon";
 import { SearchBar } from "@point_of_sale/app/screens/ticket_screen/search_bar/search_bar";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
+import { localization } from "@web/core/l10n/localization";
 import { Component, onMounted, onWillStart, useState } from "@odoo/owl";
 import {
     BACKSPACE,
@@ -431,11 +432,17 @@ export class TicketScreen extends Component {
         if (DateTime.fromSQL(order.date_order).startOf("day").ts === todayTs) {
             return _t("Today");
         } else {
-            return formatDate(parseUTCString(order.date_order));
+            return formatDateTime(parseUTCString(order.date_order), {
+                format: localization.dateFormat,
+                tz: luxon.Settings.defaultZone.name,
+            });
         }
     }
     getTime(order) {
-        return parseUTCString(order.date_order).toFormat("hh:mm");
+        return formatDateTime(parseUTCString(order.date_order), {
+            format: localization.timeFormat.replace(/:ss/, ""),
+            tz: luxon.Settings.defaultZone.name,
+        });
     }
     getTotal(order) {
         return this.env.utils.formatCurrency(order.getTotalWithTax());

--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -286,3 +286,33 @@ registry.category("web_tour.tours").add("LotTour", {
             }),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("OrderTimeTour", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            ProductScreen.setTimeZone("Asia/Tokyo"),
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            ProductScreen.clickDisplayedProduct("Desk Pad"),
+
+            Chrome.clickOrders(),
+            {
+                content: "Validate order time matches local timezone",
+                trigger: ".orders .order-row:first .small.text-muted",
+                run: function ({ anchor: displayedTimeElement }) {
+                    const displayedTimeText = displayedTimeElement.textContent.trim();
+                    const currentOrder = window.posmodel.getOrder();
+                    const orderDateUTC = currentOrder.date_order;
+                    const orderDateTime = luxon.DateTime.fromSQL(orderDateUTC, {
+                        zone: "UTC",
+                    }).toLocal();
+                    const convertedOrderTime = orderDateTime.toFormat("HH:mm");
+                    if (convertedOrderTime !== displayedTimeText) {
+                        throw new Error("Order time does not match local timezone");
+                    }
+                },
+            },
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -763,3 +763,13 @@ export function addDiscount(discount) {
             .flatMap((key) => Numpad.click(key)),
     ].flat();
 }
+
+export function setTimeZone(testTimeZone) {
+    return {
+        content: "Set test time zone to a non UTC time zone",
+        trigger: "body",
+        run: function () {
+            luxon.Settings.defaultZone = testTimeZone;
+        },
+    };
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1741,6 +1741,10 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, "AddMultipleSerialsAtOnce", login="pos_user")
 
+    def test_order_time(self):
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'OrderTimeTour', login="pos_user")
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
The date and time displayed in the order section of a POS session were always shown in GMT,
ignoring the user's time zone.

![image](https://github.com/user-attachments/assets/c5644bc7-7a12-4e69-93b9-a7eaceac5532)

opw-4416447

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
