### PR TITLE
[FIX] web: Reduce quality of images in kanban view

### DIFF
--- a/addons/web/static/src/views/fields/attachment_image/attachment_image_field.xml
+++ b/addons/web/static/src/views/fields/attachment_image/attachment_image_field.xml
@@ -3,7 +3,10 @@
 
     <t t-name="web.AttachmentImageField">
         <div class="o_attachment_image">
-            <img t-if="props.record.data[props.name]" t-attf-src="/web/image/{{ props.record.data[props.name][0] }}?unique=1" t-att-title="!!env.debug and props.record.data[props.name][1]" alt="Image" />
+            <img t-if="props.record.data[props.name]"
+                t-attf-src="/web/image/{{ props.record.data[props.name][0] }}/300x300?unique=1"
+                t-att-title="!!env.debug and props.record.data[props.name][1]"
+                alt="Image"/>
         </div>
     </t>
 


### PR DESCRIPTION
Steps to reproduce:
-------------------

- Install 'Project' module
- Create a new project
- Create 20 tasks and set a large image as `Kanban Cover` for each task (for test purposes, create multiple stages and move the tasks inside them to ensure that all tasks are visible and loaded by default)
- Open the Odoo instance in a new incognito browser (or erase cache)
- Login and open the created tasks in kanban view

Issue:
------

Kanban view is slow to load.

Cause:
------

Retrieving the covers in their original quality/size.

Solution:
---------

Hardcode the image height and width in the call of the route so that the retrieved image is cropped/resized.

opw-4438965