### PR TITLE
[IMP] mail: missing types on some patches

### DIFF
--- a/addons/mail/static/src/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/core/public_web/@types/models.d.ts
@@ -4,6 +4,7 @@ declare module "models" {
     export interface DiscussApp extends DiscussAppClass {}
 
     export interface Store {
+        action_discuss_id: number|undefined;
         discuss: DiscussApp;
         DiscussApp: StaticMailRecord<DiscussApp, typeof DiscussAppClass>;
     }

--- a/addons/mail/static/src/core/public_web/store_service_patch.js
+++ b/addons/mail/static/src/core/public_web/store_service_patch.js
@@ -7,6 +7,7 @@ patch(Store.prototype, {
     setup() {
         super.setup(...arguments);
         this.discuss = Record.one("DiscussApp");
+        /** @type {number|undefined} */
         this.action_discuss_id;
     },
     onStarted() {

--- a/addons/mail/static/src/discuss/core/public/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/public/@types/models.d.ts
@@ -1,6 +1,10 @@
 declare module "models" {
     export interface Store {
+        companyName: string|undefined;
         discuss_public_thread: Thread;
+        inPublicPage: boolean|undefined;
+        isChannelTokenSecret: boolean|undefined;
+        shouldDisplayWelcomeViewInitially: boolean|undefined;
     }
     export interface Thread {
         setActiveURL: () => void;

--- a/addons/mail/static/src/discuss/core/public/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/public/store_service_patch.js
@@ -7,10 +7,14 @@ import { patch } from "@web/core/utils/patch";
 const storeServicePatch = {
     setup() {
         super.setup();
+        /** @type {string|undefined} */
         this.companyName;
+        /** @type {boolean|undefined} */
         this.inPublicPage;
+        /** @type {boolean|undefined} */
         this.isChannelTokenSecret;
         this.discuss_public_thread = Record.one("Thread");
+        /** @type {boolean|undefined} */
         this.shouldDisplayWelcomeViewInitially;
     },
 };


### PR DESCRIPTION
Some properties added in patches are missing in the type definitions. The script that generates type defs did not take simple expression statements into account, but only assignations. This PR fixes the issue.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
