### PR TITLE
[FIX] html_editor: properly indent `LI` element in collaboration

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -512,19 +512,23 @@ export class ListPlugin extends Plugin {
      */
     indentLI(li) {
         const lip = this.document.createElement("li");
+        const parentLi = li.parentElement;
+        const nextSiblingLi = li.nextSibling;
         lip.classList.add("oe-nested");
         const destul =
             li.previousElementSibling?.querySelector("ol, ul") ||
             li.nextElementSibling?.querySelector("ol, ul") ||
             li.closest("ol, ul");
-
+        const cursors = this.dependencies.selection.preserveSelection();
+        // Remove the LI first to force a removal mutation in collaboration.
+        parentLi.removeChild(li);
         const ul = createList(this.document, this.getListMode(destul));
         lip.append(ul);
 
-        const cursors = this.dependencies.selection.preserveSelection();
         // lip replaces li
         li.before(lip);
         ul.append(li);
+        parentLi.insertBefore(lip, nextSiblingLi);
         cursors.update((cursor) => {
             if (cursor.node === lip.parentNode) {
                 const childIndex = childNodeIndex(lip);

--- a/addons/html_editor/static/tests/odoo_collaboration.test.js
+++ b/addons/html_editor/static/tests/odoo_collaboration.test.js
@@ -125,7 +125,7 @@ class Wysiwygs extends Component {
         <div>
             <t t-foreach="this.props.peerIds" t-as="peerId" t-key="peerId">
                 <Wysiwyg
-                    config="getConfig({peerId})"
+                    config="getConfig({peerId, content: this.props.content})"
                     t-key="peerId"
                     iframe="true"
                     onLoad="(editor) => this.onLoad(peerId, editor)"
@@ -137,6 +137,7 @@ class Wysiwygs extends Component {
     static props = {
         peerIds: Array,
         pool: Object,
+        content: String,
     };
     setup() {
         this.peerResolvers = {};
@@ -152,7 +153,7 @@ class Wysiwygs extends Component {
         });
         this.lastStepId = 0;
     }
-    getConfig({ peerId }) {
+    getConfig({ peerId, content }) {
         const busService = {
             subscribe() {},
             unsubscribe() {},
@@ -163,7 +164,7 @@ class Wysiwygs extends Component {
         };
         return {
             Plugins: [...MAIN_PLUGINS, ...COLLABORATION_PLUGINS],
-            content: initialValue.replaceAll("[]", ""),
+            content: content.replaceAll("[]", ""),
             collaboration: {
                 peerId,
                 busService,
@@ -280,12 +281,12 @@ class Wysiwygs extends Component {
             // if (configSelection) {
             //     editable.focus();
             // }
-            setSelection(getSelection(editable, initialValue));
+            setSelection(getSelection(editable, this.props.content));
         };
     }
 }
 
-async function createPeers(peerIds) {
+async function createPeers(peerIds, content = initialValue) {
     /**
      * @type PeerPool
      */
@@ -298,6 +299,7 @@ async function createPeers(peerIds) {
         props: {
             peerIds,
             pool,
+            content,
         },
     });
     await wysiwygs.peerPromises;
@@ -1150,6 +1152,33 @@ describe("History steps Ids", () => {
             `<p>a</p><p><br></p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
         );
         editor.destroy();
+    });
+});
+
+describe("Indent List", () => {
+    test("should sync `li` indent properly", async () => {
+        const pool = await createPeers(["p1", "p2"], `<ul><li>a[]</li></ul>`);
+        const peers = pool.peers;
+
+        await peers.p1.focus();
+        await peers.p2.focus();
+        await peers.p1.openDataChannel(peers.p2);
+        await peers.p2.openDataChannel(peers.p1);
+
+        peers.p1.editor.editable.dispatchEvent(
+            new KeyboardEvent("keydown", {
+                key: "Tab",
+                code: "Tab",
+                bubbles: true,
+            })
+        );
+        await peers.p2.focus();
+        expect(peers.p2.getValue()).toBe(
+            `<ul><li class="oe-nested"><ul><li>a[]</li></ul></li></ul>`,
+            {
+                message: "p2 should not have the same document as p1",
+            }
+        );
     });
 });
 


### PR DESCRIPTION
**Problem**:
When collaborating, indenting a list item (`LI`) using "Tab"
causes a structural issue in the DOM.

**Scenario**:
1. User C1 and C2 both edit a list item in collaboration mode.
   - Common structure at the beginning:
     `<ul><li>[]</li></ul>`
   - When C1 presses "Tab", the DOM updates to:
     `<ul (new)><li (new)><ul><li>[]</li></ul></li (new)></ul (new)>`
2. At this point C2 still has:
   `<ul><li>[]</li></ul>`
3. When C2 receives a mutation update, it tries to insert:
   `<ul (new)><li (new)><ul><li>[]</li></ul></li (new)></ul (new)>`
   before:
   `<li>[]</li>`
   - **Issue**: `li` is already inside `li (new)`, causing a DOM error.

**Solution**:
- Before inserting, remove `li2`, then reinsert it at the
  correct position.
- This ensures the `.before()` operation does not conflict
  with `li1`.

**PS**: I adapted `createPeers` and `Wysiwygs` to make it work with
custom content and by default it will use `initialValue`, because in
this test i needed to test collaboration with `ul`, `li`.

**Steps to Reproduce**:
1. Open two tabs with the editor.
2. Create a bullet list in the first tab.
3. Press "Tab" to indent a list item.
4. Observe a traceback error in the second tab.

opw-4538671

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
