### PR TITLE
[FIX] point_of_sale: consider non-existing variants as archived

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -182,7 +182,13 @@ class ProductProduct(models.Model):
     def _get_archived_combinations_per_product_tmpl_id(self, product_tmpl_ids):
         archived_combinations = {}
         for product_tmpl in self.env['product.template'].browse(product_tmpl_ids):
-            archived_combinations[product_tmpl.id] = product_tmpl._get_attribute_exclusions()['archived_combinations']
+            attribute_exclusions = product_tmpl._get_attribute_exclusions()
+            archived_combinations[product_tmpl.id] = attribute_exclusions['archived_combinations']
+            excluded = {}
+            for ptav_id, ptav_ids in attribute_exclusions['exclusions'].items():
+                for ptav_id2 in set(ptav_ids) - excluded.keys():
+                    excluded[ptav_id] = ptav_id2
+            archived_combinations[product_tmpl.id].extend(excluded.items())
         return archived_combinations
 
     @api.ondelete(at_uninstall=False)

--- a/addons/point_of_sale/tests/__init__.py
+++ b/addons/point_of_sale/tests/__init__.py
@@ -11,6 +11,7 @@ from . import test_pos_setup
 from . import test_pos_simple_orders
 from . import test_pos_simple_invoiced_orders
 from . import test_pos_basic_config
+from . import test_pos_product_variants
 from . import test_pos_products_with_tax
 from . import test_pos_margin
 from . import test_pos_multiple_receivable_accounts

--- a/addons/point_of_sale/tests/test_pos_product_variants.py
+++ b/addons/point_of_sale/tests/test_pos_product_variants.py
@@ -1,0 +1,57 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+from odoo.tests import tagged
+
+from odoo.addons.product.tests.common import ProductVariantsCommon
+
+
+@tagged('post_install', '-at_install')
+class TestPoSProductVariants(ProductVariantsCommon):
+
+    def get_ptav(self, template, pav):
+        return template.valid_product_template_attribute_line_ids.filtered(
+            lambda ptal: ptal.attribute_id == pav.attribute_id
+        ).product_template_value_ids.filtered(
+            lambda ptav: ptav.product_attribute_value_id == pav
+        )
+
+    def test_product_exclusions(self):
+        sofa = self.product_template_sofa
+        sofa.attribute_line_ids = [Command.create({
+            'attribute_id': self.size_attribute.id,
+            'value_ids': [Command.set([
+                self.size_attribute_s.id,
+                self.size_attribute_l.id,
+            ])],
+        })]
+
+        red_ptav = self.get_ptav(sofa, self.color_attribute_red)
+        blue_ptav = self.get_ptav(sofa, self.color_attribute_blue)
+        small_ptav = self.get_ptav(sofa, self.size_attribute_s)
+
+        # Create an attribute exclusion for red, small sofas
+        red_ptav.exclude_for = [Command.create({
+            'product_tmpl_id': sofa.id,
+            'value_ids': [Command.set([small_ptav.id])],
+        })]
+
+        # Archive blue, small sofa variant
+        sofa_blue_s = sofa._get_variant_for_combination(small_ptav + blue_ptav)
+        sofa_blue_s.action_archive()
+
+        Product = self.env['product.product']
+        unavailable_combinations = Product._get_archived_combinations_per_product_tmpl_id(sofa.ids)
+        unavailable_sofas = [set(combination) for combination in unavailable_combinations[sofa.id]]
+
+        self.assertEqual(len(unavailable_sofas), 2, "There should be 2 unavailable combinations")
+        self.assertIn(
+            {red_ptav.id, small_ptav.id},
+            unavailable_sofas,
+            "Red, small sofas should be unavailable for sale due to attribute exclusion",
+        )
+        self.assertIn(
+            {blue_ptav.id, small_ptav.id},
+            unavailable_sofas,
+            "Blue, small sofas should be unavailable for sale due to being archived",
+        )


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Earlier versions displayed each variant seperately.

Steps
-----
1. Have 2 product template attributes A and B;
2. have one of B's attribute values be excluded for one of A's values;
3. have a product template using these values;
4. ensure product template is available in POS;
5. sell product template in POS.

Issue
-----
The attribute combination that should be excluded isn't displayed as such.

Cause
-----
When checking for product attribute exclusions, it currently only considers attribute combinations of archived products to be unavailable for sale.

Solution
--------
In the `_get_archived_combinations_per_product_tmpl_id` method, factor in attribute exclusions, and treat them as archived product variants.

In master, rename the method & references to it to reflect more general unavailable attribute combinations instead of specifically archived products.

opw-4521198