### PR TITLE
[IMP] web, mail, *: use markup as template literal

### DIFF
--- a/addons/account/static/src/services/account_move_service.js
+++ b/addons/account/static/src/services/account_move_service.js
@@ -1,5 +1,4 @@
 import { _t } from "@web/core/l10n/translation";
-import { escape } from "@web/core/utils/strings";
 import { markup } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 
@@ -19,7 +18,7 @@ export class AccountMoveService {
         const isMoveEndOfChain = await this.orm.call("account.move", "check_move_sequence_chain", [moveIds]);
         if (!isMoveEndOfChain) {
             const message = _t("This operation will create a gap in the sequence.");
-            return markup(`<div class="text-danger">${escape(message)}</div>${escape(body)}`);
+            return markup`<div class="text-danger">${message}</div>${body}`;
         }
         return body;
     }

--- a/addons/account_payment/static/tests/interactions/portal_invoice_page_payment.test.js
+++ b/addons/account_payment/static/tests/interactions/portal_invoice_page_payment.test.js
@@ -5,6 +5,7 @@ import {
 
 import { describe, expect, test } from "@odoo/hoot";
 import { advanceTime, queryOne } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("account_payment.portal_invoice_page_payment");
 
@@ -16,7 +17,7 @@ test("portal_invoice_page_payment is not started without #portal_pay", async () 
 });
 
 test("portal_invoice_page_payment is started with #portal_pay", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
     <div id="wrapwrap" class="o_portal">
         <header style="height: 50px;"></header>
         <main>

--- a/addons/auth_totp_portal/static/src/interactions/totp_enable.js
+++ b/addons/auth_totp_portal/static/src/interactions/totp_enable.js
@@ -6,8 +6,7 @@ import { handleCheckIdentity } from "@portal/interactions/portal_security";
 import { browser } from "@web/core/browser/browser";
 import { user } from "@web/core/user";
 import { _t } from "@web/core/l10n/translation";
-
-import { markup } from "@odoo/owl";
+import { getOuterHtml } from "@web/core/utils/html";
 
 /**
  * Replaces specific <field> elements by normal HTML, strip out the rest entirely
@@ -156,7 +155,7 @@ export class TOTPEnable extends Interaction {
         const [body, ,] = fixupViewBody(xmlBody, record);
 
         this.services.dialog.add(InputConfirmationDialog, {
-            body: markup(body.outerHTML),
+            body: getOuterHtml(body),
             onInput: ({ inputEl }) => { inputEl.setCustomValidity("") },
             confirmLabel: _t("Activate"),
             confirm: async ({ inputEl }) => {

--- a/addons/html_editor/static/src/components/history_dialog/history_dialog.js
+++ b/addons/html_editor/static/src/components/history_dialog/history_dialog.js
@@ -28,7 +28,7 @@ export class HistoryDialog extends Component {
 
     static defaultProps = {
         title: _t("History"),
-        noContentHelper: markup(""),
+        noContentHelper: "",
         embeddedComponents: [...READONLY_MAIN_EMBEDDINGS],
     };
 

--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_dialog.js
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_dialog.js
@@ -2,6 +2,7 @@ import { _t } from "@web/core/l10n/translation";
 import { Dialog } from "@web/core/dialog/dialog";
 import { rpc } from "@web/core/network/rpc";
 import { useService } from "@web/core/utils/hooks";
+import { getOuterHtml } from "@web/core/utils/html";
 import { Component, useState, onWillDestroy, status, markup } from "@odoo/owl";
 
 const POSTPROCESS_GENERATED_CONTENT = (content, baseContainer) => {
@@ -84,9 +85,9 @@ export class ChatGPTDialog extends Component {
         let result = "";
         for (const child of fragment.children) {
             this.props.sanitize(child, { IN_PLACE: true });
-            result += child.outerHTML;
+            result = markup`${result}${getOuterHtml(child)}`;
         }
-        return markup(result);
+        return result;
     }
 
     generate(prompt, callback) {

--- a/addons/html_editor/static/src/main/media/image_crop.js
+++ b/addons/html_editor/static/src/main/media/image_crop.js
@@ -128,10 +128,9 @@ export class ImageCrop extends Component {
 
         if (this.uncroppable) {
             this.notification.add(
-                markup(
-                    _t(
-                        "This type of image is not supported for cropping.<br/>If you want to crop it, please first download it from the original source and upload it in Odoo."
-                    )
+                _t(
+                    "This type of image is not supported for cropping.%(new_line)sIf you want to crop it, please first download it from the original source and upload it in Odoo.",
+                    { new_line: markup`<br/>` }
                 ),
                 {
                     title: _t("This image is an external image"),

--- a/addons/html_editor/static/src/main/signature_plugin.js
+++ b/addons/html_editor/static/src/main/signature_plugin.js
@@ -48,11 +48,12 @@ export class SignaturePlugin extends Plugin {
             ["signature"]
         );
         if (currentUser && currentUser.signature) {
-            // User signature is sanitized in backend.
+            // markup: signature is coming from HTML field on res.users
+            currentUser.signature = markup(currentUser.signature);
             const signatureFragment = parseHTML(
                 this.document,
                 renderToString("html_editor.Signature", {
-                    signature: markup(currentUser.signature),
+                    signature: currentUser.signature,
                     signatureClass: SIGNATURE_CLASS,
                 })
             );

--- a/addons/html_editor/static/tests/html_viewer.test.js
+++ b/addons/html_editor/static/tests/html_viewer.test.js
@@ -13,7 +13,7 @@ test(`XML-like self-closing elements are fixed in a standalone HtmlViewer`, asyn
         Component: HtmlViewer,
         props: {
             config: {
-                value: markup(`<a href="#"/>outside<a href="#">inside</a>`),
+                value: markup`<a href="#"/>outside<a href="#">inside</a>`,
             },
         },
     });

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -12,7 +12,6 @@ import {
     waitForNone,
 } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
-import { markup } from "@odoo/owl";
 import { contains, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupEditor } from "../_helpers/editor";
 import { cleanLinkArtifacts } from "../_helpers/format";
@@ -813,7 +812,7 @@ describe("shortcut", () => {
 describe("link preview", () => {
     test("test internal link preview", async () => {
         onRpc("/html_editor/link_preview_internal", () => ({
-            description: markup("Test description"),
+            description: "Test description",
             link_preview_name: "Task name | Project name",
         }));
         onRpc("/odoo/project/1/tasks/8", () => new Response("", { status: 200 }));
@@ -862,7 +861,7 @@ describe("link preview", () => {
         onRpc("/html_editor/link_preview_internal", () => {
             expect.step("/html_editor/link_preview_internal");
             return {
-                description: markup("<p>Test description</p>"),
+                description: "<p>Test description</p>",
                 link_preview_name: "Task name | Project name",
             };
         });

--- a/addons/iap_mail/static/src/js/services/iap_notification_service.js
+++ b/addons/iap_mail/static/src/js/services/iap_notification_service.js
@@ -1,6 +1,5 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { escape } from "@web/core/utils/strings";
 
 import { markup } from "@odoo/owl";
 
@@ -25,11 +24,11 @@ export const iapNotificationService = {
         }
 
         function displayCreditErrorNotification(params) {
-            const message = markup(`
+            const message = markup`
             <a class='btn btn-link' href='${params.get_credits_url}' target='_blank'>
                 <i class='oi oi-arrow-right'></i>
-                ${escape(_t("Buy more credits"))}
-            </a>`);
+                ${_t("Buy more credits")}
+            </a>`;
             notification.add(message, {
                 title: params.title,
                 type: 'danger',

--- a/addons/lunch/static/src/components/lunch_dashboard.js
+++ b/addons/lunch/static/src/components/lunch_dashboard.js
@@ -63,10 +63,7 @@ export class LunchOrderLine extends Component {
 
 export class LunchAlert extends Component {
     static props = ["message"];
-    static template = xml`<t t-out="message"/>`;
-    get message() {
-        return markup(this.props.message);
-    }
+    static template = xml`<t t-out="props.message"/>`;
 }
 
 export class LunchAlerts extends Component {
@@ -134,6 +131,7 @@ export class LunchDashboard extends Component {
 
     async _fetchLunchInfos() {
         this.state.infos = await this.lunchRpc('/lunch/infos');
+        this.state.infos.alerts?.forEach((alert) => (alert.message = markup(alert.message)));
     }
 
     async emptyCart() {

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -6,7 +6,6 @@ import { MessageConfirmDialog } from "@mail/core/common/message_confirm_dialog";
 import { NavigableList } from "@mail/core/common/navigable_list";
 import { useSuggestion } from "@mail/core/common/suggestion_hook";
 import { prettifyMessageContent } from "@mail/utils/common/format";
-import { htmlJoin } from "@mail/utils/common/html";
 import { useSelection } from "@mail/utils/common/hooks";
 import { isDragSourceExternalFile } from "@mail/utils/common/misc";
 import { rpc } from "@web/core/network/rpc";
@@ -30,9 +29,8 @@ import {
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import { createElementWithContent } from "@web/core/utils/html";
+import { createElementWithContent, getOuterHtml, htmlJoin } from "@web/core/utils/html";
 import { FileUploader } from "@web/views/fields/file_handler";
-import { escape } from "@web/core/utils/strings";
 import { isDisplayStandalone, isIOS, isMobileOS } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
@@ -94,8 +92,9 @@ export class Composer extends Component {
         this.isIosPwa = isIOS() && isDisplayStandalone();
         this.composerActions = useComposerActions();
         this.OR_PRESS_SEND_KEYBIND = _t("or press %(send_keybind)s", {
-            send_keybind: markup(
-                this.sendKeybinds.map((key) => `<samp>${escape(key)}</samp>`).join(" + ")
+            send_keybind: htmlJoin(
+                this.sendKeybinds.map((key) => markup`<samp>${key}</samp>`),
+                " + "
             ),
         });
         this.store = useService("mail.store");
@@ -258,35 +257,23 @@ export class Composer extends Component {
             return _t(
                 "%(open_button)s%(icon)s%(open_em)sDiscard editing%(close_em)s%(close_button)s",
                 {
-                    open_button: markup(
-                        `<button class='btn px-1 py-0' data-type="${escape(
-                            EDIT_CLICK_TYPE.CANCEL
-                        )}">`
-                    ),
-                    close_button: markup("</button>"),
-                    icon: markup(
-                        `<i class='fa fa-times-circle pe-1' data-type="${escape(
-                            EDIT_CLICK_TYPE.CANCEL
-                        )}"></i>`
-                    ),
-                    open_em: markup(`<em data-type="${escape(EDIT_CLICK_TYPE.CANCEL)}">`),
-                    close_em: markup("</em>"),
+                    open_button: markup`<button class='btn px-1 py-0' data-type="${EDIT_CLICK_TYPE.CANCEL}">`,
+                    close_button: markup`</button>`,
+                    icon: markup`<i class='fa fa-times-circle pe-1' data-type="${EDIT_CLICK_TYPE.CANCEL}"></i>`,
+                    open_em: markup`<em data-type="${EDIT_CLICK_TYPE.CANCEL}">`,
+                    close_em: markup`</em>`,
                 }
             );
         } else {
             const tags = {
-                open_samp: markup("<samp>"),
-                close_samp: markup("</samp>"),
-                open_em: markup("<em>"),
-                close_em: markup("</em>"),
-                open_cancel: markup(
-                    `<a role="button" href="#" data-type="${escape(EDIT_CLICK_TYPE.CANCEL)}">`
-                ),
-                close_cancel: markup("</a>"),
-                open_save: markup(
-                    `<a role="button" href="#" data-type="${escape(EDIT_CLICK_TYPE.SAVE)}">`
-                ),
-                close_save: markup("</a>"),
+                open_samp: markup`<samp>`,
+                close_samp: markup`</samp>`,
+                open_em: markup`<em>`,
+                close_em: markup`</em>`,
+                open_cancel: markup`<a role="button" href="#" data-type="${EDIT_CLICK_TYPE.CANCEL}">`,
+                close_cancel: markup`</a>`,
+                open_save: markup`<a role="button" href="#" data-type="${EDIT_CLICK_TYPE.SAVE}">`,
+                close_save: markup`</a>`,
             };
             return this.env.inChatter
                 ? _t(
@@ -560,7 +547,7 @@ export class Composer extends Component {
                 document.createElement("br"),
                 ...createElementWithContent("div", signature).childNodes
             );
-            signature = markup(divElement.outerHTML);
+            signature = getOuterHtml(divElement);
         }
         default_body = this.formatDefaultBodyForFullComposer(
             default_body,
@@ -633,9 +620,9 @@ export class Composer extends Component {
      */
     formatDefaultBodyForFullComposer(defaultBody, signature = "") {
         if (signature) {
-            defaultBody = htmlJoin(defaultBody, markup("<br>"), signature);
+            defaultBody = markup`${defaultBody}<br/>${signature}`;
         }
-        return htmlJoin(markup("<div>"), defaultBody, markup("</div>")); // as to not wrap in <p> by html_sanitize
+        return markup`<div>${defaultBody}</div>`; // as to not wrap in <p> by html_sanitize
     }
 
     clear() {

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -444,6 +444,7 @@ export class Message extends Component {
             const { error, lang_name, body } = await rpc("/mail/message/translate", {
                 message_id: message.id,
             });
+            // markup: body is coming from sanitized field on mail.message.translation
             message.translationValue = body && markup(body);
             message.translationSource = lang_name;
             message.translationErrors = error;

--- a/addons/mail/static/src/core/common/message_search_hook.js
+++ b/addons/mail/static/src/core/common/message_search_hook.js
@@ -1,7 +1,8 @@
 import { useSequential } from "@mail/utils/common/hooks";
 import { createDocumentFragmentFromContent } from "@mail/utils/common/html";
-import { useState, onWillUnmount, markup } from "@odoo/owl";
+import { useState, onWillUnmount } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
+import { getInnerHtml } from "@web/core/utils/html";
 import { escapeRegExp } from "@web/core/utils/strings";
 
 export const HIGHLIGHT_CLASS = "o-mail-Message-searchHighlight";
@@ -59,7 +60,7 @@ export function searchHighlight(searchTerm, target) {
             element.replaceChildren(...newNode);
         }
     }
-    return markup(htmlDoc.body.innerHTML);
+    return getInnerHtml(htmlDoc.body);
 }
 
 /** @param {import('models').Thread} thread */

--- a/addons/mail/static/src/core/common/notification_message.js
+++ b/addons/mail/static/src/core/common/notification_message.js
@@ -1,5 +1,6 @@
 import {
     Component,
+    htmlEscape,
     onMounted,
     onPatched,
     onWillDestroy,
@@ -8,7 +9,6 @@ import {
 } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import { escape } from "@web/core/utils/strings";
 
 export class NotificationMessage extends Component {
     static template = "mail.NotificationMessage";
@@ -23,7 +23,7 @@ export class NotificationMessage extends Component {
         onMounted(() => this.props.registerMessageRef?.(this.props.message, this.root));
         onPatched(() => this.props.registerMessageRef?.(this.props.message, this.root));
         onWillDestroy(() => this.props.registerMessageRef?.(this.props.message, null));
-        this.escape = escape;
+        this.htmlEscape = htmlEscape;
         this.store = useService("mail.store");
     }
 

--- a/addons/mail/static/src/core/common/notification_message.xml
+++ b/addons/mail/static/src/core/common/notification_message.xml
@@ -7,7 +7,7 @@
                 <span class="text-muted opacity-75" t-esc="callInformation"/>
             </t>
             <t t-else="">
-                <span class="o-mail-NotificationMessage-author d-inline text-muted opacity-75" t-if="message.authorName and !message.richBody.includes(escape(message.authorName))" t-esc="message.authorName"/> <span class="text-muted opacity-75" t-out="message.richBody"/>
+                <span class="o-mail-NotificationMessage-author d-inline text-muted opacity-75" t-if="message.authorName and !message.richBody.includes(htmlEscape(message.authorName))" t-esc="message.authorName"/> <span class="text-muted opacity-75" t-out="message.richBody"/>
             </t>
             <span class="o-mail-Message-date o-xsmaller ms-1" t-esc="message.dateSimpleWithDay"/>
         </div>

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -23,7 +23,6 @@ import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 import { Transition } from "@web/core/transition";
 import { useBus, useRefListener, useService } from "@web/core/utils/hooks";
-import { escape } from "@web/core/utils/strings";
 
 export const PRESENT_VIEWPORT_THRESHOLD = 3;
 const PRESENT_MESSAGE_THRESHOLD = 10;
@@ -66,7 +65,6 @@ export class Thread extends Component {
 
     setup() {
         super.setup();
-        this.escape = escape;
         this.applyScroll = this.applyScroll.bind(this);
         this.saveScroll = this.saveScroll.bind(this);
         this.registerMessageRef = this.registerMessageRef.bind(this);

--- a/addons/mail/static/src/core/web/base_recipients_list.js
+++ b/addons/mail/static/src/core/web/base_recipients_list.js
@@ -1,12 +1,11 @@
-import { _t } from "@web/core/l10n/translation";
-import { escape } from "@web/core/utils/strings";
-import { formatList } from "@web/core/l10n/utils";
-import { markup, Component } from "@odoo/owl";
-import { usePopover } from "@web/core/popover/popover_hook";
-
-import { RecipientList } from "@mail/core/web/recipient_list";
 import { Thread } from "@mail/core/common/thread_model";
+import { RecipientList } from "@mail/core/web/recipient_list";
 
+import { Component, markup } from "@odoo/owl";
+
+import { _t } from "@web/core/l10n/translation";
+import { usePopover } from "@web/core/popover/popover_hook";
+import { htmlFormatList } from "@web/core/utils/html";
 
 export class BaseRecipientsList extends Component {
     static template = "mail.BaseRecipientsList";
@@ -19,19 +18,22 @@ export class BaseRecipientsList extends Component {
 
     /** @returns {Markup} */
     getRecipientListToHTML() {
-        const recipients = this.props.thread.recipients.slice(0, 5).map((
-            { partner }) => {
-                return `<span class="text-muted" title="${escape(
-                    partner.email || _t("no email address")
-                )}">${escape(partner.name)}</span>`;
-            });
+        const recipients = this.props.thread.recipients
+            .slice(0, 5)
+            .map(
+                ({ partner }) =>
+                    markup`<span class="text-muted" title="${
+                        partner.email || _t("no email address")
+                    }">${partner.name}</span>`
+            );
         if (this.props.thread.recipients.length > 5) {
-            recipients.push(escape(
+            recipients.push(
                 _t("%(recipientCount)s more", {
-                    recipientCount: this.props.thread.recipients.length - 5}))
+                    recipientCount: this.props.thread.recipients.length - 5,
+                })
             );
         }
-        return markup(formatList(recipients));
+        return htmlFormatList(recipients);
     }
 
     /** @param {Event} ev */
@@ -40,7 +42,7 @@ export class BaseRecipientsList extends Component {
             return this.recipientsPopover.close();
         }
         this.recipientsPopover.open(ev.target, {
-            thread: this.props.thread
+            thread: this.props.thread,
         });
     }
-};
+}

--- a/addons/mail/static/src/core/web/composer_patch.js
+++ b/addons/mail/static/src/core/web/composer_patch.js
@@ -5,8 +5,7 @@ import { childNodes } from "@html_editor/utils/dom_traversal";
 import { Composer } from "@mail/core/common/composer";
 import { createDocumentFragmentFromContent } from "@mail/utils/common/html";
 
-import { markup } from "@odoo/owl";
-
+import { getInnerHtml } from "@web/core/utils/html";
 import { patch } from "@web/core/utils/patch";
 import { renderToElement } from "@web/core/utils/render";
 
@@ -33,6 +32,6 @@ patch(Composer.prototype, {
         const container = document.createElement("DIV");
         container.append(...childNodes(fragment));
         wrapInlinesInBlocks(container, { baseContainerNodeName: "DIV" });
-        return markup(container.innerHTML);
+        return getInnerHtml(container);
     },
 });

--- a/addons/mail/static/src/core/web/mail_composer_bcc_list.js
+++ b/addons/mail/static/src/core/web/mail_composer_bcc_list.js
@@ -1,12 +1,12 @@
 import { MailComposerBccPopover } from "@mail/core/web/mail_composer_bcc_list_popover";
-import { formatList } from "@web/core/l10n/utils";
+
+import { Component, markup } from "@odoo/owl";
+
+import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { registry } from "@web/core/registry";
-import { _t } from "@web/core/l10n/translation";
-import { escape } from "@web/core/utils/strings";
+import { htmlFormatList } from "@web/core/utils/html";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
-
-import { markup, Component } from "@odoo/owl";
 
 export class MailComposerBccList extends Component {
     static template = "mail.MailComposerBccList";
@@ -24,20 +24,20 @@ export class MailComposerBccList extends Component {
         const records = this.getRecords();
         for (const record of records.slice(0, this.limit)) {
             const partner = record.data;
-            elements.push(`
-                <span class="text-muted" title="${escape(
+            elements.push(
+                markup`<span class="text-muted" title="${
                     partner.email_normalized || _t("no email address")
-                )}">${escape(partner.name)}</span>
-            `);
-        }
-        if (records.length > this.limit) {
-            elements.push(escape(
-                _t("%(recipientCount)s more", {
-                    recipientCount: records.length - this.limit
-                }))
+                }">${partner.name}</span>`
             );
         }
-        return markup(formatList(elements));
+        if (records.length > this.limit) {
+            elements.push(
+                _t("%(recipientCount)s more", {
+                    recipientCount: records.length - this.limit,
+                })
+            );
+        }
+        return htmlFormatList(elements);
     }
 
     /** @returns {Array[Record]} */
@@ -68,12 +68,10 @@ export class MailComposerBccList extends Component {
 
 export const mailComposerBccList = {
     component: MailComposerBccList,
-    relatedFields: (fieldInfo) => {
-        return [
-            { name: "name", type: "char" },
-            { name: "email_normalized", type: "char" }
-        ];
-    },
+    relatedFields: (fieldInfo) => [
+        { name: "name", type: "char" },
+        { name: "email_normalized", type: "char" },
+    ],
 };
 
 registry.category("fields").add("mail_composer_bcc_list", mailComposerBccList);

--- a/addons/mail/static/src/core/web/mail_composer_chatgpt.js
+++ b/addons/mail/static/src/core/web/mail_composer_chatgpt.js
@@ -1,11 +1,10 @@
 import { ChatGPTPromptDialog } from "@html_editor/main/chatgpt/chatgpt_prompt_dialog";
 
-import { htmlJoin } from "@mail/utils/common/html";
-
 import { Component, markup } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { getInnerHtml } from "@web/core/utils/html";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 
 export class MailComposerChatGPT extends Component {
@@ -23,9 +22,7 @@ export class MailComposerChatGPT extends Component {
                 const root = document.createElement("div");
                 root.appendChild(content);
                 const { body } = this.props.record.data;
-                this.props.record.update({
-                    body: htmlJoin(body, markup(root.innerHTML)),
-                });
+                this.props.record.update({ body: markup`${body}${getInnerHtml(root)}` });
             },
             /**
              * @param {HTMLElement} fragment

--- a/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
+++ b/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
@@ -1,9 +1,10 @@
+import { parseVersion } from "@mail/utils/common/misc";
+
 import { markup, reactive } from "@odoo/owl";
 
-import { parseVersion } from "@mail/utils/common/misc";
 import { browser } from "@web/core/browser/browser";
-import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
 
 export const pttExtensionHookService = {
     start(env) {
@@ -32,10 +33,8 @@ export const pttExtensionHookService = {
                 return _t(
                     "The Push-to-Talk feature is only accessible within tab focus. To enable the Push-to-Talk functionality outside of this tab, we recommend downloading our %(anchor_start)sextension%(anchor_end)s.",
                     {
-                        anchor_start: markup(
-                            `<a href="${this.downloadURL}" target="_blank" class="text-reset text-decoration-underline">`
-                        ),
-                        anchor_end: markup("</a>"),
+                        anchor_start: markup`<a href="${this.downloadURL}" target="_blank" class="text-reset text-decoration-underline">`,
+                        anchor_end: markup`</a>`,
                     }
                 );
             },

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -45,6 +45,7 @@ export class DiscussCoreCommon {
             const lastMessageId = this.store.getLastMessageId();
             const message = this.store["mail.message"].insert({
                 author: this.store.odoobot,
+                // markup: body is coming from _bus_send_transient_message which uses Markup
                 body: markup(body),
                 id: lastMessageId + 0.01,
                 is_note: true,

--- a/addons/mail/static/src/js/emojis_mixin.js
+++ b/addons/mail/static/src/js/emojis_mixin.js
@@ -1,4 +1,6 @@
-import { htmlEscape } from "@web/core/utils/html";
+import { htmlReplace, htmlReplaceAll } from "@mail/utils/common/html";
+
+import { markup } from "@odoo/owl";
 
 /**
  * Adds a span with a CSS class around chains of emojis in the message for styling purposes.
@@ -10,15 +12,15 @@ import { htmlEscape } from "@web/core/utils/html";
  * This will only match characters that have a different presentation from normal text, unlike ®
  * For alternatives, see: https://www.unicode.org/reports/tr51/#Emoji_Properties_and_Data_Files
  *
- * @param {String} message a text message to format
+ * @param {string|ReturnType<markup>} message a text message to format
+ * @returns {ReturnType<markup>}
  */
 export function formatText(message) {
-    message = htmlEscape(message);
-    message = message.replaceAll(
+    message = htmlReplaceAll(
+        message,
         /(\p{Emoji_Presentation}+)/gu,
-        "<span class='o_mail_emoji'>$1</span>"
+        (_, group1) => markup`<span class='o_mail_emoji'>${group1}</span>`
     );
-    message = message.replace(/(?:\r\n|\r|\n)/g, "<br>");
-
+    message = htmlReplace(message, /(?:\r\n|\r|\n)/g, () => markup`<br>`);
     return message;
 }

--- a/addons/mail/static/src/js/tours/discuss_channel_tour.js
+++ b/addons/mail/static/src/js/tours/discuss_channel_tour.js
@@ -1,7 +1,15 @@
+import { markup } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-import { markup } from "@odoo/owl";
+const tags = {
+    b_open: markup`<b>`,
+    b_close: markup`</b>`,
+    i_open: markup`<i>>`,
+    i_close: markup`</i>`,
+    p_open: markup`<p>>`,
+    p_close: markup`</p>`,
+};
 
 registry.category("web_tour.tours").add("discuss_channel_tour", {
     url: "/odoo",
@@ -15,32 +23,30 @@ registry.category("web_tour.tours").add("discuss_channel_tour", {
         },
         {
             trigger: ".o-mail-DiscussSidebarCategories-search",
-            content: markup(
-                _t(
-                    "<p>Channels make it easy to organize information across different topics and groups.</p> <p>Try to <b>create your first channel</b> (e.g. sales, marketing, product XYZ, after work party, etc).</p>"
-                )
+            content: _t(
+                "%{p_open}sChannels make it easy to organize information across different topics and groups.%{p_close}s %{p_open}sTry to %(b_open)screate your first channel%(b_close)s (e.g. sales, marketing, product XYZ, after work party, etc).%{p_close}s",
+                tags
             ),
             tooltipPosition: "bottom",
             run: "click",
         },
         {
             trigger: ".o_command_palette_search input",
-            content: markup(_t("<p>Create a channel here.</p>")),
+            content: _t("%{p_open}sCreate a channel here.%{p_close}s", tags),
             tooltipPosition: "bottom",
             run: `edit SomeChannel_${new Date().getTime()}`,
         },
         {
             trigger: ".o-mail-DiscussCommand-createChannel",
-            content: markup(_t("<p>Create a public or private channel.</p>")),
+            content: _t("%{p_open}sCreate a public or private channel.%{p_close}s", tags),
             run: "click",
             tooltipPosition: "right",
         },
         {
             trigger: ".o-mail-Composer-input",
-            content: markup(
-                _t(
-                    "<p><b>Write a message</b> to the members of the channel here.</p> <p>You can notify someone with <i>'@'</i> or link another channel with <i>'#'</i>. Start your message with <i>'/'</i> to get the list of possible commands.</p>"
-                )
+            content: _t(
+                "%{p_open}s%{b_open}sWrite a message%(b_close)s to the members of the channel here.%{p_close}s %{p_open}sYou can notify someone with <i>'@'</i> or link another channel with <i>'#'</i>. Start your message with <i>'/'</i> to get the list of possible commands.%{p_close}s",
+                tags
             ),
             tooltipPosition: "top",
             run: `edit SomeText_${new Date().getTime()}`,
@@ -67,10 +73,9 @@ registry.category("web_tour.tours").add("discuss_channel_tour", {
         },
         {
             trigger: ".o-mail-DiscussSidebarCategories-search",
-            content: markup(
-                _t(
-                    "<p><b>Chat with coworkers</b> in real-time using direct messages.</p><p><i>You might need to invite users from the Settings app first.</i></p>"
-                )
+            content: _t(
+                "%{p_open}s%{b_open}sChat with coworkers%(b_close)s in real-time using direct messages.%{p_close}s%{p_open}s%{i_open}sYou might need to invite users from the Settings app first.%{i_close}s%{p_close}s",
+                tags
             ),
             tooltipPosition: "bottom",
             run: "click",

--- a/addons/mail/static/src/model/store_internal.js
+++ b/addons/mail/static/src/model/store_internal.js
@@ -1,10 +1,9 @@
 /** @typedef {import("./record").Record} Record */
 /** @typedef {import("./record_list").RecordList} RecordList */
 
-import { markup, toRaw } from "@odoo/owl";
+import { htmlEscape, markup, toRaw } from "@odoo/owl";
 import { RecordInternal } from "./record_internal";
 import { deserializeDate, deserializeDateTime } from "@web/core/l10n/dates";
-import { htmlEscape } from "@web/core/utils/html";
 import { IS_DELETING_SYM, isCommand, isMany } from "./misc";
 
 const Markup = markup().constructor;
@@ -169,6 +168,7 @@ export class StoreInternal extends RecordInternal {
         }
         let newValue = value;
         if (fieldHtml) {
+            // markup: value[1] is coming from Store._add_values only when original value is Markup
             newValue =
                 Array.isArray(value) && value[0] === "markup"
                     ? value[1]

--- a/addons/mail/static/src/utils/common/html.js
+++ b/addons/mail/static/src/utils/common/html.js
@@ -1,6 +1,4 @@
-import { markup } from "@odoo/owl";
-
-import { htmlEscape } from "@web/core/utils/html";
+import { htmlEscape, markup } from "@odoo/owl";
 
 /**
  * Safely creates a Document fragment from content. If content was flagged as safe HTML using
@@ -10,16 +8,6 @@ import { htmlEscape } from "@web/core/utils/html";
  */
 export function createDocumentFragmentFromContent(content) {
     return new document.defaultView.DOMParser().parseFromString(htmlEscape(content), "text/html");
-}
-
-/**
- * Applies list join on content and returns a markup result built for HTML.
- *
- * @param {Array<string|ReturnType<markup>>} args
- * @returns {ReturnType<markup>}
- */
-export function htmlJoin(...args) {
-    return markup(args.map((arg) => htmlEscape(arg)).join(""));
 }
 
 /**
@@ -34,7 +22,6 @@ export function htmlReplace(content, search, replacement) {
     if (search instanceof RegExp && !(replacement instanceof Function)) {
         throw new Error("htmlReplace: replacement must be a function when search is a RegExp.");
     }
-    content = htmlEscape(content);
     if (typeof search === "string" || search instanceof String) {
         search = htmlEscape(search);
     }
@@ -42,7 +29,8 @@ export function htmlReplace(content, search, replacement) {
         replacement instanceof Function
             ? (...args) => htmlEscape(replacement(...args))
             : htmlEscape(replacement);
-    return markup(content.replace(search, safeReplacement));
+    // markup: escaped (or safe) content with escaped (or safe) replacements
+    return markup(htmlEscape(content).replace(search, safeReplacement));
 }
 
 /**
@@ -57,7 +45,6 @@ export function htmlReplaceAll(content, search, replacement) {
     if (search instanceof RegExp && !(replacement instanceof Function)) {
         throw new Error("htmlReplaceAll: replacement must be a function when search is a RegExp.");
     }
-    content = htmlEscape(content);
     if (typeof search === "string" || search instanceof String) {
         search = htmlEscape(search);
     }
@@ -65,7 +52,8 @@ export function htmlReplaceAll(content, search, replacement) {
         replacement instanceof Function
             ? (...args) => htmlEscape(replacement(...args))
             : htmlEscape(replacement);
-    return markup(content.replaceAll(search, safeReplacement));
+    // markup: escaped (or safe) content with escaped (or safe) replacements
+    return markup(htmlEscape(content).replaceAll(search, safeReplacement));
 }
 
 /**
@@ -75,6 +63,6 @@ export function htmlReplaceAll(content, search, replacement) {
  * @returns {string|ReturnType<markup>}
  */
 export function htmlTrim(content) {
-    content = htmlEscape(content);
-    return markup(content.trim());
+    // markup: escaped (or safe) content
+    return markup(htmlEscape(content).trim());
 }

--- a/addons/mail/static/tests/core/message_model.test.js
+++ b/addons/mail/static/tests/core/message_model.test.js
@@ -28,7 +28,7 @@ test("Message model properties", async () => {
     const message = store["mail.message"].insert({
         attachment_ids: 750,
         author: { id: 5, name: "Demo" },
-        body: markup("<p>Test</p>"),
+        body: markup`<p>Test</p>`,
         date: deserializeDateTime("2019-05-05 10:00:00"),
         id: 4000,
         starred: true,

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -407,7 +407,7 @@ test("insert on html field", async () => {
     message2.body = ["markup", false];
     expect(message2.body).toBe("");
     expect(message2.body).not.toBeInstanceOf(Markup);
-    const message3 = store.Message.insert({ body: markup("<p>hello 3</p>") });
+    const message3 = store.Message.insert({ body: markup`<p>hello 3</p>` });
     expect(message3.body?.toString()).toBe("<p>hello 3</p>");
     expect(message3.body).toBeInstanceOf(Markup);
     message3.body = false;

--- a/addons/mail/static/tests/core/search_highlight.test.js
+++ b/addons/mail/static/tests/core/search_highlight.test.js
@@ -24,12 +24,12 @@ defineMailModels();
 test("Search highlight", async () => {
     const testCases = [
         {
-            input: markup("test odoo"),
+            input: markup`test odoo`,
             output: `test <span class="${HIGHLIGHT_CLASS}">odoo</span>`,
             searchTerm: "odoo",
         },
         {
-            input: markup('<a href="https://www.odoo.com">https://www.odoo.com</a>'),
+            input: markup`<a href="https://www.odoo.com">https://www.odoo.com</a>`,
             output: `<a href="https://www.odoo.com">https://www.<span class="${HIGHLIGHT_CLASS}">odoo</span>.com</a>`,
             searchTerm: "odoo",
         },
@@ -39,30 +39,30 @@ test("Search highlight", async () => {
             searchTerm: "odoo",
         },
         {
-            input: markup('<a href="https://www.odoo.com">Odoo</a>'),
+            input: markup`<a href="https://www.odoo.com">Odoo</a>`,
             output: `<a href="https://www.odoo.com"><span class="${HIGHLIGHT_CLASS}">Odoo</span></a>`,
             searchTerm: "odoo",
         },
         {
-            input: markup('<a href="https://www.odoo.com">Odoo</a> Odoo is a free software'),
+            input: markup`<a href="https://www.odoo.com">Odoo</a> Odoo is a free software`,
             output: `<a href="https://www.odoo.com"><span class="${HIGHLIGHT_CLASS}">Odoo</span></a> <span class="${HIGHLIGHT_CLASS}">Odoo</span> is a free software`,
             searchTerm: "odoo",
         },
         {
-            input: markup("odoo is a free software"),
+            input: markup`odoo is a free software`,
             output: `<span class="${HIGHLIGHT_CLASS}">odoo</span> is a free software`,
             searchTerm: "odoo",
         },
         {
-            input: markup("software ODOO is a free"),
+            input: markup`software ODOO is a free`,
             output: `software <span class="${HIGHLIGHT_CLASS}">ODOO</span> is a free`,
             searchTerm: "odoo",
         },
         {
-            input: markup(`<ul>
+            input: markup`<ul>
                 <li>Odoo</li>
                 <li><a href="https://odoo.com">Odoo ERP</a> Best ERP</li>
-            </ul>`),
+            </ul>`,
             output: `<ul>
                 <li><span class="${HIGHLIGHT_CLASS}">Odoo</span></li>
                 <li><a href="https://odoo.com"><span class="${HIGHLIGHT_CLASS}">Odoo</span> ERP</a> Best ERP</li>
@@ -70,42 +70,42 @@ test("Search highlight", async () => {
             searchTerm: "odoo",
         },
         {
-            input: markup("test <strong>Odoo</strong> test"),
+            input: markup`test <strong>Odoo</strong> test`,
             output: `<span class="${HIGHLIGHT_CLASS}">test</span> <strong><span class="${HIGHLIGHT_CLASS}">Odoo</span></strong> <span class="${HIGHLIGHT_CLASS}">test</span>`,
             searchTerm: "odoo test",
         },
         {
-            input: markup("test <br> test"),
+            input: markup`test <br> test`,
             output: `<span class="${HIGHLIGHT_CLASS}">test</span> <br> <span class="${HIGHLIGHT_CLASS}">test</span>`,
             searchTerm: "odoo test",
         },
         {
-            input: markup("<strong>test</strong> test"),
+            input: markup`<strong>test</strong> test`,
             output: `<strong><span class="${HIGHLIGHT_CLASS}">test</span></strong> <span class="${HIGHLIGHT_CLASS}">test</span>`,
             searchTerm: "test",
         },
         {
-            input: markup("<strong>a</strong> test"),
+            input: markup`<strong>a</strong> test`,
             output: `<strong><span class="${HIGHLIGHT_CLASS}">a</span></strong> <span class="${HIGHLIGHT_CLASS}">test</span>`,
             searchTerm: "a test",
         },
         {
-            input: markup("&amp;amp;"),
+            input: markup`&amp;amp;`,
             output: `<span class="${HIGHLIGHT_CLASS}">&amp;amp;</span>`,
             searchTerm: "&amp;",
         },
         {
-            input: markup("&amp;amp;"),
+            input: markup`&amp;amp;`,
             output: `<span class="${HIGHLIGHT_CLASS}">&amp;</span>amp;`,
             searchTerm: "&",
         },
         {
-            input: markup("<strong>test</strong> hello"),
+            input: markup`<strong>test</strong> hello`,
             output: `<strong><span class="${HIGHLIGHT_CLASS}">test</span></strong> <span class="${HIGHLIGHT_CLASS}">hello</span>`,
             searchTerm: "test hello",
         },
         {
-            input: markup("<p>&lt;strong&gt;test&lt;/strong&gt; hello</p>"),
+            input: markup`<p>&lt;strong&gt;test&lt;/strong&gt; hello</p>`,
             output: `<p>&lt;strong&gt;<span class="${HIGHLIGHT_CLASS}">test</span>&lt;/strong&gt; <span class="${HIGHLIGHT_CLASS}">hello</span></p>`,
             searchTerm: "test hello",
         },

--- a/addons/mail/static/tests/emoji/emojis_mixin.test.js
+++ b/addons/mail/static/tests/emoji/emojis_mixin.test.js
@@ -3,8 +3,8 @@ import { expect, test } from "@odoo/hoot";
 import { formatText } from "@mail/js/emojis_mixin";
 
 test("Emoji formatter handles compound emojis", () => {
-    const testString = "👩🏿test👩🏿👩t👩";
+    const testString = "<p>👩🏿test👩🏿👩t👩</p>";
     const expectedString =
-        "<span class='o_mail_emoji'>👩🏿</span>test<span class='o_mail_emoji'>👩🏿👩</span>t<span class='o_mail_emoji'>👩</span>";
-    expect(formatText(testString)).toBe(expectedString);
+        "&lt;p&gt;<span class='o_mail_emoji'>👩🏿</span>test<span class='o_mail_emoji'>👩🏿👩</span>t<span class='o_mail_emoji'>👩</span>&lt;/p&gt;";
+    expect(formatText(testString).toString()).toBe(expectedString);
 });

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -23,12 +23,13 @@ import { CHAT_HUB_KEY } from "@mail/core/common/chat_hub_model";
 import { contains } from "./mail_test_helpers_contains";
 
 import { mailGlobal } from "@mail/utils/common/misc";
-import { Component, onMounted, onPatched, onWillDestroy, status } from "@odoo/owl";
+import { Component, markup, onMounted, onPatched, onWillDestroy, status } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { loadEmoji } from "@web/core/emoji_picker/emoji_picker";
 import { registry } from "@web/core/registry";
 import { MEDIAS_BREAKPOINTS, utils as uiUtils } from "@web/core/ui/ui_service";
 import { useServiceProtectMethodHandling } from "@web/core/utils/hooks";
+import { setElementContent } from "@web/core/utils/html";
 import { session } from "@web/session";
 import { WebClient } from "@web/webclient/webclient";
 export { SIZES } from "@web/core/ui/ui_service";
@@ -273,14 +274,17 @@ async function addSwitchTabDropdownItem(rootTarget, tabTarget) {
         dropdownDiv.style.position = "absolute";
         dropdownDiv.classList.add("dropdown");
         dropdownDiv.classList.add("o-mail-multi-tab-dropdown");
-        dropdownDiv.innerHTML = `
-            <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-                Switch Tab (${tabs.length})
-            </button>
-            <ul class="dropdown-menu">
-                <li><a class="dropdown-item">Hoot</a></li>
-            </ul>
-        `;
+        setElementContent(
+            dropdownDiv,
+            markup`
+                <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                    Switch Tab (${tabs.length})
+                </button>
+                <ul class="dropdown-menu">
+                    <li><a class="dropdown-item">Hoot</a></li>
+                </ul>
+            `
+        );
         dropdownDiv.querySelector("a").onclick = onClickDropdownItem;
         rootTarget.appendChild(dropdownDiv);
     }

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -600,6 +600,7 @@ export class DiscussChannel extends models.ServerModel {
                 channel_type: "channel",
                 group_public_id: self.group_public_id,
                 from_message_id: message?.id,
+                // markup: limitation of mock server, html fields are not markup by default
                 name: message
                     ? convertBrToLineBreak(markup(message.body)).substring(0, 30)
                     : name || "New Thread",

--- a/addons/mail/static/tests/utils/html.test.js
+++ b/addons/mail/static/tests/utils/html.test.js
@@ -1,6 +1,5 @@
 import {
     createDocumentFragmentFromContent,
-    htmlJoin,
     htmlReplace,
     htmlReplaceAll,
     htmlTrim,
@@ -19,14 +18,8 @@ test("createDocumentFragmentFromContent escapes text", () => {
 });
 
 test("createDocumentFragmentFromContent keeps html markup", () => {
-    const doc = createDocumentFragmentFromContent(markup("<p>test</p>"));
+    const doc = createDocumentFragmentFromContent(markup`<p>test</p>`);
     expect(doc.body.innerHTML).toEqual("<p>test</p>");
-});
-
-test("htmlJoin keeps html markup and escapes text", () => {
-    const res = htmlJoin(markup("<p>test</p>"), "<p>test</p>");
-    expect(res.toString()).toBe("<p>test</p>&lt;p&gt;test&lt;/p&gt;");
-    expect(res).toBeInstanceOf(Markup);
 });
 
 test("htmlReplace with text/text/text replaces with escaped text", () => {
@@ -187,7 +180,7 @@ test("htmlTrim escapes text", () => {
 });
 
 test("htmlTrim keeps html markup", () => {
-    const res = htmlTrim(markup(" <p>test</p> "));
+    const res = htmlTrim(markup` <p>test</p> `);
     expect(res.toString()).toBe("<p>test</p>");
     expect(res).toBeInstanceOf(Markup);
 });

--- a/addons/mass_mailing/static/src/js/snippets.editor.js
+++ b/addons/mass_mailing/static/src/js/snippets.editor.js
@@ -1,7 +1,8 @@
 import { _t } from "@web/core/l10n/translation";
+import { getInnerHtml } from "@web/core/utils/html";
 import snippetsEditor from "@web_editor/js/editor/snippets.editor";
 import { MassMailingMobilePreviewDialog } from "./mass_mailing_mobile_preview";
-import { markup, useEffect, useState } from "@odoo/owl";
+import { useEffect, useState } from "@odoo/owl";
 
 export class MassMailingSnippetsMenu extends snippetsEditor.SnippetsMenu {
     static tabs = Object.assign({}, snippetsEditor.SnippetsMenu.tabs, {
@@ -214,7 +215,7 @@ export class MassMailingSnippetsMenu extends snippetsEditor.SnippetsMenu {
         });
         this.mobilePreview = this.dialog.add(MassMailingMobilePreviewDialog, {
             title: _t("Mobile Preview"),
-            preview: markup(mailingHtml.body.innerHTML),
+            preview: getInnerHtml(mailingHtml.body),
         }, {
             onClose: () => btn.removeAttribute("disabled"),
         });

--- a/addons/mass_mailing/static/tests/tours/mass_mailing_code_view.js
+++ b/addons/mass_mailing/static/tests/tours/mass_mailing_code_view.js
@@ -14,7 +14,7 @@ registry.category("web_tour.tours").add('mass_mailing_code_view_tour', {
             run: "click",
         }, {
             trigger: 'input#subject_0',
-            content: markup('Pick the <b>email subject</b>.'),
+            content: markup`Pick the <b>email subject</b>.`,
             tooltipPosition: 'bottom',
             run: "edit Test",
         }, {
@@ -27,11 +27,11 @@ registry.category("web_tour.tours").add('mass_mailing_code_view_tour', {
             run: 'click',
         }, {
             trigger: 'div[name="body_arch"] :iframe #default',
-            content: markup('Choose this <b>theme</b>.'),
+            content: `Choose this <b>theme</b>.`,
             run: 'click',
         }, {
             trigger: '.o_codeview_btn',
-            content: markup('Click here to switch to <b>code view</b>'),
+            content: `Click here to switch to <b>code view</b>`,
             run: 'click'
         }, {
             trigger: ':iframe .o_codeview',
@@ -44,7 +44,7 @@ registry.category("web_tour.tours").add('mass_mailing_code_view_tour', {
             }
         }, {
             trigger: '.o_codeview_btn',
-            content: markup('Click here to switch back from <b>code view</b>'),
+            content: markup`Click here to switch back from <b>code view</b>`,
             run: 'click'
         }, {
             trigger: '[name="body_arch"] :iframe .o_mail_wrapper_td',

--- a/addons/point_of_sale/static/src/app/services/render_service.js
+++ b/addons/point_of_sale/static/src/app/services/render_service.js
@@ -62,7 +62,7 @@ export const renderService = {
         };
         const whenMounted = async ({ el, container, callback }) => {
             container ||= document.querySelector(".render-container");
-            container.innerHTML = "";
+            container.textContent = "";
             return await applyWhenMounted({ el, container, callback });
         };
         return { toHtml, toCanvas, toJpeg, whenMounted };

--- a/addons/portal/static/src/interactions/portal_composer.js
+++ b/addons/portal/static/src/interactions/portal_composer.js
@@ -1,9 +1,9 @@
+import { Component, markup } from "@odoo/owl";
+
 import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
-import { escape } from "@web/core/utils/strings";
 import { post } from "@web/core/network/http_service";
-import { Component } from "@odoo/owl";
 import { rpc, RPCError } from "@web/core/network/rpc";
 
 /**
@@ -36,15 +36,18 @@ export class PortalComposer extends Interaction {
                 options[name] = parseInt(options[name]);
             }
         }
-        return Object.assign({
-            "allow_composer": true,
-            "display_composer": false,
-            "csrf_token": odoo.csrf_token,
-            "token": false,
-            "res_model": false,
-            "res_id": false,
-            "send_button_label": _t("Send"),
-        }, options || {});
+        return Object.assign(
+            {
+                allow_composer: true,
+                display_composer: false,
+                csrf_token: odoo.csrf_token,
+                token: false,
+                res_model: false,
+                res_id: false,
+                send_button_label: _t("Send"),
+            },
+            options || {}
+        );
     }
 
     setup() {
@@ -53,8 +56,12 @@ export class PortalComposer extends Interaction {
         this.attachmentButtonEl = this.el.querySelector(".o_portal_chatter_attachment_btn");
         this.fileInputEl = this.el.querySelector(".o_portal_chatter_file_input");
         this.sendButtonEl = this.el.querySelector(".o_portal_chatter_composer_btn");
-        this.attachmentsEl = this.el.querySelector(".o_portal_chatter_composer_input .o_portal_chatter_attachments");
-        this.inputTextareaEl = this.el.querySelector('.o_portal_chatter_composer_input textarea[name="message"]');
+        this.attachmentsEl = this.el.querySelector(
+            ".o_portal_chatter_composer_input .o_portal_chatter_attachments"
+        );
+        this.inputTextareaEl = this.el.querySelector(
+            '.o_portal_chatter_composer_input textarea[name="message"]'
+        );
     }
 
     start() {
@@ -72,16 +79,22 @@ export class PortalComposer extends Interaction {
     }
 
     async onAttachmentDeleteClick(ev, currentTargetEl) {
-        const attachmentId = parseInt(currentTargetEl.closest(".o_portal_chatter_attachment").dataset.id);
-        const accessToken = this.attachments.find(attachment => attachment.id === attachmentId).access_token;
+        const attachmentId = parseInt(
+            currentTargetEl.closest(".o_portal_chatter_attachment").dataset.id
+        );
+        const accessToken = this.attachments.find(
+            (attachment) => attachment.id === attachmentId
+        ).access_token;
 
         this.sendButtonEl.disabled = true;
 
-        await this.waitFor(rpc("/portal/attachment/remove", {
-            "attachment_id": attachmentId,
-            "access_token": accessToken,
-        }));
-        this.attachments = this.attachments.filter(attachment => attachment.id !== attachmentId);
+        await this.waitFor(
+            rpc("/portal/attachment/remove", {
+                attachment_id: attachmentId,
+                access_token: accessToken,
+            })
+        );
+        this.attachments = this.attachments.filter((attachment) => attachment.id !== attachmentId);
         this.updateAttachments();
         this.sendButtonEl.disabled = false;
     }
@@ -99,29 +112,38 @@ export class PortalComposer extends Interaction {
     async onFileInputChange() {
         this.sendButtonEl.disabled = true;
 
-        await this.waitFor(Promise.all([...this.fileInputEl.files].map((file) => {
-            return new Promise((resolve, reject) => {
-                const data = this.prepareAttachmentData(file);
-                if (odoo.csrf_token) {
-                    data.csrf_token = odoo.csrf_token;
-                }
-                this.waitFor(post("/mail/attachment/upload", data)).then((res) => {
-                    let attachment = res.data["ir.attachment"][0]
-                    attachment.state = "pending";
-                    this.attachments.push(attachment);
-                    this.updateAttachments();
-                    resolve();
-                }).catch((error) => {
-                    if (error instanceof RPCError) {
-                        this.services.notification.add(
-                            _t("Could not save file <strong>%s</strong>", escape(file.name)),
-                            { type: "warning", sticky: true }
-                        );
-                        resolve();
-                    }
-                });
-            });
-        })));
+        await this.waitFor(
+            Promise.all(
+                [...this.fileInputEl.files].map(
+                    (file) =>
+                        new Promise((resolve, reject) => {
+                            const data = this.prepareAttachmentData(file);
+                            if (odoo.csrf_token) {
+                                data.csrf_token = odoo.csrf_token;
+                            }
+                            this.waitFor(post("/mail/attachment/upload", data))
+                                .then((res) => {
+                                    const attachment = res.data["ir.attachment"][0];
+                                    attachment.state = "pending";
+                                    this.attachments.push(attachment);
+                                    this.updateAttachments();
+                                    resolve();
+                                })
+                                .catch((error) => {
+                                    if (error instanceof RPCError) {
+                                        this.services.notification.add(
+                                            _t("Could not save file %(name)s", {
+                                                name: markup`<strong>${file.name}</strong>`,
+                                            }),
+                                            { type: "warning", sticky: true }
+                                        );
+                                        resolve();
+                                    }
+                                });
+                        })
+                )
+            )
+        );
         // ensures any selection triggers a change, even if the same files are selected again
         this.fileInputEl.value = null;
         this.sendButtonEl.disabled = false;
@@ -159,16 +181,22 @@ export class PortalComposer extends Interaction {
 
     onSubmitCheckContent() {
         if (!this.inputTextareaEl.value.trim() && !this.attachments.length) {
-            return _t("Some fields are required. Please make sure to write a message or attach a document");
-        };
+            return _t(
+                "Some fields are required. Please make sure to write a message or attach a document"
+            );
+        }
     }
 
     updateAttachments() {
         this.attachmentsEl.replaceChildren();
-        this.renderAt("portal.Chatter.Attachments", {
-            attachments: this.attachments,
-            showDelete: true,
-        }, this.attachmentsEl);
+        this.renderAt(
+            "portal.Chatter.Attachments",
+            {
+                attachments: this.attachments,
+                showDelete: true,
+            },
+            this.attachmentsEl
+        );
     }
 
     /**
@@ -184,6 +212,4 @@ export class PortalComposer extends Interaction {
     }
 }
 
-registry
-    .category("public.interactions")
-    .add("portal.portal_composer", PortalComposer);
+registry.category("public.interactions").add("portal.portal_composer", PortalComposer);

--- a/addons/product_matrix/static/src/js/product_matrix_dialog.js
+++ b/addons/product_matrix/static/src/js/product_matrix_dialog.js
@@ -1,7 +1,7 @@
 import { Dialog } from '@web/core/dialog/dialog';
 import { formatMonetary } from "@web/views/fields/formatters";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
-import { Component, onMounted, markup, useRef } from "@odoo/owl";
+import { Component, markup, onMounted, useRef } from "@odoo/owl";
 
 export class ProductMatrixDialog extends Component {
     static template = "product_matrix.dialog";
@@ -60,7 +60,7 @@ export class ProductMatrixDialog extends Component {
                 currencyId: currency_id,
             },
         );
-        return markup(`&nbsp;${sign}&nbsp;${formatted}&nbsp;`);
+        return markup`&nbsp;${sign}&nbsp;${formatted}&nbsp;`;
     }
 
     _onConfirm() {

--- a/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
+++ b/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
@@ -2,7 +2,6 @@ import { Component, useState, markup } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
-import { escape } from "@web/core/utils/strings";
 import { _t } from "@web/core/l10n/translation";
 
 import { Field, getPropertyFieldInfo } from "@web/views/fields/field";
@@ -90,13 +89,10 @@ export class SubtaskKanbanList extends Component {
 
     async _onSubtaskCreateNameChanged(name) {
         if (name.trim() === "") {
-            this.notification.add(
-                markup(`<ul><li>${escape(_t("Display Name"))}</li></ul>`),
-                {
-                    title: _t("Invalid fields: "),
-                    type: "danger",
-                }
-            );
+            this.notification.add(markup`<ul><li>${_t("Display Name")}</li></ul>`, {
+                title: _t("Invalid fields: "),
+                type: "danger",
+            });
         } else {
             await this.orm.create("project.task", [{
                 display_name: name,

--- a/addons/project/static/src/views/project_task_form/project_task_form_controller.js
+++ b/addons/project/static/src/views/project_task_form/project_task_form_controller.js
@@ -2,9 +2,8 @@ import { _t } from "@web/core/l10n/translation";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { HistoryDialog } from "@html_editor/components/history_dialog/history_dialog";
 import { useService } from '@web/core/utils/hooks';
-import { markup } from '@odoo/owl';
-import { escape } from '@web/core/utils/strings';
 import { FormControllerWithHTMLExpander } from '@resource/views/form_with_html_expander/form_controller_with_html_expander';
+import { markup } from "@odoo/owl";
 
 export const subTaskDeleteConfirmationMessage = _t(
     `Deleting a task will also delete its associated sub-tasks. \
@@ -51,9 +50,9 @@ export class ProjectTaskFormController extends FormControllerWithHTMLExpander {
         const historyMetadata = record.data["html_field_history_metadata"]?.[versionedFieldName];
         if (!historyMetadata) {
             this.notifications.add(
-                escape(_t(
+                _t(
                     "The task description lacks any past content that could be restored at the moment."
-                ))
+                )
             );
             return;
         }
@@ -62,13 +61,9 @@ export class ProjectTaskFormController extends FormControllerWithHTMLExpander {
             HistoryDialog,
             {
                 title: _t("Task Description History"),
-                noContentHelper: markup(
-                    `<span class='text-muted fst-italic'>${escape(
-                        _t(
-                            "The task description was empty at the time."
-                        )
-                    )}</span>`
-                ),
+                noContentHelper: markup`<span class='text-muted fst-italic'>${_t(
+                    "The task description was empty at the time."
+                )}</span>`,
                 recordId: record.resId,
                 recordModel: this.props.resModel,
                 versionedFieldName,

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_examples.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_examples.js
@@ -1,12 +1,12 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { renderToMarkup } from '@web/core/utils/render';
+import { renderToMarkup } from "@web/core/utils/render";
 import { markup } from "@odoo/owl";
 
-const greenBullet = markup(`<span class="o_status d-inline-block o_status_green"></span>`);
-const orangeBullet = markup(`<span class="o_status d-inline-block text-warning"></span>`);
-const star = markup(`<a style="color: gold;" class="fa fa-star"></a>`);
-const clock = markup(`<a class="fa fa-clock-o"></a>`);
+const greenBullet = markup`<span class="o_status d-inline-block o_status_green"></span>`;
+const orangeBullet = markup`<span class="o_status d-inline-block text-warning"></span>`;
+const star = markup`<a style="color: gold;" class="fa fa-star"></a>`;
+const clock = markup`<a class="fa fa-clock-o"></a>`;
 
 const exampleData = {
     ghostColumns: [_t('New'), _t('Assigned'), _t('In Progress'), _t('Done')],

--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -7,7 +7,9 @@
  * - Click the restore button and check that the content is correctly restored
  */
 
+import { markup } from "@odoo/owl";
 import { registry } from "@web/core/registry";
+import { getInnerHtml } from "@web/core/utils/html";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 const baseDescriptionContent = "Test project task history version";
@@ -108,9 +110,9 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
         content: "Verify comparaison text",
         trigger: ".modal .history-container .tab-pane",
         run: function () {
-            const comparaisonHtml = this.anchor.innerHTML;
-            const correctHtml = `<added>${baseDescriptionContent} 1</added><removed>${baseDescriptionContent} 3</removed>`;
-            if (!comparaisonHtml.includes(correctHtml)) {
+            const comparaisonHtml = getInnerHtml(this.anchor);
+            const correctHtml = markup`<added>${baseDescriptionContent} 1</added><removed>${baseDescriptionContent} 3</removed>`;
+            if (!comparaisonHtml.toString().includes(correctHtml.toString())) {
                 console.error(`Expect comparison to be ${correctHtml}, got ${comparaisonHtml}`);
             }
         },

--- a/addons/project_todo/static/tests/tours/project_todo_main_functions.js
+++ b/addons/project_todo/static/tests/tours/project_todo_main_functions.js
@@ -165,7 +165,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     run: "click",
 }, {
     trigger: ".o_project_task_form_view .breadcrumb-item:last-child",
-    content: markup("Let's go back to the <b>kanban view</b> to have an overview of tasks linked to project chosen."),
+    content: markup`Let's go back to the <b>kanban view</b> to have an overview of tasks linked to project chosen.`,
     run: "click",
 }, {
     trigger: ".o_kanban_view",

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -66,7 +66,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     run: "click",
 }, {
     trigger: 'div[name="partner_id"] input',
-    content: markup('Select the customer of your Sales Order <i>(e.g. Brandon Freeman)</i>. Since we have a Sales Order for this customer with a prepaid service product which the remaining hours to deliver is greater than 0, the Sales Order Item in the task should be contain the Sales Order Item containing this prepaid service product.'),
+    content: markup`Select the customer of your Sales Order <i>(e.g. Brandon Freeman)</i>. Since we have a Sales Order for this customer with a prepaid service product which the remaining hours to deliver is greater than 0, the Sales Order Item in the task should be contain the Sales Order Item containing this prepaid service product.`,
     run: "edit Brandon Freeman",
 }, {
     trigger: 'div[name="partner_id"] ul > li:first-child > a:contains(Freeman)',
@@ -160,7 +160,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     }
 }, {
     trigger: 'div[name="partner_id"] input',
-    content: markup('Add the customer for this project to select an SO and SOL for this customer <i>(e.g. Brandon Freeman)</i>.'),
+    content: markup`Add the customer for this project to select an SO and SOL for this customer <i>(e.g. Brandon Freeman)</i>.`,
     run: "edit Brandon Freeman",
 }, {
     trigger: 'div[name="partner_id"] ul > li:first-child > a:contains(Freeman)',
@@ -222,7 +222,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     // timer: 300,
 }, {
     trigger: 'div[name="partner_id"] input',
-    content: markup('Add the customer for this project to select an SO and SOL for this customer <i>(e.g. Brandon Freeman)</i>.'),
+    content: markup`Add the customer for this project to select an SO and SOL for this customer <i>(e.g. Brandon Freeman)</i>.`,
     run: "edit Brandon Freeman",
 }, {
     trigger: 'div[name="partner_id"] ul > li:first-child > a:contains(Freeman)',

--- a/addons/web/static/src/core/effects/effect_service.js
+++ b/addons/web/static/src/core/effects/effect_service.js
@@ -1,6 +1,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { user } from "@web/core/user";
+import { getOuterHtml } from "@web/core/utils/html";
 import { RainbowMan } from "./rainbow_man";
 
 const effectRegistry = registry.category("effects");
@@ -38,7 +39,7 @@ function rainbowMan(env, params = {}) {
         console.log(
             "Providing an HTML element to an effect is deprecated. Note that all event handlers will be lost."
         );
-        message = message.outerHTML;
+        message = getOuterHtml(message);
     } else if (!message) {
         message = _t("Well Done!");
     }

--- a/addons/web/static/src/core/l10n/translation.js
+++ b/addons/web/static/src/core/l10n/translation.js
@@ -3,7 +3,7 @@ import { markup } from "@odoo/owl";
 import { formatList } from "@web/core/l10n/utils";
 import { isIterable } from "@web/core/utils/arrays";
 import { Deferred } from "@web/core/utils/concurrency";
-import { htmlEscape } from "@web/core/utils/html";
+import { htmlSprintf } from "@web/core/utils/html";
 import { isObject } from "@web/core/utils/objects";
 import { sprintf } from "@web/core/utils/strings";
 
@@ -36,7 +36,7 @@ const Markup = markup().constructor;
  * _t("Good morning"); // "Bonjour"
  * _t("Good morning %s", user.name); // "Bonjour Marc"
  * _t("Good morning %(newcomer)s, goodbye %(departer)s", { newcomer: Marc, departer: Mitchel }); // Bonjour Marc, au revoir Mitchel
- * _t("I love %s", markup("<blink>Minecraft</blink>")); // Markup {"J'adore <blink>Minecraft</blink>"}
+ * _t("I love %s", markup`<blink>Minecraft</blink>`); // Markup {"J'adore <blink>Minecraft</blink>"}
  * _t("Good morning %s!", ["Mitchell", "Marc", "Louis"]); // Bonjour Mitchell, Marc et Louis !
  *
  * @param {string} term
@@ -137,25 +137,7 @@ function _safeFormatAndSprintf(str, ...values) {
         hasMarkup ||= value instanceof Markup;
     }
     if (hasMarkup) {
-        return markup(sprintf(htmlEscape(str), ..._escapeNonMarkup(values)));
+        return htmlSprintf(str, ...values);
     }
     return sprintf(str, ...values);
-}
-
-/**
- * Go through each value to be passed to sprintf and escape anything that isn't
- * a markup.
- *
- * @param {any[]|[Object]} values Values for use with sprintf.
- * @returns {any[]|[Object]}
- */
-function _escapeNonMarkup(values) {
-    if (isObject(values[0])) {
-        const sanitized = {};
-        for (const [key, value] of Object.entries(values[0])) {
-            sanitized[key] = htmlEscape(value);
-        }
-        return [sanitized];
-    }
-    return values.map((x) => htmlEscape(x));
 }

--- a/addons/web/static/src/core/utils/render.js
+++ b/addons/web/static/src/core/utils/render.js
@@ -1,6 +1,7 @@
-import { App, blockDom, Component, markup } from "@odoo/owl";
+import { App, blockDom, Component } from "@odoo/owl";
 import { getTemplate } from "@web/core/templates";
 import { _t } from "@web/core/l10n/translation";
+import { getInnerHtml } from "@web/core/utils/html";
 
 export function renderToElement(template, context = {}) {
     const el = render(template, context).firstElementChild;
@@ -26,12 +27,13 @@ export function renderToFragment(template, context = {}) {
 /**
  * renders a template with an (optional) context and outputs it as a string
  *
+ * @deprecated use renderToMarkup instead, as HTML string should always be stored in a markup
  * @param {string} template
  * @param {Object} context
  * @returns string: the html of the template
  */
 export function renderToString(template, context = {}) {
-    return render(template, context).innerHTML;
+    return renderToMarkup(template, context).toString();
 }
 let app;
 Object.defineProperty(renderToString, "app", {
@@ -66,5 +68,5 @@ function render(template, context = {}) {
  * @returns {ReturnType<markup>} the html of the template, as a markup string
  */
 export function renderToMarkup(template, context = {}) {
-    return markup(renderToString(template, context));
+    return getInnerHtml(render(template, context));
 }

--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -3,32 +3,6 @@ import { isObject } from "./objects";
 export const nbsp = "\u00a0";
 
 /**
- * Escapes a string for HTML.
- *
- * @param {string | number} [str] the string to escape
- * @returns {string} an escaped string
- */
-export function escape(str) {
-    if (str === undefined) {
-        return "";
-    }
-    if (typeof str === "number") {
-        return String(str);
-    }
-    [
-        ["&", "&amp;"],
-        ["<", "&lt;"],
-        [">", "&gt;"],
-        ["'", "&#x27;"],
-        ['"', "&quot;"],
-        ["`", "&#x60;"],
-    ].forEach((pairs) => {
-        str = String(str).replaceAll(pairs[0], pairs[1]);
-    });
-    return str;
-}
-
-/**
  * Escapes a string to use as a RegExp.
  * @url https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
  *

--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -8,7 +8,7 @@ import {
     humanNumber,
     insertThousandsSep,
 } from "@web/core/utils/numbers";
-import { escape, exprToBoolean } from "@web/core/utils/strings";
+import { exprToBoolean } from "@web/core/utils/strings";
 
 import { markup } from "@odoo/owl";
 import { formatCurrency } from "@web/core/currency";
@@ -52,19 +52,18 @@ export function formatBinary(value) {
  * @returns {string}
  */
 export function formatBoolean(value) {
-    return markup(`
+    return markup`
         <div class="o-checkbox d-inline-block me-2">
             <input id="boolean_checkbox" type="checkbox" class="form-check-input" disabled ${
                 value ? "checked" : ""
             }/>
             <label for="boolean_checkbox" class="form-check-label"/>
-        </div>`);
+        </div>`;
 }
 
 /**
  * @param {string} value
  * @param {Object} [options] additional options
- * @param {boolean} [options.escape=false] if true, escapes the formatted value
  * @param {boolean} [options.isPassword=false] if true, returns '********'
  *   instead of the formatted value
  * @returns {string}
@@ -72,9 +71,6 @@ export function formatBoolean(value) {
 export function formatChar(value, options) {
     if (options && options.isPassword) {
         return "*".repeat(value ? value.length : 0);
-    }
-    if (options && options.escape) {
-        value = escape(value);
     }
     return value;
 }

--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.js
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.js
@@ -7,7 +7,6 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { groupBy } from "@web/core/utils/arrays";
-import { escape } from "@web/core/utils/strings";
 import { throttleForAnimation } from "@web/core/utils/timing";
 import { getFieldDomain } from "@web/model/relational_model/utils";
 import { useSpecialData } from "@web/views/fields/relational_utils";
@@ -112,7 +111,7 @@ export class StatusBarField extends Component {
 
         // Command palette
         if (this.props.withCommand) {
-            const moveToCommandName = _t("Move to %s...", escape(this.field.string));
+            const moveToCommandName = _t("Move to %s...", this.field.string);
             useCommand(
                 moveToCommandName,
                 () => ({

--- a/addons/web/static/src/webclient/actions/client_actions.js
+++ b/addons/web/static/src/webclient/actions/client_actions.js
@@ -2,7 +2,7 @@ import { browser } from "@web/core/browser/browser";
 import { router } from "@web/core/browser/router";
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
-import { escape, sprintf } from "@web/core/utils/strings";
+import { htmlSprintf } from "@web/core/utils/html";
 
 import { markup } from "@odoo/owl";
 
@@ -14,10 +14,10 @@ export function displayNotificationAction(env, action) {
         title: params.title,
         type: params.type || "info",
     };
-    const links = (params.links || []).map((link) => {
-        return `<a href="${escape(link.url)}" target="_blank">${escape(link.label)}</a>`;
-    });
-    const message = markup(sprintf(escape(params.message), ...links));
+    const links = (params.links || []).map(
+        (link) => markup`<a href="${link.url}" target="_blank">${link.label}</a>`
+    );
+    const message = htmlSprintf(params.message, ...links);
     env.services.notification.add(message, options);
     return params.next;
 }

--- a/addons/web/static/src/webclient/user_menu/user_menu_items.js
+++ b/addons/web/static/src/webclient/user_menu/user_menu_items.js
@@ -3,7 +3,6 @@ import { isMacOS } from "@web/core/browser/feature_detection";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { user } from "@web/core/user";
-import { escape } from "@web/core/utils/strings";
 import { session } from "@web/session";
 import { browser } from "../../core/browser/browser";
 import { registry } from "../../core/registry";
@@ -51,12 +50,10 @@ function shortCutsItem(env) {
         type: "item",
         id: "shortcuts",
         hide: env.isSmall,
-        description: markup(
-            `<div class="d-flex align-items-center justify-content-between">
-                <span>${escape(_t("Shortcuts"))}</span>
+        description: markup`<div class="d-flex align-items-center justify-content-between">
+                <span>${_t("Shortcuts")}</span>
                 <span class="fw-bold">${isMacOS() ? "CMD" : "CTRL"}+K</span>
-            </div>`
-        ),
+            </div>`,
         callback: () => {
             env.services.command.openMainPalette({ FooterComponent: ShortcutsFooterComponent });
         },

--- a/addons/web/static/tests/core/code_editor.test.js
+++ b/addons/web/static/tests/core/code_editor.test.js
@@ -101,7 +101,7 @@ test("CodeEditor shouldn't accepts markup values", async () => {
     }
 
     const codeEditor = await mountWithCleanup(GrandParent);
-    const textMarkup = markup("<div>Some Text</div>");
+    const textMarkup = markup`<div>Some Text</div>`;
 
     codeEditor.state.value = textMarkup;
     await animationFrame();

--- a/addons/web/static/tests/core/effects/effect_service.test.js
+++ b/addons/web/static/tests/core/effects/effect_service.test.js
@@ -11,7 +11,7 @@ let effectParams;
 beforeEach(async () => {
     await mountWithCleanup(MainComponentsContainer);
     effectParams = {
-        message: markup("<div>Congrats!</div>"),
+        message: markup`<div>Congrats!</div>`,
     };
 });
 

--- a/addons/web/static/tests/core/l10n/translation.test.js
+++ b/addons/web/static/tests/core/l10n/translation.test.js
@@ -158,7 +158,10 @@ test("_t fills the format specifiers in translated terms with formatted lists", 
     });
     await mockLang("fr_FR");
     const translatedStr1 = _t("Due in %s days", ["30", "60", "90"]);
-    const translatedStr2 = _t("Due in %(due_dates)s days for %(user)s", {due_dates: ["30", "60", "90"], user: "Mitchell"});
+    const translatedStr2 = _t("Due in %(due_dates)s days for %(user)s", {
+        due_dates: ["30", "60", "90"],
+        user: "Mitchell",
+    });
     expect(translatedStr1).toBe("Échéance dans 30, 60 et 90 jours");
     expect(translatedStr2).toBe("Échéance dans 30, 60 et 90 jours pour Mitchell");
 });
@@ -179,8 +182,8 @@ describe("_t with markups", () => {
         const translatedStr = _t(
             "FREE %(blink_start)sROBUX%(blink_end)s, please contact %(email)s",
             {
-                blink_start: markup("<blink>"),
-                blink_end: markup("</blink>"),
+                blink_start: markup`<blink>`,
+                blink_end: markup`</blink>`,
                 email: maliciousUserInput,
             }
         );
@@ -193,7 +196,7 @@ describe("_t with markups", () => {
         translatedTerms[translationLoaded] = true;
         const maliciousTranslation = "<script>document.write('pizza hawai')</script> %s";
         patchTranslations({ "I love %s": maliciousTranslation });
-        const translatedStr = _t("I love %s", markup("<blink>Mario Kart</blink>"));
+        const translatedStr = _t("I love %s", markup`<blink>Mario Kart</blink>`);
         expect(translatedStr.valueOf()).toBe(
             "&lt;script&gt;document.write(&#x27;pizza hawai&#x27;)&lt;/script&gt; <blink>Mario Kart</blink>"
         );

--- a/addons/web/static/tests/core/notifications/notifications.test.js
+++ b/addons/web/static/tests/core/notifications/notifications.test.js
@@ -49,7 +49,7 @@ test("can display a notification with markup content", async () => {
         .category("main_components")
         .get("NotificationContainer");
     await mountWithCleanup(NotificationContainer, { props, noMainContainer: true });
-    getService("notification").add(markup("<b>I'm a <i>markup</i> notification</b>"));
+    getService("notification").add(markup`<b>I'm a <i>markup</i> notification</b>`);
     await animationFrame();
     expect(".o_notification").toHaveCount(1);
     expect(".o_notification_content").toHaveInnerHTML("<b>I'm a <i>markup</i> notification</b>");

--- a/addons/web/static/tests/core/utils/html.test.js
+++ b/addons/web/static/tests/core/utils/html.test.js
@@ -5,8 +5,9 @@ const Markup = markup().constructor;
 import { describe, expect, test } from "@odoo/hoot";
 import {
     createElementWithContent,
-    htmlEscape,
     htmlFormatList,
+    htmlJoin,
+    htmlSprintf,
     isHtmlEmpty,
     setElementContent,
 } from "@web/core/utils/html";
@@ -19,19 +20,58 @@ test("createElementWithContent escapes text", () => {
 });
 
 test("createElementWithContent keeps html markup", () => {
-    const res = createElementWithContent("div", markup("<p>test</p>"));
+    const res = createElementWithContent("div", markup`<p>test</p>`);
     expect(res.outerHTML).toBe("<div><p>test</p></div>");
 });
 
-test("htmlEscape escapes text", () => {
-    const res = htmlEscape("<p>test</p>");
-    expect(res.toString()).toBe("&lt;p&gt;test&lt;/p&gt;");
+test("htmlJoin keeps html markup and escapes text", () => {
+    const res = htmlJoin([markup`<p>test</p>`, "<p>test</p>"]);
+    expect(res.toString()).toBe("<p>test</p>&lt;p&gt;test&lt;/p&gt;");
     expect(res).toBeInstanceOf(Markup);
 });
 
-test("htmlEscape keeps html markup", () => {
-    const res = htmlEscape(markup("<p>test</p>"));
-    expect(res.toString()).toBe("<p>test</p>");
+test("htmlJoin escapes text separator", () => {
+    const res = htmlJoin(["a", "b"], "<br>");
+    expect(res.toString()).toBe("a&lt;br&gt;b");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlJoin keeps html separator", () => {
+    const res = htmlJoin(["a", "b"], markup`<br>`);
+    expect(res.toString()).toBe("a<br>b");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlSprintf escapes str with list params", () => {
+    const res = htmlSprintf("<p>%s</p>", "Hi");
+    expect(res.toString()).toBe("&lt;p&gt;Hi&lt;/p&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlSprintf escapes list params", () => {
+    const res = htmlSprintf(
+        markup`<p>%s</p>%s`,
+        markup`<span>test 1</span>`,
+        `<span>test 2</span>`
+    );
+    expect(res.toString()).toBe(
+        "<p><span>test 1</span>,&lt;span&gt;test 2&lt;/span&gt;</p>undefined"
+    );
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlSprintf escapes str with object params", () => {
+    const res = htmlSprintf("<p>%(t1)s</p>", { t1: "Hi" });
+    expect(res.toString()).toBe("&lt;p&gt;Hi&lt;/p&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlSprintf escapes object param", () => {
+    const res = htmlSprintf(markup`<p>%(t1)s</p>%(t2)s`, {
+        t1: `<span>test 1</span>`,
+        t2: markup`<span>test 2</span>`,
+    });
+    expect(res.toString()).toBe("<p>&lt;span&gt;test 1&lt;/span&gt;</p><span>test 2</span>");
     expect(res).toBeInstanceOf(Markup);
 });
 
@@ -40,7 +80,7 @@ test("isHtmlEmpty does not consider text as empty", () => {
 });
 
 test("isHtmlEmpty considers empty html markup as empty", () => {
-    expect(isHtmlEmpty(markup("<p></p>"))).toBe(true);
+    expect(isHtmlEmpty(markup`<p></p>`)).toBe(true);
 });
 
 test("setElementContent escapes text", () => {
@@ -51,12 +91,12 @@ test("setElementContent escapes text", () => {
 
 test("setElementContent keeps html markup", () => {
     const div = document.createElement("div");
-    setElementContent(div, markup("<p>test</p>"));
+    setElementContent(div, markup`<p>test</p>`);
     expect(div.innerHTML).toBe("<p>test</p>");
 });
 
 test("htmlFormatList", () => {
-    const list = ["<p>test 1</p>", markup("<p>test 2</p>"), "&lt;p&gt;test 3&lt;/p&gt;"];
+    const list = ["<p>test 1</p>", markup`<p>test 2</p>`, "&lt;p&gt;test 3&lt;/p&gt;"];
     const res = htmlFormatList(list, { localeCode: "fr-FR" });
     expect(res.toString()).toBe(
         "&lt;p&gt;test 1&lt;/p&gt;, <p>test 2</p> et &amp;lt;p&amp;gt;test 3&amp;lt;/p&amp;gt;"

--- a/addons/web/static/tests/core/utils/strings.test.js
+++ b/addons/web/static/tests/core/utils/strings.test.js
@@ -3,7 +3,6 @@ import { patchTranslations } from "@web/../tests/web_test_helpers";
 
 import {
     capitalize,
-    escape,
     escapeRegExp,
     intersperse,
     isEmail,
@@ -14,19 +13,6 @@ import {
 import { _t } from "@web/core/l10n/translation";
 
 describe.current.tags("headless");
-
-test("escape", () => {
-    expect(escape("<a>this is a link</a>")).toBe("&lt;a&gt;this is a link&lt;/a&gt;");
-    expect(escape(`<a href="https://www.odoo.com">odoo<a>`)).toBe(
-        `&lt;a href=&quot;https://www.odoo.com&quot;&gt;odoo&lt;a&gt;`
-    );
-    expect(escape(`<a href='https://www.odoo.com'>odoo<a>`)).toBe(
-        `&lt;a href=&#x27;https://www.odoo.com&#x27;&gt;odoo&lt;a&gt;`
-    );
-    expect(escape("<a href='https://www.odoo.com'>Odoo`s website<a>")).toBe(
-        `&lt;a href=&#x27;https://www.odoo.com&#x27;&gt;Odoo&#x60;s website&lt;a&gt;`
-    );
-});
 
 test("escapeRegExp", () => {
     expect(escapeRegExp("")).toBe("");

--- a/addons/web/static/tests/public/helpers.js
+++ b/addons/web/static/tests/public/helpers.js
@@ -1,6 +1,8 @@
 import { getFixture, after } from "@odoo/hoot";
+import { markup } from "@odoo/owl";
 import { clearRegistry, makeMockEnv, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { registry } from "@web/core/registry";
+import { setElementContent } from "@web/core/utils/html";
 
 let activeInteractions = null;
 const elementRegistry = registry.category("public.interactions");
@@ -35,10 +37,10 @@ export async function startInteractions(
         defineMailModels();
     }
     const fixture = getFixture();
-    if (!html.includes("wrapwrap")) {
-        html = `<div id="wrapwrap">${html}</div>`;
+    if (!html.toString().includes("wrapwrap")) {
+        html = markup`<div id="wrapwrap">${html}</div>`;
     }
-    fixture.innerHTML = html;
+    setElementContent(fixture, html);
     if (options.translateMode) {
         fixture.closest("html").dataset.edit_translations = "1";
     }

--- a/addons/web/static/tests/public/interaction.test.js
+++ b/addons/web/static/tests/public/interaction.test.js
@@ -8,34 +8,34 @@ import { Interaction } from "@web/public/interaction";
 import { patchDynamicContent } from "@web/public/utils";
 import { patch } from "@web/core/utils/patch";
 import { startInteraction } from "./helpers";
-import { Component, onWillDestroy, xml } from "@odoo/owl";
+import { Component, markup, onWillDestroy, xml } from "@odoo/owl";
 
 describe.current.tags("interaction_dev");
 
-const TemplateBase = `
+const TemplateBase = markup`
     <div>
         <span>coucou</span>
     </div>`;
 
-const TemplateTest = `
+const TemplateTest = markup`
     <div class="test">
         <span>coucou</span>
     </div>`;
 
-const TemplateTestDoubleSpan = `
+const TemplateTestDoubleSpan = markup`
     <div class="test">
         <span>span1</span>
         <span>span2</span>
     </div>`;
 
-const TemplateTestDoubleButton = `
+const TemplateTestDoubleButton = markup`
     <div class="test">
         <button>button1</button>
         <button>button2</button>
     </div>`;
 
 const getTemplateWithAttribute = function (attribute) {
-    return `
+    return markup`
     <div>
         <span ${attribute}">coucou</span>
     </div>`;
@@ -156,7 +156,7 @@ describe("adding listeners", () => {
                 spanEl.click();
             }
         }
-        await startInteraction(Test, `<iframe src="about:blank"/>`);
+        await startInteraction(Test, markup`<iframe src="about:blank"/>`);
         expect.verifySteps(["click"]);
     });
 
@@ -172,7 +172,7 @@ describe("adding listeners", () => {
                 spanEl.click();
             }
         }
-        await startInteraction(Test, `<iframe src="about:blank"/>`);
+        await startInteraction(Test, markup`<iframe src="about:blank"/>`);
         expect.verifySteps(["click"]);
     });
     test("updateContent after async listener", async () => {
@@ -271,7 +271,7 @@ describe("using selectors", () => {
                 _modal: { "t-on-click": () => clicked++ },
             };
         }
-        await startInteraction(Test, `<div class="modal">${TemplateTest}</div>`);
+        await startInteraction(Test, markup`<div class="modal">${TemplateTest}</div>`);
         expect(clicked).toBe(0);
         await click(".modal");
         expect(clicked).toBe(1);
@@ -296,7 +296,7 @@ describe("using selectors", () => {
         }
         await startInteraction(
             Test,
-            `
+            markup`
             <div class="test">
                 <span class="me">span1</span>
                 <span>span2</span>
@@ -344,7 +344,7 @@ describe("using selectors", () => {
         }
         await startInteraction(
             Test,
-            `
+            markup`
             <div class="test">
                 <span class="btn"></span>
                 <span class="btn off"></span>
@@ -369,7 +369,7 @@ describe("using selectors", () => {
         }
         await startInteraction(
             Test,
-            `
+            markup`
             <div class="test">
                 <span class="my-selector">coucou</span>
             </div>`
@@ -667,7 +667,7 @@ describe("using qualifiers", () => {
         }
         await startInteraction(
             Test,
-            `
+            markup`
             <div class="test">
                 <span>
                     <strong>coucou</strong>
@@ -689,7 +689,7 @@ describe("using qualifiers", () => {
         }
         await startInteraction(
             Test,
-            `
+            markup`
             <div class="test">
                 <span>
                     <strong>coucou</strong>
@@ -1192,7 +1192,7 @@ describe("t-att-class", () => {
                 _root: { "t-att-class": () => ({ a: false }) },
             };
         }
-        await startInteraction(Test, getTemplateWithAttribute("class='a'"));
+        await startInteraction(Test, getTemplateWithAttribute(markup`class='a'`));
         expect("span").not.toHaveClass("a");
     });
 
@@ -1215,7 +1215,7 @@ describe("t-att-class", () => {
                 _root: { "t-att-class": () => ({ b: true }) },
             };
         }
-        const { core } = await startInteraction(Test, getTemplateWithAttribute("class='a'"));
+        const { core } = await startInteraction(Test, getTemplateWithAttribute(markup`class='a'`));
         expect("span").toHaveClass("a b");
         core.stopInteractions();
         expect("span").toHaveClass("a");
@@ -1255,7 +1255,10 @@ describe("t-att-class", () => {
                 _root: { "t-att-class": () => ({ b: undefined }) },
             };
         }
-        const { core } = await startInteraction(Test, getTemplateWithAttribute("class='a b'"));
+        const { core } = await startInteraction(
+            Test,
+            getTemplateWithAttribute(markup`class='a b'`)
+        );
         expect("span").toHaveClass("a");
         expect("span").not.toHaveClass("b");
         core.interactions[0].interaction.updateContent();
@@ -1296,7 +1299,7 @@ describe("t-att-class", () => {
             };
         }
 
-        const { core } = await startInteraction(Test, getTemplateWithAttribute("class='a'"));
+        const { core } = await startInteraction(Test, getTemplateWithAttribute(markup`class='a'`));
         const span = queryOne("span");
         expect(span).toHaveClass(["a", "b"]);
         span.classList.add("c");
@@ -1326,7 +1329,7 @@ describe("t-att-style", () => {
                 _root: { "t-att-style": () => ({ color: undefined }) },
             };
         }
-        await startInteraction(Test, getTemplateWithAttribute("style='color: red;'"));
+        await startInteraction(Test, getTemplateWithAttribute(markup`style='color: red;'`));
         expect("span").not.toHaveStyle({ color: "rgb(255, 0, 0)" });
     });
 
@@ -1357,7 +1360,7 @@ describe("t-att-style", () => {
 
         const { core } = await startInteraction(
             Test,
-            getTemplateWithAttribute("style='background-color: blue'")
+            getTemplateWithAttribute(markup`style='background-color: blue'`)
         );
         const span = queryOne("span");
         expect(span).toHaveStyle({ "background-color": "rgb(0, 0, 0)", color: "rgb(255, 0, 0)" });
@@ -1412,7 +1415,7 @@ describe("t-att-style", () => {
         }
         const { core } = await startInteraction(
             Test,
-            getTemplateWithAttribute("style='background-color: blue;'")
+            getTemplateWithAttribute(markup`style='background-color: blue;'`)
         );
         expect("span").toHaveStyle({ backgroundColor: "rgb(0, 0, 255)", color: "rgb(255, 0, 0)" });
         core.stopInteractions();
@@ -1616,7 +1619,7 @@ describe("t-att and t-out", () => {
         }
         const { core } = await startInteraction(
             Test,
-            `
+            markup`
             <div>
                 <span data-animal="colibri">1</span>
                 <span data-animal="owlet">2</span>
@@ -1639,7 +1642,7 @@ describe("t-att and t-out", () => {
         }
         const { core } = await startInteraction(
             Test,
-            `
+            markup`
             <div>
                 <span data-animal="colibri">1</span>
                 <span data-animal="owlet">2</span>
@@ -1685,7 +1688,7 @@ describe("components", () => {
                 _root: { "t-component": C },
             };
         }
-        const { core } = await startInteraction(Test, `<div class="test"></div>`);
+        const { core } = await startInteraction(Test, markup`<div class="test"></div>`);
         expect(".test").toHaveOuterHTML(
             `<div class="test"><owl-component contenteditable="false" data-oe-protected="true"></owl-component></div>`
         );
@@ -1718,7 +1721,7 @@ describe("components", () => {
                 _root: { "t-component": () => [C, { prop: "hello" }] },
             };
         }
-        const { core } = await startInteraction(Test, `<div class="test"></div>`);
+        const { core } = await startInteraction(Test, markup`<div class="test"></div>`);
         expect(".test").toHaveOuterHTML(
             `<div class="test"><owl-component contenteditable="false" data-oe-protected="true"></owl-component></div>`
         );
@@ -1745,7 +1748,7 @@ describe("components", () => {
                 this.mountComponent(this.el, C);
             }
         }
-        await startInteraction(Test, `<div class="test"></div>`);
+        await startInteraction(Test, markup`<div class="test"></div>`);
         expect(".test").toHaveOuterHTML(
             `<div class="test"><owl-component contenteditable="false" data-oe-protected="true"></owl-component></div>`
         );
@@ -1770,7 +1773,7 @@ describe("components", () => {
                 this.mountComponent(this.el, C, { prop: "with prop" });
             }
         }
-        await startInteraction(Test, `<div class="test"></div>`);
+        await startInteraction(Test, markup`<div class="test"></div>`);
         expect(".test").toHaveOuterHTML(
             `<div class="test"><owl-component contenteditable="false" data-oe-protected="true"></owl-component></div>`
         );

--- a/addons/web/static/tests/public/interaction_service.test.js
+++ b/addons/web/static/tests/public/interaction_service.test.js
@@ -2,7 +2,8 @@ import { describe, expect, test } from "@odoo/hoot";
 import { queryOne } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 
-import { Component, xml } from "@odoo/owl";
+import { Component, markup, xml } from "@odoo/owl";
+import { setElementContent } from "@web/core/utils/html";
 import { makeMockEnv } from "@web/../tests/web_test_helpers";
 import { Interaction } from "@web/public/interaction";
 import { startInteraction } from "./helpers";
@@ -22,7 +23,7 @@ test("wait for translation before starting interactions", async () => {
             expect("localization" in this.services).toBe(true);
         }
     }
-    await startInteraction(Test, `<div class="test"></div>`);
+    await startInteraction(Test, markup`<div class="test"></div>`);
 });
 
 test("starting interactions twice should only actually do it once", async () => {
@@ -35,7 +36,7 @@ test("starting interactions twice should only actually do it once", async () => 
         }
     }
 
-    const { core } = await startInteraction(Test, `<div class="test"></div>`);
+    const { core } = await startInteraction(Test, markup`<div class="test"></div>`);
 
     expect(n).toBe(1);
     core.startInteractions();
@@ -66,7 +67,7 @@ test("start interactions even if there is a crash", async () => {
         }
     }
 
-    const { core } = await startInteraction([Boom, NotBoom], `<div class="test"></div>`, {
+    const { core } = await startInteraction([Boom, NotBoom], markup`<div class="test"></div>`, {
         waitForStart: false,
     });
     await expect(core.isReady).rejects.toThrow("boom");
@@ -94,7 +95,7 @@ test("start interactions even if there is a crash when evaluating selector", asy
         }
     }
 
-    const { core } = await startInteraction([Boom, NotBoom], `<div class="test"></div>`, {
+    const { core } = await startInteraction([Boom, NotBoom], markup`<div class="test"></div>`, {
         waitForStart: false,
     });
 
@@ -126,7 +127,7 @@ test("start interactions even if there is a crash when evaluating selectorHas", 
 
     const { core } = await startInteraction(
         [Boom, NotBoom],
-        `<div class="test"><div></div></div>`,
+        markup`<div class="test"><div></div></div>`,
         {
             waitForStart: false,
         }
@@ -150,10 +151,10 @@ test("start interactions with selectorHas", async () => {
 
     const { core } = await startInteraction(
         Test,
+        markup`
+            <div class="test"><div class="inner"></div></div>
+            <div class="test"><div class="not-inner"></div></div>
         `
-        <div class="test"><div class="inner"></div></div>
-        <div class="test"><div class="not-inner"></div></div>
-    `
     );
     expect(core.interactions).toHaveLength(1);
     expect.verifySteps(["start"]);
@@ -185,7 +186,7 @@ test("recover from error as much as possible when applying dynamiccontent", asyn
         }
     }
 
-    await startInteraction(Test, `<div class="test"></div>`);
+    await startInteraction(Test, markup`<div class="test"></div>`);
     expect(".test").toHaveOuterHTML(`<div class="test" a="a" b="b" c="c"></div>`);
 
     a = "aa";
@@ -213,7 +214,7 @@ test("interactions are stopped in reverse order", async () => {
 
     const { core } = await startInteraction(
         Test,
-        `<div class="test"></div><div class="test"></div>`
+        markup`<div class="test"></div><div class="test"></div>`
     );
     expect.verifySteps(["setup 1", "setup 2"]);
     core.stopInteractions();
@@ -226,7 +227,7 @@ test("can mount a component", async () => {
         static template = xml`owl component`;
         static props = {};
     }
-    const { core } = await startInteraction(Test, `<div class="test"></div>`);
+    const { core } = await startInteraction(Test, markup`<div class="test"></div>`);
     expect(".test").toHaveInnerHTML(
         `<owl-component contenteditable="false" data-oe-protected="true">owl component</owl-component>`
     );
@@ -247,11 +248,11 @@ test("can start interaction in specific el", async () => {
         }
     }
 
-    const { core } = await startInteraction(Test, `<p></p>`);
+    const { core } = await startInteraction(Test, markup`<p></p>`);
 
     expect(n).toBe(0);
     const p = queryOne("p");
-    p.innerHTML = `<div class="test">hello</div>`;
+    setElementContent(p, markup`<div class="test">hello</div>`);
     core.startInteractions(queryOne(".test"));
     await animationFrame();
     expect(n).toBe(1);
@@ -275,7 +276,7 @@ test("can start and stop interaction in specific el", async () => {
 
     const { core } = await startInteraction(
         Test,
-        `
+        markup`
         <p>
             <span class="a test"></span>
             <span class="b"></span>
@@ -314,7 +315,7 @@ test("does not start interaction in el if not attached", async () => {
         }
     }
 
-    const { core } = await startInteraction(Test, `<p><span class="test"></span></p>`);
+    const { core } = await startInteraction(Test, markup`<p><span class="test"></span></p>`);
     expect(n).toBe(1);
     const span = queryOne("span.test");
     core.stopInteractions(span);

--- a/addons/web/static/tests/public/login.test.js
+++ b/addons/web/static/tests/public/login.test.js
@@ -2,13 +2,14 @@ import { setupInteractionWhiteList, startInteractions } from "@web/../tests/publ
 
 import { describe, expect, test } from "@odoo/hoot";
 import { queryOne } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("public.login");
 
 describe.current.tags("interaction_dev");
 
 test("add and remove loading effect", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div class="oe_login_form">
             <button type="submit">log in</button>
         </div>`);

--- a/addons/web/static/tests/views/fields/formatters.test.js
+++ b/addons/web/static/tests/views/fields/formatters.test.js
@@ -103,7 +103,7 @@ test("formatText", () => {
     expect(formatText("value")).toBe("value");
     expect(formatText(1)).toBe("1");
     expect(formatText(1.5)).toBe("1.5");
-    expect(formatText(markup("<p>This is a Test</p>"))).toBe("<p>This is a Test</p>");
+    expect(formatText(markup`<p>This is a Test</p>`)).toBe("<p>This is a Test</p>");
     expect(formatText([1, 2, 3, 4, 5])).toBe("1,2,3,4,5");
     expect(formatText({ a: 1, b: 2 })).toBe("[object Object]");
 });

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -5183,7 +5183,7 @@ test(`custom delete confirmation dialog`, async () => {
     class CautiousController extends listView.Controller {
         get deleteConfirmationDialogProps() {
             const props = super.deleteConfirmationDialogProps;
-            props.body = markup(`<span class="text-danger">These are the consequences</span>`);
+            props.body = markup`<span class="text-danger">These are the consequences</span>`;
             return props;
         }
     }

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -2680,7 +2680,7 @@ test("empty pivot view with action helper", async () => {
         type: "pivot",
         resModel: "partner",
         context: { search_default_small_than_0: true },
-        noContentHelp: markup(`<p class="abc">click to add a foo</p>`),
+        noContentHelp: markup`<p class="abc">click to add a foo</p>`,
         config: {
             views: [[false, "search"]],
         },
@@ -2707,7 +2707,7 @@ test("empty pivot view with sample data", async () => {
         type: "pivot",
         resModel: "partner",
         context: { search_default_small_than_0: true },
-        noContentHelp: markup('<p class="abc">click to add a foo</p>'),
+        noContentHelp: markup`<p class="abc">click to add a foo</p>`,
         config: {
             views: [[false, "search"]],
         },
@@ -2733,7 +2733,7 @@ test("non empty pivot view with sample data", async () => {
     await mountView({
         type: "pivot",
         resModel: "partner",
-        noContentHelp: markup('<p class="abc">click to add a foo</p>'),
+        noContentHelp: markup`<p class="abc">click to add a foo</p>`,
         config: {
             views: [[false, "search"]],
         },

--- a/addons/web/static/tests/webclient/mobile/burger_user_menu.test.js
+++ b/addons/web/static/tests/webclient/mobile/burger_user_menu.test.js
@@ -70,7 +70,7 @@ test("can be rendered", async () => {
     userMenuRegistry.add("html_item", () => ({
         type: "item",
         id: "html",
-        description: markup(`<div>HTML<i class="fa fa-check px-2"></i></div>`),
+        description: markup`<div>HTML<i class="fa fa-check px-2"></i></div>`,
         callback: () => {
             expect.step("callback html_item");
         },

--- a/addons/web_editor/static/src/components/media_dialog/video_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.js
@@ -1,9 +1,10 @@
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { useAutofocus, useService } from '@web/core/utils/hooks';
+import { setElementContent } from "@web/core/utils/html";
 import { debounce } from '@web/core/utils/timing';
 
-import { Component, useState, useRef, onMounted, onWillStart } from "@odoo/owl";
+import { Component, useState, useRef, onMounted, onWillStart, markup } from "@odoo/owl";
 
 class VideoOption extends Component {
     static template = "web_editor.VideoOption";
@@ -236,11 +237,14 @@ export class VideoSelector extends Component {
         return selectedMedia.map(video => {
             const div = document.createElement('div');
             div.dataset.oeExpression = video.src;
-            div.innerHTML = `
-                <div class="css_editable_mode_display"></div>
-                <div class="media_iframe_video_size" contenteditable="false"></div>
-                <iframe loading="lazy" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen"></iframe>
-            `;
+            setElementContent(
+                div,
+                markup`
+                    <div class="css_editable_mode_display"></div>
+                    <div class="media_iframe_video_size" contenteditable="false"></div>
+                    <iframe loading="lazy" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen"></iframe>
+                `
+            );
             div.querySelector('iframe').src = video.src;
             return div;
         });

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -6,7 +6,6 @@ import { useDragAndDrop } from "@web_editor/js/editor/drag_and_drop";
 import options from "@web_editor/js/editor/snippets.options";
 import weUtils from "@web_editor/js/common/utils";
 import * as gridUtils from "@web_editor/js/common/grid_layout_utils";
-import { escape } from "@web/core/utils/strings";
 import { closestElement, isUnremovable } from "@web_editor/js/editor/odoo-editor/src/utils/utils";
 import { debounce, throttleForAnimation } from "@web/core/utils/timing";
 import { uniqueId } from "@web/core/utils/functions";
@@ -3289,8 +3288,8 @@ class SnippetsMenu extends Component {
                     displayName: snippetEl.getAttribute("name"),
                     category: category,
                     content: snippetEl.children,
-                    thumbnailSrc: escape(snippetEl.dataset.oeThumbnail),
-                    imagePreview: escape(snippetEl.dataset.oImagePreview),
+                    thumbnailSrc: snippetEl.dataset.oeThumbnail,
+                    imagePreview: snippetEl.dataset.oImagePreview,
                     visible: true,
                     baseBody: snippetEl.children[0],
                     data: {...snippetEl.dataset, ...snippetEl.children[0].dataset},
@@ -5202,7 +5201,7 @@ class SnippetsMenu extends Component {
         const linkUrl = '/odoo/action-base.open_module_tree/' + encodeURIComponent(moduleID);
         this.dialog.add(ConfirmationDialog, {
             title: _t("Install %s", snippetName),
-            body: markup(`${escape(bodyText)}\n<a href="${linkUrl}" target="_blank">${escape(linkText)}</a>`),
+            body: markup`${bodyText}\n<a href="${linkUrl}" target="_blank">${linkText}</a>`,
             confirm: async () => {
                 try {
                     this._execWithLoadingEffect(async () => {
@@ -5217,7 +5216,7 @@ class SnippetsMenu extends Component {
                     });
                 } catch (e) {
                     if (e instanceof RPCError) {
-                        const message = escape(_t("Could not install module %s", snippetName));
+                        const message = _t("Could not install module %s", snippetName);
                         this.notification.add(message, {
                             type: "danger",
                             sticky: true,

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_dialog.js
@@ -1,8 +1,8 @@
-import { Component, useState, markup, onWillDestroy, status } from "@odoo/owl";
+import { Component, useState, onWillDestroy, status } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { rpc } from "@web/core/network/rpc";
-import { escape } from "@web/core/utils/strings";
 import { _t } from "@web/core/l10n/translation";
+import { getOuterHtml, htmlJoin } from "@web/core/utils/html";
 
 /**
  * General component for common logic between different dialogs.
@@ -32,16 +32,11 @@ export class ChatGPTDialog extends Component {
         this._confirm();
     }
     formatContent(content) {
-        return markup([...this._postprocessGeneratedContent(content).childNodes].map(child => {
-            // Escape all text.
-            const nodes = new Set([...child.querySelectorAll('*')].flatMap(node => node.childNodes));
-            nodes.forEach(node => {
-                if (node.nodeType === Node.TEXT_NODE) {
-                    node.textContent = escape(node.textContent);
-                }
-            });
-            return child.outerHTML;
-        }).join(''));
+        return htmlJoin(
+            [...this._postprocessGeneratedContent(content).childNodes].map((child) =>
+                getOuterHtml(child)
+            )
+        );
     }
 
     //--------------------------------------------------------------------------

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
@@ -7,7 +7,6 @@ import {
     onMounted,
     onWillDestroy,
     onWillUpdateProps,
-    markup,
 } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { closestScrollableY } from "@web/core/utils/scrolling";
@@ -163,7 +162,9 @@ export class ImageCrop extends Component {
 
         if (this.uncroppable) {
             this.notification.add(
-                markup(_t("This type of image is not supported for cropping.<br/>If you want to crop it, please first download it from the original source and upload it in Odoo.")),
+                _t("This type of image is not supported for cropping.%(new_line)sIf you want to crop it, please first download it from the original source and upload it in Odoo.", {
+                    new_line: '<br/>',
+                }),
                 {
                     title: _t("This image is an external image"),
                     type: 'warning',

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -21,6 +21,7 @@ import { isIconElement, isSelectionInSelectors, peek } from '@web_editor/js/edit
 import { PeerToPeer, RequestError } from "@web_editor/js/wysiwyg/PeerToPeer";
 import { rpc } from "@web/core/network/rpc";
 import { uniqueId } from "@web/core/utils/functions";
+import { getOuterHtml } from "@web/core/utils/html";
 import { groupBy } from "@web/core/utils/arrays";
 import { debounce } from "@web/core/utils/timing";
 import { registry } from "@web/core/registry";
@@ -42,7 +43,6 @@ import {
     onMounted,
     onWillDestroy,
     onWillUpdateProps,
-    markup,
     status,
 } from "@odoo/owl";
 import { isCSSColor } from '@web/core/utils/colors';
@@ -3038,7 +3038,7 @@ export class Wysiwyg extends Component {
     }
     _showConflictDialog() {
         if (this._conflictDialogOpened) return;
-        const content = markup(this.odooEditor.editable.cloneNode(true).outerHTML);
+        const content = getOuterHtml(this.odooEditor.editable.cloneNode(true));
         this._conflictDialogOpened = true;
         this.env.services.dialog.add(ConflictDialog, {
             content,

--- a/addons/web_editor/static/tests/test_wysiwyg_collaboration.js
+++ b/addons/web_editor/static/tests/test_wysiwyg_collaboration.js
@@ -1,3 +1,5 @@
+import { markup } from "@odoo/owl";
+
 import { patch } from "@web/core/utils/patch";
 import {
     parseTextualSelection,
@@ -7,6 +9,7 @@ import {
 } from '@web_editor/js/editor/odoo-editor/test/utils';
 import { Wysiwyg, stripHistoryIds } from '@web_editor/js/wysiwyg/wysiwyg';
 import { Mutex } from '@web/core/utils/concurrency';
+import { setElementContent } from "@web/core/utils/html";
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
 import { makeFakeNotificationService } from "@web/../tests/helpers/mock_services";
 import { mount, getFixture } from "@web/../tests/helpers/utils";
@@ -159,7 +162,10 @@ export async function createPeers(peers) {
         }
         getFixture().append(iframe);
         patchEditorIframe(iframe);
-        iframe.contentDocument.body.innerHTML = `<div class="peer_wysiwyg_wrapper client_${peerId}"></div>`;
+        setElementContent(
+            iframe.contentDocument.body,
+            markup`<div class="peer_wysiwyg_wrapper client_${peerId}"></div>`
+        );
         const peerWysiwygWrapper = iframe.contentDocument.querySelector('.peer_wysiwyg_wrapper');
         iframe.contentWindow.$ = $;
 

--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -185,11 +185,9 @@ export const tourService = {
                     browser.console.log("tour succeeded");
                     let message = tourConfig.rainbowManMessage || tour.rainbowManMessage;
                     if (message) {
-                        message = window.DOMPurify.sanitize(tourConfig.rainbowManMessage);
-                        effect.add({
-                            type: "rainbow_man",
-                            message: markup(message),
-                        });
+                        // markup: flagging sanitized content as safe
+                        message = markup(window.DOMPurify.sanitize(tourConfig.rainbowManMessage));
+                        effect.add({ type: "rainbow_man", message });
                     }
 
                     const nextTour = await orm.call("web_tour.tour", "consume", [tour.name]);

--- a/addons/website/static/src/components/editor/editor.js
+++ b/addons/website/static/src/components/editor/editor.js
@@ -1,14 +1,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { useService } from '@web/core/utils/hooks';
-import {
-    markup,
-    Component,
-    useState,
-    useEffect,
-    onWillStart,
-    onMounted,
-    onWillUnmount,
-} from "@odoo/owl";
+import { getInnerHtml } from "@web/core/utils/html";
+import { Component, useState, useEffect, onWillStart, onMounted, onWillUnmount } from "@odoo/owl";
 
 export class WebsiteEditorComponent extends Component {
     static template = "website.WebsiteEditorComponent";
@@ -88,7 +81,7 @@ export class WebsiteEditorComponent extends Component {
     willReload(widgetEl) {
         this.websiteService.blockPreview();
         if (widgetEl) {
-            this.loadingDummy = markup(widgetEl.innerHTML);
+            this.loadingDummy = getInnerHtml(widgetEl);
         }
         this.state.reloading = true;
         document.body.classList.add('editor_has_dummy_snippets');

--- a/addons/website/static/src/components/fullscreen_indication/fullscreen_indication.js
+++ b/addons/website/static/src/components/fullscreen_indication/fullscreen_indication.js
@@ -27,6 +27,6 @@ export class FullscreenIndication extends Component {
     }
 
     get fullScreenIndicationText() {
-        return _t("Press %(key)s to exit full screen", { key: markup("<span>esc</span>") });
+        return _t("Press %(key)s to exit full screen", { key: markup`<span>esc</span>` });
     }
 }

--- a/addons/website/static/src/components/website_loader/website_loader.js
+++ b/addons/website/static/src/components/website_loader/website_loader.js
@@ -1,6 +1,6 @@
 import { rpc } from "@web/core/network/rpc";
 import { useBus, useService } from "@web/core/utils/hooks";
-import { sprintf } from "@web/core/utils/strings";
+import { htmlSprintf } from "@web/core/utils/html";
 import { _t } from "@web/core/l10n/translation";
 import { EventBus, Component, markup, useEffect, useState } from "@odoo/owl";
 
@@ -273,10 +273,8 @@ export class WebsiteLoader extends Component {
         const messagesList = websiteFeaturesMessages.filter((msg) => {
             if (filteredIds.includes(msg.id)) {
                 if (msg.name) {
-                    const highlight = sprintf(
-                        '<span class="o_website_loader_text_highlight">%s</span>', msg.name
-                    );
-                    msg.description = markup(sprintf(msg.description, highlight));
+                    const highlight = markup`<span class="o_website_loader_text_highlight">${msg.name}</span>`;
+                    msg.description = htmlSprintf(msg.description, highlight);
                 }
                 return true;
             }

--- a/addons/website/static/src/core/website_map_service.js
+++ b/addons/website/static/src/core/website_map_service.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { user } from "@web/core/user";
 import { markup } from "@odoo/owl";
-import { escape } from "@web/core/utils/strings";
 
 registry.category("services").add("website_map", {
     dependencies: ["public.interactions", "notification"],
@@ -52,10 +51,10 @@ registry.category("services").add("website_map", {
                                 const message = _t("Cannot load google map.");
                                 const urlTitle = _t("Check your configuration.");
                                 notification.add(
-                                    markup(`<div>
-                                        <span>${escape(message)}</span><br/>
-                                        <a href="/odoo/action-website.action_website_configuration">${escape(urlTitle)}</a>
-                                    </div>`),
+                                    markup`<div>
+                                        <span>${message}</span><br/>
+                                        <a href="/odoo/action-website.action_website_configuration">${urlTitle}</a>
+                                    </div>`,
                                     { type: 'warning', sticky: true }
                                 );
                             }

--- a/addons/website/static/src/interactions/video/media_video.js
+++ b/addons/website/static/src/interactions/video/media_video.js
@@ -1,8 +1,9 @@
-import { Interaction } from "@web/public/interaction";
-import { registry } from "@web/core/registry";
-
 import { _t } from "@web/core/l10n/translation";
-import { escape } from "@web/core/utils/strings";
+import { registry } from "@web/core/registry";
+import { Interaction } from "@web/public/interaction";
+
+import { htmlEscape } from "@odoo/owl";
+
 import { setupAutoplay, triggerAutoplay } from "@website/utils/videos";
 
 export class MediaVideo extends Interaction {
@@ -38,7 +39,7 @@ export class MediaVideo extends Interaction {
     generateIframe() {
         // Bug fix / compatibility: empty the <div/> element as all information
         // to rebuild the iframe should have been saved on the <div/> element
-        this.el.innerHTML = "";
+        this.el.textContent = "";
 
         // Add extra content for size / edition
         const div1 = document.createElement("div");
@@ -55,7 +56,7 @@ export class MediaVideo extends Interaction {
         // 'data-oe-expression' one (the latter is used as a workaround in 10.0
         // system but should obviously be reviewed in master).
 
-        let src = escape(this.el.getAttribute("data-oe-expression") || this.el.getAttribute("data-src"));
+        let src = htmlEscape(this.el.getAttribute("data-oe-expression") || this.el.getAttribute("data-src"));
         // Validate the src to only accept supported domains we can trust
 
         let m = src.match(/^(?:https?:)?\/\/([^/?#]+)/);

--- a/addons/website/static/src/js/content/redirect.js
+++ b/addons/website/static/src/js/content/redirect.js
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const currentUrl = new URL(window.location.href);
         currentUrl.pathname = `/@${currentUrl.pathname}`;
         if (currentUrl.searchParams.get('enable_editor') || currentUrl.searchParams.get('edit_translations')) {
-            document.body.innerHTML = '';
+            document.body.textContent = "";
             window.location.replace(currentUrl.href);
             return;
         }

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -3167,7 +3167,10 @@ options.registry.anchor = options.Class.extend({
         buttonEl.addEventListener("click", async (ev) => {
             const anchorLink = this._getAnchorLink();
             await browser.navigator.clipboard.writeText(anchorLink);
-            const message = markup(_t("Anchor copied to clipboard<br>Link: %s", anchorLink));
+            const message = _t("Anchor copied to clipboard%(new_line)sLink: %(link)s", {
+                link: anchorLink,
+                new_line: markup`<br>`,
+            });
             this.notification.add(message, {
                 type: "success",
                 buttons: [{name: _t("Edit"), onClick: () => this._openAnchorDialog(buttonEl), primary: true}],

--- a/addons/website/static/src/snippets/s_embed_code/options.js
+++ b/addons/website/static/src/snippets/s_embed_code/options.js
@@ -1,6 +1,9 @@
+import { htmlTrim } from "@mail/utils/common/html";
+
 import { Dialog } from "@web/core/dialog/dialog";
 import { CodeEditor } from "@web/core/code_editor/code_editor";
 import { useService } from "@web/core/utils/hooks";
+import { getInnerHtml } from "@web/core/utils/html";
 import options from '@web_editor/js/editor/snippets.options';
 import { _t } from "@web/core/l10n/translation";
 import { EditHeadBodyDialog } from "@website/components/edit_head_body_dialog/edit_head_body_dialog";
@@ -47,12 +50,12 @@ options.registry.EmbedCode = options.Class.extend({
     async editCode() {
         const $container = this.$target.find('.s_embed_code_embedded');
         const templateEl = this.$target[0].querySelector("template.s_embed_code_saved");
-        const embedContent = templateEl.innerHTML.trim();
+        const embedContent = htmlTrim(getInnerHtml(templateEl));
 
         await new Promise(resolve => {
             this.dialog.add(CodeEditorDialog, {
                 title: _t("Edit embedded code"),
-                value: embedContent,
+                value: embedContent.toString(),
                 mode: "xml",
                 confirm: (newValue) => {
                     // Removes scripts tags from the DOM as we don't want them

--- a/addons/website/static/src/snippets/s_table_of_content/options.js
+++ b/addons/website/static/src/snippets/s_table_of_content/options.js
@@ -145,7 +145,7 @@ options.registry.TableOfContent = options.Class.extend({
         const headingIds = headingsEls.map(headingEl => this._getTocAndHeadingId(headingEl).headingId);
         let maxHeadingIds = Math.max(0, ...headingIds);
 
-        navEl.innerHTML = '';
+        navEl.textContent = "";
         const uniqueHeadingIds = new Set();
         headingsEls.forEach((el) => {
             const $el = $(el);

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -8,7 +8,6 @@ import { redirect } from "@web/core/utils/urls";
 import { _t } from "@web/core/l10n/translation";
 import { memoize } from "@web/core/utils/functions";
 import { renderToElement } from "@web/core/utils/render";
-import { escape } from "@web/core/utils/strings";
 import { formatDate, formatDateTime } from "@web/core/l10n/dates";
 import wUtils from '@website/js/utils';
 
@@ -218,7 +217,7 @@ const FormEditor = options.Class.extend({
         if (!field.id) {
             field.id = weUtils.generateHTMLId();
         }
-        const params = { field: { ...field }, defaultName: escape(_t("Field")) };
+        const params = { field: { ...field }, defaultName: _t("Field") };
         if (["url", "email", "tel"].includes(field.type)) {
             params.field.inputType = field.type;
         }

--- a/addons/website/static/tests/interactions/anchor_slide.test.js
+++ b/addons/website/static/tests/interactions/anchor_slide.test.js
@@ -7,13 +7,14 @@ import {
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, click, queryOne } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.anchor_slide");
 
 describe.current.tags("interaction_dev");
 
 test("anchor_slide does nothing if there is no href", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <a id="somewhere"/>
         </div>
@@ -22,7 +23,7 @@ test("anchor_slide does nothing if there is no href", async () => {
 });
 
 test("anchor_slide scrolls to targetted location", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap" style="overflow: scroll; width: 500px; max-height: 500px;">
             <a href="#target">Click here</a>
             <div style="min-height: 2000px;">Tall stuff</div>
@@ -41,7 +42,7 @@ test("anchor_slide scrolls to targetted location", async () => {
 });
 
 test("without anchor_slide, instantly reach the targetted location", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap" style="overflow: scroll; width: 500px; max-height: 100%;">
             <a href="#target">Click here</a>
             <div style="min-height: 2000px;">Tall stuff</div>
@@ -60,7 +61,7 @@ test("without anchor_slide, instantly reach the targetted location", async () =>
 });
 
 test("anchor_slide scrolls to targetted location - with non-ASCII7 characters", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap" style="overflow: scroll; width: 500px; max-height: 500px;">
             <a href="#ok%C3%A9%25">Click here</a>
             <div style="min-height: 2000px;">Tall stuff</div>

--- a/addons/website/static/tests/interactions/animate_overflow.test.js
+++ b/addons/website/static/tests/interactions/animate_overflow.test.js
@@ -1,17 +1,15 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { manuallyDispatchProgrammaticEvent, queryOne } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.animate_overflow");
 
 describe.current.tags("interaction_dev");
 
 test("animate_overflow adds class during animations", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <div class="o_animate"/>
         </div>
@@ -29,7 +27,7 @@ test("animate_overflow adds class during animations", async () => {
 });
 
 test("animate_overflow always adds class if there are transforms", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <div class="o_animate" style="transform: translateY(10px)"/>
         </div>

--- a/addons/website/static/tests/interactions/animation.test.js
+++ b/addons/website/static/tests/interactions/animation.test.js
@@ -3,6 +3,7 @@ import { setupInteractionWhiteList, startInteractions } from "@web/../tests/publ
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { animationFrame, click, queryOne, scroll } from "@odoo/hoot-dom";
 import { enableTransitions } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.animation");
 beforeEach(enableTransitions);
@@ -10,7 +11,7 @@ beforeEach(enableTransitions);
 describe.current.tags("interaction_dev");
 
 test("onAppearance animation starts once visible", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap" style="overflow: scroll; max-height: 100%;">
             <a href="#target">Get there</a>
             <div style="min-height: 2000px;">Tall stuff</div>
@@ -33,7 +34,7 @@ test("onAppearance animation starts once visible", async () => {
 });
 
 test("on scroll animation changes based on scroll", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap" style="overflow: scroll; max-height: 100%;">
             <div style="min-height: 2000px;">Tall stuff</div>
             <div class="o_anim_fade_in o_animate o_animate_on_scroll"
@@ -67,7 +68,7 @@ test("on scroll animation changes based on scroll", async () => {
 });
 
 test("onAppearance animation in modal starts once visible", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <div class="modal" style="display: none;" data-show-after="1000" data-display="afterDelay" data-bs-backdrop="false">
                 <div class="modal-dialog">

--- a/addons/website/static/tests/interactions/bottom_fixed_element.test.js
+++ b/addons/website/static/tests/interactions/bottom_fixed_element.test.js
@@ -1,10 +1,8 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, getFixture, test } from "@odoo/hoot";
 import { manuallyDispatchProgrammaticEvent, queryOne, queryRect, scroll } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.bottom_fixed_element");
 
@@ -19,26 +17,26 @@ const scrollTo = async function (el, scrollTarget, bottomFixedElement) {
     bottomFixedElement.style.left = `calc(50% - ${queryRect(bottomFixedElement).width / 2}px)`;
     // Dispatch the scroll event
     await manuallyDispatchProgrammaticEvent(document, "scroll");
-}
+};
 
 const scrollToMiddle = async function (el, bottomFixedElement) {
     // 2550 = headerHeight + mainHeight + footerHeight
-    await scrollTo(el, 2550 / 2 - queryRect(bottomFixedElement).height, bottomFixedElement)
-}
+    await scrollTo(el, 2550 / 2 - queryRect(bottomFixedElement).height, bottomFixedElement);
+};
 
 const scrollToBottom = async function (el, bottomFixedElement) {
     // 2550 = headerHeight + mainHeight + footerHeight
-    await scrollTo(el, 2550 - queryRect(bottomFixedElement).height, bottomFixedElement)
-}
+    await scrollTo(el, 2550 - queryRect(bottomFixedElement).height, bottomFixedElement);
+};
 
 const getTemplate = function (options = {}) {
     const withButtonLeft = options.withButtonLeft || false;
     const withButtonCenter = options.withButtonCenter || false;
 
-    const emptyDiv = `<div style="height: 50px; width: 150px;"></div>`;
-    const buttonEl = `<a href="#" style="background-color: white; border: solid; height: 50px; width: 150px;"></a>`;
+    const emptyDiv = markup`<div style="height: 50px; width: 150px;"></div>`;
+    const buttonEl = markup`<a href="#" style="background-color: white; border: solid; height: 50px; width: 150px;"></a>`;
 
-    return `
+    return markup`
         <header style="height: 50px; background-color: #CCCCFF;"></header>
         <main style="height: 2000px; background-color: #CCFFCC;">
             <div class="o_bottom_fixed_element" style="height: 100px; width: 100px; background-color: black;"></div>
@@ -49,7 +47,7 @@ const getTemplate = function (options = {}) {
             ${emptyDiv}
         </footer>
     `;
-}
+};
 
 test("bottom_fixed_element is started when there is an element #wrapwrap", async () => {
     const { core } = await startInteractions(getTemplate());

--- a/addons/website/static/tests/interactions/carousel/carousel_bootstrap_upgrade_fix.edit.test.js
+++ b/addons/website/static/tests/interactions/carousel/carousel_bootstrap_upgrade_fix.edit.test.js
@@ -1,10 +1,8 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { queryOne } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 import { switchToEditMode } from "../../helpers";
 
@@ -13,7 +11,7 @@ setupInteractionWhiteList("website.carousel_bootstrap_upgrade_fix");
 describe.current.tags("interaction_dev");
 
 test("[EDIT] carousel_bootstrap_upgrade_fix prevents ride", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <section class="s_image_gallery o_slideshow pt24 pb24 s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right s_image_gallery_indicators_dots s_image_gallery_arrows_default" data-snippet="s_image_gallery" data-vcss="002" data-columns="3">
             <div class="o_container_small overflow-hidden">
                 <div id="slideshow_sample" class="carousel carousel-dark slide" data-bs-interval="5000">

--- a/addons/website/static/tests/interactions/carousel/carousel_bootstrap_upgrade_fix.test.js
+++ b/addons/website/static/tests/interactions/carousel/carousel_bootstrap_upgrade_fix.test.js
@@ -1,18 +1,16 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { click, queryOne } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.carousel_bootstrap_upgrade_fix");
 
 describe.current.tags("interaction_dev");
 
 test("carousel_bootstrap_upgrade_fix is tagged while sliding", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <section class="s_image_gallery o_slideshow pt24 pb24 s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right s_image_gallery_indicators_dots s_image_gallery_arrows_default" data-snippet="s_image_gallery" data-vcss="002" data-columns="3">
             <div class="o_container_small overflow-hidden">
                 <div id="slideshow_sample" class="carousel carousel-dark slide" data-bs-interval="5000">

--- a/addons/website/static/tests/interactions/carousel/carousel_section_slider.edit.test.js
+++ b/addons/website/static/tests/interactions/carousel/carousel_section_slider.edit.test.js
@@ -1,19 +1,18 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 
 import { switchToEditMode } from "../../helpers";
 import { queryAll } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.carousel_section_slider");
 
 describe.current.tags("interaction_dev");
 
 test("carousel_section_slider resets slide to attributes", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(
+        markup`
         <section>
             <div id="slideshow_sample" class="carousel carousel-dark slide" data-bs-ride="ride" data-bs-interval="0">
                 <div class="carousel-inner">
@@ -44,7 +43,9 @@ test("carousel_section_slider resets slide to attributes", async () => {
                 </div>
             </div>
         </section>
-    `, { waitForStart: true, editMode: true });
+    `,
+        { waitForStart: true, editMode: true }
+    );
     await switchToEditMode(core);
 
     expect(core.interactions).toHaveLength(1);

--- a/addons/website/static/tests/interactions/carousel/carousel_slider.edit.test.js
+++ b/addons/website/static/tests/interactions/carousel/carousel_slider.edit.test.js
@@ -2,6 +2,7 @@ import { setupInteractionWhiteList, startInteractions } from "@web/../tests/publ
 
 import { describe, expect, test } from "@odoo/hoot";
 import { manuallyDispatchProgrammaticEvent, queryFirst, queryOne } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 import { switchToEditMode } from "../../helpers";
 
@@ -10,7 +11,7 @@ setupInteractionWhiteList("website.carousel_slider");
 describe.current.tags("interaction_dev");
 
 test("[EDIT] carousel_slider prevents ride", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <section>
             <div id="slideshow_sample" class="carousel carousel-dark slide" data-bs-ride="ride" data-bs-interval="0">
                 <div class="carousel-inner">
@@ -57,7 +58,7 @@ test("[EDIT] carousel_slider prevents ride", async () => {
 });
 
 test("[EDIT] carousel_slider updates min height on content_changed", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="slideshow_sample" class="carousel carousel-dark slide" data-bs-ride="ride" data-bs-interval="0">
             <div class="carousel-inner">
                 <div class="carousel-item active">

--- a/addons/website/static/tests/interactions/carousel/carousel_slider.test.js
+++ b/addons/website/static/tests/interactions/carousel/carousel_slider.test.js
@@ -3,6 +3,7 @@ import { setupInteractionWhiteList, startInteractions } from "@web/../tests/publ
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { queryAll } from "@odoo/hoot-dom";
 import { enableTransitions } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.carousel_slider");
 beforeEach(enableTransitions);
@@ -10,7 +11,7 @@ beforeEach(enableTransitions);
 describe.current.tags("interaction_dev");
 
 test("carousel_slider updates min height of carousel items", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <section>
             <div id="slideshow_sample" class="carousel carousel-dark slide" data-bs-ride="false" data-bs-interval="0">
                 <div class="carousel-inner">

--- a/addons/website/static/tests/interactions/cookies/cookies.test.js
+++ b/addons/website/static/tests/interactions/cookies/cookies.test.js
@@ -1,19 +1,21 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { click, queryOne, waitFor } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 
 import { cookie } from "@web/core/browser/cookie";
 
-setupInteractionWhiteList(["website.cookies_bar", "website.cookies_approval", "website.cookies_warning"]);
+setupInteractionWhiteList([
+    "website.cookies_bar",
+    "website.cookies_approval",
+    "website.cookies_warning",
+]);
 
 describe.current.tags("interaction_dev");
 
-const cookiesBarTemplate = `
+const cookiesBarTemplate = markup`
     <div id="website_cookies_bar" class="s_popup o_snippet_invisible" data-name="Cookies Bar" data-vcss="001" data-invisible="1">
         <div class="modal s_popup_bottom s_popup_no_backdrop o_cookies_discrete modal_shown"
                 style="display: none;"
@@ -40,7 +42,7 @@ const cookiesBarTemplate = `
     </div>
 `;
 
-const cookiesApprovalTemplate = `
+const cookiesApprovalTemplate = markup`
     <div data-need-cookies-approval="true">
         <iframe src="about:blank" data-nocookie-src="/"></iframe>
     </div>
@@ -80,7 +82,7 @@ test("consent for optional cookies given if click on #cookies-consent-all", asyn
     await click("#cookies-consent-all");
     expect(cookiesBarEl).not.toBeVisible();
     expect(cookie.get("website_cookies_bar")).toBe('{"required": true, "optional": true}');
-})
+});
 
 test("show warning instead of iframe if no consent", async () => {
     const { core } = await startInteractions(cookiesApprovalTemplate);
@@ -93,7 +95,7 @@ test("show warning instead of iframe if no consent", async () => {
 });
 
 test("show cookies bar after clicking on warning", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div>
             ${cookiesApprovalTemplate}
             ${cookiesBarTemplate}
@@ -115,7 +117,7 @@ test("show cookies bar after clicking on warning", async () => {
 });
 
 test("remove warning, show and update iframe src after accepting cookies", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div>
             ${cookiesApprovalTemplate}
             ${cookiesBarTemplate}

--- a/addons/website/static/tests/interactions/dropdown/hoverable_dropdown.edit.test.js
+++ b/addons/website/static/tests/interactions/dropdown/hoverable_dropdown.edit.test.js
@@ -2,6 +2,7 @@ import { startInteractions, setupInteractionWhiteList } from "@web/../tests/publ
 
 import { describe, expect, test } from "@odoo/hoot";
 import { hover, leave } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 import { switchToEditMode } from "../../helpers";
 
@@ -12,7 +13,7 @@ describe.current.tags("interaction_dev");
 test.tags("desktop");
 test("[EDIT] onMouseLeave doesn't work in edit mode", async () => {
     const { core } = await startInteractions(
-        `
+        markup`
         <header class="o_hoverable_dropdown" style="display: flex; height: 50px; background-color: #CCFFCC;">
             <div class="dropdown" style="margin: auto;">
                 <a class="dropdown-toggle">Dropdown</a>
@@ -40,7 +41,7 @@ test("[EDIT] onMouseLeave doesn't work in edit mode", async () => {
 test.tags("desktop");
 test("[EDIT] onMouseEnter doesn't work in edit mode if another dropdown is opened", async () => {
     const { core } = await startInteractions(
-        `
+        markup`
         <header class="o_hoverable_dropdown" style="display: flex; height: 50px; background-color: #CCFFCC;">
             <div id="D1" class="dropdown" style="margin: auto;">
                 <a class="dropdown-toggle">Dropdown 1</a>

--- a/addons/website/static/tests/interactions/dropdown/hoverable_dropdown.test.js
+++ b/addons/website/static/tests/interactions/dropdown/hoverable_dropdown.test.js
@@ -2,12 +2,13 @@ import { startInteractions, setupInteractionWhiteList } from "@web/../tests/publ
 
 import { describe, expect, test } from "@odoo/hoot";
 import { hover, leave } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.hoverable_dropdown");
 
 describe.current.tags("interaction_dev");
 
-const dropdownTemplate = `
+const dropdownTemplate = markup`
     <header class="o_hoverable_dropdown" style="display: flex; height: 50px; background-color: #CCFFCC;">
         <div class="dropdown" style="margin: auto;">
             <a class="dropdown-toggle">Dropdown</a>

--- a/addons/website/static/tests/interactions/dropdown/mega_menu_dropdown.test.js
+++ b/addons/website/static/tests/interactions/dropdown/mega_menu_dropdown.test.js
@@ -2,6 +2,7 @@ import { startInteractions, setupInteractionWhiteList } from "@web/../tests/publ
 
 import { describe, expect, test } from "@odoo/hoot";
 import { hover, pointerDown, queryFirst } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.mega_menu_dropdown");
 
@@ -10,7 +11,7 @@ describe.current.tags("interaction_dev");
 const getTemplate = function (options = {}) {
     const contentInDesktop = options.contentInDesktop || true;
     const dropdownHoverable = options.dropdownHoverable || false;
-    return `
+    return markup`
     <header id="top">
         <nav class="o_header_desktop ${dropdownHoverable ? "o_hoverable_dropdown" : ""}">
             <div class="dropdown">

--- a/addons/website/static/tests/interactions/footer_slideout.test.js
+++ b/addons/website/static/tests/interactions/footer_slideout.test.js
@@ -1,18 +1,16 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { queryAll, queryFirst } from "@odoo/hoot-dom";
 import { mockUserAgent } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.footer_slideout");
 
 describe.current.tags("interaction_dev");
 
 test("footer_slideout does nothing if the effect is not enabled", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <main style="min-height: 1000px">Main Content</main>
             <footer>Footer Content</footer>
@@ -23,7 +21,7 @@ test("footer_slideout does nothing if the effect is not enabled", async () => {
 
 test("footer_slideout only adds a class if the effect is enabled on non-safari", async () => {
     mockUserAgent("android");
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <main style="min-height: 1000px">Main Content</main>
             <footer class="o_footer_slideout">Footer Content</footer>
@@ -35,7 +33,7 @@ test("footer_slideout only adds a class if the effect is enabled on non-safari",
 
 test("footer_slideout adds a class and a pixel if the effect is enabled on safari", async () => {
     mockUserAgent("safari");
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <main style="min-height: 1000px">Main Content</main>
             <footer class="o_footer_slideout">Footer Content</footer>
@@ -44,7 +42,7 @@ test("footer_slideout adds a class and a pixel if the effect is enabled on safar
     expect(core.interactions).toHaveLength(1);
     expect("#wrapwrap").toHaveClass("o_footer_effect_enable");
     expect(queryAll("#wrapwrap > div")).toHaveLength(1);
-    expect("#wrapwrap > div").toHaveStyle({ "width": "1px" });
+    expect("#wrapwrap > div").toHaveStyle({ width: "1px" });
     core.stopInteractions();
     expect(core.interactions).toHaveLength(0);
     expect(queryFirst("#wrapwrap > div")).toBe(null);

--- a/addons/website/static/tests/interactions/full_screen_height.test.js
+++ b/addons/website/static/tests/interactions/full_screen_height.test.js
@@ -2,6 +2,7 @@ import { setupInteractionWhiteList, startInteractions } from "@web/../tests/publ
 
 import { describe, expect, test } from "@odoo/hoot";
 import { queryOne } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.full_screen_height");
 
@@ -9,7 +10,7 @@ describe.current.tags("interaction_dev");
 
 test.tags("desktop");
 test("full_screen_height is not set on visible section", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <main>
             <section class="o_full_screen_height">content</section>
         </main>
@@ -20,7 +21,7 @@ test("full_screen_height is not set on visible section", async () => {
 });
 
 test("full_screen_height is set on hidden section", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <main>
             <section class="o_full_screen_height d-none">content</section>
         </main>

--- a/addons/website/static/tests/interactions/header/base_header_special.test.js
+++ b/addons/website/static/tests/interactions/header/base_header_special.test.js
@@ -1,13 +1,8 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 
-import {
-    getTemplateWithoutHideOnScroll,
-} from "./helpers";
+import { getTemplateWithoutHideOnScroll } from "./helpers";
 
 setupInteractionWhiteList("website.header_disappears");
 

--- a/addons/website/static/tests/interactions/header/header_top.test.js
+++ b/addons/website/static/tests/interactions/header/header_top.test.js
@@ -1,14 +1,12 @@
 import { describe, expect, test } from "@odoo/hoot";
+import { markup } from "@odoo/owl";
 
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 setupInteractionWhiteList("website.header_top");
 describe.current.tags("interaction_dev");
 
-const headerTemplate = `<header id="top"></header>`;
+const headerTemplate = markup`<header id="top"></header>`;
 
 test("header_top is started when there is an element header#top", async () => {
     const { core } = await startInteractions(headerTemplate);

--- a/addons/website/static/tests/interactions/header/helpers.js
+++ b/addons/website/static/tests/interactions/header/helpers.js
@@ -1,5 +1,6 @@
 import { expect } from "@odoo/hoot";
 import { scroll } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 import { endTransition } from "@website/../tests/interactions/snippets/helpers";
 
@@ -41,7 +42,7 @@ export function checkHeader(header, main, core, expectedStatus) {
  * @param {string} className
  */
 export function getTemplateWithoutHideOnScroll(className) {
-    return /* xml */ `
+    return markup`
         <header class="${className}" style="height:50px; background-color:#CCFFCC;">
         </header>
         <main style="height:2000px;  background-color:#CCCCFF;">
@@ -56,7 +57,7 @@ export function getTemplateWithoutHideOnScroll(className) {
  * @param {string} className
  */
 export function getTemplateWithHideOnScroll(className) {
-    return /* xml */ `
+    return markup`
         <header class="${className}" style="background-color:#CCFFCC">
             <div class="o_header_hide_on_scroll h20" style="background-color:#CCFF33;"></div>
             <div style="height: 30px; background-color:#33FFCC;"></div>

--- a/addons/website/static/tests/interactions/image_lazy_loading.test.js
+++ b/addons/website/static/tests/interactions/image_lazy_loading.test.js
@@ -2,6 +2,7 @@ import { setupInteractionWhiteList, startInteractions } from "@web/../tests/publ
 
 import { describe, expect, test } from "@odoo/hoot";
 import { advanceTime, Deferred } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { ImageLazyLoading } from "@website/interactions/image_lazy_loading";
@@ -22,7 +23,7 @@ test("images lazy loading removes height then restores it", async () => {
         },
     });
     const { core } = await startInteractions(
-        `
+        markup`
         <div>Fake surrounding
             <div id="wrapwrap">
                 <img src="/web/image/website.library_image_08" loading="lazy" style="min-height: 100px;"/>

--- a/addons/website/static/tests/interactions/image_shape_hover_effect.test.js
+++ b/addons/website/static/tests/interactions/image_shape_hover_effect.test.js
@@ -3,6 +3,7 @@ import { setupInteractionWhiteList, startInteractions } from "@web/../tests/publ
 import { describe, expect, test } from "@odoo/hoot";
 import { hover, queryOne } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 
 import { onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { onceAllImagesLoaded } from "@website/utils/images";
@@ -19,7 +20,7 @@ test("image_shape_hover_effect changes image on enter & leave", async () => {
             setTimeout(() => super.onload());
         },
     });
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <img class="img img-fluid mx-auto o_we_image_cropped o_animate_on_hover rounded-circle rounded"
                 src="/web/image/384-8a55a748/s_banner_3.svg" alt=""
@@ -40,9 +41,8 @@ test("image_shape_hover_effect changes image on enter & leave", async () => {
     `);
     onRpc(
         "/web/image/384-8a55a748/s_banner_3.svg",
-        () => {
-            return `<svg viewBox="0 0 300 100" width="500px"><g id="hoverEffects"><animate values="a=1;b=2"><rect width="100%" fill="red" height="100%" /></animate></g></svg>`;
-        },
+        () =>
+            `<svg viewBox="0 0 300 100" width="500px"><g id="hoverEffects"><animate values="a=1;b=2"><rect width="100%" fill="red" height="100%" /></animate></g></svg>`,
         { pure: true }
     );
     expect(core.interactions).toHaveLength(1);

--- a/addons/website/static/tests/interactions/listing_layout.test.js
+++ b/addons/website/static/tests/interactions/listing_layout.test.js
@@ -1,11 +1,9 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { click, queryOne } from "@odoo/hoot-dom";
 import { Deferred } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 
 import { onRpc } from "@web/../tests/web_test_helpers";
 
@@ -15,7 +13,7 @@ describe.current.tags("interaction_dev");
 
 test("listing_layout toggle to list mode", async () => {
     const deferred = new Deferred();
-    await startInteractions(`
+    await startInteractions(markup`
         <div class="container o_website_listing_layout">
             <section>
                 <div class="listing_layout_switcher btn-group" data-active-classes="border-primary" data-view-id="123">
@@ -39,7 +37,9 @@ test("listing_layout toggle to list mode", async () => {
         </div>
     `);
     onRpc("/website/save_session_layout_mode", async (request) => {
-        const jsonParams = JSON.parse(new TextDecoder("utf-8").decode(await request.arrayBuffer())).params;
+        const jsonParams = JSON.parse(
+            new TextDecoder("utf-8").decode(await request.arrayBuffer())
+        ).params;
         expect.step("rpc");
         expect(jsonParams.layout_mode).toBe("list");
         expect(jsonParams.view_id).toBe("123");
@@ -49,14 +49,20 @@ test("listing_layout toggle to list mode", async () => {
     await click("#apply_list");
     expect(gridEl).toHaveClass("o_website_list");
     expect(gridEl).not.toHaveClass("o_website_grid");
-    expect(queryOne(".o_website_list > div")).not.toHaveClass(["col-lg-3", "col-md-4", "col-sm-6", "px-2", "col-xs-12"]);
+    expect(queryOne(".o_website_list > div")).not.toHaveClass([
+        "col-lg-3",
+        "col-md-4",
+        "col-sm-6",
+        "px-2",
+        "col-xs-12",
+    ]);
     await deferred;
     expect.verifySteps(["rpc"]);
 });
 
 test("listing_layout toggle to grid mode", async () => {
     const deferred = new Deferred();
-    await startInteractions(`
+    await startInteractions(markup`
         <div class="container o_website_listing_layout">
             <section>
                 <div class="listing_layout_switcher btn-group" data-active-classes="border-primary" data-view-id="123">
@@ -80,7 +86,9 @@ test("listing_layout toggle to grid mode", async () => {
         </div>
     `);
     onRpc("/website/save_session_layout_mode", async (request) => {
-        const jsonParams = JSON.parse(new TextDecoder("utf-8").decode(await request.arrayBuffer())).params;
+        const jsonParams = JSON.parse(
+            new TextDecoder("utf-8").decode(await request.arrayBuffer())
+        ).params;
         expect.step("rpc");
         expect(jsonParams.layout_mode).toBe("grid");
         expect(jsonParams.view_id).toBe("123");
@@ -90,7 +98,13 @@ test("listing_layout toggle to grid mode", async () => {
     await click("#apply_grid");
     expect(listEl).toHaveClass("o_website_grid");
     expect(listEl).not.toHaveClass("o_website_list");
-    expect(queryOne(".o_website_grid > div")).toHaveClass(["col-lg-3", "col-md-4", "col-sm-6", "px-2", "col-xs-12"]);
+    expect(queryOne(".o_website_grid > div")).toHaveClass([
+        "col-lg-3",
+        "col-md-4",
+        "col-sm-6",
+        "px-2",
+        "col-xs-12",
+    ]);
     await deferred;
     expect.verifySteps(["rpc"]);
 });

--- a/addons/website/static/tests/interactions/multirange_input.test.js
+++ b/addons/website/static/tests/interactions/multirange_input.test.js
@@ -1,10 +1,8 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { queryAll } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.multirange_input");
 
@@ -12,7 +10,7 @@ describe.current.tags("interaction_dev");
 
 test("multirange_input lib gets initialised", async () => {
     document.querySelector("html").setAttribute("lang", "en_US");
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <input type="range" multiple="multiple"
                 class="form-range range-with-input"

--- a/addons/website/static/tests/interactions/parallax.test.js
+++ b/addons/website/static/tests/interactions/parallax.test.js
@@ -1,10 +1,8 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, getFixture, test } from "@odoo/hoot";
 import { manuallyDispatchProgrammaticEvent, queryOne, queryRect, scroll } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.parallax");
 
@@ -13,14 +11,14 @@ describe.current.tags("interaction_dev");
 const getTemplate = function (options = {}) {
     const speed = options.speed || 0;
     const height = options.height || 1000;
-    return `
+    return markup`
         <section style="height: ${height}px; background-color: #CCCCFF;"></section>
         <section class="parallax" data-scroll-background-ratio="${speed}" style="min-height: 100px; z-index: -1000;">
             <div class="s_parallax_bg" style="background-color: #CCFFCC; height: 500px; overflow: hidden;"></div>
         </section>
         <section style="height: ${height}px; background-color: #FFCCCC;"></section>
     `;
-}
+};
 
 const simulateScrolls = async function (fixture) {
     fixture.style.overflow = "scroll";
@@ -34,7 +32,7 @@ const simulateScrolls = async function (fixture) {
         spacings.push(spacing);
     }
     return spacings;
-}
+};
 
 test("parallax is started when there is an element .parallax", async () => {
     const { core } = await startInteractions(getTemplate());

--- a/addons/website/static/tests/interactions/plausible_push.test.js
+++ b/addons/website/static/tests/interactions/plausible_push.test.js
@@ -1,16 +1,14 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.plausible_push");
 
 describe.current.tags("interaction_dev");
 
 test("plausible _ush does nothing if there is no .js_plausible_push", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <input type='hidden' data-event-name='Lead Generation' data-event-params='{"CTA": "Contact Us"}' />
         </div>
@@ -20,7 +18,7 @@ test("plausible _ush does nothing if there is no .js_plausible_push", async () =
 
 test("plausible_push interaction notifies plausible if .js_plausible_push", async () => {
     expect(window.plausible).toBe(undefined);
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <input type='hidden' class='js_plausible_push' data-event-name='Lead Generation' data-event-params='{"CTA": "Contact Us"}' />
         </div>

--- a/addons/website/static/tests/interactions/popup/popup.test.js
+++ b/addons/website/static/tests/interactions/popup/popup.test.js
@@ -13,6 +13,7 @@ import {
     tick,
 } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 
 import { browser } from "@web/core/browser/browser";
 import { cookie } from "@web/core/browser/cookie";
@@ -41,7 +42,7 @@ function removeTransitions() {
  * @param {string} [options.extraPrimaryBtnClasses]
  * @param {string} [options.modalId]
  * @param {boolean} [options.focusableElements]
- * @returns {string} - popup template
+ * @returns {ReturnType<import("@odoo/owl").markup>} - popup template
  */
 function getPopupTemplate(options = {}) {
     const {
@@ -52,7 +53,7 @@ function getPopupTemplate(options = {}) {
         modalId = "",
         focusableElements = false,
     } = options;
-    return `
+    return markup`
         <div class="s_popup o_snippet_invisible" data-vcss="001" data-snippet="s_popup"
              data-name="Popup" id="sPopup" data-invisible="1">
             <div class="modal fade s_popup_middle modal_shown ${
@@ -86,7 +87,7 @@ function getPopupTemplate(options = {}) {
 const modal = "#sPopup .modal";
 
 test("popup interaction does not activate without .s_popup", async () => {
-    const { core } = await startInteractions(``);
+    const { core } = await startInteractions(markup``);
     expect(core.interactions).toHaveLength(0);
 });
 
@@ -159,7 +160,7 @@ describe("show popup", () => {
     });
 
     test("show popup after click on link", async () => {
-        const { core } = await startInteractions(`
+        const { core } = await startInteractions(markup`
             <a href="#modal">Show popup</a>
             ${getPopupTemplate({ display: "onClick", modalId: "modal" })}
         `);
@@ -189,7 +190,7 @@ describe("trap focus", () => {
     beforeEach(removeTransitions);
 
     test("focus is trapped when popup opens", async () => {
-        const { core } = await startInteractions(`
+        const { core } = await startInteractions(markup`
             <a href="#">Link</a>
             ${getPopupTemplate({ modalId: "modal", focusableElements: true })}
         `);
@@ -210,7 +211,7 @@ describe("trap focus", () => {
     });
 
     test("reset focus on the previous active element when popup is closed", async () => {
-        const { core } = await startInteractions(`
+        const { core } = await startInteractions(markup`
             <a id="showLink" href="#">Link</a>
             ${getPopupTemplate({ modalId: "modal" })}
         `);
@@ -231,7 +232,7 @@ describe("trap focus", () => {
     });
 
     test("trap & reset focus when popup opens on click", async () => {
-        const { core } = await startInteractions(`
+        const { core } = await startInteractions(markup`
             <a href="#modal">Show popup</a>
             ${getPopupTemplate({ display: "onClick", modalId: "modal", focusableElements: true })}
         `);
@@ -262,7 +263,7 @@ describe("trap focus", () => {
     });
 
     test("intercept & reset focus with no backdrop popup", async () => {
-        const { core } = await startInteractions(`
+        const { core } = await startInteractions(markup`
             <a id="link1" href="#">Link</a>
             ${getPopupTemplate({ modalId: "modal", backdrop: false })}
         `);
@@ -282,7 +283,7 @@ describe("trap focus", () => {
     });
 
     test("don't trap focus if no backdrop", async () => {
-        const { core } = await startInteractions(`
+        const { core } = await startInteractions(markup`
             <a id="link1" href="#">Link before</a>
             ${getPopupTemplate({ modalId: "modal", backdrop: false, focusableElements: true })}
             <a id="link2" href="#">Link after</a>

--- a/addons/website/static/tests/interactions/post_link.test.js
+++ b/addons/website/static/tests/interactions/post_link.test.js
@@ -6,13 +6,14 @@ import {
 
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, click } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.post_link");
 
 describe.current.tags("interaction_dev");
 
 test("post_link adds and removes class on setup/destroy", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <span data-post="/some/url" class="post_link">All</span>
         </div>
@@ -26,7 +27,7 @@ test("post_link adds and removes class on setup/destroy", async () => {
 
 test("post_link handle clicks by sending a request", async () => {
     const requests = mockSendRequests();
-    await startInteractions(`
+    await startInteractions(markup`
         <div id="wrapwrap">
             <span data-post="/some/url" class="post_link">All</span>
         </div>

--- a/addons/website/static/tests/interactions/ripple_effect.test.js
+++ b/addons/website/static/tests/interactions/ripple_effect.test.js
@@ -1,18 +1,16 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { click, queryFirst } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.ripple_effect");
 
 describe.current.tags("interaction_dev");
 
 test("ripple_effect introduces an element on click", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <a class="btn" href="#">Click here</a>
         </div>

--- a/addons/website/static/tests/interactions/scroll_button.test.js
+++ b/addons/website/static/tests/interactions/scroll_button.test.js
@@ -7,18 +7,19 @@ import {
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, click, queryAll } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.scroll_button");
 
 describe.current.tags("interaction_dev");
 
 test("scroll button does nothing if there is o_scroll_button", async () => {
-    const { core } = await startInteractions(`<div id="wrapwrap"></div>`);
+    const { core } = await startInteractions(markup`<div id="wrapwrap"></div>`);
     expect(core.interactions).toHaveLength(0);
 });
 
 test("scroll button scrolls to next section", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap" style="overflow: scroll; max-height: 500px;">
             <section style="min-height: 500px;">
                 <a class="o_scroll_button">First</a>

--- a/addons/website/static/tests/interactions/show_password.test.js
+++ b/addons/website/static/tests/interactions/show_password.test.js
@@ -1,16 +1,14 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { pointerDown, pointerUp, queryOne } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.show_password");
 
 describe.current.tags("interaction_dev");
 
-const template = `
+const template = markup`
     <div class="input-group">
         <input type="password" id="password" class="form-control" required="required" name="visibility_password" />
         <button class="btn btn-secondary" type="button" id="showPass">

--- a/addons/website/static/tests/interactions/snippets/chart.test.js
+++ b/addons/website/static/tests/interactions/snippets/chart.test.js
@@ -1,14 +1,11 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { queryOne } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
-import { escape } from "@web/core/utils/strings";
 import { patch } from "@web/core/utils/patch";
 import { Chart } from "@website/snippets/s_chart/chart";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.chart");
 
@@ -18,23 +15,23 @@ patch(Chart.prototype, {
     setup() {
         super.setup();
         this.noAnimation = true;
-    }
+    },
 });
 
 test("chart is started when there is an element .s_chart", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div class="s_chart" data-type="bar" data-legend-position="top" data-tooltip-display="true" data-stacked="false" data-border-width="2"
-            data-data="${escape(`{
-                "labels": ["First", "Second", "Third", "Fourth", "Fifth"],
-                "datasets": [
+            data-data="${JSON.stringify({
+                labels: ["First", "Second", "Third", "Fourth", "Fifth"],
+                datasets: [
                     {
-                        "label": "One",
-                        "data": ["12", "24", "18", "17", "10"],
-                        "backgroundColor": "o-color-1",
-                        "borderColor": "o-color-1"
-                    }
-                ]
-            }`)}">
+                        label: "One",
+                        data: ["12", "24", "18", "17", "10"],
+                        backgroundColor: "o-color-1",
+                        borderColor: "o-color-1",
+                    },
+                ],
+            })}">
         <h2>A Chart Title</h2>
         <canvas/>
     </div>

--- a/addons/website/static/tests/interactions/snippets/countdown.edit.test.js
+++ b/addons/website/static/tests/interactions/snippets/countdown.edit.test.js
@@ -2,14 +2,17 @@ import { describe, expect, test } from "@odoo/hoot";
 import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
 import { switchToEditMode } from "../../helpers";
 import { tick } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 describe.current.tags("interaction_dev");
 setupInteractionWhiteList("website.countdown");
 
 const getTemplate = function (options = { endAction: "nothing", endTime: "98765432100" }) {
-    return `
+    return markup`
         <div style="background-color: white;">
-            <section class="s_countdown pt48 pb48 ${options.endAction === "message_no_countdown" ? "hide-countdown" : ""}"
+            <section class="s_countdown pt48 pb48 ${
+                options.endAction === "message_no_countdown" ? "hide-countdown" : ""
+            }"
             data-display="dhms"
             data-end-action="${options.endAction}"
             data-size="175"
@@ -33,10 +36,10 @@ const getTemplate = function (options = { endAction: "nothing", endTime: "987654
                 ${["message", "message_no_countdown"].includes(options.endAction) ? endMessage : ""}
             </section>
         </div>
-    `
+    `;
 };
 
-const endMessage = `
+const endMessage = markup`
     <div class="s_countdown_end_message d-none">
         <div class="oe_structure">
             <section class="s_picture pt64 pb64" data-snippet="s_picture">

--- a/addons/website/static/tests/interactions/snippets/countdown.test.js
+++ b/addons/website/static/tests/interactions/snippets/countdown.test.js
@@ -1,20 +1,20 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { queryAll, queryOne, tick } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.countdown");
 
 describe.current.tags("interaction_dev");
 
 const getTemplate = function (options = { endAction: "nothing", endTime: "98765432100" }) {
-    return `
+    return markup`
         <div style="background-color: white;">
-            <section class="s_countdown pt48 pb48 ${options.endAction === "message_no_countdown" ? "hide-countdown" : ""}"
+            <section class="s_countdown pt48 pb48 ${
+                options.endAction === "message_no_countdown" ? "hide-countdown" : ""
+            }"
             data-display="dhms"
             data-end-action="${options.endAction}"
             data-size="175"
@@ -38,10 +38,10 @@ const getTemplate = function (options = { endAction: "nothing", endTime: "987654
                 ${["message", "message_no_countdown"].includes(options.endAction) ? endMessage : ""}
             </section>
         </div>
-    `
+    `;
 };
 
-const endMessage = `
+const endMessage = markup`
     <div class="s_countdown_end_message d-none">
         <div class="oe_structure">
             <section class="s_picture pt64 pb64" data-snippet="s_picture">
@@ -68,7 +68,7 @@ const wasDataChanged = function (data1, data2, l) {
         }
     }
     return false;
-}
+};
 
 test("countdown is started when there is an element .s_countdown", async () => {
     const { core } = await startInteractions(getTemplate());
@@ -84,11 +84,11 @@ test("countdown is started when there is an element .s_countdown", async () => {
 test("[time] countdown display is updated correctly when time pass", async () => {
     await startInteractions(getTemplate());
 
-    const canvasEls = queryAll('canvas');
+    const canvasEls = queryAll("canvas");
     const canvasHours = canvasEls[1];
     const canvasSeconds = canvasEls[3];
-    const canvasHoursCtx = canvasHours.getContext('2d');
-    const canvasSecondsCtx = canvasSeconds.getContext('2d');
+    const canvasHoursCtx = canvasHours.getContext("2d");
+    const canvasSecondsCtx = canvasSeconds.getContext("2d");
 
     // time T
     const data1Hours = canvasHoursCtx.getImageData(0, 0, canvasHours.width, canvasHours.height).data;
@@ -107,7 +107,7 @@ test("[time] countdown display is updated correctly when time pass", async () =>
     // Check that the data are not empty & the same size
 
     const dataHoursLength = data1Hours.length;
-    const dataSecondsLength = data1Seconds.length
+    const dataSecondsLength = data1Seconds.length;
     expect(dataSecondsLength).toBe(dataHoursLength);
     expect(dataSecondsLength).not.toBe(0);
 

--- a/addons/website/static/tests/interactions/snippets/dynamic_snippet.test.js
+++ b/addons/website/static/tests/interactions/snippets/dynamic_snippet.test.js
@@ -2,6 +2,7 @@ import { setupInteractionWhiteList, startInteractions } from "@web/../tests/publ
 
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { queryAll } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 import { onRpc } from "@web/../tests/web_test_helpers";
 
@@ -35,7 +36,7 @@ test("dynamic snippet loads items and displays them through template", async () 
             `<div class="s_test_dynamic_item" data-test-param="test2">Another test record</div>`,
         ];
     });
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <section data-snippet="s_dynamic_snippet" class="s_dynamic_snippet s_dynamic s_dynamic_empty pt32 pb32 o_colored_level" data-custom-template-data="{}" data-name="Dynamic Snippet"
                     data-filter-id="1"

--- a/addons/website/static/tests/interactions/snippets/dynamic_snippet_carousel.test.js
+++ b/addons/website/static/tests/interactions/snippets/dynamic_snippet_carousel.test.js
@@ -3,6 +3,7 @@ import { setupInteractionWhiteList, startInteractions } from "@web/../tests/publ
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { animationFrame, click, queryAll, queryOne } from "@odoo/hoot-dom";
 import { advanceTime, enableTransitions } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 
 import { onRpc } from "@web/../tests/web_test_helpers";
 
@@ -32,7 +33,7 @@ beforeEach(() => {
 
 describe.current.tags("interaction_dev");
 
-const testTemplate = /* xml */ `
+const testTemplate = markup`
     <div id="wrapwrap">
         <section data-snippet="s_dynamic_snippet_carousel" class="s_dynamic_snippet_carousel s_dynamic s_dynamic_empty pt32 pb32 o_colored_level" data-custom-template-data="{}" data-name="Dynamic Carousel"
                 data-filter-id="1"

--- a/addons/website/static/tests/interactions/snippets/embed_code.test.js
+++ b/addons/website/static/tests/interactions/snippets/embed_code.test.js
@@ -1,10 +1,8 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { queryOne } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.embed_code");
 
@@ -12,7 +10,7 @@ describe.current.tags("interaction_dev");
 
 /* TODO Requires a way to inject a script in a fixture.
 test("embed code executed only once", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
     <section class="s_embed_code text-center pt64 pb64 o_colored_level" data-snippet="s_embed_code" data-name="Embed Code">
         <template class="s_embed_code_saved"><script>expect.step("template");</script></template>
         <div class="s_embed_code_embedded container o_not_editable"><script>expect.step("div");</script></div>
@@ -24,7 +22,7 @@ test("embed code executed only once", async () => {
 */
 
 test("embed_code resets on stop", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <section class="s_embed_code text-center pt64 pb64 o_colored_level" data-snippet="s_embed_code" data-name="Embed Code">
             <template class="s_embed_code_saved">
                 <div>original</div>

--- a/addons/website/static/tests/interactions/snippets/faq_horizontal.test.js
+++ b/addons/website/static/tests/interactions/snippets/faq_horizontal.test.js
@@ -4,6 +4,7 @@ import { describe, expect, test } from "@odoo/hoot";
 import { queryFirst, queryOne } from "@odoo/hoot-dom";
 
 import { setupTest, simpleScroll, doubleScroll } from "./helpers";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList([
     "website.header_standard",
@@ -16,7 +17,7 @@ setupInteractionWhiteList([
 describe.current.tags("interaction_dev");
 
 const getTemplate = function (headerType) {
-    return `
+    return markup`
         <header class="${headerType}" style="background-color:#CCFFCC">
             <div style="height: 50px; background-color:#33FFCC;"></div>
         </header>

--- a/addons/website/static/tests/interactions/snippets/form.edit.test.js
+++ b/addons/website/static/tests/interactions/snippets/form.edit.test.js
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "@odoo/hoot";
+import { markup } from "@odoo/owl";
 import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
 import { onRpc } from "@web/../tests/web_test_helpers";
 import { switchToEditMode } from "../../helpers";
 
 describe.current.tags("interaction_dev");
 
-const formXml = `
+const formXml = markup`
     <div id="wrapwrap">
         <section class="s_website_form pt16 pb16" data-vcss="001" data-snippet="s_website_form" data-name="Form">
             <div class="container-fluid">

--- a/addons/website/static/tests/interactions/snippets/form.test.js
+++ b/addons/website/static/tests/interactions/snippets/form.test.js
@@ -3,6 +3,7 @@ import { setupInteractionWhiteList, startInteractions } from "@web/../tests/publ
 import { describe, expect, test } from "@odoo/hoot";
 import { click, fill, queryOne } from "@odoo/hoot-dom";
 import { advanceTime, Deferred } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 
 import { onRpc } from "@web/../tests/web_test_helpers";
 
@@ -25,7 +26,7 @@ function checkField(inputEl, isVisible, hasError) {
         : expect(fieldEl).not.toHaveClass("o_has_error");
 }
 
-const formTemplate = `
+const formTemplate = markup`
     <div id="wrapwrap">
         <section class="s_website_form pt16 pb16" data-vcss="001" data-snippet="s_website_form" data-name="Form">
             <div class="container-fluid">
@@ -139,9 +140,7 @@ test("(name) form checks conditions", async () => {
     await advanceTime(400); // Debounce delay.
     checkField(nameEl, true, false);
     // Submit
-    onRpc("/website/form/mail.mail", async () => {
-        return {};
-    });
+    onRpc("/website/form/mail.mail", async () => ({}));
     await click("a.s_website_form_send");
     checkField(nameEl, true, false);
 });
@@ -176,9 +175,7 @@ test("(mail) form checks conditions", async () => {
     await advanceTime(400); // Debounce delay.
     checkField(mailEl, true, false);
     // Submit
-    onRpc("/website/form/mail.mail", async () => {
-        return {};
-    });
+    onRpc("/website/form/mail.mail", async () => ({}));
     await click("a.s_website_form_send");
     checkField(mailEl, true, false);
 });
@@ -213,9 +210,7 @@ test("(subject) form checks conditions", async () => {
     await advanceTime(400); // Debounce delay.
     checkField(subjectEl, true, false);
     // Submit
-    onRpc("/website/form/mail.mail", async () => {
-        return {};
-    });
+    onRpc("/website/form/mail.mail", async () => ({}));
     await click("a.s_website_form_send");
     checkField(subjectEl, true, false);
 });
@@ -250,9 +245,7 @@ test("(question) form checks conditions", async () => {
     await advanceTime(400); // Debounce delay.
     checkField(questionEl, true, true);
     // Submit
-    onRpc("/website/form/mail.mail", async () => {
-        return {};
-    });
+    onRpc("/website/form/mail.mail", async () => ({}));
     await click("a.s_website_form_send");
     checkField(questionEl, true, false);
 });
@@ -305,7 +298,7 @@ test("form prefilled conditional", async () => {
     });
 
     // Phone number is only visible if name is filled.
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <section class="s_website_form pt16 pb16" data-vcss="001" data-snippet="s_website_form" data-name="Form">
                 <div class="container-fluid">

--- a/addons/website/static/tests/interactions/snippets/gallery.test.js
+++ b/addons/website/static/tests/interactions/snippets/gallery.test.js
@@ -1,18 +1,16 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, click, press, queryAll } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.gallery");
 
 describe.current.tags("interaction_dev");
 
 // TODO Obtain rendering from `website.s_images_wall` template ?
-const defaultGallery = `
+const defaultGallery = markup`
     <div id="wrapwrap">
         <section class="s_image_gallery o_spc-small o_masonry pt24 pb24 o_colored_level" data-vcss="002" data-columns="3" style="overflow: hidden;" data-snippet="s_images_wall" data-name="Images Wall">
             <div class="container">
@@ -36,7 +34,7 @@ const defaultGallery = `
 `;
 
 test("gallery does nothing if there is no non-slideshow s_image_gallery", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <section class="s_image_gallery o_slideshow"/>
         </div>
@@ -91,6 +89,7 @@ test("gallery interaction opens lightbox on click, then use mouse", async () => 
     await checkLightbox({
         close: async (lightboxEl) => await click(lightboxEl.querySelector(".btn-close")),
         next: async (lightboxEl) => await click(lightboxEl.querySelector(".carousel-control-next")),
-        previous: async (lightboxEl) => await click(lightboxEl.querySelector(".carousel-control-prev")),
+        previous: async (lightboxEl) =>
+            await click(lightboxEl.querySelector(".carousel-control-prev")),
     });
 });

--- a/addons/website/static/tests/interactions/snippets/gallery_slider.test.js
+++ b/addons/website/static/tests/interactions/snippets/gallery_slider.test.js
@@ -1,13 +1,11 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, getFixture, test } from "@odoo/hoot";
 import { animationFrame, click, queryOne } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
 
 import { onceAllImagesLoaded } from "@website/utils/images";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.gallery_slider");
 
@@ -16,7 +14,7 @@ describe.current.tags("interaction_dev");
 const SLIDE_DURATION = 1000;
 
 // TODO Obtain rendering from `website.s_images_gallery` template ?
-const defaultGallery = `
+const defaultGallery = markup`
     <div id="wrapwrap">
         <section class="s_image_gallery o_slideshow pt24 pb24 s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right s_image_gallery_indicators_dots s_image_gallery_arrows_default" data-vcss="002" data-columns="3">
             <div class="o_container_small overflow-hidden">
@@ -54,7 +52,7 @@ const defaultGallery = `
 `;
 
 // TODO Obtain rendering from `website.gallery.s_image_gallery_mirror.lightbox` template ?
-const defaultLightbox = `
+const defaultLightbox = markup`
     <main class="modal-body o_slideshow bg-transparent">
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close" style="position: absolute; right: 10px; top: 10px;">
         </button>
@@ -102,7 +100,7 @@ const defaultLightbox = `
 `;
 
 // TODO Obtain rendering from `website.gallery.slideshow` template.
-const defaultOldLightbox = `
+const defaultOldLightbox = markup`
     <main class="modal-body o_slideshow bg-transparent">
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close" style="position: absolute; right: 10px; top: 10px;">
         </button>
@@ -145,7 +143,7 @@ const defaultOldLightbox = `
 `;
 
 test("gallery_slider does nothing if there is no o_slideshow s_image_gallery", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap">
             <section class="s_image_gallery"/>
         </div>

--- a/addons/website/static/tests/interactions/snippets/search_bar.test.js
+++ b/addons/website/static/tests/interactions/snippets/search_bar.test.js
@@ -1,19 +1,17 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { click, press, queryAll, queryOne } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
 
 import { onRpc } from "@web/../tests/web_test_helpers";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.search_bar");
 
 describe.current.tags("interaction_dev");
 
-const searchTemplate = `
+const searchTemplate = markup`
     <form method="get" class="o_searchbar_form s_searchbar_input" action="/website/search" data-snippet="s_searchbar_input">
         <div role="search" class="input-group input-group-lg">
             <input type="search" name="search" class="search-query form-control oe_search_box" placeholder="Search..."
@@ -45,29 +43,29 @@ function supportAutocomplete() {
         expect(json.params.options.displayExtraLink).toBe("true");
         expect(json.params.options.displayDetail).toBe("false");
         return {
-            "results": [
+            results: [
                 {
-                    "_fa": "fa-file-o",
-                    "name": "Xyz 1",
-                    "website_url": "/website/test/xyz-1",
+                    _fa: "fa-file-o",
+                    name: "Xyz 1",
+                    website_url: "/website/test/xyz-1",
                 },
                 {
-                    "_fa": "fa-file-o",
-                    "name": "Xyz 2",
-                    "website_url": "/website/test/xyz-2",
+                    _fa: "fa-file-o",
+                    name: "Xyz 2",
+                    website_url: "/website/test/xyz-2",
                 },
                 {
-                    "_fa": "fa-file-o",
-                    "name": "Xyz 3",
-                    "website_url": "/website/test/xyz-3",
-                }
+                    _fa: "fa-file-o",
+                    name: "Xyz 3",
+                    website_url: "/website/test/xyz-3",
+                },
             ],
-            "results_count": 3,
-            "parts": {
-                "name": true,
-                "website_url": true,
+            results_count: 3,
+            parts: {
+                name: true,
+                website_url: true,
             },
-            "fuzzy_search": false
+            fuzzy_search: false,
         };
     });
 }

--- a/addons/website/static/tests/interactions/snippets/search_bar_results.test.js
+++ b/addons/website/static/tests/interactions/snippets/search_bar_results.test.js
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { press, queryAll, queryOne } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 setupInteractionWhiteList("website.search_bar_results");
 describe.current.tags("interaction_dev");
 
-const searchTemplate = `
+const searchTemplate = markup`
     <form method="get" class="o_searchbar_form s_searchbar_input" action="/website/search" data-snippet="s_searchbar_input">
         <div role="search" class="input-group input-group-lg">
             <input type="search" name="search" class="search-query form-control oe_search_box" placeholder="Search..."

--- a/addons/website/static/tests/interactions/snippets/table_of_content.test.js
+++ b/addons/website/static/tests/interactions/snippets/table_of_content.test.js
@@ -6,6 +6,7 @@ import {
 
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, click, queryAll, queryOne, scroll } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 import { setupTest, simpleScroll, doubleScroll } from "./helpers";
 
@@ -20,7 +21,7 @@ setupInteractionWhiteList([
 describe.current.tags("interaction_dev");
 
 // TODO Maybe recover from `website.s_table_of_content`.
-const tableTemplate = `
+const tableTemplate = markup`
     <section class="s_table_of_content pt24 pb24 o_cc o_cc1">
         <div class="container">
             <div class="row s_nb_column_fixed">
@@ -88,7 +89,7 @@ const tableTemplate = `
 `;
 
 const getTemplate = function (headerType) {
-    return `
+    return markup`
     <header class="${headerType}" style="background-color:#CCFFCC">
         <div style="height: 50px; background-color:#33FFCC;"></div>
     </header>
@@ -116,7 +117,7 @@ const checkVisibility = function (aEls, h2Els, wrapEl) {
 
 test.tags("desktop");
 test("table_of_content is correctly started (desktop)", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap" style="overflow: scroll; max-height: 300px;">
             ${tableTemplate}
         </div>
@@ -132,7 +133,7 @@ test("table_of_content is correctly started (desktop)", async () => {
 
 test.tags("mobile");
 test("table_of_content is correctly started (mobile)", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap" style="overflow: scroll; max-height: 300px;">
             ${tableTemplate}
         </div>
@@ -147,7 +148,7 @@ test("table_of_content is correctly started (mobile)", async () => {
 
 test.tags("desktop");
 test("table_of_content scrolls to targetted location (desktop)", async () => {
-    await startInteractions(`
+    await startInteractions(markup`
         <div id="wrapwrap" style="overflow: scroll; max-height: 300px;">
             ${tableTemplate}
         </div>
@@ -164,7 +165,7 @@ test("table_of_content scrolls to targetted location (desktop)", async () => {
 
 test.tags("mobile");
 test("table_of_content scrolls to targetted location (mobile)", async () => {
-    await startInteractions(`
+    await startInteractions(markup`
         <div id="wrapwrap" style="overflow: scroll; max-height: 300px;">
             ${tableTemplate}
         </div>
@@ -180,7 +181,7 @@ test("table_of_content scrolls to targetted location (mobile)", async () => {
 
 test.tags("desktop");
 test("table_of_content highlights reached header (desktop)", async () => {
-    await startInteractions(`
+    await startInteractions(markup`
         <div id="wrapwrap" style="overflow: scroll; max-height: 300px;">
             ${tableTemplate}
         </div>
@@ -197,7 +198,7 @@ test("table_of_content highlights reached header (desktop)", async () => {
 
 test.tags("mobile");
 test("table_of_content highlights reached header (mobile)", async () => {
-    await startInteractions(`
+    await startInteractions(markup`
         <div id="wrapwrap" style="overflow: scroll; max-height: 300px;">
             ${tableTemplate}
         </div>

--- a/addons/website/static/tests/interactions/text_highlight.test.js
+++ b/addons/website/static/tests/interactions/text_highlight.test.js
@@ -1,16 +1,14 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, queryAll, queryFirst } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.text_highlight");
 
 describe.current.tags("interaction_dev");
 
-const highlightTemplate = `
+const highlightTemplate = markup`
     <p>
         Great stories have a <b>personality</b>.
         <span class="o_text_highlight o_translate_inline o_text_highlight_circle_1" style="--text-highlight-width: 2px;">

--- a/addons/website/static/tests/interactions/zoomed_background_shape.test.js
+++ b/addons/website/static/tests/interactions/zoomed_background_shape.test.js
@@ -1,17 +1,15 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { queryOne } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 
 setupInteractionWhiteList("website.zoomed_background_shape");
 
 describe.current.tags("interaction_dev");
 
 test("zoomed_background_shape is not needed without zoom", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap" style="width: 1000px;">
             <section class="s_faq_list pt56 pb56 o_colored_level" data-snippet="s_faq_list" data-name="FAQ List" style="position: relative;" data-oe-shape-data="{&quot;shape&quot;:&quot;web_editor/Airy/13_001&quot;,&quot;colors&quot;:{&quot;c1&quot;:&quot;#714B67&quot;,&quot;c4&quot;:&quot;#D6D6E7&quot;},&quot;flip&quot;:[],&quot;showOnMobile&quot;:false,&quot;shapeAnimationSpeed&quot;:&quot;0&quot;,&quot;animated&quot;:&quot;true&quot;}">
                 <div class="o_we_shape o_web_editor_Airy_13_001 o_we_animated" style="background-image: url(&quot;/web_editor/shape/web_editor%2FAiry%2F13_001.svg?c1=%23714B67&amp;c4=%23D6D6E7&quot;);"/>
@@ -22,13 +20,13 @@ test("zoomed_background_shape is not needed without zoom", async () => {
     expect(core.interactions).toHaveLength(1);
     const shapeEl = queryOne(".o_we_shape");
     expect(shapeEl).not.toHaveAttribute("style", /left:/);
-    expect(shapeEl).toHaveStyle({"left": "0px"});
+    expect(shapeEl).toHaveStyle({ left: "0px" });
     expect(shapeEl).not.toHaveAttribute("style", /right:/);
-    expect(shapeEl).toHaveStyle({"right": "0px"});
+    expect(shapeEl).toHaveStyle({ right: "0px" });
 });
 
 test("zoomed_background_shape applies correction on zoom", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap" style="width: 1000px; transform: scale(0.9997);">
             <section style="position: relative;" data-oe-shape-data="{&quot;shape&quot;:&quot;web_editor/Airy/13_001&quot;,&quot;colors&quot;:{&quot;c1&quot;:&quot;#714B67&quot;,&quot;c4&quot;:&quot;#D6D6E7&quot;},&quot;flip&quot;:[],&quot;showOnMobile&quot;:false,&quot;shapeAnimationSpeed&quot;:&quot;0&quot;,&quot;animated&quot;:&quot;true&quot;}">
                 <div class="o_we_shape o_web_editor_Airy_13_001 o_we_animated" style="background-image: url(&quot;/web_editor/shape/web_editor%2FAiry%2F13_001.svg?c1=%23714B67&amp;c4=%23D6D6E7&quot;);"/>
@@ -40,8 +38,8 @@ test("zoomed_background_shape applies correction on zoom", async () => {
     const shapeEl = queryOne(".o_we_shape");
     // Adjustment depends on window size during test.
     expect(shapeEl).toHaveAttribute("style", /left:/);
-    expect(shapeEl).not.toHaveStyle({"left": "0px"});
+    expect(shapeEl).not.toHaveStyle({ left: "0px" });
     expect(shapeEl).toHaveAttribute("style", /right:/);
-    expect(shapeEl).not.toHaveStyle({"right": "0px"});
+    expect(shapeEl).not.toHaveStyle({ right: "0px" });
     expect(shapeEl).toHaveStyle({ left: shapeEl.style.right });
 });

--- a/addons/website_blog/static/tests/interactions/snippets/blog_posts.test.js
+++ b/addons/website_blog/static/tests/interactions/snippets/blog_posts.test.js
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { queryAll } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
 import { onRpc } from "@web/../tests/web_test_helpers";
 import { registry } from "@web/core/registry";
@@ -43,7 +44,7 @@ test("dynamic snippet blog posts loads items and displays them through template"
         `,
         ];
     });
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
       <div id="wrapwrap">
           <section data-snippet="s_blog_posts" class="s_blog_posts s_dynamic_snippet_blog_posts s_blog_post_big_picture s_blog_posts_effect_marley s_blog_posts_post_picture_size_default s_dynamic s_dynamic_empty pt32 pb32 o_colored_level"
                   data-custom-template-data="{&quot;blog_posts_post_author_active&quot;:true, &quot;blog_posts_post_teaser_active&quot;:true, &quot;blog_posts_post_date_active&quot;:true}"

--- a/addons/website_blog/static/tests/interactions/snippets/website_blog.test.js
+++ b/addons/website_blog/static/tests/interactions/snippets/website_blog.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { click } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
@@ -8,7 +9,7 @@ setupInteractionWhiteList(["website_blog.website_blog"]);
 describe.current.tags("interaction_dev");
 
 test("click on next blog updates URL", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <section class="website_blog">
             <div id="o_wblog_next_container" style="width:100px; height: 100px;">
                 <div class="o_record_cover_container h-100 o_wblog_post_page_cover o_wblog_post_page_cover_footer o_record_has_cover">
@@ -18,7 +19,7 @@ test("click on next blog updates URL", async () => {
         </section>
     `);
     expect(core.interactions).toHaveLength(1);
-    expect(browser.location.pathname).toBe("/")
+    expect(browser.location.pathname).toBe("/");
     await click("#o_wblog_next_container");
     await advanceTime(300);
     expect(browser.location.pathname).toBe("/some/blog");

--- a/addons/website_cf_turnstile/static/tests/interactions/form.test.js
+++ b/addons/website_cf_turnstile/static/tests/interactions/form.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { queryAll } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 import { session } from "@web/session";
 import { patchTurnStile } from "@website_cf_turnstile/../tests/helpers";
@@ -11,7 +12,7 @@ describe.current.tags("interaction_dev");
 
 test("turnstile captcha gets added to form snippets", async () => {
     session.turnstile_site_key = "test";
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <section class="s_website_form pt16 pb16" data-vcss="001" data-snippet="s_website_form" data-name="Form">
             <form action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required" data-mark="*" data-pre-fill="true" data-model_name="mail.mail" data-success-mode="redirect" data-success-page="/contactus-thank-you">
                 <a href="#" role="button" class="btn btn-primary s_website_form_send">Submit</a>

--- a/addons/website_cf_turnstile/static/tests/interactions/turnstile_captcha.test.js
+++ b/addons/website_cf_turnstile/static/tests/interactions/turnstile_captcha.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { queryAll } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 import { session } from "@web/session";
 import { patchTurnStile } from "@website_cf_turnstile/../tests/helpers";
@@ -11,7 +12,7 @@ describe.current.tags("interaction_dev");
 
 test("turnstile captcha gets added to a data-captcha form", async () => {
     session.turnstile_site_key = "test";
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <form data-captcha="test">
             <input name="test"/>
             <button type="submit">Submit</a>

--- a/addons/website_event/static/tests/interactions/snippets/events.test.js
+++ b/addons/website_event/static/tests/interactions/snippets/events.test.js
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { queryAll } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
 import { onRpc } from "@web/../tests/web_test_helpers";
 import { registry } from "@web/core/registry";
@@ -43,7 +44,7 @@ test("dynamic snippet loads items and displays them through template", async () 
         `,
         ];
     });
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
       <div id="wrapwrap">
           <section data-snippet="s_events" class="s_events s_event_upcoming_snippet s_event_event_picture s_dynamic s_dynamic_empty pt32 pb32 o_colored_level"
                   data-custom-template-data="{&quot;events_event_time_active&quot;:true}"

--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -91,9 +91,9 @@ function websiteEditEventTourSteps() {
         {
             content: "edit the short description of the event",
             trigger: ":iframe .opt_events_list_columns small",
-            run: function () {
-                this.anchor.innerHTML = "new short description";
-            }
+            run() {
+                this.anchor.textContent = "new short description";
+            },
         },
         ...clickOnSave(),
         {

--- a/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.js
+++ b/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.js
@@ -21,9 +21,8 @@ export class ExhibitorConnectClosedDialog extends Component {
         const sponsorData = await rpc(
             `/event_sponsor/${encodeURIComponent(this.props.sponsorId)}/read`
         );
-        // empty string on falsy so markup doesn't create a "false" string
-        sponsorData.website_description = sponsorData.website_description || "";
-        sponsorData.website_description = markup(sponsorData.website_description);
+        // markup: website_description is coming from HTML field on event.sponsor
+        sponsorData.website_description = markup(sponsorData.website_description || "");
         this.formatEventStartRemaining = formatDuration(sponsorData.event_start_remaining, true);
         this.sponsorData = sponsorData;
     }

--- a/addons/website_forum/static/src/interactions/website_forum.js
+++ b/addons/website_forum/static/src/interactions/website_forum.js
@@ -1,13 +1,11 @@
 import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
-import { htmlJoin } from "@mail/utils/common/html";
 import { markup } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
-import { cookie } from "@web/core/browser/cookie";;
+import { cookie } from "@web/core/browser/cookie";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
-import { escape } from "@web/core/utils/strings";
 import { session } from "@web/session";
 import { scrollTo, closestScrollable } from "@web_editor/js/common/scrolling";
 import { loadWysiwygFromTextarea } from "@web_editor/js/frontend/loadWysiwygFromTextarea";
@@ -72,7 +70,9 @@ export class WebsiteForum extends Interaction {
         // welcome message action button
         const forumRegisterUrlEl = this.el.querySelector(".forum_register_url");
         if (forumRegisterUrlEl) {
-            const forumLogin = `${browser.location.origin}/odoo?redirect=${encodeURIComponent(browser.location.href)}`;
+            const forumLogin = `${browser.location.origin}/odoo?redirect=${encodeURIComponent(
+                browser.location.href
+            )}`;
             forumRegisterUrlEl.href = forumLogin;
         }
 
@@ -91,7 +91,9 @@ export class WebsiteForum extends Interaction {
         if (selectMenuWrapperEl) {
             const isReadOnly = Boolean(selectMenuWrapperEl.dataset.readonly);
             // Take default tags from the input value
-            const defaulValue = JSON.parse(selectMenuWrapperEl.dataset.initValue || "[]").map((x) => x.id);
+            const defaulValue = JSON.parse(selectMenuWrapperEl.dataset.initValue || "[]").map(
+                (x) => x.id
+            );
 
             this.mountComponent(selectMenuWrapperEl, WebsiteForumTagsWrapper, {
                 defaulValue: defaulValue,
@@ -150,7 +152,10 @@ export class WebsiteForum extends Interaction {
             this.registerCleanup(() => bsPopover.dispose());
         });
 
-        this.el.querySelectorAll(".o_wforum_question, .o_wforum_answer, .o_wforum_post_comment, .o_wforum_last_activity")
+        this.el
+            .querySelectorAll(
+                ".o_wforum_question, .o_wforum_answer, .o_wforum_post_comment, .o_wforum_last_activity"
+            )
             .forEach((post) => {
                 post.querySelector(".o_wforum_relative_datetime").textContent =
                     luxon.DateTime.fromSQL(post.dataset.lastActivity, { zone: "utc" }).toRelative();
@@ -166,7 +171,9 @@ export class WebsiteForum extends Interaction {
     warnIfPublicUser() {
         if (session.is_website_user) {
             this.displayAccessDeniedNotification(
-                markup(`<a href='/web/login'>` + escape(_t("Oh no! Please sign in to perform this action")) + "</a>")
+                markup`<a href='/web/login'>${_t(
+                    "Oh no! Please sign in to perform this action"
+                )}</a>`
             );
             return true;
         }
@@ -201,8 +208,12 @@ export class WebsiteForum extends Interaction {
         // Because the textarea is hidden, we add the red or green border to its
         // container.
         if (textareaEl?.required) {
-            const textareaContainerEl = currentTargetEl.querySelector(".o_wysiwyg_textarea_wrapper");
-            const hasContent = !!textareaContainerEl.innerText.trim() || !!textareaContainerEl.querySelector("img");
+            const textareaContainerEl = currentTargetEl.querySelector(
+                ".o_wysiwyg_textarea_wrapper"
+            );
+            const hasContent =
+                !!textareaContainerEl.innerText.trim() ||
+                !!textareaContainerEl.querySelector("img");
             ["border", "border-danger", "rounded-top"].forEach((cls) => {
                 textareaContainerEl.classList.toggle(cls, hasContent);
             });
@@ -212,17 +223,24 @@ export class WebsiteForum extends Interaction {
         if (validForm) {
             // Stores social share data to display modal on next page.
             if (currentTargetEl.querySelector(".oe_social_share_call")) {
-                sessionStorage.setItem("social_share", JSON.stringify({
-                    targetType: currentTargetEl.querySelector(".o_wforum_submit_post").dataset.socialTargetType,
-                }));
+                sessionStorage.setItem(
+                    "social_share",
+                    JSON.stringify({
+                        targetType:
+                            currentTargetEl.querySelector(".o_wforum_submit_post").dataset
+                                .socialTargetType,
+                    })
+                );
             }
         } else {
             ev.preventDefault();
             this.waitForTimeout(() => {
-                currentTargetEl.querySelectorAll("button[type='submit'], a.a-submit").forEach((btnEl) => {
-                    btnEl.querySelector("i").remove();
-                    btnEl.disabled = false;
-                });
+                currentTargetEl
+                    .querySelectorAll("button[type='submit'], a.a-submit")
+                    .forEach((btnEl) => {
+                        btnEl.querySelector("i").remove();
+                        btnEl.disabled = false;
+                    });
             }, 0);
         }
     }
@@ -233,7 +251,7 @@ export class WebsiteForum extends Interaction {
      */
     onExpandAnswerClick(ev, currentTargetEl) {
         if (ev.target.matches(".o_wforum_expand_toggle")) {
-            currentTargetEl.classList.toggle("o_expand")
+            currentTargetEl.classList.toggle("o_expand");
             currentTargetEl.classList.toggle("min-vh-100");
             currentTargetEl.classList.toggle("w-lg-50");
         } else if (ev.target.matches(".o_wforum_discard_btn")) {
@@ -258,13 +276,10 @@ export class WebsiteForum extends Interaction {
         const forumId = parseInt(this.el.ownerDocument.getElementById("wrapwrap").dataset.forum_id);
         let message = _t("%(score)s karma is required to perform this action.", { score: karma });
         if (forumId) {
-            message = htmlJoin(
-                message,
-                _t("%(link_start)sRead the guidelines to know how to gain karma.%(link_end)s", {
-                    link_start: markup(`<br><a class="alert-link" href="/forum/${forumId}/faq">`),
-                    link_end: markup("</a>"),
-                })
-            );
+            message = markup`
+                ${message}<br><a class="alert-link" href="/forum/${forumId}/faq">${_t(
+                "Read the guidelines to know how to gain karma."
+            )}</a>`;
         }
         this.services.notification.add(message, {
             type: "warning",
@@ -291,15 +306,19 @@ export class WebsiteForum extends Interaction {
         if (this.warnIfPublicUser()) {
             return;
         }
-        const data = await this.waitFor(rpc(
-            currentTargetEl.dataset.href
-            || (currentTargetEl.getAttribute("href") !== "#" && currentTargetEl.getAttribute("href"))
-            || currentTargetEl.closest("form").getAttribute("action")
-        ));
+        const data = await this.waitFor(
+            rpc(
+                currentTargetEl.dataset.href ||
+                    (currentTargetEl.getAttribute("href") !== "#" &&
+                        currentTargetEl.getAttribute("href")) ||
+                    currentTargetEl.closest("form").getAttribute("action")
+            )
+        );
         if (data.error) {
-            const message = data.error === "post_already_flagged"
-                ? _t("This post is already flagged")
-                : data.error === "post_non_flaggable"
+            const message =
+                data.error === "post_already_flagged"
+                    ? _t("This post is already flagged")
+                    : data.error === "post_non_flaggable"
                     ? _t("This post can not be flagged")
                     : data.error;
             this.displayAccessDeniedNotification(message);
@@ -338,9 +357,10 @@ export class WebsiteForum extends Interaction {
         }
         const data = await this.waitFor(rpc(currentTargetEl.dataset.href));
         if (data.error) {
-            const message = data.error === "own_post"
-                ? _t("Sorry, you cannot vote for your own posts")
-                : data.error;
+            const message =
+                data.error === "own_post"
+                    ? _t("Sorry, you cannot vote for your own posts")
+                    : data.error;
             this.displayAccessDeniedNotification(message);
         } else {
             const containerEl = currentTargetEl.closest(".vote");
@@ -353,7 +373,13 @@ export class WebsiteForum extends Interaction {
             voteDownEl.disabled = userVote === -1;
 
             [voteUpEl, voteDownEl, voteCountEl].forEach((el) => {
-                el.classList.remove("text-success", "text-danger", "text-muted", "opacity-75", "o_forum_vote_animate");
+                el.classList.remove(
+                    "text-success",
+                    "text-danger",
+                    "text-muted",
+                    "opacity-75",
+                    "o_forum_vote_animate"
+                );
             });
             void containerEl.offsetWidth; // Force a refresh
 
@@ -407,9 +433,9 @@ export class WebsiteForum extends Interaction {
             postBeingValidated.classList.remove("d-none");
             return;
         }
-        const nbLeftInQueue = Array.from(document.querySelectorAll(".post_to_validate"))
-            .filter(e => window.getComputedStyle(e).display !== "none")
-            .length;
+        const nbLeftInQueue = Array.from(document.querySelectorAll(".post_to_validate")).filter(
+            (e) => window.getComputedStyle(e).display !== "none"
+        ).length;
         const queueType = document.querySelector("#queue_type").dataset.queueType;
         const queueCountBadge = document.querySelector(`#count_posts_queue_${queueType}`);
         queueCountBadge.innerText = nbLeftInQueue;
@@ -431,9 +457,10 @@ export class WebsiteForum extends Interaction {
         const target = currentTargetEl.dataset.target;
         const data = await this.waitFor(rpc(currentTargetEl.dataset.href));
         if (data.error) {
-            const message = data.error === "own_post"
-                ? _t("Sorry, you cannot select your own posts as best answer")
-                : data.error;
+            const message =
+                data.error === "own_post"
+                    ? _t("Sorry, you cannot select your own posts as best answer")
+                    : data.error;
             this.displayAccessDeniedNotification(message);
             return;
         }
@@ -448,7 +475,15 @@ export class WebsiteForum extends Interaction {
             const styleForIncorrect = isCorrect ? answer.classList.remove : answer.classList.add;
             styleForCorrect.call(
                 answer.classList,
-                "o_wforum_answer_correct", "my-2", "mx-n3", "mx-lg-n2", "mx-xl-n3", "py-3", "px-3", "px-lg-2", "px-xl-3"
+                "o_wforum_answer_correct",
+                "my-2",
+                "mx-n3",
+                "mx-lg-n2",
+                "mx-xl-n3",
+                "py-3",
+                "px-3",
+                "px-lg-2",
+                "px-xl-3"
             );
             styleForIncorrect.call(toggler.classList, "opacity-50");
             const answerBorder = answer.querySelector("div .border-start");
@@ -472,8 +507,8 @@ export class WebsiteForum extends Interaction {
         currentTargetEl.classList.toggle("opacity-100-hover", !data);
         const currentTargetEl_icon = currentTargetEl.querySelector(".fa");
         currentTargetEl_icon.classList.toggle("fa-star-o", !data);
-        currentTargetEl_icon.classList.toggle("o_wforum_gold", data)
-        currentTargetEl_icon.classList.toggle("fa-star", data)
+        currentTargetEl_icon.classList.toggle("o_wforum_gold", data);
+        currentTargetEl_icon.classList.toggle("fa-star", data);
     }
 
     /**
@@ -488,17 +523,19 @@ export class WebsiteForum extends Interaction {
             body: _t("Are you sure you want to delete this comment?"),
             confirmLabel: _t("Delete"),
             confirm: () => {
-                rpc(currentTargetEl.closest("form").attributes.action.value).then(() => {
-                    currentTargetEl.closest(".o_wforum_post_comment").remove();
-                }).catch((error) => {
-                    this.services.notification.add(error.data.message, {
-                        title: _t("Karma Error"),
-                        sticky: false,
-                        type: "warning",
+                rpc(currentTargetEl.closest("form").attributes.action.value)
+                    .then(() => {
+                        currentTargetEl.closest(".o_wforum_post_comment").remove();
+                    })
+                    .catch((error) => {
+                        this.services.notification.add(error.data.message, {
+                            title: _t("Karma Error"),
+                            sticky: false,
+                            type: "warning",
+                        });
                     });
-                });
             },
-            cancel: () => { },
+            cancel: () => {},
         });
     }
 
@@ -517,9 +554,11 @@ export class WebsiteForum extends Interaction {
      * @param {HTMLElement} currentTargetEl
      */
     async onFlagValidatorClick(ev, currentTargetEl) {
-        await this.waitFor(this.services.orm.call("forum.post", currentTargetEl.dataset.action, [
-            parseInt(currentTargetEl.dataset.postId),
-        ]));
+        await this.waitFor(
+            this.services.orm.call("forum.post", currentTargetEl.dataset.action, [
+                parseInt(currentTargetEl.dataset.postId),
+            ])
+        );
         currentTargetEl.closest(".o_wforum_flag_alert")?.classList.toggle("d-none");
         const flaggedButton = currentTargetEl.parentElement.firstElementChild,
             child = flaggedButton.firstElementChild,
@@ -555,10 +594,10 @@ export class WebsiteForum extends Interaction {
      */
     onCollapseShown(ev, currentTargetEl) {
         const scrollingElement = closestScrollable(currentTargetEl.parentNode);
-        scrollTo(currentTargetEl, { forcedOffset: scrollingElement.clientHeight - currentTargetEl.clientHeight });
+        scrollTo(currentTargetEl, {
+            forcedOffset: scrollingElement.clientHeight - currentTargetEl.clientHeight,
+        });
     }
 }
 
-registry
-    .category("public.interactions")
-    .add("website_forum.website_forum", WebsiteForum);
+registry.category("public.interactions").add("website_forum.website_forum", WebsiteForum);

--- a/addons/website_forum/static/tests/interactions/website_forum_share.test.js
+++ b/addons/website_forum/static/tests/interactions/website_forum_share.test.js
@@ -1,24 +1,27 @@
 import { afterEach, beforeEach, describe, expect, test } from "@odoo/hoot";
 import { animationFrame, tick } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 import { defineStyle } from "@web/../tests/web_test_helpers";
 
 setupInteractionWhiteList(["website_forum.website_forum_share", "website.share"]);
 describe.current.tags("interaction_dev");
 
-
-beforeEach(() => defineStyle(/* css */`* { transition: none !important; }`));
+beforeEach(() => defineStyle(/* css */ `* { transition: none !important; }`));
 afterEach(() => {
     document.body.querySelector("#oe_social_share_modal")?.remove();
 });
 
 test("sessionStorage social_share is cleared after start", async () => {
-    sessionStorage.setItem("social_share", JSON.stringify({
-        targetType: "answer",
-    }));
+    sessionStorage.setItem(
+        "social_share",
+        JSON.stringify({
+            targetType: "answer",
+        })
+    );
     expect(sessionStorage.getItem("social_share")).toEqual('{"targetType":"answer"}');
-    await startInteractions(`
+    await startInteractions(markup`
          <div id="wrapwrap" class="website_forum">
             <div class="o_wforum_question" data-state="active"></div>
          </div>
@@ -26,13 +29,15 @@ test("sessionStorage social_share is cleared after start", async () => {
     expect(sessionStorage.getItem("social_share")).toBe(null);
 });
 
-
 describe("target types", () => {
     test("target type answer shows modal with website_forum.social_message_answer", async () => {
-        sessionStorage.setItem("social_share", JSON.stringify({
-            targetType: "answer",
-        }));
-        const { core } = await startInteractions(`
+        sessionStorage.setItem(
+            "social_share",
+            JSON.stringify({
+                targetType: "answer",
+            })
+        );
+        const { core } = await startInteractions(markup`
              <div id="wrapwrap" class="website_forum">
                 <div class="o_wforum_question" data-state="active"></div>
              </div>
@@ -42,14 +47,19 @@ describe("target types", () => {
         await animationFrame();
         await advanceTime(100);
         expect(document.querySelector(".modal")).toBeVisible();
-        expect(document.querySelector(".modal p")).toHaveText(/^By sharing you answer, you will get additional/);
+        expect(document.querySelector(".modal p")).toHaveText(
+            /^By sharing you answer, you will get additional/
+        );
     });
 
     test("target type question shows modal with website_forum.social_message_question", async () => {
-        sessionStorage.setItem("social_share", JSON.stringify({
-            targetType: "question",
-        }));
-        const { core } = await startInteractions(`
+        sessionStorage.setItem(
+            "social_share",
+            JSON.stringify({
+                targetType: "question",
+            })
+        );
+        const { core } = await startInteractions(markup`
              <div id="wrapwrap" class="website_forum">
                 <div class="o_wforum_question" data-state="active"></div>
              </div>
@@ -63,10 +73,13 @@ describe("target types", () => {
     });
 
     test("target type default shows modal with website_forum.social_message_default", async () => {
-        sessionStorage.setItem("social_share", JSON.stringify({
-            targetType: "default",
-        }));
-        const { core } = await startInteractions(`
+        sessionStorage.setItem(
+            "social_share",
+            JSON.stringify({
+                targetType: "default",
+            })
+        );
+        const { core } = await startInteractions(markup`
              <div id="wrapwrap" class="website_forum">
                 <div class="o_wforum_question" data-state="active"></div>
              </div>
@@ -76,16 +89,21 @@ describe("target types", () => {
         await animationFrame();
         await advanceTime(100);
         expect(document.querySelector(".modal")).toBeVisible();
-        expect(document.querySelector(".modal p")).toHaveText(/^Share this content to increase your chances/);
+        expect(document.querySelector(".modal p")).toHaveText(
+            /^Share this content to increase your chances/
+        );
     });
 });
 
 describe("forum share state", () => {
     test("pending state doesn't show .s_share", async () => {
-        sessionStorage.setItem("social_share", JSON.stringify({
-            targetType: "answer",
-        }));
-        const { core } = await startInteractions(`
+        sessionStorage.setItem(
+            "social_share",
+            JSON.stringify({
+                targetType: "answer",
+            })
+        );
+        const { core } = await startInteractions(markup`
              <div id="wrapwrap" class="website_forum">
                 <div class="o_wforum_question" data-state="pending"></div>
              </div>
@@ -99,10 +117,13 @@ describe("forum share state", () => {
     });
 
     test("active state shows .s_share", async () => {
-        sessionStorage.setItem("social_share", JSON.stringify({
-            targetType: "answer",
-        }));
-        const { core } = await startInteractions(`
+        sessionStorage.setItem(
+            "social_share",
+            JSON.stringify({
+                targetType: "answer",
+            })
+        );
+        const { core } = await startInteractions(markup`
              <div id="wrapwrap" class="website_forum">
                 <div class="o_wforum_question" data-state="active"></div>
              </div>

--- a/addons/website_forum/static/tests/interactions/website_forum_spam.test.js
+++ b/addons/website_forum/static/tests/interactions/website_forum_spam.test.js
@@ -1,13 +1,14 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { advanceTime, click, edit, fill, queryAll, tick } from "@odoo/hoot-dom";
 import { Deferred } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 import { onRpc } from "@web/../tests/web_test_helpers";
 
 setupInteractionWhiteList("website_forum.website_forum_spam");
 describe.current.tags("interaction_dev");
 
-const template = (options = {}) => `
+const template = (options = {}) => markup`
  <div id="wrap" class="o_wforum_wrapper o_wforum_moderation_queue">
     <div class="modal fade show modal_shown" id="markAllAsSpam" data-spam-ids="${options.spamIds ? "[1,2]" : ""}" style="display: block;">
         <div class="modal-dialog">
@@ -47,14 +48,14 @@ test("keep last spam input search", async () => {
     await edit("hello");
     await advanceTime(201); // debounced
     expect.verifySteps([]);
-    def.resolve([{ content: "<div>hello</div>"}]);
+    def.resolve([{ content: "<div>hello</div>" }]);
     await tick();
     expect.verifySteps(["rpc"]);
     expect(".post_spam").toHaveText("hello");
 });
 
 test("select all checkboxes", async () => {
-    await startInteractions(`
+    await startInteractions(markup`
     <div id="wrap" class="o_wforum_wrapper o_wforum_moderation_queue">
         <div class="modal fade show modal_shown" id="markAllAsSpam" data-spam-ids="[1,2]" style="display: block;">
             <div class="modal-dialog">

--- a/addons/website_mass_mailing/static/tests/interactions/popup.test.js
+++ b/addons/website_mass_mailing/static/tests/interactions/popup.test.js
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { animationFrame, tick } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 import { defineStyle } from "@web/../tests/web_test_helpers";
 import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
 
@@ -7,7 +8,7 @@ setupInteractionWhiteList("website.popup");
 describe.current.tags("interaction_dev");
 
 function getTemplate(disabled = false) {
-    return `
+    return markup`
         <div class="s_popup o_newsletter_popup o_snippet_invisible"
              data-name="Newsletter Popup" data-vcss="001" data-snippet="s_newsletter_subscribe_popup" id="sPopup" data-invisible="1">
             <div class="modal fade s_popup_middle o_newsletter_modal modal_shown"
@@ -37,7 +38,7 @@ function getTemplate(disabled = false) {
 }
 
 describe("mail popup", () => {
-    beforeEach(() => defineStyle(/* css */`* { transition: none !important; }`));
+    beforeEach(() => defineStyle(/* css */ `* { transition: none !important; }`));
     test("popup is shown if user is not subscribed (mail input not disabled)", async () => {
         const { core } = await startInteractions(getTemplate());
         expect(core.interactions).toHaveLength(1);

--- a/addons/website_sale/static/tests/interactions/carousel_product.test.js
+++ b/addons/website_sale/static/tests/interactions/carousel_product.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, click, queryOne } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 import { defineStyle } from "@web/../tests/web_test_helpers";
 import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
 
@@ -8,7 +9,7 @@ describe.current.tags("interaction_dev");
 
 test("scroll miniatures", async () => {
     defineStyle(/* css */`li { min-width: 64px !important; }`);
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div class="o_wsale_product_images position-relative" style="width: 600px" data-image-amount="16">
             <div id="o-carousel-product" data-bs-ride="true" class="o_carousel_not_single carousel slide position-sticky mb-3 overflow-hidden" data-name="Product Carousel">
                 <div class="o_carousel_product_outer carousel-outer position-relative d-flex align-items-center w-100 overflow-hidden">

--- a/addons/website_sale/static/tests/interactions/popup.test.js
+++ b/addons/website_sale/static/tests/interactions/popup.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, click, tick } from "@odoo/hoot-dom";
+import { markup } from "@odoo/owl";
 import { defineStyle } from "@web/../tests/web_test_helpers";
 import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
 
@@ -8,7 +9,7 @@ describe.current.tags("interaction_dev");
 
 test("click on primary button which is add to cart button doesn't close popup", async () => {
     defineStyle(/* css */`* { transition: none !important; }`);
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div class="s_popup o_snippet_invisible" data-vcss="001" data-snippet="s_popup"
              data-name="Popup" id="sPopup" data-invisible="1">
             <div class="modal fade s_popup_middle modal_shown"

--- a/addons/website_sale/static/tests/interactions/snippets/dynamic_snippet_products.test.js
+++ b/addons/website_sale/static/tests/interactions/snippets/dynamic_snippet_products.test.js
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { animationFrame, click, queryAll, queryOne } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
+import { markup } from "@odoo/owl";
 import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
 import { onRpc } from "@web/../tests/web_test_helpers";
 import { registry } from "@web/core/registry";
@@ -66,7 +67,7 @@ test("dynamic snippet products loads items and displays them through template", 
         `,
         ];
     });
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
       <div id="wrapwrap">
           <section data-snippet="s_dynamic_snippet_products" class="s_dynamic_snippet_products s_dynamic s_dynamic_empty pt32 pb32 o_colored_level s_product_product_borderless_1"
                   data-name="Products"

--- a/addons/website_sale_loyalty/static/src/interactions/coupon_toaster.js
+++ b/addons/website_sale_loyalty/static/src/interactions/coupon_toaster.js
@@ -5,18 +5,18 @@ export class CouponToaster extends Interaction {
     static selector = ".coupon-message";
 
     start() {
-        let options = {};
+        const options = {};
         const titleEl = this.el.querySelector(".coupon-message-title");
         const contentEl = this.el.querySelector(".coupon-message-content");
         let message = null;
 
         if (contentEl) {
-            message = contentEl.innerHTML;
+            message = contentEl.textContent;
             if (titleEl) {
-                Object.assign(options, { title: titleEl.innerHTML });
+                Object.assign(options, { title: titleEl.textContent });
             }
         } else if (titleEl) {
-            message = titleEl.innerHTML;
+            message = titleEl.textContent;
         }
 
         if (this.el.classList.contains("coupon-info-message")) {

--- a/addons/website_sale_loyalty/static/src/js/checkout.js
+++ b/addons/website_sale_loyalty/static/src/js/checkout.js
@@ -1,6 +1,17 @@
+import { markup } from "@odoo/owl";
+import { setElementContent } from "@web/core/utils/html";
 import WebsiteSaleCheckout from '@website_sale/js/checkout';
 
 WebsiteSaleCheckout.include({
+    /** @override */
+    async _setDeliveryMethod() {
+        const result = await this._super.apply(this, arguments);
+        // markup: discount_reward_amounts is coming from Monetary.value_to_html in _order_summary_values
+        result.discount_reward_amounts = result.discount_reward_amounts.map(
+            (discount_reward_amount) => markup(discount_reward_amount)
+        );
+        return result;
+    },
     /**
      * @override
      */
@@ -12,7 +23,7 @@ WebsiteSaleCheckout.include({
                 '[data-reward-type="shipping"]'
             );
             if (cart_summary_shipping_reward) {
-                cart_summary_shipping_reward.innerHTML = result.amount_delivery_discounted;
+                setElementContent(cart_summary_shipping_reward, result.amount_delivery_discounted);
             }
         }
         if (result.discount_reward_amounts) {
@@ -23,8 +34,8 @@ WebsiteSaleCheckout.include({
                 // refresh cart summary to sync number of discount items
                 location.reload();
             } else {
-                cart_summary_discount_rewards.forEach(
-                    (el, i) => (el.innerHTML = result.discount_reward_amounts[i])
+                cart_summary_discount_rewards.forEach((el, i) =>
+                    setElementContent(el, result.discount_reward_amounts[i])
                 );
             }
         }

--- a/addons/website_slides/static/src/interactions/enroll_email.js
+++ b/addons/website_slides/static/src/interactions/enroll_email.js
@@ -2,8 +2,8 @@ import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 
 import { _t } from "@web/core/l10n/translation";
-import { escape } from "@web/core/utils/strings";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { createElementWithContent } from "@web/core/utils/html";
 
 export class EnrollEmail extends Interaction {
     static selector = "#wrapwrap";
@@ -26,30 +26,23 @@ export class EnrollEmail extends Interaction {
             confirmLabel: _t("Yes"),
             confim: async () => {
                 const { error, done } = await this.waitFor(
-                    this.services.orm.call(
-                        "slide.channel",
-                        "action_request_access",
-                        [channelId],
-                    )
+                    this.services.orm.call("slide.channel", "action_request_access", [channelId])
                 );
-                const message = done ? _t("Request sent!") : error || _t("Unknown error, try again.");
+                const message = done
+                    ? _t("Request sent!")
+                    : error || _t("Unknown error, try again.");
 
                 const newAlertEl = document.createElement("div");
                 newAlertEl.classList.add("alert", done ? "alert-success" : "alert-danger");
                 newAlertEl.role = "alert";
-                const strongEl = document.createElement("strong");
-                strongEl.innerText = escape(message);
-                newAlertEl.appendChild(strongEl);
-
+                newAlertEl.appendChild(createElementWithContent("strong", message));
                 this.insert(newAlertEl, alertEl, "afterend");
                 alertEl.remove();
             },
             cancelLabel: _t("Cancel"),
-            cancel: () => { },
+            cancel: () => {},
         });
     }
 }
 
-registry
-    .category("public.interactions")
-    .add("website_slides.enroll_email", EnrollEmail);
+registry.category("public.interactions").add("website_slides.enroll_email", EnrollEmail);

--- a/addons/website_slides/static/src/interactions/slide_like.js
+++ b/addons/website_slides/static/src/interactions/slide_like.js
@@ -1,15 +1,19 @@
-import { Interaction } from "@web/public/interaction";
-import { registry } from "@web/core/registry";
+import { htmlEscape, markup } from "@odoo/owl";
 
-import { escape, sprintf } from '@web/core/utils/strings';
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
+import { registry } from "@web/core/registry";
+import { Interaction } from "@web/public/interaction";
 
 export class SlideLike extends Interaction {
     static selector = ".o_wslides_js_slide_like";
     dynamicContent = {
-        ".o_wslides_js_slide_like_up": { "t-on-click": (ev) => this.onClick(ev.currentTarget.dataset.slideId, 'like') },
-        ".o_wslides_js_slide_like_down": { "t-on-click": (ev) => this.onClick(ev.currentTarget.dataset.slideId, 'dislike') },
+        ".o_wslides_js_slide_like_up": {
+            "t-on-click": (ev) => this.onClick(ev.currentTarget.dataset.slideId, "like"),
+        },
+        ".o_wslides_js_slide_like_down": {
+            "t-on-click": (ev) => this.onClick(ev.currentTarget.dataset.slideId, "dislike"),
+        },
     };
 
     /**
@@ -17,14 +21,14 @@ export class SlideLike extends Interaction {
      */
     showAlert(message) {
         const bsPopover = window.Popover.getOrCreateInstance(this.el, {
-            trigger: 'focus',
-            delay: { 'hide': 300 },
-            placement: 'bottom',
-            container: 'body',
+            trigger: "focus",
+            delay: { hide: 300 },
+            placement: "bottom",
+            container: "body",
             html: true,
-            content: function () {
-                return message;
-            }
+            content() {
+                return htmlEscape(message).toString();
+            },
         });
         bsPopover.show();
         this.registerCleanup(() => bsPopover.dispose());
@@ -35,47 +39,64 @@ export class SlideLike extends Interaction {
      * @param {string} voteType
      */
     async onClick(slideId, voteType) {
-        const data = await this.waitFor(rpc('/slides/slide/like', {
-            slide_id: slideId,
-            upvote: voteType === 'like',
-        }))
+        const data = await this.waitFor(
+            rpc("/slides/slide/like", {
+                slide_id: slideId,
+                upvote: voteType === "like",
+            })
+        );
         if (!data.error) {
-            const likeButtonEl = this.el.querySelector('span.o_wslides_js_slide_like_up');
-            const likesIcon = likeButtonEl.querySelector('i.fa');
-            const dislikeButtonEl = this.el.querySelector('span.o_wslides_js_slide_like_down');
-            const dislikesIcon = dislikeButtonEl.querySelector('i.fa');
+            const likeButtonEl = this.el.querySelector("span.o_wslides_js_slide_like_up");
+            const likesIcon = likeButtonEl.querySelector("i.fa");
+            const dislikeButtonEl = this.el.querySelector("span.o_wslides_js_slide_like_down");
+            const dislikesIcon = dislikeButtonEl.querySelector("i.fa");
 
             // update 'thumbs-up' button with latest state
             likeButtonEl.dataset.userVote = data.user_vote;
-            likeButtonEl.querySelector('span').innerText = data.likes;
+            likeButtonEl.querySelector("span").innerText = data.likes;
             likesIcon.classList.toggle("fa-thumbs-up", data.user_vote === 1);
             likesIcon.classList.toggle("fa-thumbs-o-up", data.user_vote !== 1);
             // update 'thumbs-down' button with latest state
             dislikeButtonEl.dataset.userVote = data.user_vote;
-            dislikeButtonEl.querySelector('span').innerText = data.dislikes;
+            dislikeButtonEl.querySelector("span").innerText = data.dislikes;
             dislikesIcon.classList.toggle("fa-thumbs-down", data.user_vote === -1);
             dislikesIcon.classList.toggle("fa-thumbs-o-down", data.user_vote !== -1);
         } else {
-            if (data.error === 'public_user') {
-                const message = data.error_signup_allowed ?
-                    _t('Please <a href="/web/login?redirect=%(url)s">login</a> or <a href="/web/signup?redirect=%(url)s">create an account</a> to vote for this lesson') :
-                    _t('Please <a href="/web/login?redirect=%(url)s">login</a> to vote for this lesson');
-                this.showAlert(sprintf(message, { url: encodeURIComponent(document.URL) }));
-            } else if (data.error === 'slide_access') {
-                this.showAlert(escape(_t('You don\'t have access to this lesson')));
-            } else if (data.error === 'channel_membership_required') {
-                this.showAlert(escape(_t('You must be member of this course to vote')));
-            } else if (data.error === 'channel_comment_disabled') {
-                this.showAlert(escape(_t('Votes and comments are disabled for this course')));
-            } else if (data.error === 'channel_karma_required') {
-                this.showAlert(escape(_t('You don\'t have enough karma to vote')));
+            if (data.error === "public_user") {
+                const tags = {
+                    a_login_open: markup`<a href="/web/login?redirect=${encodeURIComponent(
+                        document.URL
+                    )}">`,
+                    a_login_close: markup`</a>`,
+                    a_signup_open: markup`<a href="/web/signup?redirect=${encodeURIComponent(
+                        document.URL
+                    )}">`,
+                    a_signup_close: markup`</a>`,
+                };
+                this.showAlert(
+                    data.error_signup_allowed
+                        ? _t(
+                              "Please %(a_login_open)slogin%(a_login_close)s or %(a_signup_open)screate an account%(a_signup_close)s to vote for this lesson",
+                              tags
+                          )
+                        : _t(
+                              "Please %(a_login_open)slogin%(a_login_close)s to vote for this lesson",
+                              tags
+                          )
+                );
+            } else if (data.error === "slide_access") {
+                this.showAlert(_t("You don't have access to this lesson"));
+            } else if (data.error === "channel_membership_required") {
+                this.showAlert(_t("You must be member of this course to vote"));
+            } else if (data.error === "channel_comment_disabled") {
+                this.showAlert(_t("Votes and comments are disabled for this course"));
+            } else if (data.error === "channel_karma_required") {
+                this.showAlert(_t("You don't have enough karma to vote"));
             } else {
-                this.showAlert(escape(_t('Unknown error')));
+                this.showAlert(_t("Unknown error"));
             }
         }
     }
 }
 
-registry
-    .category("public.interactions")
-    .add("website_slides.slide_like", SlideLike);
+registry.category("public.interactions").add("website_slides.slide_like", SlideLike);

--- a/addons/website_slides/static/src/js/slides_course_quiz.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz.js
@@ -1,7 +1,6 @@
     import publicWidget from '@web/legacy/js/public/public_widget';
     import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
     import { renderToElement } from "@web/core/utils/render";
-    import { escape } from "@web/core/utils/strings";
     import { session } from "@web/session";
     import CourseJoin from '@website_slides/js/slides_course_join';
     import QuestionFormWidget from '@website_slides/js/slides_course_quiz_question_form';
@@ -559,7 +558,9 @@
             const questionId = parseInt(question.dataset.questionId);
             this.call('dialog', 'add', ConfirmationDialog, {
                 title: _t('Delete Question'),
-                body: markup(_t('Are you sure you want to delete this question "<strong>%s</strong>"?', escape(question.dataset.title))),
+                body: _t('Are you sure you want to delete this question "%(title)s"?', {
+                    title: markup`<strong>${question.dataset.title}</strong>`,
+                }),
                 cancel: () => {
                 },
                 cancelLabel: _t('No'),

--- a/addons/website_slides/static/tests/interactions/animation.test.js
+++ b/addons/website_slides/static/tests/interactions/animation.test.js
@@ -1,15 +1,13 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { queryOne } from "@odoo/hoot-dom";
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { markup } from "@odoo/owl";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 setupInteractionWhiteList("website.animation");
 describe.current.tags("interaction_dev");
 
 test("on scroll animation changes based on scroll", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(markup`
         <div id="wrapwrap" style="overflow: scroll; max-height: 100%;">
             <div style="min-height: 2000px;">Tall stuff</div>
             <div class="o_wslide_fs_article_content">

--- a/addons/website_slides_survey/static/src/js/slides_course_fullscreen_player.js
+++ b/addons/website_slides_survey/static/src/js/slides_course_fullscreen_player.js
@@ -13,7 +13,7 @@ Fullscreen.include({
         var def = this._super.apply(this, arguments);
         const contentEl = this.el.querySelector(".o_wslides_fs_content");
         if (this._slideValue.category === "certification") {
-            contentEl.innerHTML = "";
+            contentEl.textContent = "";
             contentEl.append(
                 renderToElement("website.slides.fullscreen.certification", { widget: this })
             );


### PR DESCRIPTION
\* = account, html_editor, iap_mail, lunch, portal, product_matrix, project, web_tour, website, website_event_exhibitor, website_forum, website_slides

Manually calling markup() and escaping parameters is cumbersome and prone to error. The goal of this commit is use the newly introduced markup template literal from OWL (https://github.com/odoo/odoo/pull/203652). This allows developers to safely build HTML string, without requiring any security check, as parameters are automatically escaped.

Usage of `escape`, now called `htmlEscape`, should typically be absent from business code, as developers should use markup template literals and other safe html constructs instead. Typical exception to this rule is when building HTML string for non-markup aware APIs, such as external libraries and native browser features, and only those for which we don't provide a markup-aware alternative such as `setElementContent` (also see the various helpers in html.js in both web and mail modules).

Usage of `markup()` (as a function) should also be seldom used in code as template literal is both safer and more powerful. The only excpetion to this rule is when flagging a string as safe when it was sanitized beforehand, typically a server value coming from a sanitized HTML field.

The opportunity is taken to add markup awareness to `formatList` and `sprintf`, as well as improve the various other safe construct methods.

Finally the various places in code where those tools could be used have been adapted, on top of adapting most remaining markup() calls to follow correct guidelines, in particular to markup as close as possible to the source of the "safeness" (rather than close to the usage).

https://github.com/odoo/enterprise/pull/80163