### PR TITLE
[FIX] mrp: display correct cost of manufacturing order

### DIFF
--- a/addons/mrp/tests/test_stock_report.py
+++ b/addons/mrp/tests/test_stock_report.py
@@ -513,3 +513,125 @@ class TestMrpStockReports(TestReportsCommon):
         self.assertEqual(len(repl1), 1)
         self.assertEqual(repl0[0]['summary']['quantity'], 3)
         self.assertEqual(repl1[0]['summary']['quantity'], 5)
+
+    def test_report_price_variants(self):
+        """
+        This tests the MO's report price when a variant is involved. It makes sure
+        that the BoM price takes only the current variant and not all of them. It also
+        tests that the lines that were removed from the MO but are still in the bom are
+        used in the BoM cost computing. Lastly, it makes sure that Kits are also accounted
+        for and used in the BoM cost as they should.
+        """
+        # Create a color variant, which will be used to create a Product
+        attribute_color = self.env['product.attribute'].create({'name': 'Color'})
+        value_black, value_white = self.env['product.attribute.value'].create({
+            'name': name,
+            'attribute_id': attribute_color.id,
+        } for name in ['Black', 'White'])
+        # Create 3 product templates, one for the variants, to check to not all variants are used
+        # to compute the cost of the MO, another one to make sure the 'missing components' are still
+        # taken into account (they are the product that were removed from the MO but are still present
+        # in the BoM), and the last one to make sure that kits are still taken in as well.
+        product_variants, missing_product, kit_product = self.env['product.template'].create([
+            {
+                'name': 'Variant Product',
+                'type': 'consu',
+                'attribute_line_ids': [Command.create(
+                    {
+                        'attribute_id': attribute_color.id,
+                        'value_ids': [
+                            Command.link(value_black.id),
+                            Command.link(value_white.id),
+                        ],
+                    },
+                )],
+            },
+            {
+                'name': 'Missing Component',
+                'type': 'consu',
+                'standard_price': 40,
+            },
+            {
+                'name': 'Kit Product',
+                'type': 'consu',
+                'standard_price': 60,
+            },
+        ])
+
+        variant_black = product_variants.product_variant_ids[0]
+        variant_white = product_variants.product_variant_ids[1]
+        variant_black.standard_price = 50
+        variant_white.standard_price = 30
+        bom_normal, _ = self.env['mrp.bom'].create([
+            {
+                'product_tmpl_id': product_variants.id,
+                'type': 'normal',
+                'bom_line_ids': [Command.create({
+                    'product_id': missing_product.product_variant_id.id,
+                    'product_qty': 1,
+                }),
+                Command.create({
+                    'product_id': kit_product.product_variant_id.id,
+                    'product_qty': 1,
+                })],
+            },
+            {
+                'product_tmpl_id': kit_product.id,
+                'type': 'phantom',
+                'bom_line_ids': [Command.create({
+                    'product_id': missing_product.product_variant_id.id,
+                    'product_qty': 1,
+                })]
+            },
+        ])
+        white_tmpl = bom_normal.product_tmpl_id.product_variant_ids.product_template_attribute_value_ids.filtered(lambda tmpl: tmpl.product_attribute_value_id == value_white)
+        black_tmpl = bom_normal.product_tmpl_id.product_variant_ids.product_template_attribute_value_ids.filtered(lambda tmpl: tmpl.product_attribute_value_id == value_black)
+        black_white_product, black_product, white_product = self.env['product.product'].create([{
+                'name': 'Black White',
+                'type': 'consu',
+                'standard_price': 25,
+            },
+            {
+                'name': 'Black Only',
+                'type': 'consu',
+                'standard_price': 15,
+            },
+            {
+                'name': 'White Only',
+                'type': 'consu',
+                'standard_price': 10,
+            },
+        ])
+        self.env['mrp.bom.line'].create([{
+                'bom_id': bom_normal.id,
+                'product_id': black_white_product.id,
+                'product_qty': 1,
+                'bom_product_template_attribute_value_ids': [Command.set([black_tmpl.id, white_tmpl.id])],
+            },
+            {
+                'bom_id': bom_normal.id,
+                'product_id': black_product.id,
+                'product_qty': 1,
+                'bom_product_template_attribute_value_ids': [Command.set([black_tmpl.id])],
+            },
+                        {
+                'bom_id': bom_normal.id,
+                'product_id': white_product.id,
+                'product_qty': 1,
+                'bom_product_template_attribute_value_ids': [Command.set([white_tmpl.id])],
+            }
+        ])
+        mo = self.env['mrp.production'].create({
+            'product_id': variant_black.id,
+            'product_qty': 1,
+            'bom_id': bom_normal.id,
+        })
+        mo_report = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
+        self.assertEqual(mo_report['data']['extras']['unit_bom_cost'], mo_report['data']['extras']['unit_mo_cost'], 'The BoM unit cost should be equal to the sum of the products of said BoM')
+        # Check that the missing components (the components that were removed from the MO but are still in the BoM)
+        # are taken into account when computing the BoM cost
+        mo.move_raw_ids.filtered(lambda m: m.product_id == missing_product.product_variant_id and m.bom_line_id.bom_id.type != 'phantom').unlink()
+        # When a product has two possible variants, and then is deleted, it should be taken in the missing components
+        mo.move_raw_ids.filtered(lambda m: m.product_id == black_white_product and m.bom_line_id.bom_id.type != 'phantom').unlink()
+        mo_report = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
+        self.assertEqual(mo_report['data']['extras']['unit_bom_cost'], mo_report['data']['extras']['unit_mo_cost'] + missing_product.standard_price + black_white_product.standard_price, 'The BoM unit cost should take the missing components into account, which are the deleted MO lines')


### PR DESCRIPTION
**Problem:**
For products with variants and differents steps for the BoM depending
on the variant, the Manufacturing Order overview for a given product
with a given variant would display the sum of the cost of all variants
possible for this product. If we had a product "Drawer" with a color
variant "Black" and "White", which cost 10 and 20 euros respectively,
the Manufacturing Order overview of a Black Drawer would display the
cost of the drawer + **30** euros (10+20), instead of being the cost
of the drawer + **10** euros. The display cost is the sum of the price
of every variants for this product, instead of being the price of the
current variant of the product.

**Steps to reproduce:**
- Create a product with variants
- Change the BoM and make some components needed only for certain variants and add a price for them
- Go to the MO overview
- The Cost BoM cost total is the sum of all prices AND variants

**Cause of the issue:**
https://github.com/odoo/odoo/blob/d3ab7b2c3ceddbb4cb8d8e91fac0d60e28e5673a/addons/mrp/report/mrp_report_mo_overview.py#L85
This treats every remaining lines of the BoM as a missing component,
thus adding it's price to the total price. Some lines should only be
applied if a specific variant is selected, but with this code, every
line that has a condition depending on variants will be taken in.

**Fix:**
Before adding the product of a BoM line to the missing components, we
check that the BoM line should be applied to the current variant.
The missing components are still used and can be not empty in the
case where the BoM includes a line that was deleted from the MO,
making the MO cost and the BoM cost different. In this case, the
missing components will not be empty and will still work as
intended without taking the unwanted variants into account.

opw-4557169