### PR TITLE
[FIX] website_event_sale: set country during tests

### DIFF
--- a/addons/website_event_sale/tests/common.py
+++ b/addons/website_event_sale/tests/common.py
@@ -13,6 +13,7 @@ class TestWebsiteEventSaleCommon(WebsiteSaleCommon):
     def setUpClass(cls):
         super().setUpClass()
 
+        cls.env.company.country_id = cls.env.ref('base.us')
         cls.currency_test = cls.env['res.currency'].create({
             'name': 'eventX',
             'rounding': 0.01,


### PR DESCRIPTION
Taxes require a country_id when created and infer it from the company, however without demo data, the company has no country_id leading to a crash during the setUpClass.
We now fix a country at the start of the test to make sure we have one.

Runbot Error 114358
Runbot Error 114359
