### PR TITLE
[FIX] all: Add 'sequence' in res.groups data

### DIFF
--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -59,6 +59,7 @@
 
     <record id="group_account_invoice" model="res.groups">
         <field name="name">Invoicing</field>
+        <field name="sequence">20</field>
         <field name="category_id" ref="base.module_category_accounting_accounting"/>
         <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
     </record>
@@ -77,6 +78,7 @@
 
     <record id="group_account_manager" model="res.groups">
         <field name="name">Administrator</field>
+        <field name="sequence">50</field>
         <field name="category_id" ref="base.module_category_accounting_accounting"/>
         <field name="implied_ids" eval="[(4, ref('group_account_invoice'))]"/>
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/event/security/event_security.xml
+++ b/addons/event/security/event_security.xml
@@ -8,18 +8,21 @@
 
         <record id="group_event_registration_desk" model="res.groups">
             <field name="name">Registration Desk</field>
+            <field name="sequence">10</field>
             <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
             <field name="category_id" ref="base.module_category_marketing_events"/>
         </record>
 
         <record id="group_event_user" model="res.groups">
             <field name="name">User</field>
+            <field name="sequence">20</field>
             <field name="implied_ids" eval="[(4, ref('group_event_registration_desk'))]"/>
             <field name="category_id" ref="base.module_category_marketing_events"/>
         </record>
 
         <record id="group_event_manager" model="res.groups">
             <field name="name">Administrator</field>
+            <field name="sequence">30</field>
             <field name="category_id" ref="base.module_category_marketing_events"/>
             <field name="implied_ids" eval="[(4, ref('group_event_user'))]"/>
             <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/fleet/security/fleet_security.xml
+++ b/addons/fleet/security/fleet_security.xml
@@ -6,11 +6,13 @@
         </record>
         <record id="fleet_group_user" model="res.groups">
             <field name="name">Officer: Manage all vehicles</field>
+            <field name="sequence">10</field>
             <field name="category_id" ref="base.module_category_human_resources_fleet"/>
             <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
         </record>
         <record id="fleet_group_manager" model="res.groups">
             <field name="name">Administrator</field>
+            <field name="sequence">20</field>
             <field name="implied_ids" eval="[(4, ref('fleet_group_user'))]"/>
             <field name="category_id" ref="base.module_category_human_resources_fleet"/>
             <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -7,6 +7,7 @@
 
     <record id="group_hr_user" model="res.groups">
         <field name="name">Officer: Manage all employees</field>
+        <field name="sequence">10</field>
         <field name="category_id" ref="base.module_category_human_resources_employees"/>
         <field name="implied_ids" eval="[(6, 0, [ref('base.group_user')])]"/>
         <field name="comment">The user will be able to approve document created by employees.</field>
@@ -14,6 +15,7 @@
 
     <record id="group_hr_manager" model="res.groups">
         <field name="name">Administrator</field>
+        <field name="sequence">20</field>
         <field name="comment">The user will have access to the human resources configuration as well as statistic reports.</field>
         <field name="category_id" ref="base.module_category_human_resources_employees"/>
         <field name="implied_ids" eval="[(4, ref('group_hr_user'))]"/>

--- a/addons/hr_attendance/security/hr_attendance_security.xml
+++ b/addons/hr_attendance/security/hr_attendance_security.xml
@@ -16,12 +16,14 @@
 
     <record id="group_hr_attendance_officer" model="res.groups">
         <field name="name">Officer: Manage attendances</field>
+        <field name="sequence">10</field>
         <field name="category_id" ref="base.module_category_hidden"/>
         <field name="comment">The user will have access to the attendance records and reporting of employees where he's set as an attendance manager</field>
     </record>
 
     <record id="group_hr_attendance_manager" model="res.groups">
         <field name="name">Administrator</field>
+        <field name="sequence">20</field>
         <field name="category_id" ref="base.module_category_human_resources_attendances"/>
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         <field name="implied_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_officer'))]"/>

