### PR TITLE
[FIX] barcodes_gs1_nomenclature: add context to skip process

### DIFF
--- a/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
+++ b/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
@@ -139,7 +139,7 @@ class BarcodeNomenclature(models.Model):
         is only digits to keep the original barcode part only.
         """
         nomenclature = self.env.company.nomenclature_id
-        if nomenclature.is_gs1_nomenclature:
+        if nomenclature.is_gs1_nomenclature and not self.env.context.get('skip_gs1_pre'):
             for i, arg in enumerate(args):
                 if not isinstance(arg, (list, tuple)) or len(arg) != 3:
                     continue


### PR DESCRIPTION
Issue -->
On the Lots/Serial Numbers view, with GS1 enabled, searching by a serial number can cause search arguments to get warped, unbeknownst to the end user. This can return unexpected results in the list view.

Solution -->
Add a context that skips the `_preprocess_gs1_search_args` method if the search is done from the list/graph view. This solution retains usage for any other purposes of the method.

Enterprise PR --> https://github.com/odoo/enterprise/pull/82989

opw-4574666

