### PR TITLE
[IMP] account: Hide analytic menu items when feature is disabled

### DIFF
--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -26,7 +26,7 @@
         <menuitem id="menu_finance_entries" name="Accounting" sequence="4" groups="account.group_account_readonly">
             <menuitem id="menu_action_move_journal_line_form" action="action_move_journal_line" groups="account.group_account_readonly" sequence="1"/>
             <menuitem id="menu_action_account_moves_all" action="action_account_moves_all" groups="account.group_account_readonly" sequence="10"/>
-            <menuitem id="menu_action_analytic_lines_tree" name="Analytic Items" action="analytic.account_analytic_line_action_entries" groups="account.group_account_invoice,account.group_account_readonly,analytic.group_analytic_accounting" sequence="31"/>
+            <menuitem id="menu_action_analytic_lines_tree" name="Analytic Items" action="analytic.account_analytic_line_action_entries" groups="analytic.group_analytic_accounting" sequence="31"/>
         </menuitem>
         <menuitem id="menu_finance_reports" name="Reporting" sequence="20" groups="account.group_account_readonly,account.group_account_invoice">
             <menuitem id="account_reports_partners_reports_menu" name="Partner Reports" sequence="3"/>


### PR DESCRIPTION
Before this commit, the "Analytic Items" and "Analytic Report" menu items were visible even when the analytic feature was disabled, leading to potential confusion.

To address this:
- "Analytic Items": The solution is to restrict visibility by keeping only the `group_analytic_accounting` group and removing all the other groups.
- "Analytic Report": After consideration, it was decided to leave this menu item with `group_account_readonly`. While this is not a perfect solution, it remains the best option compared to the alternatives:
  - Making it visible to everyone when the analytic feature is enabled, which would grant access too broadly.
  - Creating a dedicated parent menu item to set `group_account_readonly` at the parent level and `group_analytic_accounting` at the child level. However, this would introduce unnecessary complexity and negatively impact the UI/UX.

task-4497442

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
