### PR TITLE
[IMP] account: Cleanup code after revert

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -941,9 +941,6 @@ class AccountTax(models.Model):
             incl_base_multiplicator = 1.0 if total_percentage == 1.0 else 1 - total_percentage
             return raw_base * self.amount / 100.0 / incl_base_multiplicator
 
-    def _eval_raw_base(self, quantity, price_unit, evaluation_context):
-        return quantity * price_unit
-
     def _get_tax_details(
         self,
         price_unit,
@@ -1039,11 +1036,7 @@ class AccountTax(models.Model):
                     'is_reverse_charge': True,
                 }
 
-        raw_base_evaluation_context = {
-            'taxes': sorted_taxes,
-            'precision_rounding': precision_rounding,
-        }
-        raw_base = self._eval_raw_base(quantity, price_unit, raw_base_evaluation_context)
+        raw_base = quantity * price_unit
         if rounding_method == 'round_per_line':
             raw_base = float_round(raw_base, precision_rounding=precision_rounding or self.env.company.currency_id.rounding)
 
@@ -1053,7 +1046,6 @@ class AccountTax(models.Model):
             'quantity': quantity,
             'raw_base': raw_base,
             'special_mode': special_mode,
-            'precision_rounding': precision_rounding,
         }
 
         # Define the order in which the taxes must be evaluated.

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -209,10 +209,6 @@ export const accountTaxHelpers = {
         return null;
     },
 
-    eval_raw_base(quantity, price_unit, evaluation_context) {
-        return quantity * price_unit;
-    },
-
     get_tax_details(
         taxes,
         price_unit,
@@ -309,11 +305,7 @@ export const accountTaxHelpers = {
             }
         }
 
-        const raw_base_evaluation_context = {
-            taxes: sorted_taxes,
-            precision_rounding: precision_rounding,
-        };
-        let raw_base = this.eval_raw_base(quantity, price_unit, raw_base_evaluation_context);
+        let raw_base = quantity * price_unit;
         if (rounding_method === "round_per_line") {
             raw_base = roundPrecision(raw_base, precision_rounding);
         }
@@ -324,7 +316,6 @@ export const accountTaxHelpers = {
             quantity: quantity,
             raw_base: raw_base,
             special_mode: special_mode,
-            precision_rounding: precision_rounding,
         };
 
         // Define the order in which the taxes must be evaluated.


### PR DESCRIPTION
The code has been introduced initialy by:
https://github.com/odoo/odoo/commit/4cbd6cc52cb96cc20d41974a37410a37fd9902f5

...but since the override has been reverted in:
https://github.com/odoo/enterprise/commit/4f77e313ee9e97164f3ffe0e492f8f036fa53c50

... those hooks are no longer necessary.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
