### PR TITLE
[FIX] point_of_sale: fix error in POS cancel payment (online payment)

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -237,7 +237,10 @@ export class PaymentScreen extends Component {
         // If a paymentline with a payment terminal linked to
         // it is removed, the terminal should get a cancel
         // request.
-        if (["waiting", "waitingCard", "timeout"].includes(line.get_payment_status())) {
+        if (
+            ["waiting", "waitingCard", "timeout"].includes(line.get_payment_status()) &&
+            line.payment_method_id.payment_terminal
+        ) {
             line.set_payment_status("waitingCancel");
             line.payment_method_id.payment_terminal
                 .send_payment_cancel(this.currentOrder, uuid)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Steps to reproduce 
- Create and open POS, set it up with online payment (Demo)
- Enter the payment (online payment), don't pay and refresh the page
- After refresh, go to payment screen again
- You'll get the error in my attachment
![Screenshot 2025-02-27 at 09 42 35](https://github.com/user-attachments/assets/43384d13-4cf3-4bbe-854b-0fd8cc5e8b8c)


Current behavior before PR:
- After selecting online payment, refresh the page, then you cannot cancel the payment line and error pop up appear

Desired behavior after PR is merged:
- Can cancel the payment line after refresh

opw-4608951
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
