### PR TITLE
[FIX] website: actually stack bar charts

### DIFF
--- a/addons/website/static/src/snippets/s_chart/000.js
+++ b/addons/website/static/src/snippets/s_chart/000.js
@@ -48,6 +48,7 @@ const ChartWidget = publicWidget.Widget.extend({
 
         const categoryAxis = {
             type: "category",
+            stacked: this.el.dataset.stacked === "true",
         };
 
         // Make chart data


### PR DESCRIPTION
Since the upgrade of Chartjs to v4.3 in [commit 1], stacked charts in website were wrongly computed. This commit fixes it.

[commit 1]: https://github.com/odoo/odoo/commit/7e3c1ecdb86110912b15722e600f9571692807ed

task-4603349