### PR TITLE
[FIX] payment_worldline: handle 402 payment rejected response (again)

### DIFF
--- a/addons/payment_worldline/models/payment_transaction.py
+++ b/addons/payment_worldline/models/payment_transaction.py
@@ -245,7 +245,9 @@ class PaymentTransaction(models.Model):
         if provider_code != 'worldline' or len(tx) == 1:
             return tx
 
-        payment_output = notification_data.get('payment', {}).get('paymentOutput', {})
+        # In case of failed payment, paymentResult could be given as a seperate key
+        payment_result = notification_data.get('paymentResult', notification_data)
+        payment_output = payment_result.get('payment', {}).get('paymentOutput', {})
         reference = payment_output.get('references', {}).get('merchantReference', '')
         if not reference:
             raise ValidationError(
@@ -273,8 +275,11 @@ class PaymentTransaction(models.Model):
         if self.provider_code != 'worldline':
             return
 
+        # In case of failed payment, paymentResult could be given as a seperate key
+        payment_result = notification_data.get('paymentResult', notification_data)
+        payment_data = payment_result.get('payment', {})
+
         # Update the provider reference.
-        payment_data = notification_data['payment']
         self.provider_reference = payment_data.get('id', '').rsplit('_', 1)[0]
 
         # Update the payment method.

--- a/addons/payment_worldline/tests/common.py
+++ b/addons/payment_worldline/tests/common.py
@@ -39,3 +39,112 @@ class WorldlineCommon(AccountTestInvoicingCommon, PaymentCommon):
                 'status': 'CAPTURED',
             },
         }
+
+        cls.notification_data_insufficient_funds = {
+            'errorId': 'ffffffff-fff-fffff-ffff-ffffffffffff',
+            'errors': [{
+                'category': 'IO_ERROR',
+                'code': '9999',
+                'errorCode': '30511001',
+                'httpStatusCode': 402,
+                'id': 'EXTERNAL_ACQUIRER_ERROR',
+                'message': '',
+                'retriable': False,
+            }],
+            'paymentResult': {
+                'creationOutput': {
+                    'externalReference': 'aaaaaaaa-5555-eeee-eeee-eeeeeeeeeeee',
+                    'isNewToken': False,
+                    'token': 'aaaaaaaa-5555-eeee-eeee-eeeeeeeeeeee',
+                    'tokenizationSucceeded': False,
+                },
+                'payment': {
+                    'id': '7777777000_0',
+                    'paymentOutput': {
+                        'acquiredAmount': {'amount': 0, 'currencyCode': 'EUR'},
+                        'amountOfMoney': {'amount': 4990, 'currencyCode': 'EUR'},
+                        'cardPaymentMethodSpecificOutput': {
+                            'acquirerInformation': {'name': "Test Pay"},
+                            'card': {
+                                'bin': '50010000',
+                                'cardNumber': '************7777',
+                                'countryCode': 'BE',
+                                'expiryDate': '1244',
+                            },
+                            'fraudResults': {'cvvResult': 'P', 'fraudServiceResult': 'accepted'},
+                            'paymentProductId': 3,
+                            'threeDSecureResults': {'eci': '9', 'xid': 'zOMTQ5TcODUxMg=='},
+                            'token': 'aaaaaaaa-5555-eeee-eeee-eeeeeeeeeeee',
+                        },
+                        'customer': {'device': {'ipAddressCountryCode': '99'}},
+                        'paymentMethod': 'card',
+                        'references': {'merchantReference': cls.reference},
+                    },
+                    'status': 'REJECTED',
+                    'statusOutput': {
+                        'errors': [{
+                            'category': 'IO_ERROR',
+                            'code': '9999',
+                            'errorCode': '30511001',
+                            'httpStatusCode': 402,
+                            'id': 'EXTERNAL_ACQUIRER_ERROR',
+                            'message': '',
+                            'retriable': False,
+                        }],
+                        'isAuthorized': False,
+                        'isCancellable': False,
+                        'isRefundable': False,
+                        'statusCategory': 'UNSUCCESSFUL',
+                        'statusCode': 2,
+                    },
+                },
+            },
+        }
+
+        cls.notification_data_expired_card = {
+            'apiFullVersion': 'v1.1',
+            'apiVersion': 'v1',
+            'created': '2025-02-20T03:09:47.3706109+01:00',
+            'id': 'ffffffff-fff-fffff-ffff-ffffffffffff',
+            'merchantId': 'MyCompany',
+            'payment': {
+                'id': '9999999999_0',
+                'paymentOutput': {
+                    'acquiredAmount': {'amount': 0, 'currencyCode': 'EUR'},
+                    'amountOfMoney': {'amount': 4980, 'currencyCode': 'EUR'},
+                    'cardPaymentMethodSpecificOutput': {
+                        'acquirerInformation': {'name': "Test Pay"},
+                        'card': {
+                            'bin': '47777700',
+                            'cardNumber': '************9999',
+                            'countryCode': 'FR',
+                            'expiryDate': '1234',
+                        },
+                        'fraudResults': {'cvvResult': 'P', 'fraudServiceResult': 'accepted'},
+                        'paymentProductId': 1,
+                        'threeDSecureResults': {'eci': '9'},
+                        'token': 'ODOO-ALIAS-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'},
+                    'customer': {'device': {'ipAddressCountryCode': '99'}},
+                    'paymentMethod': 'card',
+                    'references': {'merchantReference': cls.reference},
+                },
+                'status': 'REJECTED',
+                'statusOutput': {
+                    'errors': [{
+                        'category': 'PAYMENT_PLATFORM_ERROR',
+                        'code': '9999',
+                        'errorCode': '30331001',
+                        'httpStatusCode': 402,
+                        'id': 'INVALID_CARD',
+                        'message': '',
+                        'retriable': False,
+                    }],
+                    'isAuthorized': False,
+                    'isCancellable': False,
+                    'isRefundable': False,
+                    'statusCategory': 'UNSUCCESSFUL',
+                    'statusCode': 2
+                },
+            },
+            'type': 'payment.rejected',
+        }

