### PR TITLE
[FIX] point_of_sale, pos_sale: remove the payment terms on invoices from POS

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -675,7 +675,7 @@ class PosOrder(models.Model):
             'invoice_date': invoice_date.astimezone(timezone).date(),
             'fiscal_position_id': self.fiscal_position_id.id,
             'invoice_line_ids': self._prepare_invoice_lines(),
-            'invoice_payment_term_id': self.partner_id.property_payment_term_id.id or False,
+            'invoice_payment_term_id': False,
             'invoice_cash_rounding_id': self.config_id.rounding_method.id
             if self.config_id.cash_rounding and (not self.config_id.only_round_cash_method or any(p.payment_method_id.is_cash_count for p in self.payment_ids))
             else False

--- a/addons/point_of_sale/static/tests/tours/PaymentScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/PaymentScreen.tour.js
@@ -297,3 +297,22 @@ registry.category("web_tour.tours").add("CashRoundingPayment", {
             ErrorPopup.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PaymentScreenInvoiceOrder", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickHomeCategory(),
+            ProductScreen.addOrderline("Product Test", "1"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Partner Test 1"),
+            ProductScreen.clickPayButton(),
+
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickInvoiceButton(),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.receiptIsThere(),
+        ].flat(),
+});

--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -39,7 +39,7 @@ class PosOrder(models.Model):
                 addr = self.partner_id.address_get(['delivery'])
                 invoice_vals['partner_shipping_id'] = addr['delivery']
             if sale_orders[0].payment_term_id:
-                invoice_vals['invoice_payment_term_id'] = sale_orders[0].payment_term_id.id
+                invoice_vals['invoice_payment_term_id'] = False
             if sale_orders[0].partner_invoice_id != sale_orders[0].partner_id:
                 invoice_vals['partner_id'] = sale_orders[0].partner_invoice_id.id
         return invoice_vals


### PR DESCRIPTION
### Steps to reproduce:
- In Accounting create a new Payment Term with an early discount set on "Always(upon invoice)"
- Create a new Contact and add the payment term to this contact
- Open POS and create an order
- Select the new contact as the customer
- Go to payment, select the option to create an invoice and validate
- The receipt and the generated invoice have different amounts: the payment terms were applied on the invoice but not on the receipt

### Cause:
POS does not consider at any point the payment terms so the total to be paid does not include the payment terms. Payment terms were included in invoices from POS with this [commit](https://github.com/odoo/odoo/pull/100100/commits/c1cd62f0b207b3f3bbf5a03009bd8e34ee9b479f)

### Solution:
Remove the payment terms on invoices from POS.

opw-4458036