### PR TITLE
[IMP] base_automation: simpler error dialog

### DIFF
--- a/addons/base_automation/static/src/base_automation_error_dialog.xml
+++ b/addons/base_automation/static/src/base_automation_error_dialog.xml
@@ -5,32 +5,20 @@
         <xpath expr="//div[@role='alert']" position="attributes">
             <attribute name="class" add="o_base_automation_error" separator=" "/>
         </xpath>
-        <xpath expr="//div[@role='alert']" position="inside">
+        <xpath expr="//div[@role='alert']/p[1]" position="after">
             <p class="mt-2">
                 The error occurred during the execution of the automation rule
                 "<t t-esc="automationName"/>"
                 (ID: <t t-esc="automationId"/>).
-                <br/>
             </p>
-            <p t-if="isUserAdmin">
-                You can disable this automation rule or edit it to solve the issue.<br/>
-                Disabling this automation rule will enable you to continue your workflow
-                but any data created after this could potentially be corrupted,
-                as you are effectively disabling a customization that may set
-                important and/or required fields.
-            </p>
-            <p t-else="">
-                You can ask an administrator to disable or correct this automation rule.
+            <p t-if="!isUserAdmin">
+                You can ask an administrator to disable or fix this automation.
             </p>
         </xpath>
-        <xpath expr="//div[@role='alert']//button" position="after">
+        <xpath expr="//t[@t-set-slot='footer']" position="inside">
             <t t-if="isUserAdmin">
-                <button class="btn btn-secondary mt4 o_disable_action_button me-3" t-on-click.prevent="disableAutomation">
-                    <i class="fa fa-ban mr8"/>Disable Automation Rule
-                </button>
-                <button class="btn btn-secondary mt4 o_edit_action_button" t-on-click.prevent="editAutomation">
-                    <i class="fa fa-edit mr8"/>Edit Automation Rule
-                </button>
+                <button class="btn btn-secondary ms-auto ms-md-2 o_disable_action_button" t-on-click.prevent="disableAutomation">Disable</button>
+                <button class="btn btn-secondary ms-auto ms-md-2 o_edit_action_button" t-on-click.prevent="editAutomation">Edit</button>
             </t>
         </xpath>
     </t>

--- a/addons/base_automation/static/tests/base_automation_error_dialog.test.js
+++ b/addons/base_automation/static/tests/base_automation_error_dialog.test.js
@@ -39,8 +39,8 @@ test("Error due to an automation rule", async () => {
     await animationFrame();
     expect.verifyErrors(["Message"]);
     expect.verifySteps(["error setup"]);
-    expect(".modal .o_disable_action_button").toHaveCount(1);
-    expect(".modal .o_edit_action_button").toHaveCount(1);
+    expect(".modal .modal-footer .o_disable_action_button").toHaveCount(1);
+    expect(".modal .modal-footer .o_edit_action_button").toHaveCount(1);
 });
 
 test("Error not due to an automation rule", async () => {
@@ -56,8 +56,8 @@ test("Error not due to an automation rule", async () => {
     Promise.reject(error);
     await animationFrame();
     expect.verifyErrors(["Message"]);
-    expect(".modal .o_disable_action_button").toHaveCount(0);
-    expect(".modal .o_edit_action_button").toHaveCount(0);
+    expect(".modal .modal-footer .o_disable_action_button").toHaveCount(0);
+    expect(".modal .modal-footer .o_edit_action_button").toHaveCount(0);
 });
 
 test("display automation rule id and name in Error dialog", async () => {
@@ -88,7 +88,7 @@ test("display automation rule id and name in Error dialog", async () => {
     await animationFrame();
     expect.verifyErrors(["Message"]);
     expect.verifySteps(["error setup"]);
-    expect(".modal-body p:nth-child(5)").toHaveText(
+    expect(".modal-body p:nth-child(2)").toHaveText(
         `The error occurred during the execution of the automation rule "Test base automation error dialog" (ID: 1).`
     );
 });


### PR DESCRIPTION
The UI of the base_automation_error_dialog is a bit simplified.

Taskid: opw-4600013

### Before
![image](https://github.com/user-attachments/assets/80b1fd00-d3bd-4e47-8c25-ae6b6d7b1ce6)

### After
![image](https://github.com/user-attachments/assets/b53edad8-09a7-40a3-ab2a-3d0245d4a4c3)
