### PR TITLE
[FIX] account_payment: avoid locking when posting journal entries

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -423,7 +423,7 @@ class AccountJournal(models.Model):
         move_date = self.env.context.get('move_date') or fields.Date.context_today(self)
         has_tax = self.env.context.get('has_tax') or False
         for journal in self:
-            temp_move = self.env['account.move'].new({'journal_id': journal.id})
+            temp_move = self.env['account.move'].new({'journal_id': journal.id, 'company_id': journal.company_id.id})
             journal.accounting_date = temp_move._get_accounting_date(move_date, has_tax)
 
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -785,7 +785,7 @@ class AccountMove(models.Model):
 
     @api.depends('posted_before', 'state', 'journal_id', 'date', 'move_type', 'payment_id')
     def _compute_name(self):
-        self = self.sorted(lambda m: (m.date, m.ref or '', m._origin.id))
+        self = self.sorted(lambda m: (m.journal_id.id, m.date, m.ref or '', m._origin.id))
 
         for move in self:
             if move.state == 'cancel':

--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -291,37 +291,26 @@ class SequenceMixin(models.AbstractModel):
             format_values['year_end'] = self._truncate_year_to_length(date_end.year, format_values['year_end_length'])
             format_values['month'] = date_start.month
 
-        # before flushing inside the savepoint (which may be rolled back!), make sure everything
-        # is already flushed, otherwise we could lose non-sequence fields values, as the ORM believes
-        # them to be flushed.
-        self.flush_recordset()
+        with self.env.cr.savepoint() as sp:
+            while True:
+                format_values['seq'] = format_values['seq'] + 1
+                sequence = format_string.format(**format_values)
+                try:
+                    with mute_logger('odoo.sql_db'):
+                        self[self._sequence_field] = sequence
+                        self.flush_recordset([self._sequence_field])
+                        break
+                except DatabaseError as e:
+                    # 23P01 ExclusionViolation
+                    # 23505 UniqueViolation
+                    if e.pgcode not in ('23P01', '23505'):
+                        raise e
+                    sp.rollback()
+
         # because we are flushing, and because the business code might be flushing elsewhere (i.e. to
         # validate constraints), the fields depending on the sequence field might be protected by the
         # ORM. This is not desired, so we already reset them here.
-        registry = self.env.registry
-        triggers = registry._field_triggers[self._fields[self._sequence_field]]
-        for inverse_field, triggered_fields in triggers.items():
-            for triggered_field in triggered_fields:
-                if not triggered_field.store or not triggered_field.compute:
-                    continue
-                for field in registry.field_inverses[inverse_field[0]] if inverse_field else [None]:
-                    self.env.add_to_compute(triggered_field, self[field.name] if field else self)
-        while True:
-            format_values['seq'] = format_values['seq'] + 1
-            sequence = format_string.format(**format_values)
-            try:
-                with self.env.cr.savepoint(flush=False), mute_logger('odoo.sql_db'):
-                    self[self._sequence_field] = sequence
-                    self.flush_recordset([self._sequence_field])
-                    break
-            except DatabaseError as e:
-                # 23P01 ExclusionViolation
-                # 23505 UniqueViolation
-                if e.pgcode not in ('23P01', '23505'):
-                    raise e
-        self._compute_split_sequence()
-        self.flush_recordset(['sequence_prefix', 'sequence_number'])
-
+        self.modified([self._sequence_field])
 
     def _is_last_from_seq_chain(self):
         """Tells whether or not this element is the last one of the sequence chain.

--- a/addons/account_payment/models/account_payment.py
+++ b/addons/account_payment/models/account_payment.py
@@ -131,8 +131,6 @@ class AccountPayment(models.Model):
         # able to create payments
         transactions = payments_need_tx.sudo()._create_payment_transaction()
 
-        res = super(AccountPayment, self - payments_need_tx).action_post()
-
         for tx in transactions:  # Process the transactions with a payment by token
             tx._send_payment_request()
 
@@ -141,7 +139,7 @@ class AccountPayment(models.Model):
         payments_tx_done = payments_need_tx.filtered(
             lambda p: p.payment_transaction_id.state == 'done'
         )
-        super(AccountPayment, payments_tx_done).action_post()
+        res = super(AccountPayment, self - payments_need_tx + payments_tx_done).action_post()
         payments_tx_not_done = payments_need_tx.filtered(
             lambda p: p.payment_transaction_id.state != 'done'
         )

--- a/addons/account_payment/tests/test_account_payment.py
+++ b/addons/account_payment/tests/test_account_payment.py
@@ -271,7 +271,7 @@ class TestAccountPayment(AccountPaymentCommon):
         This test verifies the correct application of early payment discount on an eligible invoice without taxes.
         """
         invoice_eligible = self._create_invoice_with_early_discount()
