### PR TITLE
[FIX] turnstile: add missing turnstile on JS forms

### DIFF
--- a/addons/website_cf_turnstile/static/src/js/turnstile.js
+++ b/addons/website_cf_turnstile/static/src/js/turnstile.js
@@ -6,18 +6,22 @@ import { session } from "@web/session";
 
 export const turnStile = {
     addTurnstile: function (action) {
-        if (!this.isEditable && !this.$(".s_turnstile").length) {
+        if (!this.isEditable) {
             const mode = new URLSearchParams(window.location.search).get('cf') == 'show' ? 'always' : 'interaction-only';
-            return $(`<div class="s_turnstile cf-turnstile float-end"
-                        style="display: none;"
-                        data-action="${action}"
-                        data-appearance="${mode}"
-                        data-response-field-name="turnstile_captcha"
-                        data-sitekey="${session.turnstile_site_key}"
-                        data-error-callback="throwTurnstileError"
-                        data-callback="turnstileSuccess"
-                        data-before-interactive-callback="turnstileBecomeVisible"
+            let html = `
+                <div class="s_turnstile cf-turnstile float-end"
+                    style="display: none;"
+                    data-action="${action}"
+                    data-appearance="${mode}"
+                    data-response-field-name="turnstile_captcha"
+                    data-sitekey="${session.turnstile_site_key}"
+                    data-error-callback="throwTurnstileError"
+                    data-callback="turnstileSuccess"
+                    data-before-interactive-callback="turnstileBecomeVisible"
                 ></div>
+            `
+            if(!document.getElementsByClassName("s_turnstile").length) {
+                html += `
                 <script class="s_turnstile">
                     // Rethrow the error, or we only will catch a "Script error" without any info
                     // because of the script api.js originating from a different domain.
@@ -39,7 +43,9 @@ export const turnStile = {
                     }
                 </script>
                 <script class="s_turnstile" src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>
-            `);
+            `
+            }
+            return $(html);
         }
     },
 

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -268,6 +268,7 @@ class WebsiteEventController(http.Controller):
             {'1-name': 'r', '1-email': 'r@r.com', '1-phone': '', '1-event_ticket_id': '1'}
         """
         form_details.pop("recaptcha_token_response", None)
+        form_details.pop("turnstile_captcha", None)
         allowed_fields = request.env['event.registration']._get_website_registration_allowed_fields()
         registration_fields = {key: v for key, v in request.env['event.registration']._fields.items() if key in allowed_fields}
         for ticket_id in list(filter(lambda x: x is not None, [form_details[field] if 'event_ticket_id' in field else None for field in form_details.keys()])):

--- a/addons/website_mass_mailing/static/src/js/website_mass_mailing.js
+++ b/addons/website_mass_mailing/static/src/js/website_mass_mailing.js
@@ -2,6 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import publicWidget from "@web/legacy/js/public/public_widget";
+import { session } from "@web/session";
 import {ReCaptcha} from "@google_recaptcha/js/recaptcha";
 
 publicWidget.registry.subscribe = publicWidget.Widget.extend({
@@ -19,6 +20,10 @@ publicWidget.registry.subscribe = publicWidget.Widget.extend({
         this._recaptcha = new ReCaptcha();
         this.rpc = this.bindService("rpc");
         this.notification = this.bindService("notification");
+        if(session.turnstile_site_key) {
+            const { turnStile } = odoo.loader.modules.get('@website_cf_turnstile/js/turnstile');
+            this._turnstile = turnStile;
+        }
     },
     /**
      * @override
@@ -76,6 +81,15 @@ publicWidget.registry.subscribe = publicWidget.Widget.extend({
 
         subscribeBtnEl.classList.toggle('d-none', !!isSubscriber);
         thanksBtnEl.classList.toggle('d-none', !isSubscriber);
+
+        if(!isSubscriber && this._turnstile && window.top == window) {
+            const el = this._turnstile.addTurnstile('website_mass_mailing_subscribe');
+            if(el) {
+                this._turnstile.addSpinner(subscribeBtnEl);
+                el[0].classList.add('mt-3');
+                el.insertAfter(this.el);
+            }
+        }
     },
 
     _getListId: function () {
@@ -112,6 +126,7 @@ publicWidget.registry.subscribe = publicWidget.Widget.extend({
             'value': $input.length ? $input.val() : false,
             'subscription_type': inputName,
             recaptcha_token_response: tokenObj.token,
+            turnstile_captcha: this.el.parentElement.querySelector('input[name="turnstile_captcha"]')?.value,
         }).then(function (result) {
             let toastType = result.toast_type;
             if (toastType === 'success') {


### PR DESCRIPTION
Turnstile was missing on website_event and website_mass_mailing. This commit now implements turnstile in those two modules.

This lack of implementation is a problem because it tries to verify the google recaptcha by calling _verify_request_recaptcha_token, which Turnstile also overrides. Therefore when Turnstile was enabled none of these forms would work anymore.

Due to website_mass_mailing allowing multiple places to subscribe to the newsletter (pop up and custom form), Turnstile needed to be made compatible with multiple inputs. This commit also makes that a possibility.

Task-4592066