### PR TITLE
[FIX] test_website, website_crm_partner_assign: fix systray tests

### DIFF
--- a/addons/test_website/static/tests/tours/systray.js
+++ b/addons/test_website/static/tests/tours/systray.js
@@ -42,15 +42,33 @@ const canToggleMobilePreview = [{
     trigger: '.o_menu_systray .o_menu_systray_item.o_mobile_preview.o_mobile_preview_active',
 }];
 
+const cannotToggleMobilePreview = [{
+    content: 'Enable mobile preview',
+    trigger: '.o_menu_systray:not(:has(.o_menu_systray_item.o_mobile_preview))',
+    run: () => {}, // This is a check.
+}];
+
+// For non-website users, switching across website only works if the domains are
+// specified. Within the scope of test tours, this cannot be achieved.
+const canSwitchWebsiteNoCheck = [{
+    content: 'Open website switcher',
+    trigger: '.o_menu_systray .o_menu_systray_item.o_website_switcher_container .dropdown-toggle:contains("My Website"):not(:contains("My Website 2"))',
+}, {
+    content: 'Switch to other website',
+    trigger: '.o_menu_systray .o_menu_systray_item.o_website_switcher_container .dropdown-item:contains("Other")',
+    run: () => {}, // This is a check.
+}];
+
+
 const canSwitchWebsite = [{
     content: 'Open website switcher',
     trigger: '.o_menu_systray .o_menu_systray_item.o_website_switcher_container .dropdown-toggle:contains("My Website"):not(:contains("My Website 2"))',
 }, {
-    content: 'Switch to website 2',
-    trigger: '.o_menu_systray .o_menu_systray_item.o_website_switcher_container .dropdown-item:contains("My Website 2")',
+    content: 'Switch to other website',
+    trigger: '.o_menu_systray .o_menu_systray_item.o_website_switcher_container .dropdown-item:contains("Other")',
 }, {
-    content: 'Wait for Website 2',
-    trigger: 'iframe html[data-website-id="2"] body:contains("Test Model")',
+    content: 'Wait for other website',
+    trigger: 'iframe body:contains("Test Model") div:contains("Other")',
     run: () => {}, // This is a check.
 }];
 
