### PR TITLE
[FIX] project: make sure milestone is saved before continuing tour

### DIFF
--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -135,6 +135,9 @@ registry.category("web_tour.tours").add('project_update_tour', {
     trigger: ".o_list_button_save",
     run: "click",
 }, {
+    trigger: ".o_list_button_add",
+    content: "Make sure the milestone is saved before continuing",
+}, {
     trigger: "td[data-tooltip='New milestone'] + td",
     run: "click",
 }, {


### PR DESCRIPTION
Before this commit, the `project_update_tour` sometimes fails because the save action takes more time than usually and so the UI does not get the click event on the new milestone created and so the line does not go back in edit mode.

This commit adds a new step to make sure the create action is correctly made before doing the next steps.

runbot-104048
