### PR TITLE
[FIX] point_of_sale: limit closing difference to two decimal digits

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1522,9 +1522,8 @@ class PosSession(models.Model):
         message = ""
         if difference:
             message = f"{state} difference: " \
-                      f"{self.currency_id.symbol + ' ' if self.currency_id.position == 'before' else ''}" \
-                      f"{self.currency_id.round(difference)} " \
-                      f"{self.currency_id.symbol if self.currency_id.position == 'after' else ''}" + Markup('<br/>')
+                      f"{self.currency_id.format(difference) }" \
+                          + Markup('<br/>')
         if notes:
             message += escape(notes).replace('\n', Markup('<br/>'))
         if message:

--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -177,6 +177,17 @@ registry.category("web_tour.tours").add("CashClosingDetails", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("CashClosingDecimals", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            ProductScreen.enterOpeningAmount("558.49"),
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.checkSecondCashClosingDetailsLineAmount("1.91", "-"),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("ShowTaxExcludedTour", {
     test: true,
     url: "/pos/ui",

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -818,6 +818,22 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertEqual(len(pos_session.statement_line_ids), 1)
         self.assertEqual(pos_session.statement_line_ids[0].amount, -10)
 
+    def test_pos_closing_cash_decimals(self):
+        """
+        Test that the closing cash difference is rounded according to the currency specification
+        and does not have excessive decimal places.
+        """
+        self.main_pos_config.open_ui()
+        current_session = self.main_pos_config.current_session_id
+        current_session.post_closing_cash_details(560.40)
+        current_session.close_session_from_ui()
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CashClosingDecimals', login="pos_user")
+
+        pos_session = self.main_pos_config.current_session_id
+        self.assertEqual(pos_session.message_ids[0].body.striptags(), 'Opening difference: $\xa0-\ufeff1.91')
+
     def test_cash_payments_should_reflect_on_next_opening(self):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'OrderPaidInCash', login="pos_user")


### PR DESCRIPTION
**Issue:**
When closing a PoS session with negative balances, the closing difference is displayed in the chatter box with an excessive number of decimal digits.

**Steps to Reproduce:**
1. Install the Point of Sale app.
2. Navigate to Point of Sale > Open a new session.
3. Set the Opening Cash to 496.45.
4. Add a product priced at 65.86 to an order.
5. Confirm the payment via Payment > Cash > Validate.
6. Close the session and set Counted Cash to 560.40.
7. Navigate to Orders > Sessions.
8. Open the last closed session.
9. Observe that the closing difference is displayed with more than two decimal digits.

Expected Behavior: The closing difference should be rounded to two decimal places for clarity.

Actual Behavior: The closing difference is displayed with excessive decimal digits.

**Root Cause**

Floating-point arithmetic in Python causes small precision errors when performing calculations involving monetary values. Since Odoo's Monetary fields are based on float types, operations such as balance calculations retain unnecessary decimal places instead of rounding them correctly to two digits.

**Fix**
To prevent this from happening, at the moment of crafting the message to display on the chatter, it is explicitly requested to only show two decimal digits of the rounded closing difference.

Opw-4483487

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
