### PR TITLE
[FIX] core: reflect inherits done via delegate fields

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import inspect
 import itertools
 import logging
 import random
@@ -1391,7 +1392,7 @@ class ModelInherit(models.Model):
         IrModel = self.env["ir.model"]
         get_model_id = IrModel._get_id
 
-        module_mapping = defaultdict(list)
+        module_mapping = defaultdict(OrderedSet)
         for model_name in model_names:
             get_field_id = self.env["ir.model.fields"]._get_ids(model_name).get
             model_id = get_model_id(model_name)
@@ -1408,10 +1409,16 @@ class ModelInherit(models.Model):
                 ] + [
                     (model_id, get_model_id(parent_name), get_field_id(field))
                     for parent_name, field in cls._inherits.items()
+                ] + [
+                    (model_id, get_model_id(field.comodel_name), get_field_id(field_name))
+                    for (field_name, field) in inspect.getmembers(cls)
+                    if isinstance(field, fields.Many2one)
+                    if field.type == 'many2one' and not field.related and field.delegate
+                    if field_name not in cls._inherits.values()
                 ]
 
                 for item in items:
-                    module_mapping[item].append(cls._module)
+                    module_mapping[item].add(cls._module)
 
         if not module_mapping:
             return

--- a/odoo/addons/base/tests/test_ir_model.py
+++ b/odoo/addons/base/tests/test_ir_model.py
@@ -545,3 +545,27 @@ class TestIrModelFieldsTranslation(HttpCase):
         field.update_field_translations('field_description', {'fr_FR': 'Identifiant2'})
         # check the name column of res.users is displayed as 'Identifiant2'
         self.start_tour("/web", 'ir_model_fields_translation_fr_tour2', login="admin")
+
+
+class TestIrModelInherit(TransactionCase):
+    def test_inherit(self):
+        imi = self.env["ir.model.inherit"].search([("model_id.model", "=", "ir.actions.server")])
+        self.assertEqual(len(imi), 1)
+        self.assertEqual(imi.parent_id.model, "ir.actions.actions")
+        self.assertFalse(imi.parent_field_id)
+
+    def test_inherits(self):
+        imi = self.env["ir.model.inherit"].search(
+            [("model_id.model", "=", "res.users"), ("parent_field_id", "!=", False)]
+        )
+        self.assertEqual(len(imi), 1)
+        self.assertEqual(imi.parent_id.model, "res.partner")
+        self.assertEqual(imi.parent_field_id.name, "partner_id")
+
+    def test_delegate_field(self):
+        imi = self.env["ir.model.inherit"].search(
+            [("model_id.model", "=", "ir.cron"), ("parent_field_id", "!=", False)]
+        )
+        self.assertEqual(len(imi), 1)
+        self.assertEqual(imi.parent_id.model, "ir.actions.server")
+        self.assertEqual(imi.parent_field_id.name, "ir_actions_server_id")


### PR DESCRIPTION
When we reflect inherit models in the database, we walk through the MRO to have access to the module that added the info. This mean that we skipped the inherits created by delegate fields (the info is in the `_inherits` of the final model in the registry, but we don't process it as we don't know the origin module).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
