### PR TITLE
[FIX] html_editor: apply opacity for custom background colors

### DIFF
--- a/addons/html_editor/static/src/utils/color.js
+++ b/addons/html_editor/static/src/utils/color.js
@@ -58,6 +58,8 @@ for (let i = 100; i <= 900; i += 100) {
     EDITOR_COLOR_CSS_VARIABLES.push(`${i}`);
 }
 
+export const RGBA_REGEX = /[\d.]{1,5}/g;
+
 /**
  * Takes a color (rgb, rgba or hex) and returns its hex representation. If the
  * color is given in rgba, the background color of the node whose color we're
@@ -73,7 +75,7 @@ export function rgbToHex(rgb = "", node = null) {
     if (rgb.startsWith("#")) {
         return rgb;
     } else if (rgb.startsWith("rgba")) {
-        const values = rgb.match(/[\d.]{1,5}/g) || [];
+        const values = rgb.match(RGBA_REGEX) || [];
         const alpha = parseFloat(values.pop());
         // Retrieve the background color.
         let bgRgbValues = [];
@@ -88,7 +90,7 @@ export function rgbToHex(rgb = "", node = null) {
             if (bgColor && bgColor.startsWith("#")) {
                 bgRgbValues = (bgColor.match(/[\da-f]{2}/gi) || []).map((val) => parseInt(val, 16));
             } else if (bgColor && bgColor.startsWith("rgb")) {
-                bgRgbValues = (bgColor.match(/[\d.]{1,5}/g) || []).map((val) => parseInt(val));
+                bgRgbValues = (bgColor.match(RGBA_REGEX) || []).map((val) => parseInt(val));
             }
         }
         bgRgbValues = bgRgbValues.length ? bgRgbValues : [255, 255, 255]; // Default to white.

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -50,8 +50,40 @@ test("can set background color", async () => {
     expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
     expect(".o_font_color_selector").toHaveCount(0); // selector closed
     expect(getContent(el)).toBe(
-        `<p><font style="background-color: rgb(107, 173, 222);">[test]</font></p>`
+        `<p><font style="background-color: rgba(107, 173, 222, 0.6);">[test]</font></p>`
     );
+});
+
+test("should add opacity to custom background colors but not to theme colors", async () => {
+    const { el } = await setupEditor("<p>[test]</p>");
+
+    await waitFor(".o-we-toolbar");
+    expect(".o_font_color_selector").toHaveCount(0);
+
+    await contains(".o-select-color-background").click();
+    expect(".o_font_color_selector").toHaveCount(1);
+
+    await contains(".o_color_button[data-color='#FF0000']").click(); // Select a custom color.
+    await waitFor(".o-we-toolbar");
+    expect(".o-we-toolbar").toHaveCount(1);
+    expect(".o_font_color_selector").toHaveCount(0);
+    // Verify custom color applies RGBA with 0.6 opacity.
+    expect(getContent(el)).toBe(
+        `<p><font style="background-color: rgba(255, 0, 0, 0.6);">[test]</font></p>`
+    );
+    // Verify paintbrush border bottom color has no opacity.
+    expect("i.fa-paint-brush").toHaveStyle({ borderBottomColor: "rgb(255, 0, 0)" });
+
+    await contains(".o-select-color-background").click();
+    expect(".o_font_color_selector").toHaveCount(1);
+    expect(".o_color_button[data-color='#FF0000']").toHaveClass("selected");
+
+    await contains(".o_color_button[data-color='o-color-1']").click(); // Select a theme color
+    await waitFor(".o-we-toolbar");
+    expect(getContent(el)).toBe(`<p><font style="" class="bg-o-color-1">[test]</font></p>`);
+    // Verify computed background color has no opacity.
+    const backgroundColor = getComputedStyle(el.querySelector("p font")).backgroundColor;
+    expect(backgroundColor).toBe("rgb(113, 75, 103)");
 });
 
 test("can render and apply color theme", async () => {


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- Applying a background color to text caused visibility issues in dark mode.

### Current behavior before PR:

- 60% opacity is applied to background colors in the solid tab, except for theme colors.

task-4566382

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
