### PR TITLE
[IMP] html_editor: wrap selected text in inline code

### DIFF
--- a/addons/html_editor/static/src/main/inline_code.js
+++ b/addons/html_editor/static/src/main/inline_code.js
@@ -142,7 +142,7 @@ export class InlineCodePlugin extends Plugin {
             const insertedBacktickIndex = offset - 1;
             const textBeforeInsertedBacktick = textNode.textContent.substring(
                 0,
-                insertedBacktickIndex - 1
+                insertedBacktickIndex
             );
             let startOffset, endOffset;
             const isClosingForward = textBeforeInsertedBacktick.includes("`");
@@ -174,13 +174,13 @@ export class InlineCodePlugin extends Plugin {
             codeElement.classList.add("o_inline_code");
             textNode.before(codeElement);
             codeElement.append(textNode);
-            if (
-                !codeElement.previousSibling ||
-                codeElement.previousSibling.nodeType !== Node.TEXT_NODE
-            ) {
-                codeElement.before(document.createTextNode("\u200B"));
-            }
-            if (isClosingForward) {
+            if (!codeElement.textContent.length) {
+                this.dependencies.history.addStep();
+                this.dependencies.selection.setSelection({
+                    anchorNode: codeElement.firstChild,
+                    anchorOffset: 1,
+                });
+            } else if (isClosingForward) {
                 // Move selection out of code element.
                 this.dependencies.history.addStep();
                 this.dependencies.selection.setSelection({

--- a/addons/html_editor/static/src/main/inline_code.js
+++ b/addons/html_editor/static/src/main/inline_code.js
@@ -18,24 +18,25 @@ export class InlineCodePlugin extends Plugin {
         // We just inserted a backtick, check if there was another
         // one in the text.
         let textNode = selection.startContainer;
-        let offset = selection.startOffset;
-        let sibling = textNode.previousSibling;
-        while (sibling && sibling.nodeType === Node.TEXT_NODE) {
-            offset += sibling.textContent.length;
-            sibling.textContent += textNode.textContent;
-            textNode.remove();
-            textNode = sibling;
-            sibling = textNode.previousSibling;
-        }
-        sibling = textNode.nextSibling;
-        while (sibling && sibling.nodeType === Node.TEXT_NODE) {
-            textNode.textContent += sibling.textContent;
-            sibling.remove();
-            sibling = textNode.nextSibling;
-        }
-        const textHasTwoTicks = /`.*`/.test(textNode.textContent);
+        const wholeText = textNode.wholeText;
+        const textHasTwoTicks = /`.*`/.test(wholeText);
         // We don't apply the code tag if there is no content between the two `
-        if (textHasTwoTicks && textNode.textContent.replace(/`/g, "").length) {
+        if (textHasTwoTicks && wholeText.replace(/`/g, "").length) {
+            let offset = selection.startOffset;
+            let sibling = textNode.previousSibling;
+            while (sibling && sibling.nodeType === Node.TEXT_NODE) {
+                offset += sibling.textContent.length;
+                sibling.textContent += textNode.textContent;
+                textNode.remove();
+                textNode = sibling;
+                sibling = sibling.previousSibling;
+            }
+            sibling = textNode.nextSibling;
+            while (sibling && sibling.nodeType === Node.TEXT_NODE) {
+                textNode.textContent += sibling.textContent;
+                sibling.remove();
+                sibling = sibling.nextSibling;
+            }
             this.dependencies.selection.setSelection({
                 anchorNode: textNode,
                 anchorOffset: offset,

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -276,6 +276,17 @@ export class LinkPlugin extends Plugin {
         delete_image_overrides: this.deleteImageLink.bind(this),
         double_click_overrides: this.doubleClickLinkOverrides.bind(this),
         triple_click_overrides: this.tripleClickButtonOverrides.bind(this),
+
+        /** Processors */
+        to_inline_code_processors: (node) => {
+            this.removeEmptyLinks(node);
+            for (const btn of selectElements(node, "a.btn")) {
+                // Remove all attributes from the button link except "href"
+                [...btn.attributes].forEach(
+                    (attr) => attr.name !== "href" && btn.removeAttribute(attr.name)
+                );
+            }
+        },
     };
 
     setup() {

--- a/addons/html_editor/static/tests/markdown.test.js
+++ b/addons/html_editor/static/tests/markdown.test.js
@@ -9,16 +9,16 @@ describe("inline code", () => {
             contentBefore: "<p>`ab[]cd</p>",
             stepFunction: async (editor) => await insertText(editor, "`"),
             contentAfterEdit:
-                '<p>\u200b\ufeff<code class="o_inline_code">\ufeffab\ufeff</code>\ufeff[]cd</p>',
-            contentAfter: '<p>\u200b<code class="o_inline_code">ab</code>[]cd</p>',
+                '<p>\ufeff<code class="o_inline_code">\ufeffab\ufeff</code>\ufeff[]cd</p>',
+            contentAfter: '<p><code class="o_inline_code">ab</code>[]cd</p>',
         });
         // BACKWARDS
         await testEditor({
             contentBefore: "<p>[]ab`cd</p>",
             stepFunction: async (editor) => await insertText(editor, "`"),
             contentAfterEdit:
-                '<p>\u200b\ufeff<code class="o_inline_code">[]\ufeffab\ufeff</code>\ufeffcd</p>',
-            contentAfter: '<p>\u200b<code class="o_inline_code">[]ab</code>cd</p>',
+                '<p>\ufeff<code class="o_inline_code">[]\ufeffab\ufeff</code>\ufeffcd</p>',
+            contentAfter: '<p><code class="o_inline_code">[]ab</code>cd</p>',
         });
     });
 
@@ -269,6 +269,16 @@ describe("inline code", () => {
                 '<p>ab\ufeff<code class="o_inline_code">\ufeffcd\ufeff<a href="#" class="o_link_in_selection">\ufeffte[]\ufeff</a>\ufeff</code>\ufeff<a href="#" class="btn btn-primary">\ufeffst\ufeff</a>\ufeffef</p>',
             contentAfter:
                 '<p>ab<code class="o_inline_code">cd<a href="#">te[]</a></code><a href="#" class="btn btn-primary">st</a>ef</p>',
+        });
+    });
+
+    test("should create an empty inline code when their is no text in between two backtics", async () => {
+        await testEditor({
+            contentBefore: "<p>a`[]b</p>",
+            stepFunction: async (editor) => insertText(editor, "`"),
+            contentAfterEdit:
+                '<p>a\ufeff<code class="o_inline_code">\ufeff[]\ufeff</code>\ufeffb</p>',
+            contentAfter: '<p>a<code class="o_inline_code">[]</code>b</p>',
         });
     });
 

--- a/addons/html_editor/static/tests/markdown.test.js
+++ b/addons/html_editor/static/tests/markdown.test.js
@@ -8,13 +8,17 @@ describe("inline code", () => {
         await testEditor({
             contentBefore: "<p>`ab[]cd</p>",
             stepFunction: async (editor) => await insertText(editor, "`"),
-            contentAfter: '<p>\u200B<code class="o_inline_code">ab</code>\u200B[]cd</p>',
+            contentAfterEdit:
+                '<p>\u200b\ufeff<code class="o_inline_code">\ufeffab\ufeff</code>\ufeff[]cd</p>',
+            contentAfter: '<p>\u200b<code class="o_inline_code">ab</code>[]cd</p>',
         });
         // BACKWARDS
         await testEditor({
             contentBefore: "<p>[]ab`cd</p>",
             stepFunction: async (editor) => await insertText(editor, "`"),
-            contentAfter: '<p>\u200B<code class="o_inline_code">[]ab</code>cd</p>',
+            contentAfterEdit:
+                '<p>\u200b\ufeff<code class="o_inline_code">[]\ufeffab\ufeff</code>\ufeffcd</p>',
+            contentAfter: '<p>\u200b<code class="o_inline_code">[]ab</code>cd</p>',
         });
     });
 
@@ -22,12 +26,16 @@ describe("inline code", () => {
         await testEditor({
             contentBefore: "<p>ab`cd[]ef</p>",
             stepFunction: async (editor) => await insertText(editor, "`"),
-            contentAfter: '<p>ab<code class="o_inline_code">cd</code>\u200B[]ef</p>',
+            contentAfterEdit:
+                '<p>ab\ufeff<code class="o_inline_code">\ufeffcd\ufeff</code>\ufeff[]ef</p>',
+            contentAfter: '<p>ab<code class="o_inline_code">cd</code>[]ef</p>',
         });
         // BACKWARDS
         await testEditor({
             contentBefore: "<p>ab[]cd`ef</p>",
             stepFunction: async (editor) => await insertText(editor, "`"),
+            contentAfterEdit:
+                '<p>ab\ufeff<code class="o_inline_code">[]\ufeffcd\ufeff</code>\ufeffef</p>',
             contentAfter: '<p>ab<code class="o_inline_code">[]cd</code>ef</p>',
         });
     });
@@ -36,12 +44,16 @@ describe("inline code", () => {
         await testEditor({
             contentBefore: "<p>ab`cd[]</p>",
             stepFunction: async (editor) => await insertText(editor, "`"),
-            contentAfter: '<p>ab<code class="o_inline_code">cd</code>\u200B[]</p>',
+            contentAfterEdit:
+                '<p>ab\ufeff<code class="o_inline_code">\ufeffcd\ufeff</code>\ufeff[]</p>',
+            contentAfter: '<p>ab<code class="o_inline_code">cd</code>[]</p>',
         });
         // BACKWARDS
         await testEditor({
             contentBefore: "<p>ab[]cd`</p>",
             stepFunction: async (editor) => await insertText(editor, "`"),
+            contentAfterEdit:
+                '<p>ab\ufeff<code class="o_inline_code">[]\ufeffcd\ufeff</code>\ufeff</p>',
             contentAfter: '<p>ab<code class="o_inline_code">[]cd</code></p>',
         });
     });
@@ -51,12 +63,16 @@ describe("inline code", () => {
             contentBefore: "<p>a`b`cd[]e`f</p>",
             stepFunction: async (editor) => await insertText(editor, "`"),
             // The closest PREVIOUS backtick is prioritary
-            contentAfter: '<p>a`b<code class="o_inline_code">cd</code>\u200B[]e`f</p>',
+            contentAfterEdit:
+                '<p>a`b\ufeff<code class="o_inline_code">\ufeffcd\ufeff</code>\ufeff[]e`f</p>',
+            contentAfter: '<p>a`b<code class="o_inline_code">cd</code>[]e`f</p>',
         });
         await testEditor({
             contentBefore: "<p>ab[]cd`e`f</p>",
             stepFunction: async (editor) => await insertText(editor, "`"),
             // If there is no previous backtick, use the closest NEXT backtick.
+            contentAfterEdit:
+                '<p>ab\ufeff<code class="o_inline_code">[]\ufeffcd\ufeff</code>\ufeffe`f</p>',
             contentAfter: '<p>ab<code class="o_inline_code">[]cd</code>e`f</p>',
         });
     });
@@ -81,6 +97,8 @@ describe("inline code", () => {
         await testEditor({
             contentBefore: '<p>a<code class="o_inline_code">b`cd[]e</code>f</p>',
             stepFunction: async (editor) => await insertText(editor, "`"),
+            contentAfterEdit:
+                '<p>a\ufeff<code class="o_inline_code">\ufeffb`cd`[]e\ufeff</code>\ufefff</p>',
             contentAfter: '<p>a<code class="o_inline_code">b`cd`[]e</code>f</p>',
         });
     });
@@ -97,7 +115,9 @@ describe("inline code", () => {
 
                 await insertText(editor, "`");
             },
-            contentAfter: '<p>ab<code class="o_inline_code">c</code>\u200B[]d</p>',
+            contentAfterEdit:
+                '<p>ab\ufeff<code class="o_inline_code">\ufeffc\ufeff</code>\ufeff[]d</p>',
+            contentAfter: '<p>ab<code class="o_inline_code">c</code>[]d</p>',
         });
         // AFTER
         await testEditor({
@@ -106,7 +126,9 @@ describe("inline code", () => {
                 editor.document.getSelection().anchorNode.after(document.createTextNode("d"));
                 await insertText(editor, "`");
             },
-            contentAfter: '<p>a<code class="o_inline_code">b</code>\u200B[]cd</p>',
+            contentAfterEdit:
+                '<p>a\ufeff<code class="o_inline_code">\ufeffb\ufeff</code>\ufeff[]cd</p>',
+            contentAfter: '<p>a<code class="o_inline_code">b</code>[]cd</p>',
         });
         // BOTH
         await testEditor({
@@ -116,7 +138,9 @@ describe("inline code", () => {
                 editor.document.getSelection().anchorNode.after(document.createTextNode("e"));
                 await insertText(editor, "`");
             },
-            contentAfter: '<p>ab<code class="o_inline_code">c</code>\u200B[]de</p>',
+            contentAfterEdit:
+                '<p>ab\ufeff<code class="o_inline_code">\ufeffc\ufeff</code>\ufeff[]de</p>',
+            contentAfter: '<p>ab<code class="o_inline_code">c</code>[]de</p>',
         });
     });
 
@@ -132,7 +156,9 @@ describe("inline code", () => {
 
                 await insertText(editor, "`");
             },
-            contentAfter: '<p>\u200B<code class="o_inline_code">ab</code>\u200B[]c</p>',
+            contentAfterEdit:
+                '<p>\ufeff<code class="o_inline_code">\ufeffab\ufeff</code>\ufeff[]c</p>',
+            contentAfter: '<p><code class="o_inline_code">ab</code>[]c</p>',
         });
         // BACKTICK IS NEXT SIBLING
         await testEditor({
@@ -141,6 +167,8 @@ describe("inline code", () => {
                 editor.document.getSelection().anchorNode.after(document.createTextNode("`"));
                 await insertText(editor, "`");
             },
+            contentAfterEdit:
+                '<p>ab\ufeff<code class="o_inline_code">[]\ufeffc\ufeff</code>\ufeff</p>',
             contentAfter: '<p>ab<code class="o_inline_code">[]c</code></p>',
         });
     });
@@ -172,12 +200,15 @@ describe("inline code", () => {
         await testEditor({
             contentBefore: "<p>a[bc]d</p>",
             stepFunction: async (editor) => insertText(editor, "`"),
-            contentAfter: '<p>a<code class="o_inline_code">bc[]</code>\u200Bd</p>',
+            contentAfterEdit:
+                '<p>a\ufeff<code class="o_inline_code">\ufeffbc[]\ufeff</code>\ufeffd</p>',
+            contentAfter: '<p>a<code class="o_inline_code">bc[]</code>d</p>',
         });
         await testEditor({
             contentBefore: `<p>ab[cd<a href="#">test</a>ef]gh</p>`,
             stepFunction: async (editor) => insertText(editor, "`"),
-            contentAfter: `<p>ab<code class="o_inline_code">cd<a href="#">test</a>ef[]</code>\u200Bgh</p>`,
+            contentAfterEdit: `<p>ab\ufeff<code class="o_inline_code">\ufeffcd\ufeff<a href="#">\ufefftest\ufeff</a>\ufeffef[]\ufeff</code>\ufeffgh</p>`,
+            contentAfter: `<p>ab<code class="o_inline_code">cd<a href="#">test</a>ef[]</code>gh</p>`,
         });
     });
 
@@ -185,8 +216,10 @@ describe("inline code", () => {
         await testEditor({
             contentBefore: "<p>ab[cd<strong>ef]g</strong>h</p>",
             stepFunction: async (editor) => insertText(editor, "`"),
+            contentAfterEdit:
+                '<p>ab\ufeff<code class="o_inline_code">\ufeffcd<strong>ef[]</strong>\ufeff</code>\ufeff<strong>g</strong>h</p>',
             contentAfter:
-                '<p>ab<code class="o_inline_code">cd<strong>ef[]</strong></code>\u200B<strong>g</strong>h</p>',
+                '<p>ab<code class="o_inline_code">cd<strong>ef[]</strong></code><strong>g</strong>h</p>',
         });
     });
 
@@ -194,8 +227,10 @@ describe("inline code", () => {
         await testEditor({
             contentBefore: "<p><strong>a<u>b[cd</u>ef]g</strong></p>",
             stepFunction: async (editor) => insertText(editor, "`"),
+            contentAfterEdit:
+                '<p><strong>a<u>b</u></strong>\ufeff<code class="o_inline_code">\ufeff<strong><u>cd</u>ef[]</strong>\ufeff</code>\ufeff<strong>g</strong></p>',
             contentAfter:
-                '<p><strong>a<u>b</u></strong>\u200b<code class="o_inline_code"><strong><u>cd</u>ef[]</strong></code>\u200b<strong>g</strong></p>',
+                '<p><strong>a<u>b</u></strong><code class="o_inline_code"><strong><u>cd</u>ef[]</strong></code><strong>g</strong></p>',
         });
     });
 
@@ -203,7 +238,10 @@ describe("inline code", () => {
         await testEditor({
             contentBefore: `<p>ab[cd<a href="#">te]st</a>ef</p>`,
             stepFunction: async (editor) => insertText(editor, "`"),
-            contentAfter: '<p>ab`[]<a href="#">st</a>ef</p>',
+            contentAfterEdit:
+                '<p>ab\ufeff<code class="o_inline_code">\ufeffcd\ufeff<a href="#" class="o_link_in_selection">\ufeffte[]\ufeff</a>\ufeff</code>\ufeff<a href="#">\ufeffst\ufeff</a>\ufeffef</p>',
+            contentAfter:
+                '<p>ab<code class="o_inline_code">cd<a href="#">te[]</a></code><a href="#">st</a>ef</p>',
         });
     });
 
@@ -211,12 +249,14 @@ describe("inline code", () => {
         await testEditor({
             contentBefore: `<p>a[bc<img src="${base64Img}">de]f</p>`,
             stepFunction: async (editor) => insertText(editor, "`"),
+            contentAfterEdit: `<p>a\ufeff<code class="o_inline_code">\ufeffbc\ufeff</code>\ufeff<img src="${base64Img}">\ufeff<code class="o_inline_code">\ufeffde[]\ufeff</code>\ufefff</p>`,
             contentAfter: `<p>a<code class="o_inline_code">bc</code><img src="${base64Img}"><code class="o_inline_code">de[]</code>f</p>`,
         });
 
         await testEditor({
             contentBefore: `<p>a[bcde<img src="${base64Img}">]</p>`,
             stepFunction: async (editor) => insertText(editor, "`"),
+            contentAfterEdit: `<p>a\ufeff<code class="o_inline_code">\ufeffbcde[]\ufeff</code>\ufeff<img src="${base64Img}"></p>`,
             contentAfter: `<p>a<code class="o_inline_code">bcde[]</code><img src="${base64Img}"></p>`,
         });
     });
@@ -225,6 +265,8 @@ describe("inline code", () => {
         await testEditor({
             contentBefore: `<p>ab[cd<a href="#" class="btn btn-primary">te]st</a>ef</p>`,
             stepFunction: async (editor) => insertText(editor, "`"),
+            contentAfterEdit:
+                '<p>ab\ufeff<code class="o_inline_code">\ufeffcd\ufeff<a href="#" class="o_link_in_selection">\ufeffte[]\ufeff</a>\ufeff</code>\ufeff<a href="#" class="btn btn-primary">\ufeffst\ufeff</a>\ufeffef</p>',
             contentAfter:
                 '<p>ab<code class="o_inline_code">cd<a href="#">te[]</a></code><a href="#" class="btn btn-primary">st</a>ef</p>',
         });


### PR DESCRIPTION
**Purpose of this PR:**

This PR includes multiple fixes and improvements related to typing and navigating around inline code elements.

**Current behavior before this PR:**

- Because of the change made in commit [1], the selection was not set until two backticks were detected. As a result, inserting a single backtick caused the cursor position to change unexpectedly.

- Typing two backticks (``) without any text between them did not properly create an inline code element.

Desired behavior after this PR is merged:

- The text node is merged with its siblings only when two backtick are detected, so no DOM changes occur with a single backtick, and the selection no longer needs to be updated in that case.

- Now, a zws is added as a sibling of the inline code element to ensure proper navigation outside the code element.

- Typing two backticks with nothing in between now correctly creates an empty inline code element.

- Wrap the selected text in a inline code element when the '`' key is pressed.

-  Replaced ZWS with feffs around and inside inline code elements.
   This improves:
    - feffs are now added on editor initialization (like links) and removed during cleanForSave.
   - Arrow key navigation no longer skips characters at code boundaries.
   - Empty inline code elements can properly hold the cursor(via mouse or arrow keys).

task: 4585706

[1]: https://github.com/odoo/odoo/commit/f792acf0bc66fb77e25bf8a0753c6a2f4284f0e8
