### PR TITLE
Fix translation for "left"  in fr.po

### DIFF
--- a/addons/pos_event/i18n/fr.po
+++ b/addons/pos_event/i18n/fr.po
@@ -243,4 +243,4 @@ msgstr "pour"
 #: code:addons/pos_event/static/src/app/generic_components/product_card/product_card.xml:0
 #: code:addons/pos_event/static/src/app/popup/event_configurator_popup/event_configurator_popup.xml:0
 msgid "left"
-msgstr "gauche"
+msgstr "places restantes"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In the POS, when selecting events with limited number of seats, It displays "10 gauche" in french which is a mistake.
it should display "places restantes" instead of "gauche" since we are talking about a direction (left, right)..

Current behavior before PR:

The translation is incorrect in pos_event.

Desired behavior after PR is merged:

Fix the the translation by displaying "places restantes" instead of "gauche"


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
