### PR TITLE
[FIX] stock: correct field used in report

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -177,7 +177,7 @@
                                                     <span t-out="format_number(line.quantity)">3.00</span>
                                                     <span t-field="line.product_uom_id" groups="uom.group_uom">units</span>
                                                     <span t-if="line.move_id.packaging_uom_id">
-                                                        (<span t-field="line.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="line.move_id.packaging_uom_id.name"/>)
+                                                        (<span t-field="line.move_id.packaging_uom_qty" t-options='{"widget": "integer"}'/> <span t-field="line.move_id.packaging_uom_id.name"/>)
                                                     </span>
                                                 </td>
                                                 <td class="text-start" t-if="from_col_exists" groups="stock.group_stock_multi_locations">


### PR DESCRIPTION
Before this commit:
The report will crash as the field `product_packaging_qty` does not exist (in 18.2 at least)

Side effect of recent PR:
https://github.com/odoo/odoo/pull/198067

rb-135015