### PR TITLE
[FIX] hr_holidays: compute has mandatory day ensure one

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 import pytz
 
 from odoo import _, api, fields, models
+from odoo.osv import expression
 
 
 class HrEmployee(models.Model):
@@ -116,17 +117,13 @@ class HrEmployee(models.Model):
             ('company_id', 'in', self.env.companies.ids),
             '|',
             ('resource_calendar_id', '=', False),
-            ('resource_calendar_id', '=', self.resource_calendar_id.id),
+            ('resource_calendar_id', 'in', self.resource_calendar_id.ids),
         ]
 
-        if self.department_id:
-            domain += [
-                '|',
-                ('department_ids', '=', False),
-                ('department_ids', 'parent_of', self.department_id.id),
-            ]
-        else:
-            domain += [('department_ids', '=', False)]
+        department_domain = [('department_ids', '=', False)]
+        for department in self.department_id:
+            department_domain = expression.OR([department_domain, [('department_ids', 'parent_of', department.id)]])
+        domain = expression.AND([domain, department_domain])
 
         return self.env['hr.leave.mandatory.day'].search(domain)
 

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -530,7 +530,6 @@ class HolidaysRequest(models.Model):
             mandatory_days = self.employee_id._get_mandatory_days(
                 date_from.date(),
                 date_to.date())
-
             for leave in self:
                 domain = [
                     ('start_date', '<=', leave.date_to.date()),
@@ -539,6 +538,10 @@ class HolidaysRequest(models.Model):
                         ('resource_calendar_id', '=', False),
                         ('resource_calendar_id', '=', leave.resource_calendar_id.id),
                 ]
+                department_domain = [('department_ids', '=', False)]
+                if leave.employee_id.department_id:
+                    department_domain = expression.OR([department_domain, [('department_ids', 'parent_of', leave.employee_id.department_id.id)]])
+                domain = expression.AND([domain, department_domain])
 
                 if leave.holiday_status_id.company_id:
                     domain += [('company_id', '=', leave.holiday_status_id.company_id.id)]


### PR DESCRIPTION
Steps:
- try to compute has mandatory day for multiple records

Actual result:
- error due to calendar usage in domain for _get_mandatory_days
- https://github.com/odoo/odoo/blob/17.0/addons/hr_holidays/models/hr_employee.py#L119

Expected result:
- no error