### PR TITLE
[FIX] hr_recruitment, hr_recruitment_sms: bridge module

### DIFF
--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -439,20 +439,6 @@
         </field>
     </record>
 
-    <record id="action_hr_applicant_mass_sms" model="ir.actions.act_window">
-        <field name="name">Send SMS</field>
-        <field name="res_model">sms.composer</field>
-        <field name="view_mode">form</field>
-        <field name="target">new</field>
-        <field name="context">{
-            'default_composition_mode': 'mass',
-            'default_mass_keep_log': True,
-            'default_res_ids': active_ids,
-        }</field>
-        <field name="binding_model_id" ref="hr_recruitment.model_hr_applicant"/>
-        <field name="binding_view_types">tree</field>
-    </record>
-
     <record model="ir.actions.act_window" id="action_hr_applicant_new">
         <field name="res_model">hr.applicant</field>
         <field name="view_mode">form</field>

--- a/addons/hr_recruitment_sms/__init__.py
+++ b/addons/hr_recruitment_sms/__init__.py
@@ -1,0 +1,1 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/addons/hr_recruitment_sms/__manifest__.py
+++ b/addons/hr_recruitment_sms/__manifest__.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Recruitment - SMS',
+    'version': '1.0',
+    'summary': 'Mass mailing sms to job applicants',
+    'description': 'Mass mailing sms to job applicants',
+    'category': 'Hidden',
+    'depends': ['hr_recruitment', 'sms'],
+    'data': [
+        'views/hr_applicant_views.xml',
+    ],
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/hr_recruitment_sms/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_sms/views/hr_applicant_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="action_hr_applicant_mass_sms" model="ir.actions.act_window">
+        <field name="name">Send SMS</field>
+        <field name="res_model">sms.composer</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="context">{
+            'default_composition_mode': 'mass',
+            'default_mass_keep_log': True,
+            'default_res_ids': active_ids,
+        }</field>
+        <field name="binding_model_id" ref="hr_recruitment.model_hr_applicant"/>
+        <field name="binding_view_types">tree</field>
+    </record>
+</odoo>


### PR DESCRIPTION
Backport of #194647
Basically, starting from `saas~16.4` we have action window in `hr_recruitment` which is pointing at `sms` module.

If client does this steps:
1. Install `hr_recruitment` in version 17.0
2. Uninstall the module `sms`
3. Try to upgrade db to `18.0`

We will have the issue similar to this:

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/18.0/odoo/service/server.py", line 1318, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-13>", line 2, in new
  File "/home/odoo/src/odoo/18.0/odoo/tools/func.py", line 97, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/18.0/odoo/modules/registry.py", line 127, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 476, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 364, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 227, in load_module_graph
    load_data(env, idref, mode, kind='data', package=package)
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 71, in load_data
    tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
  File "/home/odoo/src/odoo/18.0/odoo/tools/convert.py", line 608, in convert_file
    convert_xml_import(env, module, fp, idref, mode, noupdate)
  File "/home/odoo/src/odoo/18.0/odoo/tools/convert.py", line 679, in convert_xml_import
    obj.parse(doc.getroot())
  File "/home/odoo/src/odoo/18.0/odoo/tools/convert.py", line 594, in parse
    self._tag_root(de)
  File "/home/odoo/src/odoo/18.0/odoo/tools/convert.py", line 548, in _tag_root
    raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
odoo.tools.convert.ParseError: while parsing /home/odoo/src/odoo/18.0/addons/hr_recruitment/views/hr_candidate_views.xml:220
Invalid model name “sms.composer” in action definition.

View error context:
'-no context-'

```

Th bridge module was intrdocued in #194647 targeting to version `saas~18.2`, but we need it for `17.0, 18.0, saas~18.1` as you see in the example above. This PR will only target to `17.0` and `saas~17.4`. Then we will make another patch for `18.0` and `saas~18.1` as they have some additional change.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
