### PR TITLE
[IMP] web: tree editor: date/datetime options

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
@@ -94,6 +94,10 @@ export function getDomainDisplayedOperators(fieldDef) {
             return ["=", "!=", "ilike", "not ilike", "set", "not_set"];
         case "properties":
             return ["set", "not_set"];
+        case "date_option":
+        case "datetime_option":
+        case "time_option":
+            return ["=", "!=", ">", ">=", "<", "<=", "between", "is_not_between", "set", "not_set"];
         case undefined:
             return ["="];
         default:

--- a/addons/web/static/src/core/field_service.js
+++ b/addons/web/static/src/core/field_service.js
@@ -1,11 +1,80 @@
 import { Domain } from "@web/core/domain";
+import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { deepCopy } from "@web/core/utils/objects";
 
 /**
  * @typedef {Object} LoadFieldsOptions
  * @property {string[]|false} [fieldNames]
  * @property {string[]} [attributes]
  */
+
+const MODEL_DATE_PROPERTIES = "__model__date_properties__";
+const DATE_PROPERTIES = Object.fromEntries(
+    Object.entries({
+        day_of_week: { string: _t("Weekday") },
+        day_of_month: { string: _t("Day of month") },
+        day_of_year: { string: _t("Day of year") },
+        iso_week_number: { string: _t("Week number") },
+        month_number: { string: _t("Month") },
+        quarter_number: { string: _t("Quarter") },
+        year_number: { string: _t("Year") },
+    }).map(([name, o]) => [name, { ...o, searchable: true, name, type: "date_option" }])
+);
+
+const MODEL_TIME_PROPERTIES = "__model__time_properties__";
+const TIME_PROPERTIES = Object.fromEntries(
+    Object.entries({
+        hour_number: { string: _t("Hour") },
+        minute_number: { string: _t("Minute") },
+        second_number: { string: _t("Second") },
+    }).map(([name, o]) => [name, { ...o, searchable: true, name, type: "time_option" }])
+);
+
+const MODEL_DATETIME_PROPERTIES = "__model__datetime_properties__";
+const DATETIME_PROPERTIES = Object.fromEntries(
+    Object.entries({
+        __date: { string: _t("Date"), relation: MODEL_DATE_PROPERTIES }, // virtual: defined via year_number, month_number, and day_of_month
+        __time: { string: _t("Time"), relation: MODEL_TIME_PROPERTIES }, // virtual: defined via hour_number, minute_number, and second_number
+    }).map(([name, o]) => [name, { ...o, searchable: true, name, type: "datetime_option" }])
+);
+
+export const SPECIAL_MODEL_NAMES = new Set([
+    MODEL_DATETIME_PROPERTIES,
+    MODEL_DATE_PROPERTIES,
+    MODEL_TIME_PROPERTIES,
+]);
+function getSpecialModelFields(resModel) {
+    switch (resModel) {
+        case MODEL_DATETIME_PROPERTIES:
+            return Object.assign(
+                {},
+                deepCopy(DATETIME_PROPERTIES),
+                deepCopy(DATE_PROPERTIES),
+                deepCopy(TIME_PROPERTIES)
+            );
+        case MODEL_DATE_PROPERTIES:
+            return deepCopy(DATE_PROPERTIES);
+        case MODEL_TIME_PROPERTIES:
+            return deepCopy(TIME_PROPERTIES);
+    }
+}
+
+function getRelation(fieldDef, followRelationalProperties = false) {
+    if (fieldDef.relation) {
+        return fieldDef.relation;
+    }
+    if (fieldDef.comodel && followRelationalProperties) {
+        return fieldDef.comodel;
+    }
+    if (fieldDef.type === "datetime") {
+        return MODEL_DATETIME_PROPERTIES;
+    }
+    if (fieldDef.type === "date") {
+        return MODEL_DATE_PROPERTIES;
+    }
+    return null;
+}
 
 export const fieldService = {
     dependencies: ["orm"],
@@ -17,6 +86,9 @@ export const fieldService = {
          * @returns {Promise<object>}
          */
         async function loadFields(resModel, options = {}) {
+            if (SPECIAL_MODEL_NAMES.has(resModel)) {
+                return getSpecialModelFields(resModel);
+            }
             if (typeof resModel !== "string" || !resModel) {
                 throw new Error(`Invalid model name: ${resModel}`);
             }
@@ -39,6 +111,7 @@ export const fieldService = {
             } = fieldDefs[name];
             const definitionRecordModel = fieldDefs[definitionRecord].relation;
 
+            // @ts-ignore
             domain = Domain.and([[[definitionRecordField, "!=", false]], domain]).toList();
 
             const result = await orm.webSearchRead(definitionRecordModel, domain, {
@@ -81,9 +154,9 @@ export const fieldService = {
          * @param {string|null} resModel valid model name or null (case virtual)
          * @param {Object|null} fieldDefs
          * @param {string[]} names
-         * @param {boolean} followRelationalProperties
+         * @param {boolean} [followRelationalProperties=false]
          */
-        async function _loadPath(resModel, fieldDefs, names, followRelationalProperties) {
+        async function _loadPath(resModel, fieldDefs, names, followRelationalProperties = false) {
             if (!fieldDefs) {
                 return { isInvalid: "path", names, modelsInfo: [] };
             }
@@ -104,13 +177,9 @@ export const fieldService = {
             }
 
             let subResult;
-            if (fieldDef.relation || (fieldDef.comodel && followRelationalProperties)) {
-                // Properties use `comodel`
-                subResult = await _loadPath(
-                    fieldDef.relation || fieldDef.comodel,
-                    await loadFields(fieldDef.relation || fieldDef.comodel),
-                    remainingNames
-                );
+            const relation = getRelation(fieldDef, followRelationalProperties);
+            if (relation) {
+                subResult = await _loadPath(relation, await loadFields(relation), remainingNames);
             } else if (fieldDef.type === "properties") {
                 subResult = await _loadPath(
                     followRelationalProperties ? resModel : "*",

--- a/addons/web/static/src/core/model_field_selector/model_field_selector.xml
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector.xml
@@ -6,7 +6,7 @@
             <div class="o_model_field_selector_value flex-grow-1 h-100" tabindex="0" t-att-data-tooltip="state.displayNames.join(' > ')" data-tooltip-position="top">
                 <t t-foreach="state.displayNames" t-as="displayName" t-key="displayName_index">
                     <t t-if="!displayName_first">
-                        <i class="oi oi-chevron-right m-1" role="img" aria-label="Followed by" title="Followed by" />
+                        <i class="oi oi-chevron-right m-1" role="img" aria-label="Followed by" data-tooltip="Followed by" />
                     </t>
                     <span t-attf-class="o_model_field_selector_chain_part mb-1 #{props.readonly ? 'border-0 fw-bolder' : 'px-1'} text-nowrap">
                         <t t-esc="displayName" />
@@ -14,10 +14,10 @@
                 </t>
             </div>
             <div t-if="!props.readonly and state.isInvalid" class="o_model_field_selector_controls ms-2" tabindex="0">
-                <i class="fa fa-exclamation-triangle text-warning o_model_field_selector_warning" role="alert"  aria-label="Invalid field chain" title="Invalid field chain"/>
+                <i class="fa fa-exclamation-triangle text-warning o_model_field_selector_warning" role="alert"  aria-label="Invalid field chain" data-tooltip="Invalid field chain"/>
             </div>
             <div t-if="!props.readonly and props.allowEmpty and state.displayNames.length" class="o_model_field_selector_controls ms-2" tabindex="0">
-                <i class="fa fa-times" t-on-click.stop="clear" aria-label="Clear" title="Clear"/>
+                <i class="fa fa-times" t-on-click.stop="clear" aria-label="Clear" data-tooltip="Clear"/>
             </div>
         </div>
     </t>

--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.xml
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.xml
@@ -7,7 +7,7 @@
                 <div class="d-flex justify-content-between align-items-center">
                     <t t-if="state.page.previousPage">
                         <i class="o_model_field_selector_popover_prev_page btn btn-link oi oi-arrow-left ms-n2 text-dark"
-                           title="Previous"
+                           data-tooltip="Previous"
                            role="img"
                            aria-label="Previous"
                            t-on-click="() => this.goToPreviousPage()"
@@ -17,7 +17,7 @@
                         <t t-esc="state.page.title"/>
                     </div>
                     <i class="o_model_field_selector_popover_close btn btn-link me-n2 fa fa-times text-dark"
-                       title="Close"
+                       data-tooltip="Close"
                        role="img"
                        aria-label="Close"
                        t-on-click="() => props.close()"
@@ -43,9 +43,17 @@
                                 <t t-if="fieldDef.record_name"> (<t t-esc="fieldDef.record_name" />)</t>
                                 <div t-if="props.isDebugMode" class="o_model_field_selector_popover_item_title text-break text-muted small"><t t-esc="fieldName"/> (<t t-esc="fieldDef.type"/>)</div>
                             </button>
-                            <t t-if="(fieldDef.relation and props.followRelations) or fieldDef.type === 'properties'">
-                                <button class="o_model_field_selector_popover_item_relation btn btn-light border-0 border-start rounded-0" t-on-click.stop="() => this.followRelation(fieldDef)">
-                                    <i class="oi oi-chevron-right o_model_field_selector_popover_relation_icon" role="img" aria-label="Relation to follow" title="Relation to follow" />
+                            <t t-if="this.canFollowRelationFor(fieldDef)">
+                                <t t-set="label">
+                                    <t t-if="fieldDef.relation">Relation to follow</t>
+                                    <t t-else="">Show options</t>
+                                </t>
+                                <button class="o_model_field_selector_popover_item_relation btn btn-light border-0 border-start rounded-0"
+                                    t-att-data-tooltip="label"
+                                    t-att-aria-label="label"
+                                    t-on-click.stop="() => this.followRelation(fieldDef)"
+                                >
+                                    <i class="oi oi-chevron-right o_model_field_selector_popover_relation_icon" role="img"/>
                                 </button>
                             </t>
                         </li>

--- a/addons/web/static/src/core/tree_editor/ast_pattern.js
+++ b/addons/web/static/src/core/tree_editor/ast_pattern.js
@@ -1,0 +1,151 @@
+import { parseExpr } from "@web/core/py_js/py";
+import { Hole, setHoleValues, upToHole } from "@web/core/tree_editor/hole";
+import { Just, Nothing } from "@web/core/tree_editor/maybe_monad";
+import { Pattern } from "@web/core/tree_editor/pattern";
+import { deepCopy } from "@web/core/utils/objects";
+
+const areEqualArraysOfASTs = upToHole((array, otherArray) => {
+    if (array.length !== otherArray.length) {
+        return false;
+    }
+    for (let i = 0; i < array.length; i++) {
+        const elem = array[i];
+        const otherElem = otherArray[i];
+        if (!areEqualASTs(elem, otherElem)) {
+            return false;
+        }
+    }
+    return true;
+});
+
+const areEqualObjectsOfASTs = upToHole((object, otherObject) => {
+    const keys = new Set(Object.keys(object));
+    const otherKeys = new Set(Object.keys(otherObject));
+    // @ts-ignore
+    if (keys.symmetricDifference(otherKeys).size) {
+        return false;
+    }
+    for (const key of keys) {
+        const value = object[key];
+        const otherValue = otherObject[key];
+        if (!areEqualASTs(value, otherValue)) {
+            return false;
+        }
+    }
+    return true;
+});
+
+const areEqualValues = upToHole((value, otherValue) => value === otherValue);
+
+const areEqualASTs = upToHole((ast, otherAST) => {
+    if (ast.type !== otherAST.type) {
+        return false;
+    }
+    switch (ast.type) {
+        case 0 /** ASTNumber */:
+        case 1 /** ASTString */:
+        case 2 /** ASTBoolean */:
+        case 5 /** ASTName */: {
+            return areEqualValues(ast.value, otherAST.value);
+        }
+        case 3 /** ASTNone */:
+            return true;
+        case 4 /** ASTList */:
+        case 10 /** ASTTuple */:
+            return areEqualArraysOfASTs(ast.value, otherAST.value);
+        case 6 /** ASTUnaryOperator */:
+            return areEqualValues(ast.op, otherAST.op) && areEqualASTs(ast.right, otherAST.right);
+        case 7 /** ASTBinaryOperator */:
+        case 14 /** ASTBooleanOperator */:
+            return (
+                areEqualValues(ast.op, otherAST.op) &&
+                areEqualASTs(ast.left, otherAST.left) &&
+                areEqualASTs(ast.right, otherAST.right)
+            );
+        case 8 /** ASTFunctionCall */:
+            return (
+                areEqualASTs(ast.fn, otherAST.fn) &&
+                areEqualArraysOfASTs(ast.args, otherAST.args) &&
+                areEqualObjectsOfASTs(ast.kwargs, otherAST.kwargs)
+            );
+        case 9 /** ASTAssignment */:
+            return areEqualASTs(ast.name, otherAST.name) && areEqualASTs(ast.value, otherAST.value);
+        case 11 /** ASTDictionary */:
+            return areEqualObjectsOfASTs(ast.value, otherAST.value);
+        case 12 /** ASTLookup */:
+            return areEqualASTs(ast.target, otherAST.target) && areEqualASTs(ast.key, otherAST.key);
+        case 13 /** ASTIf */:
+            return (
+                areEqualASTs(ast.condition, otherAST.condition) &&
+                areEqualASTs(ast.ifTrue, otherAST.ifTrue) &&
+                areEqualASTs(ast.ifFalse, otherAST.ifFalse)
+            );
+        case 15 /** ASTObjLookup */:
+            return areEqualValues(ast.key, otherAST.key) && areEqualASTs(ast.obj, otherAST.obj);
+    }
+});
+
+function areEqualASTsUpToHole(ast, otherAST) {
+    const { holeValues, unset } = setHoleValues();
+    const equal = areEqualASTs(ast, otherAST);
+    unset();
+    return equal && holeValues;
+}
+
+const re = /(\w+)(\[(\d+)\])?/;
+function writeAtLocation(struct, location, val) {
+    // only support location of type "a.b[i].c...." but we don't need more here
+    const parts = location.split(".").map((p) => {
+        const [, key, , index] = re.exec(p);
+        return [key, index && parseInt(index)];
+    });
+    let res = struct;
+    for (let i = 0; i < parts.length - 1; i++) {
+        const [key, index] = parts[i];
+        res = res[key];
+        if (index !== undefined) {
+            res = res[index];
+        }
+    }
+    const [key, index] = parts.at(-1);
+    if (index !== undefined) {
+        res[key][index] = val;
+    } else {
+        res[key] = val;
+    }
+}
+
+export class ASTPattern extends Pattern {
+    static of(ast, holeLocations = {}) {
+        return new ASTPattern(ast, holeLocations);
+    }
+    constructor(ast, holeLocations = {}) {
+        super();
+        this._holeLocations = holeLocations;
+        this._template = typeof ast === "string" ? parseExpr(ast) : ast;
+        for (const [name, locations] of Object.entries(this._holeLocations)) {
+            const val = new Hole(name);
+            for (const location of locations) {
+                writeAtLocation(this._template, location, val);
+            }
+        }
+    }
+    detect(ast) {
+        ast = typeof ast === "string" ? parseExpr(ast) : ast;
+        const holeValues = areEqualASTsUpToHole(this._template, ast);
+        if (holeValues) {
+            return Just.of(holeValues);
+        }
+        return Nothing.of();
+    }
+    make(holeValues) {
+        const ast = deepCopy(this._template);
+        for (const [name, locations] of Object.entries(this._holeLocations)) {
+            const val = holeValues[name];
+            for (const location of locations) {
+                writeAtLocation(ast, location, val);
+            }
+        }
+        return Just.of(ast);
+    }
+}

--- a/addons/web/static/src/core/tree_editor/hole.js
+++ b/addons/web/static/src/core/tree_editor/hole.js
@@ -1,0 +1,29 @@
+export class Hole {
+    constructor(name) {
+        this.name = name;
+    }
+}
+
+let _holeValues = null;
+export function setHoleValues() {
+    _holeValues = {};
+    return {
+        holeValues: _holeValues,
+        unset() {
+            _holeValues = null;
+        },
+    };
+}
+
+export function upToHole(areEqual) {
+    return (v, w) => {
+        if (v instanceof Hole) {
+            if (_holeValues && v.name in _holeValues) {
+                return areEqual(_holeValues[v.name], w);
+            }
+            _holeValues[v.name] = w;
+            return true;
+        }
+        return areEqual(v, w);
+    };
+}

--- a/addons/web/static/src/core/tree_editor/maybe_monad.js
+++ b/addons/web/static/src/core/tree_editor/maybe_monad.js
@@ -1,0 +1,35 @@
+export class Maybe {
+    static S(mvs) {
+        for (const mv of mvs) {
+            if (mv instanceof Just) {
+                return mv;
+            }
+        }
+        return Nothing.of();
+    }
+}
+
+export class Nothing extends Maybe {
+    static of() {
+        return new Nothing();
+    }
+    bind(_fn, ..._fns) {
+        return Nothing.of();
+    }
+}
+
+export class Just extends Maybe {
+    static of(value) {
+        return new Just(value);
+    }
+    constructor(value) {
+        super();
+        this.value = value;
+    }
+    bind(fn, ...fns) {
+        if (!fn) {
+            return this;
+        }
+        return fn(this.value).bind(...fns);
+    }
+}

--- a/addons/web/static/src/core/tree_editor/pattern.js
+++ b/addons/web/static/src/core/tree_editor/pattern.js
@@ -1,0 +1,61 @@
+import { Just, Maybe, Nothing } from "@web/core/tree_editor/maybe_monad";
+
+function* lazyValues(fns, v) {
+    for (const fn of fns) {
+        yield fn(v);
+    }
+}
+
+export class Pattern {
+    static C(patterns) {
+        return _Pattern.of(
+            (r) => Just.of(r).bind(...patterns.map((p) => p.detect.bind(p))),
+            (r) => Just.of(r).bind(...patterns.map((p) => p.make.bind(p)).reverse())
+        );
+    }
+    static S(patterns) {
+        return _Pattern.of(
+            (r) =>
+                Maybe.S(
+                    lazyValues(
+                        patterns.map((p) => p.detect.bind(p)),
+                        r
+                    )
+                ),
+            (r) =>
+                Maybe.S(
+                    lazyValues(
+                        patterns.map((p) => p.make.bind(p)),
+                        r
+                    )
+                )
+        );
+    }
+    /**
+     * @param {any} _o
+     * @returns {Just|Nothing}
+     */
+    detect(_o) {
+        return Nothing.of();
+    }
+    make(_v) {
+        return Nothing.of();
+    }
+}
+
+export class _Pattern extends Pattern {
+    static of(detect, make) {
+        return new _Pattern(detect, make);
+    }
+    constructor(detect, make) {
+        super();
+        this._detect = detect;
+        this._make = make;
+    }
+    detect(o) {
+        return this._detect(o);
+    }
+    make(v) {
+        return this._make(v);
+    }
+}

--- a/addons/web/static/src/core/tree_editor/tree_editor.xml
+++ b/addons/web/static/src/core/tree_editor/tree_editor.xml
@@ -42,7 +42,7 @@
             <button
                 class="btn px-2 fs-4"
                 role="button"
-                title="Add New Rule"
+                data-tooltip="Add New Rule"
                 aria-label="Add New Rule"
                 t-on-click="() => this.insertLeaf(parent, node)"
                 t-on-mouseenter="(ev) => this.highlightNode(ev.target, true)"
@@ -53,7 +53,7 @@
             <button
                 class="btn px-2 fs-4"
                 role="button"
-                title="Add branch"
+                data-tooltip="Add branch"
                 aria-label="Add branch"
                 t-on-click="() => this.insertBranch(parent, node)"
                 t-on-mouseenter="(ev) => this.highlightNode(ev.target, true)"
@@ -64,7 +64,7 @@
             <button
                 class="btn btn-link px-2 text-danger fs-4"
                 role="button"
-                title="Delete node"
+                data-tooltip="Delete node"
                 aria-label="Delete node"
                 t-on-click="() => this.delete(ancestors, node)"
                 t-on-mouseenter="(ev) => this.highlightNode(ev.target, true)"
@@ -182,8 +182,8 @@
             <div t-attf-class="o_tree_editor_editor #{_classes}">
                 <div class="o_input d-flex align-items-center">
                     <span class="flex-grow-1 text-truncate" t-esc="info.stringify(value)" />
-                    <i role="alert" class="fa fa-exclamation-triangle text-warning mx-2" t-att-title="(typeof info.message === 'function') ? info.message(value) : info.message" />
-                    <i class="fa fa-times" title="Clear" t-on-click="() => update(info.defaultValue())" />
+                    <i role="alert" class="fa fa-exclamation-triangle text-warning mx-2" t-att-data-tooltip="(typeof info.message === 'function') ? info.message(value) : info.message" />
+                    <i class="fa fa-times" data-tooltip="Clear" t-on-click="() => update(info.defaultValue())" />
                 </div>
             </div>
         </t>

--- a/addons/web/static/src/core/tree_editor/tree_editor_datetime_options.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_datetime_options.js
@@ -1,0 +1,93 @@
+import { localization } from "@web/core/l10n/localization";
+import { _t } from "@web/core/l10n/translation";
+
+const { DateTime } = luxon;
+
+function range(start, stop) {
+    const range = [];
+    for (let i = start; i <= stop; i++) {
+        range.push(i);
+    }
+    return range;
+}
+
+function isIntegerInRange(start, stop) {
+    return (num) => Number.isInteger(num) && start <= num && num <= stop;
+}
+
+function getCurrent(unit) {
+    return () => DateTime.now()[unit];
+}
+
+let OPTIONS_WITH_SELECT;
+export function get_OPTIONS_WITH_SELECT() {
+    if (!OPTIONS_WITH_SELECT) {
+        const { weekStart } = localization;
+        OPTIONS_WITH_SELECT = {
+            month_number: {
+                options: range(1, 12).map((month) => [
+                    month,
+                    luxon.DateTime.now().set({ month }).toFormat("MMMM"),
+                ]),
+                defaultValue: getCurrent("month"),
+                isSupported: isIntegerInRange(1, 12),
+            },
+            quarter_number: {
+                options: range(1, 4).map((quarter) => [
+                    quarter,
+                    _t("Quarter %(quarter)s", { quarter }),
+                ]),
+                defaultValue: getCurrent("quarter"),
+                isSupported: isIntegerInRange(1, 4),
+            },
+            day_of_week: {
+                options: range(0, 6).map((weekday) => [
+                    (weekday + weekStart) % 7,
+                    luxon.DateTime.now()
+                        .set({ weekday: (weekday + weekStart) % 7 })
+                        .toFormat("cccc"),
+                ]),
+                defaultValue: getCurrent("weekday"),
+                isSupported: isIntegerInRange(0, 6),
+            },
+        };
+    }
+    return OPTIONS_WITH_SELECT;
+}
+
+let OPTIONS_WITH_INPUT;
+export function get_OPTIONS_WITH_INPUT() {
+    if (!OPTIONS_WITH_INPUT) {
+        OPTIONS_WITH_INPUT = {
+            year_number: {
+                defaultValue: getCurrent("year"),
+                isSupported: Number.isInteger,
+            },
+            day_of_year: {
+                defaultValue: getCurrent("ordinal"),
+                isSupported: isIntegerInRange(1, 366),
+            },
+            iso_week_number: {
+                defaultValue: getCurrent("weekNumber"),
+                isSupported: isIntegerInRange(1, 53),
+            },
+            hour_number: {
+                defaultValue: getCurrent("hour"),
+                isSupported: isIntegerInRange(0, 23),
+            },
+            minute_number: {
+                defaultValue: getCurrent("minute"),
+                isSupported: isIntegerInRange(0, 59),
+            },
+            second_number: {
+                defaultValue: getCurrent("second"),
+                isSupported: isIntegerInRange(0, 59),
+            },
+            day_of_month: {
+                defaultValue: getCurrent("day"),
+                isSupported: isIntegerInRange(1, 31),
+            },
+        };
+    }
+    return OPTIONS_WITH_INPUT;
+}

--- a/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
@@ -1,18 +1,15 @@
+import { DateTimeInput } from "@web/core/datetime/datetime_input";
+import { Domain } from "@web/core/domain";
 import {
     deserializeDate,
     deserializeDateTime,
     serializeDate,
     serializeDateTime,
 } from "@web/core/l10n/dates";
+import { parseTime } from "@web/core/l10n/time";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { DateTimeInput } from "@web/core/datetime/datetime_input";
-import {
-    DomainSelectorAutocomplete,
-    DomainSelectorSingleAutocomplete,
-} from "@web/core/tree_editor/tree_editor_autocomplete";
-import { unique } from "@web/core/utils/arrays";
-import { Input, Select, List, Range, Within } from "@web/core/tree_editor/tree_editor_components";
+import { TimePicker } from "@web/core/time_picker/time_picker";
 import {
     connector,
     DATE_TODAY_STRING_EXPRESSION,
@@ -24,8 +21,18 @@ import {
     isTodayExpr,
     isTree,
 } from "@web/core/tree_editor/condition_tree";
-import { getResModel, disambiguate, isId } from "@web/core/tree_editor/utils";
-import { Domain } from "@web/core/domain";
+import {
+    DomainSelectorAutocomplete,
+    DomainSelectorSingleAutocomplete,
+} from "@web/core/tree_editor/tree_editor_autocomplete";
+import { Input, List, Range, Select, Within } from "@web/core/tree_editor/tree_editor_components";
+import {
+    get_OPTIONS_WITH_INPUT,
+    get_OPTIONS_WITH_SELECT,
+} from "@web/core/tree_editor/tree_editor_datetime_options";
+import { disambiguate, getResModel, isId } from "@web/core/tree_editor/utils";
+import { unique } from "@web/core/utils/arrays";
+import { pick } from "@web/core/utils/objects";
 
 const { DateTime } = luxon;
 
@@ -352,6 +359,46 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
         case "selection": {
             const options = fieldDef.selection || [];
             return makeSelectEditor(options, params);
+        }
+        case "date_option":
+        case "datetime_option":
+        case "time_option": {
+            if (fieldDef.name in get_OPTIONS_WITH_SELECT()) {
+                const { options, defaultValue, isSupported } =
+                    get_OPTIONS_WITH_SELECT()[fieldDef.name];
+                return { ...makeSelectEditor(options, params), defaultValue, isSupported };
+            } else if (fieldDef.name === "__time") {
+                return {
+                    component: TimePicker,
+                    extractProps: ({ value, update }) => ({
+                        value: parseTime(value, true),
+                        onChange: (time) =>
+                            update(
+                                DateTime.fromObject(
+                                    pick(time, "hour", "minute", "second")
+                                ).toFormat("HH:mm:ss")
+                            ),
+                        showSeconds: true,
+                    }),
+                    isSupported: (value) =>
+                        typeof value === "string" && Boolean(parseTime(value, true)),
+                    defaultValue: () =>
+                        params.forBetween
+                            ? {
+                                  start: "00:00:00",
+                                  end: "23:59:59",
+                              }
+                            : DateTime.now().toFormat("HH:mm:ss"),
+                };
+            } else if (fieldDef.name === "__date") {
+                return getValueEditorInfo({ type: "date" }, operator, params);
+            }
+            const { defaultValue, isSupported } = get_OPTIONS_WITH_INPUT()[fieldDef.name];
+            return {
+                ...getValueEditorInfo({ type: "integer" }, operator, params),
+                defaultValue,
+                isSupported,
+            };
         }
         case undefined: {
             const options = [[1, "1"]];

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -179,7 +179,10 @@ test("building a domain with an invalid path", async () => {
 
     expect(getCurrentPath()).toBe("fooooooo");
     expect(".o_model_field_selector_warning").toHaveCount(1);
-    expect(".o_model_field_selector_warning").toHaveAttribute("title", "Invalid field chain");
+    expect(".o_model_field_selector_warning").toHaveAttribute(
+        "data-tooltip",
+        "Invalid field chain"
+    );
     expect(getOperatorOptions()).toHaveLength(1);
     expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("abc");

--- a/addons/web/static/tests/core/tree_editor/condition_tree_editor_test_helpers.js
+++ b/addons/web/static/tests/core/tree_editor/condition_tree_editor_test_helpers.js
@@ -388,9 +388,10 @@ export async function clickPrev() {
 
 /**
  * @param {number} [index=0]
+ * @param {Target} [target]
  */
-export async function followRelation(index = 0) {
-    await contains(`.o_model_field_selector_popover_item_relation:eq(${index})`).click();
+export async function followRelation(index, target) {
+    await contains(queryAt(".o_model_field_selector_popover_item_relation", index, target)).click();
 }
 
 export function getFocusedFieldName() {

--- a/addons/web/static/tests/views/fields/field_selector_field.test.js
+++ b/addons/web/static/tests/views/fields/field_selector_field.test.js
@@ -1,6 +1,7 @@
 import { expect, test } from "@odoo/hoot";
+import { animationFrame, queryAllTexts } from "@odoo/hoot-dom";
+import { followRelation } from "@web/../tests/core/tree_editor/condition_tree_editor_test_helpers";
 import { contains, defineModels, fields, models, mountView } from "../../web_test_helpers";
-import { animationFrame, click, queryAllTexts } from "@odoo/hoot-dom";
 
 class Contact extends models.Model {
     email = fields.Char();
@@ -117,12 +118,10 @@ test("model option", async () => {
         ["Contact", "Created on", "Display name", "Id", "Last Modified on", "Note", "Salesperson"],
         { message: "should display fields of the specified model" }
     );
-    expect(".o_model_field_selector_popover_item_relation").toHaveCount(2, {
+    expect(".o_model_field_selector_popover_item_relation").toHaveCount(4, {
         message: "following relations is supported by default",
     });
-    click(
-        ".o_model_field_selector_popover_item[data-name='salesperson_id'] .o_model_field_selector_popover_item_relation"
-    );
+    await followRelation();
     await animationFrame();
     expect(queryAllTexts(".o_model_field_selector_popover_item")).toEqual(
         ["Childs", "Created on", "Display name", "Email", "Id", "Last Modified on"],


### PR DESCRIPTION
We allow the selection of options like year_number, hour_number in the model field selector and there usage in the domain selector. More precisely, for date/datetime fields, some new options are available by following "relations" like for relational fields (by clicking on the arrows displayed at the right of the fields).

- for date fields, the options are:
    year_number, quarter_number, month_number, iso_week_number, day_of_year, day_of_month, day_of_week (*).
    Once selected, it is possible to create conditions based on them.
    The operators
    =, !=, >, >=, <, <=, between, is_not_between, set, not_set (**)
    are supported for them

- for datetime fields, the (virtual) options:
    __date, __time (defined in terms of year_number, hour_number, ...)
    are first proposed and can be used to create conditions.
    The edition of values for __time is done via the new TimePicker component.
    If __date is selected, the options (*) for a field date are accessible
    If __time is selected, the options
        hour_number, minute_number, second_number
    are accessible.
    In each case, the same operators (**) are supported.

Task ID: 4659055