### PR TITLE
[FIX] product: avoid archive attribute value when is not been used

### DIFF
--- a/addons/product/models/product_attribute_value.py
+++ b/addons/product/models/product_attribute_value.py
@@ -128,7 +128,7 @@ class ProductAttributeValue(models.Model):
                 [('product_attribute_value_id', '=', pav.id)]
             ).with_context(active_test=False).ptav_product_variant_ids
             active_linked_products = linked_products.filtered('active')
-            if not active_linked_products:
+            if not active_linked_products and linked_products:
                 # If product attribute value found on non-active product variants
                 # archive PAV instead of deleting
                 pavs_to_archive |= pav


### PR DESCRIPTION
**Avoid archive attribute value when is not been used**

Impacted versions:
 
 - 18.0 and later
 
### Steps to reproduce:
 
 1. Create a new attribute with attribute values (ex: value 1)
 2. Delete the attribute value
 3. Confirm that the attribute value still exists (archived instead of deleted)

 
### Current behavior:
 
 - Attribute value is being archived
 
### Expected behavior:
 
 - Attribute value must be deleted

Task: [4551094](https://www.odoo.com/odoo/my-tasks/4551094)