### PR TITLE
[IMP] test_mail, various: unbordelize test classes

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6271,8 +6271,9 @@ class AccountMove(models.Model):
     @api.model
     def message_new(self, msg_dict, custom_values=None):
         # EXTENDS mail mail.thread
+        custom_values = custom_values or {}
         # Add custom behavior when receiving a new invoice through the mail's gateway.
-        if (custom_values or {}).get('move_type', 'entry') not in ('out_invoice', 'in_invoice', 'entry'):
+        if custom_values.get('move_type', 'entry') not in ('out_invoice', 'in_invoice', 'entry'):
             return super().message_new(msg_dict, custom_values=custom_values)
 
         self = self.with_context(skip_is_manually_modified=True)  # noqa: PLW0642
@@ -6321,7 +6322,7 @@ class AccountMove(models.Model):
             'invoice_source_email': from_mail_addresses[0],
             'partner_id': partners and partners[0].id or False,
         }
-        move_ctx = self.with_context(default_move_type=custom_values['move_type'], default_journal_id=custom_values['journal_id'])
+        move_ctx = self.with_context(default_move_type=custom_values.get('move_type', 'entry'), default_journal_id=custom_values.get('journal_id'))
         move = super(AccountMove, move_ctx).message_new(msg_dict, custom_values=values)
         move._compute_name()  # because the name is given, we need to recompute in case it is the first invoice of the journal
 

--- a/addons/account/tests/test_mail_tracking_value.py
+++ b/addons/account/tests/test_mail_tracking_value.py
@@ -4,13 +4,13 @@
 
 from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
-from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.mail.tests.common import MailCase
 from odoo.tests import Form
 from odoo.tests.common import tagged
 
 
 @tagged('post_install', '-at_install')
-class TestTracking(AccountTestInvoicingCommon, MailCommon):
+class TestTracking(AccountTestInvoicingCommon, MailCase):
 
     @classmethod
     def default_env_context(cls):

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -7,13 +7,13 @@ from freezegun import freeze_time
 
 from odoo import fields
 from odoo.tests import Form, tagged
-from odoo.tests.common import TransactionCase, new_test_user
+from odoo.tests.common import new_test_user
 from odoo.addons.base.tests.test_ir_cron import CronMixinCase
 from odoo.addons.mail.tests.common import MailCase, MockEmail
 
 
 @tagged('post_install', '-at_install', 'mail_flow')
-class TestEventNotifications(TransactionCase, MailCase, MockEmail, CronMixinCase):
+class TestEventNotifications(MailCase, MockEmail, CronMixinCase):
 
     @classmethod
     def setUpClass(cls):

--- a/addons/hr_recruitment/tests/test_recruitment_interviewer.py
+++ b/addons/hr_recruitment/tests/test_recruitment_interviewer.py
@@ -4,12 +4,12 @@
 from odoo.exceptions import AccessError, UserError
 from odoo.tests.common import new_test_user
 
-from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.mail.tests.common import MailCase
 from odoo.tests import tagged
 
 
 @tagged('recruitment_interviewer')
