### PR TITLE
[FIX] hr_recruitment: Restrict resume content search to `hr.applicant`

### DIFF
--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -232,7 +232,7 @@
                 <field name="refuse_reason_id"/>
                 <field name="application_status"/>
                 <field name="date_closed"/>
-                <field name="attachment_ids" filter_domain="[('attachment_ids.index_content', 'ilike', self)]" string="Resume's content"/>
+                <field name="attachment_ids" filter_domain="[('attachment_ids', 'any', [('index_content', 'ilike', self), ('res_model', '=', 'hr.applicant')])]" string="Resume's content"/>
                 <filter string="My Applications" name="my_applications" domain="[('user_id', '=', uid)]"/>
                 <filter string="Unassigned" name="unassigned" domain="[('user_id', '=', False)]"/>
                 <separator/>


### PR DESCRIPTION
Currently, searching for `Resume's Content` on applicants uses the domain `attachment_ids.index_content`, which searches the `index_content` of all attachments, ignoring the model they are linked to.

This update modifies the domain to include a `res_model` filter, ensuring the search is limited to applicants' attachments, which are typically CVs added by recruiters.

opw-4558352

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
