### PR TITLE
[FIX] web: fix query count following accounting changes

### DIFF
--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -61,8 +61,8 @@ class TestPerfSessionInfo(common.HttpCase):
     def test_visible_menu_ids(self):
         self.env.registry.clear_all_caches()
         self.env.invalidate_all()
-        # cold ormcache (only web: 5, all module: 14 (+3 if not has group account.group_account_readonly))
-        with self.assertQueryCount(17):
+        # cold ormcache (only web: 5, all module: 14 (+4 if not has group account.group_account_readonly))
+        with self.assertQueryCount(18):
             self.env['ir.ui.menu']._visible_menu_ids()
 
         # cold fields cache - warm orm cache (only web: 0, all module: 0)


### PR DESCRIPTION
The following PR: https://github.com/odoo/enterprise/pull/77895
introduced a new report in the menu:
`account_reports.menu_action_account_report_tree` without incrementing the menu test query counter.
Extra SQL query log:
```
odoo.sql_db: [0.308 ms] query: SELECT model, res_id FROM ir_model_data WHERE module='account_reports' AND name='menu_action_account_report_tree'
```

rb-134659