### PR TITLE
[FIX] im_livechat: no close confirm when another operator is available

### DIFF
--- a/addons/im_livechat/static/src/core/common/chat_window_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/chat_window_model_patch.js
@@ -40,6 +40,10 @@ const chatWindowPatch = {
                 }
                 this.actionsDisabled = true;
                 this.livechatStep = CW_LIVECHAT_STEP.CONFIRM_CLOSE;
+                if (!isSelfVisitor && this.thread.channel_member_ids.length > 2) {
+                    super.close(...arguments);
+                    break;
+                }
                 if (!this.hubAsOpened) {
                     this.open({ focus: true });
                 }
@@ -47,7 +51,7 @@ const chatWindowPatch = {
             }
             case CW_LIVECHAT_STEP.CONFIRM_CLOSE: {
                 this.actionsDisabled = false;
-                if (this.thread.livechatVisitorMember?.persona?.eq(this.store.self)) {
+                if (isSelfVisitor) {
                     this.open({ focus: true, notifyState: this.thread?.state !== "open" });
                     this.livechatStep = CW_LIVECHAT_STEP.FEEDBACK;
                 } else {

--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -67,7 +67,7 @@ patch(Thread.prototype, {
     },
 
     get leaveNotificationMessage() {
-        if (this.channel_type === "livechat") {
+        if (this.channel_type === "livechat" && !this.livechat_active) {
             return _t("You ended the conversation with %(name)s.", { name: this.displayName });
         }
         return super.leaveNotificationMessage;

--- a/addons/im_livechat/static/tests/chat_window_patch.test.js
+++ b/addons/im_livechat/static/tests/chat_window_patch.test.js
@@ -1,4 +1,11 @@
-import { click, contains, openDiscuss, start, startServer } from "@mail/../tests/mail_test_helpers";
+import {
+    click,
+    contains,
+    openDiscuss,
+    setupChatHub,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
 import { animationFrame } from "@odoo/hoot-mock";
 import { describe, test } from "@odoo/hoot";
 import { Command, serverState } from "@web/../tests/web_test_helpers";
@@ -109,4 +116,25 @@ test("Focus should not be stolen when a new livechat open", async () => {
     await contains(".o-mail-ChatWindow", { text: "Visitor 12" });
     await animationFrame();
     await contains(".o-mail-Composer-input[placeholder='Message #general…']:focus");
+});
+
+test("do not ask confirmation if other operators are present", async () => {
+    const pyEnv = await startServer();
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor #12" });
+    const otherOperatorId = pyEnv["res.partner"].create({ name: "John" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: otherOperatorId }),
+        ],
+        livechat_operator_id: serverState.partnerId,
+        channel_type: "livechat",
+        livechat_active: true,
+    });
+    setupChatHub({ opened: [channelId] });
+    await start();
+    await contains(".o-mail-ChatWindow");
+    await click("[title*='Close Chat Window']");
+    await contains(".o_notification", { text: "You left Visitor #12." });
 });


### PR DESCRIPTION
Before this PR, live chat was closed automatically when the operator left the channel. However, it should not be closed until the last operator or the visitor leaves. This PR fixes the issue.

task-4575328

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
