### PR TITLE
[FIX] mrp: simplify access to bom for non-mrp users

### DIFF
--- a/addons/mrp/models/product_document.py
+++ b/addons/mrp/models/product_document.py
@@ -20,5 +20,4 @@ class ProductDocument(models.Model):
         help="Leave hidden if document only accessible on product form.\n"
             "Select Bill of Materials to visualise this document as a product attachment when this product is in a bill of material.",
         default=lambda self: self._default_attached_on_mrp(),
-        groups='mrp.group_mrp_user',
     )

--- a/addons/mrp/views/product_document_views.xml
+++ b/addons/mrp/views/product_document_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="product.product_document_form"/>
         <field name="arch" type="xml">
             <sheet position="inside">
-                <group name="mrp" string="Manufacturing">
+                <group name="mrp" string="Manufacturing" groups="mrp.group_mrp_user">
                     <field name="attached_on_mrp" class="oe_inline"/>
                 </group>
             </sheet>


### PR DESCRIPTION
### Steps to reproduce
1. Create a new group
2. Give the group access to the following models:
   - `mrp.bom`
   - `mrp.bom.line`
   - `mrp.routing.workcenter`
   - `product.document`
3. Create a new menu using studio to access `mrp.bom` directly
4. Create a new user with the newly created group
5. Sign-in with this user and go on a BoM
6. AccessError

### Before this commit:
Users without the `mrp.group_mrp_user` group cannot display bills of material, even if we add the necessary access rights. The record loads without issue, but the chatter displays an error when loading the attachments, due to strict group access on the field `attached_on_mrp`.

### After this commit:
Remove the group from the field and move it into the view. This allows easier and more flexible access rights to the BoM without writing any custom code.

opw-4538532