--- a/addons/payment_worldline/tests/test_worldline.py
+++ b/addons/payment_worldline/tests/test_worldline.py
@@ -55,28 +55,27 @@ class WorldlineTest(WorldlineCommon, PaymentHttpCommon):
         self.assertEqual(tx.token_id.payment_details, '4242')
 
     @mute_logger('odoo.addons.payment_worldline.controllers.main')
-    def test_failed_webhook_notification_set_tx_as_error(self):
+    def test_failed_webhook_notification_set_tx_as_error_1(self):
         """ Test the processing of a webhook notification for a failed transaction. """
         tx = self._create_transaction('redirect')
-        test = {
-            'payment': {
-                'paymentOutput': self.notification_data['payment']['paymentOutput'],
-                'hostedCheckoutSpecificOutput': {
-                    'hostedCheckoutId': '123456789',
-                },
-                'status': 'REJECTED',
-                'statusOutput': {
-                    'errors': [{
-                        'errorCode': '30741001',
-                    }],
-                },
-            },
-        }
+        test = self.notification_data_insufficient_funds
         self._webhook_notification_flow(test)
         self.assertEqual(tx.state, 'error')
         self.assertEqual(
             tx.state_message,
-            "Worldline: Transaction declined with error code 30741001.",
+            "Worldline: Transaction declined with error code 30511001.",
+        )
+
+    @mute_logger('odoo.addons.payment_worldline.controllers.main')
+    def test_failed_webhook_notification_set_tx_as_error_2(self):
+        """ Test the processing of a webhook notification for a failed transaction. """
+        tx = self._create_transaction('redirect')
+        test = self.notification_data_expired_card
+        self._webhook_notification_flow(test)
+        self.assertEqual(tx.state, 'error')
+        self.assertEqual(
+            tx.state_message,
+            "Worldline: Transaction declined with error code 30331001.",
         )
 
     @mute_logger('odoo.addons.payment_worldline.controllers.main')


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have an expired credit card;
2. have an Odoo subscription;
3. pay subscription with expired credit card.

Issue
-----
Handling of notification data crashes when fetching a dict key:
```python
payment_data = notification_data['payment']
```

Cause
-----
Commit c3c9c12d790e forwards rejected payments to handle the reason they were rejected. The issue is that notification data from rejected payments doesn't have an immediate `payment` key. Instead, it contains the following keys:
- `errorId`
- `errors`
- `paymentResult`

The `payment` key we need is located in the `paymentResult` value.

Solution
--------
Use a new variable `payment_result`, and set it to the `paymentResult` value if it exists, otherwise to `notification_data`.

We can ignore the `errors` value as it is identical to the one in the `statusOutput` value of `paymentResult`.

opw-4481602
