### PR TITLE
[FIX] mail: ensure tracking m2o values are translated

### DIFF
--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -221,6 +221,14 @@ class MailTracking(models.Model):
                     result.append(f'{value}Z')
             elif field_type == 'boolean':
                 result.append(bool(value))
+            elif field_type == 'many2one':
+                record_id = record.new_value_integer if new else record.old_value_integer
+                if record_id and record.field_id.relation:
+                    value = self.env[record.field_id.relation].browse(record_id).display_name
+                    related_model = self.env[record.field_id.model]._fields[record.field_id.name].comodel_name
+                    translated_record = self.env[related_model].browse(record_id).with_context(lang=self.env.user.lang)
+                    value = translated_record.display_name
+                result.append(value)
             else:
                 result.append(value)
         return result

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1271,7 +1271,7 @@ class TestMailFormattersPerformance(BaseMailPerformance):
         """
         messages_all = self.messages_all.with_env(self.env)
 
-        with self.assertQueryCount(employee=27):
+        with self.assertQueryCount(employee=28):
             res = messages_all.message_format()
 
         self.assertEqual(len(res), 2*2)
@@ -1284,7 +1284,7 @@ class TestMailFormattersPerformance(BaseMailPerformance):
     def test_message_format_single(self):
         message = self.messages_all[0].with_env(self.env)
 
-        with self.assertQueryCount(employee=24):
+        with self.assertQueryCount(employee=25):
             res = message.message_format()
 
         self.assertEqual(len(res), 1)


### PR DESCRIPTION
Before this fix, many2one tracking values were stored as plain text (`display_name`) in the language of the user who made the change. As a result, when another user with a different language viewed the tracking log, the values were displayed in the original language instead of their preferred language.

Reproduce
---
- In Project app
- Have two users:
  - One using DEFAULT_LANGUAGE
  - Another using ADDITIONAL_LANGUAGE
- Log in as the ADDITIONAL_LANGUAGE user
- Modify a tracked many2one field (e.g., change a task stage)
- Log in as the DEFAULT_LANGUAGE user
- Open the tracking log for the modified field
- BUG: The value appears in ADDITIONAL_LANGUAGE instead of DEFAULT_LANGUAGE

Fix
---
Retrieve many2one values using `new_value_integer` and `old_value_integer` (instead of relying on stored `display_name`)

Potential Performance Impact:
This adds an extra `browse()` lookup per tracking value.

Potential Future Improvement (master)
---
- Consider storing translated values inside `new_value_char` and `old_value_char` at the time of `mail.tracking.value` creation to avoid runtime lookups.

opw-4562872