### PR TITLE
[FIX] mail: ensure Ctrl + K opens @ command palette when in chat window

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -21,6 +21,7 @@ import { localization } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { Typing } from "@mail/discuss/typing/common/typing";
+import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 
 /**
  * @typedef {Object} Props
@@ -108,8 +109,8 @@ export class ChatWindow extends Component {
             return;
         }
         ev.stopPropagation(); // not letting home menu steal my CTRL-C
-        switch (ev.key) {
-            case "Escape":
+        switch (getActiveHotkey(ev)) {
+            case "escape":
                 if (
                     isEventHandled(ev, "NavigableList.close") ||
                     isEventHandled(ev, "Composer.discard")
@@ -122,7 +123,7 @@ export class ChatWindow extends Component {
                 }
                 this.close({ escape: true });
                 break;
-            case "Tab": {
+            case "tab": {
                 const index = this.store.chatHub.opened.findIndex((cw) => cw.eq(chatWindow));
                 if (index === this.store.chatHub.opened.length - 1) {
                     this.store.chatHub.opened[0].focus({ jumpToNewMessage: true });
@@ -131,6 +132,10 @@ export class ChatWindow extends Component {
                 }
                 break;
             }
+            case "control+k":
+                this.store.env.services.command.openMainPalette({ searchValue: "@" });
+                ev.preventDefault();
+                break;
         }
     }
 

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -1046,3 +1046,18 @@ test("getting focus of chat window through tab key should jump to new message se
         ".o-mail-ChatWindow:eq(0) .o-mail-Thread"
     );
 });
+
+test("Ctrl+k opens the @ command palette", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create([
+        {
+            name: "General",
+            channel_member_ids: [Command.create({ partner_id: serverState.partnerId })],
+        },
+    ]);
+    setupChatHub({ opened: channelId });
+    await start();
+    await focus(".o-mail-ChatWindow", { text: "General" });
+    triggerHotkey("control+k");
+    await contains(".o_command_palette_search", { text: "@" });
+});


### PR DESCRIPTION
**Current behavior before PR**:

Pressing Ctrl + K while focused on the chat window did not open the command palette, as the event was captured by the chat window and prevented from propagating further.

**Desired behavior after PR is merged**:

Ctrl + K is now properly handled when the chat window is focused, allowing the @ command palette to open as expected.

**task-id**:[4593364](https://www.odoo.com/odoo/project/1519/tasks/4593364)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
