### PR TITLE
[FIX] website_links: importing the test

### DIFF
--- a/addons/website_links/tests/__init__.py
+++ b/addons/website_links/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 
 from . import test_controller
+from . import test_link_tracker
 from . import test_ui


### PR DESCRIPTION
I edited this commit https://github.com/odoo/odoo/pull/194331/commits/9b74eec3e175b7982cae67d1219197634fdfe00d and I forgot to re-stadge `__init__.py` file.

OPW-4235176



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
