### PR TITLE
[FIX] point_of_sale: extra prices not shown in combo product

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
@@ -23,6 +23,9 @@
                     t-out="props.productCartQty"
                     class="product-cart-qty text-muted display-6 fw-bolder m-0 mt-auto" />
             </div>
+            <div class="w-100 d-flex justify-content-between align-items-center px-2">
+                <span t-if="props.price" class="price-tag py-1 text-end" t-esc="props.price" />
+            </div>
         </article>
     </t>
 </templates>

--- a/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
@@ -120,6 +120,7 @@ registry.category("web_tour.tours").add("ProductComboChangeFP", {
             Dialog.confirm("Open Register"),
 
             ProductScreen.clickDisplayedProduct("Office Combo"),
+            ProductScreen.checkExtraPrice("2"),
             combo.select("Combo Product 2"),
             combo.select("Combo Product 4"),
             combo.select("Combo Product 6"),

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -650,6 +650,12 @@ export function checkTaxAmount(amount) {
     };
 }
 
+export function checkExtraPrice(amount) {
+    return {
+        trigger: `.price-tag.py-1:contains(${amount})`,
+    };
+}
+
 export function addDiscount(discount) {
     return [
         Numpad.click("%"),


### PR DESCRIPTION
Extra prices are not displayed in the POS when selecting a combo product with defined combo choices.
When a combo product is created with combo choices that have extra prices,
those extra prices should be visible in the POS interface.

Steps to Reproduce:
1. Create a new combo product with multiple combo choices.
2. Set an extra price for one or more of the combo choices.
3. In the POS, select the combo product.
4. Notice that the extra price is not shown.

opw-4485134



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
