### PR TITLE
[IMP] account: align taxes button with content

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -16,8 +16,8 @@
                                 string="here"
                                 type="object"
                                 name="action_create_foreign_taxes"
-                                class="oe_link"
-                                style="padding: 0; vertical-align: baseline;"/>
+                                class="oe_link p-0 align-baseline"
+                            />
                             to create the taxes for this country.
                         </div>
                     </div>


### PR DESCRIPTION
In ViewButton, style is present in attrs.style but
missing from props.style, likely due to being
overridden by a bug in Owl. This causes the Create
Taxes button to be misaligned with the alert
content. This commit adds a workaround to ensure
proper alignment.

Task ID: 4600491

Question: 

The original code OCO wrote a few years ago should do the trick. The problem is that the style attribute is not being carried over to the DOM, that's why I resorted to using a flex box. Did something change internally to reflect that ? I dug around quite a bit and didn't find something that made sense.