### PR TITLE
[FIX] stock: display the right quants from forecast

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1248,7 +1248,7 @@ class StockQuant(models.Model):
         return self
 
     @api.model
-    def _get_quants_action(self, domain=None, extend=False):
+    def _get_quants_action(self, extend=False):
         """ Returns an action to open (non-inventory adjustment) quant view.
         Depending of the context (user have right to be inventory mode or not),
         the list view will be editable or readonly.
@@ -1274,6 +1274,7 @@ class StockQuant(models.Model):
                 (action['view_id'], 'list'),
                 (form_view, 'form'),
             ],
+            'context': ctx,
         })
         if extend:
             action.update({


### PR DESCRIPTION
Steps to reproduce:
- Go to any storable product form
- Open the Forecast report
- Click on the quantity on hand to open the quants

Issue:
All quants are displayed, as no product filter is applied.

Follow up to #198488.
During the conversion, the context wasn't set in the newly used action. Also removed the `domain` parameter as it wasn't used anymore either.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
