### PR TITLE
[FIX] mail: chat window above from view scrollbar

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -1,7 +1,7 @@
 .o-mail-ChatWindow {
     width: $o-mail-ChatWindow-width;
 
-    z-index: $zindex-dropdown + 1;
+    z-index: $zindex-sticky;
     &:not(.o-mobile) {
         --border-opacity: .15;
         aspect-ratio: 9 / 15;


### PR DESCRIPTION
Before this commit, when chat windows are open above form view, the scrollbar of form view was shown above the chat window.

Steps to reproduce:
- open project task with pad aside (1080p+ screen)
- open 2 or 3 chat windows
- type many lines in project task pad to make form view scrollable
- (optional) scroll on the form view => the scrollbar is above the chat windows

This happens from a recent change [1] that increased the z-index of statusbar and ribbon of form view. This had the side-effect of also making z-index of scrollbar as high as their new z-index, which is `$zindex-sticky: 1020`.

Chat window z-index was `$zindex-dropdown + 1: 1001`, slightly higher than the z-index of document views elements that were also negatively affecting chat windows [2].

This commit fixes the issue by increasing even more the z-index of chat windows, from 1001 to 1020. This puts them at the same level as sticky.

Task-4604254

Before
![before](https://github.com/user-attachments/assets/5f744fd4-adb9-4937-8589-9567a3d3225c)

After
![after](https://github.com/user-attachments/assets/dedba5cc-de88-4258-b2f1-441ccca6aa53)



[1]: https://github.com/odoo/odoo/pull/197581
[2]: https://github.com/odoo/odoo/pull/198362
