### PR TITLE
[IMP] mail: open command palette in conversation mode by default from discuss.

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss.js
+++ b/addons/mail/static/src/core/public_web/discuss.js
@@ -74,6 +74,11 @@ export class Discuss extends Component {
                         this.thread.composer.autofocus++;
                     }
                 }
+                if (getActiveHotkey(ev) === "control+k") {
+                    this.store.env.services.command.openMainPalette({ searchValue: "@" });
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                }
             },
             { capture: true }
         );

--- a/addons/mail/static/tests/discuss/core/web/command_palette.test.js
+++ b/addons/mail/static/tests/discuss/core/web/command_palette.test.js
@@ -3,6 +3,7 @@ import {
     contains,
     defineMailModels,
     insertText,
+    openDiscuss,
     start,
     startServer,
     triggerHotkey,
@@ -130,4 +131,13 @@ test("only partners with dedicated users will be displayed in command palette", 
     await contains(".o_command_name", { text: "Create Channel" });
     await contains(".o_command_name", { text: "Create Chat" });
     await contains(".o_command_name", { text: "Portal", count: 0 });
+});
+
+test("should open command palette in discuss with conversation mode enabled by default", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "channel_1" });
+    await start();
+    await openDiscuss(channelId);
+    triggerHotkey("control+k");
+    await contains(".o_command_palette_search", { text: "@" });
 });


### PR DESCRIPTION
**Current behavior before PR:**

when opening command palette from discuss app it opens in default mode to
search for a command.

**Desired behavior after PR is merged:**

now when opening command palette from discuss app it automatically opens
in `search a conversation` mode.

task-4510185

before PR:
![image](https://github.com/user-attachments/assets/fc4cce73-2bcc-43a9-9942-96bfdad938ca)

after PR:
![image](https://github.com/user-attachments/assets/c2d20a4f-629c-48ca-b91e-e716ea443655)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
