### PR TITLE
[FIX] point_of_sale : Add refunded qty just once

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1161,7 +1161,10 @@ export class PosStore extends Reactive {
                     if (order) {
                         delete order.uiState.lineToRefund[refundedOrderLine.uuid];
                     }
-                    refundedOrderLine.refunded_qty += Math.abs(line.qty);
+                    refundedOrderLine.refunded_qty = refundedOrderLine.refund_orderline_ids.reduce(
+                        (sum, obj) => sum + Math.abs(obj.qty),
+                        0
+                    );
                 }
             }
 

--- a/addons/pos_restaurant/static/tests/tours/refund_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/refund_tour.js
@@ -7,6 +7,7 @@ import * as ReceiptScreen from "@point_of_sale/../tests/tours/utils/receipt_scre
 import * as FloorScreen from "@pos_restaurant/../tests/tours/utils/floor_screen_util";
 import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen_util";
 import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/order_widget_util";
+import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("RefundStayCurrentTableTour", {
@@ -40,5 +41,46 @@ registry.category("web_tour.tours").add("RefundStayCurrentTableTour", {
             ProductScreen.isShown(),
             ProductScreen.selectedOrderlineHas("Coca-Cola"),
             ProductScreen.totalAmountIs("-4.40"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("RefundQtyTour", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+
+            // Create first order and pay it
+            FloorScreen.clickTable("2"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola", true, "1.0"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola", true, "2.0"),
+            ProductScreen.clickDisplayedProduct("Water", true, "1.0"),
+            ProductScreen.totalAmountIs("6.60"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.selectFilter("Paid"),
+            TicketScreen.selectOrder("-0001"),
+            Order.hasLine({
+                productName: "Coca-Cola",
+            }),
+            ProductScreen.clickNumpad("2"),
+            TicketScreen.toRefundTextContains("To Refund: 2.00"),
+            TicketScreen.confirmRefund(),
+            ProductScreen.isShown(),
+            ProductScreen.selectedOrderlineHas("Coca-Cola"),
+            ProductScreen.totalAmountIs("-4.40"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.selectFilter("Paid"),
+            TicketScreen.selectOrder("-0001"),
+            TicketScreen.refundedNoteContains("2.00 Refunded"),
         ].flat(),
 });

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -324,3 +324,7 @@ class TestFrontend(TestFrontendCommon):
         assert_payment(1, 4.4)
         self.start_pos_tour('PoSPaymentSyncTour3')
         assert_payment(2, 6.6)
+
+    def test_15_pos_refund_qty(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('RefundQtyTour')


### PR DESCRIPTION
### Steps to reproduce:
	- Create a PoS order in restaurant and proceed with payment
	- Create a refund for some items in the created order
	- Go to the order screens and notice the refunded qty in the main order

### Cause:
Since syncAllOrders method gets executed in different flows we are adding to the refunded_qty more than once.
https://github.com/odoo/odoo/blob/bfbf47d7b70d9bc180968a69d0ab6c522ee877a8/addons/point_of_sale/static/src/app/store/pos_store.js#L1164

### Fix:
Set the refunded qty as sum of quantities for the related refund
order lines.
opw-4536644