### PR TITLE
[FIX] stock: fix 2 steps delivery customer sublocation

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -227,6 +227,9 @@ class StockRule(models.Model):
         else:
             new_move_vals = self._push_prepare_move_copy_values(move, new_date)
             new_move = move.sudo().copy(new_move_vals)
+            # when no more push we should reach final destination
+            if new_move._skip_push():
+                new_move.write({'location_dest_id': new_move.location_final_id.id})
             if new_move._should_bypass_reservation():
                 new_move.write({'procure_method': 'make_to_stock'})
             if not new_move.location_id.should_bypass_reservation():


### PR DESCRIPTION
To reproduce:
=============
- create a contact with customer location : Partners/Customer/test
- enable 2 steps delivery on warehouse
- create SO for the contact and confirm it
- validate first step of delivery
- check second step of delivery -> the destination location is Partners/Customer instead of Partners/Customer/test

Problem:
========
Now that we are creating moves step by step we are not passing the destination location to the second move and using the one set on the rule.

Solution:
=========
when creating second move and it's last step we set destination to final destination location.

opw-4374075

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
