### PR TITLE
[FIX] {,test_}mail: activity type default user

### DIFF
--- a/addons/mail/wizard/mail_activity_schedule.py
+++ b/addons/mail/wizard/mail_activity_schedule.py
@@ -179,10 +179,7 @@ class MailActivitySchedule(models.TransientModel):
     @api.depends('activity_type_id')
     def _compute_activity_user_id(self):
         for scheduler in self:
-            if scheduler.activity_type_id.default_user_id:
-                scheduler.activity_user_id = scheduler.activity_type_id.default_user_id
-            elif not scheduler.activity_user_id:
-                scheduler.activity_user_id = self.env.user
+            scheduler.activity_user_id = scheduler.activity_type_id.default_user_id or self.env.user
 
     # Any writable fields that can change error computed field
     @api.constrains('res_model_id', 'res_ids',  # records (-> responsible)

--- a/addons/test_mail/tests/test_mail_activity_plan.py
+++ b/addons/test_mail/tests/test_mail_activity_plan.py
@@ -295,3 +295,18 @@ class TestActivitySchedule(ActivityScheduleCase):
                 ValidationError, msg='When selecting responsible "other", you must specify a responsible.'):
             template.responsible_type = 'other'
         template.write({'responsible_type': 'other', 'responsible_id': self.user_admin})
+
+    def test_user_recompute_onchange_activity_type(self):
+        user_test = self.env['res.users'].create({
+            'name': 'user_test',
+            'login': 'a_user',
+        })
+        self.activity_type_call.default_user_id = user_test
+        with Form(self.env['mail.activity.schedule'].with_context({
+            'active_model': 'mail.activity.schedule',
+        })) as form:
+            form.activity_type_id = self.activity_type_todo
+            before_change_user = form.activity_user_id.name
+            form.activity_type_id = self.activity_type_call
+            form.activity_type_id = self.activity_type_todo
+            self.assertEqual(before_change_user, form.activity_user_id.name)


### PR DESCRIPTION
Steps to reproduce:

- Open settings and search for "Activity Types"
- Choose an activity Type and set a default user (different than the current user)
- Open Project and select a task in one project
- Click on activities
- Select the activity type with the default user
- Select another activity type

Problem:
Once the activity type with a default user has been selected, the "assigned to" field does not change (it keeps the value of the default user) even after changing the activity type.

https://github.com/odoo/odoo/blob/8b0dddf8b4fb68fc12f15a71e150cf1607d5cd24/addons/mail/wizard/mail_activity_schedule.py#L182

opw-4459016