### PR TITLE
[FIX] purchase_stock: Handle exchange creation without origin

### DIFF
--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -213,7 +213,7 @@ class ReturnPicking(models.TransientModel):
             proc_list.append(self.env["procurement.group"].Procurement(
                 line.product_id, line.quantity, line.uom_id,
                 line.move_id.location_dest_id or self.picking_id.location_dest_id,
-                line.product_id.display_name, self.picking_id.origin, self.picking_id.company_id,
+                line.product_id.display_name, self.picking_id.origin if self.picking_id.origin else '', self.picking_id.company_id,
                 proc_values,
             ))
         if proc_list:


### PR DESCRIPTION
Steps to reproduce:

1. Create a storable product.
2. Link a vendor to the product.
3. Create and validate an incoming picking from the vendor for the product.
4. Initiate an exchange.

Issue:
A traceback occurs during exchange creation when the original picking lacks an "origin." The system attempts to parse a False value as a string, causing an error.

Solution:
Ensure the origin is populated before running the procurement. If no origin is set, pass an empty string instead of False.

opw-4556305

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
