### PR TITLE
[FIX] l10n_es_edi_tbai: avoid sending to Ticketbai when errors in SII

### DIFF
--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -71,6 +71,10 @@ class AccountEdiFormat(models.Model):
         if self.code != 'es_tbai' or invoice.country_code != 'ES':
             return errors
 
+        if invoice.edi_document_ids.filtered(lambda d: d.edi_format_id.code == 'es_sii'
+                                                       and d.edi_state == 'to_send' and d.error):
+            errors.append(_("Make sure SII does not give errors before sending to TicketBai. "))
+
         if invoice.is_purchase_document() and not invoice.ref:
             errors.append(_("You need to fill in the Reference field as the invoice number from your vendor."))
 


### PR DESCRIPTION
If you have SII and Ticketbai and SII is sometimes more strict, you do not want Ticketbai to be sent if SII gave errors.

opw-4484386

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
