### PR TITLE
[IMP] im_livechat, mail: show operator call status on channel invite

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -83,6 +83,7 @@ class Im_LivechatChannel(models.Model):
         "user_ids.channel_ids.livechat_active",
         "user_ids.channel_ids.livechat_channel_id",
         "user_ids.channel_ids.livechat_operator_id",
+        "user_ids.channel_member_ids",
         "user_ids.im_status",
         "user_ids.is_in_call",
         "user_ids.partner_id",

--- a/addons/im_livechat/models/res_partner.py
+++ b/addons/im_livechat/models/res_partner.py
@@ -44,6 +44,9 @@ class ResPartner(models.Model):
                     "livechat_expertise": partner.user_ids.sudo().livechat_expertise_ids.mapped("name"),
                     "livechat_languages": languages[1:],
                 },
+                # sudo - res.partner: checking if operator is in call for live
+                # chat invitation is acceptable.
+                extra_fields=[Store.Attr("is_in_call", sudo=True)]
             )
 
     @api.depends('user_ids.livechat_username')

--- a/addons/im_livechat/models/res_users.py
+++ b/addons/im_livechat/models/res_users.py
@@ -21,7 +21,6 @@ class ResUsers(models.Model):
         help="When forwarding live chat conversations, the chatbot will prioritize users with matching expertise.",
     )
     has_access_livechat = fields.Boolean(compute='_compute_has_access_livechat', string='Has access to Livechat', store=False, readonly=True)
-    is_in_call = fields.Boolean("Is in call", compute="_compute_is_in_call")
 
     @property
     def SELF_READABLE_FIELDS(self):
@@ -74,14 +73,6 @@ class ResUsers(models.Model):
     def _compute_has_access_livechat(self):
         for user in self.sudo():
             user.has_access_livechat = user.has_group('im_livechat.im_livechat_group_user')
-
-    @api.depends("partner_id.channel_member_ids.rtc_session_ids")
-    def _compute_is_in_call(self):
-        rtc_sessions = self.env["discuss.channel.rtc.session"].search(
-            [("partner_id", "in", self.partner_id.ids)]
-        )
-        for user in self:
-            user.is_in_call = user.partner_id in rtc_sessions.partner_id
 
     def _init_store_data(self, store: Store):
         super()._init_store_data(store)

--- a/addons/im_livechat/static/src/core/web/channel_invitation_patch.scss
+++ b/addons/im_livechat/static/src/core/web/channel_invitation_patch.scss
@@ -1,0 +1,3 @@
+.o-discuss-ChannelInvitation-inCallTextColor {
+    color: lighten($o-action, 5%);
+}

--- a/addons/im_livechat/static/src/core/web/channel_invitation_patch.xml
+++ b/addons/im_livechat/static/src/core/web/channel_invitation_patch.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="discuss.ChannelInvitation.main" t-inherit-mode="extension">
+        <xpath expr="//*[@name='selectablePartnerDetail']//*" position="inside">
+            <span t-if="props.thread?.channel_type === 'livechat' and selectablePartner.is_in_call" class="flex-shrink-0 opacity-75 smaller mx-2">
+                <i class="fa fa-volume-up o-discuss-inCallIconColor me-1"/>
+                <span class="o-discuss-ChannelInvitation-inCallTextColor">in a call</span>
+            </span>
+        </xpath>
         <xpath expr="//*[@name='selectablePartnerDetail']" position="replace">
             <t t-if="props.thread?.channel_type !== 'livechat' or !selectablePartner.lang_name">$0</t>
-            <div t-else="" class="d-flex flex-column flex-grow-1">
+            <div t-else="" class="d-flex flex-column flex-grow-1 overflow-hidden">
                 <t>$0</t>
                 <div class="d-flex flex-wrap align-items-center gap-1 ms-2">
                     <span class="d-flex text-start fs-6 gap-1">

--- a/addons/im_livechat/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/res_partner.js
@@ -1,6 +1,6 @@
 import { mailModels } from "@mail/../tests/mail_test_helpers";
 