-        payment = self._create_transaction(
+        tx = self._create_transaction(
             reference='payment_1',
             flow='direct',
             state='done',
@@ -280,7 +280,9 @@ class TestAccountPayment(AccountPaymentCommon):
                 untaxed_amount=invoice_eligible.amount_tax,         # 0.0
             ),                                                      # 90.0
             invoice_ids=[invoice_eligible.id],
-        )._create_payment()
+        )
+        tx._reconcile_after_done()
+        payment = tx.payment_id
 
         self.assert_invoice_payment(
             payment=payment,
@@ -303,13 +305,15 @@ class TestAccountPayment(AccountPaymentCommon):
         This test ensures no discount is applied to an invoice past the early payment discount date.
         """
         invoice_ineligible = self._create_invoice_with_early_discount(invoice_date=(datetime.now() - timedelta(days=30)).date())
-        payment = self._create_transaction(
+        tx = self._create_transaction(
             reference='payment_2',
             flow='direct',
             state='done',
             amount=invoice_ineligible.amount_residual,  # 100.0
             invoice_ids=[invoice_ineligible.id],
-        )._create_payment()
+        )
+        tx._reconcile_after_done()
+        payment = tx.payment_id
 
         self.assert_invoice_payment(
             payment=payment,
@@ -337,7 +341,7 @@ class TestAccountPayment(AccountPaymentCommon):
                 'tax_ids': [(6, 0, self.company_data['default_tax_sale'].ids)],  # 15%
             })],
         )
-        payment = self._create_transaction(
+        tx = self._create_transaction(
             reference='payment_3',
             flow='direct',
             state='done',
@@ -346,7 +350,9 @@ class TestAccountPayment(AccountPaymentCommon):
                 untaxed_amount=invoice_eligible_with_tax.amount_tax,        # 15.0
             ),                                                              # 115.0 - 10% -> 115 * (1 - 0.1) = 103.5
             invoice_ids=[invoice_eligible_with_tax.id],
-        )._create_payment()
+        )
+        tx._reconcile_after_done()
+        payment = tx.payment_id
 
         self.assert_invoice_payment(
             payment=payment,
@@ -384,13 +390,15 @@ class TestAccountPayment(AccountPaymentCommon):
                 'tax_ids': [(6, 0, self.company_data['default_tax_sale'].ids)],  # 15%
             })],
         )
-        payment = self._create_transaction(
+        tx = self._create_transaction(
             reference='payment_4',
             flow='direct',
             state='done',
             amount=invoice_ineligible_with_mixed_and_tax.amount_residual,  # 100 + (15 * (1 - 0.1)) = 113.5
             invoice_ids=[invoice_ineligible_with_mixed_and_tax.id],
-        )._create_payment()
+        )
+        tx._reconcile_after_done()
+        payment = tx.payment_id
 
         self.assert_invoice_payment(
             payment=payment,
@@ -424,7 +432,7 @@ class TestAccountPayment(AccountPaymentCommon):
                 'tax_ids': [(6, 0, self.company_data['default_tax_sale'].ids)],  # 15%
             })],
         )
-        payment = self._create_transaction(
+        tx = self._create_transaction(
             reference='payment_5',
             flow='direct',
             state='done',
@@ -433,7 +441,9 @@ class TestAccountPayment(AccountPaymentCommon):
                 untaxed_amount=invoice_eligible_with_excluded_and_tax.amount_tax,       # 15.0
             ),                                                                          # (100 - 10%), 90 + 15 = 105
             invoice_ids=[invoice_eligible_with_excluded_and_tax.id],
-        )._create_payment()
+        )
+        tx._reconcile_after_done()
+        payment = tx.payment_id
 
         self.assert_invoice_payment(
             payment=payment,
@@ -460,7 +470,7 @@ class TestAccountPayment(AccountPaymentCommon):
             currency_id=foreign_currency.id,
             company_currency_id=self.currency.id,
         )
-        payment = self._create_transaction(
+        tx = self._create_transaction(
             reference='payment_6',
             flow='direct',
             state='done',
@@ -470,7 +480,9 @@ class TestAccountPayment(AccountPaymentCommon):
             ),                                                                          # 90.0 gold     / 45.0$
             currency_id=foreign_currency.id,
             invoice_ids=[invoice_eligible_with_foreign_currency.id],
-        )._create_payment()
+        )
+        tx._reconcile_after_done()
+        payment = tx.payment_id
 
         self.assert_invoice_payment(
             payment=payment,


### PR DESCRIPTION
Issue
=====

When multiple orders are being made at the same time and paid at the same time, for instance for a blitz ticket sale, we encountered congestion on the database.

Investigation
=============

The locking is done because of a postgres constraint on `account_move` (`account_move_unique_name`). This lock is released as soon as the other transaction is locked.
This locking is necessary to ensure that no gaps are made when numbering the journal entries, for legal reasons.

There are multiple causes possible:
* The transactions are open for too long after the locking has been made. This can be reduced by pushing the posting of the journal entries as for as possible to the end of the transaction. Most of the work done after posting the invoices is creating, posting, and reconciling the payments. Creating the payment can easily be move before posting anything.
* Posting moves in different journals can cause a deadlock if the order of the journal is not always the same. It was actually the case in `_reconcile_after_done`:
  * first all the invoices related to the transaction (`invoice_ids`) were posted (journal A)
  * then the payments were created and posted (journal B)
  * then, in case there was a source transaction, we were posting other invoices (`source_transaction_id.invoice_ids`) This could lead to:
  * one transaction having acquired the lock on the invoice journal, then waiting for the lock on the payment journal (posting invoice first)
  * another transaction having acquired the lock on the payment journal, then waiting on the lock on the invoice journal (creating and posting the payment first)

Solution
========

For the first issue, simply create the payments before posting anything.

For the second issue, we can post everything at the same time. This will lead to let `<account.move>.action_post` determine the order. This order is the first post payments, the the other moves. And the orders in each group is now determined by the journal's id.

Using the same approach (posting everything at once using only one call to `action_post`) should be enough to prevent any deadlock due to this constraint.