--- a/addons/hr_contract/security/security.xml
+++ b/addons/hr_contract/security/security.xml
@@ -8,12 +8,14 @@
 
         <record id="hr_contract.group_hr_contract_employee_manager" model="res.groups">
             <field name="name">Employee Manager</field>
+            <field name="sequence">10</field>
             <field name="category_id" ref="base.module_category_human_resources_contracts"/>
             <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
         </record>
 
         <record id="hr_contract.group_hr_contract_manager" model="res.groups">
             <field name="name">Administrator</field>
+            <field name="sequence">20</field>
             <field name="category_id" ref="base.module_category_human_resources_contracts"/>
             <field name="implied_ids" eval="[(4, ref('hr_contract.group_hr_contract_employee_manager')), (4, ref('hr.group_hr_user'))]"/>
             <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/hr_expense/security/hr_expense_security.xml
+++ b/addons/hr_expense/security/hr_expense_security.xml
@@ -7,18 +7,21 @@
 
     <record id="group_hr_expense_team_approver" model="res.groups">
         <field name="name">Team Approver</field>
+        <field name="sequence">10</field>
         <field name="category_id" ref="base.module_category_human_resources_expenses"/>
         <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
     </record>
 
     <record id="group_hr_expense_user" model="res.groups">
         <field name="name">All Approver</field>
+        <field name="sequence">20</field>
         <field name="category_id" ref="base.module_category_human_resources_expenses"/>
         <field name="implied_ids" eval="[(4, ref('hr_expense.group_hr_expense_team_approver'))]"/>
     </record>
 
     <record id="group_hr_expense_manager" model="res.groups">
         <field name="name">Administrator</field>
+        <field name="sequence">30</field>
         <field name="category_id" ref="base.module_category_human_resources_expenses"/>
         <field name="implied_ids" eval="[(4, ref('hr_expense.group_hr_expense_user'))]"/>
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -13,12 +13,14 @@
 
     <record id="group_hr_holidays_user" model="res.groups">
         <field name="name">Officer: Manage all requests</field>
+        <field name="sequence">10</field>
         <field name="category_id" ref="base.module_category_human_resources_time_off"/>
         <field name="implied_ids" eval="[(4, ref('hr_holidays.group_hr_holidays_responsible')), (4, ref('hr.group_hr_user'))]"/>
     </record>
 
     <record id="group_hr_holidays_manager" model="res.groups">
         <field name="name">Administrator</field>
+        <field name="sequence">20</field>
         <field name="category_id" ref="base.module_category_human_resources_time_off"/>
         <field name="implied_ids" eval="[(4, ref('hr_holidays.group_hr_holidays_user'))]"/>
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/hr_recruitment/security/hr_recruitment_security.xml
+++ b/addons/hr_recruitment/security/hr_recruitment_security.xml
@@ -15,18 +15,21 @@
 
     <record id="group_hr_recruitment_interviewer" model="res.groups">
         <field name="name">Interviewer</field>
+        <field name="sequence">10</field>
         <field name="category_id" ref="base.module_category_human_resources_recruitment"/>
         <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
     </record>
 
     <record id="group_hr_recruitment_user" model="res.groups">
         <field name="name">Officer: Manage all applicants</field>
+        <field name="sequence">20</field>
         <field name="category_id" ref="base.module_category_human_resources_recruitment"/>
         <field name="implied_ids" eval="[(4, ref('group_hr_recruitment_interviewer'))]"/>
     </record>
 
     <record id="group_hr_recruitment_manager" model="res.groups">
         <field name="name">Administrator</field>
+        <field name="sequence">30</field>
         <field name="category_id" ref="base.module_category_human_resources_recruitment"/>
         <field name="implied_ids" eval="[(4, ref('group_hr_recruitment_user'))]"/>
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -8,6 +8,7 @@
 
         <record id="group_hr_timesheet_user" model="res.groups">
             <field name="name">User: own timesheets only</field>