-import { getKwArgs, serverState } from "@web/../tests/web_test_helpers";
+import { getKwArgs, makeKwArgs, serverState } from "@web/../tests/web_test_helpers";
 
 export class ResPartner extends mailModels.ResPartner {
     /**
@@ -56,6 +56,7 @@ export class ResPartner extends mailModels.ResPartner {
                 }
             }
             store.add(this.browse(partner.id), data);
+            store.add(this.browse(partner.id), makeKwArgs({ extra_fields: ["is_in_call"] }));
         }
     }
     /**

--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -21,7 +21,7 @@ class DiscussChannelRtcSession(models.Model):
 
     channel_member_id = fields.Many2one('discuss.channel.member', required=True, ondelete='cascade')
     channel_id = fields.Many2one('discuss.channel', related='channel_member_id.channel_id', store=True, readonly=True)
-    partner_id = fields.Many2one('res.partner', related='channel_member_id.partner_id', string="Partner")
+    partner_id = fields.Many2one('res.partner', related='channel_member_id.partner_id', string="Partner", store=True, index=True)
     guest_id = fields.Many2one('mail.guest', related='channel_member_id.guest_id')
 
     write_date = fields.Datetime("Last Updated On", index=True)

--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -18,6 +18,13 @@ class ResPartner(models.Model):
         copy=False,
     )
     channel_member_ids = fields.One2many("discuss.channel.member", "partner_id")
+    is_in_call = fields.Boolean(compute="_compute_is_in_call", groups="base.group_system")
+    rtc_session_ids = fields.One2many("discuss.channel.rtc.session", "partner_id")
+
+    @api.depends("rtc_session_ids")
+    def _compute_is_in_call(self):
+        for partner in self:
+            partner.is_in_call = bool(partner.rtc_session_ids)
 
     @api.readonly
     @api.model

--- a/addons/mail/models/discuss/res_users.py
+++ b/addons/mail/models/discuss/res_users.py
@@ -1,11 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models
+from odoo import api, fields, models
 from odoo.addons.mail.tools.discuss import Store
 
 
 class ResUsers(models.Model):
     _inherit = "res.users"
+
+    is_in_call = fields.Boolean("Is in call", related="partner_id.is_in_call")
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -27,7 +27,9 @@
                                 </div>
                             </div>
                             <t name="selectablePartnerDetail">
-                                <span class="flex-grow-1 mx-2 text-truncate text-start" t-esc="selectablePartner.name"/>
+                                <div class="d-flex flex-grow-1 mx-2 overflow-hidden align-items-baseline">
+                                    <span class="text-truncate" t-esc="selectablePartner.name"/>
+                                </div>
                             </t>
                             <input class="form-check-input flex-shrink-0 me-1" type="checkbox" t-att-checked="selectablePartner.in(selectedPartners) ? 'checked' : undefined"/>
                         </li>

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -20,6 +20,7 @@ export class ResPartner extends webModels.ResPartner {
         relation: "ir.attachment",
         string: "Main attachment",
     });
+    is_in_call = fields.Boolean({ compute: "_compute_is_in_call" });
 
     _views = {
         [`search, ${DEFAULT_MAIL_SEARCH_ID}`]: /* xml */ `<search/>`,
@@ -31,6 +32,16 @@ export class ResPartner extends webModels.ResPartner {
                 <chatter/>
             </form>`,
     };
+
+    _compute_is_in_call() {
+        for (const partner of this) {
+            partner.is_in_call =
+                this.env["discuss.channel.member"].search([
+                    ["rtc_session_ids", "!=", []],
+                    ["partner_id", "=", partner.id],
+                ]).length > 0;
+        }
+    }
 
     /**
      * @param {string} [search]
@@ -203,12 +214,14 @@ export class ResPartner extends webModels.ResPartner {
      * @param {number[]} ids
      * @returns {Record<string, ModelRecord>}
      */
-    _to_store(ids, store, fields) {
-        const kwargs = getKwArgs(arguments, "id", "store", "fields");
+    _to_store(ids, store, fields, extra_fields) {
+        const kwargs = getKwArgs(arguments, "id", "store", "fields", "extra_fields");
         fields = kwargs.fields;
+        extra_fields = kwargs.extra_fields ?? [];
         if (!fields) {
             fields = ["avatar_128", "name", "email", "active", "im_status", "is_company", "user"];
         }
+        fields = [...fields, extra_fields];
 
         /** @type {import("mock_models").ResCountry} */
         const ResCountry = this.env["res.country"];


### PR DESCRIPTION
Live chat operators are considered as anavailable to take over new conversations when they are already in a call. However, there is no way for an operator to know which operator is already in a call from the channel invitation panel. This PR adds this information.

task-4593168

upgrade: https://github.com/odoo/upgrade/pull/7376