### PR TITLE
[FIX] point_of_sale: stop event out of screen saver

### DIFF
--- a/addons/point_of_sale/static/src/app/pos_app.js
+++ b/addons/point_of_sale/static/src/app/pos_app.js
@@ -19,7 +19,13 @@ export class Chrome extends Component {
     static props = { disableLoader: Function };
     setup() {
         this.pos = usePos();
-        useIdleTimer(this.pos.idleTimeout, () => this.pos.showScreen(this.pos.firstScreen));
+        useIdleTimer(this.pos.idleTimeout, (ev) => {
+            const stopEventPropagation = ["mousedown", "click", "keypress"];
+            if (stopEventPropagation.includes(ev.type)) {
+                ev.stopPropagation();
+            }
+            this.pos.showScreen(this.pos.firstScreen);
+        });
         const reactivePos = reactive(this.pos);
         // TODO: Should we continue on exposing posmodel as global variable?
         window.posmodel = reactivePos;

--- a/addons/point_of_sale/static/src/app/utils/use_idle_timer.js
+++ b/addons/point_of_sale/static/src/app/utils/use_idle_timer.js
@@ -1,15 +1,6 @@
 import { useExternalListener, useState } from "@odoo/owl";
 
-const UserPresenceEvents = [
-    "mousemove",
-    "mousedown",
-    "touchstart",
-    "touchend",
-    "touchmove",
-    "click",
-    "scroll",
-    "keypress",
-];
+const UserPresenceEvents = ["mousemove", "mousedown", "touchmove", "click", "scroll", "keypress"];
 
 export function useIdleTimer(steps, onAlive) {
     const state = useState({
@@ -27,10 +18,10 @@ export function useIdleTimer(steps, onAlive) {
         }
     };
 
-    const onMove = () => {
+    const onMove = (ev) => {
         if (state.idle) {
             state.idle = false;
-            onAlive();
+            onAlive(ev);
         }
         state.time = 0;
     };


### PR DESCRIPTION
When the user is on the screen saver, we do not want to propagate some events like click so that his click does not do something unexpected in the POS (like adding a product or something).

This commit adds a check in the onAlive method of the pos app to stop the event propagation of some events when the screen saver is active.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
