### PR TITLE
[FIX] pos_restaurant: correct tax merged table order line

### DIFF
--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -81,7 +81,7 @@ patch(PosStore.prototype, {
                     orphanLine.qty
                 );
             } else {
-                const serializedLine = orphanLine.serialize({ orm: true });
+                const serializedLine = orphanLine.serialize();
                 serializedLine.order_id = destOrder.id;
                 delete serializedLine.uuid;
                 delete serializedLine.id;

--- a/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
@@ -280,3 +280,24 @@ registry.category("web_tour.tours").add("test_create_floor_tour", {
             FloorScreen.addFloor("AAA"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_tax_in_merge_table_order_line_tour", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickFloor("Main Floor"),
+            FloorScreen.clickTable("4"),
+            ProductScreen.clickDisplayedProduct("product_1"),
+            ProductScreen.orderlineIsToOrder("product_1"),
+            ProductScreen.clickOrderButton(),
+            FloorScreen.clickFloor("Main Floor"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("product_2"),
+            ProductScreen.orderlineIsToOrder("product_2"),
+            ProductScreen.clickOrderButton(),
+            FloorScreen.isShown(),
+            FloorScreen.linkTables("5", "4"),
+            FloorScreen.isChildTable("5"),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -450,3 +450,30 @@ class TestFrontend(TestFrontendCommon):
         orders = self.env['pos.order'].search([])
         self.assertEqual(orders[0].user_id.id, self.pos_user.id, "Pos user not registered on order")
         self.assertEqual(orders[1].user_id.id, self.pos_admin.id, "Pos admin not registered on order")
+
+    def test_tax_in_merge_table_order_line(self):
+        """
+        Test that when merging orders of two tables in POS restaurant, the product tax is applied on the order lines of the destination table.
+        """
+        drinks_category = self.env['pos.category'].search([('name', '=', 'Drinks'), ('sequence', '=', 2)])
+        product_1 = self.env['product.product'].create({
+            'available_in_pos': True,
+            'list_price': 2.20,
+            'name': 'product_1',
+            'taxes_id': self.tax_sale_a,
+            'pos_categ_ids': [(4, drinks_category.id)]
+        })
+        product_2 = self.env['product.product'].create({
+            'available_in_pos': True,
+            'list_price': 2.20,
+            'name': 'product_2',
+            'taxes_id': self.tax_sale_a,
+            'pos_categ_ids': [(4, drinks_category.id)]
+        })
+        self.pos_config.is_order_printer = False
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_tax_in_merge_table_order_line_tour', login="pos_admin")
+        line_1 = self.env['pos.order.line'].search([('full_product_name', '=', 'product_1')])
+        line_2 = self.env['pos.order.line'].search([('full_product_name', '=', 'product_2')])
+        self.assertEqual(line_1.tax_ids, self.tax_sale_a)
+        self.assertEqual(line_2.tax_ids, self.tax_sale_a)


### PR DESCRIPTION
Merging orders of two tables in POS restaurant only applies the product tax on the order lines of the destination table.

How to reproduce the issue:

- In pos select table 1 and order a product.
- Select table 2 and order another product.
- Merge table 1 into table 2.

In Orders/Orders the pos order corresponding to the merged time does not have the tax displayed for the lines of table 1.

In pos_store of pos_restaurant in handlePreparationHistory we did not transfer the tax_ids from sourceOrder into the newly created order line.

opw-4563168

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
