### PR TITLE
[FIX] iap: fix error handling of `iap_jsonrpc`

### DIFF
--- a/addons/iap/tools/iap_tools.py
+++ b/addons/iap/tools/iap_tools.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 from odoo import exceptions, _
 from odoo.tests.common import BaseCase
-from odoo.tools import email_normalize, pycompat
+from odoo.tools import email_normalize, exception_to_unicode, pycompat
 
 _logger = logging.getLogger(__name__)
 
@@ -122,6 +122,10 @@ class InsufficientCreditError(Exception):
     pass
 
 
+class IAPServerError(Exception):
+    pass
+
+
 def iap_jsonrpc(url, method='call', params=None, timeout=15):
     """
     Calls the provided JSON-RPC endpoint, unwraps the result and
@@ -141,28 +145,20 @@ def iap_jsonrpc(url, method='call', params=None, timeout=15):
         response = req.json()
         if 'error' in response:
             name = response['error']['data'].get('name').rpartition('.')[-1]
-            message = response['error']['data'].get('message')
             if name == 'InsufficientCreditError':
-                e_class = InsufficientCreditError
-            elif name == 'AccessError':
-                e_class = exceptions.AccessError
-            elif name == 'UserError':
-                e_class = exceptions.UserError
-            elif name == "ReadTimeout":
-                raise requests.exceptions.Timeout()
+                credit_error = InsufficientCreditError(response['error']['data'].get('message'))
+                credit_error.data = response['error']['data']
+                raise credit_error
             else:
-                raise requests.exceptions.ConnectionError()
-            e = e_class(message)
-            e.data = response['error']['data']
-            raise e
+                raise IAPServerError("An error occurred on the IAP server")
         return response.get('result')
     except requests.exceptions.Timeout:
-        _logger.warning('Request timeout with the URL: %s', url)
-        raise exceptions.ValidationError(
+        _logger.warning("iap jsonrpc %s timed out", url)
+        raise exceptions.AccessError(
             _('The request to the service timed out. Please contact the author of the app. The URL it tried to contact was %s', url)
         )
-    except (ValueError, requests.exceptions.ConnectionError, requests.exceptions.MissingSchema, requests.exceptions.HTTPError):
-        _logger.exception("iap jsonrpc %s failed", url)
+    except (requests.exceptions.RequestException, IAPServerError) as e:
+        _logger.warning("iap jsonrpc %s failed, %s: %s", url, e.__class__.__name__, exception_to_unicode(e))
         raise exceptions.AccessError(
             _('The url that this service requested returned an error. Please contact the author of the app. The url it tried to contact was %s', url)
         )


### PR DESCRIPTION
This commit fixes the following issues:
- Only re-raise `InsufficientCreditError` from IAP. `UserError`, `AccessError` and `ReadTimeout` shouldn't be re-raised, they should considered as an internal error of the IAP server.
- Instead of raising a `requests.exceptions.ConnectionError` in case of an unknown error from IAP (which didn't make much sense), it will now raise a `IAPServerError`
- The logging level has been changed from `exception` to `warning`. There is indeed no useful information in the logged traceback as the interesting part is in the traceback on the IAP server logs.
