### PR TITLE
[IMP] web, mail, *: introduce Markup utils and template literal

### DIFF
--- a/addons/account/static/src/services/account_move_service.js
+++ b/addons/account/static/src/services/account_move_service.js
@@ -1,8 +1,7 @@
-import { _t } from "@web/core/l10n/translation";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-import { escape } from "@web/core/utils/strings";
-import { markup } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { Markup } from "@web/core/utils/html";
 
 export class AccountMoveService {
     constructor(env, services) {
@@ -21,7 +20,7 @@ export class AccountMoveService {
         if (!isMoveEndOfChain) {
             const message = _t("This operation will create a gap in the sequence.");
             const confirmationDialogProps = component.deleteConfirmationDialogProps;
-            confirmationDialogProps.body = markup(`<div class="text-danger">${escape(message)}</div>${escape(confirmationDialogProps.body)}`);
+            confirmationDialogProps.body = Markup.build`<div class="text-danger">${message}</div>${confirmationDialogProps.body}`;
             this.dialog.add(ConfirmationDialog, confirmationDialogProps);
             return true;
         }

--- a/addons/html_editor/static/src/components/history_dialog/history_dialog.js
+++ b/addons/html_editor/static/src/components/history_dialog/history_dialog.js
@@ -28,7 +28,7 @@ export class HistoryDialog extends Component {
 
     static defaultProps = {
         title: _t("History"),
-        noContentHelper: markup(""),
+        noContentHelper: "",
         embeddedComponents: [...READONLY_MAIN_EMBEDDINGS],
     };
 

--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_dialog.js
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_dialog.js
@@ -2,6 +2,7 @@ import { _t } from "@web/core/l10n/translation";
 import { Dialog } from "@web/core/dialog/dialog";
 import { rpc } from "@web/core/network/rpc";
 import { useService } from "@web/core/utils/hooks";
+import { Markup } from "@web/core/utils/html";
 import { Component, useState, onWillDestroy, status, markup } from "@odoo/owl";
 
 const POSTPROCESS_GENERATED_CONTENT = (content, baseContainer) => {
@@ -84,9 +85,9 @@ export class ChatGPTDialog extends Component {
         let result = "";
         for (const child of fragment.children) {
             this.props.sanitize(child, { IN_PLACE: true });
-            result += child.outerHTML;
+            result = Markup.join([result, markup(child.outerHTML)]);
         }
-        return markup(result);
+        return result;
     }
 
     generate(prompt, callback) {

--- a/addons/html_editor/static/src/main/signature_plugin.js
+++ b/addons/html_editor/static/src/main/signature_plugin.js
@@ -48,11 +48,12 @@ export class SignaturePlugin extends Plugin {
             ["signature"]
         );
         if (currentUser && currentUser.signature) {
+            currentUser.signature = markup(currentUser.signature);
             // User signature is sanitized in backend.
             const signatureFragment = parseHTML(
                 this.document,
                 renderToString("html_editor.Signature", {
-                    signature: markup(currentUser.signature),
+                    signature: currentUser.signature,
                     signatureClass: SIGNATURE_CLASS,
                 })
             );

--- a/addons/html_editor/static/tests/html_viewer.test.js
+++ b/addons/html_editor/static/tests/html_viewer.test.js
@@ -1,9 +1,9 @@
 import { HtmlViewer } from "@html_editor/fields/html_viewer";
 import { expect, test } from "@odoo/hoot";
 import { animationFrame } from "@odoo/hoot-mock";
-import { markup } from "@odoo/owl";
 import { mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { registry } from "@web/core/registry";
+import { Markup } from "@web/core/utils/html";
 import { WebClient } from "@web/webclient/webclient";
 
 test(`XML-like self-closing elements are fixed in a standalone HtmlViewer`, async () => {
@@ -13,7 +13,7 @@ test(`XML-like self-closing elements are fixed in a standalone HtmlViewer`, asyn
         Component: HtmlViewer,
         props: {
             config: {
-                value: markup(`<a href="#"/>outside<a href="#">inside</a>`),
+                value: Markup.build`<a href="#"/>outside<a href="#">inside</a>`,
             },
         },
     });

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -13,7 +13,6 @@ import {
     waitUntil,
 } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
-import { markup } from "@odoo/owl";
 import { contains, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupEditor } from "../_helpers/editor";
 import { cleanLinkArtifacts } from "../_helpers/format";
@@ -816,7 +815,7 @@ describe("shortcut", () => {
 describe("link preview", () => {
     test("test internal link preview", async () => {
         onRpc("/html_editor/link_preview_internal", () => ({
-            description: markup("Test description"),
+            description: "Test description",
             link_preview_name: "Task name | Project name",
         }));
         onRpc("/odoo/project/1/tasks/8", () => new Response("", { status: 200 }));
@@ -865,7 +864,7 @@ describe("link preview", () => {
         onRpc("/html_editor/link_preview_internal", () => {
             expect.step("/html_editor/link_preview_internal");
             return {
-                description: markup("<p>Test description</p>"),
+                description: "<p>Test description</p>",
                 link_preview_name: "Task name | Project name",
             };
         });

--- a/addons/iap_mail/static/src/js/services/iap_notification_service.js
+++ b/addons/iap_mail/static/src/js/services/iap_notification_service.js
@@ -1,7 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-
-import { markup } from "@odoo/owl";
+import { Markup } from "@web/core/utils/html";
 
 export const iapNotificationService = {
     dependencies: ["bus_service", "notification"],
@@ -27,11 +26,11 @@ export const iapNotificationService = {
             // ℹ️ `_t` can only be inlined directly inside JS template literals
             // after Babel has been updated to version 2.12.
             const translatedText = _t("Buy more credits");
-            const message = markup(`
+            const message = Markup.build`
             <a class='btn btn-link' href='${params.get_credits_url}' target='_blank'>
                 <i class='oi oi-arrow-right'></i>
                 ${translatedText}
-            </a>`);
+            </a>`;
             notification.add(message, {
                 title: params.title,
                 type: 'danger',

--- a/addons/lunch/static/src/components/lunch_dashboard.js
+++ b/addons/lunch/static/src/components/lunch_dashboard.js
@@ -63,10 +63,7 @@ export class LunchOrderLine extends Component {
 
 export class LunchAlert extends Component {
     static props = ["message"];
-    static template = xml`<t t-out="message"/>`;
-    get message() {
-        return markup(this.props.message);
-    }
+    static template = xml`<t t-out="props.message"/>`;
 }
 
 export class LunchAlerts extends Component {
@@ -134,6 +131,7 @@ export class LunchDashboard extends Component {
 
     async _fetchLunchInfos() {
         this.state.infos = await this.lunchRpc('/lunch/infos');
+        this.state.infos.alerts?.forEach((alert) => (alert.message = markup(alert.message)));
     }
 
     async emptyCart() {

--- a/addons/mail/static/src/chatter/web/form_controller.js
+++ b/addons/mail/static/src/chatter/web/form_controller.js
@@ -1,9 +1,8 @@
-import { createDocumentFragmentFromContent } from "@mail/utils/common/html";
-
 import { useSubEnv } from "@odoo/owl";
 
 import { x2ManyCommands } from "@web/core/orm_service";
 import { useService } from "@web/core/utils/hooks";
+import { Markup } from "@web/core/utils/html";
 import { patch } from "@web/core/utils/patch";
 import { FormController } from "@web/views/form/form_controller";
 
@@ -36,7 +35,7 @@ patch(FormController.prototype, {
 
     async onWillSaveRecord(record, changes) {
         if (record.resModel === "mail.compose.message") {
-            const doc = createDocumentFragmentFromContent(changes.body);
+            const doc = Markup.createDocumentFragmentFromContent(changes.body);
             const partnerElements = doc.querySelectorAll('[data-oe-model="res.partner"]');
             const partnerIds = Array.from(partnerElements).map((element) =>
                 parseInt(element.dataset.oeId)

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -6,7 +6,6 @@ import { MessageConfirmDialog } from "@mail/core/common/message_confirm_dialog";
 import { NavigableList } from "@mail/core/common/navigable_list";
 import { useSuggestion } from "@mail/core/common/suggestion_hook";
 import { prettifyMessageContent } from "@mail/utils/common/format";
-import { htmlJoin } from "@mail/utils/common/html";
 import { useSelection } from "@mail/utils/common/hooks";
 import { isDragSourceExternalFile } from "@mail/utils/common/misc";
 import { rpc } from "@web/core/network/rpc";
@@ -29,9 +28,8 @@ import {
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import { createElementWithContent } from "@web/core/utils/html";
+import { Markup } from "@web/core/utils/html";
 import { FileUploader } from "@web/views/fields/file_handler";
-import { escape } from "@web/core/utils/strings";
 import { isDisplayStandalone, isIOS, isMobileOS } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
@@ -97,8 +95,9 @@ export class Composer extends Component {
         this.isIosPwa = isIOS() && isDisplayStandalone();
         this.composerActions = useComposerActions();
         this.OR_PRESS_SEND_KEYBIND = _t("or press %(send_keybind)s", {
-            send_keybind: markup(
-                this.sendKeybinds.map((key) => `<samp>${escape(key)}</samp>`).join(" + ")
+            send_keybind: Markup.join(
+                this.sendKeybinds.map((key) => Markup.build`<samp>${key}</samp>`),
+                " + "
             ),
         });
         this.store = useService("mail.store");
@@ -257,35 +256,23 @@ export class Composer extends Component {
             return _t(
                 "%(open_button)s%(icon)s%(open_em)sDiscard editing%(close_em)s%(close_button)s",
                 {
-                    open_button: markup(
-                        `<button class='btn px-1 py-0' data-type="${escape(
-                            EDIT_CLICK_TYPE.CANCEL
-                        )}">`
-                    ),
-                    close_button: markup("</button>"),
-                    icon: markup(
-                        `<i class='fa fa-times-circle pe-1' data-type="${escape(
-                            EDIT_CLICK_TYPE.CANCEL
-                        )}"></i>`
-                    ),
-                    open_em: markup(`<em data-type="${escape(EDIT_CLICK_TYPE.CANCEL)}">`),
-                    close_em: markup("</em>"),
+                    open_button: Markup.build`<button class='btn px-1 py-0' data-type="${EDIT_CLICK_TYPE.CANCEL}">`,
+                    close_button: Markup.build`</button>`,
+                    icon: Markup.build`<i class='fa fa-times-circle pe-1' data-type="${EDIT_CLICK_TYPE.CANCEL}"></i>`,
+                    open_em: Markup.build`<em data-type="${EDIT_CLICK_TYPE.CANCEL}">`,
+                    close_em: Markup.build`</em>`,
                 }
             );
         } else {
             const tags = {
-                open_samp: markup("<samp>"),
-                close_samp: markup("</samp>"),
-                open_em: markup("<em>"),
-                close_em: markup("</em>"),
-                open_cancel: markup(
-                    `<a role="button" href="#" data-type="${escape(EDIT_CLICK_TYPE.CANCEL)}">`
-                ),
-                close_cancel: markup("</a>"),
-                open_save: markup(
-                    `<a role="button" href="#" data-type="${escape(EDIT_CLICK_TYPE.SAVE)}">`
-                ),
-                close_save: markup("</a>"),
+                open_samp: Markup.build`<samp>`,
+                close_samp: Markup.build`</samp>`,
+                open_em: Markup.build`<em>`,
+                close_em: Markup.build`</em>`,
+                open_cancel: Markup.build`<a role="button" href="#" data-type="${EDIT_CLICK_TYPE.CANCEL}">`,
+                close_cancel: Markup.build`</a>`,
+                open_save: Markup.build`<a role="button" href="#" data-type="${EDIT_CLICK_TYPE.SAVE}">`,
+                close_save: Markup.build`</a>`,
             };
             return this.env.inChatter
                 ? _t(
@@ -546,7 +533,7 @@ export class Composer extends Component {
             divElement.append(
                 document.createTextNode("-- "),
                 document.createElement("br"),
-                ...createElementWithContent("div", signature).childNodes
+                ...Markup.createElementWithContent("div", signature).childNodes
             );
             signature = markup(divElement.outerHTML);
         }
@@ -621,9 +608,9 @@ export class Composer extends Component {
      */
     formatDefaultBodyForFullComposer(defaultBody, signature = "") {
         if (signature) {
-            defaultBody = htmlJoin(defaultBody, markup("<br>"), signature);
+            defaultBody = Markup.build`${defaultBody}<br/>${signature}`;
         }
-        return htmlJoin(markup("<div>"), defaultBody, markup("</div>")); // as to not wrap in <p> by html_sanitize
+        return Markup.build`<div>${defaultBody}</div>`; // as to not wrap in <p> by html_sanitize
     }
 
     clear() {

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -33,12 +33,11 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { useService } from "@web/core/utils/hooks";
-import { createElementWithContent } from "@web/core/utils/html";
+import { Markup } from "@web/core/utils/html";
 import { url } from "@web/core/utils/urls";
 import { messageActionsRegistry, useMessageActions } from "./message_actions";
 import { cookie } from "@web/core/browser/cookie";
 import { rpc } from "@web/core/network/rpc";
-import { escape } from "@web/core/utils/strings";
 import { MessageActionMenuMobile } from "./message_action_menu_mobile";
 import { discussComponentRegistry } from "./discuss_component_registry";
 
@@ -99,7 +98,7 @@ export class Message extends Component {
 
     setup() {
         super.setup();
-        this.escape = escape;
+        this.Markup = Markup;
         this.popover = usePopover(this.constructor.components.Popover, { position: "top" });
         this.state = useState({
             isEditing: false,
@@ -168,7 +167,7 @@ export class Message extends Component {
         useEffect(
             () => {
                 if (this.shadowBody.el) {
-                    const bodyEl = createElementWithContent(
+                    const bodyEl = Markup.createElementWithContent(
                         "span",
                         this.state.showTranslation
                             ? this.message.translationValue

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.Message">
         <div t-if="message.isNotification" class="o-mail-NotificationMessage text-break mx-auto text-muted opacity-75 px-3 text-center smaller" t-on-click="onClickNotificationMessage"  t-att-class="props.className" t-ref="root">
             <i t-if="message.notificationIcon" t-attf-class="{{ message.notificationIcon }} me-1"/>
-            <span class="o-mail-NotificationMessage-author d-inline" t-if="message.author and !message.body.includes(escape(message.author.name))" t-esc="message.author.name"/> <t t-out="message.body"/>
+            <span class="o-mail-NotificationMessage-author d-inline" t-if="message.author and !message.body.includes(Markup.escape(message.author.name))" t-esc="message.author.name"/> <t t-out="message.body"/>
         </div>
         <ActionSwiper t-else="" onRightSwipe="hasTouch() and props.thread?.eq(store.inbox) ? { action: () => this.message.setDone(), bgColor: 'bg-success', icon: 'fa-check-circle' } : undefined">
             <div class="o-mail-Message position-relative rounded-0"

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -5,14 +5,13 @@ import {
     htmlToTextContentInline,
     prettifyMessageContent,
 } from "@mail/utils/common/format";
-import { createDocumentFragmentFromContent } from "@mail/utils/common/html";
 
 import { browser } from "@web/core/browser/browser";
 import { stateToUrl } from "@web/core/browser/router";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { user } from "@web/core/user";
-import { createElementWithContent } from "@web/core/utils/html";
+import { Markup } from "@web/core/utils/html";
 import { url } from "@web/core/utils/urls";
 
 const { DateTime } = luxon;
@@ -24,7 +23,7 @@ export class Message extends Record {
     update(data) {
         super.update(data);
         if (this.isNotification && !this.notificationType) {
-            const htmlBody = createDocumentFragmentFromContent(this.body);
+            const htmlBody = Markup.createDocumentFragmentFromContent(this.body);
             this.notificationType = htmlBody.querySelector(".o_mail_notification")?.dataset.oeType;
         }
     }
@@ -43,7 +42,9 @@ export class Message extends Record {
             return Boolean(
                 // ".o-mail-Message-edited" is the class added by the mail.thread in _message_update_content
                 // when the message is edited
-                createDocumentFragmentFromContent(this.body).querySelector(".o-mail-Message-edited")
+                Markup.createDocumentFragmentFromContent(this.body).querySelector(
+                    ".o-mail-Message-edited"
+                )
             );
         },
     });
@@ -52,7 +53,7 @@ export class Message extends Record {
             if (this.isBodyEmpty) {
                 return false;
             }
-            const div = createElementWithContent("div", this.body);
+            const div = Markup.createElementWithContent("div", this.body);
             return Boolean(div.querySelector("a:not([data-oe-model])"));
         },
     });
@@ -104,7 +105,7 @@ export class Message extends Record {
     scheduledDatetime = Record.attr(undefined, { type: "datetime" });
     onlyEmojis = Record.attr(false, {
         compute() {
-            const bodyWithoutTags = createElementWithContent("div", this.body).textContent;
+            const bodyWithoutTags = Markup.createElementWithContent("div", this.body).textContent;
             const withoutEmojis = bodyWithoutTags.replace(EMOJI_REGEX, "");
             return (
                 bodyWithoutTags.length > 0 &&

--- a/addons/mail/static/src/core/common/message_search_hook.js
+++ b/addons/mail/static/src/core/common/message_search_hook.js
@@ -1,7 +1,7 @@
 import { useSequential } from "@mail/utils/common/hooks";
-import { createDocumentFragmentFromContent } from "@mail/utils/common/html";
 import { useState, onWillUnmount, markup } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
+import { Markup } from "@web/core/utils/html";
 import { escapeRegExp } from "@web/core/utils/strings";
 
 export const HIGHLIGHT_CLASS = "o-mail-Message-searchHighlight";
@@ -14,7 +14,7 @@ export function searchHighlight(searchTerm, target) {
     if (!searchTerm) {
         return target;
     }
-    const htmlDoc = createDocumentFragmentFromContent(target);
+    const htmlDoc = Markup.createDocumentFragmentFromContent(target);
     for (const term of searchTerm.split(" ")) {
         const regexp = new RegExp(`(${escapeRegExp(term)})`, "gi");
         // Special handling for '

--- a/addons/mail/static/src/core/web/base_recipients_list.js
+++ b/addons/mail/static/src/core/web/base_recipients_list.js
@@ -1,12 +1,11 @@
-import { _t } from "@web/core/l10n/translation";
-import { escape } from "@web/core/utils/strings";
-import { formatList } from "@web/core/l10n/utils";
-import { markup, Component } from "@odoo/owl";
-import { usePopover } from "@web/core/popover/popover_hook";
-
-import { RecipientList } from "@mail/core/web/recipient_list";
 import { Thread } from "@mail/core/common/thread_model";
+import { RecipientList } from "@mail/core/web/recipient_list";
 
+import { Component } from "@odoo/owl";
+
+import { _t } from "@web/core/l10n/translation";
+import { usePopover } from "@web/core/popover/popover_hook";
+import { Markup } from "@web/core/utils/html";
 
 export class BaseRecipientsList extends Component {
     static template = "mail.BaseRecipientsList";
@@ -19,19 +18,22 @@ export class BaseRecipientsList extends Component {
 
     /** @returns {Markup} */
     getRecipientListToHTML() {
-        const recipients = this.props.thread.recipients.slice(0, 5).map((
-            { partner }) => {
-                return `<span class="text-muted" title="${escape(
-                    partner.email || _t("no email address")
-                )}">${escape(partner.name)}</span>`;
-            });
+        const recipients = this.props.thread.recipients
+            .slice(0, 5)
+            .map(
+                ({ partner }) =>
+                    Markup.build`<span class="text-muted" title="${
+                        partner.email || _t("no email address")
+                    }">${partner.name}</span>`
+            );
         if (this.props.thread.recipients.length > 5) {
-            recipients.push(escape(
+            recipients.push(
                 _t("%(recipientCount)s more", {
-                    recipientCount: this.props.thread.recipients.length - 5}))
+                    recipientCount: this.props.thread.recipients.length - 5,
+                })
             );
         }
-        return markup(formatList(recipients));
+        return Markup.formatList(recipients);
     }
 
     /** @param {Event} ev */
@@ -40,7 +42,7 @@ export class BaseRecipientsList extends Component {
             return this.recipientsPopover.close();
         }
         this.recipientsPopover.open(ev.target, {
-            thread: this.props.thread
+            thread: this.props.thread,
         });
     }
-};
+}

--- a/addons/mail/static/src/core/web/composer_patch.js
+++ b/addons/mail/static/src/core/web/composer_patch.js
@@ -3,10 +3,10 @@ import { wrapInlinesInBlocks } from "@html_editor/utils/dom";
 import { childNodes } from "@html_editor/utils/dom_traversal";
 
 import { Composer } from "@mail/core/common/composer";
-import { createDocumentFragmentFromContent } from "@mail/utils/common/html";
 
 import { markup } from "@odoo/owl";
 
+import { Markup } from "@web/core/utils/html";
 import { patch } from "@web/core/utils/patch";
 import { renderToElement } from "@web/core/utils/render";
 
@@ -19,7 +19,7 @@ patch(Composer.prototype, {
      * @returns {ReturnType<markup>}
      */
     formatDefaultBodyForFullComposer(defaultBody, signature = "") {
-        const fragment = createDocumentFragmentFromContent(defaultBody).body;
+        const fragment = Markup.createDocumentFragmentFromContent(defaultBody).body;
         if (!fragment.firstChild) {
             fragment.append(document.createElement("BR"));
         }

--- a/addons/mail/static/src/core/web/mail_composer_bcc_list.js
+++ b/addons/mail/static/src/core/web/mail_composer_bcc_list.js
@@ -1,12 +1,12 @@
 import { MailComposerBccPopover } from "@mail/core/web/mail_composer_bcc_list_popover";
-import { formatList } from "@web/core/l10n/utils";
+
+import { Component } from "@odoo/owl";
+
+import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { registry } from "@web/core/registry";
-import { _t } from "@web/core/l10n/translation";
-import { escape } from "@web/core/utils/strings";
+import { Markup } from "@web/core/utils/html";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
-
-import { markup, Component } from "@odoo/owl";
 
 export class MailComposerBccList extends Component {
     static template = "mail.MailComposerBccList";
@@ -24,20 +24,20 @@ export class MailComposerBccList extends Component {
         const records = this.getRecords();
         for (const record of records.slice(0, this.limit)) {
             const partner = record.data;
-            elements.push(`
-                <span class="text-muted" title="${escape(
+            elements.push(
+                Markup.build`<span class="text-muted" title="${
                     partner.email_normalized || _t("no email address")
-                )}">${escape(partner.name)}</span>
-            `);
-        }
-        if (records.length > this.limit) {
-            elements.push(escape(
-                _t("%(recipientCount)s more", {
-                    recipientCount: records.length - this.limit
-                }))
+                }">${partner.name}</span>`
             );
         }
-        return markup(formatList(elements));
+        if (records.length > this.limit) {
+            elements.push(
+                _t("%(recipientCount)s more", {
+                    recipientCount: records.length - this.limit,
+                })
+            );
+        }
+        return Markup.formatList(elements);
     }
 
     /** @returns {Array[Record]} */
@@ -68,12 +68,10 @@ export class MailComposerBccList extends Component {
 
 export const mailComposerBccList = {
     component: MailComposerBccList,
-    relatedFields: (fieldInfo) => {
-        return [
-            { name: "name", type: "char" },
-            { name: "email_normalized", type: "char" }
-        ];
-    },
+    relatedFields: (fieldInfo) => [
+        { name: "name", type: "char" },
+        { name: "email_normalized", type: "char" },
+    ],
 };
 
 registry.category("fields").add("mail_composer_bcc_list", mailComposerBccList);

--- a/addons/mail/static/src/core/web/mail_composer_chatgpt.js
+++ b/addons/mail/static/src/core/web/mail_composer_chatgpt.js
@@ -1,11 +1,10 @@
 import { ChatGPTPromptDialog } from "@html_editor/main/chatgpt/chatgpt_prompt_dialog";
 
-import { htmlJoin } from "@mail/utils/common/html";
-
 import { Component, markup } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { Markup } from "@web/core/utils/html";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 
 export class MailComposerChatGPT extends Component {
@@ -24,7 +23,7 @@ export class MailComposerChatGPT extends Component {
                 root.appendChild(content);
                 const { body } = this.props.record.data;
                 this.props.record.update({
-                    body: htmlJoin(body, markup(root.innerHTML)),
+                    body: Markup.join([body, markup(root.innerHTML)]),
                 });
             },
             /**

--- a/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
+++ b/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
@@ -1,9 +1,11 @@
-import { markup, reactive } from "@odoo/owl";
-
 import { parseVersion } from "@mail/utils/common/misc";
+
+import { reactive } from "@odoo/owl";
+
 import { browser } from "@web/core/browser/browser";
-import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { Markup } from "@web/core/utils/html";
 
 export const pttExtensionHookService = {
     start(env) {
@@ -32,10 +34,8 @@ export const pttExtensionHookService = {
                 return _t(
                     "The Push-to-Talk feature is only accessible within tab focus. To enable the Push-to-Talk functionality outside of this tab, we recommend downloading our %(anchor_start)sextension%(anchor_end)s.",
                     {
-                        anchor_start: markup(
-                            `<a href="${this.downloadURL}" target="_blank" class="text-reset text-decoration-underline">`
-                        ),
-                        anchor_end: markup("</a>"),
+                        anchor_start: Markup.build`<a href="${this.downloadURL}" target="_blank" class="text-reset text-decoration-underline">`,
+                        anchor_end: Markup.build`</a>`,
                     }
                 );
             },

--- a/addons/mail/static/src/discuss/core/common/message_actions.js
+++ b/addons/mail/static/src/discuss/core/common/message_actions.js
@@ -1,10 +1,10 @@
 import { messageActionsRegistry } from "@mail/core/common/message_actions";
-import { createDocumentFragmentFromContent } from "@mail/utils/common/html";
 
 import { toRaw } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
+import { Markup } from "@web/core/utils/html";
 import { patch } from "@web/core/utils/patch";
 
 messageActionsRegistry.add("set-new-message-separator", {
@@ -36,7 +36,7 @@ const editAction = messageActionsRegistry.get("edit");
 patch(editAction, {
     /** @param {import("@mail/core/common/message").Message} component */
     onClick(component) {
-        const doc = createDocumentFragmentFromContent(component.message.body);
+        const doc = Markup.createDocumentFragmentFromContent(component.message.body);
         const mentionedChannelElements = doc.querySelectorAll(".o_channel_redirect");
         component.message.mentionedChannelPromises = Array.from(mentionedChannelElements)
             .filter((el) => el.dataset.oeModel === "discuss.channel")

--- a/addons/mail/static/src/js/emojis_mixin.js
+++ b/addons/mail/static/src/js/emojis_mixin.js
@@ -1,4 +1,4 @@
-import { htmlEscape } from "@web/core/utils/html";
+import { Markup } from "@web/core/utils/html";
 
 /**
  * Adds a span with a CSS class around chains of emojis in the message for styling purposes.
@@ -10,15 +10,15 @@ import { htmlEscape } from "@web/core/utils/html";
  * This will only match characters that have a different presentation from normal text, unlike ®
  * For alternatives, see: https://www.unicode.org/reports/tr51/#Emoji_Properties_and_Data_Files
  *
- * @param {String} message a text message to format
+ * @param {string|ReturnType<markup>} message a text message to format
+ * @returns {ReturnType<markup>}
  */
 export function formatText(message) {
-    message = htmlEscape(message);
-    message = message.replaceAll(
+    message = Markup.replaceAll(
+        message,
         /(\p{Emoji_Presentation}+)/gu,
-        "<span class='o_mail_emoji'>$1</span>"
+        Markup.build`<span class='o_mail_emoji'>$1</span>`
     );
-    message = message.replace(/(?:\r\n|\r|\n)/g, "<br>");
-
+    message = Markup.replace(message, /(?:\r\n|\r|\n)/g, Markup.build`<br>`);
     return message;
 }

--- a/addons/mail/static/src/js/tours/discuss_channel_tour.js
+++ b/addons/mail/static/src/js/tours/discuss_channel_tour.js
@@ -1,7 +1,15 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { Markup } from "@web/core/utils/html";
 
-import { markup } from "@odoo/owl";
+const tags = {
+    b_open: Markup.build`<b>`,
+    b_close: Markup.build`</b>`,
+    i_open: Markup.build`<i>>`,
+    i_close: Markup.build`</i>`,
+    p_open: Markup.build`<p>>`,
+    p_close: Markup.build`</p>`,
+};
 
 registry.category("web_tour.tours").add("discuss_channel_tour", {
     url: "/odoo",
@@ -15,32 +23,30 @@ registry.category("web_tour.tours").add("discuss_channel_tour", {
         },
         {
             trigger: ".o-mail-DiscussSidebarCategories-search",
-            content: markup(
-                _t(
-                    "<p>Channels make it easy to organize information across different topics and groups.</p> <p>Try to <b>create your first channel</b> (e.g. sales, marketing, product XYZ, after work party, etc).</p>"
-                )
+            content: _t(
+                "%{p_open}sChannels make it easy to organize information across different topics and groups.%{p_close}s %{p_open}sTry to %(b_open)screate your first channel%(b_close)s (e.g. sales, marketing, product XYZ, after work party, etc).%{p_close}s",
+                tags
             ),
             tooltipPosition: "bottom",
             run: "click",
         },
         {
             trigger: ".o_command_palette_search input",
-            content: markup(_t("<p>Create a channel here.</p>")),
+            content: _t("%{p_open}sCreate a channel here.%{p_close}s", tags),
             tooltipPosition: "bottom",
             run: `edit SomeChannel_${new Date().getTime()}`,
         },
         {
             trigger: ".o-mail-DiscussCommand-createChannel",
-            content: markup(_t("<p>Create a public or private channel.</p>")),
+            content: _t("%{p_open}sCreate a public or private channel.%{p_close}s", tags),
             run: "click",
             tooltipPosition: "right",
         },
         {
             trigger: ".o-mail-Composer-input",
-            content: markup(
-                _t(
-                    "<p><b>Write a message</b> to the members of the channel here.</p> <p>You can notify someone with <i>'@'</i> or link another channel with <i>'#'</i>. Start your message with <i>'/'</i> to get the list of possible commands.</p>"
-                )
+            content: _t(
+                "%{p_open}s%{b_open}sWrite a message%(b_close)s to the members of the channel here.%{p_close}s %{p_open}sYou can notify someone with <i>'@'</i> or link another channel with <i>'#'</i>. Start your message with <i>'/'</i> to get the list of possible commands.%{p_close}s",
+                tags
             ),
             tooltipPosition: "top",
             run: `edit SomeText_${new Date().getTime()}`,
@@ -67,10 +73,9 @@ registry.category("web_tour.tours").add("discuss_channel_tour", {
         },
         {
             trigger: ".o-mail-DiscussSidebarCategories-search",
-            content: markup(
-                _t(
-                    "<p><b>Chat with coworkers</b> in real-time using direct messages.</p><p><i>You might need to invite users from the Settings app first.</i></p>"
-                )
+            content: _t(
+                "%{p_open}s%{b_open}sChat with coworkers%(b_close)s in real-time using direct messages.%{p_close}s%{p_open}s%{i_open}sYou might need to invite users from the Settings app first.%{i_close}s%{p_close}s",
+                tags
             ),
             tooltipPosition: "bottom",
             run: "click",

--- a/addons/mail/static/src/utils/common/html.js
+++ b/addons/mail/static/src/utils/common/html.js
@@ -1,51 +1,63 @@
 import { markup } from "@odoo/owl";
 
-import { htmlEscape } from "@web/core/utils/html";
+import { Markup } from "@web/core/utils/html";
+import { patch } from "@web/core/utils/patch";
 
-/**
- * Safely creates a Document fragment from content. If content was flagged as safe HTML using
- * `markup()` it is parsed as HTML. Otherwise it is escaped and parsed as text.
- *
- * @param {string|ReturnType<markup>} content
- */
-export function createDocumentFragmentFromContent(content) {
-    return new document.defaultView.DOMParser().parseFromString(htmlEscape(content), "text/html");
-}
-
-/**
- * Applies list join on content and returns a markup result built for HTML.
- *
- * @param {Array<string|ReturnType<markup>>} args
- * @returns {ReturnType<markup>}
- */
-export function htmlJoin(...args) {
-    return markup(args.map((arg) => htmlEscape(arg)).join(""));
-}
-
-/**
- * Applies string replace on content and returns a markup result built for HTML.
- *
- * @param {string|ReturnType<markup>} content
- * @param {string | RegExp} search
- * @param {string} replacement
- * @returns {ReturnType<markup>}
- */
-export function htmlReplace(content, search, replacement) {
-    content = htmlEscape(content);
-    if (typeof search === "string" || search instanceof String) {
-        search = htmlEscape(search);
-    }
-    replacement = htmlEscape(replacement);
-    return markup(content.replace(search, replacement));
-}
-
-/**
- * Applies string trim on content and returns a markup result built for HTML.
- *
- * @param {string|ReturnType<markup>} content
- * @returns {string|ReturnType<markup>}
- */
-export function htmlTrim(content) {
-    content = htmlEscape(content);
-    return markup(content.trim());
-}
+/** @type {Markup} */
+const markupStaticPatch = {
+    /**
+     * Safely creates a Document fragment from content. If content was flagged as safe HTML using
+     * `markup()` it is parsed as HTML. Otherwise it is escaped and parsed as text.
+     *
+     * @param {string|ReturnType<markup>} content
+     */
+    createDocumentFragmentFromContent(content) {
+        return new document.defaultView.DOMParser().parseFromString(
+            Markup.escape(content),
+            "text/html"
+        );
+    },
+    /**
+     * Applies string replace on content and returns a markup result built for HTML.
+     *
+     * @param {string|ReturnType<markup>} content
+     * @param {string | RegExp} search
+     * @param {string} replacement
+     * @returns {ReturnType<markup>}
+     */
+    replace(content, search, replacement) {
+        content = Markup.escape(content);
+        if (typeof search === "string" || search instanceof String) {
+            search = Markup.escape(search);
+        }
+        replacement = Markup.escape(replacement);
+        return markup(content.replace(search, replacement));
+    },
+    /**
+     * Applies string replaceAll on content and returns a markup result built for HTML.
+     *
+     * @param {string|ReturnType<markup>} content
+     * @param {string | RegExp} search
+     * @param {string} replacement
+     * @returns {ReturnType<markup>}
+     */
+    replaceAll(content, search, replacement) {
+        content = Markup.escape(content);
+        if (typeof search === "string" || search instanceof String) {
+            search = Markup.escape(search);
+        }
+        replacement = Markup.escape(replacement);
+        return markup(content.replaceAll(search, replacement));
+    },
+    /**
+     * Applies string trim on content and returns a markup result built for HTML.
+     *
+     * @param {string|ReturnType<markup>} content
+     * @returns {string|ReturnType<markup>}
+     */
+    trim(content) {
+        content = Markup.escape(content);
+        return markup(content.trim());
+    },
+};
+patch(Markup, markupStaticPatch);

--- a/addons/mail/static/src/views/web/activity/activity_record.js
+++ b/addons/mail/static/src/views/web/activity/activity_record.js
@@ -4,7 +4,7 @@ import { Component } from "@odoo/owl";
 
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { user } from "@web/core/user";
-import { isHtmlEmpty } from "@web/core/utils/html";
+import { Markup } from "@web/core/utils/html";
 import { Field } from "@web/views/fields/field";
 import { getFormattedRecord, getImageSrcFromRecordInfo } from "@web/views/kanban/kanban_record";
 import { useViewCompiler } from "@web/views/view_compiler";
@@ -25,7 +25,7 @@ export class ActivityRecord extends Component {
         this.widget = {
             deletable: false,
             editable: false,
-            isHtmlEmpty,
+            Markup,
         };
         const { templateDocs } = this.props.archInfo;
         const templates = useViewCompiler(ActivityCompiler, templateDocs);

--- a/addons/mail/static/tests/core/search_highlight.test.js
+++ b/addons/mail/static/tests/core/search_highlight.test.js
@@ -14,9 +14,9 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
-import { markup } from "@odoo/owl";
 
 import { serverState } from "@web/../tests/web_test_helpers";
+import { Markup } from "@web/core/utils/html";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -24,12 +24,12 @@ defineMailModels();
 test("Search highlight", async () => {
     const testCases = [
         {
-            input: markup("test odoo"),
+            input: Markup.build`test odoo`,
             output: `test <span class="${HIGHLIGHT_CLASS}">odoo</span>`,
             searchTerm: "odoo",
         },
         {
-            input: markup('<a href="https://www.odoo.com">https://www.odoo.com</a>'),
+            input: Markup.build`<a href="https://www.odoo.com">https://www.odoo.com</a>`,
             output: `<a href="https://www.odoo.com">https://www.<span class="${HIGHLIGHT_CLASS}">odoo</span>.com</a>`,
             searchTerm: "odoo",
         },
@@ -39,30 +39,30 @@ test("Search highlight", async () => {
             searchTerm: "odoo",
         },
         {
-            input: markup('<a href="https://www.odoo.com">Odoo</a>'),
+            input: Markup.build`<a href="https://www.odoo.com">Odoo</a>`,
             output: `<a href="https://www.odoo.com"><span class="${HIGHLIGHT_CLASS}">Odoo</span></a>`,
             searchTerm: "odoo",
         },
         {
-            input: markup('<a href="https://www.odoo.com">Odoo</a> Odoo is a free software'),
+            input: Markup.build`<a href="https://www.odoo.com">Odoo</a> Odoo is a free software`,
             output: `<a href="https://www.odoo.com"><span class="${HIGHLIGHT_CLASS}">Odoo</span></a> <span class="${HIGHLIGHT_CLASS}">Odoo</span> is a free software`,
             searchTerm: "odoo",
         },
         {
-            input: markup("odoo is a free software"),
+            input: Markup.build`odoo is a free software`,
             output: `<span class="${HIGHLIGHT_CLASS}">odoo</span> is a free software`,
             searchTerm: "odoo",
         },
         {
-            input: markup("software ODOO is a free"),
+            input: Markup.build`software ODOO is a free`,
             output: `software <span class="${HIGHLIGHT_CLASS}">ODOO</span> is a free`,
             searchTerm: "odoo",
         },
         {
-            input: markup(`<ul>
+            input: Markup.build`<ul>
                 <li>Odoo</li>
                 <li><a href="https://odoo.com">Odoo ERP</a> Best ERP</li>
-            </ul>`),
+            </ul>`,
             output: `<ul>
                 <li><span class="${HIGHLIGHT_CLASS}">Odoo</span></li>
                 <li><a href="https://odoo.com"><span class="${HIGHLIGHT_CLASS}">Odoo</span> ERP</a> Best ERP</li>
@@ -70,42 +70,42 @@ test("Search highlight", async () => {
             searchTerm: "odoo",
         },
         {
-            input: markup("test <strong>Odoo</strong> test"),
+            input: Markup.build`test <strong>Odoo</strong> test`,
             output: `<span class="${HIGHLIGHT_CLASS}">test</span> <strong><span class="${HIGHLIGHT_CLASS}">Odoo</span></strong> <span class="${HIGHLIGHT_CLASS}">test</span>`,
             searchTerm: "odoo test",
         },
         {
-            input: markup("test <br> test"),
+            input: Markup.build`test <br> test`,
             output: `<span class="${HIGHLIGHT_CLASS}">test</span> <br> <span class="${HIGHLIGHT_CLASS}">test</span>`,
             searchTerm: "odoo test",
         },
         {
-            input: markup("<strong>test</strong> test"),
+            input: Markup.build`<strong>test</strong> test`,
             output: `<strong><span class="${HIGHLIGHT_CLASS}">test</span></strong> <span class="${HIGHLIGHT_CLASS}">test</span>`,
             searchTerm: "test",
         },
         {
-            input: markup("<strong>a</strong> test"),
+            input: Markup.build`<strong>a</strong> test`,
             output: `<strong><span class="${HIGHLIGHT_CLASS}">a</span></strong> <span class="${HIGHLIGHT_CLASS}">test</span>`,
             searchTerm: "a test",
         },
         {
-            input: markup("&amp;amp;"),
+            input: Markup.build`&amp;amp;`,
             output: `<span class="${HIGHLIGHT_CLASS}">&amp;amp;</span>`,
             searchTerm: "&amp;",
         },
         {
-            input: markup("&amp;amp;"),
+            input: Markup.build`&amp;amp;`,
             output: `<span class="${HIGHLIGHT_CLASS}">&amp;</span>amp;`,
             searchTerm: "&",
         },
         {
-            input: markup("<strong>test</strong> hello"),
+            input: Markup.build`<strong>test</strong> hello`,
             output: `<strong><span class="${HIGHLIGHT_CLASS}">test</span></strong> <span class="${HIGHLIGHT_CLASS}">hello</span>`,
             searchTerm: "test hello",
         },
         {
-            input: markup("<p>&lt;strong&gt;test&lt;/strong&gt; hello</p>"),
+            input: Markup.build`<p>&lt;strong&gt;test&lt;/strong&gt; hello</p>`,
             output: `<p>&lt;strong&gt;<span class="${HIGHLIGHT_CLASS}">test</span>&lt;/strong&gt; <span class="${HIGHLIGHT_CLASS}">hello</span></p>`,
             searchTerm: "test hello",
         },

--- a/addons/mail/static/tests/emoji/emojis_mixin.test.js
+++ b/addons/mail/static/tests/emoji/emojis_mixin.test.js
@@ -3,8 +3,8 @@ import { expect, test } from "@odoo/hoot";
 import { formatText } from "@mail/js/emojis_mixin";
 
 test("Emoji formatter handles compound emojis", () => {
-    const testString = "👩🏿test👩🏿👩t👩";
+    const testString = "<p>👩🏿test👩🏿👩t👩</p>";
     const expectedString =
-        "<span class='o_mail_emoji'>👩🏿</span>test<span class='o_mail_emoji'>👩🏿👩</span>t<span class='o_mail_emoji'>👩</span>";
-    expect(formatText(testString)).toBe(expectedString);
+        "&lt;p&gt;<span class='o_mail_emoji'>👩🏿</span>test<span class='o_mail_emoji'>👩🏿👩</span>t<span class='o_mail_emoji'>👩</span>&lt;/p&gt;";
+    expect(formatText(testString).toString()).toBe(expectedString);
 });

--- a/addons/mail/static/tests/mail_utils.test.js
+++ b/addons/mail/static/tests/mail_utils.test.js
@@ -12,6 +12,7 @@ import {
 import { describe, expect, test } from "@odoo/hoot";
 import { press } from "@odoo/hoot-dom";
 import { markup } from "@odoo/owl";
+import { Markup } from "@web/core/utils/html";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -52,39 +53,39 @@ test("addLink: utility function and special entities", () => {
     const testInputs = [
         // textContent not unescaped
         [
-            markup("<p>https://example.com/?&amp;currency_id</p>"),
+            Markup.build`<p>https://example.com/?&amp;currency_id</p>`,
             '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/?&amp;currency_id">https://example.com/?&amp;currency_id</a></p>',
         ],
         // entities not unescaped
-        [markup("&amp; &amp;amp; &gt; &lt;"), "&amp; &amp;amp; &gt; &lt;"],
+        [Markup.build`&amp; &amp;amp; &gt; &lt;`, "&amp; &amp;amp; &gt; &lt;"],
         // > and " not linkified since they are not in URL regex
         [
-            markup("<p>https://example.com/&gt;</p>"),
+            Markup.build`<p>https://example.com/&gt;</p>`,
             '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/">https://example.com/</a>&gt;</p>',
         ],
         [
-            markup('<p>https://example.com/"hello"&gt;</p>'),
+            Markup.build`<p>https://example.com/"hello"&gt;</p>`,
             '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/">https://example.com/</a>"hello"&gt;</p>',
         ],
         // & and ' linkified since they are in URL regex
         [
-            markup("<p>https://example.com/&amp;hello</p>"),
+            Markup.build`<p>https://example.com/&amp;hello</p>`,
             '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/&amp;hello">https://example.com/&amp;hello</a></p>',
         ],
         [
-            markup("<p>https://example.com/'yeah'</p>"),
+            Markup.build`<p>https://example.com/'yeah'</p>`,
             '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/\'yeah\'">https://example.com/\'yeah\'</a></p>',
         ],
-        [markup("<p>:'(</p>"), "<p>:'(</p>"],
-        [markup(":'("), ":&#x27;("],
+        [Markup.build`<p>:'(</p>`, "<p>:'(</p>"],
+        [Markup.build`:'(`, ":&#x27;("],
         ["<p>:'(</p>", "&lt;p&gt;:&#x27;(&lt;/p&gt;"],
         [":'(", ":&#x27;("],
-        [markup("<3"), "&lt;3"],
-        [markup("&lt;3"), "&lt;3"],
+        [Markup.build`<3`, "&lt;3"],
+        [Markup.build`&lt;3`, "&lt;3"],
         ["<3", "&lt;3"],
         // Already encoded url should not be encoded twice
         [
-            markup("https://odoo.com/%5B%5D"),
+            Markup.build`https://odoo.com/%5B%5D`,
             `<a target="_blank" rel="noreferrer noopener" href="https://odoo.com/%5B%5D">https://odoo.com/[]</a>`,
         ],
     ];
@@ -97,7 +98,7 @@ test("addLink: utility function and special entities", () => {
 });
 
 test("addLink: linkify inside text node (1 occurrence)", async () => {
-    const content = markup("<p>some text https://somelink.com</p>");
+    const content = Markup.build`<p>some text https://somelink.com</p>`;
     const linkified = parseAndTransform(content, addLink);
     expect(linkified.startsWith("<p>some text <a")).toBe(true);
     expect(linkified.endsWith("</a></p>")).toBe(true);
@@ -118,9 +119,7 @@ test("addLink: linkify inside text node (2 occurrences)", () => {
     // linkify may add some attributes. Since we do not care of their exact
     // stringified representation, we continue deeper assertion with query
     // selectors.
-    const content = markup(
-        "<p>some text https://somelink.com and again https://somelink2.com ...</p>"
-    );
+    const content = Markup.build`<p>some text https://somelink.com and again https://somelink2.com ...</p>`;
     const linkified = parseAndTransform(content, addLink);
     const fragment = document.createDocumentFragment();
     const div = document.createElement("div");

--- a/addons/mail/static/tests/utils/html.test.js
+++ b/addons/mail/static/tests/utils/html.test.js
@@ -1,81 +1,130 @@
-import {
-    createDocumentFragmentFromContent,
-    htmlJoin,
-    htmlReplace,
-    htmlTrim,
-} from "@mail/utils/common/html";
-
 import { describe, expect, test } from "@odoo/hoot";
-import { markup } from "@odoo/owl";
-
-const Markup = markup().constructor;
+import { Markup } from "@web/core/utils/html";
 
 describe.current.tags("headless");
 
-test("createDocumentFragmentFromContent escapes text", () => {
-    const doc = createDocumentFragmentFromContent("<p>test</p>");
+test("Markup.createDocumentFragmentFromContent escapes text", () => {
+    const doc = Markup.createDocumentFragmentFromContent("<p>test</p>");
     expect(doc.body.innerHTML).toEqual("&lt;p&gt;test&lt;/p&gt;");
 });
 
-test("createDocumentFragmentFromContent keeps html markup", () => {
-    const doc = createDocumentFragmentFromContent(markup("<p>test</p>"));
+test("Markup.createDocumentFragmentFromContent keeps html markup", () => {
+    const doc = Markup.createDocumentFragmentFromContent(Markup.build`<p>test</p>`);
     expect(doc.body.innerHTML).toEqual("<p>test</p>");
 });
 
-test("htmlJoin keeps html markup and escapes text", () => {
-    const res = htmlJoin(markup("<p>test</p>"), "<p>test</p>");
-    expect(res.toString()).toBe("<p>test</p>&lt;p&gt;test&lt;/p&gt;");
+test("Markup.replace with text/text/text replaces first with escaped text, escapes second", () => {
+    const res = Markup.replace("<p>test</p> <p>test</p>", "<p>test</p>", "<span>test</span>");
+    expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt; &lt;p&gt;test&lt;/p&gt;");
     expect(res).toBeInstanceOf(Markup);
 });
 
-test("htmlReplace with text/text/text replaces with escaped text", () => {
-    const res = htmlReplace("<p>test</p>", "<p>test</p>", "<span>test</span>");
-    expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt;");
-    expect(res).toBeInstanceOf(Markup);
-});
-
-test("htmlReplace with text/text/html replaces with html markup", () => {
-    const res = htmlReplace("<p>test</p>", "<p>test</p>", markup("<span>test</span>"));
-    expect(res.toString()).toBe("<span>test</span>");
-    expect(res).toBeInstanceOf(Markup);
-});
-
-test("htmlReplace with text/html does not find", () => {
-    const res = htmlReplace("<p>test</p>", markup("<p>test</p>"), "never found");
-    expect(res.toString()).toBe("&lt;p&gt;test&lt;/p&gt;");
-    expect(res).toBeInstanceOf(Markup);
-});
-
-test("htmlReplace with html/html/html replaces with html markup", () => {
-    const res = htmlReplace(
-        markup("<p>test</p>"),
-        markup("<p>test</p>"),
-        markup("<span>test</span>")
+test("Markup.replace with text/text/html replaces first with html markup, escapes second", () => {
+    const res = Markup.replace(
+        "<p>test</p> <p>test</p>",
+        "<p>test</p>",
+        Markup.build`<span>test</span>`
     );
-    expect(res.toString()).toBe("<span>test</span>");
+    expect(res.toString()).toBe("<span>test</span> &lt;p&gt;test&lt;/p&gt;");
     expect(res).toBeInstanceOf(Markup);
 });
 
-test("htmlReplace with html/html/text replaces with escaped text", () => {
-    const res = htmlReplace(markup("<p>test</p>"), markup("<p>test</p>"), "<span>test</span>");
-    expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt;");
+test("Markup.replace with text/html does not find, escapes both", () => {
+    const res = Markup.replace("<p>test</p> <p>test</p>", Markup.build`<p>test</p>`, "never found");
+    expect(res.toString()).toBe("&lt;p&gt;test&lt;/p&gt; &lt;p&gt;test&lt;/p&gt;");
     expect(res).toBeInstanceOf(Markup);
 });
 
-test("htmlReplace with html/text does not find", () => {
-    const res = htmlReplace(markup("<p>test</p>"), "<p>test</p>", "never found");
-    expect(res.toString()).toBe("<p>test</p>");
+test("Markup.replace with html/html/html replaces first with html markup, keeps second", () => {
+    const res = Markup.replace(
+        Markup.build`<p>test</p> <p>test</p>`,
+        Markup.build`<p>test</p>`,
+        Markup.build`<span>test</span>`
+    );
+    expect(res.toString()).toBe("<span>test</span> <p>test</p>");
     expect(res).toBeInstanceOf(Markup);
 });
 
-test("htmlTrim escapes text", () => {
-    const res = htmlTrim(" <p>test</p> ");
+test("Markup.replace with html/html/text replaces first with escaped text, keeps second", () => {
+    const res = Markup.replace(
+        Markup.build`<p>test</p> <p>test</p>`,
+        Markup.build`<p>test</p>`,
+        "<span>test</span>"
+    );
+    expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt; <p>test</p>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.replace with html/text does not find, keeps both", () => {
+    const res = Markup.replace(Markup.build`<p>test</p> <p>test</p>`, "<p>test</p>", "never found");
+    expect(res.toString()).toBe("<p>test</p> <p>test</p>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.replaceAll with text/text/text replaces all with escaped text", () => {
+    const res = Markup.replaceAll("<p>test</p> <p>test</p>", "<p>test</p>", "<span>test</span>");
+    expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt; &lt;span&gt;test&lt;/span&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.replaceAll with text/text/html replaces all with html markup", () => {
+    const res = Markup.replaceAll(
+        "<p>test</p> <p>test</p>",
+        "<p>test</p>",
+        Markup.build`<span>test</span>`
+    );
+    expect(res.toString()).toBe("<span>test</span> <span>test</span>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.replaceAll with text/html does not find, escapes all", () => {
+    const res = Markup.replaceAll(
+        "<p>test</p> <p>test</p>",
+        Markup.build`<p>test</p>`,
+        "never found"
+    );
+    expect(res.toString()).toBe("&lt;p&gt;test&lt;/p&gt; &lt;p&gt;test&lt;/p&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.replaceAll with html/html/html replaces all with html markup", () => {
+    const res = Markup.replaceAll(
+        Markup.build`<p>test</p> <p>test</p>`,
+        Markup.build`<p>test</p>`,
+        Markup.build`<span>test</span>`
+    );
+    expect(res.toString()).toBe("<span>test</span> <span>test</span>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.replaceAll with html/html/text replaces all with escaped text", () => {
+    const res = Markup.replaceAll(
+        Markup.build`<p>test</p> <p>test</p>`,
+        Markup.build`<p>test</p>`,
+        "<span>test</span>"
+    );
+    expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt; &lt;span&gt;test&lt;/span&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.replaceAll with html/text does not find, keeps all", () => {
+    const res = Markup.replaceAll(
+        Markup.build`<p>test</p> <p>test</p>`,
+        "<p>test</p>",
+        "never found"
+    );
+    expect(res.toString()).toBe("<p>test</p> <p>test</p>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.trim escapes text", () => {
+    const res = Markup.trim(" <p>test</p> ");
     expect(res.toString()).toBe("&lt;p&gt;test&lt;/p&gt;");
     expect(res).toBeInstanceOf(Markup);
 });
 
-test("htmlTrim keeps html markup", () => {
-    const res = htmlTrim(markup(" <p>test</p> "));
+test("Markup.trim keeps html markup", () => {
+    const res = Markup.trim(Markup.build` <p>test</p> `);
     expect(res.toString()).toBe("<p>test</p>");
     expect(res).toBeInstanceOf(Markup);
 });

--- a/addons/mass_mailing/static/src/js/mailing_portal_subscription_blocklist.js
+++ b/addons/mass_mailing/static/src/js/mailing_portal_subscription_blocklist.js
@@ -1,7 +1,7 @@
 /** @odoo-module alias=mailing.PortalSubscriptionBlocklist **/
 
 import { rpc } from "@web/core/network/rpc";
-import { setElementContent } from "@web/core/utils/html";
+import { Markup } from "@web/core/utils/html";
 import { renderToMarkup } from "@web/core/utils/render";
 import publicWidget from "@web/legacy/js/public/public_widget";
 
@@ -120,7 +120,7 @@ publicWidget.registry.MailingPortalSubscriptionBlocklist = publicWidget.Widget.e
                     infoKey: infoKey,
                 }
             );
-            setElementContent(updateInfo, infoContent);
+            Markup.setElementContent(updateInfo, infoContent);
             if (['blocklist_add', 'blocklist_remove'].includes(infoKey)) {
                 updateInfo.classList.add('text-success');
                 updateInfo.classList.remove('text-danger');

--- a/addons/mass_mailing/static/src/js/mailing_portal_subscription_feedback.js
+++ b/addons/mass_mailing/static/src/js/mailing_portal_subscription_feedback.js
@@ -4,7 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import publicWidget from "@web/legacy/js/public/public_widget";
 import { renderToMarkup } from "@web/core/utils/render";
-import { setElementContent } from "@web/core/utils/html";
+import { Markup } from "@web/core/utils/html";
 
 publicWidget.registry.MailingPortalSubscriptionFeedback = publicWidget.Widget.extend({
     events: {
@@ -136,7 +136,7 @@ publicWidget.registry.MailingPortalSubscriptionFeedback = publicWidget.Widget.ex
                     infoKey: infoKey,
                 }
             );
-            setElementContent(feedbackInfo, infoContent);
+            Markup.setElementContent(feedbackInfo, infoContent);
             feedbackInfo.classList.add(infoKey === 'feedback_sent' ? 'text-success' : 'text-danger');
             feedbackInfo.classList.remove('d-none', infoKey === 'feedback_sent' ? 'text-danger': 'text-success');
         }

--- a/addons/mass_mailing/static/src/js/mass_mailing_mobile_preview.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_mobile_preview.js
@@ -1,6 +1,6 @@
 import { Component, useEffect, useRef } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
-import { setElementContent } from "@web/core/utils/html";
+import { Markup } from "@web/core/utils/html";
 
 export class MassMailingMobilePreviewDialog extends Component {
     static components = {
@@ -16,7 +16,7 @@ export class MassMailingMobilePreviewDialog extends Component {
     appendPreview() {
         const iframe = this.iframeRef.el.contentDocument;
         const body = iframe.querySelector("body");
-        setElementContent(body, this.props.preview);
+        Markup.setElementContent(body, this.props.preview);
     }
 
     setup() {

--- a/addons/portal/static/src/interactions/portal_composer.js
+++ b/addons/portal/static/src/interactions/portal_composer.js
@@ -1,10 +1,11 @@
+import { Component } from "@odoo/owl";
+
 import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
-import { escape } from "@web/core/utils/strings";
 import { post } from "@web/core/network/http_service";
-import { Component } from "@odoo/owl";
 import { rpc, RPCError } from "@web/core/network/rpc";
+import { Markup } from "@web/core/utils/html";
 
 /**
  * Display the composer (according to access right)
@@ -36,15 +37,18 @@ export class PortalComposer extends Interaction {
                 options[name] = parseInt(options[name]);
             }
         }
-        return Object.assign({
-            "allow_composer": true,
-            "display_composer": false,
-            "csrf_token": odoo.csrf_token,
-            "token": false,
-            "res_model": false,
-            "res_id": false,
-            "send_button_label": _t("Send"),
-        }, options || {});
+        return Object.assign(
+            {
+                allow_composer: true,
+                display_composer: false,
+                csrf_token: odoo.csrf_token,
+                token: false,
+                res_model: false,
+                res_id: false,
+                send_button_label: _t("Send"),
+            },
+            options || {}
+        );
     }
 
     setup() {
@@ -53,8 +57,12 @@ export class PortalComposer extends Interaction {
         this.attachmentButtonEl = this.el.querySelector(".o_portal_chatter_attachment_btn");
         this.fileInputEl = this.el.querySelector(".o_portal_chatter_file_input");
         this.sendButtonEl = this.el.querySelector(".o_portal_chatter_composer_btn");
-        this.attachmentsEl = this.el.querySelector(".o_portal_chatter_composer_input .o_portal_chatter_attachments");
-        this.inputTextareaEl = this.el.querySelector('.o_portal_chatter_composer_input textarea[name="message"]');
+        this.attachmentsEl = this.el.querySelector(
+            ".o_portal_chatter_composer_input .o_portal_chatter_attachments"
+        );
+        this.inputTextareaEl = this.el.querySelector(
+            '.o_portal_chatter_composer_input textarea[name="message"]'
+        );
     }
 
     start() {
@@ -72,16 +80,22 @@ export class PortalComposer extends Interaction {
     }
 
     async onAttachmentDeleteClick(ev, currentTargetEl) {
-        const attachmentId = parseInt(currentTargetEl.closest(".o_portal_chatter_attachment").dataset.id);
-        const accessToken = this.attachments.find(attachment => attachment.id === attachmentId).access_token;
+        const attachmentId = parseInt(
+            currentTargetEl.closest(".o_portal_chatter_attachment").dataset.id
+        );
+        const accessToken = this.attachments.find(
+            (attachment) => attachment.id === attachmentId
+        ).access_token;
 
         this.sendButtonEl.disabled = true;
 
-        await this.waitFor(rpc("/portal/attachment/remove", {
-            "attachment_id": attachmentId,
-            "access_token": accessToken,
-        }));
-        this.attachments = this.attachments.filter(attachment => attachment.id !== attachmentId);
+        await this.waitFor(
+            rpc("/portal/attachment/remove", {
+                attachment_id: attachmentId,
+                access_token: accessToken,
+            })
+        );
+        this.attachments = this.attachments.filter((attachment) => attachment.id !== attachmentId);
         this.updateAttachments();
         this.sendButtonEl.disabled = false;
     }
@@ -99,29 +113,38 @@ export class PortalComposer extends Interaction {
     async onFileInputChange() {
         this.sendButtonEl.disabled = true;
 
-        await this.waitFor(Promise.all([...this.fileInputEl.files].map((file) => {
-            return new Promise((resolve, reject) => {
-                const data = this.prepareAttachmentData(file);
-                if (odoo.csrf_token) {
-                    data.csrf_token = odoo.csrf_token;
-                }
-                this.waitFor(post("/mail/attachment/upload", data)).then((res) => {
-                    let attachment = res.data["ir.attachment"][0]
-                    attachment.state = "pending";
-                    this.attachments.push(attachment);
-                    this.updateAttachments();
-                    resolve();
-                }).catch((error) => {
-                    if (error instanceof RPCError) {
-                        this.services.notification.add(
-                            _t("Could not save file <strong>%s</strong>", escape(file.name)),
-                            { type: "warning", sticky: true }
-                        );
-                        resolve();
-                    }
-                });
-            });
-        })));
+        await this.waitFor(
+            Promise.all(
+                [...this.fileInputEl.files].map(
+                    (file) =>
+                        new Promise((resolve, reject) => {
+                            const data = this.prepareAttachmentData(file);
+                            if (odoo.csrf_token) {
+                                data.csrf_token = odoo.csrf_token;
+                            }
+                            this.waitFor(post("/mail/attachment/upload", data))
+                                .then((res) => {
+                                    const attachment = res.data["ir.attachment"][0];
+                                    attachment.state = "pending";
+                                    this.attachments.push(attachment);
+                                    this.updateAttachments();
+                                    resolve();
+                                })
+                                .catch((error) => {
+                                    if (error instanceof RPCError) {
+                                        this.services.notification.add(
+                                            _t("Could not save file %(name)s", {
+                                                name: Markup.build`<strong>${file.name}</strong>`,
+                                            }),
+                                            { type: "warning", sticky: true }
+                                        );
+                                        resolve();
+                                    }
+                                });
+                        })
+                )
+            )
+        );
         // ensures any selection triggers a change, even if the same files are selected again
         this.fileInputEl.value = null;
         this.sendButtonEl.disabled = false;
@@ -159,16 +182,22 @@ export class PortalComposer extends Interaction {
 
     onSubmitCheckContent() {
         if (!this.inputTextareaEl.value.trim() && !this.attachments.length) {
-            return _t("Some fields are required. Please make sure to write a message or attach a document");
-        };
+            return _t(
+                "Some fields are required. Please make sure to write a message or attach a document"
+            );
+        }
     }
 
     updateAttachments() {
         this.attachmentsEl.replaceChildren();
-        this.renderAt("portal.Chatter.Attachments", {
-            attachments: this.attachments,
-            showDelete: true,
-        }, this.attachmentsEl);
+        this.renderAt(
+            "portal.Chatter.Attachments",
+            {
+                attachments: this.attachments,
+                showDelete: true,
+            },
+            this.attachmentsEl
+        );
     }
 
     /**
@@ -184,6 +213,4 @@ export class PortalComposer extends Interaction {
     }
 }
 
-registry
-    .category("public.interactions")
-    .add("portal.portal_composer", PortalComposer);
+registry.category("public.interactions").add("portal.portal_composer", PortalComposer);

--- a/addons/product_matrix/static/src/js/product_matrix_dialog.js
+++ b/addons/product_matrix/static/src/js/product_matrix_dialog.js
@@ -1,7 +1,8 @@
 import { Dialog } from '@web/core/dialog/dialog';
 import { formatMonetary } from "@web/views/fields/formatters";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
-import { Component, onMounted, markup, useRef } from "@odoo/owl";
+import { Markup } from "@web/core/utils/html";
+import { Component, onMounted, useRef } from "@odoo/owl";
 
 export class ProductMatrixDialog extends Component {
     static template = "product_matrix.dialog";
@@ -60,7 +61,7 @@ export class ProductMatrixDialog extends Component {
                 currencyId: currency_id,
             },
         );
-        return markup(`&nbsp;${sign}&nbsp;${formatted}&nbsp;`);
+        return Markup.build`&nbsp;${sign}&nbsp;${formatted}&nbsp;`;
     }
 
     _onConfirm() {

--- a/addons/project/static/src/views/project_task_form/project_task_form_controller.js
+++ b/addons/project/static/src/views/project_task_form/project_task_form_controller.js
@@ -2,8 +2,7 @@ import { _t } from "@web/core/l10n/translation";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { HistoryDialog } from "@html_editor/components/history_dialog/history_dialog";
 import { useService } from '@web/core/utils/hooks';
-import { markup } from '@odoo/owl';
-import { escape } from '@web/core/utils/strings';
+import { Markup } from "@web/core/utils/html";
 import { FormControllerWithHTMLExpander } from '@resource/views/form_with_html_expander/form_controller_with_html_expander';
 
 export const subTaskDeleteConfirmationMessage = _t(
@@ -51,9 +50,9 @@ export class ProjectTaskFormController extends FormControllerWithHTMLExpander {
         const historyMetadata = record.data["html_field_history_metadata"]?.[versionedFieldName];
         if (!historyMetadata) {
             this.notifications.add(
-                escape(_t(
+                _t(
                     "The task description lacks any past content that could be restored at the moment."
-                ))
+                )
             );
             return;
         }
@@ -62,13 +61,9 @@ export class ProjectTaskFormController extends FormControllerWithHTMLExpander {
             HistoryDialog,
             {
                 title: _t("Task Description History"),
-                noContentHelper: markup(
-                    `<span class='text-muted fst-italic'>${escape(
-                        _t(
-                            "The task description was empty at the time."
-                        )
-                    )}</span>`
-                ),
+                noContentHelper: Markup.build`<span class='text-muted fst-italic'>${_t(
+                    "The task description was empty at the time."
+                )}</span>`,
                 recordId: record.resId,
                 recordModel: this.props.resModel,
                 versionedFieldName,

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_examples.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_examples.js
@@ -1,12 +1,12 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { renderToMarkup } from '@web/core/utils/render';
-import { markup } from "@odoo/owl";
+import { Markup } from "@web/core/utils/html";
+import { renderToMarkup } from "@web/core/utils/render";
 
-const greenBullet = markup(`<span class="o_status d-inline-block o_status_green"></span>`);
-const orangeBullet = markup(`<span class="o_status d-inline-block text-warning"></span>`);
-const star = markup(`<a style="color: gold;" class="fa fa-star"></a>`);
-const clock = markup(`<a class="fa fa-clock-o"></a>`);
+const greenBullet = Markup.build`<span class="o_status d-inline-block o_status_green"></span>`;
+const orangeBullet = Markup.build`<span class="o_status d-inline-block text-warning"></span>`;
+const star = Markup.build`<a style="color: gold;" class="fa fa-star"></a>`;
+const clock = Markup.build`<a class="fa fa-clock-o"></a>`;
 
 const exampleData = {
     ghostColumns: [_t('New'), _t('Assigned'), _t('In Progress'), _t('Done')],

--- a/addons/web/static/src/core/l10n/translation.js
+++ b/addons/web/static/src/core/l10n/translation.js
@@ -1,7 +1,5 @@
-import { markup } from "@odoo/owl";
-
 import { Deferred } from "@web/core/utils/concurrency";
-import { htmlEscape } from "@web/core/utils/html";
+import { Markup } from "@web/core/utils/html";
 import { sprintf } from "@web/core/utils/strings";
 
 export const translationLoaded = Symbol("translationLoaded");
@@ -9,8 +7,6 @@ export const translatedTerms = {
     [translationLoaded]: false,
 };
 export const translationIsReady = new Deferred();
-
-const Markup = markup().constructor;
 
 /**
  * Translates a term, or returns the term as it is if no translation can be
@@ -29,7 +25,7 @@ const Markup = markup().constructor;
  * _t("Good morning"); // "Bonjour"
  * _t("Good morning %s", user.name); // "Bonjour Marc"
  * _t("Good morning %(newcomer)s, goodbye %(departer)s", { newcomer: Marc, departer: Mitchel }); // Bonjour Marc, au revoir Mitchel
- * _t("I love %s", markup("<blink>Minecraft</blink>")); // Markup {"J'adore <blink>Minecraft</blink>"}
+ * _t("I love %s", Markup.build`<blink>Minecraft</blink>`); // Markup {"J'adore <blink>Minecraft</blink>"}
  *
  * @param {string} term
  * @returns {string|Markup|LazyTranslatedString}
@@ -118,25 +114,7 @@ function _safeSprintf(str, ...values) {
         hasMarkup = values.some((v) => v instanceof Markup);
     }
     if (hasMarkup) {
-        return markup(sprintf(htmlEscape(str), ..._escapeNonMarkup(values)));
+        return Markup.sprintf(str, ...values);
     }
     return sprintf(str, ...values);
-}
-
-/**
- * Go through each value to be passed to sprintf and escape anything that isn't
- * a markup.
- *
- * @param {any[]|[Object]} values Values for use with sprintf.
- * @returns {any[]|[Object]}
- */
-function _escapeNonMarkup(values) {
-    if (Object.prototype.toString.call(values[0]) === "[object Object]") {
-        const sanitized = {};
-        for (const [key, value] of Object.entries(values[0])) {
-            sanitized[key] = htmlEscape(value);
-        }
-        return [sanitized];
-    }
-    return values.map((x) => htmlEscape(x));
 }

--- a/addons/web/static/src/core/utils/html.js
+++ b/addons/web/static/src/core/utils/html.js
@@ -1,59 +1,160 @@
 import { markup } from "@odoo/owl";
 
-import { escape } from "@web/core/utils/strings";
+import { formatList } from "@web/core/l10n/utils";
+import { patch } from "@web/core/utils/patch";
+import { sprintf } from "@web/core/utils/strings";
 
-const Markup = markup().constructor;
+export const Markup = markup().constructor;
+
+/** @type {Markup} */
+const markupStaticPatch = {
+    /**
+     * Safely creates a string with the given template and params. If a param was flagged as safe HTML
+     * using `markup()` it is set as it is. Otherwise it is escaped.
+     *
+     * @param {string[]} strings
+     * @param {Array<string|ReturnType<markup>>} values
+     * @returns {ReturnType<markup>}
+     */
+    build(strings, ...values) {
+        return strings.reduce((res, str, i) => Markup.join([res, markup(str), values[i]]), "");
+    },
+    /**
+     * Safely creates an element with the given content. If content was flagged as safe HTML using
+     * `markup()` it is set as innerHTML. Otherwise it is set as text.
+     *
+     * @param {string} elementName
+     * @param {string|ReturnType<markup>} content
+     * @returns {Element}
+     */
+    createElementWithContent(elementName, content) {
+        const element = document.createElement(elementName);
+        Markup.setElementContent(element, content);
+        return element;
+    },
+    /**
+     * Escapes content for HTML. Content is unchanged if it is already a Markup.
+     *
+     * @param {string|ReturnType<markup>} content
+     * @returns {ReturnType<markup>}
+     */
+    escape(content) {
+        return content instanceof Markup ? content : markup(escape(content));
+    },
+    /**
+     * Same behavior as formatList, but produces safe HTML. If the values are flagged as safe HTML using
+     * `markup()` they are set as it is. Otherwise they are escaped.
+     *
+     * @param {Array<string|ReturnType<markup>>} list The array of values to format into a list.
+     * @param {Object} [param0]
+     * @param {string} [param0.localeCode] The locale to use (e.g. en-US).
+     * @param {"standard"|"standard-short"|"or"|"or-short"|"unit"|"unit-short"|"unit-narrow"} [param0.style="standard"] The style to format the list with.
+     * @returns {ReturnType<markup>} The formatted list.
+     */
+    formatList(list, ...args) {
+        return markup(
+            formatList(
+                Array.from(list, (val) => Markup.escape(val).toString()),
+                ...args
+            )
+        );
+    },
+    /**
+     * Checks if a html content is empty. If there are only formatting tags
+     * with style attributes or a void content. Famous use case is
+     * '<p style="..." class=".."><br></p>' added by some web editor(s).
+     * Note that because the use of this method is limited, we ignore the cases
+     * like there's one <img> tag in the content. In such case, even if it's the
+     * actual content, we consider it empty.
+     *
+     * @param {string|ReturnType<markup>} content
+     * @returns {boolean} true if no content found or if containing only formatting tags
+     */
+    isEmpty(content = "") {
+        return Markup.createElementWithContent("div", content).textContent.trim() === "";
+    },
+    /**
+     * Applies list join on content and returns a markup result built for HTML.
+     *
+     * @param {Array<string|ReturnType<markup>>} args
+     * @returns {ReturnType<markup>}
+     */
+    join(list, separator = "") {
+        return markup(list.map((arg) => Markup.escape(arg)).join(Markup.escape(separator)));
+    },
+    /**
+     * Safely sets content on element. If content was flagged as safe HTML using `markup()` it is set as
+     * innerHTML. Otherwise it is set as text.
+     *
+     * @param {Element} element
+     * @param {string|ReturnType<markup>} content
+     */
+    setElementContent(element, content) {
+        if (content instanceof Markup) {
+            element.innerHTML = content;
+        } else {
+            element.textContent = content;
+        }
+    },
+    /**
+     * Same behavior as sprintf, but produces safe HTML. If the string or values are flagged as safe HTML
+     * using `markup()` they are set as it is. Otherwise they are escaped.
+     *
+     * @param {string} str The string with placeholders (%s) to insert values into.
+     * @param  {...any} values Primitive values to insert in place of placeholders.
+     * @returns {string|Markup}
+     */
+    sprintf(str, ...values) {
+        const valuesDict = values[0];
+        if (
+            valuesDict &&
+            Object.prototype.toString.call(valuesDict) === "[object Object]" &&
+            !(valuesDict instanceof Markup)
+        ) {
+            return markup(
+                sprintf(
+                    Markup.escape(str).toString(),
+                    Object.fromEntries(
+                        Object.entries(valuesDict).map(([key, value]) => [
+                            key,
+                            Markup.escape(value).toString(),
+                        ])
+                    )
+                )
+            );
+        }
+        return markup(
+            sprintf(
+                Markup.escape(str).toString(),
+                values.map((value) => Markup.escape(value).toString())
+            )
+        );
+    },
+};
+patch(Markup, markupStaticPatch);
 
 /**
- * Safely creates an element with the given content. If content was flagged as safe HTML using
- * `markup()` it is set as innerHTML. Otherwise it is set as text.
+ * Escapes a string for HTML.
  *
- * @param {string} elementName
- * @param {string|ReturnType<markup>} content
- * @returns {Element}
+ * @param {string | number} [str] the string to escape
+ * @returns {string} an escaped string
  */
-export function createElementWithContent(elementName, content) {
-    const element = document.createElement(elementName);
-    setElementContent(element, content);
-    return element;
-}
-
-/**
- * Escapes content for HTML. Content is unchanged if it is already a Markup.
- *
- * @param {string|ReturnType<markup>} content
- * @returns {ReturnType<markup>}
- */
-export function htmlEscape(content) {
-    return content instanceof Markup ? content : markup(escape(content));
-}
-
-/**
- * Checks if a html content is empty. If there are only formatting tags
- * with style attributes or a void content. Famous use case is
- * '<p style="..." class=".."><br></p>' added by some web editor(s).
- * Note that because the use of this method is limited, we ignore the cases
- * like there's one <img> tag in the content. In such case, even if it's the
- * actual content, we consider it empty.
- *
- * @param {string|ReturnType<markup>} content
- * @returns {boolean} true if no content found or if containing only formatting tags
- */
-export function isHtmlEmpty(content = "") {
-    return createElementWithContent("div", content).textContent.trim() === "";
-}
-
-/**
- * Safely sets content on element. If content was flagged as safe HTML using `markup()` it is set as
- * innerHTML. Otherwise it is set as text.
- *
- * @param {Element} element
- * @param {string|ReturnType<markup>} content
- */
-export function setElementContent(element, content) {
-    if (content instanceof Markup) {
-        element.innerHTML = content;
-    } else {
-        element.textContent = content;
+function escape(str) {
+    if (str === undefined) {
+        return "";
     }
+    if (typeof str === "number") {
+        return String(str);
+    }
+    [
+        ["&", "&amp;"],
+        ["<", "&lt;"],
+        [">", "&gt;"],
+        ["'", "&#x27;"],
+        ['"', "&quot;"],
+        ["`", "&#x60;"],
+    ].forEach((pairs) => {
+        str = String(str).replaceAll(pairs[0], pairs[1]);
+    });
+    return str;
 }

--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -1,32 +1,6 @@
 export const nbsp = "\u00a0";
 
 /**
- * Escapes a string for HTML.
- *
- * @param {string | number} [str] the string to escape
- * @returns {string} an escaped string
- */
-export function escape(str) {
-    if (str === undefined) {
-        return "";
-    }
-    if (typeof str === "number") {
-        return String(str);
-    }
-    [
-        ["&", "&amp;"],
-        ["<", "&lt;"],
-        [">", "&gt;"],
-        ["'", "&#x27;"],
-        ['"', "&quot;"],
-        ["`", "&#x60;"],
-    ].forEach((pairs) => {
-        str = String(str).replaceAll(pairs[0], pairs[1]);
-    });
-    return str;
-}
-
-/**
  * Escapes a string to use as a RegExp.
  * @url https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
  *

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -4,7 +4,6 @@ import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { x2ManyCommands } from "@web/core/orm_service";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
-import { escape } from "@web/core/utils/strings";
 import { DataPoint } from "./datapoint";
 import {
     createPropertyActiveField,
@@ -14,6 +13,7 @@ import {
     parseServerValue,
 } from "./utils";
 import { FetchRecordError } from "./errors";
+import { Markup } from "@web/core/utils/html";
 
 export class Record extends DataPoint {
     static type = "Record";
@@ -447,11 +447,11 @@ export class Record extends DataPoint {
         const isValid = !this._invalidFields.size;
         if (!isValid && displayNotification) {
             const items = [...this._invalidFields].map(
-                (fieldName) => `<li>${escape(this.fields[fieldName].string || fieldName)}</li>`,
+                (fieldName) => Markup.build`<li>${this.fields[fieldName].string || fieldName}</li>`,
                 this
             );
             this._closeInvalidFieldsNotification = this.model.notification.add(
-                markup(`<ul>${items.join("")}</ul>`),
+                Markup.build`<ul>${Markup.join(items)}</ul>`,
                 {
                     title: _t("Invalid fields: "),
                     type: "danger",
@@ -1025,10 +1025,9 @@ export class Record extends DataPoint {
                 this.dirty = false;
             } else {
                 this.model._closeUrgentSaveNotification = this.model.notification.add(
-                    markup(
-                        _t(
-                            `Heads up! Your recent changes are too large to save automatically. Please click the <i class="fa fa-cloud-upload fa-fw"></i> button now to ensure your work is saved before you exit this tab.`
-                        )
+                    _t(
+                        `Heads up! Your recent changes are too large to save automatically. Please click the %(icon)s button now to ensure your work is saved before you exit this tab.`,
+                        { icon: Markup.build`<i class="fa fa-cloud-upload fa-fw"></i>` }
                     ),
                     { sticky: true }
                 );

--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -3,14 +3,14 @@ import { localization as l10n } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { isBinarySize } from "@web/core/utils/binary";
+import { Markup } from "@web/core/utils/html";
 import {
     formatFloat as formatFloatNumber,
     humanNumber,
     insertThousandsSep,
 } from "@web/core/utils/numbers";
-import { escape, exprToBoolean } from "@web/core/utils/strings";
+import { exprToBoolean } from "@web/core/utils/strings";
 
-import { markup } from "@odoo/owl";
 import { formatCurrency } from "@web/core/currency";
 
 // -----------------------------------------------------------------------------
@@ -52,19 +52,18 @@ export function formatBinary(value) {
  * @returns {string}
  */
 export function formatBoolean(value) {
-    return markup(`
+    return Markup.build`
         <div class="o-checkbox d-inline-block me-2">
             <input id="boolean_checkbox" type="checkbox" class="form-check-input" disabled ${
                 value ? "checked" : ""
             }/>
             <label for="boolean_checkbox" class="form-check-label"/>
-        </div>`);
+        </div>`;
 }
 
 /**
  * @param {string} value
  * @param {Object} [options] additional options
- * @param {boolean} [options.escape=false] if true, escapes the formatted value
  * @param {boolean} [options.isPassword=false] if true, returns '********'
  *   instead of the formatted value
  * @returns {string}
@@ -73,23 +72,16 @@ export function formatChar(value, options) {
     if (options && options.isPassword) {
         return "*".repeat(value ? value.length : 0);
     }
-    if (options && options.escape) {
-        value = escape(value);
-    }
     return value;
 }
-formatChar.extractOptions = ({ attrs }) => {
-    return {
-        isPassword: exprToBoolean(attrs.password),
-    };
-};
+formatChar.extractOptions = ({ attrs }) => ({
+    isPassword: exprToBoolean(attrs.password),
+});
 
 export function formatDate(value, options) {
     return _formatDate(value, options);
 }
-formatDate.extractOptions = ({ options }) => {
-    return { condensed: options.condensed };
-};
+formatDate.extractOptions = ({ options }) => ({ condensed: options.condensed });
 
 export function formatDateTime(value, options = {}) {
     if (options.showTime === false) {
@@ -97,13 +89,11 @@ export function formatDateTime(value, options = {}) {
     }
     return _formatDateTime(value, options);
 }
-formatDateTime.extractOptions = ({ attrs, options }) => {
-    return {
-        ...formatDate.extractOptions({ attrs, options }),
-        showSeconds: exprToBoolean(options.show_seconds ?? true),
-        showTime: exprToBoolean(options.show_time ?? true),
-    };
-};
+formatDateTime.extractOptions = ({ attrs, options }) => ({
+    ...formatDate.extractOptions({ attrs, options }),
+    showSeconds: exprToBoolean(options.show_seconds ?? true),
+    showTime: exprToBoolean(options.show_time ?? true),
+});
 
 /**
  * Returns a string representing a float.  The result takes into account the
@@ -166,12 +156,10 @@ export function formatFloatFactor(value, options = {}) {
     }
     return formatFloatNumber(value * factor, options);
 }
-formatFloatFactor.extractOptions = ({ attrs, options }) => {
-    return {
-        ...formatFloat.extractOptions({ attrs, options }),
-        factor: options.factor,
-    };
-};
+formatFloatFactor.extractOptions = ({ attrs, options }) => ({
+    ...formatFloat.extractOptions({ attrs, options }),
+    factor: options.factor,
+});
 
 /**
  * Returns a string representing a time value, from a float.  The idea is that
@@ -215,11 +203,9 @@ export function formatFloatTime(value, options = {}) {
     }
     return `${isNegative ? "-" : ""}${hour}:${min}${sec}`;
 }
-formatFloatTime.extractOptions = ({ options }) => {
-    return {
-        displaySeconds: options.displaySeconds,
-    };
-};
+formatFloatTime.extractOptions = ({ options }) => ({
+    displaySeconds: options.displaySeconds,
+});
 
 /**
  * Returns a string representing an integer.  If the value is false, then we
@@ -250,13 +236,11 @@ export function formatInteger(value, options = {}) {
     const thousandsSep = "thousandsSep" in options ? options.thousandsSep : l10n.thousandsSep;
     return insertThousandsSep(value.toFixed(0), thousandsSep, grouping);
 }
-formatInteger.extractOptions = ({ attrs, options }) => {
-    return {
-        decimals: options.decimals || 0,
-        humanReadable: !!options.human_readable,
-        isPassword: exprToBoolean(attrs.password),
-    };
-};
+formatInteger.extractOptions = ({ attrs, options }) => ({
+    decimals: options.decimals || 0,
+    humanReadable: !!options.human_readable,
+    isPassword: exprToBoolean(attrs.password),
+});
 
 /**
  * Returns a string representing a many2one value. The value is expected to be
@@ -343,12 +327,10 @@ export function formatMonetary(value, options = {}) {
     }
     return formatCurrency(value, currencyId, options);
 }
-formatMonetary.extractOptions = ({ options }) => {
-    return {
-        noSymbol: options.no_symbol,
-        currencyField: options.currency_field,
-    };
-};
+formatMonetary.extractOptions = ({ options }) => ({
+    noSymbol: options.no_symbol,
+    currencyField: options.currency_field,
+});
 
 /**
  * Returns a string representing the given value (multiplied by 100)

--- a/addons/web/static/src/views/fields/many2one/many2one_field.js
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.js
@@ -6,14 +6,14 @@ import { _t } from "@web/core/l10n/translation";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
 import { useChildRef, useOwnedDialogs, useService } from "@web/core/utils/hooks";
-import { escape } from "@web/core/utils/strings";
 import { Many2XAutocomplete, useOpenMany2XRecord } from "@web/views/fields/relational_utils";
 import * as BarcodeScanner from "@web/core/barcode/barcode_dialog";
 import { isBarcodeScannerSupported } from "@web/core/barcode/barcode_video_scanner";
 import { standardFieldProps } from "../standard_field_props";
 
-import { Component, markup, onWillUpdateProps, useState } from "@odoo/owl";
+import { Component, onWillUpdateProps, useState } from "@odoo/owl";
 import { getFieldDomain } from "@web/model/relational_model/utils";
+import { Markup } from "@web/core/utils/html";
 
 class CreateConfirmationDialog extends Component {
     static template = "web.Many2OneField.CreateConfirmationDialog";
@@ -31,7 +31,7 @@ class CreateConfirmationDialog extends Component {
 
     get dialogContent() {
         return _t("Create %(value)s as a new %(field)s?", {
-            value: markup(`<strong>${escape(this.props.value)}</strong>`),
+            value: Markup.build`<strong>${this.props.value}</strong>`,
             field: this.props.name,
         });
     }

--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.js
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.js
@@ -7,7 +7,6 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { groupBy } from "@web/core/utils/arrays";
-import { escape } from "@web/core/utils/strings";
 import { throttleForAnimation } from "@web/core/utils/timing";
 import { getFieldDomain } from "@web/model/relational_model/utils";
 import { useSpecialData } from "@web/views/fields/relational_utils";
@@ -112,7 +111,7 @@ export class StatusBarField extends Component {
 
         // Command palette
         if (this.props.withCommand) {
-            const moveToCommandName = _t("Move to %s...", escape(this.field.string));
+            const moveToCommandName = _t("Move to %s...", this.field.string);
             useCommand(
                 moveToCommandName,
                 () => ({

--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -19,7 +19,7 @@ import { Component, onWillUnmount, useEffect, useRef, onWillStart } from "@odoo/
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { cookie } from "@web/core/browser/cookie";
-import { createElementWithContent } from "@web/core/utils/html";
+import { Markup } from "@web/core/utils/html";
 import { ReportViewMeasures } from "@web/views/view_components/report_view_measures";
 
 const NO_DATA = _t("No data");
@@ -199,7 +199,7 @@ export class GraphRenderer extends Component {
             mode: this.model.metaData.mode,
             tooltipItems: this.getTooltipItems(data, metaData, tooltipModel),
         });
-        const template = createElementWithContent("template", content);
+        const template = Markup.createElementWithContent("template", content);
         const tooltip = template.content.firstChild;
         this.containerRef.el.prepend(tooltip);
 

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -29,7 +29,7 @@ import {
 } from "@odoo/owl";
 import { downloadReport, getReportUrl } from "./reports/utils";
 import { zip } from "@web/core/utils/arrays";
-import { isHtmlEmpty } from "@web/core/utils/html";
+import { Markup } from "@web/core/utils/html";
 import { omit, pick, shallowEqual } from "@web/core/utils/objects";
 import { session } from "@web/session";
 import { exprToBoolean } from "@web/core/utils/strings";
@@ -404,7 +404,7 @@ export function makeActionManager(env, router = _router) {
                 ? evaluateExpr(domain, Object.assign({}, user.context, action.context))
                 : domain;
         if (action.help) {
-            if (isHtmlEmpty(action.help)) {
+            if (Markup.isEmpty(action.help)) {
                 delete action.help;
             }
         }

--- a/addons/web/static/src/webclient/actions/client_actions.js
+++ b/addons/web/static/src/webclient/actions/client_actions.js
@@ -2,9 +2,8 @@ import { browser } from "@web/core/browser/browser";
 import { router } from "@web/core/browser/router";
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
-import { escape, sprintf } from "@web/core/utils/strings";
 
-import { markup } from "@odoo/owl";
+import { Markup } from "@web/core/utils/html";
 
 export function displayNotificationAction(env, action) {
     const params = action.params || {};
@@ -14,10 +13,10 @@ export function displayNotificationAction(env, action) {
         title: params.title,
         type: params.type || "info",
     };
-    const links = (params.links || []).map((link) => {
-        return `<a href="${escape(link.url)}" target="_blank">${escape(link.label)}</a>`;
-    });
-    const message = markup(sprintf(escape(params.message), ...links));
+    const links = (params.links || []).map(
+        (link) => Markup.build`<a href="${link.url}" target="_blank">${link.label}</a>`
+    );
+    const message = Markup.sprintf(params.message, ...links);
     env.services.notification.add(message, options);
     return params.next;
 }

--- a/addons/web/static/src/webclient/user_menu/user_menu_items.js
+++ b/addons/web/static/src/webclient/user_menu/user_menu_items.js
@@ -1,12 +1,12 @@
-import { Component, markup } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { isMacOS } from "@web/core/browser/feature_detection";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { user } from "@web/core/user";
-import { escape } from "@web/core/utils/strings";
 import { session } from "@web/session";
 import { browser } from "../../core/browser/browser";
 import { registry } from "../../core/registry";
+import { Markup } from "@web/core/utils/html";
 
 function documentationItem(env) {
     const documentationURL = "https://www.odoo.com/documentation/master";
@@ -54,12 +54,11 @@ function shortCutsItem(env) {
         type: "item",
         id: "shortcuts",
         hide: env.isSmall,
-        description: markup(
-            `<div class="d-flex align-items-center justify-content-between">
-                <span>${escape(translatedText)}</span>
+        description: Markup.build`
+            <div class="d-flex align-items-center justify-content-between">
+                <span>${translatedText}</span>
                 <span class="fw-bold">${isMacOS() ? "CMD" : "CTRL"}+K</span>
-            </div>`
-        ),
+            </div>`,
         callback: () => {
             env.services.command.openMainPalette({ FooterComponent: ShortcutsFooterComponent });
         },

--- a/addons/web/static/tests/core/code_editor.test.js
+++ b/addons/web/static/tests/core/code_editor.test.js
@@ -1,7 +1,7 @@
 import { expect, test } from "@odoo/hoot";
 import { queryAll, queryAllTexts, queryOne } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
-import { Component, markup, useState, xml } from "@odoo/owl";
+import { Component, useState, xml } from "@odoo/owl";
 import {
     editAce,
     mountWithCleanup,
@@ -11,6 +11,7 @@ import {
 } from "@web/../tests/web_test_helpers";
 
 import { CodeEditor } from "@web/core/code_editor/code_editor";
+import { Markup } from "@web/core/utils/html";
 import { debounce } from "@web/core/utils/timing";
 
 preloadBundle("web.ace_lib");
@@ -101,7 +102,7 @@ test("CodeEditor shouldn't accepts markup values", async () => {
     }
 
     const codeEditor = await mountWithCleanup(GrandParent);
-    const textMarkup = markup("<div>Some Text</div>");
+    const textMarkup = Markup.build`<div>Some Text</div>`;
 
     codeEditor.state.value = textMarkup;
     await animationFrame();

--- a/addons/web/static/tests/core/effects/effect_service.test.js
+++ b/addons/web/static/tests/core/effects/effect_service.test.js
@@ -1,17 +1,18 @@
 import { beforeEach, expect, test } from "@odoo/hoot";
 import { click, manuallyDispatchProgrammaticEvent, queryOne } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
-import { Component, markup, xml } from "@odoo/owl";
+import { Component, xml } from "@odoo/owl";
 import { getService, mountWithCleanup, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { user } from "@web/core/user";
+import { Markup } from "@web/core/utils/html";
 
 let effectParams;
 
 beforeEach(async () => {
     await mountWithCleanup(MainComponentsContainer);
     effectParams = {
-        message: markup("<div>Congrats!</div>"),
+        message: Markup.build`<div>Congrats!</div>`,
     };
 });
 

--- a/addons/web/static/tests/core/l10n/translation.test.js
+++ b/addons/web/static/tests/core/l10n/translation.test.js
@@ -9,6 +9,7 @@ import {
     serverState,
 } from "@web/../tests/web_test_helpers";
 import { _t, translatedTerms, translationLoaded } from "@web/core/l10n/translation";
+import { Markup } from "@web/core/utils/html";
 import { session } from "@web/session";
 
 import { Component, markup, xml } from "@odoo/owl";
@@ -167,8 +168,8 @@ describe("_t with markups", () => {
         const translatedStr = _t(
             "FREE %(blink_start)sROBUX%(blink_end)s, please contact %(email)s",
             {
-                blink_start: markup("<blink>"),
-                blink_end: markup("</blink>"),
+                blink_start: Markup.build`<blink>`,
+                blink_end: Markup.build`</blink>`,
                 email: maliciousUserInput,
             }
         );
@@ -181,7 +182,7 @@ describe("_t with markups", () => {
         translatedTerms[translationLoaded] = true;
         const maliciousTranslation = "<script>document.write('pizza hawai')</script> %s";
         patchTranslations({ "I love %s": maliciousTranslation });
-        const translatedStr = _t("I love %s", markup("<blink>Mario Kart</blink>"));
+        const translatedStr = _t("I love %s", Markup.build`<blink>Mario Kart</blink>`);
         expect(translatedStr.valueOf()).toBe(
             "&lt;script&gt;document.write(&#x27;pizza hawai&#x27;)&lt;/script&gt; <blink>Mario Kart</blink>"
         );

--- a/addons/web/static/tests/core/notifications/notifications.test.js
+++ b/addons/web/static/tests/core/notifications/notifications.test.js
@@ -1,10 +1,10 @@
 import { expect, test } from "@odoo/hoot";
 import { click, hover, leave } from "@odoo/hoot-dom";
 import { advanceTime, animationFrame, runAllTimers } from "@odoo/hoot-mock";
-import { markup } from "@odoo/owl";
 import { getService, makeMockEnv, mountWithCleanup } from "@web/../tests/web_test_helpers";
 
 import { registry } from "@web/core/registry";
+import { Markup } from "@web/core/utils/html";
 
 test("can display a basic notification", async () => {
     await makeMockEnv();
@@ -49,7 +49,7 @@ test("can display a notification with markup content", async () => {
         .category("main_components")
         .get("NotificationContainer");
     await mountWithCleanup(NotificationContainer, { props, noMainContainer: true });
-    getService("notification").add(markup("<b>I'm a <i>markup</i> notification</b>"));
+    getService("notification").add(Markup.build`<b>I'm a <i>markup</i> notification</b>`);
     await animationFrame();
     expect(".o_notification").toHaveCount(1);
     expect(".o_notification_content").toHaveInnerHTML("<b>I'm a <i>markup</i> notification</b>");

--- a/addons/web/static/tests/core/utils/html.test.js
+++ b/addons/web/static/tests/core/utils/html.test.js
@@ -1,55 +1,139 @@
-import { markup } from "@odoo/owl";
-
-const Markup = markup().constructor;
-
 import { describe, expect, test } from "@odoo/hoot";
-import {
-    createElementWithContent,
-    htmlEscape,
-    isHtmlEmpty,
-    setElementContent,
-} from "@web/core/utils/html";
+import { Markup } from "@web/core/utils/html";
 
 describe.current.tags("headless");
 
-test("createElementWithContent escapes text", () => {
-    const res = createElementWithContent("div", "<p>test</p>");
+test("Markup.createElementWithContent escapes text", () => {
+    const res = Markup.createElementWithContent("div", "<p>test</p>");
     expect(res.outerHTML).toBe("<div>&lt;p&gt;test&lt;/p&gt;</div>");
 });
 
-test("createElementWithContent keeps html markup", () => {
-    const res = createElementWithContent("div", markup("<p>test</p>"));
+test("Markup.createElementWithContent keeps html markup", () => {
+    const res = Markup.createElementWithContent("div", Markup.build`<p>test</p>`);
     expect(res.outerHTML).toBe("<div><p>test</p></div>");
 });
 
-test("htmlEscape escapes text", () => {
-    const res = htmlEscape("<p>test</p>");
+test("Markup.escape escapes text", () => {
+    const res = Markup.escape("<p>test</p>");
     expect(res.toString()).toBe("&lt;p&gt;test&lt;/p&gt;");
     expect(res).toBeInstanceOf(Markup);
 });
 
-test("htmlEscape keeps html markup", () => {
-    const res = htmlEscape(markup("<p>test</p>"));
+test("Markup.escape keeps html markup", () => {
+    const res = Markup.escape(Markup.build`<p>test</p>`);
     expect(res.toString()).toBe("<p>test</p>");
     expect(res).toBeInstanceOf(Markup);
 });
 
-test("isHtmlEmpty does not consider text as empty", () => {
-    expect(isHtmlEmpty("<p></p>")).toBe(false);
+test("Markup.escape", () => {
+    expect(Markup.escape("<a>this is a link</a>").toString()).toBe(
+        "&lt;a&gt;this is a link&lt;/a&gt;"
+    );
+    expect(Markup.escape(`<a href="https://www.odoo.com">odoo<a>`).toString()).toBe(
+        `&lt;a href=&quot;https://www.odoo.com&quot;&gt;odoo&lt;a&gt;`
+    );
+    expect(Markup.escape(`<a href='https://www.odoo.com'>odoo<a>`).toString()).toBe(
+        `&lt;a href=&#x27;https://www.odoo.com&#x27;&gt;odoo&lt;a&gt;`
+    );
+    expect(Markup.escape("<a href='https://www.odoo.com'>Odoo`s website<a>").toString()).toBe(
+        `&lt;a href=&#x27;https://www.odoo.com&#x27;&gt;Odoo&#x60;s website&lt;a&gt;`
+    );
 });
 
-test("isHtmlEmpty considers empty html markup as empty", () => {
-    expect(isHtmlEmpty(markup("<p></p>"))).toBe(true);
+test("Markup.formatList", () => {
+    const list = ["<p>test 1</p>", Markup.build`<p>test 2</p>`, "&lt;p&gt;test 3&lt;/p&gt;"];
+    const res = Markup.formatList(list, { localeCode: "fr-FR" });
+    expect(res.toString()).toBe(
+        "&lt;p&gt;test 1&lt;/p&gt;, <p>test 2</p> et &amp;lt;p&amp;gt;test 3&amp;lt;/p&amp;gt;"
+    );
+    expect(res).toBeInstanceOf(Markup);
 });
 
-test("setElementContent escapes text", () => {
+test("Markup.join keeps html markup and escapes text", () => {
+    const res = Markup.join([Markup.build`<p>test</p>`, "<p>test</p>"]);
+    expect(res.toString()).toBe("<p>test</p>&lt;p&gt;test&lt;/p&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.join escapes text separator", () => {
+    const res = Markup.join(["a", "b"], "<br>");
+    expect(res.toString()).toBe("a&lt;br&gt;b");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.join keeps html separator", () => {
+    const res = Markup.join(["a", "b"], Markup.build`<br>`);
+    expect(res.toString()).toBe("a<br>b");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.build`` escapes text in param", () => {
+    const res = Markup.build`<div>${"<p>test</p>"}</div>`;
+    expect(res.toString()).toBe("<div>&lt;p&gt;test&lt;/p&gt;</div>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.build`` keeps html markup in param", () => {
+    const res = Markup.build`<div>${Markup.build`<p>test</p>`}</div>`;
+    expect(res.toString()).toBe("<div><p>test</p></div>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.build`` doesn't change text in template", () => {
+    const res = Markup.build`&lt;p&gt;test&lt;/p&gt;`;
+    expect(res.toString()).toBe("&lt;p&gt;test&lt;/p&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.sprintf escapes str with list params", () => {
+    const res = Markup.sprintf("<p>%s</p>", "Hi");
+    expect(res.toString()).toBe("&lt;p&gt;Hi&lt;/p&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.sprintf escapes list params", () => {
+    const res = Markup.sprintf(
+        Markup.build`<p>%s</p>%s`,
+        Markup.build`<span>test 1</span>`,
+        `<span>test 2</span>`
+    );
+    expect(res.toString()).toBe(
+        "<p><span>test 1</span>,&lt;span&gt;test 2&lt;/span&gt;</p>undefined"
+    );
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.sprintf escapes str with object params", () => {
+    const res = Markup.sprintf("<p>%(t1)s</p>", { t1: "Hi" });
+    expect(res.toString()).toBe("&lt;p&gt;Hi&lt;/p&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.sprintf escapes object param", () => {
+    const res = Markup.sprintf(Markup.build`<p>%(t1)s</p>%(t2)s`, {
+        t1: `<span>test 1</span>`,
+        t2: Markup.build`<span>test 2</span>`,
+    });
+    expect(res.toString()).toBe("<p>&lt;span&gt;test 1&lt;/span&gt;</p><span>test 2</span>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("Markup.isEmpty does not consider text as empty", () => {
+    expect(Markup.isEmpty("<p></p>")).toBe(false);
+});
+
+test("Markup.isEmpty considers empty html markup as empty", () => {
+    expect(Markup.isEmpty(Markup.build`<p></p>`)).toBe(true);
+});
+
+test("Markup.setElementContent escapes text", () => {
     const div = document.createElement("div");
-    setElementContent(div, "<p>test</p>");
+    Markup.setElementContent(div, "<p>test</p>");
     expect(div.innerHTML).toBe("&lt;p&gt;test&lt;/p&gt;");
 });
 
-test("setElementContent keeps html markup", () => {
+test("Markup.setElementContent keeps html markup", () => {
     const div = document.createElement("div");
-    setElementContent(div, markup("<p>test</p>"));
+    Markup.setElementContent(div, Markup.build`<p>test</p>`);
     expect(div.innerHTML).toBe("<p>test</p>");
 });

--- a/addons/web/static/tests/core/utils/strings.test.js
+++ b/addons/web/static/tests/core/utils/strings.test.js
@@ -3,7 +3,6 @@ import { patchTranslations } from "@web/../tests/web_test_helpers";
 
 import {
     capitalize,
-    escape,
     escapeRegExp,
     intersperse,
     isEmail,
@@ -14,19 +13,6 @@ import {
 import { _t } from "@web/core/l10n/translation";
 
 describe.current.tags("headless");
-
-test("escape", () => {
-    expect(escape("<a>this is a link</a>")).toBe("&lt;a&gt;this is a link&lt;/a&gt;");
-    expect(escape(`<a href="https://www.odoo.com">odoo<a>`)).toBe(
-        `&lt;a href=&quot;https://www.odoo.com&quot;&gt;odoo&lt;a&gt;`
-    );
-    expect(escape(`<a href='https://www.odoo.com'>odoo<a>`)).toBe(
-        `&lt;a href=&#x27;https://www.odoo.com&#x27;&gt;odoo&lt;a&gt;`
-    );
-    expect(escape("<a href='https://www.odoo.com'>Odoo`s website<a>")).toBe(
-        `&lt;a href=&#x27;https://www.odoo.com&#x27;&gt;Odoo&#x60;s website&lt;a&gt;`
-    );
-});
 
 test("escapeRegExp", () => {
     expect(escapeRegExp("")).toBe("");

--- a/addons/web/static/tests/views/fields/formatters.test.js
+++ b/addons/web/static/tests/views/fields/formatters.test.js
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { patchTranslations, patchWithCleanup } from "@web/../tests/web_test_helpers";
 
-import { markup } from "@odoo/owl";
 import { currencies } from "@web/core/currency";
 import { localization } from "@web/core/l10n/localization";
+import { Markup } from "@web/core/utils/html";
 import {
     formatFloat,
     formatFloatFactor,
@@ -103,7 +103,7 @@ test("formatText", () => {
     expect(formatText("value")).toBe("value");
     expect(formatText(1)).toBe("1");
     expect(formatText(1.5)).toBe("1.5");
-    expect(formatText(markup("<p>This is a Test</p>"))).toBe("<p>This is a Test</p>");
+    expect(formatText(Markup.build`<p>This is a Test</p>`)).toBe("<p>This is a Test</p>");
     expect(formatText([1, 2, 3, 4, 5])).toBe("1,2,3,4,5");
     expect(formatText({ a: 1, b: 2 })).toBe("[object Object]");
 });

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -28,7 +28,7 @@ import {
     runAllTimers,
     tick,
 } from "@odoo/hoot-mock";
-import { Component, markup, onRendered, onWillStart, useRef, xml } from "@odoo/owl";
+import { Component, onRendered, onWillStart, useRef, xml } from "@odoo/owl";
 import {
     getPickerApplyButton,
     getPickerCell,
@@ -81,6 +81,7 @@ import { Domain } from "@web/core/domain";
 import { registry } from "@web/core/registry";
 import { user } from "@web/core/user";
 import { useBus } from "@web/core/utils/hooks";
+import { Markup } from "@web/core/utils/html";
 import { RelationalModel } from "@web/model/relational_model/relational_model";
 import { session } from "@web/session";
 import { floatField } from "@web/views/fields/float/float_field";
@@ -5142,7 +5143,7 @@ test(`custom delete confirmation dialog`, async () => {
     class CautiousController extends listView.Controller {
         get deleteConfirmationDialogProps() {
             const props = super.deleteConfirmationDialogProps;
-            props.body = markup(`<span class="text-danger">These are the consequences</span>`);
+            props.body = Markup.build`<span class="text-danger">These are the consequences</span>`;
             return props;
         }
     }

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -1,7 +1,6 @@
 import { expect, test } from "@odoo/hoot";
 import { queryAll, queryAllTexts, queryFirst, queryOne, queryText } from "@odoo/hoot-dom";
 import { Deferred, animationFrame, mockDate } from "@odoo/hoot-mock";
-import { markup } from "@odoo/owl";
 import {
     contains,
     defineModels,
@@ -26,6 +25,7 @@ import {
 } from "@web/../tests/web_test_helpers";
 import { _t } from "@web/core/l10n/translation";
 import { download } from "@web/core/network/download";
+import { Markup } from "@web/core/utils/html";
 import { PivotController } from "@web/views/pivot/pivot_controller";
 import { WebClient } from "@web/webclient/webclient";
 
@@ -2642,7 +2642,7 @@ test("empty pivot view with action helper", async () => {
         type: "pivot",
         resModel: "partner",
         context: { search_default_small_than_0: true },
-        noContentHelp: markup(`<p class="abc">click to add a foo</p>`),
+        noContentHelp: Markup.build`<p class="abc">click to add a foo</p>`,
         config: {
             views: [[false, "search"]],
         },
@@ -2669,7 +2669,7 @@ test("empty pivot view with sample data", async () => {
         type: "pivot",
         resModel: "partner",
         context: { search_default_small_than_0: true },
-        noContentHelp: markup('<p class="abc">click to add a foo</p>'),
+        noContentHelp: Markup.build`<p class="abc">click to add a foo</p>`,
         config: {
             views: [[false, "search"]],
         },
@@ -2695,7 +2695,7 @@ test("non empty pivot view with sample data", async () => {
     await mountView({
         type: "pivot",
         resModel: "partner",
-        noContentHelp: markup('<p class="abc">click to add a foo</p>'),
+        noContentHelp: Markup.build`<p class="abc">click to add a foo</p>`,
         config: {
             views: [[false, "search"]],
         },

--- a/addons/web/static/tests/webclient/mobile/burger_user_menu.test.js
+++ b/addons/web/static/tests/webclient/mobile/burger_user_menu.test.js
@@ -1,6 +1,7 @@
 import { BurgerUserMenu } from "@web/webclient/burger_menu/burger_user_menu/burger_user_menu";
 import { preferencesItem } from "@web/webclient/user_menu/user_menu_items";
 import { registry } from "@web/core/registry";
+import { Markup } from "@web/core/utils/html";
 
 import {
     clearRegistry,
@@ -10,7 +11,6 @@ import {
 } from "@web/../tests/web_test_helpers";
 import { beforeEach, expect, test } from "@odoo/hoot";
 import { click, queryAll, queryAllTexts } from "@odoo/hoot-dom";
-import { markup } from "@odoo/owl";
 
 const userMenuRegistry = registry.category("user_menuitems");
 
@@ -70,7 +70,7 @@ test("can be rendered", async () => {
     userMenuRegistry.add("html_item", () => ({
         type: "item",
         id: "html",
-        description: markup(`<div>HTML<i class="fa fa-check px-2"></i></div>`),
+        description: Markup.build`<div>HTML<i class="fa fa-check px-2"></i></div>`,
         callback: () => {
             expect.step("callback html_item");
         },

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1,12 +1,12 @@
 import { clamp } from "@web/core/utils/numbers";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { useService, useBus } from "@web/core/utils/hooks";
+import { Markup } from "@web/core/utils/html";
 import publicWidget from "@web/legacy/js/public/public_widget";
 import { useDragAndDrop } from "@web_editor/js/editor/drag_and_drop";
 import options from "@web_editor/js/editor/snippets.options";
 import weUtils from "@web_editor/js/common/utils";
 import * as gridUtils from "@web_editor/js/common/grid_layout_utils";
-import { escape } from "@web/core/utils/strings";
 import { closestElement, isUnremovable } from "@web_editor/js/editor/odoo-editor/src/utils/utils";
 import { debounce, throttleForAnimation } from "@web/core/utils/timing";
 import { uniqueId } from "@web/core/utils/functions";
@@ -16,7 +16,6 @@ import { Toolbar } from "@web_editor/js/editor/toolbar";
 import {
     Component,
     EventBus,
-    markup,
     onMounted,
     onWillStart,
     onWillUnmount,
@@ -3289,8 +3288,8 @@ class SnippetsMenu extends Component {
                     displayName: snippetEl.getAttribute("name"),
                     category: category,
                     content: snippetEl.children,
-                    thumbnailSrc: escape(snippetEl.dataset.oeThumbnail),
-                    imagePreview: escape(snippetEl.dataset.oImagePreview),
+                    thumbnailSrc: snippetEl.dataset.oeThumbnail,
+                    imagePreview: snippetEl.dataset.oImagePreview,
                     visible: true,
                     baseBody: snippetEl.children[0],
                     data: {...snippetEl.dataset, ...snippetEl.children[0].dataset},
@@ -5184,7 +5183,7 @@ class SnippetsMenu extends Component {
         const linkUrl = '/odoo/action-base.open_module_tree/' + encodeURIComponent(moduleID);
         this.dialog.add(ConfirmationDialog, {
             title: _t("Install %s", snippetName),
-            body: markup(`${escape(bodyText)}\n<a href="${linkUrl}" target="_blank">${escape(linkText)}</a>`),
+            body: Markup.build`${bodyText}\n<a href="${linkUrl}" target="_blank">${linkText}</a>`,
             confirm: async () => {
                 try {
                     await this.orm.call("ir.module.module", "button_immediate_install", [[moduleID]]);
@@ -5196,7 +5195,7 @@ class SnippetsMenu extends Component {
                     });
                 } catch (e) {
                     if (e instanceof RPCError) {
-                        const message = escape(_t("Could not install module %s", snippetName));
+                        const message = _t("Could not install module %s", snippetName);
                         this.notification.add(message, {
                             type: "danger",
                             sticky: true,

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_dialog.js
@@ -1,8 +1,8 @@
 import { Component, useState, markup, onWillDestroy, status } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { rpc } from "@web/core/network/rpc";
-import { escape } from "@web/core/utils/strings";
 import { _t } from "@web/core/l10n/translation";
+import { Markup } from "@web/core/utils/html";
 
 /**
  * General component for common logic between different dialogs.
@@ -32,16 +32,11 @@ export class ChatGPTDialog extends Component {
         this._confirm();
     }
     formatContent(content) {
-        return markup([...this._postprocessGeneratedContent(content).childNodes].map(child => {
-            // Escape all text.
-            const nodes = new Set([...child.querySelectorAll('*')].flatMap(node => node.childNodes));
-            nodes.forEach(node => {
-                if (node.nodeType === Node.TEXT_NODE) {
-                    node.textContent = escape(node.textContent);
-                }
-            });
-            return child.outerHTML;
-        }).join(''));
+        return Markup.join(
+            [...this._postprocessGeneratedContent(content).childNodes].map((child) =>
+                markup(child.outerHTML)
+            )
+        );
     }
 
     //--------------------------------------------------------------------------

--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -185,11 +185,8 @@ export const tourService = {
                     browser.console.log("tour succeeded");
                     let message = tourConfig.rainbowManMessage || tour.rainbowManMessage;
                     if (message) {
-                        message = window.DOMPurify.sanitize(tourConfig.rainbowManMessage);
-                        effect.add({
-                            type: "rainbow_man",
-                            message: markup(message),
-                        });
+                        message = markup(window.DOMPurify.sanitize(tourConfig.rainbowManMessage));
+                        effect.add({ type: "rainbow_man", message });
                     }
 
                     const nextTour = await orm.call("web_tour.tour", "consume", [tour.name]);

--- a/addons/website/static/src/components/fullscreen_indication/fullscreen_indication.js
+++ b/addons/website/static/src/components/fullscreen_indication/fullscreen_indication.js
@@ -1,5 +1,6 @@
 import { useBus } from "@web/core/utils/hooks";
-import { EventBus, Component, useState, markup } from "@odoo/owl";
+import { Markup } from "@web/core/utils/html";
+import { EventBus, Component, useState } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 
 export class FullscreenIndication extends Component {
@@ -27,6 +28,6 @@ export class FullscreenIndication extends Component {
     }
 
     get fullScreenIndicationText() {
-        return _t("Press %(key)s to exit full screen", { key: markup("<span>esc</span>") });
+        return _t("Press %(key)s to exit full screen", { key: Markup.build`<span>esc</span>` });
     }
 }

--- a/addons/website/static/src/components/website_loader/website_loader.js
+++ b/addons/website/static/src/components/website_loader/website_loader.js
@@ -1,8 +1,8 @@
 import { rpc } from "@web/core/network/rpc";
 import { useBus, useService } from "@web/core/utils/hooks";
-import { sprintf } from "@web/core/utils/strings";
+import { Markup } from "@web/core/utils/html";
 import { _t } from "@web/core/l10n/translation";
-import { EventBus, Component, markup, useEffect, useState } from "@odoo/owl";
+import { EventBus, Component, useEffect, useState } from "@odoo/owl";
 
 export class WebsiteLoader extends Component {
     static props = {
@@ -273,10 +273,8 @@ export class WebsiteLoader extends Component {
         const messagesList = websiteFeaturesMessages.filter((msg) => {
             if (filteredIds.includes(msg.id)) {
                 if (msg.name) {
-                    const highlight = sprintf(
-                        '<span class="o_website_loader_text_highlight">%s</span>', msg.name
-                    );
-                    msg.description = markup(sprintf(msg.description, highlight));
+                    const highlight = Markup.build`<span class="o_website_loader_text_highlight">${msg.name}</span>`;
+                    msg.description = Markup.sprintf(msg.description, highlight);
                 }
                 return true;
             }

--- a/addons/website/static/src/core/website_map_service.js
+++ b/addons/website/static/src/core/website_map_service.js
@@ -3,8 +3,7 @@ import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { user } from "@web/core/user";
-import { markup } from "@odoo/owl";
-import { escape } from "@web/core/utils/strings";
+import { Markup } from "@web/core/utils/html";
 
 registry.category("services").add("website_map", {
     dependencies: ["public.interactions", "notification"],
@@ -52,10 +51,10 @@ registry.category("services").add("website_map", {
                                 const message = _t("Cannot load google map.");
                                 const urlTitle = _t("Check your configuration.");
                                 notification.add(
-                                    markup(`<div>
-                                        <span>${escape(message)}</span><br/>
-                                        <a href="/odoo/action-website.action_website_configuration">${escape(urlTitle)}</a>
-                                    </div>`),
+                                    Markup.build`<div>
+                                        <span>${message}</span><br/>
+                                        <a href="/odoo/action-website.action_website_configuration">${urlTitle}</a>
+                                    </div>`,
                                     { type: 'warning', sticky: true }
                                 );
                             }

--- a/addons/website/static/src/interactions/video/media_video.js
+++ b/addons/website/static/src/interactions/video/media_video.js
@@ -2,7 +2,6 @@ import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 
 import { _t } from "@web/core/l10n/translation";
-import { escape } from "@web/core/utils/strings";
 import { setupAutoplay, triggerAutoplay } from "@website/utils/videos";
 
 export class MediaVideo extends Interaction {
@@ -55,7 +54,7 @@ export class MediaVideo extends Interaction {
         // 'data-oe-expression' one (the latter is used as a workaround in 10.0
         // system but should obviously be reviewed in master).
 
-        let src = escape(this.el.getAttribute('oe-expression') || this.el.getAttribute('src'));
+        let src = this.el.getAttribute('oe-expression') || this.el.getAttribute('src');
         // Validate the src to only accept supported domains we can trust
 
         let m = src.match(/^(?:https?:)?\/\/([^/?#]+)/);

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -8,7 +8,6 @@ import { redirect } from "@web/core/utils/urls";
 import { _t } from "@web/core/l10n/translation";
 import { memoize } from "@web/core/utils/functions";
 import { renderToElement } from "@web/core/utils/render";
-import { escape } from "@web/core/utils/strings";
 import { formatDate, formatDateTime } from "@web/core/l10n/dates";
 import wUtils from '@website/js/utils';
 
@@ -218,7 +217,7 @@ const FormEditor = options.Class.extend({
         if (!field.id) {
             field.id = weUtils.generateHTMLId();
         }
-        const params = { field: { ...field }, defaultName: escape(_t("Field")) };
+        const params = { field: { ...field }, defaultName: _t("Field") };
         if (["url", "email", "tel"].includes(field.type)) {
             params.field.inputType = field.type;
         }

--- a/addons/website/static/tests/interactions/snippets/chart.test.js
+++ b/addons/website/static/tests/interactions/snippets/chart.test.js
@@ -1,12 +1,9 @@
-import {
-    startInteractions,
-    setupInteractionWhiteList,
-} from "@web/../tests/public/helpers";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { queryOne } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
-import { escape } from "@web/core/utils/strings";
+import { Markup } from "@web/core/utils/html";
 import { patch } from "@web/core/utils/patch";
 import { Chart } from "@website/snippets/s_chart/chart";
 
@@ -18,23 +15,23 @@ patch(Chart.prototype, {
     setup() {
         super.setup();
         this.noAnimation = true;
-    }
+    },
 });
 
 test("chart is started when there is an element .s_chart", async () => {
-    const { core } = await startInteractions(`
+    const { core } = await startInteractions(Markup.build`
         <div class="s_chart" data-type="bar" data-legend-position="top" data-tooltip-display="true" data-stacked="false" data-border-width="2"
-            data-data="${escape(`{
-                "labels": ["First", "Second", "Third", "Fourth", "Fifth"],
-                "datasets": [
+            data-data="${JSON.stringify({
+                labels: ["First", "Second", "Third", "Fourth", "Fifth"],
+                datasets: [
                     {
-                        "label": "One",
-                        "data": ["12", "24", "18", "17", "10"],
-                        "backgroundColor": "o-color-1",
-                        "borderColor": "o-color-1"
-                    }
-                ]
-            }`)}">
+                        label: "One",
+                        data: ["12", "24", "18", "17", "10"],
+                        backgroundColor: "o-color-1",
+                        borderColor: "o-color-1",
+                    },
+                ],
+            })}">
         <h2>A Chart Title</h2>
         <canvas/>
     </div>

--- a/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.js
+++ b/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.js
@@ -21,9 +21,7 @@ export class ExhibitorConnectClosedDialog extends Component {
         const sponsorData = await rpc(
             `/event_sponsor/${encodeURIComponent(this.props.sponsorId)}/read`
         );
-        // empty string on falsy so markup doesn't create a "false" string
-        sponsorData.website_description = sponsorData.website_description || "";
-        sponsorData.website_description = markup(sponsorData.website_description);
+        sponsorData.website_description = markup(sponsorData.website_description || "");
         this.formatEventStartRemaining = formatDuration(sponsorData.event_start_remaining, true);
         this.sponsorData = sponsorData;
     }

--- a/addons/website_forum/static/src/interactions/website_forum.js
+++ b/addons/website_forum/static/src/interactions/website_forum.js
@@ -7,12 +7,12 @@ import { cookie } from "@web/core/browser/cookie";;
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
-import { escape } from "@web/core/utils/strings";
 import { session } from "@web/session";
 import { scrollTo, closestScrollable } from "@web_editor/js/common/scrolling";
 import { loadWysiwygFromTextarea } from "@web_editor/js/frontend/loadWysiwygFromTextarea";
 import { FlagMarkAsOffensiveDialog } from "../components/flag_mark_as_offensive/flag_mark_as_offensive";
 import { WebsiteForumTagsWrapper } from "../components/website_forum_tags_wrapper";
+import { Markup } from "@web/core/utils/html";
 
 export class WebsiteForum extends Interaction {
     static selector = ".website_forum";
@@ -166,7 +166,9 @@ export class WebsiteForum extends Interaction {
     warnIfPublicUser() {
         if (session.is_website_user) {
             this.displayAccessDeniedNotification(
-                markup(`<a href='/web/login'>` + escape(_t("Oh no! Please sign in to perform this action")) + "</a>")
+                Markup.build`<a href='/web/login'>${_t(
+                    "Oh no! Please sign in to perform this action"
+                )}</a>`
             );
             return true;
         }
@@ -257,13 +259,13 @@ export class WebsiteForum extends Interaction {
         }
         const forumId = parseInt(this.el.ownerDocument.getElementById("wrapwrap").dataset.forum_id);
         const additionalInfoWithForumID = forumId
-            ? markup(`<br/>
+            ? Markup.build`<br/>
                 <a class="alert-link" href="/forum/${forumId}/faq">
-                    ${escape(_t("Read the guidelines to know how to gain karma."))}
-                </a>`)
+                    ${_t("Read the guidelines to know how to gain karma.")}
+                </a>`
             : "";
         const translatedText = _t("karma is required to perform this action. ");
-        const message = markup(`${karma} ${escape(translatedText)}${additionalInfoWithForumID}`);
+        const message = Markup.build`${karma} ${translatedText}${additionalInfoWithForumID}`;
         this.services.notification.add(message, {
             type: "warning",
             sticky: false,

--- a/addons/website_slides/static/src/interactions/enroll_email.js
+++ b/addons/website_slides/static/src/interactions/enroll_email.js
@@ -2,8 +2,8 @@ import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 
 import { _t } from "@web/core/l10n/translation";
-import { escape } from "@web/core/utils/strings";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { Markup } from "@web/core/utils/html";
 
 export class EnrollEmail extends Interaction {
     static selector = "#wrapwrap";
@@ -26,30 +26,23 @@ export class EnrollEmail extends Interaction {
             confirmLabel: _t("Yes"),
             confim: async () => {
                 const { error, done } = await this.waitFor(
-                    this.services.orm.call(
-                        "slide.channel",
-                        "action_request_access",
-                        [channelId],
-                    )
+                    this.services.orm.call("slide.channel", "action_request_access", [channelId])
                 );
-                const message = done ? _t("Request sent!") : error || _t("Unknown error, try again.");
+                const message = done
+                    ? _t("Request sent!")
+                    : error || _t("Unknown error, try again.");
 
                 const newAlertEl = document.createElement("div");
                 newAlertEl.classList.add("alert", done ? "alert-success" : "alert-danger");
                 newAlertEl.role = "alert";
-                const strongEl = document.createElement("strong");
-                strongEl.innerText = escape(message);
-                newAlertEl.appendChild(strongEl);
-
+                newAlertEl.appendChild(Markup.createElementWithContent("strong", message));
                 this.insert(newAlertEl, alertEl, "afterend");
                 alertEl.remove();
             },
             cancelLabel: _t("Cancel"),
-            cancel: () => { },
+            cancel: () => {},
         });
     }
 }
 
-registry
-    .category("public.interactions")
-    .add("website_slides.enroll_email", EnrollEmail);
+registry.category("public.interactions").add("website_slides.enroll_email", EnrollEmail);

--- a/addons/website_slides/static/src/interactions/slide_like.js
+++ b/addons/website_slides/static/src/interactions/slide_like.js
@@ -1,15 +1,19 @@
 import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 
-import { escape, sprintf } from '@web/core/utils/strings';
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
+import { Markup } from "@web/core/utils/html";
 
 export class SlideLike extends Interaction {
     static selector = ".o_wslides_js_slide_like";
     dynamicContent = {
-        ".o_wslides_js_slide_like_up": { "t-on-click": (ev) => this.onClick(ev.currentTarget.dataset.slideId, 'like') },
-        ".o_wslides_js_slide_like_down": { "t-on-click": (ev) => this.onClick(ev.currentTarget.dataset.slideId, 'dislike') },
+        ".o_wslides_js_slide_like_up": {
+            "t-on-click": (ev) => this.onClick(ev.currentTarget.dataset.slideId, "like"),
+        },
+        ".o_wslides_js_slide_like_down": {
+            "t-on-click": (ev) => this.onClick(ev.currentTarget.dataset.slideId, "dislike"),
+        },
     };
 
     /**
@@ -17,14 +21,14 @@ export class SlideLike extends Interaction {
      */
     showAlert(message) {
         const bsPopover = window.Popover.getOrCreateInstance(this.el, {
-            trigger: 'focus',
-            delay: { 'hide': 300 },
-            placement: 'bottom',
-            container: 'body',
+            trigger: "focus",
+            delay: { hide: 300 },
+            placement: "bottom",
+            container: "body",
             html: true,
-            content: function () {
-                return message;
-            }
+            content() {
+                return Markup.escape(message).toString();
+            },
         });
         bsPopover.show();
         this.registerCleanup(() => bsPopover.dispose());
@@ -35,47 +39,64 @@ export class SlideLike extends Interaction {
      * @param {string} voteType
      */
     async onClick(slideId, voteType) {
-        const data = await this.waitFor(rpc('/slides/slide/like', {
-            slide_id: slideId,
-            upvote: voteType === 'like',
-        }))
+        const data = await this.waitFor(
+            rpc("/slides/slide/like", {
+                slide_id: slideId,
+                upvote: voteType === "like",
+            })
+        );
         if (!data.error) {
-            const likeButtonEl = this.el.querySelector('span.o_wslides_js_slide_like_up');
-            const likesIcon = likeButtonEl.querySelector('i.fa');
-            const dislikeButtonEl = this.el.querySelector('span.o_wslides_js_slide_like_down');
-            const dislikesIcon = dislikeButtonEl.querySelector('i.fa');
+            const likeButtonEl = this.el.querySelector("span.o_wslides_js_slide_like_up");
+            const likesIcon = likeButtonEl.querySelector("i.fa");
+            const dislikeButtonEl = this.el.querySelector("span.o_wslides_js_slide_like_down");
+            const dislikesIcon = dislikeButtonEl.querySelector("i.fa");
 
             // update 'thumbs-up' button with latest state
             likeButtonEl.dataset.userVote = data.user_vote;
-            likeButtonEl.querySelector('span').innerText = data.likes;
+            likeButtonEl.querySelector("span").innerText = data.likes;
             likesIcon.classList.toggle("fa-thumbs-up", data.user_vote === 1);
             likesIcon.classList.toggle("fa-thumbs-o-up", data.user_vote !== 1);
             // update 'thumbs-down' button with latest state
             dislikeButtonEl.dataset.userVote = data.user_vote;
-            dislikeButtonEl.querySelector('span').innerText = data.dislikes;
+            dislikeButtonEl.querySelector("span").innerText = data.dislikes;
             dislikesIcon.classList.toggle("fa-thumbs-down", data.user_vote === -1);
             dislikesIcon.classList.toggle("fa-thumbs-o-down", data.user_vote !== -1);
         } else {
-            if (data.error === 'public_user') {
-                const message = data.error_signup_allowed ?
-                    _t('Please <a href="/web/login?redirect=%(url)s">login</a> or <a href="/web/signup?redirect=%(url)s">create an account</a> to vote for this lesson') :
-                    _t('Please <a href="/web/login?redirect=%(url)s">login</a> to vote for this lesson');
-                this.showAlert(sprintf(message, { url: encodeURIComponent(document.URL) }));
-            } else if (data.error === 'slide_access') {
-                this.showAlert(escape(_t('You don\'t have access to this lesson')));
-            } else if (data.error === 'channel_membership_required') {
-                this.showAlert(escape(_t('You must be member of this course to vote')));
-            } else if (data.error === 'channel_comment_disabled') {
-                this.showAlert(escape(_t('Votes and comments are disabled for this course')));
-            } else if (data.error === 'channel_karma_required') {
-                this.showAlert(escape(_t('You don\'t have enough karma to vote')));
+            if (data.error === "public_user") {
+                const tags = {
+                    a_login_open: Markup.build`<a href="/web/login?redirect=${encodeURIComponent(
+                        document.URL
+                    )}">`,
+                    a_login_close: Markup.build`</a>`,
+                    a_signup_open: Markup.build`<a href="/web/signup?redirect=${encodeURIComponent(
+                        document.URL
+                    )}">`,
+                    a_signup_close: Markup.build`</a>`,
+                };
+                this.showAlert(
+                    data.error_signup_allowed
+                        ? _t(
+                              "Please %(a_login_open)slogin%(a_login_close)s or %(a_signup_open)screate an account%(a_signup_close)s to vote for this lesson",
+                              tags
+                          )
+                        : _t(
+                              "Please %(a_login_open)slogin%(a_login_close)s to vote for this lesson",
+                              tags
+                          )
+                );
+            } else if (data.error === "slide_access") {
+                this.showAlert(_t("You don't have access to this lesson"));
+            } else if (data.error === "channel_membership_required") {
+                this.showAlert(_t("You must be member of this course to vote"));
+            } else if (data.error === "channel_comment_disabled") {
+                this.showAlert(_t("Votes and comments are disabled for this course"));
+            } else if (data.error === "channel_karma_required") {
+                this.showAlert(_t("You don't have enough karma to vote"));
             } else {
-                this.showAlert(escape(_t('Unknown error')));
+                this.showAlert(_t("Unknown error"));
             }
         }
     }
 }
 
-registry
-    .category("public.interactions")
-    .add("website_slides.slide_like", SlideLike);
+registry.category("public.interactions").add("website_slides.slide_like", SlideLike);

--- a/addons/website_slides/static/src/js/slides_course_quiz.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz.js
@@ -1,7 +1,7 @@
     import publicWidget from '@web/legacy/js/public/public_widget';
     import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+    import { Markup } from "@web/core/utils/html";
     import { renderToElement } from "@web/core/utils/render";
-    import { escape } from "@web/core/utils/strings";
     import { session } from "@web/session";
     import CourseJoin from '@website_slides/js/slides_course_join';
     import QuestionFormWidget from '@website_slides/js/slides_course_quiz_question_form';
@@ -559,7 +559,9 @@
             const questionId = parseInt(question.dataset.questionId);
             this.call('dialog', 'add', ConfirmationDialog, {
                 title: _t('Delete Question'),
-                body: markup(_t('Are you sure you want to delete this question "<strong>%s</strong>"?', escape(question.dataset.title))),
+                body: _t('Are you sure you want to delete this question "%(title)s"?', {
+                    title: Markup.build`<strong>${question.dataset.title}</strong>`,
+                }),
                 cancel: () => {
                 },
                 cancelLabel: _t('No'),


### PR DESCRIPTION
**Proof of concept, not yet validated by anyone**
Alternative version with separate functions: https://github.com/odoo/odoo/pull/199300

\* = account, html_editor, iap_mail, lunch, portal, project, web_editor,
  web_tour, website, website_event_exhibitor, website_forum,
  website_slides

Manually calling markup() and escaping parameters is cumbersome and prone to error. The goal of this commit is to provide tools that developers can use to safely manipulate HTML string, without requiring any security check.

To achieve this, the commit introduces introduce a template literal that combines both markup and escape in a safe way.

The opportunity is taken to remove `escape` from string in favor of the more robust `htmlEscape` which takes markup into account properly (both as parameter and as return value).

The opportunity is also taken to add markup awareness to `formatList` and `sprintf`, as well as improve the various other safe construct methods.

Finally the various places in code where those tools could be used have been adapted, on top of adapting most remaining markup() calls to follow correct guidelines, in particular to markup as close as possible to the source of the "safeness" (rather than close to the usage).

https://github.com/odoo/enterprise/pull/80213