### PR TITLE
 [IMP] web: render web client without waiting for menus

### DIFF
--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -71,11 +71,11 @@ class Home(http.Controller):
         except AccessError:
             return request.redirect('/web/login?error=access')
 
-    @http.route('/web/webclient/load_menus/<string:unique>', type='http', auth='user', methods=['GET'], readonly=True)
-    def web_load_menus(self, unique, lang=None):
+    @http.route('/web/webclient/load_menus', type='http', auth='user', methods=['GET'], readonly=True)
+    def web_load_menus(self, unique=None, lang=None):
         """
         Loads the menus for the webclient
-        :param unique: this parameters is not used, but mandatory: it is used by the HTTP stack to make a unique request
+        :param unique: this parameters is not used: it is used by the HTTP stack to make a unique request
         :param lang: language in which the menus should be loaded (only works if language is installed)
         :return: the menus (including the images in Base64)
         """

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -138,16 +138,6 @@ class IrHttp(models.AbstractModel):
         if request.session.debug:
             session_info['bundle_params']['debug'] = request.session.debug
         if is_internal_user:
-            # the following is only useful in the context of a webclient bootstrapping
-            # but is still included in some other calls (e.g. '/web/session/authenticate')
-            # to avoid access errors and unnecessary information, it is only included for users
-            # with access to the backend ('internal'-type users)
-            menus = self.env['ir.ui.menu'].with_context(lang=request.session.context['lang']).load_menus(request.session.debug)
-            ordered_menus = {str(k): v for k, v in menus.items()}
-            menu_json_utf8 = json.dumps(ordered_menus, sort_keys=True).encode()
-            session_info['cache_hashes'].update({
-                "load_menus": hashlib.sha512(menu_json_utf8).hexdigest()[:64], # sha512/256
-            })
             # We need sudo since a user may not have access to ancestor companies
             # We use `_get_company_ids` because it is cached and we sudo it because env.user return a sudo user.
             user_companies = self.env['res.company'].browse(user._get_company_ids()).sudo()

--- a/addons/web/static/src/webclient/menus/menu_service.js
+++ b/addons/web/static/src/webclient/menus/menu_service.js
@@ -1,89 +1,97 @@
 import { browser } from "../../core/browser/browser";
 import { registry } from "../../core/registry";
-import { session } from "@web/session";
 
 const loadMenusUrl = `/web/webclient/load_menus`;
