### PR TITLE
[FIX] point_of_sale: show price extra on combo

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.js
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.js
@@ -8,6 +8,7 @@ export class ProductCard extends Component {
         product: Object,
         productId: Number | String,
         price: String,
+        priceExtra: { type: String, optional: true },
         color: { type: [Number, undefined], optional: true },
         imageUrl: [String, Boolean],
         productInfo: { Boolean, optional: true },

--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
@@ -22,6 +22,8 @@
                 <h1 t-if="props.productCartQty"
                     t-out="props.productCartQty"
                     class="product-cart-qty text-muted display-6 fw-bolder m-0 mt-auto" />
+                <span t-if="props.priceExtra" class="price-extra-tag d-flex my-2 align-items-end"
+                    t-esc="props.priceExtra" />
             </div>
         </article>
     </t>

--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
@@ -23,6 +23,7 @@
                                     productId="product.id"
                                     product="product"
                                     price="formattedComboPrice(combo_item)"
+                                    priceExtra="formattedComboPrice(combo_item)"
                                     imageUrl="product.getImageUrl()"
                                     onClick="(ev) => this.onClickProduct({ product, combo_item }, ev)" />
                             </label>

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
@@ -61,7 +61,7 @@
                     <t t-set="is_custom" t-value="is_custom || (value.is_custom and value.id == state.attribute_value_ids)"/>
                     <t t-esc="value.name"/>
                     <t t-if="value.price_extra">
-                        <t t-esc="getFormatPriceExtra(value.price_extra)"/>
+                        <span> (<t t-esc="getFormatPriceExtra(value.price_extra)"/>)</span>
                     </t>
                 </option>
             </select>


### PR DESCRIPTION
Before this commit, the price extra of a product in a combo was not shown in the POS interface. This commit fixes this issue by adding the price extra to the product card in the combo configurator popup.

The commit also adds a space between the option name and the option extra price in the case of an "select" attribute selection.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
