### PR TITLE
[FIX] account: unable to open bill cash rounding tax that is with no tax

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -2250,18 +2250,23 @@ class AccountTax(models.Model):
                     subtotals[untaxed_amount_subtotal_label]['base_amount_currency'] += cash_rounding_base_amount_currency
                     subtotals[untaxed_amount_subtotal_label]['base_amount'] += cash_rounding_base_amount
                 elif strategy == 'biggest_tax':
-                    max_subtotal, max_tax_group = max(
-                        [
-                            (subtotal, tax_group)
-                            for subtotal in tax_totals_summary['subtotals']
-                            for tax_group in subtotal['tax_groups']
-                        ],
-                        key=lambda item: item[1]['tax_amount_currency'],
-                    )
-                    max_tax_group['tax_amount_currency'] += cash_rounding_base_amount_currency
-                    max_tax_group['tax_amount'] += cash_rounding_base_amount
-                    max_subtotal['tax_amount_currency'] += cash_rounding_base_amount_currency
-                    max_subtotal['tax_amount'] += cash_rounding_base_amount
+                    tax_data = [
+                        (subtotal, tax_group)
+                        for subtotal in subtotals.values()
+                    if 'tax_groups' in subtotal and subtotal['tax_groups']
+                        for tax_group in subtotal['tax_groups']
+                    ]
+
+                    if tax_data:
+                        max_subtotal, max_tax_group = max(
+                            tax_data,
+                            key=lambda item: item[1]['tax_amount_currency'],
+                        )
+                        max_tax_group['tax_amount_currency'] += cash_rounding_base_amount_currency
+                        max_tax_group['tax_amount'] += cash_rounding_base_amount
+                        max_subtotal['tax_amount_currency'] += cash_rounding_base_amount_currency
+                        max_subtotal['tax_amount'] += cash_rounding_base_amount
+                        
                     tax_totals_summary['tax_amount_currency'] += cash_rounding_base_amount_currency
                     tax_totals_summary['tax_amount'] += cash_rounding_base_amount
 

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -482,6 +482,13 @@ class StockMove(models.Model):
         # we go further with the list of ids potentially changed by action_explode
         return super(StockMove, moves)._action_confirm(merge=merge, merge_into=merge_into)
 
+    def _action_done(self, cancel_backorder=False):
+        # explode kit moves that avoided the action_explode of any confirmation process
+        moves_to_explode = self.filtered(lambda m: m.product_id.is_kits and m.state not in ('draft', 'cancel'))
+        exploded_moves = moves_to_explode.action_explode()
+        moves = (self - moves_to_explode) | exploded_moves
+        return super(StockMove, moves)._action_done(cancel_backorder)
+
     def _should_bypass_reservation(self, forced_location=False):
         return super()._should_bypass_reservation(forced_location) or self.product_id.is_kits
 

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -1342,7 +1342,7 @@ class TestSubcontractingTracking(TransactionCase):
         picking_form.partner_id = self.subcontractor_partner1
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.finished_product
-            move.quantity = nb_finished_product
+            move.product_uom_qty = nb_finished_product
         picking_receipt = picking_form.save()
         picking_receipt.action_confirm()
         picking_receipt.do_unreserve()

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1978,9 +1978,7 @@ Please change the quantity done or the rounding precision of your unit of measur
 
     def _action_done(self, cancel_backorder=False):
         moves = self.filtered(
-            lambda move: move.state == 'draft'
-            or float_is_zero(move.product_uom_qty, precision_rounding=move.product_uom.rounding)
-        )._action_confirm(merge=False)  # MRP allows scrapping draft moves
+            lambda move: move.state == 'draft')._action_confirm(merge=False)
         moves = (self | moves).exists().filtered(lambda x: x.state not in ('done', 'cancel'))
 
         # Cancel moves where necessary ; we should do it before creating the extra moves because
@@ -2130,6 +2128,8 @@ Please change the quantity done or the rounding precision of your unit of measur
         return new_move_vals
 
     def _recompute_state(self):
+        if self._context.get('preserve_state'):
+            return
         moves_state_to_write = defaultdict(set)
         for move in self:
             rounding = move.product_uom.rounding


### PR DESCRIPTION
The Error is reproducible in the runbot here is an attached video with the steps: https://drive.google.com/file/d/1W1ZJG7aYueFa8Y24LSZlsil0caZB9mE5/view?usp=sharing

This happens because of :

1- cash rounding is enabled in the settings of accounting 2 - cash rounding by tax is chosen
3 - opening a vendor bill
4 - putting a decimal price and removing taxes
5- then choosing cash rounding by tax

The Error :
  File "/home/odoo/odoo/odoo/addons/account/models/account_move.py", line 1570, in _compute_tax_totals
    move.tax_totals = self.env['account.tax']._get_tax_totals_summary(
  File "/home/odoo/odoo/odoo/addons/account/models/account_tax.py", line 2090, in _get_tax_totals_summary
    max_subtotal, max_tax_group = max(
ValueError: max() arg is an empty sequence

opw-4558251 (related to ticket)
