### PR TITLE
[FIX] sale_timesheet: fix SOL update for timesheets when modifying sol mapping

### DIFF
--- a/addons/sale_timesheet/models/project_sale_line_employee_map.py
+++ b/addons/sale_timesheet/models/project_sale_line_employee_map.py
@@ -129,6 +129,9 @@ class ProjectProductEmployeeMap(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         maps = super().create(vals_list)
+        for project, employee_maps in maps.grouped('project_id').items():
+            if not project.sale_line_id and not project.partner_id and (partner := employee_maps[:1].sale_line_id.order_partner_id):
+                project.partner_id = partner
         maps._update_project_timesheet()
         return maps
 

--- a/addons/sale_timesheet/tests/test_project_billing.py
+++ b/addons/sale_timesheet/tests/test_project_billing.py
@@ -449,8 +449,9 @@ class TestProjectBilling(TestCommonSaleTimesheet):
             with project_form.sale_line_employee_ids.new() as mapping_form:
                 mapping_form.employee_id = self.employee_manager
                 mapping_form.sale_line_id = self.so.order_line[:1]
-            self.assertEqual(project_form.partner_id, self.so.partner_id, 'The partner should be the one defined the SO linked to the SOL defined in the mapping.')
+            self.assertFalse(project_form.partner_id, 'The partner should be the one defined the SO linked to the SOL defined in the mapping.')
             project = project_form.save()
+            self.assertEqual(project_form.partner_id, self.so.partner_id, 'The partner should be the one defined the SO linked to the SOL defined in the mapping.')
             self.assertEqual(project.pricing_type, 'employee_rate', 'Since there is a mapping in this project, the pricing type should be employee rate.')
 
     def test_take_into_account_invoicing_app_legacy(self):


### PR DESCRIPTION
Steps to Reproduce:
-------
1. Create a billable project and set a partner and a SOL
2. Create a task and make it non-billable by removing the SOL.
3. Add timesheets for employee A on the task.
4. Open the project form view → Invoicing tab → Add employee B to the
   employee/SOL mapping.
5. Go back to the non-billable task created earlier.

Issue:
-------
- The SOL from the project is incorrectly assigned to the task and all its
  timesheets making previously non-billable entries billable.

Cause :
-------------
- The timesheet's so_line is linked to the task's `sale_line_id`.
  if sale_line_id is null it automatically inherits the sale_project's
  sale_line_id through the compute method `_compute_sale_line` in sale_project
  causing both the task and its timesheets to become billable.

Fix:
-----------------
- we rely on the timesheet to determine the billing status. If both the
  timesheet and task are non-billable, modifying the SOL mapping should only
  update timesheets for employees included in the SOL mapping.
- we filter the records that are billable, ensuring that only billable records
  are computed.
- Removed the `_get_last_sol_of_customer` method call during SOL mapping updates


task-4477367