+            <field name="sequence">10</field>
             <field name="category_id" ref="base.module_category_services_timesheets"/>
             <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
             <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
@@ -15,12 +16,14 @@
 
         <record id="group_hr_timesheet_approver" model="res.groups">
             <field name="name">User: all timesheets</field>
+            <field name="sequence">20</field>
             <field name="category_id" ref="base.module_category_services_timesheets"/>
             <field name="implied_ids" eval="[(4, ref('hr_timesheet.group_hr_timesheet_user'))]"/>
         </record>
 
         <record id="group_timesheet_manager" model="res.groups">
             <field name="name">Administrator</field>
+            <field name="sequence">30</field>
             <field name="category_id" ref="base.module_category_services_timesheets"/>
             <field name="implied_ids" eval="[(4, ref('hr_timesheet.group_hr_timesheet_approver')), (4, ref('hr.group_hr_user'))]"/>
             <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/im_livechat/security/im_livechat_channel_security.xml
+++ b/addons/im_livechat/security/im_livechat_channel_security.xml
@@ -7,12 +7,14 @@
 
         <record id="im_livechat_group_user" model="res.groups">
             <field name="name">User</field>
+            <field name="sequence">10</field>
             <field name="category_id" ref="base.module_category_website_live_chat"/>
             <field name="comment">The user will be able to join support channels.</field>
         </record>
 
         <record id="im_livechat_group_manager" model="res.groups">
             <field name="name">Administrator</field>
+            <field name="sequence">20</field>
             <field name="comment">The user will be able to delete support channels.</field>
             <field name="category_id" ref="base.module_category_website_live_chat"/>
             <field name="implied_ids" eval="[(4, ref('im_livechat.im_livechat_group_user')), (4, ref('mail.group_mail_canned_response_admin'))]"/>

--- a/addons/lunch/security/lunch_security.xml
+++ b/addons/lunch/security/lunch_security.xml
@@ -7,10 +7,12 @@
         </record>
         <record id="group_lunch_user" model="res.groups">
             <field name="name">User : Order your meal</field>
+            <field name="sequence">10</field>
             <field name="category_id" ref="base.module_category_human_resources_lunch"/>
         </record>
         <record id="group_lunch_manager" model="res.groups">
             <field name="name">Administrator</field>
+            <field name="sequence">20</field>
             <field name="implied_ids" eval="[(4, ref('group_lunch_user'))]"/>
             <field name="category_id" ref="base.module_category_human_resources_lunch"/>
             <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/maintenance/security/maintenance.xml
+++ b/addons/maintenance/security/maintenance.xml
@@ -3,6 +3,7 @@
     <!-- This group is only allowed to deal with equipment registration and maintenance -->
     <record id="group_equipment_manager" model="res.groups">
         <field name="name">Equipment Manager</field>
+        <field name="sequence">10</field>
         <field name="category_id" ref="base.module_category_manufacturing_maintenance"/>
         <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/marketing_card/security/marketing_card_groups.xml
+++ b/addons/marketing_card/security/marketing_card_groups.xml
@@ -8,12 +8,14 @@
 
     <record id="marketing_card_group_user" model="res.groups">
         <field name="name">Marketing Card User</field>
+        <field name="sequence">10</field>
         <field name="category_id" ref="base.module_category_marketing_marketing_card"/>
         <field name="implied_ids" eval="[(4, ref('base.group_user')), (4, ref('mass_mailing.group_mass_mailing_user'))]"/>
     </record>
 
     <record id="marketing_card_group_manager" model="res.groups">
         <field name="name">Marketing Card Manager</field>
+        <field name="sequence">20</field>
         <field name="category_id" ref="base.module_category_marketing_marketing_card"/>
         <field name="implied_ids" eval="[(4, ref('marketing_card_group_user'))]"/>
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/mass_mailing/security/res_groups_data.xml
+++ b/addons/mass_mailing/security/res_groups_data.xml
@@ -2,6 +2,7 @@
 <odoo>
     <record id="group_mass_mailing_user" model="res.groups">
         <field name="name">User</field>
