### PR TITLE
[FIX] pos_restaurant: fix traceback when activating new pos restaurant

### DIFF
--- a/addons/pos_restaurant/data/restaurant_session_floor.xml
+++ b/addons/pos_restaurant/data/restaurant_session_floor.xml
@@ -35,7 +35,7 @@
             <field name="amount_tax">0.0</field>
             <field name="amount_paid">14.0</field>
             <field name="amount_return">0.0</field>
-            <field name="preset_id" ref="pos_takein_preset"/>
+            <field name="preset_id" eval="ref('pos_takein_preset', raise_if_not_found=False)"/>
         </record>
 
         <record id="pos_closed_orderline_3_1_1" model="pos.order.line" forcecreate="False">
@@ -70,7 +70,7 @@
             <field name="amount_tax">0.0</field>
             <field name="amount_paid">7.0</field>
             <field name="amount_return">0.0</field>
-            <field name="preset_id" ref="pos_takein_preset"/>
+            <field name="preset_id" eval="ref('pos_takein_preset', raise_if_not_found=False)"/>
         </record>
 
         <record id="pos_closed_orderline_3_2_1" model="pos.order.line" forcecreate="False">
@@ -109,7 +109,7 @@
             <field name="amount_tax">0.0</field>
             <field name="amount_paid">6.7</field>
             <field name="amount_return">0.0</field>
-            <field name="preset_id" ref="pos_takein_preset"/>
+            <field name="preset_id" eval="ref('pos_takein_preset', raise_if_not_found=False)"/>
         </record>
 
         <record id="pos_closed_orderline_4_1_1" model="pos.order.line" forcecreate="False">
@@ -144,7 +144,7 @@
             <field name="amount_tax">0.0</field>
             <field name="amount_paid">28.0</field>
             <field name="amount_return">0.0</field>
-            <field name="preset_id" ref="pos_takein_preset"/>
+            <field name="preset_id" eval="ref('pos_takein_preset', raise_if_not_found=False)"/>
         </record>
 
         <record id="pos_closed_orderline_4_2_1" model="pos.order.line" forcecreate="False">
@@ -499,7 +499,7 @@
             <field name="partner_id" ref="customer_1" />
             <field name="table_id" ref="table_01" />
             <field name="customer_count">8</field>
-            <field name="preset_id" ref="pos_takein_preset"/>
+            <field name="preset_id" eval="ref('pos_takein_preset', raise_if_not_found=False)"/>
         </record>
 
         <record id="pos_orderline_2" model="pos.order.line" forcecreate="False">
@@ -533,7 +533,7 @@
             <field name="partner_id" ref="customer_1" />
             <field name="table_id" ref="table_02" />
             <field name="customer_count">3</field>
-            <field name="preset_id" ref="pos_takein_preset"/>
+            <field name="preset_id" eval="ref('pos_takein_preset', raise_if_not_found=False)"/>
         </record>
 
         <record id="pos_orderline_4" model="pos.order.line" forcecreate="False">
@@ -567,7 +567,7 @@
             <field name="partner_id" ref="customer_1" />
             <field name="table_id" ref="table_04" />
             <field name="customer_count">5</field>
-            <field name="preset_id" ref="pos_takein_preset"/>
+            <field name="preset_id" eval="ref('pos_takein_preset', raise_if_not_found=False)"/>
         </record>
 
         <record id="pos_orderline_6" model="pos.order.line" forcecreate="False">
@@ -601,7 +601,7 @@
             <field name="partner_id" ref="customer_1" />
             <field name="table_id" ref="table_06" />
             <field name="customer_count">1</field>
-            <field name="preset_id" ref="pos_takein_preset"/>
+            <field name="preset_id" eval="ref('pos_takein_preset', raise_if_not_found=False)"/>
         </record>
 
         <record id="pos_orderline_8" model="pos.order.line" forcecreate="False">

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -128,7 +128,7 @@ class PosConfig(models.Model):
             'iface_splitbill': True,
             'module_pos_restaurant': True,
             'use_presets': True,
-            'default_preset_id': presets[0],
+            'default_preset_id': presets[0] if presets else False,
             'available_preset_ids': [(6, 0, presets[1:])],
         })
         self.env['ir.model.data']._update_xmlids([{


### PR DESCRIPTION
Currently, a traceback occurs when the user deletes the presets and try to open a new restaurant session.

To reproduce this issue:
1) Install `Restaurant` without demo
2) Delete all the `presets` data from the POS/Configuration 
3) Now open the `Restaurant` from the POS Dashboard

Error:- 
```
IndexError: list index out of range
```

When the user tries to open a new `Restaurant` from the Dashboard, the `load_onboarding_restaurant_scenario` method triggers.

In that method, we try to assign the `default_preset_id` value from presets[0]. We get presets as an empty list because the user deleted all the `presets` data.

https://github.com/odoo/odoo/blob/4aa3f035f9e633ee50e8538abf0bffc5a246e643/addons/pos_restaurant/models/pos_config.py#L116-L120 https://github.com/odoo/odoo/blob/4aa3f035f9e633ee50e8538abf0bffc5a246e643/addons/pos_restaurant/models/pos_config.py#L131

This leads to the above traceback when accessing the first index from presets.

**Note:-** When resolving the above issue we get the `ParseError`, This will also resolved in this PR.

sentry-6327697722,6329224724,6328865117

