### PR TITLE
[FIX] mail: properly render special mentions in text messages

### DIFF
--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -209,9 +209,10 @@ function generateMentionsLinks(body, { partners = [], threads = [], specialMenti
         body = htmlReplace(body, text, placeholder);
     }
     for (const special of specialMentions) {
-        body = body.replace(
-            `@${escape(special)}`,
-            `<a href="#" class="o-discuss-mention">@${escape(special)}</a>`
+        body = htmlReplace(
+            body,
+            `@${special}`,
+            markup(`<a href="#" class="o-discuss-mention">@${htmlEscape(special)}</a>`)
         );
     }
     const baseHREF = url("/web");

--- a/addons/mail/static/tests/suggestion/suggestion.test.js
+++ b/addons/mail/static/tests/suggestion/suggestion.test.js
@@ -329,6 +329,8 @@ test("Mention with @everyone", async () => {
     await insertText(".o-mail-Composer-input", "@ever");
     await click(".o-mail-Composer-suggestion");
     await contains(".o-mail-Composer-input", { value: "@everyone " });
+    await click(".o-mail-Composer-send:enabled");
+    await contains(".o-mail-Message a:contains('@everyone')");
 });
 
 test("Suggestions that begin with the search term should have priority", async () => {


### PR DESCRIPTION
**Current behavior before PR:**

Special mentions (@ everyone) appeared as raw HTML instead of links because when
message content is not `markup()`, it is rendered as text instead of HTML when using `t-out`.

**Desired behavior after PR is merged:**

This commit ensures that special mentions are correctly rendered as links.

Before / After 
![image](https://github.com/user-attachments/assets/868f00b3-a3e0-47ee-a2e7-3d6c6d76b948)
![image](https://github.com/user-attachments/assets/063f0b41-d214-49b1-83fa-7403884006e1)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
