### PR TITLE
[IMP] hr_contract: remove savepoints for cron in update_state

### DIFF
--- a/addons/hr_contract/data/hr_contract_data.xml
+++ b/addons/hr_contract/data/hr_contract_data.xml
@@ -50,7 +50,7 @@
             <field name="name">HR Contract: update state</field>
             <field name="model_id" ref="model_hr_contract"/>
             <field name="state">code</field>
-            <field name="code">model.with_context(from_cron=True).update_state()</field>
+            <field name="code">model.update_state()</field>
             <field name="interval_number">1</field>
             <field name="interval_type">days</field>
         </record>


### PR DESCRIPTION
`update_state` does not require savepoints, we can just commit/rollback
when the cron job is running.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
