### PR TITLE
[FIX] mail: subtype with parent in same model

### DIFF
--- a/addons/mail/models/mail_message_subtype.py
+++ b/addons/mail/models/mail_message_subtype.py
@@ -89,7 +89,7 @@ class MailMessageSubtype(models.Model):
                 child_ids += subtype.ids
                 if subtype.default:
                     def_ids += subtype.ids
-            elif subtype.relation_field:
+            if subtype.relation_field:
                 parent[subtype.id] = subtype.parent_id.id
                 relation.setdefault(subtype.res_model, set()).add(subtype.relation_field)
             # required for backward compatibility

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -169,6 +169,7 @@ class MailTestTrack(models.Model):
     company_id = fields.Many2one('res.company')
     track_fields_tofilter = fields.Char()  # comma-separated list of field names
     track_enable_default_log = fields.Boolean(default=False)
+    parent_id = fields.Many2one('mail.test.track', string='Parent')
 
     def _track_filter_for_display(self, tracking_values):
         values = super()._track_filter_for_display(tracking_values)


### PR DESCRIPTION
When you create a mail subtype having the same model than the subtype of which linked through his relational field.

The followers of the parent are not correctly taken into account because the parenting relation is ignored as we get into the first 'if' part and so not in the 'elif'.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
