### PR TITLE
[FIX] account: stop installing demo in tests

### DIFF
--- a/addons/account/tests/test_chart_template.py
+++ b/addons/account/tests/test_chart_template.py
@@ -714,7 +714,7 @@ class TestChartTemplate(AccountTestInvoicingCommon):
             patch.object(AccountChartTemplate, '_get_chart_template_mapping', _get_chart_template_mapping),
             patch.object(AccountChartTemplate, '_get_chart_template_data', side_effect=test_get_data, autospec=True)
         ):
-            self.env['account.chart.template'].try_loading('other_test', company=self.company, install_demo=True)
+            self.env['account.chart.template'].try_loading('other_test', company=self.company, install_demo=False)
 
             # Create a branch and an unrelated company
             branch, other_company = self.env['res.company'].create([


### PR DESCRIPTION
`install_demo=True` should not be used when loading account chart templates during tests as they rely on demo data which is not guaranteed to be installed.

Runbot Error 134673
