### PR TITLE
[FIX] im_livechat: chat bot step incorrect id

### DIFF
--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -70,26 +70,17 @@ class LivechatChatbotScriptController(http.Controller):
         store = Store(posted_message, for_current_user=True)
         store.add(next_step)
         store.add_model_values(
-            "ChatbotStep",
-            {
-                "id": (next_step.id, posted_message.id),
-                "isLast": next_step._is_last_step(discuss_channel),
-                "message": posted_message.id,
-                "operatorFound": next_step.is_forward_operator
-                and discuss_channel.livechat_operator_id != chatbot.operator_partner_id,
-                "scriptStep": next_step.id,
-            },
-        )
-        store.add_model_values(
             "Chatbot",
             {
                 "currentStep": {
-                    "id": (next_step.id, discuss_channel.id),
-                    "scriptStep": next_step.id,
+                    "isLast": next_step._is_last_step(discuss_channel),
                     "message": posted_message.id,
+                    "operatorFound": next_step.is_forward_operator
+                    and discuss_channel.livechat_operator_id != chatbot.operator_partner_id,
+                    "scriptStep": next_step.id,
                 },
-                "id": (chatbot.id, discuss_channel.id),
                 "script": chatbot.id,
+                "steps": [["ADD", [{"scriptStep": next_step.id, "message": posted_message.id}]]],
                 "thread": Store.One(discuss_channel, [], as_thread=True),
             },
         )

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -404,7 +404,6 @@ class ChatbotScriptStep(models.Model):
                 store.add_model_values(
                     "ChatbotStep",
                     {
-                        "id": (self.id, step_message.id),
                         "scriptStep": self.id,
                         "message": step_message.id,
                         "operatorFound": True,

--- a/addons/im_livechat/models/mail_message.py
+++ b/addons/im_livechat/models/mail_message.py
@@ -48,7 +48,6 @@ class MailMessage(models.Model):
                 )
                 if step := chatbot_message.script_step_id:
                     step_data = {
-                        "id": (step.id, message.id),
                         "message": message.id,
                         "scriptStep": step.id,
                         "operatorFound": step.is_forward_operator

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
@@ -113,8 +113,7 @@ export class Chatbot extends Record {
                 this.currentStep.isLast = true;
                 return;
             }
-            const { ChatbotStep: steps } = this.store.insert(storeData, { html: true });
-            this.steps.push(steps[0]);
+            this.store.insert(storeData, { html: true });
         } else {
             const nextStepIndex = this.steps.lastIndexOf(this.currentStep) + 1;
             this.currentStep = this.steps[nextStepIndex];

--- a/addons/im_livechat/tools/__init__.py
+++ b/addons/im_livechat/tools/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import discuss
 from . import misc

--- a/addons/im_livechat/tools/discuss.py
+++ b/addons/im_livechat/tools/discuss.py
@@ -1,0 +1,4 @@
+from odoo.addons.mail.tools.discuss import ids_by_model
+
+ids_by_model["ChatbotStep"] = ("scriptStep", "message")
+ids_by_model["Chatbot"] = ("script", "thread")

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -218,7 +218,7 @@ class Store:
     def _get_record_index(self, model_name, values):
         ids = ids_by_model[model_name]
         for i in ids:
-            assert values.get(i), f"missing id {i} in {model_name}: {values}"
+            assert i in values, f"missing id {i} in {model_name}: {values}"
         return tuple(values[i] for i in ids)
 
     class Attr:


### PR DESCRIPTION
Before this PR, chat bot data was sent with incorrecet ids. This can lead to inconsistencies. This PR fixes the issue.

part of task-4607689