### PR TITLE
[FIX] pos_restaurant: push order select table

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -180,6 +180,7 @@ patch(PosStore.prototype, {
      * @throws error
      */
     async _syncTableOrdersFromServer(tableId) {
+        await this.push_orders({ show_error: true }); // in case we were offline and we paid orders in the mean time
         await this._removeOrdersFromServer(); // in case we were offline and we deleted orders in the mean time
         const ordersJsons = await this._getTableOrdersFromServer([tableId]);
         await this._addPricelists(ordersJsons);


### PR DESCRIPTION
steps to reproduce:
-------------------
- Install the module pos_restaurant
- Open PoS
- Open a table and add some products on it
- Go back to the floor plan (this is to make sure the order is saved on the server)
- Go offline with the chrome devtools
- Pay the order
- Go back online
- Click on the table where you made the order
> Observation: The order is still there even if you already paid it

why the fix:
------------
When clicking on the table we will fetch all the orders from the server and because you were offline the version of the order that comes from the server is the one that is not paid. So we need to push the order to the server before fetching the orders.

opw-4591204