### PR TITLE
[FIX] l10n_sa_edi: QR missing from POS invoice

### DIFF
--- a/addons/l10n_sa_edi/i18n/ar.po
+++ b/addons/l10n_sa_edi/i18n/ar.po
@@ -865,6 +865,12 @@ msgid "Sandbox"
 msgstr "Sandbox"
 
 #. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move_send.py:0
+msgid "Send to Zatca"
+msgstr "إرسال إلى زاتكا"
+
+#. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_journal__l10n_sa_serial_number
 msgid "Serial Number"
 msgstr "الرقم التسلسلي"

--- a/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
+++ b/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
@@ -788,6 +788,12 @@ msgid "Sandbox"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move_send.py:0
+msgid "Send to Zatca"
+msgstr ""
+
+#. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_journal__l10n_sa_serial_number
 msgid "Serial Number"
 msgstr ""

--- a/addons/l10n_sa_edi/models/__init__.py
+++ b/addons/l10n_sa_edi/models/__init__.py
@@ -8,3 +8,4 @@ from . import res_partner
 from . import res_company
 from . import res_config_settings
 from . import account_edi_xml_ubl_21_zatca
+from . import account_move_send

--- a/addons/l10n_sa_edi/models/account_move_send.py
+++ b/addons/l10n_sa_edi/models/account_move_send.py
@@ -1,0 +1,26 @@
+from odoo import api, models, _
+
+
+class AccountMoveSend(models.AbstractModel):
+    _inherit = 'account.move.send'
+
+    @api.model
+    def _is_sa_edi_applicable(self, move):
+        zatca_document = move.edi_document_ids.filtered(lambda d: d.edi_format_id.code == 'sa_zatca' and d.state == 'to_send')
+        return move.country_code == 'SA' and move.move_type in ('out_invoice', 'out_refund') and zatca_document and move.state != 'draft'
+
+    def _get_all_extra_edis(self) -> dict:
+        # EXTENDS 'account'
+        res = super()._get_all_extra_edis()
+        res.update({'sa_edi': {'label': _("Send to Zatca"), 'is_applicable': self._is_sa_edi_applicable}})
+        return res
+
+    def _call_web_service_before_invoice_pdf_render(self, invoices_data):
+        # EXTENDS 'account'
+        super()._call_web_service_before_invoice_pdf_render(invoices_data)
+
+        to_process = self.env['account.move']
+        for invoice, invoice_data in invoices_data.items():
+            if 'sa_edi' in invoice_data['extra_edis']:
+                to_process |= invoice
+        to_process.action_process_edi_web_services()


### PR DESCRIPTION
Users of SA localization needs to add a QR (resulting from the EDI
validation) to their official invoices. This should occurs also for
point of sales invoices but this is currently not working.

Steps to reproduce:
- With SA localization setup
- Open POS session
- Add a product
- Invoice to a customer
- Validate order
- Check generated invoice

Issue: QR is missing

This occurs because we print the invoice before sending it to ZATCA.
This way we generate an invoice without the needed fiscal information

opw-4562837