### PR TITLE
[FIX] website_links: ensure correct base URL

### DIFF
--- a/addons/website_links/models/link_tracker.py
+++ b/addons/website_links/models/link_tracker.py
@@ -21,5 +21,4 @@ class LinkTracker(models.Model):
         current_website = self.env['website'].get_current_website()
         base_url = current_website.get_base_url() if current_website == self.env.company.website_id else self.env.company.get_base_url()
         for tracker in self:
-            base_url = self.env['website'].get_current_website().get_base_url()
             tracker.short_url_host = urls.url_join(base_url, '/r/')

--- a/addons/website_links/tests/__init__.py
+++ b/addons/website_links/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 
 from . import test_controller
+from . import test_link_tracker
 from . import test_ui


### PR DESCRIPTION
This commit e35b3b088584b45b0278174da355d09e7e47633b was a fix for wrong calculation of base_url but the old calculation still there

This was not detected because the test was not imported in __init__ file

now it is removed and the test is imported in `__init__.py`

 opw-4235176



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
