### PR TITLE
[FIX] pos_loyalty: loyalty points added for draft orders

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -71,8 +71,9 @@ patch(PaymentScreen.prototype, {
      * @override
      */
     async _postPushOrderResolve(order, server_ids) {
-        for (const order_id of server_ids) {
-            await this._postProcessLoyalty(this.pos.models["pos.order"].get(order_id));
+        const orders = this.pos.models["pos.order"].readMany(server_ids).filter((o) => o.is_paid());
+        for (const order of orders) {
+            await this._postProcessLoyalty(order);
         }
         return super._postPushOrderResolve(order, server_ids);
     },

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
@@ -4,6 +4,8 @@ import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_scre
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import * as combo from "@point_of_sale/../tests/tours/utils/combo_popup_util";
 import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/order_widget_util";
+import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
+import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen_util";
 import { inLeftSide } from "@point_of_sale/../tests/tours/utils/common";
 import { registry } from "@web/core/registry";
 
@@ -271,5 +273,23 @@ registry.category("web_tour.tours").add("PosCheapestProductTaxInclude", {
             ProductScreen.addOrderline("Desk Organizer", "1"),
             Order.hasLine({ productName: "10% on the cheapest product" }),
             PosLoyalty.orderTotalIs("6.00"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PosLoyaltyMultipleOrders", {
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+
+            // Order1: Add a product and leave the order in draft.
+            ProductScreen.addOrderline("Whiteboard Pen", "2"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Test Partner"),
+
+            // Order2: Finalize a different order.
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.clickNewTicket(),
+            ProductScreen.addOrderline("Desk Organizer", "1"),
+            PosLoyalty.finalizeOrder("Cash", "10"),
         ].flat(),
 });

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -859,6 +859,41 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.start_pos_tour("PosLoyaltyFreeProductTour2")
 
+    def test_loyalty_program_different_orders(self):
+        loyalty_program = self.env['loyalty.program'].create({
+            'name': 'Loyalty Program Test',
+            'program_type': 'loyalty',
+            'trigger': 'auto',
+            'applies_on': 'both',
+            'pos_ok': True,
+            'pos_config_ids': [Command.link(self.main_pos_config.id)],
+            'rule_ids': [(0, 0, {
+                'reward_point_mode': 'order',
+                'reward_point_amount': 10,
+                'minimum_amount': 5,
+                'minimum_qty': 1,
+            })],
+            'reward_ids': [(0, 0, {
+                'reward_type': 'product',
+                'required_points': 30,
+                'reward_product_id': self.product_a.id,
+                'reward_product_qty': 1,
+            })],
+        })
+
+        partner = self.env['res.partner'].create({'name': 'Test Partner'})
+        card = self.env['loyalty.card'].create({
+            'partner_id': partner.id,
+            'program_id': loyalty_program.id,
+            'points': 0,
+        })
+
+        self.main_pos_config.open_ui()
+
+        self.start_pos_tour("PosLoyaltyMultipleOrders")
+
+        self.assertEqual(card.points, 0, "Loyalty card credited for a draft order")
+
     def test_refund_with_gift_card(self):
         """When adding a gift card when there is a refund in the order, the amount
         of the gift card is set to the amount of the refund"""


### PR DESCRIPTION
In point of sale it is possible to manage several orders at the same time and, whenever an order is paid, all orders will be synchronized with the backend. This causes an issue with loyalty rewards that are granted even for orders not yet completed.

Steps to reproduce:
- Have a Loyalty Program configured as follows:
  - Program Type: Loyalty Card
  - Grant 1 point per $ spent
- Create a Loyalty card for [Partner]
- Open POS Session
- Add a [Partner] as customer
- Add product
- Leaving the order as it is, create a new order
- Add just a product
- Validate & Pay the second order

Issue: Loyalty points will be added to [Partner] Card, as if the order was actually paid

This occurs because we don't check that the order has been actually paid before processing rewards

opw-4538040

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
