### PR TITLE
[IMP] mail: cancel call invitations after some time

### DIFF
--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -1,5 +1,6 @@
 import { Record } from "@mail/core/common/record";
 import { Thread } from "@mail/core/common/thread_model";
+import { browser } from "@web/core/browser/browser";
 
 import { patch } from "@web/core/utils/patch";
 
@@ -19,14 +20,20 @@ const ThreadPatch = {
         });
         this.hadSelfSession = false;
         this.lastSessionIds = new Set();
+        /** @type {number|undefined} */
+        this.cancelRtcInvitationTimeout;
         this.rtcInvitingSession = Record.one("RtcSession", {
             /** @this {import("models").Thread} */
             onAdd(r) {
                 this.rtcSessions.add(r);
                 this.store.ringingThreads.add(this);
+                this.cancelRtcInvitationTimeout = browser.setTimeout(() => {
+                    this.store.env.services["discuss.rtc"].leaveCall(this);
+                }, 30000);
             },
             /** @this {import("models").Thread} */
             onDelete(r) {
+                browser.clearTimeout(this.cancelRtcInvitationTimeout);
                 this.store.ringingThreads.delete(this);
             },
         });


### PR DESCRIPTION
Before this PR, rtc invitations were only canceled when the user clicked on the decline button. Sometimes, users are busy and having this call invitation that keeps ringing forever is cumbersome. This PR removes this invitation after 30s.

task-4345479

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
