### PR TITLE
[FIX] point_of_sale: no caba move during reconciliation

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1121,11 +1121,11 @@ class PosSession(models.Model):
         for payment_method, lines in payment_method_to_receivable_lines.items():
             receivable_account = self._get_receivable_account(payment_method)
             if receivable_account.reconcile:
-                lines.filtered(lambda line: not line.reconciled).reconcile()
+                lines.filtered(lambda line: not line.reconciled).with_context(no_cash_basis=True).reconcile()
 
         for payment, lines in payment_to_receivable_lines.items():
             if payment.partner_id.property_account_receivable_id.reconcile:
-                lines.filtered(lambda line: not line.reconciled).reconcile()
+                lines.filtered(lambda line: not line.reconciled).with_context(no_cash_basis=True).reconcile()
 
         # Reconcile invoice payments' receivable lines. But we only do when the account is reconcilable.
         # Though `account_default_pos_receivable_account_id` should be of type receivable, there is currently
@@ -1133,11 +1133,11 @@ class PosSession(models.Model):
         if self.company_id.account_default_pos_receivable_account_id.reconcile:
             for payment_method in combine_inv_payment_receivable_lines:
                 lines = combine_inv_payment_receivable_lines[payment_method] | combine_invoice_receivable_lines.get(payment_method, self.env['account.move.line'])
-                lines.filtered(lambda line: not line.reconciled).reconcile()
+                lines.filtered(lambda line: not line.reconciled).with_context(no_cash_basis=True).reconcile()
 
             for payment in split_inv_payment_receivable_lines:
                 lines = split_inv_payment_receivable_lines[payment] | split_invoice_receivable_lines.get(payment, self.env['account.move.line'])
-                lines.filtered(lambda line: not line.reconciled).reconcile()
+                lines.filtered(lambda line: not line.reconciled).with_context(no_cash_basis=True).reconcile()
 
         # reconcile stock output lines
         pickings = self.picking_ids.filtered(lambda p: not p.pos_order_id)
@@ -1147,7 +1147,7 @@ class PosSession(models.Model):
         for account_id in stock_output_lines:
             ( stock_output_lines[account_id]
             | stock_account_move_lines.filtered(lambda aml: aml.account_id == account_id)
-            ).filtered(lambda aml: not aml.reconciled).reconcile()
+            ).filtered(lambda aml: not aml.reconciled).with_context(no_cash_basis=True).reconcile()
         return data
 
     def _prepare_line(self, order_line):


### PR DESCRIPTION
In commit 2f62d5c0d78371be70586c79cb2b5931e733b042 the issue was fixed for some cases.

But the problem remains in some other cases.

In the original fix a special context value was added to the reconciliation of some lines. It prevents the creation of cash basis related moves for that reconciliation. This commit adds the same context to all the other reconciliations in the same function as the original reconciliation.

Reproduce on runbot for l10n_mx for bank payment method
1. Install l10n_mx
2. Set the 'IVA 16% VENTAS' tax as Customer Taxes on a product. Set the Sales Price to 100.
3. Create a payment method and journal for the PoS 
    * Payment method: Bank on journal BNK1
    * Journal: POS
5. Create a PoS using the payment method and journal from the previous step.
6. Start a PoS session
7. Sell the product from step 2 via the Bank payment method.
8. Close the Session
9. The following journal entries will be created: (All the tax lines use the same tax account; the "final" and not the caba transition account)
   ```
    * 1 entry in the POS journal (order)
       base:       | - 100.0 $
       tax:        | -  16.0 $
       receivable: | + 116.0 $
     * 1 entry in the BNK1 journal (bank / payment)
       bank:       | + 116.0 $
       receivable: | - 116.0 $
     * 1 entry in the CBMX journal (caba)
       base:       | - 100.0 $
       base:       | + 100.0 $
       tax:        | -  16.0 $
       tax:        | +  16.0 $
     * 1 entry in the EXCH journal (exchange difference)
       for the cash basis rounding difference
       tax:        | -  16.0 $
       tax:        | +  16.0 $
   ```
opw-4355124
