### PR TITLE
[FIX] l10n_din5008: fix broken style on DIN5008 report

### DIFF
--- a/addons/l10n_din5008/static/src/scss/report_din5008.scss
+++ b/addons/l10n_din5008/static/src/scss/report_din5008.scss
@@ -116,6 +116,32 @@
             }
         }
     }
+    table.o_main_table{
+        tr {
+            &.o_line_section td {
+                background-color: rgba($gray-300, .5);
+            }
+    
+            th {
+                font-weight: bolder;
+            }
+        }
+    }
+    div#total {
+        tr {
+            &.o_subtotal,
+            &.o_total {
+                td {
+                    border-top: 1px solid black !important;
+                }
+                &.o_border_bottom {
+                    td {
+                        border-bottom: 1px solid black !important;
+                    }
+                }
+            }
+        }
+    }
 }
 
 .din_page_pdf {


### PR DESCRIPTION
### Steps to reproduce:
- Install l10_din5008 and select the DIN5008 layout in the settings
- Go to Sale, create a quotation with section lines
- Confirm and send
- The generated PDF have several styles missing:
    - Section lines have no background color
    - There are no line separations
    - Column titles are not bold

### Cause:
The style that was applied to all reports was removed during a refactoring in 18.0.
https://github.com/odoo/odoo/pull/169512

### Solution:
Change the CSS of the DIN5008 report to make it look like in 17.0.

In 17.0
![image](https://github.com/user-attachments/assets/26dfd385-18eb-4543-93d4-9dc6a7795317)

In 18.0
![image](https://github.com/user-attachments/assets/69e56ffb-0d57-4856-b128-4562df78c4db)

After this commit
![DIN_post_commit](https://github.com/user-attachments/assets/8e23dca1-c29f-4cfc-8833-eb831f8d70b1)

opw-4572732