### PR TITLE
[FIX] website_event: fix crash when registration form have extra form details

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -267,7 +267,6 @@ class WebsiteEventController(http.Controller):
         :param form_details: posted data from frontend registration form, like
             {'1-name': 'r', '1-email': 'r@r.com', '1-phone': '', '1-event_ticket_id': '1'}
         """
-        form_details.pop("recaptcha_token_response", None)
         allowed_fields = request.env['event.registration']._get_website_registration_allowed_fields()
         registration_fields = {key: v for key, v in request.env['event.registration']._fields.items() if key in allowed_fields}
         for ticket_id in list(filter(lambda x: x is not None, [form_details[field] if 'event_ticket_id' in field else None for field in form_details.keys()])):
@@ -281,7 +280,7 @@ class WebsiteEventController(http.Controller):
         # goal is to use the answer to the first question of every 'type' (aka name / phone / email / company name)
         already_handled_fields_data = {}
         for key, value in form_details.items():
-            if not value:
+            if not value or '-' not in key:
                 continue
 
             key_values = key.split('-')
@@ -291,6 +290,9 @@ class WebsiteEventController(http.Controller):
                 if field_name not in registration_fields:
                     continue
                 registrations.setdefault(registration_index, dict())[field_name] = int(value) or False
+                continue
+
+            if len(key_values) != 3:
                 continue
 
             registration_index, question_type, question_id = key_values

--- a/addons/website_event/tests/test_event_internals.py
+++ b/addons/website_event/tests/test_event_internals.py
@@ -106,6 +106,8 @@ class TestEventData(TestEventQuestionCommon):
             '2-simple_choice-%s' % self.event_question_1.id: '9',
             '0-simple_choice-%s' % self.event_question_2.id: '7',
             '0-text_box-%s' % self.event_question_3.id: 'Free Text',
+            'custom-field': 'custom-value',
+            'recaptcha_token_response': 'opaquetokenvalue',
         }
 
         with MockRequest(self.env):


### PR DESCRIPTION
When registration form have extra form details where the field value doesn't match an attendee field format (2 or 3 values separated by a dash) we where crashing while trying to unpack the split value.

This commit simply ignore the field if its value doesn't match the expected format of an attendee field.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
