### PR TITLE
[FIX] stock: remove packaging conversion

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -176,9 +176,6 @@
                                                 <td class="text-end">
                                                     <span t-out="format_number(line.quantity)">3.00</span>
                                                     <span t-field="line.product_uom_id" groups="uom.group_uom">units</span>
-                                                    <span t-if="line.move_id.packaging_uom_id">
-                                                        (<span t-field="line.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="line.move_id.packaging_uom_id.name"/>)
-                                                    </span>
                                                 </td>
                                                 <td class="text-start" t-if="from_col_exists" groups="stock.group_stock_multi_locations">
                                                     <span t-field="line.location_id.display_name">WH/Stock</span>


### PR DESCRIPTION
Since 28b69daefddbb74ad9ac3fd55df88028e6de972b, the stock move line don't have the field `product_packaging_qty` to compute their quantity in the packaging unit. This commit removes a missing occurence of this field.

rb-135015

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
