### PR TITLE
[FIX] analytic: adapt lines columns when changing plan of account

### DIFF
--- a/addons/analytic/i18n/analytic.pot
+++ b/addons/analytic/i18n/analytic.pot
@@ -799,6 +799,13 @@ msgid "Search Analytic Lines"
 msgstr ""
 
 #. module: analytic
+#. odoo-python
+#: code:addons/analytic/models/analytic_account.py:0
+#, python-format
+msgid "See them"
+msgstr ""
+
+#. module: analytic
 #: model:ir.model.fields,help:analytic.field_account_analytic_distribution_model__company_id
 msgid ""
 "Select a company for which the analytic distribution will be used (e.g. "
@@ -871,6 +878,15 @@ msgstr ""
 #. module: analytic
 #: model_terms:ir.ui.view,arch_db:analytic.account_analytic_distribution_model_tree_view
 msgid "View"
+msgstr ""
+
+#. module: analytic
+#. odoo-python
+#: code:addons/analytic/models/analytic_account.py:0
+#, python-format
+msgid ""
+"Whoa there! Moving this account would wipe out your current data. Let's avoid "
+"that, shall we?"
 msgstr ""
 
 #. module: analytic

--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -4,8 +4,8 @@
 from collections import defaultdict
 import itertools
 from odoo import api, fields, models, _
-from odoo.exceptions import UserError
-from odoo.tools import groupby
+from odoo.exceptions import UserError, RedirectWarning
+from odoo.tools import groupby, SQL
 
 
 class AccountAnalyticAccount(models.Model):
@@ -174,3 +174,40 @@ class AccountAnalyticAccount(models.Model):
                 account.debit = -data_debit.get(account.id, 0.0)
                 account.credit = data_credit.get(account.id, 0.0)
                 account.balance = account.credit - account.debit
+
+    def write(self, vals):
+        if vals.get('plan_id'):
+            new_fname = self.env['account.analytic.plan'].browse(vals['plan_id'])._column_name()
+            for account in self:
+                current_fname = account.plan_id._column_name()
+                if current_fname != new_fname:
+                    domain = [
+                        (new_fname, 'not in', (account.id, False)),
+                        (current_fname, '=', account.id),
+                    ]
+                    if self.env['account.analytic.line'].sudo().search_count(domain, limit=1):
+                        list_view = self.env.ref('analytic.view_account_analytic_line_tree', raise_if_not_found=False)
+                        raise RedirectWarning(
+                            message=_("Whoa there! Moving this account would wipe out your current data. Let's avoid that, shall we?"),
+                            action={
+                                'res_model': 'account.analytic.line',
+                                'type': 'ir.actions.act_window',
+                                'domain': domain,
+                                'target': 'new',
+                                'views': [(list_view and list_view.id, 'list')]
+                            },
+                            button_text=_("See them"),
+                        )
+                    self.env.cr.execute(SQL(
+                        """
+                        UPDATE account_analytic_line
+                           SET %(new_fname)s = %(account_id)s,
+                               %(current_fname)s = NULL
+                         WHERE %(current_fname)s = %(account_id)s
+                        """,
+                        new_fname=SQL.identifier(new_fname),
+                        current_fname=SQL.identifier(current_fname),
+                        account_id=account.id,
+                    ))
+                    self.env['account.analytic.line'].invalidate_model()
+        return super().write(vals)

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -328,6 +328,7 @@ export class FormController extends Component {
         const proceed = await new Promise((resolve) => {
             this.model.dialog.add(FormErrorDialog, {
                 message: error.data.message,
+                data: error.data,
                 onDiscard: () => {
                     discard();
                     resolve(true);

--- a/addons/web/static/src/views/form/form_error_dialog/form_error_dialog.js
+++ b/addons/web/static/src/views/form/form_error_dialog/form_error_dialog.js
@@ -1,10 +1,25 @@
 /** @odoo-module **/
 
 import { Dialog } from "@web/core/dialog/dialog";
+import { useService } from "@web/core/utils/hooks";
 
 import { Component } from "@odoo/owl";
 
 export class FormErrorDialog extends Component {
+    setup() {
+        this.action = useService("action");
+        this.message = this.props.message;
+        if (this.props.data.name === "odoo.exceptions.RedirectWarning") {
+            this.message = this.props.data.arguments[0];
+            this.redirectAction = this.props.data.arguments[1];
+            this.redirectBtnLabel = this.props.data.arguments[2];
+        }
+    }
+
+    onRedirectBtnClicked() {
+        this.action.doAction(this.redirectAction);
+    }
+
     async discard() {
         await this.props.onDiscard();
         this.props.close();

--- a/addons/web/static/src/views/form/form_error_dialog/form_error_dialog.xml
+++ b/addons/web/static/src/views/form/form_error_dialog/form_error_dialog.xml
@@ -5,10 +5,11 @@
         <Dialog header="false" size="'md'" contentClass="'o_error_dialog'">
             <div role="alert">
                 <h1 class="text-danger">Oh snap!</h1>
-                <p t-esc="props.message" class="text-prewrap"/>
+                <p t-esc="message" class="text-prewrap"/>
             </div>
             <t t-set-slot="footer">
                 <button class="btn btn-primary" t-on-click="stay">Stay here</button>
+                <button class="btn btn-secondary" t-if="redirectAction" t-on-click="onRedirectBtnClicked"><t t-esc="redirectBtnLabel"/></button>
                 <button class="btn btn-secondary" t-on-click="discard">Discard changes</button>
             </t>
         </Dialog>

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -107,14 +107,14 @@ function makeLogger(prefix, title) {
     return { request, response };
 }
 
-export function makeServerError({ code, context, description, message, subType, type } = {}) {
+export function makeServerError({ code, context, description, message, subType, type, args } = {}) {
     return makeErrorFromResponse({
         code: code || 200,
         message: message || "Odoo Server Error",
         data: {
             name: `odoo.exceptions.${type || "UserError"}`,
             debug: "traceback",
-            arguments: [],
+            arguments: args || [],
             context: context || {},
             subType,
             message: description,


### PR DESCRIPTION
Currently, changing the plan of an analytic account won't do anything with regards to the analytic lines currently using that account: the value will stay recorded in a wrong field.

This commit will update all the lines currently using that account in the column of the previous plan.

opw-4338406
