### PR TITLE
[FIX] web_tour: Prevent traceback on safari 18.3

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_pointer_state.js
+++ b/addons/web_tour/static/src/tour_service/tour_pointer_state.js
@@ -50,7 +50,8 @@ class Intersection {
             if (observation.isIntersecting) {
                 this._targetPosition = "in";
             } else {
-                const scrollParentElement = getScrollParent(this.currentTarget);
+                const scrollParentElement =
+                    getScrollParent(this.currentTarget) || document.documentElement;
                 const targetBounds = this.currentTarget.getBoundingClientRect();
                 if (targetBounds.bottom > scrollParentElement.clientHeight) {
                     this._targetPosition = "out-below";


### PR DESCRIPTION
Steps:
- Install `sale_management`
- Open Sales
- Go back to home menu
- traceback

`getParentScroll` can return `null`

```js
const scrollParentElement = getScrollParent(this.currentTarget);
const targetBounds = this.currentTarget.getBoundingClientRect();
if (targetBounds.bottom > scrollParentElement.clientHeight)
```

```js
export function getScrollParent(element) {
    if (!element) {
        return null;
    }
```

This commit adds a fallback for the return value of `getScrollParent` to
prevent this traceback.

opw-4600271