### PR TITLE
[FIX] website: update the markers in google maps

### DIFF
--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -923,6 +923,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
             'ready_to_clean_for_save': this._onRootEventRequest.bind(this),
             'will_remove_snippet': this._onRootEventRequest.bind(this),
             'gmap_api_request': this._onRootEventRequest.bind(this),
+            'gmap_api_request_2': this._onRootEventRequest.bind(this),
             'gmap_api_key_request': this._onRootEventRequest.bind(this),
             'request_save': this._onSaveRequest.bind(this),
             'context_get': this._onContextGet.bind(this),

--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -25,6 +25,7 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
     }),
     custom_events: Object.assign({}, weSnippetEditor.SnippetsMenu.prototype.custom_events, {
         'gmap_api_request': '_onGMapAPIRequest',
+        'gmap_api_request_2': '_onGMapAPIRequest2',
         'gmap_api_key_request': '_onGMapAPIKeyRequest',
         'reload_bundles': '_onReloadBundles',
     }),
@@ -663,6 +664,13 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
      */
     _onGMapAPIRequest(ev) {
         this._handleGMapRequest(ev, 'gmap_api_request');
+    },
+    /**
+     * @private
+     * @param {OdooEvent} ev
+     */
+    _onGMapAPIRequest2(ev) {
+        this._handleGMapRequest(ev, 'gmap_api_request_2');
     },
     /**
      * @private

--- a/addons/website/static/src/scss/website.wysiwyg.scss
+++ b/addons/website/static/src/scss/website.wysiwyg.scss
@@ -278,6 +278,51 @@ html[data-edit_translations="1"] {
         }
     }
 }
+.s_google_map_suggestion_box {
+    z-index: $zindex-modal-backdrop; // > $o-we-zindex
+    position: absolute;
+    top: 110%;
+    right: 0;
+    width: ceil($o-we-sidebar-width * 0.9) !important;
+    font-size: $o-we-sidebar-font-size;
+    border: $o-we-sidebar-content-field-border-width solid $o-we-sidebar-content-field-dropdown-border-color;
+    border-top: none;
+    border-radius: $o-we-item-border-radius;
+    overflow: hidden;
+    background-color: $o-we-sidebar-content-field-dropdown-bg;
+    box-shadow: $o-we-sidebar-content-field-dropdown-shadow;
+
+    &:after {
+        display: none;
+    }
+
+    .s_google_map_suggestion_item {
+        @include o-text-overflow(block);
+        line-height: $o-we-sidebar-content-field-dropdown-item-height;
+        color: $o-we-sidebar-content-field-clickable-color;
+        padding: 0 1em 0 (2 * $o-we-sidebar-content-field-control-item-spacing + $o-we-sidebar-content-field-control-item-size);
+        border-top: $o-we-sidebar-content-field-border-width solid lighten($o-we-sidebar-content-field-dropdown-border-color, 15%);
+        border-radius: $o-we-sidebar-content-field-border-radius;
+        background-color: $o-we-sidebar-content-field-clickable-bg;
+        color: $o-we-sidebar-content-field-clickable-color;
+        font-size: $o-we-sidebar-font-size;
+
+        &:hover, &:focus, &.s_google_map_suggestion_item_selected {
+            background-color: $o-we-sidebar-content-field-dropdown-item-bg-hover;
+            cursor: pointer;
+        }
+
+        .s_google_map_suggestion_icon_marker {
+            position: absolute;
+            margin-left: -1em;
+
+            &::after {
+                content: '\f041';
+                font-family: FontAwesome;
+            }
+        }
+    }
+}
 
 // Editor UI
 .o_table_ui {

--- a/addons/website/static/src/snippets/s_google_map/000.js
+++ b/addons/website/static/src/snippets/s_google_map/000.js
@@ -4,7 +4,7 @@
 import publicWidget from "@web/legacy/js/public/public_widget";
 
 publicWidget.registry.GoogleMap = publicWidget.Widget.extend({
-    selector: '.s_google_map',
+    selector: '.s_google_map_deactivated',
     disabledInEditableMode: false,
 
     mapColors: {
@@ -90,6 +90,130 @@ publicWidget.registry.GoogleMap = publicWidget.Widget.extend({
             const mapColor = this.mapColors[mapColorAttr];
             map.mapTypes.set('map_style', new google.maps.StyledMapType(mapColor, {name: "Styled Map"}));
             map.setMapTypeId('map_style');
+        }
+    },
+});
+
+publicWidget.registry.GoogleMap2 = publicWidget.Widget.extend({
+    selector: ".s_google_map",
+    disabledInEditableMode: false,
+
+    mapColors: {
+        lightMonoMap: [{"featureType": "administrative.locality", "elementType": "all", "stylers": [{"hue": "#2c2e33"}, {"saturation": 7}, {"lightness": 19}, {"visibility": "on"}]}, {"featureType": "landscape", "elementType": "all", "stylers": [{"hue": "#ffffff"}, {"saturation": -100}, {"lightness": 100}, {"visibility": "simplified"}]}, {"featureType": "poi", "elementType": "all", "stylers": [{"hue": "#ffffff"}, {"saturation": -100}, {"lightness": 100}, {"visibility": "off"}]}, {"featureType": "road", "elementType": "geometry", "stylers": [{"hue": "#bbc0c4"}, {"saturation": -93}, {"lightness": 31}, {"visibility": "simplified"}]}, {"featureType": "road", "elementType": "labels", "stylers": [{"hue": "#bbc0c4"}, {"saturation": -93}, {"lightness": 31}, {"visibility": "on"}]}, {"featureType": "road.arterial", "elementType": "labels", "stylers": [{"hue": "#bbc0c4"}, {"saturation": -93}, {"lightness": -2}, {"visibility": "simplified"}]}, {"featureType": "road.local", "elementType": "geometry", "stylers": [{"hue": "#e9ebed"}, {"saturation": -90}, {"lightness": -8}, {"visibility": "simplified"}]}, {"featureType": "transit", "elementType": "all", "stylers": [{"hue": "#e9ebed"}, {"saturation": 10}, {"lightness": 69}, {"visibility": "on"}]}, {"featureType": "water", "elementType": "all", "stylers": [{"hue": "#e9ebed"}, {"saturation": -78}, {"lightness": 67}, {"visibility": "simplified"}]}],
+        lillaMap: [{elementType: "labels", stylers: [{saturation: -20}]}, {featureType: "poi", elementType: "labels", stylers: [{visibility: "off"}]}, {featureType: 'road.highway', elementType: 'labels', stylers: [{visibility: "off"}]}, {featureType: "road.local", elementType: "labels.icon", stylers: [{visibility: "off"}]}, {featureType: "road.arterial", elementType: "labels.icon", stylers: [{visibility: "off"}]}, {featureType: "road", elementType: "geometry.stroke", stylers: [{visibility: "off"}]}, {featureType: "transit", elementType: "geometry.fill", stylers: [{hue: '#2d313f'}, {visibility: "on"}, {lightness: 5}, {saturation: -20}]}, {featureType: "poi", elementType: "geometry.fill", stylers: [{hue: '#2d313f'}, {visibility: "on"}, {lightness: 5}, {saturation: -20}]}, {featureType: "poi.government", elementType: "geometry.fill", stylers: [{hue: '#2d313f'}, {visibility: "on"}, {lightness: 5}, {saturation: -20}]}, {featureType: "poi.sport_complex", elementType: "geometry.fill", stylers: [{hue: '#2d313f'}, {visibility: "on"}, {lightness: 5}, {saturation: -20}]}, {featureType: "poi.attraction", elementType: "geometry.fill", stylers: [{hue: '#2d313f'}, {visibility: "on"}, {lightness: 5}, {saturation: -20}]}, {featureType: "poi.business", elementType: "geometry.fill", stylers: [{hue: '#2d313f'}, {visibility: "on"}, {lightness: 5}, {saturation: -20}]}, {featureType: "transit", elementType: "geometry.fill", stylers: [{hue: '#2d313f'}, {visibility: "on"}, {lightness: 5}, {saturation: -20}]}, {featureType: "transit.station", elementType: "geometry.fill", stylers: [{hue: '#2d313f'}, {visibility: "on"}, {lightness: 5}, {saturation: -20}]}, {featureType: "landscape", stylers: [{hue: '#2d313f'}, {visibility: "on"}, {lightness: 5}, {saturation: -20}]}, {featureType: "road", elementType: "geometry.fill", stylers: [{hue: '#2d313f'}, {visibility: "on"}, {lightness: 5}, {saturation: -20}]}, {featureType: "road.highway", elementType: "geometry.fill", stylers: [{hue: '#2d313f'}, {visibility: "on"}, {lightness: 5}, {saturation: -20}]}, {featureType: "water", elementType: "geometry", stylers: [{hue: '#2d313f'}, {visibility: "on"}, {lightness: 5}, {saturation: -20}]}],
+        blueMap: [{stylers: [{hue: "#00ffe6"}, {saturation: -20}]}, {featureType: "road", elementType: "geometry", stylers: [{lightness: 100}, {visibility: "simplified"}]}, {featureType: "road", elementType: "labels", stylers: [{visibility: "off"}]}],
+        retroMap: [{"featureType": "administrative", "elementType": "all", "stylers": [{"visibility": "on"}, {"lightness": 33}]}, {"featureType": "landscape", "elementType": "all", "stylers": [{"color": "#f2e5d4"}]}, {"featureType": "poi.park", "elementType": "geometry", "stylers": [{"color": "#c5dac6"}]}, {"featureType": "poi.park", "elementType": "labels", "stylers": [{"visibility": "on"}, {"lightness": 20}]}, {"featureType": "road", "elementType": "all", "stylers": [{"lightness": 20}]}, {"featureType": "road.highway", "elementType": "geometry", "stylers": [{"color": "#c5c6c6"}]}, {"featureType": "road.arterial", "elementType": "geometry", "stylers": [{"color": "#e4d7c6"}]}, {"featureType": "road.local", "elementType": "geometry", "stylers": [{"color": "#fbfaf7"}]}, {"featureType": "water", "elementType": "all", "stylers": [{"visibility": "on"}, {"color": "#acbcc9"}]}],
+        flatMap: [{"stylers": [{"visibility": "off"}]}, {"featureType": "road", "stylers": [{"visibility": "on"}, {"color": "#ffffff"}]}, {"featureType": "road.arterial", "stylers": [{"visibility": "on"}, {"color": "#fee379"}]}, {"featureType": "road.highway", "stylers": [{"visibility": "on"}, {"color": "#fee379"}]}, {"featureType": "landscape", "stylers": [{"visibility": "on"}, {"color": "#f3f4f4"}]}, {"featureType": "water", "stylers": [{"visibility": "on"}, {"color": "#7fc8ed"}]}, {}, {"featureType": "road", "elementType": "labels", "stylers": [{"visibility": "on"}]}, {"featureType": "poi.park", "elementType": "geometry.fill", "stylers": [{"visibility": "on"}, {"color": "#83cead"}]}, {"elementType": "labels", "stylers": [{"visibility": "on"}]}, {"featureType": "landscape.man_made", "elementType": "geometry", "stylers": [{"weight": 0.9}, {"visibility": "off"}]}],
+        cobaltMap: [{"featureType": "all", "elementType": "all", "stylers": [{"invert_lightness": true}, {"saturation": 10}, {"lightness": 30}, {"gamma": 0.5}, {"hue": "#435158"}]}],
+        cupertinoMap: [{"featureType": "water", "elementType": "geometry", "stylers": [{"color": "#a2daf2"}]}, {"featureType": "landscape.man_made", "elementType": "geometry", "stylers": [{"color": "#f7f1df"}]}, {"featureType": "landscape.natural", "elementType": "geometry", "stylers": [{"color": "#d0e3b4"}]}, {"featureType": "landscape.natural.terrain", "elementType": "geometry", "stylers": [{"visibility": "off"}]}, {"featureType": "poi.park", "elementType": "geometry", "stylers": [{"color": "#bde6ab"}]}, {"featureType": "poi", "elementType": "labels", "stylers": [{"visibility": "off"}]}, {"featureType": "poi.medical", "elementType": "geometry", "stylers": [{"color": "#fbd3da"}]}, {"featureType": "poi.business", "stylers": [{"visibility": "off"}]}, {"featureType": "road", "elementType": "geometry.stroke", "stylers": [{"visibility": "off"}]}, {"featureType": "road", "elementType": "labels", "stylers": [{"visibility": "off"}]}, {"featureType": "road.highway", "elementType": "geometry.fill", "stylers": [{"color": "#ffe15f"}]}, {"featureType": "road.highway", "elementType": "geometry.stroke", "stylers": [{"color": "#efd151"}]}, {"featureType": "road.arterial", "elementType": "geometry.fill", "stylers": [{"color": "#ffffff"}]}, {"featureType": "road.local", "elementType": "geometry.fill", "stylers": [{"color": "black"}]}, {"featureType": "transit.station.airport", "elementType": "geometry.fill", "stylers": [{"color": "#cfb2db"}]}],
+        carMap: [{"featureType": "administrative", "stylers": [{"visibility": "off"}]}, {"featureType": "poi", "stylers": [{"visibility": "simplified"}]}, {"featureType": "road", "stylers": [{"visibility": "simplified"}]}, {"featureType": "water", "stylers": [{"visibility": "simplified"}]}, {"featureType": "transit", "stylers": [{"visibility": "simplified"}]}, {"featureType": "landscape", "stylers": [{"visibility": "simplified"}]}, {"featureType": "road.highway", "stylers": [{"visibility": "off"}]}, {"featureType": "road.local", "stylers": [{"visibility": "on"}]}, {"featureType": "road.highway", "elementType": "geometry", "stylers": [{"visibility": "on"}]}, {"featureType": "water", "stylers": [{"color": "#84afa3"}, {"lightness": 52}]}, {"stylers": [{"saturation": -77}]}, {"featureType": "road"}],
+        bwMap: [{stylers: [{hue: "#00ffe6"}, {saturation: -100}]}, {featureType: "road", elementType: "geometry", stylers: [{lightness: 100}, {visibility: "simplified"}]}, {featureType: "road", elementType: "labels", stylers: [{visibility: "off"}]}],
+    },
+
+    /**
+     * @override
+     */
+    async start() {
+        await this._super(...arguments);
+
+        if (typeof google !== "object" || typeof google.maps !== "object") {
+            await new Promise((resolve) => {
+                this.trigger_up("gmap_api_request_2", {
+                    editableMode: this.editableMode,
+                    onSuccess: () => resolve(),
+                });
+            });
+        }
+
+        const p = this.el.dataset.mapGps.substring(1).slice(0, -1).split(",");
+        const gps = { lat: Number(p[0]), lng: Number(p[1]) };
+
+        // Default options, will be overwritten by the user
+        const myOptions = {
+            zoom: 12,
+            center: gps,
+            mapId: "DEMO_MAP_ID",
+            mapTypeId: "roadmap",
+            panControl: false,
+            zoomControl: false,
+            mapTypeControl: false,
+            streetViewControl: false,
+            scrollwheel: false,
+            mapTypeControlOptions: {
+                mapTypeIds: ["roadmap", "map_style"],
+            },
+        };
+        // Render Map
+        const mapC = this.$(".map_container");
+        const [{ Map }, { AdvancedMarkerElement }] = await Promise.all([
+            google.maps.importLibrary("maps"),
+            google.maps.importLibrary("marker"),
+        ]);
+        const map = new Map(mapC[0], myOptions);
+        // Update Map on screen resize
+        window.addEventListener("resize", () => {
+            map.setCenter(gps);
+        });
+
+        let markerIcon;
+        if (this.el.dataset.pinStyle === "flat") {
+            markerIcon = document.createElement("img");
+            markerIcon.src = "/website/static/src/img/snippets_thumbs/s_google_map_marker.png";
+            // Handle the drop animation of the marker
+            const intersectionObserver = new IntersectionObserver((entries) => {
+                for (const entry of entries) {
+                    if (entry.isIntersecting) {
+                        entry.target.classList.add("s_google_map_drop");
+                        intersectionObserver.unobserve(entry.target);
+                    }
+                }
+            });
+            intersectionObserver.observe(markerIcon);
+            markerIcon.style.opacity = "0";
+            markerIcon.addEventListener(
+                "animationend",
+                () => {
+                    markerIcon.classList.remove("s_google_map_drop");
+                    markerIcon.style.opacity = "1";
+                },
+                { once: true }
+            );
+        } else {
+            const { PinElement } = await google.maps.importLibrary("marker");
+            markerIcon = new PinElement();
+        }
+        // Create Marker & Infowindow
+        const markerOptions = {
+            map,
+            position: { lat: Number(p[0]), lng: Number(p[1]) },
+            content: markerIcon,
+        };
+
+        new AdvancedMarkerElement(markerOptions);
+
+        // Other option to keep the drop animation on both pin (default and flat)
+        // google.maps.event.addListenerOnce(map, "idle", () => {
+        //     markerIcon.style.opacity = "0";
+        //     markerIcon.classList.add("s_google_map_drop");
+        //     new AdvancedMarkerElement(markerOptions);
+        //     setTimeout(() => {
+        //         markerIcon.classList.remove("s_google_map_drop");
+        //         markerIcon.style.opacity = "1";
+        //     }, 800);
+        // });
+
+        map.setMapTypeId(google.maps.MapTypeId[this.el.dataset.mapType]); // Update Map Type
+        map.setZoom(parseInt(this.el.dataset.mapZoom)); // Update Map Zoom
+
+        // Update Map Color
+        const mapColorAttr = this.el.dataset.mapColor;
+        if (mapColorAttr) {
+            const mapColor = this.mapColors[mapColorAttr];
+            map.mapTypes.set(
+                "map_style",
+                new google.maps.StyledMapType(mapColor, { name: "Styled Map" })
+            );
+            map.setMapTypeId("map_style");
         }
     },
 });

