### PR TITLE
[FIX] point_of_sale: correct refund quantity displayed on ticket screen

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1219,13 +1219,8 @@ export class PosStore extends WithLazyGetterTrap {
 
             for (const line of newData["pos.order.line"]) {
                 const refundedOrderLine = line.refunded_orderline_id;
-
-                if (refundedOrderLine && ["paid", "done"].includes(line.order_id.state)) {
-                    const order = refundedOrderLine.order_id;
-                    if (order) {
-                        delete order.uiState.lineToRefund[refundedOrderLine.uuid];
-                    }
-                    refundedOrderLine.refunded_qty += Math.abs(line.qty);
+                if (refundedOrderLine?.order_id && ["paid", "done"].includes(line.order_id.state)) {
+                    delete refundedOrderLine.order_id.uiState.lineToRefund[refundedOrderLine.uuid];
                 }
             }
 


### PR DESCRIPTION
Before this commit:
====================
Refunded order quantities were incorrectly displayed on the ticket screen. For example, if a product with a quantity of 1 was refunded, the ticket screen showed a refund quantity of 2, even though the backend calculation was correct.

After this commit:
====================
The refund quantity is now correctly displayed on the ticket screen, ensuring consistency with the backend calculations.

Task-4599120

