### PR TITLE
[FIX] point_of_sale: rename incorrect role field

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
@@ -18,7 +18,7 @@ export class ProductInfoPopup extends Component {
     }
     _hasMarginsCostsAccessRights() {
         const isAccessibleToEveryUser = this.pos.config.is_margins_costs_accessible_to_every_user;
-        const isCashierManager = this.pos.get_cashier().role === "manager";
+        const isCashierManager = this.pos.get_cashier()._role === "manager";
         return isAccessibleToEveryUser || isCashierManager;
     }
     editProduct() {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Create POS, set login with employees, assign an employee as advanced user (manager)
- Disable margin & costs configuration
- Open POS, click the information icon in Product Screen
- Margin & costs is not visible

Current behavior before PR:
- In POS the margin & costs is not visible with advanced access rights (manager)

Desired behavior after PR is merged:
- Show the margin & costs information in product information pop up

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