--- a/addons/website/static/src/snippets/s_google_map/000.scss
+++ b/addons/website/static/src/snippets/s_google_map/000.scss
@@ -39,4 +39,32 @@ $s-google-map-desc-hover-alpha: 0.55 !default;
         background: rgba($s-google-map-desc-hover-bg, $s-google-map-desc-hover-alpha);
         color: color-contrast(rgba($s-google-map-desc-hover-bg, $s-google-map-desc-hover-alpha));
     }
+    @keyframes s_google_map_drop {
+        0% {
+            transform: translateY(-200px) scaleY(0.9);
+            opacity: 0;
+        }
+        5% {
+            opacity: 0.7;
+        }
+        50% {
+            transform: translateY(0px) scaleY(1);
+            opacity: 1;
+        }
+        65% {
+            transform: translateY(-17px) scaleY(0.9);
+            opacity: 1;
+        }
+        75% {
+            transform: translateY(-22px) scaleY(0.9);
+            opacity: 1;
+        }
+        100% {
+            transform: translateY(0px) scaleY(1);
+            opacity: 1;
+        }
+    }
+    .s_google_map_drop {
+        animation: s_google_map_drop 0.3s linear forwards 0.5s;
+    }
 }


### PR DESCRIPTION
Replaced the deprecated `google.maps.Marker` with
`google.maps.marker.AdvancedMarkerElement`, as the former has been deprecated since February 2024.

Additionally, updated the method for loading the Google Maps JS API to use the recommended dynamic library import for improved performance and compliance with the latest guidelines.

References:
- Migration to Advanced Marker: https://developers.google.com/maps/documentation/javascript/advanced-markers/migration
- Dynamic library import: https://developers.google.com/maps/documentation/javascript/load-maps-js-api

task-4441041
