### PR TITLE
[IMP] flatten Record.to_data()

### DIFF
--- a/addons/mail/static/src/core/common/activity_model.js
+++ b/addons/mail/static/src/core/common/activity_model.js
@@ -83,7 +83,7 @@ export class Activity extends Record {
     write_uid;
 
     serialize() {
-        return JSON.parse(JSON.stringify(this.toData()));
+        return JSON.parse(JSON.stringify(this.toData(["persona"])));
     }
 }
 

--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -147,6 +147,10 @@ export class Persona extends Record {
         }
         this.im_status = newStatus;
     }
+
+    _getPyModelName() {
+        return this.type === "partner" ? "res.partner" : "mail.guest";
+    }
 }
 
 Persona.register();

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -881,6 +881,10 @@ export class Thread extends Record {
         }
         this.leave();
     }
+
+    _getPyModelName() {
+        return this.model === "discuss.channel" ? "discuss.channel" : "mail.thread";
+    }
 }
 
 Thread.register();

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -102,7 +102,7 @@ const StorePatch = {
     _onActivityBroadcastChannelMessage({ data }) {
         switch (data.type) {
             case "INSERT":
-                this["mail.activity"].insert(data.payload, { broadcast: false, html: true });
+                this.insert(data.payload, { broadcast: false, html: true });
                 break;
             case "DELETE": {
                 const activity = this["mail.activity"].insert(data.payload, { broadcast: false });

--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -17,6 +17,13 @@ import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
 
 /** @typedef {import("./misc").FieldDefinition} FieldDefinition */
 /** @typedef {import("./record_list").RecordList} RecordList */
+/**
+ * @typedef {Object} Ongoing
+ * @property {Object} storeData Store insert-able data grouped by model names
+ * @property {Set<string>} seenRecords A set of localIDs to track visited records
+ * @property {boolean} depth Whether to recursively fetch deep data for all related records
+ * @property {string[]} fields An array of field names to fetch, using dot notation (e.g., `"persona.group_ids"`).
+ */
 
 export class Record {
     /** @type {import("./model_internal").ModelInternal} */
@@ -414,20 +421,75 @@ export class Record {
         return !this.in(collection);
     }
 
-    toData() {
+    /**
+     * Converts the current record and its related data into Store insert-able data.
+     * @param {Array<string> | { depth: boolean }} options Configuration options or an array of field names.
+     * @returns {Object} A data object grouped by model names.
+     */
+    toData(options = { depth: false }) {
+        const prefix = this._getPyModelName();
+        const ongoing = {
+            seenRecords: new Set(),
+            storeData: {},
+            depth: options.depth,
+            fields: undefined,
+        };
+        if (Array.isArray(options)) {
+            ongoing.fields = options.map((field) => `${prefix}.${field}`);
+        }
+        this._toData(ongoing, prefix);
+        return ongoing.storeData;
+    }
+
+    _cleanupData(data) {
+        const fieldsToDelete = [
+            "_",
+            "_fieldsValue",
+            "_proxy",
+            "_proxyInternal",
+            "_raw",
+            "env",
+            "Model",
+        ];
+        fieldsToDelete.forEach((field) => delete data[field]);
+    }
+
+    _getPyModelName() {
+        return this.Model.getName();
+    }
+
+    /**
+     * @param {Ongoing} ongoing The ongoing data conversion state.
+     * @param {string} [prefix] The prefix for the current field (used for nested fields).
+     */
+    _toData(ongoing, prefix = undefined) {
+        if (ongoing.seenRecords.has(this.localId)) {
+            return;
+        }
+        ongoing.seenRecords.add(this.localId);
+
         const recordProxy = this;
         const record = toRaw(recordProxy)._raw;
         const Model = record.Model;
         const data = { ...recordProxy };
         for (const name of Model._.fields.keys()) {
+            const fullFieldName = prefix ? `${prefix}.${name}` : name;
             if (isMany(Model, name)) {
                 data[name] = record._proxyInternal[name].map((recordProxy) => {
                     const record = toRaw(recordProxy)._raw;
-                    return record.toIdData.call(record._proxyInternal);
+                    return record._toDataRelationalRecord.call(
+                        record._proxyInternal,
+                        ongoing,
+                        fullFieldName
+                    );
                 });
             } else if (isOne(Model, name)) {
                 const otherRecord = toRaw(record._proxyInternal[name])?._raw;
-                data[name] = otherRecord?.toIdData.call(otherRecord._proxyInternal);
+                data[name] = otherRecord?._toDataRelationalRecord.call(
+                    otherRecord._proxyInternal,
+                    ongoing,
+                    fullFieldName
+                );
             } else {
                 // Record.attr()
                 const value = recordProxy[name];
@@ -440,19 +502,26 @@ export class Record {
                 }
             }
         }
-        delete data._;
-        delete data._fieldsValue;
-        delete data._proxy;
-        delete data._proxyInternal;
-        delete data._raw;
-        delete data.Model;
-        return data;
+
+        this._cleanupData(data);
+        const pyModelName = record._getPyModelName();
+        ongoing.storeData[pyModelName] ||= [];
+        ongoing.storeData[pyModelName].push(data);
     }
-    toIdData() {
+
+    /**
+     * @param {Ongoing} ongoing The ongoing data conversion state.
+     * @param {string} prefix The prefix for the current field (used for nested fields).
+     * @returns {Object} A data object grouped by model names.
+     */
+    _toDataRelationalRecord(ongoing, prefix = undefined) {
         const data = this.Model._retrieveIdFromData(this);
+        if (ongoing.depth || ongoing.fields?.some((field) => field.startsWith(prefix))) {
+            this._toData(ongoing, prefix);
+        }
         for (const [name, val] of Object.entries(data)) {
             if (isRecord(val)) {
-                data[name] = val.toIdData();
+                data[name] = val._toDataRelationalRecord(ongoing, prefix);
             }
         }
         return data;

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -1,5 +1,5 @@
 import { Record } from "./record";
-import { IS_DELETED_SYM, STORE_SYM } from "./misc";
+import { IS_DELETED_SYM, STORE_SYM, modelRegistry } from "./misc";
 import { reactive, toRaw } from "@odoo/owl";
 
 /** @typedef {import("./record_list").RecordList} RecordList */
@@ -202,5 +202,14 @@ export class Store extends Record {
         return () => {
             ready = false;
         };
+    }
+    _cleanupData(data) {
+        super._cleanupData(data);
+        if (this._getPyModelName() === "Store") {
+            delete data.Models;
+            for (const [name] of modelRegistry.getEntries()) {
+                delete data[name];
+            }
+        }
     }
 }

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -952,13 +952,132 @@ test("record.toData() is JSON stringified and can be reinserted as record", asyn
     store.Message.get("2").delete();
     store.Team.get("Discuss").delete();
     expect(toRaw(store.Person.records[p.localId])).toBe(undefined);
-    const p2 = store.Person.insert(data);
+    const p2 = store.Person.insert(data.Person[0]);
     // Same assertions as before
     expect(p2.names).toEqual(["John", "Marc"]);
     expect(p2.messages.map((msg) => msg.body)).toEqual(["1", "2"]);
     expect(p2.team.name).toBe("Discuss");
     expect(toRaw(store.Person.records[p2.localId])).toBe(toRaw(p2));
     expect(serializeDateTime(p2.due_datetime)).toBe("2024-08-28 10:19:44");
+});
+
+test("record.toData() returns flat data", async () => {
+    (class Person extends Record {
+        static id = "id";
+        id;
+        names = Record.attr([]);
+        due_datetime = Record.attr(undefined, { type: "datetime" });
+        messages = Record.many("Message");
+        team = Record.one("Team");
+    }).register(localRegistry);
+    (class Message extends Record {
+        static id = "id";
+        id;
+        body = Record.attr("");
+    }).register(localRegistry);
+    (class Team extends Record {
+        static id = "id";
+        id;
+        name;
+        leader = Record.one("Person");
+    }).register(localRegistry);
+    const store = await start();
+    store.Person.insert([
+        {
+            id: 1,
+            due_datetime: "2024-08-28 10:19:44",
+            names: ["Seb", "Theys"],
+            messages: [
+                { id: 1, body: "1" },
+                { id: 2, body: "2" },
+            ],
+            team: { id: 1, name: "Discuss", leader: { id: 2 } },
+        },
+        {
+            id: 2,
+            due_datetime: "2025-01-23 12:12:12",
+            names: ["Louis", "Wicket"],
+            messages: [
+                { id: 1, body: "1" },
+                { id: 3, body: "3" },
+            ],
+            team: { id: 2, name: "VoIP", leader: { id: 1 } },
+        },
+    ]);
+    const p = store.Person.get(1);
+    expect(p.toData()).toEqual({
+        Person: [
+            {
+                id: 1,
+                due_datetime: "2024-08-28 10:19:44",
+                names: ["Seb", "Theys"],
+                messages: [{ id: 1 }, { id: 2 }],
+                team: { id: 1 },
+            },
+        ],
+    });
+    expect(p.toData(["messages", "team"])).toEqual({
+        Person: [
+            {
+                id: 1,
+                due_datetime: "2024-08-28 10:19:44",
+                names: ["Seb", "Theys"],
+                messages: [{ id: 1 }, { id: 2 }],
+                team: { id: 1 },
+            },
+        ],
+        Message: [
+            { id: 1, body: "1" },
+            { id: 2, body: "2" },
+        ],
+        Team: [{ id: 1, name: "Discuss", leader: { id: 2 } }],
+    });
+    expect(p.toData(["team.leader"])).toEqual({
+        Person: [
+            {
+                id: 2,
+                due_datetime: "2025-01-23 12:12:12",
+                names: ["Louis", "Wicket"],
+                messages: [{ id: 1 }, { id: 3 }],
+                team: { id: 2 },
+            },
+            {
+                id: 1,
+                due_datetime: "2024-08-28 10:19:44",
+                names: ["Seb", "Theys"],
+                messages: [{ id: 1 }, { id: 2 }],
+                team: { id: 1 },
+            },
+        ],
+        Team: [{ id: 1, name: "Discuss", leader: { id: 2 } }],
+    });
+    expect(p.toData({ depth: true })).toEqual({
+        Person: [
+            {
+                id: 2,
+                due_datetime: "2025-01-23 12:12:12",
+                names: ["Louis", "Wicket"],
+                messages: [{ id: 1 }, { id: 3 }],
+                team: { id: 2 },
+            },
+            {
+                id: 1,
+                due_datetime: "2024-08-28 10:19:44",
+                names: ["Seb", "Theys"],
+                messages: [{ id: 1 }, { id: 2 }],
+                team: { id: 1 },
+            },
+        ],
+        Message: [
+            { id: 1, body: "1" },
+            { id: 2, body: "2" },
+            { id: 3, body: "3" },
+        ],
+        Team: [
+            { id: 2, name: "VoIP", leader: { id: 1 } },
+            { id: 1, name: "Discuss", leader: { id: 2 } },
+        ],
+    });
 });
 
 test("Methods are bound to records", async () => {


### PR DESCRIPTION
Imporve Record.to_data() to make the results can be easily inserted in
a multi-tab context. Previously, we only return the shallow data of the
given record, for example, Message.toData() may return:
```
[{ id: 1, body: "hello-world!", author: { id: 10, type: "partner" } }]
```
While insert the data to another tab, we may lack the data of the
`author`.
In this commit, we make toData() to return the flatened data of all the
model, for example:
```
{
   "mail.message": [{ id: 1, body: "hello-world!", author: { id: 10, type: "partner" } }],
   "res.partner": [{ id: 10, type: "partner", name: "John" }],
}
```
so that, we can insert all the data we need to another tab.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
