### PR TITLE
[FIX] account: fix description updatation issue

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -224,7 +224,11 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
 
     updateLabel(value) {
         this.props.record.update({
-            name: value ? value : this.productName,
+            name: (
+                this.productName && value && this.productName.concat("\n", value)
+                || !value && this.productName
+                || value
+            ),
         });
     }
 }


### PR DESCRIPTION
Steps:
- Install account app.
- Go to invoice add a product.
- Update product description from invoice line.
- Print invoice.

Issue:
- Product name is missing in PDF file.

Cause:
- Updating line name remove product name from line name and only add newly added string description. In `product_label_section_and_note_field` widget we only display description without product name in description input even description contains product name in it but when user update that description input we forgot to take product name into account.

Fix:
- Take product name into account when updating description from that widget.

opw-4599839
opw-4603802
opw-4571431
