### PR TITLE
[FIX] website: disable failing tour step in popover tour

### DIFF
--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -55,11 +55,15 @@ wTourUtils.registerWebsitePreviewTour('edit_link_popover', {
         content: "Click on newly created link",
         trigger: `${FIRST_PARAGRAPH} a`,
     },
+    // Disabling this step as the feature is not robust and leads to undeterministic behavior
+    // For more information, see https://github.com/odoo/odoo/pull/154244
+    /*
     {
         content: "Popover should be shown",
         trigger: 'iframe .o_edit_menu_popover .o_we_url_link:contains("Contact Us")', // At this point preview is loaded
         run: function () {}, // it's a check
     },
+    */
     ...clickEditLink,
     {
         content: "Type the link URL /",


### PR DESCRIPTION
This commit disables a tour step that used to fail randomly because the feature was not robust. The step is already disabled in 17.0 and up. This commit makes the same change in 16.0.

For more info see
https://github.com/odoo/odoo/pull/154244/files#diff-6121302bddf42e5c165adacc3356578b9cef40a838fd2f8e32daf61ef4dfb5f3R255

Runbot Error: https://runbot.odoo.com/odoo/action-573/58125



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
