### PR TITLE
[FIX] mail: ctrl-k in discuss app opens `@` command palette

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss.js
+++ b/addons/mail/static/src/core/public_web/discuss.js
@@ -74,6 +74,11 @@ export class Discuss extends Component {
                         this.thread.composer.autofocus++;
                     }
                 }
+                if (getActiveHotkey(ev) === "control+k") {
+                    this.store.env.services.command.openMainPalette({ searchValue: "@" });
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                }
             },
             { capture: true }
         );

--- a/addons/mail/static/tests/discuss/core/web/command_palette.test.js
+++ b/addons/mail/static/tests/discuss/core/web/command_palette.test.js
@@ -3,6 +3,7 @@ import {
     contains,
     defineMailModels,
     insertText,
+    openDiscuss,
     start,
     startServer,
     triggerHotkey,
@@ -155,4 +156,11 @@ test("hide conversations in recent if they have mentions", async () => {
         text: "OdooBot",
         count: 1,
     });
+});
+
+test("Ctrl-K opens @ command palette in discuss app", async () => {
+    await start();
+    await openDiscuss();
+    triggerHotkey("control+k");
+    await contains(".o_command_palette_search", { text: "@" });
 });


### PR DESCRIPTION
Discuss find or search conversation makes use of ctrl-k in `@` mode (= conversation mode). Using ctrl-k in discuss app is very likely to find or search conversations, therefore this should be the default rather than global ctrl-k.

This commit makes ctrl-k inside discuss app have the `@` conversation mode.

task-4510185