### PR TITLE
[FIX] hw_{drivers,posbox_homepage}: Windows IoT Box issues after recent changes

### DIFF
--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from dbus.mainloop.glib import DBusGMainLoop
 import logging
 import platform
 import requests
@@ -10,6 +9,10 @@ import time
 
 from odoo.addons.hw_drivers.tools import helpers, wifi
 from odoo.addons.hw_drivers.websocket_client import WebsocketClient
+
+if platform.system() == 'Linux':
+    from dbus.mainloop.glib import DBusGMainLoop
+    DBusGMainLoop(set_as_default=True) # Must be started from main thread
 
 _logger = logging.getLogger(__name__)
 
@@ -124,9 +127,6 @@ class Manager(Thread):
             except Exception:
                 # No matter what goes wrong, the Manager loop needs to keep running
                 _logger.exception("Manager loop unexpected error")
-
-# Must be started from main thread
-DBusGMainLoop(set_as_default=True)
 
 manager = Manager()
 manager.daemon = True

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -3,7 +3,6 @@
 
 import configparser
 import contextlib
-import crypt
 import datetime
 from enum import Enum
 from functools import cache, wraps
@@ -33,6 +32,9 @@ from odoo.tools.misc import file_path
 
 lock = Lock()
 _logger = logging.getLogger(__name__)
+
+if platform.system() == 'Linux':
+    import crypt
 
 
 class Orientation(Enum):

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -72,7 +72,8 @@ class IotBoxOwlHomePage(http.Controller):
 
     @http.route('/hw_posbox_homepage/iot_logs', auth='none', type='http', cors='*')
     def get_iot_logs(self):
-        with open("/var/log/odoo/odoo-server.log", encoding="utf-8") as file:
+        logs_path = "/var/log/odoo/odoo-server.log" if platform.system() == 'Linux' else Path().absolute().parent.joinpath('odoo.log')
+        with open(logs_path, encoding="utf-8") as file:
             return json.dumps({
                 'status': 'success',
                 'logs': file.read(),
@@ -155,7 +156,7 @@ class IotBoxOwlHomePage(http.Controller):
         }
 
         six_terminal = helpers.get_conf('six_payment_terminal') or 'Not Configured'
-        network_qr_codes = wifi.generate_network_qr_codes()
+        network_qr_codes = wifi.generate_network_qr_codes() if platform.system() == 'Linux' else {}
         odoo_server_url = helpers.get_odoo_server_url() or ''
 
         return json.dumps({
@@ -176,8 +177,8 @@ class IotBoxOwlHomePage(http.Controller):
             'is_certificate_ok': is_certificate_ok,
             'certificate_details': certificate_details,
             'wifi_ssid': helpers.get_conf('wifi_ssid'),
-            'qr_code_wifi' : network_qr_codes['qr_wifi'],
-            'qr_code_url' : network_qr_codes['qr_url'],
+            'qr_code_wifi' : network_qr_codes.get('qr_wifi'),
+            'qr_code_url' : network_qr_codes.get('qr_url'),
         })
 
     @http.route('/hw_posbox_homepage/wifi', auth="none", type="http", cors='*')

--- a/addons/hw_posbox_homepage/static/src/app/components/FooterButtons.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/FooterButtons.js
@@ -19,9 +19,15 @@ export class FooterButtons extends Component {
         this.store = useStore();
     }
 
+    get url() {
+        const url = new URL(window.location.href);
+        const port = url.protocol === "https:" ? "" : ":8069";
+        return `${url.protocol}//${this.store.base.ip}${port}`;
+    }
+
     static template = xml`
     <div class="w-100 d-flex flex-wrap align-items-cente gap-2 justify-content-center">
-        <a t-if="store.isLinux and !store.base.is_access_point_up" class="btn btn-primary btn-sm" t-att-href="'http://' + this.store.base.ip + '/status'" target="_blank">
+        <a t-if="store.isLinux and !store.base.is_access_point_up" class="btn btn-primary btn-sm" t-att-href="this.url + '/status'" target="_blank">
             Status Display
         </a>
         <a t-if="store.isLinux and !store.base.is_access_point_up" class="btn btn-primary btn-sm" t-att-href="'http://' + this.store.base.ip + ':631'" target="_blank">
@@ -30,7 +36,7 @@ export class FooterButtons extends Component {
         <RemoteDebugDialog t-if="this.store.advanced and this.store.isLinux" />
         <CredentialDialog t-if="this.store.advanced" />
         <HandlerDialog t-if="this.store.advanced" />
-        <a t-if="this.store.advanced" class="btn btn-primary btn-sm" t-att-href="'http://' + this.store.base.ip + '/logs'" target="_blank">View Logs</a>
+        <a t-if="this.store.advanced" class="btn btn-primary btn-sm" t-att-href="this.url + '/logs'" target="_blank">View Logs</a>
     </div>
   `;
 }

--- a/setup/package.dfwine
+++ b/setup/package.dfwine
@@ -12,12 +12,11 @@ RUN apt-get update \
     && apt-get install -y curl unzip 7zip \
     && rm -rf /var/lib/apt/lists/*
 
-# Use wine-devel to get the fix for this bug (fixed in wine 9.3): https://bugs.winehq.org/show_bug.cgi?id=55897
 RUN mkdir -pm755 /etc/apt/keyrings \
     && curl -sSL https://dl.winehq.org/wine-builds/winehq.key -o /etc/apt/keyrings/winehq-archive.key \
     && curl -sSL https://dl.winehq.org/wine-builds/debian/dists/bookworm/winehq-bookworm.sources -o /etc/apt/sources.list.d/winehq.sources \
     && apt-get update \
-    && apt-get install --install-recommends -y winehq-devel \
+    && apt-get install --install-recommends -y winehq-stable \
     && rm -rf /var/lib/apt/lists/*
 
 USER odoo


### PR DESCRIPTION
- logs path was incorrect (`server/odoo.log` instead of `odoo.log`),
- some imports were not supported for windows: a condition to import only on linux has been added,
- qr code generation methods to connect to Wi-Fi (from status display) were called without checking the system,
- switched back from `wine-devel` to `wine-stable` as the fix used is now available in stable.