-
-function makeFetchLoadMenus() {
-    const cacheHashes = session.cache_hashes;
-    let loadMenusHash = cacheHashes.load_menus || new Date().getTime().toString();
-    return async function fetchLoadMenus(reload) {
-        if (reload) {
-            loadMenusHash = new Date().getTime().toString();
-        } else if (odoo.loadMenusPromise) {
-            return odoo.loadMenusPromise;
-        }
-        const res = await browser.fetch(`${loadMenusUrl}/${loadMenusHash}`);
-        if (!res.ok) {
-            throw new Error("Error while fetching menus");
-        }
-        return res.json();
-    };
-}
-
-function makeMenus(env, menusData, fetchLoadMenus) {
-    let currentAppId;
-    function _getMenu(menuId) {
-        return menusData[menuId];
-    }
-    function setCurrentMenu(menu) {
-        menu = typeof menu === "number" ? _getMenu(menu) : menu;
-        if (menu && menu.appID !== currentAppId) {
-            currentAppId = menu.appID;
-            browser.sessionStorage.setItem("menu_id", currentAppId);
-            env.bus.trigger("MENUS:APP-CHANGED");
-        }
-    }
-
-    return {
-        getAll() {
-            return Object.values(menusData);
-        },
-        getApps() {
-            return this.getMenu("root").children.map((mid) => this.getMenu(mid));
-        },
-        getMenu: _getMenu,
-        getCurrentApp() {
-            if (!currentAppId) {
-                return;
-            }
-            return this.getMenu(currentAppId);
-        },
-        getMenuAsTree(menuID) {
-            const menu = this.getMenu(menuID);
-            if (!menu.childrenTree) {
-                menu.childrenTree = menu.children.map((mid) => this.getMenuAsTree(mid));
-            }
-            return menu;
-        },
-        async selectMenu(menu) {
-            menu = typeof menu === "number" ? this.getMenu(menu) : menu;
-            if (!menu.actionID) {
-                return;
-            }
-            await env.services.action.doAction(menu.actionID, {
-                clearBreadcrumbs: true,
-                onActionReady: () => {
-                    setCurrentMenu(menu);
-                },
-            });
-        },
-        setCurrentMenu,
-        async reload() {
-            if (fetchLoadMenus) {
-                menusData = await fetchLoadMenus(true);
-                env.bus.trigger("MENUS:APP-CHANGED");
-            }
-        },
-    };
-}
 
 export const menuService = {
     dependencies: ["action"],
     async start(env) {
-        const fetchLoadMenus = makeFetchLoadMenus();
-        const menusData = await fetchLoadMenus();
-        return makeMenus(env, menusData, fetchLoadMenus);
+        let currentAppId;
+        let menusData;
+
+        const fetchMenus = async (reload) => {
+            if (!reload && odoo.loadMenusPromise) {
+                return odoo.loadMenusPromise;
+            }
+            const loadMenusHash = new Date().getTime().toString();
+            const res = await browser.fetch(`${loadMenusUrl}/${loadMenusHash}`);
+            if (!res.ok) {
+                throw new Error("Error while fetching menus");
+            }
+            return res.json();
+        };
+        const storedMenus = browser.localStorage.getItem("webclient_menus");
+        const storedMenusVersion = browser.localStorage.getItem("webclient_menus_version");
+
+        if (storedMenus && storedMenusVersion === odoo.info.server_version) {
+            fetchMenus().then((res) => {
+                const fetchedMenus = JSON.stringify(res);
+                if (fetchedMenus !== storedMenus) {
+                    browser.localStorage.setItem("webclient_menus", fetchedMenus);
+                    menusData = res;
+                    env.bus.trigger("MENUS:APP-CHANGED");
+                }
+            });
+            menusData = JSON.parse(storedMenus);
+        } else {
+            menusData = await fetchMenus();
+            browser.localStorage.setItem("webclient_menus_version", odoo.info.server_version);
+            browser.localStorage.setItem("webclient_menus", JSON.stringify(menusData));
+        }
+
+        function _getMenu(menuId) {
+            return menusData[menuId];
+        }
+        function setCurrentMenu(menu) {
+            menu = typeof menu === "number" ? _getMenu(menu) : menu;
+            if (menu && menu.appID !== currentAppId) {
+                currentAppId = menu.appID;
+                browser.sessionStorage.setItem("menu_id", currentAppId);
+                env.bus.trigger("MENUS:APP-CHANGED");
+            }
+        }
+
+        return {
+            getAll() {
+                return Object.values(menusData);
+            },
+            getApps() {
+                return this.getMenu("root").children.map((mid) => this.getMenu(mid));
+            },
+            getMenu: _getMenu,
+            getCurrentApp() {
+                if (!currentAppId) {
+                    return;
+                }
+                return this.getMenu(currentAppId);
+            },
+            getMenuAsTree(menuID) {
+                const menu = this.getMenu(menuID);
+                if (!menu.childrenTree) {
+                    menu.childrenTree = menu.children.map((mid) => this.getMenuAsTree(mid));
+                }
+                return menu;
+            },
+            async selectMenu(menu) {
+                menu = typeof menu === "number" ? this.getMenu(menu) : menu;
+                if (!menu.actionID) {
+                    return;
+                }
+                await env.services.action.doAction(menu.actionID, {
+                    clearBreadcrumbs: true,
+                    onActionReady: () => {
+                        setCurrentMenu(menu);
+                    },
+                });
+            },
+            setCurrentMenu,
+            async reload() {
+                if (fetchMenus) {
+                    menusData = await fetchMenus(true);
+                    env.bus.trigger("MENUS:APP-CHANGED");
+                }
+            },
+        };
     },
 };
 

--- a/addons/web/static/src/webclient/menus/menu_service.js
+++ b/addons/web/static/src/webclient/menus/menu_service.js
@@ -14,7 +14,7 @@ export const menuService = {
                 return odoo.loadMenusPromise;
             }
             const loadMenusHash = new Date().getTime().toString();
-            const res = await browser.fetch(`${loadMenusUrl}/${loadMenusHash}`);
+            const res = await browser.fetch(`${loadMenusUrl}?unique=${loadMenusHash}`);
             if (!res.ok) {
                 throw new Error("Error while fetching menus");
             }

