### PR TITLE
[FIX] account_accountant: xpath was overwriting a group to show the g…

### DIFF
--- a/odoo/addons/base/tests/test_form_create.py
+++ b/odoo/addons/base/tests/test_form_create.py
@@ -16,10 +16,10 @@ class TestFormCreate(TransactionCase):
         if hasattr(self.env['res.partner'], 'property_account_payable_id'):
             # Required for `property_account_payable_id`, `property_account_receivable_id` to be visible in the view
             # By default, it's the `group` `group_account_readonly` which is required to see it, in the `account` module
-            # But once `account_accountant` gets installed, it becomes `account.group_account_manager`
+            # But once `account_accountant` gets installed, it becomes `account.group_account_user`
             # https://github.com/odoo/enterprise/blob/bfa643278028da0bfabded2f87ccb7e323d697c1/account_accountant/views/product_views.xml#L9
             self.env.user.groups_id += self.env.ref('account.group_account_readonly')
-            self.env.user.groups_id += self.env.ref('account.group_account_manager')
+            self.env.user.groups_id += self.env.ref('account.group_account_user')
         partner_form = Form(self.env['res.partner'])
         partner_form.name = 'a partner'
         # YTI: Clean that brol


### PR DESCRIPTION
That test .test_create_res_partner Fails in the [runbot nightly builds }(https://runbot.odoo.com/odoo/runbot.build.error/135354).

So I have modified account.group_account_manager to  account.group_account_user

Original PR is https://github.com/odoo/enterprise/pull/79111 