### PR TITLE
[FIX] mail: can fold livechat in mobile for visitors

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -13,7 +13,7 @@ import {
 } from "@mail/utils/common/hooks";
 import { isEventHandled } from "@web/core/utils/misc";
 
-import { Component, useChildSubEnv, useRef, useState } from "@odoo/owl";
+import { Component, useChildSubEnv, useExternalListener, useRef, useState } from "@odoo/owl";
 
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
@@ -63,6 +63,15 @@ export class ChatWindow extends Component {
             inChatWindow: true,
             messageHighlight: this.messageHighlight,
         });
+
+        if (this.isMobileForLivechatVisitor) {
+            useExternalListener(document.body, "scroll", this._onScroll, { capture: true });
+        }
+    }
+
+    _onScroll(ev) {
+        const container = ev.target;
+        this.state.moveUp = container.scrollHeight - container.scrollTop === container.clientHeight;
     }
 
     get composerType() {
@@ -80,7 +89,10 @@ export class ChatWindow extends Component {
         const maxHeight = !this.ui.isSmall ? "max-height: 95vh;" : "";
         const textDirection = localization.direction;
         const offsetFrom = textDirection === "rtl" ? "left" : "right";
-        const visibleOffset = this.ui.isSmall ? 0 : this.props.right;
+        let visibleOffset = this.ui.isSmall ? 0 : this.props.right;
+        if (this.isMobileFoldedForLivechatVisitor) {
+            visibleOffset = 10;
+        }
         const oppositeFrom = offsetFrom === "right" ? "left" : "right";
         return `${offsetFrom}: ${visibleOffset}px; ${oppositeFrom}: auto; ${maxHeight}`;
     }
@@ -125,13 +137,25 @@ export class ChatWindow extends Component {
     }
 
     onClickHeader() {
-        if (!this.ui.isSmall && !this.state.editingName) {
+        if ((!this.ui.isSmall || this.isMobileForLivechatVisitor) && !this.state.editingName) {
             this.toggleFold();
         }
     }
 
+    get isMobileFoldedForLivechatVisitor() {
+        return (
+            this.ui.isSmall &&
+            this.env.services["im_livechat.livechat"] &&
+            this.props.chatWindow.folded
+        );
+    }
+
+    get isMobileForLivechatVisitor() {
+        return this.ui.isSmall && this.env.services["im_livechat.livechat"];
+    }
+
     toggleFold() {
-        if (this.ui.isSmall || this.state.actionsMenuOpened) {
+        if ((this.ui.isSmall && !this.isMobileForLivechatVisitor) || this.state.actionsMenuOpened) {
             return;
         }
         if (this.props.chatWindow.hidden) {

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -1,6 +1,14 @@
 .o-mail-ChatWindow {
     height: 480px;
     width: $o-mail-ChatWindow-width;
+    &.o-isMobileFoldedForLivechatVisitor {
+        width: $o-mail-Discuss-headerHeight;
+        bottom: 10px;
+
+        &.o-moveUp {
+            bottom: 40px;
+        }
+    }
     z-index: 999; // messaging menu is dropdown (1000)
     &.o-mobile {
         z-index: 1001; // above messaging menu (chat window takes whole screen)
@@ -35,6 +43,11 @@
     .o-mail-ChatWindow-threadAvatar img {
         height: 28px;
         width: 28px;
+
+        &.o-isMobileFoldedForLivechatVisitor {
+            height: $o-mail-Discuss-headerHeight;
+            width: $o-mail-Discuss-headerHeight;
+        }
     }
 }
 

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -5,15 +5,19 @@
     <div class="o-mail-ChatWindow"
         t-att-style="style"
         t-att-class="{
-                'w-100 h-100 o-mobile': ui.isSmall,
+                'o-mobile': ui.isSmall,
+                'w-100 h-100': ui.isSmall and !isMobileFoldedForLivechatVisitor,
                 'o-folded': props.chatWindow.folded or props.chatWindow.hidden,
-                'position-fixed bottom-0 overflow-hidden d-flex flex-column': !props.chatWindow.hidden,
+                'position-fixed d-flex flex-column': !props.chatWindow.hidden,
+                'overflow-hidden bottom-0': !props.chatWindow.hidden and !isMobileFoldedForLivechatVisitor,
                 'rounded-top-3': !props.chatWindow.hidden and !ui.isSmall,
+                'o-isMobileFoldedForLivechatVisitor': isMobileFoldedForLivechatVisitor,
+                'o-moveUp': isMobileFoldedForLivechatVisitor and state.moveUp,
                 }"
         t-on-keydown="onKeydown"
         tabindex="1"
     >
-        <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall, 'border-bottom': !props.chatWindow.folded }">
+        <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall, 'border-bottom': !props.chatWindow.folded, 'position-relative rounded-circle': isMobileFoldedForLivechatVisitor }">
             <t t-if="threadActions.actions.length > 3">
                 <Dropdown position="'bottom-start'" onStateChanged="state => this.onActionsMenuStateChanged(state)" togglerClass="`o-mail-ChatWindow-command d-flex btn align-items-center text-truncate p-0 p-1 ${ !ui.isSmall ? 'ms-2' : '' } ${state.actionsMenuOpened ? 'o-active' : ''}`" menuClass="'d-flex flex-column py-0'" class="'d-flex text-truncate'" disabled="state.editingName" title="actionsMenuTitleText">
                     <t t-set-slot="toggler">
@@ -38,18 +42,20 @@
                 <t t-call="mail.ChatWindow.headerContent"/>
             </t>
             <div class="flex-grow-1"/>
-            <div t-if="thread and thread.needactionCounter > 0" class="o-mail-ChatWindow-counter mx-1 my-0 badge rounded-pill fw-bold o-discuss-badge" t-ref="needactionCounter">
+            <div t-if="thread and thread.needactionCounter > 0" class="o-mail-ChatWindow-counter mx-1 my-0 badge rounded-pill fw-bold o-discuss-badge" t-ref="needactionCounter" t-att-class="{
+                'position-absolute': isMobileFoldedForLivechatVisitor,
+            }" t-att-style="isMobileFoldedForLivechatVisitor ? 'top: -5px; right: -10px;' : ''">
                 <t t-out="thread.needactionCounter"/>
             </div>
-            <t t-if="threadActions.actions.length > 1" t-call="mail.ChatWindow.dropdownAction">
+            <t t-if="threadActions.actions.length > 1 and !isMobileFoldedForLivechatVisitor" t-call="mail.ChatWindow.dropdownAction">
                 <t t-set="action" t-value="threadActions.actions[0]"/>
             </t>
-            <t t-if="!ui.isSmall and threadActions.actions.length > 2">
+            <t t-if="!ui.isSmall and threadActions.actions.length > 2 and !isMobileFoldedForLivechatVisitor">
                 <t t-call="mail.ChatWindow.dropdownAction">
                     <t t-set="action" t-value="threadActions.actions.at(-2)"/>
                 </t>
             </t>
-            <t t-call="mail.ChatWindow.dropdownAction">
+            <t t-if="!isMobileFoldedForLivechatVisitor" t-call="mail.ChatWindow.dropdownAction">
                 <t t-set="action" t-value="threadActions.actions.at(-1)"/>
                 <t t-set="itemClass" t-value="'me-1'"/>
             </t>
@@ -78,10 +84,14 @@
 </t>
 
 <t t-name="mail.ChatWindow.headerContent">
-    <div t-if="thread" class="o-mail-ChatWindow-threadAvatar my-0" t-attf-class="{{ threadActions.actions.length > 4 ? 'ms-1' : 'ms-3' }} me-1">
-        <img class="rounded" t-att-src="thread.imgUrl" alt="Thread Image"/>
+    <div t-if="thread" class="o-mail-ChatWindow-threadAvatar my-0" t-att-class="{
+        'ms-1': threadActions.actions.length > 4 and !isMobileFoldedForLivechatVisitor,
+        'ms-3': threadActions.actions.length lte 4 and !isMobileFoldedForLivechatVisitor,
+        'me-1': !isMobileFoldedForLivechatVisitor,
+    }">
+        <img t-att-class="{ 'o-isMobileFoldedForLivechatVisitor rounded-circle': isMobileFoldedForLivechatVisitor, 'rounded': !isMobileFoldedForLivechatVisitor }" t-att-src="thread.imgUrl" alt="Thread Image"/>
     </div>
     <ThreadIcon t-if="thread and thread.type === 'chat' and thread.chatPartner" thread="thread"/>
-    <div t-if="!state.editingName" class="text-truncate fw-bold border border-transparent me-1 my-0" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="thread ? 'ms-1' : 'ms-3'"/>
+    <div t-if="!state.editingName and !isMobileFoldedForLivechatVisitor" class="text-truncate fw-bold border border-transparent me-1 my-0" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="thread ? 'ms-1' : 'ms-3'"/>
 </t>
 </templates>

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -11,7 +11,10 @@ export const threadActionsRegistry = registry.category("mail.thread/actions");
 threadActionsRegistry
     .add("fold-chat-window", {
         condition(component) {
-            return !component.ui.isSmall && component.props.chatWindow;
+            return (
+                (!component.ui.isSmall || component.isMobileForLivechatVisitor) &&
+                component.props.chatWindow
+            );
         },
         icon: "fa fa-fw fa-minus",
         name(component) {
@@ -42,7 +45,7 @@ threadActionsRegistry
     })
     .add("close", {
         condition(component) {
-            return component.props.chatWindow;
+            return component.props.chatWindow && !component.isMobileFoldedForLivechatVisitor;
         },
         icon: "fa fa-fw fa-close",
         name: _t("Close Chat Window"),


### PR DESCRIPTION
Before this commit, when a website visitor is live chating with an operator on a mobile device, it's not possible to navigate on website.

This happens because the livechat conversation takes the whole screen, and the only way to see the website on the same page is to close the livechat conversation.

This commit fixes the issue by allowing to fold a chat window for livechat visitor in mobile specifically. When this is folded, it is shown as a small chat bubble, which displays the avatar of operator and the unread counter. Clicking on the bubble expands the conversation to full-screen again.

Website footer can have some helpful information, so there's a special behaviour to move the chat bubble up when reaching the bottom of the website.

Task-4599435

![Feb-24-2025 17-10-05](https://github.com/user-attachments/assets/b585b41b-6b0b-4925-85ba-26152183d0a0)

