### PR TITLE
[FIX] base: run all multi-state actions as multi(record) 

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -790,7 +790,8 @@ class IrActionsServer(models.Model):
         multi = True
         t = self.env.registry[self._name]
         fn = getattr(t, f'_run_action_{self.state}_multi', None)\
-          or getattr(t, f'run_action_{self.state}_multi', None)
+          or getattr(t, f'run_action_{self.state}_multi', None)\
+          or (self.state == 'multi' and getattr(t, f'_run_action_{self.state}', None) )
         if not fn:
             multi = False
             fn = getattr(t, f'_run_action_{self.state}', None)\


### PR DESCRIPTION
[FIX] base: run all multi-state actions as multi(record) 

Context
---

In the Documents module, users can select one or more records and run an action on them. Recent changes (ref.1) replaced documents.workflow.action with `ir.embedded.actions`, which are linked to `ir.actions.server`.

Some actions, such as `ir_actions_server_create_vendor_bill`, are multi-state actions (where "state" is sometimes referred to as "TYPE" in `IrActionsServer.run`). These actions execute dependent actions when triggered.

A distinct but related concept is multi-action, which refers to actions defined with a method suffixed `_multi`. These methods are designed to handle multiple records at once.

What seem to be a separate concept is a **multi action**. That is an action defined by a method suffixed `_multi`.
Such action can handle multiple records at its execution.

Reproduce
---
- install documents_account
- open documents -> finance folder
- select two (or more) documents (shift + click)
- run action "Create Vendor Bill", bills are created ok for all documents
- BUG: you are taken to a from view of a single bill...

... instead of to the list of all created documents, like it used to be in the previous version

Root Cause of the Bug
---
- When `ir_actions_server_create_vendor_bill` is executed, Odoo searches for the appropriate runner method.
- Since `_run_action_multi_multi` does not exist, Odoo defaults to `_run_action_multi`, which is executed in single-record mode.
- The term multi in this case refers to the action's state, not the number of records being processed.
- Because `_run_action_multi` is not designed for multi-record execution, it is called individually for each record.
- This approach works for invoice creation but is inefficient and restricts navigation, as it only opens a single document (`account_create_account_move`) instead of the full list.


FIX
---
- Treat all server actions with state=multi as multi-record actions.
- Pass all active_ids to the runner method to process all selected records in a single execution.

References
---
(ref.1)
a32825ee00f2b330d99113f4d8c1488903fe744e
[IMP] documents, *: modernize access rights, sharing, and actions

opw-4547250
