### PR TITLE
[FIX] web: Remove non exportable External ids fields from the export …

### DIFF
--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -378,7 +378,9 @@ class Export(http.Controller):
 
         fields['id']['string'] = request.env._('External ID')
 
-        if parent_field:
+        if not Model._is_an_ordinary_table():
+            fields.pop("id", None)
+        elif parent_field:
             parent_field['string'] = request.env._('External ID')
             fields['id'] = parent_field
 


### PR DESCRIPTION
…wizards

- In the wizard of exporting data there are fields that may be not in our data base with attribute _table_query not set to none. -I have modified the export.py file to make the field of id in our fild dict only if the _table_query is set to None.

task-4592514

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
