### PR TITLE
[FIX] portal: fix tours without demo

### DIFF
--- a/addons/portal/tests/test_tours.py
+++ b/addons/portal/tests/test_tours.py
@@ -19,6 +19,7 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
             "phone": "(683)-556-5104",
             "street": "858 Lynn Street",
             "zip": "07002",
+            "state_id": cls.env.ref("base.state_us_5").id,
         })
 
     def test_01_portal_load_tour(self):


### PR DESCRIPTION
Some portal tours relied on partner values being set, however state_id was missing when the base was installed without demo data.

Runbot Error 134882
Runbot Error 134883
