### PR TITLE
[FIX] point_of_sale: prevent redirect when in payment screen

### DIFF
--- a/addons/point_of_sale/static/src/app/pos_app.js
+++ b/addons/point_of_sale/static/src/app/pos_app.js
@@ -25,6 +25,7 @@ export class Chrome extends Component {
                 ev.stopPropagation();
             }
             this.pos.showScreen(this.pos.firstScreen);
+            return false;
         });
         const reactivePos = reactive(this.pos);
         // TODO: Should we continue on exposing posmodel as global variable?

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1606,6 +1606,8 @@ export class PosStore extends Reactive {
         if (component.storeOnOrder ?? true) {
             this.get_order()?.set_screen_data({ name, props });
         }
+
+        return true;
     }
     orderExportForPrinting(order) {
         const headerData = this.getReceiptHeaderData(order);

--- a/addons/point_of_sale/static/src/app/utils/use_idle_timer.js
+++ b/addons/point_of_sale/static/src/app/utils/use_idle_timer.js
@@ -11,17 +11,15 @@ export function useIdleTimer(steps, onAlive) {
 
     const checkSteps = () => {
         for (const step of steps) {
-            if (step.timeout === state.time * 1000) {
-                state.idle = true;
-                step.action();
+            if (step.timeout === state.time * 1000 && !state.idle) {
+                state.idle = step.action();
             }
         }
     };
 
     const onMove = (ev) => {
         if (state.idle) {
-            state.idle = false;
-            onAlive(ev);
+            state.idle = onAlive(ev);
         }
         state.time = 0;
     };


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When doing online payment in POS, customer may take some time and the POS may go to idle state. This causes when it goes to idle and back to alive, it will direct to the first screen.
Steps to reproduce:
- Create POS & setup POS online payment (use Demo online payment)
- Open POS, add a product, go to payment screen, select the online payment method
- Let it go to idle state (triggered by useIdleTimer)
- Move the cursor, or at least make it back to active state
- You'll see the screen be redirected to first screen
- Do the payment, it will redirect to TicketScreen with empty order info, and when you click new order the previous one is still hanging there

Alternatively take a look at the recording:
https://github.com/user-attachments/assets/b8e8ae81-df04-41e0-b122-002413714735

Current behavior before PR:
- Because it bounces to first screen, when attempting payment the pos does not have the order state 

Desired behavior after PR is merged:
- Do not redirect if in payment screen, so that order context won't be lost

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
