### PR TITLE
[FIX] event_booth_sale: remove unnecessary journal

### DIFF
--- a/addons/event_booth_sale/tests/test_event_booth_sale.py
+++ b/addons/event_booth_sale/tests/test_event_booth_sale.py
@@ -193,12 +193,8 @@ class TestEventBoothSaleInvoice(AccountTestInvoicingCommon, TestEventBoothSaleWD
         self.assertEqual(
             sale_order.invoice_status, 'invoiced',
             f"Order is in '{sale_order.invoice_status}' status while it should be 'invoiced'.")
-        # Pay the invoice.
-        journal = self.env['account.journal'].search([('type', '=', 'cash'), ('company_id', '=', sale_order.company_id.id)], limit=1)
 
-        register_payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
-            'journal_id': journal.id,
-        })
+        register_payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({})
         register_payments._create_payments()
 
         # Check the invoice payment state after paying the invoice


### PR DESCRIPTION
The test uses `account.payment.register` but provides the journal_id explicitly instead of relying on the compute method. This causes issues when demo data is not installed as the test does not check if that journal exists.

Runbot Error 116695
Runbot Error 116696