+        <field name="sequence">10</field>
         <field name="category_id" ref="base.module_category_marketing_email_marketing"/>
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>

--- a/addons/mrp/security/mrp_security.xml
+++ b/addons/mrp/security/mrp_security.xml
@@ -9,11 +9,13 @@
 
     <record id="group_mrp_user" model="res.groups">
         <field name="name">User</field>
+        <field name="sequence">10</field>
         <field name="implied_ids" eval="[(4, ref('stock.group_stock_user'))]"/>
         <field name="category_id" ref="base.module_category_manufacturing_manufacturing"/>
     </record>
     <record id="group_mrp_manager" model="res.groups">
         <field name="name">Administrator</field>
+        <field name="sequence">20</field>
         <field name="category_id" ref="base.module_category_manufacturing_manufacturing"/>
         <field name="implied_ids" eval="[(4, ref('group_mrp_user'))]"/>
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/point_of_sale/security/point_of_sale_security.xml
+++ b/addons/point_of_sale/security/point_of_sale_security.xml
@@ -7,10 +7,12 @@
 
     <record id="group_pos_user" model="res.groups">
         <field name="name">User</field>
+        <field name="sequence">10</field>
         <field name="category_id" ref="base.module_category_sales_point_of_sale"/>
     </record>
     <record id="group_pos_manager" model="res.groups">
         <field name="name">Administrator</field>
+        <field name="sequence">20</field>
         <field name="category_id" ref="base.module_category_sales_point_of_sale"/>
         <field name="implied_ids" eval="[(4, ref('group_pos_user')), (4, ref('stock.group_stock_user'))]"/>
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -9,6 +9,7 @@
     <record id="group_project_user" model="res.groups">
         <field name="name">User</field>
         <field name="comment">User can user the your employees' schedule</field>
+        <field name="sequence">10</field>
         <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
         <field name="category_id" ref="base.module_category_services_project"/>
     </record>
@@ -16,6 +17,7 @@
     <record id="group_project_manager" model="res.groups">
         <field name="name">Administrator</field>
         <field name="comment">Administrator can manage the employees' schedule</field>
+        <field name="sequence">20</field>
         <field name="category_id" ref="base.module_category_services_project"/>
         <field name="implied_ids" eval="[(4, ref('project.group_project_user')), (4, ref('mail.group_mail_canned_response_admin'))]"/>
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/purchase/security/purchase_security.xml
+++ b/addons/purchase/security/purchase_security.xml
@@ -9,12 +9,14 @@
 
     <record id="group_purchase_user" model="res.groups">
         <field name="name">User</field>
+        <field name="sequence">10</field>
         <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
         <field name="category_id" ref="base.module_category_inventory_purchase"/>
     </record>
 
     <record id="group_purchase_manager" model="res.groups">
         <field name="name">Administrator</field>
+        <field name="sequence">20</field>
         <field name="category_id" ref="base.module_category_inventory_purchase"/>
         <field name="implied_ids" eval="[(4, ref('group_purchase_user'))]"/>
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/sales_team/security/sales_team_security.xml
+++ b/addons/sales_team/security/sales_team_security.xml
@@ -7,6 +7,7 @@
 
         <record id="group_sale_salesman" model="res.groups">
             <field name="name">User: Own Documents Only</field>
+            <field name="sequence">10</field>
             <field name="category_id" ref="base.module_category_sales_sales"/>
             <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
             <field name="comment">the user will have access to his own data in the sales application.</field>
@@ -14,6 +15,7 @@
 
         <record id="group_sale_salesman_all_leads" model="res.groups">
             <field name="name">User: All Documents</field>
+            <field name="sequence">20</field>
             <field name="category_id" ref="base.module_category_sales_sales"/>
             <field name="implied_ids" eval="[(4, ref('group_sale_salesman'))]"/>
             <field name="comment">the user will have access to all records of everyone in the sales application.</field>