@@ -60,6 +78,12 @@ const canAddNewContent = [{
 }, {
     content: 'Close +New content',
     trigger: '#o_new_content_menu_choices',
+}];
+
+const cannotAddNewContent = [{
+    content: 'No +New content',
+    trigger: '.o_menu_systray:not(:has(.o_menu_systray_item.o_new_content_container))',
+    run: () => {}, // This is a check.
 }];
 
 const canEditInBackEnd = [{
@@ -117,19 +141,8 @@ const cannotEdit = [{
 const canEditButCannotChange = [
     ...wTourUtils.clickOnEditAndWaitEditMode(),
     {
-        content: 'Change name',
-        trigger: 'iframe span[data-oe-expression="test_model.name"][contenteditable="true"]',
-        run: 'text Better name',
-    }, {
-        // Shouldn't the field rather not be editable ?
-        content: 'Check that field becomes dirty',
-        trigger: 'iframe span.o_dirty[data-oe-expression="test_model.name"]',
-        run: () => {}, // This is a check.
-    },
-    wTourUtils.clickOnSave()[0], // Do not wait for save to succeed.
-    {
-        content: 'Check access error popup',
-        trigger: 'iframe .popover:contains("You are not allowed")',
+        content: 'Cannot change name',
+        trigger: 'iframe main:not(:has([data-oe-expression])):contains("Test Model")',
         run: () => {}, // This is a check.
     },
 ];
@@ -170,18 +183,18 @@ register('test_systray_reditor_not_tester', [
 
 register('test_systray_not_reditor_tester', [
     ...canPublish,
-    ...canToggleMobilePreview,
-    ...canSwitchWebsite,
-    ...canAddNewContent,
+    ...cannotToggleMobilePreview,
+    ...canSwitchWebsiteNoCheck,
+    ...cannotAddNewContent,
     ...canEditInBackEnd,
     ...cannotEdit,
 ]);
 
 register('test_systray_not_reditor_not_tester', [
     ...cannotPublish,
-    ...canToggleMobilePreview,
-    ...canSwitchWebsite,
-    ...canAddNewContent,
+    ...cannotToggleMobilePreview,
+    ...canSwitchWebsiteNoCheck,
+    ...cannotAddNewContent,
     ...canViewInBackEnd,
     ...cannotEdit,
 ]);

--- a/addons/test_website/tests/test_systray.py
+++ b/addons/test_website/tests/test_systray.py
@@ -1,19 +1,37 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import tagged
-from odoo.tools import mute_logger
+from odoo.tests.common import HOST, new_test_user, tagged
+from odoo.tools import config, mute_logger
 
-from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+from odoo.addons.base.tests.common import HttpCase
 
 
 @tagged('post_install', '-at_install')
-class TestSystray(HttpCaseWithUserDemo):
+class TestSystray(HttpCase):
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.group_restricted_editor = cls.env.ref('website.group_website_restricted_editor')
         cls.group_tester = cls.env.ref('test_website.group_test_website_tester')
+        # Do not rely on HttpCaseWithUserDemo to avoid having different user
+        # definitions with and without demo data.
+        cls.user_test = new_test_user(cls.env, login='testtest', website_id=False)
+        other_website = cls.env['website'].create({
+            'name': 'Other',
+        })
+        cls.env['ir.ui.view'].create({
+            'name': "Patch to recognize other website",
+            'website_id': other_website.id,
+            'type': 'qweb',
+            'inherit_id': cls.env.ref('test_website.test_model_page_layout').id,
+            'arch': """
+                <xpath expr="//span" position="after">
+                    <div>Other</div>
+                </xpath>
+            """
+        })
+
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_01_admin(self):
@@ -21,23 +39,27 @@ class TestSystray(HttpCaseWithUserDemo):
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_02_reditor_tester(self):
-        self.user_demo.groups_id |= self.group_restricted_editor
-        self.user_demo.groups_id |= self.group_tester
-        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_reditor_tester', login="demo")
+        self.user_test.groups_id |= self.group_restricted_editor
+        self.user_test.groups_id |= self.group_tester
+        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_reditor_tester', login="testtest")
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_03_reditor_not_tester(self):
-        self.user_demo.groups_id |= self.group_restricted_editor
-        self.user_demo.groups_id = self.user_demo.groups_id.filtered(lambda group: group != self.group_tester)
-        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_reditor_not_tester', login="demo")
+        self.user_test.groups_id |= self.group_restricted_editor
+        self.user_test.groups_id = self.user_test.groups_id.filtered(lambda group: group != self.group_tester)
+        self.assertNotIn(self.group_tester.id, self.user_test.groups_id.ids, "User should not be a group_tester")
+        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_reditor_not_tester', login="testtest")
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_04_not_reditor_tester(self):
-        self.user_demo.groups_id = self.user_demo.groups_id.filtered(lambda group: group != self.group_restricted_editor)
-        self.user_demo.groups_id |= self.group_tester
-        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_not_reditor_tester', login="demo")
+        self.user_test.groups_id = self.user_test.groups_id.filtered(lambda group: group != self.group_restricted_editor)
+        self.user_test.groups_id |= self.group_tester
+        self.assertNotIn(self.group_restricted_editor.id, self.user_test.groups_id.ids, "User should not be a group_restricted_editor")
+        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_not_reditor_tester', login="testtest")
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_05_not_reditor_not_tester(self):
-        self.user_demo.groups_id = self.user_demo.groups_id.filtered(lambda group: group not in [self.group_restricted_editor, self.group_tester])
-        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_not_reditor_not_tester', login="demo")
+        self.user_test.groups_id = self.user_test.groups_id.filtered(lambda group: group not in [self.group_restricted_editor, self.group_tester])
+        self.assertNotIn(self.group_restricted_editor.id, self.user_test.groups_id.ids, "User should not be a group_restricted_editor")
+        self.assertNotIn(self.group_tester.id, self.user_test.groups_id.ids, "User should not be a group_tester")
+        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_not_reditor_not_tester', login="testtest")

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -231,8 +231,12 @@ class WebsitePublishedMixin(models.AbstractModel):
         the 'website_published' value if this method sets can_publish False """
         for record in self:
             try:
-                self.check_access_rights('write')
-                self.check_access_rule('write')
+                # Some main_record might be in sudo because their content needs
+                # to be rendered by a template even if they were not supposed
+                # to be accessible
+                plain_record = record.sudo(flag=False) if self._context.get('can_publish_unsudo_main_object', False) else record
+                plain_record.check_access_rights('write')
+                plain_record.check_access_rule('write')
                 record.can_publish = True
             except AccessError:
                 record.can_publish = False

--- a/addons/website/models/res_partner.py
+++ b/addons/website/models/res_partner.py
@@ -41,3 +41,7 @@ class Partner(models.Model):
     def _compute_display_name(self):
         self2 = self.with_context(display_website=False)
         super(Partner, self2)._compute_display_name()
+
+    def _compute_can_publish(self):
+        self2 = self.with_context(can_publish_unsudo_main_object=False)
+        super(Partner, self2)._compute_can_publish()

--- a/addons/website/static/src/js/content/website_root_instance.js
+++ b/addons/website/static/src/js/content/website_root_instance.js
@@ -8,8 +8,12 @@ import { loadWysiwyg } from "web_editor.loader";
 const prom = createPublicRoot(WebsiteRoot).then(rootInstance => {
     // This data attribute is set by the WebsitePreview client action for a
     // restricted editor user.
-    if (window.frameElement && window.frameElement.dataset.loadWysiwyg === 'true') {
-        loadWysiwyg(['website.assets_wysiwyg']).then(() => {
+    if (window.frameElement) {
+        let prepare = Promise.resolve();
+        if (window.frameElement.dataset.loadWysiwyg === 'true') {
+            prepare = loadWysiwyg(['website.assets_wysiwyg']);
+        }
+        prepare.then(() => {
             window.dispatchEvent(new CustomEvent('PUBLIC-ROOT-READY', {detail: {rootInstance}}));
         });
     }

--- a/addons/website_crm_partner_assign/static/tests/tours/publish.js
+++ b/addons/website_crm_partner_assign/static/tests/tours/publish.js
@@ -10,7 +10,14 @@ import wTourUtils from 'website.tour_utils';
 wTourUtils.registerWebsitePreviewTour('test_can_publish_partner', {
     edition: false,
     test: true,
+    url: '/partners',
 }, [{
+    content: 'Filter on Grade Test', // needed if there are demo data
+    trigger: 'iframe a:contains("Grade Test")',
+}, {
+    content: 'Go to partner',
+    trigger: 'iframe a:contains("Agrolait")',
+}, {
     content: 'Unpublish',
     trigger: '.o_menu_systray .o_menu_systray_item.o_publish_container:contains("Published")',
 }, {
@@ -29,7 +36,14 @@ wTourUtils.registerWebsitePreviewTour('test_can_publish_partner', {
 wTourUtils.registerWebsitePreviewTour('test_cannot_publish_partner', {
     edition: false,
     test: true,
+    url: '/partners',
 }, [{
+    content: 'Filter on Grade Test', // needed if there are demo data
+    trigger: 'iframe a:contains("Grade Test")',
+}, {
+    content: 'Go to partner',
+    trigger: 'iframe a:contains("Agrolait")',
+}, {
     content: 'Check there is no Publish/Unpublish',
     trigger: '.o_menu_systray:not(:has(.o_menu_systray_item.o_publish_container))',
 }]);

--- a/addons/website_crm_partner_assign/tests/test_partner_assign.py
+++ b/addons/website_crm_partner_assign/tests/test_partner_assign.py
@@ -5,10 +5,10 @@ from unittest.mock import patch
 
 from odoo.exceptions import AccessError
 from odoo.fields import Command
-from odoo.tests.common import tagged, TransactionCase
+from odoo.tests.common import tagged, new_test_user, TransactionCase
 from odoo.tools import mute_logger
 
-from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+from odoo.addons.base.tests.common import HttpCase
 from odoo.addons.crm.tests.common import TestCrmCommon
 from odoo.addons.mail.tests.common import mail_new_test_user
 
@@ -225,58 +225,78 @@ class TestPartnerLeadPortal(TestCrmCommon):
 
 
 @tagged('post_install', '-at_install')
-class TestPublish(HttpCaseWithUserDemo):
+class TestPublish(HttpCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.group_partner_manager = cls.env.ref('base.group_partner_manager')
         cls.group_restricted_editor = cls.env.ref('website.group_website_restricted_editor')
-        cls.group_salesman = cls.env.ref('sales_team.group_sale_salesman')
+        cls.group_sale_salesman = cls.env.ref('sales_team.group_sale_salesman')
+        # Do not rely on HttpCaseWithUserDemo to avoid having different user
+        # definitions with and without demo data.
+        cls.user_test = new_test_user(cls.env, login='testtest', website_id=False)
+
+        # Partner Grade
+        grade = cls.env['res.partner.grade'].create({
+            'name': "Grade Test",
+            'partner_weight': 42,
+            'sequence': 3,
+        })
         cls.partner = cls.env['res.partner'].create({
             'name': "Agrolait",
             'is_company': True,
             'city': "Wavre",
             'zip': "1300",
-            'country_id': cls.env.ref("base.be").id,
+            'country_id': cls.env.ref('base.be').id,
             'street': "69 rue de Namur",
             'partner_weight': 10,
             'website_published': True,
+            'grade_id': grade.id,
         })
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_01_admin(self):
-        self.start_tour(self.env['website'].get_client_action_url(self.partner.website_url), 'test_can_publish_partner', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/partners'), 'test_can_publish_partner', login="admin")
         self.assertTrue(self.partner.website_published, "Partner should have been published")
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_02_reditor_salesman(self):
-        self.user_demo.groups_id = [
+        self.user_test.groups_id = [
             Command.link(self.group_restricted_editor.id),
-            Command.link(self.group_salesman.id),
+            Command.link(self.group_sale_salesman.id),
         ]
-        self.start_tour(self.env['website'].get_client_action_url(self.partner.website_url), 'test_can_publish_partner', login="demo")
+        self.start_tour(self.env['website'].get_client_action_url('/partners'), 'test_can_publish_partner', login="testtest")
         self.assertTrue(self.partner.website_published, "Partner should have been published")
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_03_reditor_not_salesman(self):
-        self.user_demo.groups_id = [
+        self.user_test.groups_id = [
             Command.link(self.group_restricted_editor.id),
-            Command.unlink(self.group_salesman.id),
+            Command.unlink(self.group_sale_salesman.id),
+            Command.unlink(self.group_partner_manager.id)
         ]
-        self.start_tour(self.env['website'].get_client_action_url(self.partner.website_url), 'test_cannot_publish_partner', login="demo")
+        self.assertNotIn(self.group_sale_salesman.id, self.user_test.groups_id.ids, "User should not be a group_sale_salesman")
+        self.assertNotIn(self.group_partner_manager.id, self.user_test.groups_id.ids, "User should not be a group_partner_manager")
+        self.start_tour(self.env['website'].get_client_action_url('/partners'), 'test_cannot_publish_partner', login="testtest")
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_04_not_reditor_salesman(self):
-        self.user_demo.groups_id = [
+        self.user_test.groups_id = [
             Command.unlink(self.group_restricted_editor.id),
-            Command.link(self.group_salesman.id),
+            Command.link(self.group_sale_salesman.id),
         ]
-        self.start_tour(self.env['website'].get_client_action_url(self.partner.website_url), 'test_can_publish_partner', login="demo")
+        self.assertNotIn(self.group_restricted_editor.id, self.user_test.groups_id.ids, "User should not be a group_restricted_editor")
+        self.start_tour(self.env['website'].get_client_action_url('/partners'), 'test_can_publish_partner', login="testtest")
         self.assertTrue(self.partner.website_published, "Partner should have been published")
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_05_not_reditor_not_salesman(self):
-        self.user_demo.groups_id = [
+        self.user_test.groups_id = [
             Command.unlink(self.group_restricted_editor.id),
-            Command.unlink(self.group_salesman.id),
+            Command.unlink(self.group_sale_salesman.id),
+            Command.unlink(self.group_partner_manager.id)
         ]
-        self.start_tour(self.env['website'].get_client_action_url(self.partner.website_url), 'test_cannot_publish_partner', login="demo")
+        self.assertNotIn(self.group_sale_salesman.id, self.user_test.groups_id.ids, "User should not be a group_sale_salesman")
+        self.assertNotIn(self.group_partner_manager.id, self.user_test.groups_id.ids, "User should not be a group_partner_manager")
+        self.assertNotIn(self.group_restricted_editor.id, self.user_test.groups_id.ids, "User should not be a group_restricted_editor")
+        self.start_tour(self.env['website'].get_client_action_url('/partners'), 'test_cannot_publish_partner', login="testtest")


### PR DESCRIPTION
Commit [1] introduced tests that fail when they are run without demo data. The difference comes from the fact that the demo user has different rights when obtained from demo data or when generated by `HttpCaseWithUserDemo`. Investigating this failure has put in light a combination of other mistakes:
- the rights on the user used for the test were not the expected ones: asserts have been added to make sure the scenario matches the expectation
- the URL of the partner that was given to `start_tour` was actually ignored on the Javascript side which redirected to the home page
- the test miraculously passed on the home page because the combination of rights of the patched demo user worked for publishing a page (which is not what was supposed to be tested)
- while fixing the test, it was noticed that the `_compute_can_publish` method that was updated in [2] was actually run in sudo for the specific scenario of the test, because it is obtained during the rendering of a QWeb template which reads `can_publish` to fill the `html_data` structure, while the `main_object` is a sudoed `res.partner` in order to be able to display some of its fields within the page, which leads to accesses always being considered as granted

This commit fixes this by:
- un-sudoing the records in `_compute_can_publish` in order to properly check for access rights
- starting the test tours from a `/partners` and adding a step to browse to the specific partner page
- assigning a level to the test partner so that it appears in the `/partners` page

[1]: https://github.com/odoo/odoo/commit/dbed390e645c93de1145662e9e00938fed984b5f
[2]: https://github.com/odoo/odoo/commit/1a83b2508b9383e2b7df192f8641751f71f852da

task-3175890
runbot-114278
runbot-114279
runbot-114281
runbot-114283
runbot-114287
runbot-114289
