### PR TITLE
[FIX] pos_self_order: fix slow connection error when printing order

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
@@ -28,29 +28,7 @@ export class ConfirmationPage extends Component {
                     this.setDefautLanguage();
                 }, 5000);
 
-                setTimeout(async () => {
-                    try {
-                        await this.printer.print(OrderReceipt, {
-                            data: this.selfOrder.orderExportForPrinting(this.confirmedOrder),
-                            formatCurrency: this.selfOrder.formatMonetary.bind(this.selfOrder),
-                        });
-                        if (!this.selfOrder.has_paper) {
-                            this.updateHasPaper(true);
-                        }
-                    } catch (e) {
-                        if (e.errorCode === "EPTR_REC_EMPTY") {
-                            this.dialog.add(OutOfPaperPopup, {
-                                title: `No more paper in the printer, please remember your order number: '${this.confirmedOrder.trackingNumber}'.`,
-                                close: () => {
-                                    this.router.navigate("default");
-                                },
-                            });
-                            this.updateHasPaper(false);
-                        } else {
-                            console.error(e);
-                        }
-                    }
-                }, 500);
+                setTimeout(() => this.printOrderAfterTime(), 500);
                 this.defaultTimeout = setTimeout(() => {
                     this.router.navigate("default");
                 }, 30000);
@@ -63,6 +41,34 @@ export class ConfirmationPage extends Component {
         onWillStart(() => {
             this.initOrder();
         });
+    }
+
+    async printOrderAfterTime() {
+        try {
+            if (this.confirmedOrder && Object.keys(this.confirmedOrder).length > 0) {
+                await this.printer.print(OrderReceipt, {
+                    data: this.selfOrder.orderExportForPrinting(this.confirmedOrder),
+                    formatCurrency: this.selfOrder.formatMonetary.bind(this.selfOrder),
+                });
+                if (!this.selfOrder.has_paper) {
+                    this.updateHasPaper(true);
+                }
+            } else {
+                setTimeout(() => this.printOrderAfterTime(), 500);
+            }
+        } catch (e) {
+            if (e.errorCode === "EPTR_REC_EMPTY") {
+                this.dialog.add(OutOfPaperPopup, {
+                    title: `No more paper in the printer, please remember your order number: '${this.confirmedOrder.trackingNumber}'.`,
+                    close: () => {
+                        this.router.navigate("default");
+                    },
+                });
+                this.updateHasPaper(false);
+            } else {
+                console.error(e);
+            }
+        }
     }
 
     async initOrder() {


### PR DESCRIPTION
At confirmation page, we wait 500 ms before printing the order. That led to some problems when the user did not have a good network connection since the order was not yet initialized that the order would be printed and thus leading to an error.

Here, if the order is not initialized yet, we reset a timeout to print the order

runbot-error: 111762

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
