### PR TITLE
[IMP] l10n_fr: adapt invoice layout for better readability

### DIFF
--- a/addons/l10n_fr_account/views/report_invoice.xml
+++ b/addons/l10n_fr_account/views/report_invoice.xml
@@ -20,8 +20,8 @@
         <xpath expr="//div[@id='informations']" position="inside">
             <t t-if="o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id != o.partner_id and o.move_type.startswith('out_')">
                 <t t-set="partner" t-value="o.partner_id.commercial_partner_id"/>
-                <div t-attf-class="#{'col-auto col-3 mw-100' if report_type != 'html' else 'col'} mb-2" name="customer_address">
-                    <strong>Customer Address:</strong>
+                <div name="customer_address" class='col'>
+                    <strong>Customer Address</strong>
                     <br/>
                     <address t-field="partner.self" class="m-0" t-options="{'widget': 'contact', 'fields': ['address'], 'no_marker': True}"/>
                 </div>
@@ -34,8 +34,8 @@
                 <t t-set="has_service" t-value="'service' in tax_scopes"/>
                 <t t-set="has_consu" t-value="'consu' in tax_scopes"/>
 
-                <div t-if="has_service or has_consu" t-attf-class="#{'col-auto col-3 mw-100' if report_type != 'html' else 'col'} mb-2" name="operation_type">
-                    <strong>Operation Type:</strong>
+                <div t-if="has_service or has_consu" name="operation_type" class='col'>
+                    <strong>Operation Type</strong>
                     <br/>
                     <span t-if="has_service and has_consu">
                         Mixed Operation


### PR DESCRIPTION
This commit https://github.com/odoo/odoo/commit/d10174e49759a58058aed6c44026060a4d293cc3 made a change in the report invoice information block and changed the class to only use col which was not changed in the french localisation.

Adapted the layout to be more readable by using proper spacing and column sizing when displaying a lot of information (Sales reference, delivery address, incoterm, customer address, operation type).

Task ID: 4555856





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
