### PR TITLE
[FIX] web_editor: traceback when pasting due to empty text node

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -338,7 +338,7 @@ export const editorCommands = {
                         } else if (isEmptyBlock(right)) {
                             right.remove();
                         }
-                        currentNode = insertBefore ? right : left;
+                        currentNode = insertBefore && right.isConnected ? right : left;
                     } else {
                         currentNode = currentNode.parentElement;
                     }


### PR DESCRIPTION
Description of the issue this PR addresses:

Pasting content on a node with an invisible empty text node as the last child would result in a traceback. This occured because the empty node being removed when inserting text.

task-4566557

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
