### PR TITLE
[FIX] core: WWW-Authenticate with 401-Unauthorized

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -228,12 +228,16 @@ class IrHttp(models.AbstractModel):
             # 'rpc' scope does not really exist, we basically require a global key (scope NULL)
             uid = request.env['res.users.apikeys']._check_credentials(scope='rpc', key=token)
             if not uid:
-                raise werkzeug.exceptions.Unauthorized("Invalid apikey")
+                raise werkzeug.exceptions.Unauthorized(
+                    "Invalid apikey",
+                    www_authenticate=werkzeug.datastructures.WWWAuthenticate('bearer'))
             if request.env.uid and request.env.uid != uid:
                 raise AccessDenied("Session user does not match the used apikey")
             request.update_env(user=uid)
         elif not request.env.uid:
-            raise werkzeug.exceptions.Unauthorized('User not authenticated, use the "Authorization" header')
+            raise werkzeug.exceptions.Unauthorized(
+                'User not authenticated, use the "Authorization" header',
+                www_authenticate=werkzeug.datastructures.WWWAuthenticate('bearer'))
         elif not check_sec_headers():
             raise AccessDenied("Missing \"Authorization\" or Sec-headers for interactive usage")
         cls._auth_method_user()


### PR DESCRIPTION
There are many places where we use 401-Unauthorized where we really should be using 403-Forbidden instead. That's because 401-Unauthorized mandates using the `WWW-Authenticate` header with the response which is only defined for http auth schemes (basic, digest, bearer, ...), but we don't use thoses schemes with Odoo.

One place where we are correctly using the 401-Unauthorized response is with `@route(auth='bearer')`, but it lacked the `WWW-Authenticate` header to be fully compliant with the http.

> The server generating a 401 response MUST send a WWW-Authenticate
> header field containing at least one challenge applicable to the
> target resource.

https://httpwg.org/specs/rfc9110.html#status.401
https://httpwg.org/specs/rfc9110.html#field.www-authenticate

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
