### PR TITLE
[FIX] mail: display live chat user name as notification message author

### DIFF
--- a/addons/im_livechat/static/tests/channel_invite.test.js
+++ b/addons/im_livechat/static/tests/channel_invite.test.js
@@ -10,6 +10,7 @@ defineLivechatModels();
 test("Can invite a partner to a livechat channel", async () => {
     mockDate("2023-01-03 12:00:00");
     const pyEnv = await startServer();
+    pyEnv["res.partner"].write([serverState.partnerId], { user_livechat_username: "Mitch (FR)" });
     const userId = pyEnv["res.users"].create({ name: "James" });
     pyEnv["res.partner"].create({
         name: "James",
@@ -36,6 +37,9 @@ test("Can invite a partner to a livechat channel", async () => {
         parent: [".o-discuss-ChannelInvitation-selectable", { text: "James" }],
     });
     await click("button:enabled", { text: "Invite" });
+    await contains(".o-mail-NotificationMessage", {
+        text: "Mitch (FR) invited James to the channel",
+    });
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await click("button[title='Members']");
     await contains(".o-discuss-ChannelMember", { text: "James" });

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.Message">
         <div t-if="message.isNotification" class="o-mail-NotificationMessage text-break mx-auto text-muted opacity-75 px-3 text-center smaller" t-on-click="onClickNotificationMessage"  t-att-class="props.className" t-ref="root">
             <i t-if="message.notificationIcon" t-attf-class="{{ message.notificationIcon }} me-1"/>
-            <span class="o-mail-NotificationMessage-author d-inline" t-if="message.author and !message.body.includes(escape(message.author.name))" t-esc="message.author.name"/> <t t-out="message.body"/>
+            <span class="o-mail-NotificationMessage-author d-inline" t-if="authorName and !message.body.includes(escape(authorName))" t-esc="authorName"/> <t t-out="message.body"/>
         </div>
         <ActionSwiper t-else="" onRightSwipe="hasTouch() and props.thread?.eq(store.inbox) ? { action: () => this.message.setDone(), bgColor: 'bg-success', icon: 'fa-check-circle' } : undefined">
             <div class="o-mail-Message position-relative rounded-0"


### PR DESCRIPTION
For visitors, the name of the author might not be known, only their live chat user name. Use the getter that takes this into account when displaying the author name of notifications such as "join", "left" or "invited to the channel" to actually display the live chat user name rather than nothing.

task-4433078