### PR TITLE
[FIX] website: fix carousel bootstrap upgrade fix interaction

### DIFF
--- a/addons/website/static/src/interactions/carousel/carousel_bootstrap_upgrade_fix.edit.js
+++ b/addons/website/static/src/interactions/carousel/carousel_bootstrap_upgrade_fix.edit.js
@@ -1,9 +1,15 @@
 import { CarouselBootstrapUpgradeFix } from "@website/interactions/carousel/carousel_bootstrap_upgrade_fix";
 import { registry } from "@web/core/registry";
+import { withHistory } from "@website/core/website_edit_service";
 
 const CarouselBootstrapUpgradeFixEdit = I => class extends I {
     // Suspend ride in edit mode.
     carouselOptions = { ride: false, pause: true };
+
+    setup() {
+        super.setup();
+        this.dynamicContent = withHistory(this.dynamicContent);
+    }
 };
 
 registry

--- a/addons/website/static/src/interactions/carousel/carousel_bootstrap_upgrade_fix.js
+++ b/addons/website/static/src/interactions/carousel/carousel_bootstrap_upgrade_fix.js
@@ -61,7 +61,7 @@ export class CarouselBootstrapUpgradeFix extends Interaction {
             // Wait for carousel to finish sliding.
             if (this.el.classList.contains("o_carousel_sliding")) {
                 await new Promise(resolve => {
-                    this.el.addEventListener("slid.bs.carousel", () => resolve(), { once: true });
+                    this.addListener(this.el, "slid.bs.carousel", () => resolve(), { once: true });
                 });
             }
             window.Carousel.getInstance(this.el)?.dispose();


### PR DESCRIPTION
In [1] when `CarouselBootstrapUpgradeFix` was converted from a public widget to an interaction, the change of the `o_carousel_sliding` class was not recorded in the history anymore.
Because of this, using the undo button after moving around carousel slides led to an unstable version of the carousel snippet.

This commit introduces a mechanism for interactions to request that edit mode interactions are not stealth:
- a new `.history` suffix on `t-on-...` in the `dynamicContent`
- a `{ history: true }` in the options when using `addListener`

Steps to reproduce:
- Drop a Carousel snippet
- Go to next slide
- Undo: the wrong slide was displayed
- Go to next slide again

=> A traceback was shown

[1]: https://github.com/odoo/odoo/commit/b9b3a605e0f4c5da3a258c980107d6162da7f44f

task-4367641
