### PR TITLE
[REF] spreadsheet: split list core in two

### DIFF
--- a/addons/spreadsheet/static/src/index.js
+++ b/addons/spreadsheet/static/src/index.js
@@ -15,14 +15,19 @@
 
 /** TODO: Introduce a position parameter to the plugin registry in order to load them in a specific order */
 import * as spreadsheet from "@odoo/o-spreadsheet";
-const { corePluginRegistry, coreViewsPluginRegistry, featurePluginRegistry } = spreadsheet.registries;
+const { corePluginRegistry, coreViewsPluginRegistry, featurePluginRegistry } =
+    spreadsheet.registries;
 
 import {
-  GlobalFiltersCorePlugin,
-  GlobalFiltersUIPlugin,
-  GlobalFiltersCoreViewPlugin,
+    GlobalFiltersCorePlugin,
+    GlobalFiltersUIPlugin,
+    GlobalFiltersCoreViewPlugin,
 } from "@spreadsheet/global_filters/index";
-import { PivotOdooCorePlugin, PivotCoreViewGlobalFilterPlugin, PivotUIGlobalFilterPlugin } from "@spreadsheet/pivot/index"; // list depends on filter for its getters
+import {
+    PivotOdooCorePlugin,
+    PivotCoreViewGlobalFilterPlugin,
+    PivotUIGlobalFilterPlugin,
+} from "@spreadsheet/pivot/index"; // list depends on filter for its getters
 import { ListCorePlugin, ListCoreViewPlugin, ListUIPlugin } from "@spreadsheet/list/index"; // pivot depends on filter for its getters
 import {
     ChartOdooMenuPlugin,
@@ -31,16 +36,21 @@ import {
 } from "@spreadsheet/chart/index"; // Odoochart depends on filter for its getters
 import { PivotCoreGlobalFilterPlugin } from "./pivot/plugins/pivot_core_global_filter_plugin";
 import { PivotOdooUIPlugin } from "./pivot/plugins/pivot_odoo_ui_plugin";
+import { ListCoreGlobalFilterPlugin } from "./list/plugins/list_core_global_filter_plugin";
 
 corePluginRegistry.add("OdooGlobalFiltersCorePlugin", GlobalFiltersCorePlugin);
 corePluginRegistry.add("PivotOdooCorePlugin", PivotOdooCorePlugin);
 corePluginRegistry.add("OdooPivotGlobalFiltersCorePlugin", PivotCoreGlobalFilterPlugin);
 corePluginRegistry.add("OdooListCorePlugin", ListCorePlugin);
+corePluginRegistry.add("OdooListCoreGlobalFilterPlugin", ListCoreGlobalFilterPlugin);
 corePluginRegistry.add("odooChartCorePlugin", OdooChartCorePlugin);
 corePluginRegistry.add("chartOdooMenuPlugin", ChartOdooMenuPlugin);
 
 coreViewsPluginRegistry.add("OdooGlobalFiltersCoreViewPlugin", GlobalFiltersCoreViewPlugin);
-coreViewsPluginRegistry.add("OdooPivotGlobalFiltersCoreViewPlugin", PivotCoreViewGlobalFilterPlugin);
+coreViewsPluginRegistry.add(
+    "OdooPivotGlobalFiltersCoreViewPlugin",
+    PivotCoreViewGlobalFilterPlugin
+);
 coreViewsPluginRegistry.add("OdooListCoreViewPlugin", ListCoreViewPlugin);
 coreViewsPluginRegistry.add("odooChartUIPlugin", OdooChartUIPlugin);
 

--- a/addons/spreadsheet/static/src/list/plugins/list_core_global_filter_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_core_global_filter_plugin.js
@@ -1,0 +1,158 @@
+import { CommandResult } from "../../o_spreadsheet/cancelled_reason";
+import { _t } from "@web/core/l10n/translation";
+import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
+import { checkFilterFieldMatching } from "@spreadsheet/global_filters/helpers";
+import { deepCopy } from "@web/core/utils/objects";
+import { OdooCorePlugin } from "@spreadsheet/plugins";
+
+/**
+ * @typedef GFLocalList
+ * @property {string} id
+ * @property {Record<string, FieldMatching>} fieldMatching
+ *
+ */
+
+export class ListCoreGlobalFilterPlugin extends OdooCorePlugin {
+    static getters = /** @type {const} */ (["getListFieldMatch", "getListFieldMatching"]);
+    constructor(config) {
+        super(config);
+
+        /** @type {Object.<string, GFLocalList>} */
+        this.fieldMatchings = {};
+        globalFiltersFieldMatchers["list"] = {
+            getIds: () => Object.keys(this.fieldMatchings),
+            getDisplayName: (listId) => this.getters.getListName(listId),
+            getTag: (listId) => _t(`List #%(list_id)s`, { list_id: listId }),
+            getFieldMatching: (listId, filterId) => this.getListFieldMatching(listId, filterId),
+            getModel: (listId) => this.getters.getListDefinition(listId).model,
+        };
+    }
+
+    /**
+     * @param {AllCoreCommand} cmd
+     *
+     * @returns {string | string[]}
+     */
+    allowDispatch(cmd) {
+        switch (cmd.type) {
+            case "ADD_GLOBAL_FILTER":
+            case "EDIT_GLOBAL_FILTER":
+                if (cmd.list) {
+                    return checkFilterFieldMatching(cmd.list);
+                }
+        }
+        return CommandResult.Success;
+    }
+
+    /**
+     * @param {AllCoreCommand} cmd
+     *
+     */
+    handle(cmd) {
+        switch (cmd.type) {
+            case "INSERT_ODOO_LIST": {
+                this._addList(cmd.id);
+                break;
+            }
+            case "REMOVE_ODOO_LIST": {
+                this.history.update("fieldMatchings", cmd.listId, undefined);
+                break;
+            }
+            case "DUPLICATE_ODOO_LIST": {
+                const { listId, newListId } = cmd;
+                const fieldMatch = deepCopy(this.fieldMatchings[listId]);
+                this._addList(newListId, fieldMatch);
+                break;
+            }
+            case "ADD_GLOBAL_FILTER":
+            case "EDIT_GLOBAL_FILTER":
+                if (cmd.list) {
+                    this._setListFieldMatching(cmd.filter.id, cmd.list);
+                }
+                break;
+            case "REMOVE_GLOBAL_FILTER":
+                this._onFilterDeletion(cmd.id);
+                break;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Getters
+    // -------------------------------------------------------------------------
+
+    /**
+     * @param {string} id
+     * @returns {string}
+     */
+    getListFieldMatch(id) {
+        return this.fieldMatchings[id];
+    }
+
+    /**
+     *
+     * @param {string} listId
+     * @param {string} filterId
+     */
+    getListFieldMatching(listId, filterId) {
+        return this.getListFieldMatch(listId)[filterId];
+    }
+
+    // -------------------------------------------------------------------------
+    // Private
+    // -------------------------------------------------------------------------
+
+    /**
+     * Sets the current FieldMatching on a list
+     *
+     * @param {string} filterId
+     * @param {Record<string,FieldMatching>} listFieldMatches
+     */
+    _setListFieldMatching(filterId, listFieldMatches) {
+        const fieldMatchings = { ...this.fieldMatchings };
+        for (const [listId, fieldMatch] of Object.entries(listFieldMatches)) {
+            fieldMatchings[listId][filterId] = fieldMatch;
+        }
+        this.history.update("fieldMatchings", fieldMatchings);
+    }
+
+    _onFilterDeletion(filterId) {
+        const fieldMatchings = { ...this.fieldMatchings };
+        for (const listId in fieldMatchings) {
+            this.history.update("fieldMatchings", listId, filterId, undefined);
+        }
+    }
+
+    _addList(id, fieldMatching = undefined) {
+        const list = this.getters.getListDefinition(id);
+        const model = list.model;
+        this.history.update(
+            "fieldMatchings",
+            id,
+            fieldMatching || this.getters.getFieldMatchingForModel(model)
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Import/Export
+    // ---------------------------------------------------------------------
+
+    /**
+     * @param {Object} data
+     */
+    import(data) {
+        if (data.lists) {
+            for (const [id, list] of Object.entries(data.lists)) {
+                this._addList(id, list.fieldMatching);
+            }
+        }
+    }
+    /**
+     *
+     * @param {Object} data
+     */
+    export(data) {
+        for (const id in this.lists) {
+            data.lists[id].fieldMatching = this.fieldMatchings[id];
+        }
+    }
+}


### PR DESCRIPTION
Similar to https://github.com/odoo/odoo/commit/d303a24c1b37eff1347393b5e0226bb40bb8efd5 This commit splits the list core in two parts:
- list_core_plugin.js: the plugin that handles the list commands
- list_core_global_filters.js: the plugin that handles the global filters related to list

Task: 4398439

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
