### PR TITLE
[FIX] point_of_sale: added rounding to 2 decimals on product card

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.js
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.js
@@ -22,4 +22,8 @@ export class ProductCard extends Component {
         class: "",
         showWarning: false,
     };
+
+    get productQty() {
+        return this.env.utils.formatProductQty(this.props.productCartQty ?? 0, false);
+    }
 }

--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
@@ -20,7 +20,7 @@
                     t-attf-id="article_product_{{props.productId}}"
                     t-esc="props.name" />
                 <h1 t-if="props.productCartQty"
-                    t-out="props.productCartQty"
+                    t-out="this.productQty"
                     class="product-cart-qty text-muted display-6 fw-bolder m-0 mt-auto" />
             </div>
         </article>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -193,7 +193,10 @@ export class ProductScreen extends Component {
         return this.env.utils.formatCurrency(this.currentOrder?.get_total_with_tax() ?? 0);
     }
     get items() {
-        return this.currentOrder.lines?.reduce((items, line) => items + line.qty, 0) ?? 0;
+        return this.env.utils.formatProductQty(
+            this.currentOrder.lines?.reduce((items, line) => items + line.qty, 0) ?? 0,
+            false
+        );
     }
     getProductName(product) {
         const productTmplValIds = product.attribute_line_ids

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -505,3 +505,41 @@ registry.category("web_tour.tours").add("ProductSearchTour", {
             ProductScreen.productIsDisplayed("Test Product 2"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("ProductCardUoMPrecision", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Configurable Chair", false),
+            ProductConfiguratorPopup.pickRadio("Leather"),
+            Chrome.clickBtn("Add"),
+            inLeftSide([
+                Numpad.click("."),
+                Numpad.click("1"),
+                ...Order.hasLine({
+                    productName: "Configurable Chair",
+                    quantity: "0.1",
+                }),
+            ]),
+            ProductScreen.clickDisplayedProduct("Configurable Chair", false),
+            ProductConfiguratorPopup.pickRadio("wool"),
+            Chrome.clickBtn("Add"),
+            inLeftSide([
+                Numpad.click("."),
+                Numpad.click("7"),
+                ...Order.hasLine({
+                    productName: "Configurable Chair",
+                    quantity: "0.7",
+                }),
+            ]),
+            ProductScreen.productCardQtyIs("Configurable Chair", "0.8"),
+            {
+                content:
+                    "Check the cart button if it shows the quantity in correct format/precision",
+                isActive: ["mobile"],
+                trigger: ".review-button:contains('0.8')",
+            },
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1634,6 +1634,10 @@ class TestUi(TestPointOfSaleHttpCommon):
         for order in self.env['pos.order'].search([]):
             self.assertEqual(int(order.tracking_number) % 100, 1)
 
+    def test_product_card_qty_precision(self):
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'ProductCardUoMPrecision', login="pos_user")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Steps to reproduce:
- install pos
- create a product with weigh on scale
- open pos session and add it twice, once in 1.9 and once in 2.3
- you will find the number on the card number as 4.1999999999999999

Problem:
issue in the precision of decimal additions in javascript, so added a rounding to max 2 decimal places

opw-4529408

Description of the issue/feature this PR addresses:

Current behavior before PR:
![image](https://github.com/user-attachments/assets/5df6e626-4ad1-43d8-9738-74ea776733c9)


Desired behavior after PR is merged:
![image](https://github.com/user-attachments/assets/e316e829-d4eb-40f9-a4a2-d6fd0580cedc)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
