### PR TITLE
[IMP] web: remove useless !important in scss

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record.scss
+++ b/addons/web/static/src/views/kanban/kanban_record.scss
@@ -147,12 +147,12 @@
 }
 
 .o_kanban_selection_available .o_kanban_record.o_record_selection_available {
-    background-color: rgba(0, 0, 0, 0.1) !important;
+    background-color: rgba(0, 0, 0, 0.1);
     > *:not(.o_record_selection_tooltip) {
         filter: brightness(0.9);
     }
     &:hover {
-        background-color: rgba(0, 0, 0, 0.5) !important;
+        background-color: rgba(0, 0, 0, 0.5);
         > *:not(.o_record_selection_tooltip) {
             filter: brightness(0.6);
         }


### PR DESCRIPTION
This commit removes '!important' from scss rules where it is not useful. This was wrongly added from the beginning, and it can safely be removed without having any visual impact.
