### PR TITLE
[FIX]: data_recycle,stock: buttons never shown when selecting list items

### DIFF
--- a/addons/data_recycle/static/src/views/data_recycle_list_view.xml
+++ b/addons/data_recycle/static/src/views/data_recycle_list_view.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-name="DataRecycle.buttons" t-inherit="web.ListView.Buttons" t-inherit-mode="primary">
         <xpath expr="//div[hasclass('o_list_buttons')]" position="inside">
-            <t t-if="nbSelected">
+            <t t-if="hasSelectedRecords">
                 <button type="button" class="btn btn-primary o_data_recycle_validate_button" t-on-click="onValidateClick">
                     Validate
                 </button>

--- a/addons/stock/static/src/views/stock_orderpoint_list_view.xml
+++ b/addons/stock/static/src/views/stock_orderpoint_list_view.xml
@@ -9,15 +9,15 @@
                     <i class="fa fa-caret-down ms-1"/>
                 </button>
                 <t t-set-slot="content">
-                    <DropdownItem t-if="nbSelected" onSelected="() => this.onClickOrder(false)">
+                    <DropdownItem t-if="hasSelectedRecords" onSelected="() => this.onClickOrder(false)">
                         Order
                     </DropdownItem>
-                    <DropdownItem t-if="nbSelected" onSelected="() => this.onClickOrder(true)">
+                    <DropdownItem t-if="hasSelectedRecords" onSelected="() => this.onClickOrder(true)">
                         Order To Max
                     </DropdownItem>
                 </t>
             </Dropdown>
-            <button t-if="nbSelected" type="button" t-on-click="onClickSnooze"
+            <button t-if="hasSelectedRecords" type="button" t-on-click="onClickSnooze"
                     class="o_button_snooze btn btn-secondary me-1">
                 Snooze
             </button>


### PR DESCRIPTION
During the introduction of the Kanban's selection feature (cf. commit
[1]), the extraction of the SelectionBox component left some
`nbSelected` getters' references while it actually was renamed
`hasSelectedRecords`.

This commit adapts them properly.

[1]: https://github.com/odoo/odoo/commit/877895cc10b1218396f77f995dc7c87a9d22f585