### PR TITLE
[REV] payment_worldline: undo handle 402 payment rejected response

### DIFF
--- a/addons/payment_worldline/const.py
+++ b/addons/payment_worldline/const.py
@@ -62,11 +62,3 @@ PAYMENT_STATUS_MAPPING = {
     'cancel': ('CANCELLED',),
     'declined': ('REJECTED', 'REJECTED_CAPTURE'),
 }
-
-# Mapping of response codes indicating Worldline handled the request
-# See https://apireference.connect.worldline-solutions.com/s2sapi/v1/en_US/json/response-codes.html.
-VALID_RESPONSE_CODES = {
-    200: 'Successful',
-    201: 'Created',
-    402: 'Payment Rejected',
-}

--- a/addons/payment_worldline/models/payment_provider.py
+++ b/addons/payment_worldline/models/payment_provider.py
@@ -81,8 +81,7 @@ class PaymentProvider(models.Model):
         try:
             response = requests.request(method, url, json=payload, headers=headers, timeout=10)
             try:
-                if response.status_code not in const.VALID_RESPONSE_CODES:
-                    response.raise_for_status()
+                response.raise_for_status()
             except requests.exceptions.HTTPError:
                 _logger.exception(
                     "Invalid API request at %s with data:\n%s", url, pprint.pformat(payload)


### PR DESCRIPTION
Versions
--------
- 18.0+

Reason
------

Payment processing may crash on
```python
payment_data = notification_data['payment']
```

This reverts commit c3c9c12d790ee3acfe9f637358e306b75616c76f.
