### PR TITLE
[FIX] pos_self_order: combo product traceback and quantity mismatch issues

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
@@ -27,6 +27,7 @@ export class ComboPage extends Component {
         }
 
         this.state = useState({
+            selectedValues: this.env.selectedValues,
             currentComboIndex: 0,
             selectedCombos: [],
             showResume: false,
@@ -52,6 +53,10 @@ export class ComboPage extends Component {
 
     get currentCombo() {
         return this.comboIds[this.state.currentComboIndex];
+    }
+
+    isEveryValueSelected() {
+        return Object.values(this.state.selectedValues).find((value) => !value) == false;
     }
 
     getSelectedValues(attrValIds) {
@@ -123,7 +128,14 @@ export class ComboPage extends Component {
             this.selfOrder.editedLine.delete();
         }
 
-        this.selfOrder.addToCart(this.props.product, 1, "", {}, {}, this.state.selectedCombos);
+        this.selfOrder.addToCart(
+            this.props.product,
+            this.state.qty,
+            "",
+            {},
+            {},
+            this.state.selectedCombos
+        );
         this.router.back();
     }
 

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -113,7 +113,7 @@
         <div
             t-if="state.showResume || (!state.showResume and showQtyButtons)"
             class="page-buttons d-flex justify-content-end gap-3 p-3 border-top bg-view">
-            <button t-if="!state.showResume and showQtyButtons" class="btn btn-primary btn-lg" t-on-click="next">Next</button>
+            <button t-if="!state.showResume and showQtyButtons" class="btn btn-primary btn-lg" t-on-click="next" t-att-disabled="this.isEveryValueSelected()">Next</button>
             <button t-if="state.showResume and selfOrder.ordering" class="btn btn-primary btn-lg" t-on-click="addToCart">Add to cart</button>
         </div>
     </t>

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -293,7 +293,7 @@ export class SelfOrder extends Reactive {
                     combo_line_id: comboLine.combo_line_id,
                     price_unit: comboLine.price_unit,
                     order_id: this.currentOrder,
-                    qty: 1,
+                    qty: values.qty,
                     attribute_value_ids: comboLine.attribute_value_ids?.map((attr) => [
                         "link",
                         attr,


### PR DESCRIPTION
Issue 1: Traceback
===================
Steps to Reproduce:
---------------------
1. Open POS Self Order.
2. Select a combo product (e.g., "Burger Menu Combo").
3. Choose a main product (e.g., "Cheese Burger") but **do not** select its attributes.
4. Click the "Next" button.
5. Select the remaining combo child product (e.g., "Water").
6. Click "Add to Cart" → **Traceback occurs.**

Fix:
====
The "Next" button is now **disabled** until all required product attributes are selected, ensuring behavior is consistent with normal products.

---

Issue 2: Combo Product Quantity Mismatch
==================================
Before this commit:
-------------------------
When increasing the quantity of a combo product before adding it to the cart, only `1 unit` was added due to a hardcoded quantity value.

After this commit:
-----------------------
- The hardcoded quantity of `1` was removed.
- The selected quantity is now correctly added to the cart, preserving user input.

Task-4592610


