### PR TITLE
[FIX] mail: prevent public users to add reactions on messages

### DIFF
--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -261,6 +261,8 @@ class Partner(models.Model):
                     data["notification_preference"] = main_user.notification_type
                 if "signature" in fields:
                     data["signature"] = main_user.signature
+                if main_user and main_user._is_public():
+                    data["isPublicUser"] = True
             store.add(partner, data)
 
     @api.readonly

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -404,7 +404,7 @@ export class Message extends Record {
 
     /** @param {import("models").Thread} thread the thread where the message is shown */
     canAddReaction(thread) {
-        return Boolean(!this.is_transient && this.thread);
+        return Boolean(!this.is_transient && this.thread && !this.store.self.isPublicUser);
     }
 
     /** @param {import("models").Thread} thread the thread where the message is shown */


### PR DESCRIPTION
Since [this commit], the backend chatter can be used on the portal. Public users were able to attempt adding reactions to messages, which led to an error. This commit hides the add reaction button for public users to prevent this issue.

Steps to reproduce the issue:
1. Install website_sale module.
2. Go to a website page product.
3. Open the edit mode, click on the product.
4. Activate the Rating option and save the page.
5. Scroll down the product page and add a customer review.
6. Log out and go to the product page.
7. Try to add a reaction to the review.

=> Traceback.

[this commit]: https://github.com/odoo/odoo/commit/368eb78a9cedfce0802b64fd2782e1c018541e40

opw-4436633