### PR TITLE
[FIX] web: NameAndSignature handles device rotation

### DIFF
--- a/addons/web/static/src/core/signature/name_and_signature.js
+++ b/addons/web/static/src/core/signature/name_and_signature.js
@@ -7,9 +7,18 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useService, useAutofocus } from "@web/core/utils/hooks";
 import { pick } from "@web/core/utils/objects";
 import { renderToString } from "@web/core/utils/render";
+import { debounce } from "@web/core/utils/timing";
 import { getDataURLFromFile } from "@web/core/utils/urls";
 
-import { Component, useState, onWillStart, useRef, useEffect } from "@odoo/owl";
+import {
+    Component,
+    useState,
+    onWillStart,
+    useRef,
+    useEffect,
+    useExternalListener,
+    status,
+} from "@odoo/owl";
 
 let htmlId = 0;
 export class NameAndSignature extends Component {
@@ -70,6 +79,8 @@ export class NameAndSignature extends Component {
             },
             () => [this.signatureRef.el]
         );
+
+        useExternalListener(window, "resize", debounce(this.onResize, 250));
     }
 
     /**
@@ -207,6 +218,13 @@ export class NameAndSignature extends Component {
         this.drawCurrentName();
     }
 
+    onResize() {
+        // May happen since this is debounced
+        if (status(this) !== "destroyed") {
+            this.resizeSignature();
+        }
+    }
+
     /**
      * Displays the given image in the signature field.
      * If needed, resizes the image to fit the existing area.
@@ -289,6 +307,9 @@ export class NameAndSignature extends Component {
     }
 
     resizeSignature() {
+        if (!this.signatureRef.el) {
+            return;
+        }
         // recompute size based on the current width
         this.signatureRef.el.style.width = "unset";
         const width = this.signatureRef.el.clientWidth;


### PR DESCRIPTION
Steps to reproduce
==================

- Use a mobile device/viewport
- Create a new Quotation
- Click on preview
- Click on Sign & Pay
- Draw
- Fill the canvas
- Rotate your device

=> The canvas is no longer centered

Cause of the issue
==================

A resize handler was forgotten in the conversion to owl:

https://github.com/odoo/odoo/blob/f4f0f783183507df8227b37fe1234c256325df6d/addons/web/static/src/legacy/js/widgets/name_and_signature.js#L153-L159

opw-4343646

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
