### PR TITLE
[IMP] web: improve Header buttons in Kanban

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -51,7 +51,7 @@ export class KanbanArchParser {
                 headerButtons = [...node.children]
                     .filter((node) => node.tagName === "button")
                     .map((node) => ({
-                        ...processButton(node),
+                        ...this.processButton(node),
                         type: "button",
                         id: button_id++,
                     }))
@@ -180,5 +180,9 @@ export class KanbanArchParser {
             sumField: fields[attrs.sum_field] || false,
             help: attrs.help,
         };
+    }
+
+    processButton(node) {
+        return processButton(node);
     }
 }

--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -54,8 +54,7 @@ export class KanbanArchParser {
                         ...this.processButton(node),
                         type: "button",
                         id: button_id++,
-                    }))
-                    .filter((button) => button.invisible !== "True" && button.invisible !== "1");
+                    }));
                 return false;
             } else if (node.tagName === "control") {
                 for (const childNode of node.children) {

--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -157,9 +157,6 @@ export class ListArchParser {
                 };
                 return false;
             } else if (node.tagName === "header") {
-                // AAB: not sure we need to handle invisible="True" button as the usecase seems way
-                // less relevant than for fields (so for buttons, relying on the modifiers logic
-                // that applies later on could be enough, even if the value is always true)
                 headerButtons = [...node.children].map((node) => ({
                     ...this.processButton(node),
                     type: "button",

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1451,6 +1451,9 @@ export function makeActionManager(env, router = _router) {
      * @returns {Promise<void>}
      */
     async function doActionButton(params, { isEmbeddedAction, newWindow } = {}) {
+        if (!params.name) {
+            return;
+        }
         // determine the action to execute according to the params
         let action;
         if (!isEmbeddedAction) {

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1701,7 +1701,7 @@ actual arch.
             if type_ != 'action' and type_ != 'object':
                 return
             elif not name:
-                self._raise_view_error(_("Button must have a name"), node)
+                return
             elif type_ == 'object':
                 func = getattr(name_manager.model, name, None)
                 if not func:

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -3115,7 +3115,6 @@ class TestViews(ViewCase):
         """
         self.assertInvalid(arch % 0, 'Action 0 (id: 0) does not exist for button of type action.')
         self.assertInvalid(arch % 'base.random_xmlid', 'Invalid xmlid base.random_xmlid for button of type action')
-        self.assertInvalid('<form><button type="action"/></form>', 'Button must have a name')
         self.assertInvalid('<form><button special="dummy"/></form>', "Invalid special 'dummy' in button")
         self.assertInvalid(arch % 'base.partner_root', "base.partner_root is of type res.partner, expected a subclass of ir.actions.actions")
 


### PR DESCRIPTION
- The first commit brings the possibility to override the processButton call
from the compiler. It is used mostly by web_studio, which needs to add
more attributes to the parsed button.

- In the second commit, we make sure we use the same logic for Kanban 
headers buttons as the one we already use for the List view. As the removed
comment in ListArchParser suggested, it might not be interesting enough
to handle invisible attribute from there, as it was effectively removed from
the List view parser, while being kept for the kanban parser (previously
unused code, since it was not possible to show HeaderButtons).

- The third commit removes the requirement of the 'name' attribute being
present on a button node. This simplifies the view validation process, and
allow a dummy button doing nothing being added of no name is given.
For studio, it allows to add a button node without the need for a custom dialog
to enter the 'name' and 'type' attribute. The user can add a value after the
button has been added effectively.

task-4318325