### PR TITLE
[FIX] l10n_ar_website_sale: Fix journal finding for timezone

### DIFF
--- a/addons/l10n_ar_website_sale/models/sale_order.py
+++ b/addons/l10n_ar_website_sale/models/sale_order.py
@@ -6,25 +6,18 @@ from odoo import fields, models
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    def _prepare_invoice(self):
-        """ Necessary because if someone creates an invoice after 9 pm Argentina time, if the invoice is created
+    def _create_account_invoices(self, invoice_vals_list, final):
+        """ EXTENDS 'sale'
+        Necessary because if someone creates an invoice after 9 pm Argentina time, if the invoice is created
         automatically, then it is created with the date of the next day (UTC date) instead of today.
-
         This fix is necessary because it causes problems validating invoices in ARCA (ex AFIP), since when generating
         the invoice with the date of the next day, no more invoices could be generated with today's date.
-
         We took the same approach that was used in the POS module to set the date, in this case always forcing the
         Argentina timezone """
-        res = super()._prepare_invoice()
-
-        # Find the invoice journal (given, or default one)
-        journal_id = res.get('journal_id')
-        journal = self.env['account.journal'].browse(journal_id) if journal_id else \
-            self.env['account.journal'].search([('type', '=', 'sale')], limit=1)
-
-        if journal.country_code == 'AR':
-            timezone = pytz.timezone('America/Buenos_Aires')
-            context_today_ar = fields.Datetime.now().astimezone(timezone).date()
-            res.update({'invoice_date': context_today_ar})
-
-        return res
+        invoices = super()._create_account_invoices(invoice_vals_list, final)
+        for invoice in invoices:
+            if invoice.country_code == 'AR':
+                timezone = pytz.timezone('America/Buenos_Aires')
+                context_today_ar = fields.Datetime.now().astimezone(timezone).date()
+                invoice.invoice_date = context_today_ar
+        return invoices


### PR DESCRIPTION
Previously [1], we adapted the generation of invoices from sale order to retrieve the correct date depending on the local timezone for Argentina. This fix was incorrect because the journal is rarely provided to `prepare_invoices` therefore most of the time we fallback on the journal found in the search, which was too naive. It doesn't retrieve the right journal if you have multiple sale journals with different countries.

To fix this problem, we move the update of the invoice_date after the actual creation of the moves to ensure the journal we get is the correct one.

[1]: odoo#192808
task-no
