### PR TITLE
[FIX] Fix table row movement errors due to text nodes

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4726,8 +4726,8 @@ export class OdooEditor extends EventTarget {
         ev.preventDefault();
         const sel = this.document.getSelection();
         const files = getImageFiles(ev.clipboardData);
-        const odooEditorHtml = ev.clipboardData.getData('text/odoo-editor');
-        const clipboardHtml = ev.clipboardData.getData('text/html');
+        let odooEditorHtml = ev.clipboardData.getData('text/odoo-editor');
+        let clipboardHtml = ev.clipboardData.getData('text/html');
         const targetSupportsHtmlContent = isHtmlContentSupported(sel.anchorNode);
         // Replace entire link if its label is fully selected.
         const link = closestElement(sel.anchorNode, 'a');
@@ -4740,6 +4740,7 @@ export class OdooEditor extends EventTarget {
             const text = ev.clipboardData.getData("text/plain");
             this._applyCommand("insert", text);
         } else if (odooEditorHtml) {
+            odooEditorHtml = odooEditorHtml.replace(/(?<=>)\s+(?=<\/?(?:table|thead|tbody|tfoot|tr|th|td)\b)/gs, '');
             const fragment = parseHTML(odooEditorHtml);
             const selector = this.options.renderingClasses.map(c => `.${c}`).join(',');
             if (selector) {
@@ -4752,6 +4753,7 @@ export class OdooEditor extends EventTarget {
                 this._applyCommand('insert', fragment);
             }
         } else if (files.length || clipboardHtml) {
+            clipboardHtml = clipboardHtml.replace(/(?<=>)\s+(?=<\/?(?:table|thead|tbody|tfoot|tr|th|td)\b)/gs, '');
             const clipboardElem = this._prepareClipboardData(clipboardHtml);
             // When copy pasting a table from the outside, a picture of the
             // table can be included in the clipboard as an image file. In that


### PR DESCRIPTION
__Errors occurred in onTableMoveUpClick and onTableMoveDownClick:__
- Moving rows up/down failed intermittently when previousSibling/nextSibling returned text nodes (e.g., whitespace) instead of \<tr> elements, breaking the move operation.
- Accessing style.width on childNodes threw errors when child nodes were text (e.g., whitespace between \<td>s)

__Fix:__
- Use previousElementSibling/nextElementSibling to target \<tr> elements, skipping text nodes between rows.
- Replace childNodes with children to iterate only over \<td> elements, avoiding text nodes within rows.

opw-4536390
