### PR TITLE
[FIX] hr_holidays: prevent error when creating a hr leave (Time Off Request)

### DIFF
--- a/addons/hr_holidays/views/resource_views.xml
+++ b/addons/hr_holidays/views/resource_views.xml
@@ -17,7 +17,7 @@
         <field name="inherit_id" ref="resource.resource_calendar_leave_form"/>
         <field name="arch" type="xml">
             <field name="name" position="after">
-                <field name="holiday_id"/>
+                <field name="holiday_id" options="{'no_quick_create': True}"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Currently, An error occurs when quick create an hr leave (Time Off Request).

Step to produce:

- Install the `hr_holidays` module.
- Enable debug mode.
- Open Settings / Technical / Resource / Resource Time Off, Create a new record, and attempt to quick create a 'Time Off Request'.

Traceback:

```
  File "/home/odoo/odoo/community/odoo/http.py", line 1788, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/odoo/odoo/community/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/home/odoo/odoo/community/odoo/http.py", line 1816, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/odoo/community/odoo/http.py", line 2020, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/odoo/community/odoo/addons/base/models/ir_http.py", line 221, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo/odoo/community/odoo/http.py", line 757, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo/odoo/community/addons/web/controllers/dataset.py", line 24, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/odoo/odoo/community/addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/odoo/odoo/community/odoo/api.py", line 464, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "/home/odoo/odoo/community/odoo/api.py", line 435, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "/home/odoo/odoo/community/odoo/models.py", line 1708, in name_create
    record = self.create({self._rec_name: name})
  File "<decorator-gen-165>", line 2, in create
  File "/home/odoo/odoo/community/odoo/api.py", line 414, in _model_create_multi
    return create(self, [arg])
  File "/home/odoo/odoo/community/addons/hr_holidays/models/hr_leave.py", line 937, in create
    if mapped_validation_type[leave_type_id] == 'no_validation':
KeyError: None

```

The error occurs because the system attempts to access 'leave_type_id'  from the `vals_list` at [1], But vals_list has no data.

Link [1]: https://github.com/odoo/odoo/blob/a1969de6e6a292b14ad1d19c256ead04dc202528/addons/hr_holidays/models/hr_leave.py#L945C17-L945C68

To resolve this issue, remove the `quick_create` option for `Time Off Request` field from the 'Resource Time Off' form view.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
