### PR TITLE
[FIX] point_of_sale,*: screensaver overlay issues

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/saver_screen/saver_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/saver_screen/saver_screen.js
@@ -1,6 +1,7 @@
 import { registry } from "@web/core/registry";
 import { Component } from "@odoo/owl";
 import { useTime } from "@point_of_sale/app/utils/time_hook";
+import { useService } from "@web/core/utils/hooks";
 
 export class SaverScreen extends Component {
     static template = "point_of_sale.SaverScreen";
@@ -10,6 +11,8 @@ export class SaverScreen extends Component {
 
     setup() {
         this.time = useTime();
+        this.dialog = useService("dialog");
+        this.dialog.closeAll();
     }
 }
 

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -20,7 +20,7 @@ patch(PosStore.prototype, {
                 action: () =>
                     this.dialog.closeAll() &&
                     this.config.module_pos_restaurant &&
-                    this.mainScreen.component.name !== "PaymentScreen" &&
+                    !["LoginScreen", "PaymentScreen"].includes(this.mainScreen.component.name) &&
                     this.showScreen("FloorScreen"),
             },
         ];


### PR DESCRIPTION
* = pos_restaurant

In this commit:
===
- Ensured that when a popup is open and the screensaver appears, the popup no longer overlays the screensaver.
- Fixed an issue in the restaurant module is installed, after the screensaver appears on the login screen, clicking would bring back the login screen, but attempting to open a session would trigger the screensaver again.

task-4607035
