### PR TITLE
[FIX] web: res_user_group_ids widget: keep hidden groups

### DIFF
--- a/addons/web/static/src/webclient/res_user_group_ids_field/res_user_group_ids_field.js
+++ b/addons/web/static/src/webclient/res_user_group_ids_field/res_user_group_ids_field.js
@@ -20,6 +20,9 @@ export class ResUserGroupIdsField extends Component {
     setup() {
         this.sections = this.props.record.data.view_group_hierarchy;
         this.categories = this.sections.map((section) => section.categories).flat();
+        this.groupIdsInCategories = Object.values(this.categories)
+            .map((c) => c.groups.map((g) => g[0]))
+            .flat();
 
         this.fields = {};
         for (const category of this.categories) {
@@ -61,7 +64,11 @@ export class ResUserGroupIdsField extends Component {
 
     onRecordChanged(_, values) {
         const groupIds = Object.values(values).filter((groupId) => groupId);
-        return this.props.record.update({ group_ids: [x2ManyCommands.set(groupIds)] });
+        const groupIdsNotInCategories = this.props.record.data.group_ids.currentIds.filter(
+            (id) => !this.groupIdsInCategories.includes(id)
+        );
+        const allGroupIds = groupIdsNotInCategories.concat(groupIds);
+        return this.props.record.update({ group_ids: [x2ManyCommands.set(allGroupIds)] });
     }
 }
 

--- a/addons/web/static/tests/webclient/res_user_group_ids_field.test.js
+++ b/addons/web/static/tests/webclient/res_user_group_ids_field.test.js
@@ -175,6 +175,38 @@ test("add and remove groups", async () => {
     await contains(`.o_form_button_save`).click();
 });
 
+test("editing groups doesn't remove groups that are not in categories", async () => {
+    // this group doesn't belong to a category, so it can't be added/removed from the relation
+    // with the `res_user_group_ids` widget.
+    ResGroups._records.push({
+        id: 101,
+        name: "Extra Rights",
+    });
+    ResUsers._records[0].group_ids.push(101);
+
+    onRpc("web_save", ({ args }) => {
+        expect(args[1].group_ids).toEqual([[6, false, [101, 1]]]);
+    });
+
+    await mountView({
+        type: "form",
+        arch: `
+            <form>
+                <sheet>
+                    <group>
+                        <field name="group_ids" nolabel="1" widget="res_user_group_ids"/>
+                    </group>
+                </sheet>
+            </form>`,
+        resModel: "res.users",
+        resId: 1,
+    });
+
+    await click(".o_field_selection select:eq(1)");
+    await select("false");
+    await contains(`.o_form_button_save`).click();
+});
+
 test.tags("desktop");
 test(`category tooltips`, async () => {
     await mountView({


### PR DESCRIPTION
Before this commit, when editing the user groups via the new `res_user_group_ids` widget, a command 6 (replace all) was generated, to re-write the whole relation. However, the ids sent were only those belonging to categories (i.e. those accessible from that widget), but the `group_ids` field can also have groups that do not belong to any category (e.g. "Extra Rights > Technical Features"). Those groups were automatically removed from the relation.

This commit fixes the issue by ensuring to also keep those groups in the list of ids sent to the command 6.

opw-4603720

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
