### PR TITLE
[FIX] auth_signup: send_unregistered_user_reminder loop

### DIFF
--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -4,7 +4,6 @@ import contextlib
 import logging
 
 from ast import literal_eval
-from collections import defaultdict
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
@@ -235,37 +234,33 @@ class ResUsers(models.Model):
             }
         }
 
-    def send_unregistered_user_reminder(self, after_days=5, batch_size=100):
+    def send_unregistered_user_reminder(self, *, after_days=5, batch_size=100):
         email_template = self.env.ref('auth_signup.mail_template_data_unregistered_users', raise_if_not_found=False)
         if not email_template:
             _logger.warning("Template 'auth_signup.mail_template_data_unregistered_users' was not found. Cannot send reminder notifications.")
+            self.env['ir.cron']._commit_progress(deactivate=True)
             return
         datetime_min = fields.Datetime.today() - relativedelta(days=after_days)
-        datetime_max = datetime_min + relativedelta(hours=23, minutes=59, seconds=59)
+        datetime_max = datetime_min + relativedelta(days=1)
 
-        domain = [('share', '=', False),
+        invited_by_users = self.search_fetch([
+            ('share', '=', False),
             ('create_uid.email', '!=', False),
             ('create_date', '>=', datetime_min),
-            ('create_date', '<=', datetime_max),
-            ('log_ids', '=', False)]
+            ('create_date', '<', datetime_max),
+            ('log_ids', '=', False),
+        ], ['name', 'login', 'create_uid']).grouped('create_uid')
 
-        res_users_with_details = self.env['res.users'].search_read(domain, ['create_uid', 'name', 'login'], limit=batch_size)
+        # Do not use progress since we have no way of knowing to whom we have
+        # already sent e-mails.
 
-        # group by invited by
-        invited_users = defaultdict(list)
-        for user in res_users_with_details:
-            invited_users[user.get('create_uid')[0]].append("%s (%s)" % (user.get('name'), user.get('login')))
-
-        # For sending mail to all the invitors about their invited users
-        for user in invited_users:
-            template = email_template.with_context(dbname=self._cr.dbname, invited_users=invited_users[user])
-            template.send_mail(user, email_layout_xmlid='mail.mail_notification_light', force_send=False)
-
-        done = len(res_users_with_details)
-        self.env['ir.cron']._notify_progress(
-            done=done,
-            remaining=0 if done < batch_size else self.env['res.users'].search_count(domain)
-        )
+        for user, invited_users in invited_by_users.items():
+            invited_user_emails = [f"{u.name} ({u.login})" for u in invited_users]
+            template = email_template.with_context(dbname=self.env.cr.dbname, invited_users=invited_user_emails)
+            template.send_mail(user.id, email_layout_xmlid='mail.mail_notification_light', force_send=False)
+            if not self.env['ir.cron']._commit_progress(len(invited_users)):
+                _logger.info("send_unregistered_user_reminder: timeout reached, stopping")
+                break
 
     @api.model
     def web_create_users(self, emails):

--- a/addons/auth_signup/tests/test_auth_signup.py
+++ b/addons/auth_signup/tests/test_auth_signup.py
@@ -8,6 +8,7 @@ from odoo import http
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal, HttpCaseWithUserDemo
 from odoo.exceptions import AccessError
 
+from datetime import datetime, timedelta
 
 class TestAuthSignupFlow(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
 
@@ -76,3 +77,12 @@ class TestAuthSignupFlow(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
             self.env['res.users'].search_count([]),
             initial_user_count + len(users)
         )
+
+    def test_notify_unregistered(self):
+        users = self.env['res.users'].create([
+            {'login': 'testuser1', 'name': 'Test User 1', 'email': 'test1@odoo.com'},
+            {'login': 'testuser2', 'name': 'Test User 2', 'email': 'test2@odoo.com'},
+        ])
+        for u in users:
+            u.create_date = datetime.now() - timedelta(days=5, minutes=10)
+        users.send_unregistered_user_reminder(after_days=5, batch_size=100)


### PR DESCRIPTION
When we have more than 100 users, we send e-mails in an endless loop because we always process the same records.
The fix sends all e-mails in one pass. We still check the timeout for the cron job and can stop early.

Needs #197781



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
