### PR TITLE
[IMP] sale, website_sale: pricelist rule clarification message

### DIFF
--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import SUPERUSER_ID, _, api, fields, models, tools
+from odoo import _, api, fields, models, tools
 from odoo.exceptions import ValidationError
 from odoo.tools import format_amount, format_datetime, formatLang
 
@@ -614,15 +614,3 @@ class ProductPricelistItem(models.Model):
                 break
 
         return pricelist_item._compute_base_price(*args, **kwargs)
-
-    @api.model
-    def _is_discount_feature_enabled(self):
-        superuser = self.env['res.users'].browse(SUPERUSER_ID)
-        return superuser.has_group('sale.group_discount_per_so_line')
-
-    def _show_discount(self):
-        if not self:
-            return False
-
-        self.ensure_one()
-        return self._is_discount_feature_enabled() and self.compute_price == 'percentage'

--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -47,6 +47,7 @@ This module contains all the common features of Sales Management and eCommerce.
         'views/mail_activity_plan_views.xml',
         'views/payment_views.xml',
         'views/product_document_views.xml',
+        'views/product_pricelist_item_views.xml',
         'views/product_template_views.xml',
         'views/product_views.xml',
         'views/res_partner_views.xml',

--- a/addons/sale/models/__init__.py
+++ b/addons/sale/models/__init__.py
@@ -10,6 +10,7 @@ from . import payment_provider
 from . import payment_transaction
 from . import product_category
 from . import product_document
+from . import product_pricelist_item
 from . import product_product
 from . import product_template
 from . import res_company

--- a/addons/sale/models/product_pricelist_item.py
+++ b/addons/sale/models/product_pricelist_item.py
@@ -1,0 +1,16 @@
+from odoo import api, models
+
+
+class ProductPricelistItem(models.Model):
+    _inherit = 'product.pricelist.item'
+
+    @api.model
+    def _is_discount_feature_enabled(self):
+        return self.env['res.groups']._is_feature_enabled('sale.group_discount_per_so_line')
+
+    def _show_discount(self):
+        if not self:
+            return False
+
+        self.ensure_one()
+        return self._is_discount_feature_enabled() and self.compute_price == 'percentage'

--- a/addons/sale/views/product_pricelist_item_views.xml
+++ b/addons/sale/views/product_pricelist_item_views.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="product_pricelist_item_form" model="ir.ui.view">
+        <field name="name">product.pricelist.item.view.form.inherit</field>
+        <field name="model">product.pricelist.item</field>
+        <field name="inherit_id" ref="product.product_pricelist_item_form_view"/>
+        <field name="arch" type="xml">
+            <group name="pricelist_rule_limits" position="replace">
+                <div>
+                    <group name="pricelist_rule_limits">
+                        <field name="min_quantity" string="Min Qty"/>
+                        <field
+                            name="date_start"
+                            string="Validity Period"
+                            widget="daterange"
+                            options="{'end_date_field': 'date_end'}"
+                        />
+                        <field name="date_end" invisible="1"/>
+                    </group>
+                    <div groups="sale.group_discount_per_so_line">
+                        <div
+                            class="alert alert-info"
+                            role="alert"
+                            invisible="compute_price != 'percentage'"
+                        >
+                            <div id="discount_price_warning">
+                                In sale order line original price is unit price and discount is in
+                                discount column.
+                            </div>
+                        </div>
+                        <div
+                            class="alert alert-danger"
+                            role="alert"
+                            invisible="compute_price == 'percentage'"
+                        >
+                            <div id="formula_fixed_price_warning">
+                                When prices are calculated through formula or fixed, original price is NOT
+                                displayed in sale order lines. Calculated/fixed price is set as unit price
+                                with 0% discount.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </group>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -39,6 +39,7 @@
         'views/product_attribute_views.xml',
         'views/product_document_views.xml',
         'views/product_image_views.xml',
+        'views/product_pricelist_item_views.xml',
         'views/product_pricelist_views.xml',
         'views/product_product_add.xml',
         'views/product_public_category_views.xml',

--- a/addons/website_sale/views/product_pricelist_item_views.xml
+++ b/addons/website_sale/views/product_pricelist_item_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="product_pricelist_item_form" model="ir.ui.view">
+        <field name="name">product.pricelist.item.view.form.inherit</field>
+        <field name="model">product.pricelist.item</field>
+        <field name="inherit_id" ref="sale.product_pricelist_item_form"/>
+        <field name="arch" type="xml">
+            <div id="discount_price_warning" position="after">
+                <div>On the website original price is crossed out.</div>
+            </div>
+            <div id="formula_fixed_price_warning" position="replace">
+                <div>
+                    When prices are calculated through a formula or fixed, the original price is
+                    generally not displayed in the sale order lines or checkout. However, for
+                    specific formula-based pricing rules, the discount can be shown on the shop
+                    page (e.g. product pages and configurators), but not in the cart or at checkout.
+                    In these cases, the calculated/fixed price is set as the unit price with 0% discount
+                    in the order.
+                </div>
+            </div>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**  
- Clarification of price display behavior in pricelist rules.  

**Current behavior before PR:**  
- Since the discount policy has been removed from pricelists, users may find it difficult to determine when a discount is applied and when it is not.  

**Desired behavior after PR is merged:**  
- When selecting the price computation method in pricelist rules, users will see a clarification indicating whether the original price will be displayed on the sale order line and website.
- When discounts are enabled from settings, add alert boxes for user information based on the selected price type.


affected version - master
task - [4502296](https://www.odoo.com/odoo/project.task/4502296)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
