### PR TITLE
[IMP] account: review cron jobs

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5695,33 +5695,41 @@ class AccountMove(models.Model):
     # CRON
     # -------------------------------------------------------------------------
 
-    def _autopost_draft_entries(self):
+    def _autopost_draft_entries(self, batch_size=100):
         ''' This method is called from a cron job.
         It is used to post entries such as those created by the module
         account_asset and recurring entries created in _post().
         '''
-        moves = self.search([
+        domain = [
             ('state', '=', 'draft'),
             ('date', '<=', fields.Date.context_today(self)),
             ('auto_post', '!=', 'no'),
             '|', ('checked', '=', True), ('journal_id.autocheck_on_post', '=', True)
-        ], limit=100)
+        ]
+        moves = self.search(domain, limit=batch_size)
+        remaining = len(moves) if len(moves) < batch_size else self.search_count(domain)
+        self.env['ir.cron']._commit_progress(remaining=remaining)
 
         try:  # try posting in batch
-            with self.env.cr.savepoint():
-                moves._post()
+            moves._post()
+            self.env['ir.cron']._commit_progress(len(moves))
+            return
         except UserError:  # if at least one move cannot be posted, handle moves one by one
-            for move in moves:
-                try:
-                    with self.env.cr.savepoint():
-                        move._post()
-                except UserError as e:
-                    move.checked = False
-                    msg = _('The move could not be posted for the following reason: %(error_message)s', error_message=e)
-                    move.message_post(body=msg, message_type='comment')
+            self.env.cr.rollback()
 
-        if len(moves) == 100:  # assumes there are more whenever search hits limit
-            self.env.ref('account.ir_cron_auto_post_draft_entry')._trigger()
+        for move in moves:
+            try:
+                move = move.try_lock_for_update().filtered_domain(domain)
+                if not move:
+                    continue
+                move._post()
+                self.env['ir.cron']._commit_progress(1)
+            except UserError as e:
+                self.env.cr.rollback()
+                move.checked = False
+                msg = _('The move could not be posted for the following reason: %(error_message)s', error_message=e)
+                move.message_post(body=msg, message_type='comment')
+                self.env['ir.cron']._commit_progress()
 
     @api.model
     def _cron_account_move_send(self, job_count=10):

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5754,17 +5754,9 @@ class AccountMove(models.Model):
                 },
             ]
 
-        limit = job_count + 1
-        to_process = self.env['account.move'].search(
-            [('sending_data', '!=', False)],
-            limit=limit,
-        )
-        need_retrigger = len(to_process) > job_count
+        domain = [('sending_data', '!=', False)]
+        to_process = self.search(domain, limit=job_count).try_lock_for_update()
         if not to_process:
-            return
-
-        to_process = to_process[:job_count]
-        if not self.env['res.company']._with_locked_records(to_process, allow_raising=False):
             return
 
         # Collect moves by res.partner that executed the Send & Print wizard, must be done before the _process
@@ -5786,8 +5778,7 @@ class AccountMove(models.Model):
                 partner._bus_send(*get_account_notification(partner_moves_success, True))
             partner_moves_error.sending_data = False
 
-        if need_retrigger:
-            self.env.ref('account.ir_cron_account_move_send')._trigger()
+        self.env['ir.cron']._commit_progress(len(to_process), remaining=self.search_count(domain))
 
     # -------------------------------------------------------------------------
     # HELPER METHODS

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4104,7 +4104,8 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
 
         (valid_invoice + invalid_invoice_1 + invalid_invoice_2).auto_post = 'at_date'
 
-        self.env['account.move']._autopost_draft_entries()
+        with self.enter_registry_test_mode():
+            self.env.ref('account.ir_cron_auto_post_draft_entry').method_direct_trigger()
         self.assertEqual(valid_invoice.state, 'posted')
         self.assertEqual(invalid_invoice_1.state, 'draft')
 


### PR DESCRIPTION
account: cron _autopost_draft_entries
Rewrite the method to stop using savepoints and instead commit/rollback
when needed. We also add the parameter to limit the batch size.

account: cron _cron_account_move_send progress
We don't need to retrigger the the cron job manually. Just find the
records to process in the batch and let the scheduler call the function
as many times as needed.

account: notify from send invoice
When generating and sending invoices, inject the the notification as
needed so that the send method does not have to be aware whether it is
called from a cron job or not.

odoo/enterprise#82018



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