--- a/addons/web/static/tests/_framework/mock_server/mock_server.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_server.js
@@ -398,7 +398,7 @@ export class MockServer {
         this._onRoute(["/web/image/<string:model>/<int:id>/<string:field>"], this.loadImage, {
             pure: true,
         });
-        this._onRoute(["/web/webclient/load_menus/<string:unique>"], this.loadMenus, {
+        this._onRoute(["/web/webclient/load_menus"], this.loadMenus, {
             pure: true,
         });
         this._onRoute(["/web/webclient/translations/<string:unique>"], this.loadTranslations, {

--- a/addons/web/static/tests/_framework/mock_session.hoot.js
+++ b/addons/web/static/tests/_framework/mock_session.hoot.js
@@ -27,7 +27,6 @@ const makeSession = ({
         lang,
     },
     cache_hashes: {
-        load_menus: "164b675eb9bf49f8bca52e350cd81482a8cf0d0c1c8a47d99bd063c0a0bf4f0d",
         translations: "f17c8e4bb0fd4d5db2615d28713486df97853a8f",
     },
     can_insert_in_spreadsheet: true,

--- a/addons/web/static/tests/_framework/webclient_test_helpers.js
+++ b/addons/web/static/tests/_framework/webclient_test_helpers.js
@@ -26,12 +26,16 @@ export function useTestClientAction() {
 /**
  * @param {Parameters<typeof mountWithCleanup>[1]} [options]
  */
-export async function mountWebClient(options) {
-    await mountWithCleanup(WebClient, options);
+export async function mountWebClient(options = {}) {
+    const WebClientComponent = options.WebClient || WebClient;
+    delete options.WebClient;
+    const webClient = await mountWithCleanup(WebClientComponent, options);
     // Wait for visual changes caused by a potential loadState
     await animationFrame();
     // wait for BlankComponent
     await animationFrame();
     // wait for the regular rendering
     await animationFrame();
+
+    return webClient;
 }

--- a/addons/web/static/tests/legacy/helpers/mock_services.js
+++ b/addons/web/static/tests/legacy/helpers/mock_services.js
@@ -137,11 +137,7 @@ export function makeMockFetch(mockRPC) {
     return async (input, params) => {
         let route = typeof input === "string" ? input : input.url;
         if (route.includes("load_menus")) {
-            const routeArray = route.split("/");
-            params = {
-                hash: routeArray.pop(),
-            };
-            route = routeArray.join("/");
+            route = route.split("?")[0];
         }
         let res;
         let status;

--- a/addons/web/static/tests/legacy/setup.js
+++ b/addons/web/static/tests/legacy/setup.js
@@ -213,6 +213,12 @@ function patchBodyAddEventListener() {
 function patchOdoo() {
     patchWithCleanup(odoo, {
         debug: "",
+        info: {
+            db: sessionInfo.db,
+            server_version: sessionInfo.server_version,
+            server_version_info: sessionInfo.server_version_info,
+            isEnterprise: sessionInfo.server_version_info.slice(-1)[0] === "e",
+        },
     });
 }
 
@@ -225,7 +231,6 @@ function cleanLoadedLanguages() {
 function patchSessionInfo() {
     patchWithCleanup(sessionInfo, {
         cache_hashes: {
-            load_menus: "161803",
             translations: "314159",
         },
         qweb: "owl",
@@ -365,8 +370,8 @@ export async function setupTests() {
         patchCookie();
         patchBodyAddEventListener();
         patchEventBus();
-        patchOdoo();
         patchSessionInfo();
+        patchOdoo();
         patchOwlApp();
     });
 

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -11643,10 +11643,14 @@ test("open a one2many record containing a one2many", async () => {
 
     patchWithCleanup(browser.localStorage, {
         setItem(args) {
-            expect.step(`localStorage setItem ${args}`);
+            if (["optional_fields", "debug_open_view"].some((word) => args.startsWith(word))) {
+                expect.step(`localStorage setItem ${args}`);
+            }
         },
         getItem(args) {
-            expect.step(`localStorage getItem ${args}`);
+            if (["optional_fields", "debug_open_view"].some((word) => args.startsWith(word))) {
+                expect.step(`localStorage getItem ${args}`);
+            }
             return null;
         },
     });
@@ -11665,8 +11669,6 @@ test("open a one2many record containing a one2many", async () => {
     });
 
     expect.verifySteps([
-        "localStorage getItem web.emoji.frequent",
-        "localStorage getItem pwaService.installationState",
         "localStorage getItem optional_fields,partner,form,123456789,p,list,name",
         "localStorage getItem debug_open_view,partner,form,123456789,p,list,name",
     ]);

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -10074,11 +10074,15 @@ test(`"bare" buttons in template should not trigger button click`, async () => {
 test(`form view with inline list view with optional fields and local storage mock`, async () => {
     patchWithCleanup(browser.localStorage, {
         getItem(key) {
-            expect.step(`getItem ${key}`);
+            if (["optional_fields", "debug_open_view"].some((word) => key.startsWith(word))) {
+                expect.step(`getItem ${key}`);
+            }
             return super.getItem(key);
         },
         setItem(key, value) {
-            expect.step(`setItem ${key} to ${value}`);
+            if (["optional_fields", "debug_open_view"].some((word) => key.startsWith(word))) {
+                expect.step(`setItem ${key} to ${value}`);
+            }
             return super.setItem(key, value);
         },
     });
@@ -10101,8 +10105,6 @@ test(`form view with inline list view with optional fields and local storage moc
 
     const localStorageKey = "partner,form,123456789,child_ids,list,bar,foo";
     expect.verifySteps([
-        "getItem web.emoji.frequent",
-        "getItem pwaService.installationState",
         `getItem optional_fields,${localStorageKey}`,
         `getItem debug_open_view,${localStorageKey}`,
     ]);
@@ -10131,11 +10133,15 @@ test.tags("desktop");
 test(`form view with list_view_ref with optional fields and local storage mock`, async () => {
     patchWithCleanup(browser.localStorage, {
         getItem(key) {
-            expect.step(`getItem ${key}`);
+            if (["optional_fields", "debug_open_view"].some((word) => key.startsWith(word))) {
+                expect.step(`getItem ${key}`);
+            }
             return super.getItem(key);
         },
         setItem(key, value) {
-            expect.step(`setItem ${key} to ${value}`);
+            if (["optional_fields", "debug_open_view"].some((word) => key.startsWith(word))) {
+                expect.step(`setItem ${key} to ${value}`);
+            }
             return super.setItem(key, value);
         },
     });
@@ -10166,8 +10172,6 @@ test(`form view with list_view_ref with optional fields and local storage mock`,
 
     const localStorageKey = "partner,form,123456789,child_ids,list,bar,foo";
     expect.verifySteps([
-        "getItem web.emoji.frequent",
-        "getItem pwaService.installationState",
         `getItem optional_fields,${localStorageKey}`,
         `getItem debug_open_view,${localStorageKey}`,
     ]);

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -2722,7 +2722,7 @@ test("pivot is reloaded when leaving and coming back", async () => {
     onRpc("partner", "*", ({ method }) => {
         expect.step(method);
     });
-    onRpc("/web/webclient/load_menus/*", () => {
+    onRpc("/web/webclient/load_menus", () => {
         expect.step("/web/webclient/load_menus");
     });
 

--- a/addons/web/static/tests/webclient/menu_service.test.js
+++ b/addons/web/static/tests/webclient/menu_service.test.js
@@ -83,7 +83,7 @@ test.tags("desktop");
 test(`use stored menus, and don't update on load_menus return (if identical)`, async () => {
     const def = new Deferred();
     redirect("/odoo/action-666");
-    onRpc("/web/webclient/load_menus/*", () => def);
+    onRpc("/web/webclient/load_menus", () => def);
 
     // Initial Stored values
     browser.localStorage.webclient_menus_version = "1.0";
@@ -110,7 +110,7 @@ test.tags("desktop");
 test(`use stored menus, and update on load_menus return`, async () => {
     const def = new Deferred();
     redirect("/odoo/action-666");
-    onRpc("/web/webclient/load_menus/*", () => def);
+    onRpc("/web/webclient/load_menus", () => def);
 
     // Initial Stored values
     // There is no menu "Test2" in the initial values

--- a/addons/web/static/tests/webclient/menu_service.test.js
+++ b/addons/web/static/tests/webclient/menu_service.test.js
@@ -1,0 +1,170 @@
+import { expect, test } from "@odoo/hoot";
+import { redirect } from "@web/core/utils/urls";
+import {
+    defineActions,
+    defineMenus,
+    defineModels,
+    fields,
+    models,
+    mountWebClient,
+    onRpc,
+    webModels,
+} from "@web/../tests/web_test_helpers";
+import { browser } from "@web/core/browser/browser";
+import { Deferred } from "@odoo/hoot-mock";
+import { animationFrame } from "@odoo/hoot-dom";
+
+defineActions([
+    {
+        id: 666,
+        xml_id: "action_1",
+        name: "Partners Action 1",
+        res_model: "partner",
+        views: [[false, "kanban"]],
+    },
+]);
+
+class Partner extends models.Model {
+    name = fields.Char();
+    foo = fields.Char();
+
+    _records = [
+        { id: 1, name: "First record", foo: "yop" },
+        { id: 2, name: "Second record", foo: "blip" },
+        { id: 3, name: "Third record", foo: "gnap" },
+        { id: 4, name: "Fourth record", foo: "plop" },
+        { id: 5, name: "Fifth record", foo: "zoup" },
+    ];
+    _views = {
+        kanban: `
+            <kanban>
+                <templates>
+                    <t t-name="card">
+                        <field name="foo"/>
+                    </t>
+                </templates>
+            </kanban>
+        `,
+        list: `<list><field name="foo"/></list>`,
+        form: `
+            <form>
+                <group>
+                    <field name="display_name"/>
+                    <field name="foo"/>
+                </group>
+            </form>
+        `,
+        search: `<search><field name="foo" string="Foo"/></search>`,
+    };
+}
+const { ResCompany, ResPartner, ResUsers } = webModels;
+defineModels([Partner, ResCompany, ResPartner, ResUsers]);
+defineMenus([
+    {
+        id: "root",
+        children: [
+            {
+                id: 1,
+                children: [
+                    { id: 2, children: [], name: "Test1", appID: 1, actionID: 666 },
+                    { id: 3, children: [], name: "Test2", appID: 1, actionID: 666 },
+                ],
+                name: "App1",
+                appID: 1,
+                actionID: 666,
+            },
+        ],
+        name: "root",
+        appID: "root",
+    },
+]);
+
+test.tags("desktop");
+test(`use stored menus, and don't update on load_menus return (if identical)`, async () => {
+    const def = new Deferred();
+    redirect("/odoo/action-666");
+    onRpc("/web/webclient/load_menus/*", () => def);
+
+    // Initial Stored values
+    browser.localStorage.webclient_menus_version = "1.0";
+    browser.localStorage.webclient_menus = JSON.stringify({
+        1: { id: 1, children: [2, 3], name: "App1", appID: 1, actionID: 666 },
+        2: { id: 2, children: [], name: "Test1", appID: 1, actionID: 666 },
+        3: { id: 3, children: [], name: "Test2", appID: 1, actionID: 666 },
+        99999: { id: 99999, appID: 1, children: [], name: "App0" },
+        root: { id: "root", children: [1], name: "root", appID: "root" },
+    });
+
+    const webClient = await mountWebClient();
+    webClient.env.bus.addEventListener("MENUS:APP-CHANGED", () => expect.step("Don't Update"));
+    expect(`.o_menu_brand`).toHaveText("App1");
+    expect(browser.sessionStorage.getItem("menu_id")).toBe("1");
+    expect(".o_menu_sections").toHaveText("Test1\nTest2");
+    def.resolve();
+    await animationFrame();
+    expect(".o_menu_sections").toHaveText("Test1\nTest2");
+    expect.verifySteps([]);
+});
+
+test.tags("desktop");
+test(`use stored menus, and update on load_menus return`, async () => {
+    const def = new Deferred();
+    redirect("/odoo/action-666");
+    onRpc("/web/webclient/load_menus/*", () => def);
+
+    // Initial Stored values
+    // There is no menu "Test2" in the initial values
+    browser.localStorage.webclient_menus_version = "1.0";
+    browser.localStorage.webclient_menus = JSON.stringify({
+        1: { id: 1, children: [2], name: "App1", appID: 1, actionID: 666 },
+        2: { id: 2, children: [], name: "Test1", appID: 1, actionID: 666 },
+        99999: { id: 99999, appID: 1, children: [], name: "App0" },
+        root: { id: "root", children: [1], name: "root", appID: "root" },
+    });
+
+    const webClient = await mountWebClient();
+    webClient.env.bus.addEventListener("MENUS:APP-CHANGED", () => expect.step("Update Menus"));
+    expect(`.o_menu_brand`).toHaveText("App1");
+    expect(browser.sessionStorage.getItem("menu_id")).toBe("1");
+    expect(".o_menu_sections").toHaveText("Test1");
+    expect.verifySteps([]);
+    def.resolve();
+    await animationFrame();
+    expect(".o_menu_sections").toHaveText("Test1\nTest2");
+    expect(JSON.parse(browser.localStorage.webclient_menus)).toEqual({
+        1: {
+            actionID: 666,
+            appID: 1,
+            children: [2, 3],
+            id: 1,
+            name: "App1",
+        },
+        2: {
+            actionID: 666,
+            appID: 1,
+            children: [],
+            id: 2,
+            name: "Test1",
+        },
+        3: {
+            actionID: 666,
+            appID: 1,
+            children: [],
+            id: 3,
+            name: "Test2",
+        },
+        99999: {
+            appID: 1,
+            children: [],
+            id: 99999,
+            name: "App0",
+        },
+        root: {
+            appID: "root",
+            children: [1],
+            id: "root",
+            name: "root",
+        },
+    });
+    expect.verifySteps(["Update Menus"]);
+});

--- a/addons/web/tests/test_load_menus.py
+++ b/addons/web/tests/test_load_menus.py
@@ -36,7 +36,7 @@ class LoadMenusTests(HttpCase):
         self.authenticate("admin", "admin")
 
     def test_load_menus(self):
-        menu_loaded = self.url_open("/web/webclient/load_menus/1234")
+        menu_loaded = self.url_open("/web/webclient/load_menus?unique=1234")
         expected = {
             str(self.menu.id): {
                 'actionID': self.action.id,  # Take the first action in children (see load_web_menus)

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -265,7 +265,7 @@
                         odoo.__session_info__ = <t t-out="json.dumps(session_info)"/>;
                         const { user_context,  cache_hashes } = odoo.__session_info__;
                         const lang = new URLSearchParams(document.location.search).get("lang");
-                        let menuURL = `/web/webclient/load_menus/${cache_hashes.load_menus}`;
+                        let menuURL = `/web/webclient/load_menus/${new Date().getTime().toString()}`;
                         if (lang) {
                             user_context.lang = lang;
                             menuURL += `?lang=${lang}`

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -265,10 +265,10 @@
                         odoo.__session_info__ = <t t-out="json.dumps(session_info)"/>;
                         const { user_context,  cache_hashes } = odoo.__session_info__;
                         const lang = new URLSearchParams(document.location.search).get("lang");
-                        let menuURL = `/web/webclient/load_menus/${new Date().getTime().toString()}`;
+                        let menuURL = `/web/webclient/load_menus?unique=${new Date().getTime().toString()}`;
                         if (lang) {
                             user_context.lang = lang;
-                            menuURL += `?lang=${lang}`
+                            menuURL += `&amp;lang=${lang}`;
                         }
                         odoo.reloadMenus = () => fetch(menuURL).then(res => res.json());
                         odoo.loadMenusPromise = odoo.reloadMenus();


### PR DESCRIPTION
Before this commit, the menus were cached inefficiently. In fact, the current
menu hash is computed in order to store it it in the session_info.
Unfortunately, to compute the hash, the entire menus have to be built (but only
the hash is stored in the session_info). The previously calculated hash is then
used to fetch the menus. This way, if the menus haven't changed, the request is
already cached in the browser.

This means that the first time a user accesses the web client, the menu is
calculated twice (once to calculate the hash, and once for the menus
themselves). The next time the user accesses the web client, if the menus
haven't changed, the menu is calculated once, to compute the hash. And twice if
the menus have changed.
Note that there is an ORM inter-request cache that is shared by multiple
methods, and various actions can invalidate this cache. On large databases this
can happen several times a minute, in which case cache hits are unlikely.
Note also that, the web client, waits for this process to finish before
rendering itself. For large databases, calculating the menus can take a long
time, and slows down the web client quite a bit. Note that, the menus available
to a particular user depend not only on the ir.ui.menu, but also on groups.
This makes it difficult to compute the hash differently than it's done now.

Now, each time the user accesses the web client, the menus are fetched. Only
the first access, the web client will wait for the menus to render itself. The
menus are stored in the browser's local storage. The next time the user
accesses the web client, the saved menus are used to render the web client.
When the menus are returned from the fetch, the web client will evaluate them,
and if they are different, the web client will update them.
This means that the first time a user accesses the web client, the menus are
calculated and waited for only once. The next time the user accesses the web
client, the calculation for the menus is not waited for, and the web client is
rendered with the stored menus, and only updated if necessary.

task-id 4479844
