### PR TITLE
[FIX] pos,pos_restaurant: Adds `pos_reference` when splitting bills

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1011,7 +1011,7 @@ export class PosStore extends WithLazyGetterTrap {
     cashierHasPriceControlRights() {
         return !this.config.restrict_price_control || this.getCashier()._role == "manager";
     }
-    createNewOrder(data = {}) {
+    createNewOrder(data = {}, onGetNextOrderRefs = () => {}) {
         const fiscalPosition = this.models["account.fiscal.position"].find(
             (fp) => fp.id === this.config.default_fiscal_position_id?.id
         );
@@ -1031,7 +1031,7 @@ export class PosStore extends WithLazyGetterTrap {
             ...data,
         });
 
-        this.getNextOrderRefs(order);
+        this.getNextOrderRefs(order).then(() => onGetNextOrderRefs(order));
         order.setPricelist(this.config.pricelist_id);
 
         if (this.config.use_presets) {

--- a/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
@@ -125,13 +125,21 @@ export class SplitBillScreen extends Component {
         };
     }
 
+    waitForNewOrder(data) {
+        return new Promise((resolve) => {
+            this.pos.createNewOrder(data, (order) => {
+                resolve(order);
+            });
+        });
+    }
+
     async createSplittedOrder() {
         const curOrderUuid = this.currentOrder.uuid;
         const originalOrder = this.pos.models["pos.order"].find((o) => o.uuid === curOrderUuid);
         const originalOrderName = this._getOrderName(originalOrder);
         const newOrderName = this._getSplitOrderName(originalOrderName);
 
-        const newOrder = this.pos.createNewOrder();
+        const newOrder = await this.waitForNewOrder({});
         newOrder.floating_order_name = newOrderName;
         newOrder.uiState.splittedOrderUuid = curOrderUuid;
         originalOrder.uiState.splittedOrderUuid = newOrder.uuid;

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -265,6 +265,8 @@ class TestFrontend(TestFrontendCommon):
     def test_06_split_bill_screen(self):
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('SplitBillScreenTour2')
+        orders = self.env['pos.order'].search([('pos_reference', '!=', '')], limit=2, order='id desc')
+        self.assertEqual(len(orders), 2)
 
     def test_07_split_bill_screen(self):
         # disable kitchen printer to avoid printing errors


### PR DESCRIPTION
Steps:
- install `pos_restaurant`
- open pos restaurant
- create new order
- add two products
- split the bill in two
- 1 product per bill
- pay for both of them
- go to pos.order
- the second bill does not have `pos_reference`

When we split a bill in two, for example, we'll transform our order into two orders. This is done in `createSplittedOrder` via the method ` this.pos.createNewOrder()`.

The `pos.order` is created in it and via `getNextOrderRefs` is called to set some values retrieved from the `get_next_order_refs` server, such as the `pos_reference`, `sequence_number` etc...

Except that `getNextOrderRefs` is an asynchronous function, as it emits an rpc call.

The problem is that in `createSplittedOrder` we never wait for this rpc call to finish before continuing, which causes our bug: the second order created contains no `pos_reference`.

The solution provided by this commit is to use the asynchronism of `getNextOrderRefs` by using an optional callback passed to `getNextOrderRefs.then()` to make sure we've received the information from the server before continuing. With this method we don't change `createNewOrder` => it will still returns an order and not a `Promise`


opw-4573422