### PR TITLE
[FIX] point_of_sale: keep tracking number of orders from another session

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1214,6 +1214,7 @@ class PosOrder(models.Model):
             'access_token': order.access_token,
             'ticket_code': order.ticket_code,
             'last_order_preparation_change': order.last_order_preparation_change,
+            'tracking_number': order.tracking_number,
         }
 
     @api.model

--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -1463,7 +1463,7 @@ export class Order extends PosModel {
         }
 
         this.lastOrderPrepaChange = this.lastOrderPrepaChange || {};
-        this.trackingNumber = (
+        this.trackingNumber = this.trackingNumber || (
             (this.pos_session_id % 10) * 100 +
             (this.sequence_number % 100)
         ).toString();
@@ -1585,6 +1585,7 @@ export class Order extends PosModel {
         this.ticketCode = json.ticket_code || "";
         this.lastOrderPrepaChange =
             json.last_order_preparation_change && JSON.parse(json.last_order_preparation_change);
+        this.trackingNumber = json.tracking_number;
     }
     updateSequenceNumber(json) {
         this.pos.pos_session.sequence_number = Math.max(


### PR DESCRIPTION
**Steps to reproduce:**
- Create a normal POS restaurant and a Kiosk
- Create a Preparation Display with both POS restaurant and Kiosk
- Open a POS restaurant session, a Kiosk session and the preparation display
- Create an order with the Kiosk
- Check the order number on the preparation display
- From the POS restaurant, check all the orders

**Issue:**
The order number of the POS order coming from the Kiosk has a totally different than the original one displayed on the preparation display.

**Cause:**
The front-end is always recomputing the tracking number from the current session, instead of using the value computed in the backend.

opw-4438678




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
