### PR TITLE
[FIX] web: missing props in user_menu_items

### DIFF
--- a/addons/web/static/src/webclient/user_menu/user_menu_items.js
+++ b/addons/web/static/src/webclient/user_menu/user_menu_items.js
@@ -39,7 +39,9 @@ function supportItem(env) {
 
 class ShortcutsFooterComponent extends Component {
     static template = "web.UserMenu.ShortcutsFooterComponent";
-    static props = {};
+    static props = {
+        switchNamespace: { type: Function, optional: true },
+    };
     setup() {
         this.runShortcutKey = isMacOS() ? "CONTROL" : "ALT";
     }


### PR DESCRIPTION
This commit fills in the missing prop of the ShortcutsFooterComponent which was forgotten in https://github.com/odoo/odoo/commit/dd583fd670e0ee03b04711780bad2429b18a0788
