### PR TITLE
[IMP] l10n_jo_edi: Allow JO EDI failure XML download

### DIFF
--- a/addons/l10n_jo_edi/models/__init__.py
+++ b/addons/l10n_jo_edi/models/__init__.py
@@ -1,5 +1,6 @@
 from . import account_edi_xml_ubl_21_jo
 from . import account_move
 from . import account_tax
+from . import ir_attachment
 from . import res_company
 from . import res_config_settings

--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -149,7 +149,7 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
             return [{
                 'payment_means_code': 10,
                 'payment_means_code_attrs': {'listID': "UN/ECE 4461"},
-                'instruction_note': invoice.ref.replace('/', '_'),
+                'instruction_note': invoice.ref.replace('/', '_') if invoice.ref else '',
             }]
         else:
             return []

--- a/addons/l10n_jo_edi/models/ir_attachment.py
+++ b/addons/l10n_jo_edi/models/ir_attachment.py
@@ -1,0 +1,20 @@
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+
+class IrAttachment(models.Model):
+    _inherit = 'ir.attachment'
+
+    @api.ondelete(at_uninstall=True)
+    def _except_submitted_invoices_pdfs(self):
+        submitted_invoices_pdfs = self.filtered(
+            lambda attachment:
+            attachment.res_model == 'account.move'
+            and attachment.res_id
+            and attachment.res_field == 'invoice_pdf_report_file'
+        )
+
+        moves = self.env['account.move'].browse(submitted_invoices_pdfs.mapped('res_id')).exists()
+        moves_with_jo_qr = moves.filtered('l10n_jo_edi_qr')
+        if moves_with_jo_qr:
+            raise UserError(_("You cannot delete this Invoice PDF as it has been submitted to JoFotara"))

--- a/addons/l10n_jo_edi/views/account_move_views.xml
+++ b/addons/l10n_jo_edi/views/account_move_views.xml
@@ -9,8 +9,8 @@
                 <xpath expr="//sheet" position="before">
                     <div class="alert alert-warning" role="alert" invisible="not l10n_jo_edi_error">
                         <div class="p-0 m-0">
-                            <i class="fa fa-warning" role="img" title="EDI (Jordan)"/>
-                            <span class="mx-1">E-invoicing (Jordan) last attempt error</span>
+                            <span class="mx-1"><b>Warning</b>: this invoice cannot be sent to JoFotara.</span>
+                            <a name="download_l10n_jo_edi_computed_xml" type="object" groups="base.group_no_one" class="float-end">Download XML</a>
                         </div>
                         <field name="l10n_jo_edi_error"/>
                     </div>


### PR DESCRIPTION
This commit gives the users access to the XML of an invoice whose submission to JoFotara failed.
This allows for better debugging of failed invoices.
It also prevents the users from deleting PDFs of successfully submitted invoices.

task-4571479



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
