### PR TITLE
[FIX] website_crm: prevent error during module installation

### DIFF
--- a/addons/website_crm/views/website_templates_contactus.xml
+++ b/addons/website_crm/views/website_templates_contactus.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
-        <template id="contactus_form" name="Contact Form (Opportunity)" inherit_id="website.contactus">
+        <template id="contactus_form" name="Contact Form (Opportunity)" inherit_id="website.contactus" forcecreate="0">
             <xpath expr="//t[@t-set='contactus_form_values']" position="after">
                 <t t-set="contactus_form_values" t-value="dict(contactus_form_values, **{
                     'contact_name': request.params.get('contact_name', ''),


### PR DESCRIPTION
Currently, an exception is generated when a user tries to install the `website_crm` module after deleting the external identifier `website.contactus`.

Steps to Reproduce:

1. Install the `website` module.
2. Go to Settings -> Technical -> Sequences and Identifiers -> External Identifiers.
3. Delete the `website.contactus` identifier.
4. Try to install the `website_crm` module.
5. An error occurs.

Error:
`ParseError
while parsing None:4, somewhere inside
`

This issue [1] occurs because, during the installation of `website_crm`, Odoo tries to reference the deleted external identifier `website.contactus`.

[1] - https://github.com/odoo/odoo/blob/a1969de6e6a292b14ad1d19c256ead04dc202528/addons/website_crm/views/website_templates_contactus.xml#L3-L13

This fix resolves the issue by using `forcecreate=0` to bypass record creation if it violates.

sentry-6255808403

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