-class TestRecruitmentInterviewer(MailCommon):
+class TestRecruitmentInterviewer(MailCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/addons/microsoft_calendar/tests/test_sync_odoo2microsoft_mail.py
+++ b/addons/microsoft_calendar/tests/test_sync_odoo2microsoft_mail.py
@@ -4,13 +4,13 @@ from unittest.mock import patch
 from datetime import datetime
 from freezegun import freeze_time
 
-from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.mail.tests.common import MailCase
 from odoo.addons.microsoft_calendar.utils.microsoft_calendar import MicrosoftCalendarService
 from odoo.addons.microsoft_calendar.models.res_users import ResUsers
 from odoo.addons.microsoft_calendar.tests.common import TestCommon
 
 
-class TestSyncOdoo2MicrosoftMail(TestCommon, MailCommon):
+class TestSyncOdoo2MicrosoftMail(TestCommon, MailCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/addons/project/tests/test_project_flow.py
+++ b/addons/project/tests/test_project_flow.py
@@ -1,10 +1,10 @@
 from .test_project_base import TestProjectCommon
 from odoo import Command
-from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.mail.tests.common import MailCase
 from odoo.exceptions import AccessError
 
 
-class TestProjectFlow(TestProjectCommon, MailCommon):
+class TestProjectFlow(TestProjectCommon, MailCase):
 
     def test_project_process_project_manager_duplicate(self):
         pigs = self.project_pigs.with_user(self.user_projectmanager)

--- a/addons/survey/tests/test_survey_invite.py
+++ b/addons/survey/tests/test_survey_invite.py
@@ -7,13 +7,13 @@ from lxml import etree
 
 from odoo import fields, Command
 from odoo.addons.survey.tests import common
-from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.mail.tests.common import MailCase
 from odoo.exceptions import UserError
 from odoo.tests import Form
 from odoo.tests.common import users
 
 
-class TestSurveyInvite(common.TestSurveyCommon, MailCommon):
+class TestSurveyInvite(common.TestSurveyCommon, MailCase):
 
     def setUp(self):
         res = super(TestSurveyInvite, self).setUp()
@@ -198,11 +198,14 @@ class TestSurveyInvite(common.TestSurveyCommon, MailCommon):
     @users('survey_manager')
     def test_survey_invite_email_from(self):
         # Verifies whether changing the value of the "email_from" field reflects on the receiving end.
+        # by default avoid rendering restriction complexity
+        self.env['ir.config_parameter'].sudo().set_param('mail.restrict.template.rendering', False)
+
         action = self.survey.action_send_survey()
         action['context']['default_send_email'] = True
         invite_form = Form.from_action(self.env, action)
         invite_form.partner_ids.add(self.survey_user.partner_id)
-        invite_form.template_id.write({'email_from':'{{ object.partner_id.email_formatted }}'})
+        invite_form.template_id.write({'email_from': '{{ object.partner_id.email_formatted }}'})
         invite = invite_form.save()
         with self.mock_mail_gateway():
             invite.action_invite()

--- a/addons/test_event_full/tests/common.py
+++ b/addons/test_event_full/tests/common.py
@@ -7,7 +7,7 @@ from odoo.addons.base.tests.common import HttpCaseWithUserDemo, HttpCaseWithUser
 from odoo.addons.base.tests.test_ir_cron import CronMixinCase
 from odoo.addons.event.tests.common import EventCase
 from odoo.addons.event_crm.tests.common import EventCrmCase
-from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
+from odoo.addons.mail.tests.common import mail_new_test_user, MailCase
 from odoo.addons.sales_team.tests.common import TestSalesCommon
 from odoo.addons.sms.tests.common import SMSCase
 from odoo.addons.website.tests.test_website_visitor import MockVisitor
@@ -301,7 +301,7 @@ class TestEventFullCommon(EventCrmCase, TestSalesCommon, MockVisitor):
                     self.assertIn(answer.value_text_box, lead.description)  # better: check multi line
 
 
-class TestEventMailCommon(EventCase, SMSCase, MailCommon, CronMixinCase):
+class TestEventMailCommon(EventCase, SMSCase, MailCase, CronMixinCase):
 
     @classmethod
     def setUpClass(cls):

--- a/addons/website_event/tests/test_event_mail.py
+++ b/addons/website_event/tests/test_event_mail.py
@@ -3,11 +3,11 @@
 
 from datetime import datetime, timedelta
 
-from odoo.addons.mail.tests.common import  MailCommon
+from odoo.addons.mail.tests.common import MailCase
 from odoo.tests import tagged
 
 @tagged('post_install', '-at_install')
-class TestMail(MailCommon):
+class TestMail(MailCase):
 
     def test_website_publish_notification(self):
         """ Test that the published/unpublished notifications are sent when publishing/unpublishing an event"""
@@ -20,7 +20,7 @@ class TestMail(MailCommon):
         })
         self.flush_tracking()
 
-        follower = self.user_employee.partner_id
+        follower = self.env.ref('base.user_admin').partner_id
         event.message_subscribe(partner_ids=follower.ids, subtype_ids=[published_subtype.id, unpublished_subtype.id])
 
         event.website_published = True

--- a/addons/website_event_track/tests/test_mail_features.py
+++ b/addons/website_event_track/tests/test_mail_features.py
@@ -1,10 +1,10 @@
-from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.mail.tests.common import MailCase
 from odoo.addons.website_event.tests.common import TestEventOnlineCommon
 from odoo.tests import tagged, users
 
 
 @tagged('post_install', '-at_install', 'mail_flow', 'mail_tools')
-class TestTrackMailFeatures(TestEventOnlineCommon, MailCommon):
+class TestTrackMailFeatures(TestEventOnlineCommon, MailCase):
 
     @classmethod
     def setUpClass(cls):

--- a/addons/website_slides/tests/common.py
+++ b/addons/website_slides/tests/common.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
+from odoo.addons.mail.tests.common import mail_new_test_user, MailCase
 
 
-class SlidesCase(MailCommon):
+class SlidesCase(MailCase):
 
     @classmethod
     def setUpClass(cls):

--- a/addons/website_slides/tests/test_slide_channel.py
+++ b/addons/website_slides/tests/test_slide_channel.py
@@ -174,7 +174,8 @@ class TestSlidesManagement(slides_common.SlidesCase):
             })],
             'completed_template_id': mail_template.id
         })
-        self.channel.completed_template_id.body_html = '<p>TestBodyTemplate</p>'
+        # sudo because creator has no rights to modify templates
+        self.channel.sudo().completed_template_id.body_html = '<p>TestBodyTemplate</p>'
 
         all_channels = self.channel | channel_2
         all_channels.sudo()._action_add_members(self.user_officer.partner_id)


### PR DESCRIPTION
Move tools in mail tool class. That way modules don't have to depend
on the MailCommon class, just the lower one MailCase without demo
and data setup.

Lessen usage of MailCommon

When possible, use a lower class like MailCase that holds tools and
helpers but does not propagate setup data. While browsing through test
classes, remove useless setup.

Task-4605118: [marketing_automation] Unbordelize test classes
Prepares Task-4224152: [marketing_automation] Performance / Scalability