@@ -21,6 +23,7 @@
 
         <record id="group_sale_manager" model="res.groups">
             <field name="name">Administrator</field>
+            <field name="sequence">30</field>
             <field name="comment">the user will have an access to the sales configuration as well as statistic reports.</field>
             <field name="category_id" ref="base.module_category_sales_sales"/>
             <field name="implied_ids" eval="[(4, ref('group_sale_salesman_all_leads')),

--- a/addons/spreadsheet_dashboard/security/security.xml
+++ b/addons/spreadsheet_dashboard/security/security.xml
@@ -22,6 +22,7 @@
 
     <record id="spreadsheet_dashboard.group_dashboard_manager" model="res.groups">
         <field name="name">Admin</field>
+        <field name="sequence">10</field>
         <field name="category_id" ref="base.module_category_productivity_dashboard" />
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]" />
         <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>

--- a/addons/stock/security/stock_security.xml
+++ b/addons/stock/security/stock_security.xml
@@ -19,11 +19,13 @@
 
     <record id="group_stock_user" model="res.groups">
         <field name="name">User</field>
+        <field name="sequence">10</field>
         <field name="category_id" ref="base.module_category_inventory_inventory"/>
         <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
     </record>
     <record id="group_stock_manager" model="res.groups">
         <field name="name">Administrator</field>
+        <field name="sequence">20</field>
         <field name="category_id" ref="base.module_category_inventory_inventory"/>
         <field name="implied_ids" eval="[(4, ref('group_stock_user'))]"/>
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/survey/security/survey_security.xml
+++ b/addons/survey/security/survey_security.xml
@@ -9,12 +9,14 @@
         <!-- Survey users -->
         <record model="res.groups" id="group_survey_user">
             <field name="name">User</field>
+            <field name="sequence">10</field>
             <field name="category_id" ref="base.module_category_marketing_surveys"/>
         </record>
 
         <!-- Survey managers -->
         <record model="res.groups" id="group_survey_manager">
             <field name="name">Administrator</field>
+            <field name="sequence">20</field>
             <field name="category_id" ref="base.module_category_marketing_surveys"/>
             <field name="implied_ids" eval="[(4, ref('group_survey_user'))]"/>
             <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>

--- a/addons/website/security/website_security.xml
+++ b/addons/website/security/website_security.xml
@@ -6,10 +6,12 @@
 
     <record id="group_website_restricted_editor" model="res.groups">
         <field name="name">Restricted Editor</field>
+        <field name="sequence">10</field>
         <field name="category_id" ref="base.module_category_website_website"/>
     </record>
     <record id="group_website_designer" model="res.groups">
         <field name="name">Editor and Designer</field>
+        <field name="sequence">20</field>
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         <field name="implied_ids" eval="[(4, ref('group_website_restricted_editor')), (4, ref('base.group_sanitize_override'))]"/>
         <field name="category_id" ref="base.module_category_website_website"/>

--- a/addons/website_slides/security/website_slides_security.xml
+++ b/addons/website_slides/security/website_slides_security.xml
@@ -6,12 +6,14 @@
 
         <record id="group_website_slides_officer" model="res.groups">
             <field name="name">Officer</field>
+            <field name="sequence">10</field>
             <field name="category_id" ref="base.module_category_website_elearning"/>
             <field name="implied_ids" eval="[(4, ref('website.group_website_restricted_editor'))]"/>
         </record>
 
         <record id="group_website_slides_manager" model="res.groups">
             <field name="name">Manager</field>
+            <field name="sequence">20</field>
             <field name="category_id" ref="base.module_category_website_elearning"/>
             <field name="implied_ids" eval="[(4, ref('group_website_slides_officer'))]"/>
             <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>


### PR DESCRIPTION
Since the change of res.users from view (UI for groups), the sequence is used, but the data has not been updated.

related: https://github.com/odoo/odoo/commit/2258fe4071f15ae72ab3384de6bbe43ff0db5848
