### PR TITLE
[IMP] point_of_sale: add more service types

### DIFF
--- a/addons/point_of_sale/static/src/@types/services.d.ts
+++ b/addons/point_of_sale/static/src/@types/services.d.ts
@@ -1,16 +1,26 @@
+
 declare module "services" {
+    import { alertService } from "@point_of_sale/app/services/alert_service";
     import { barcodeReaderService } from "@point_of_sale/app/services/barcode_reader_service";
+    import { contextualUtilsService } from "@point_of_sale/app/services/contextual_utils_service";
     import { debugService } from "@point_of_sale/app/services/debug_service";
     import { hardwareProxyService } from "@point_of_sale/app/services/hardware_proxy_service";
     import { numberBufferService } from "@point_of_sale/app/services/number_buffer_service";
-    import { notificationService } from "@point_of_sale/app/notification/notification_service";
+    import { PosDataService } from "@point_of_sale/app/services/data_service";
+    import { posPrinterService } from "@point_of_sale/app/services/pos_printer_service";
+    import { renderService } from "@point_of_sale/app/services/render_service";
     import { reportService } from "@point_of_sale/app/services/report_service";
 
     export interface Services {
+        alert: typeof alertService;
         barcode_reader: typeof barcodeReaderService;
+        contextual_utils_service: typeof contextualUtilsService;
         debug: typeof debugService;
         hardware_proxy: typeof hardwareProxyService;
         number_buffer: typeof numberBufferService;
+        pos_data: typeof PosDataService;
+        printer: typeof posPrinterService;
+        renderer: typeof renderService;
         report: typeof reportService;
     }
 }

--- a/addons/point_of_sale/static/src/app/services/pos_printer_service.js
+++ b/addons/point_of_sale/static/src/app/services/pos_printer_service.js
@@ -3,7 +3,7 @@ import { registry } from "@web/core/registry";
 import { PrinterService } from "@point_of_sale/app/services/printer_service";
 import { AlertDialog, ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
-const posPrinterService = {
+export const posPrinterService = {
     dependencies: ["hardware_proxy", "dialog", "renderer"],
     start(env, { hardware_proxy, dialog, renderer }) {
         return new PosPrinterService(env, { hardware_proxy, dialog, renderer });

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -932,6 +932,9 @@ export const selfOrderService = {
 registry.category("services").add("printer", printerService);
 registry.category("services").add("self_order", selfOrderService);
 
+/**
+ * @returns {SelfOrder}
+ */
 export function useSelfOrder() {
     return useService("self_order");
 }


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/80196

This commit adds POS services that were previously
missing from the `@types/services.d.ts` file.
This should allow editor auto-completion when
using these services via `useService`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
