### PR TITLE
[FIX] hr_holidays: prevent error when create a resource time off

### DIFF
--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -64,14 +64,14 @@ class CalendarLeaves(models.Model):
         })
         self.env.add_to_compute(self.env['hr.leave']._fields['number_of_days'], leaves)
         self.env.add_to_compute(self.env['hr.leave']._fields['duration_display'], leaves)
-        sick_time_status = self.env.ref('hr_holidays.holiday_status_sl')
+        sick_time_status = self.env.ref('hr_holidays.holiday_status_sl', raise_if_not_found=False)
         for previous_duration, leave, state in zip(previous_durations, leaves, previous_states):
             duration_difference = previous_duration - leave.number_of_days
             message = False
             if duration_difference > 0 and leave.holiday_status_id.requires_allocation == 'yes':
                 message = _("Due to a change in global time offs, you have been granted %s day(s) back.", duration_difference)
             if leave.number_of_days > previous_duration\
-                    and leave.holiday_status_id not in sick_time_status:
+                    and (not sick_time_status or leave.holiday_status_id not in sick_time_status):
                 message = _("Due to a change in global time offs, %s extra day(s) have been taken from your allocation. Please review this leave if you need it to be changed.", -1 * duration_difference)
             try:
                 leave.write({'state': state})


### PR DESCRIPTION
Currently, An error occurs when creating a resource time off.

Step to produce:

- Install the `hr_holidays` module.
- Enable debug mode.
- Go to Time Off / Configuration / Time Off Types, And delete `Sick Time Off`.
- Go to Settings / Technical / Resource / Resource Time Off, and create a new record.
- Add a Time Off Request with the following conditions: The start date is before today's date, end date is after today's date, And state is set to Draft.
- Try to save a Resource Time Off record.

`ValueError: External ID not found in the system: hr_holidays.holiday_status_sl`

An error occurs when the system tries to retrieve an external ID of the 'Sick Time Off' at [1], but it is not available.

Link [1]: https://github.com/odoo/odoo/blob/1303193386665d120ccb5d0045ee984337af0826/addons/hr_holidays/models/resource.py#L67

To handle this issue, add 'raise_if_not_found=False' in ref() argument if the external ID of the 'Sick Time Off' is not available.

Sentry-6320807644


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
