### PR TITLE
[FIX] auth_password_policy_signup: minlength in form

### DIFF
--- a/addons/auth_password_policy_portal/views/templates.xml
+++ b/addons/auth_password_policy_portal/views/templates.xml
@@ -9,7 +9,7 @@
             <owl-component name="password_meter" props='{"selector": "input[name=new1]"}'/>
         </xpath>
         <xpath expr="//input[@name='new1']" position="attributes">
-            <attribute name="t-att-data-minlength">password_minimum_length</attribute>
+            <attribute name="t-att-minlength">password_minimum_length</attribute>
         </xpath>
     </template>
 </odoo>

--- a/addons/auth_password_policy_signup/static/src/public/components/password_meter/password_meter.js
+++ b/addons/auth_password_policy_signup/static/src/public/components/password_meter/password_meter.js
@@ -22,7 +22,7 @@ class PasswordMeter extends Component {
             this.state.password = e.target.value || "";
         });
 
-        const minlength = Number(inputEl.dataset?.minlength || inputEl.getAttribute("minlength"));
+        const minlength = Number(inputEl.getAttribute("minlength"));
         this.hasMinlength = !isNaN(minlength);
         this.state = useState({
             password: inputEl.value || "",

--- a/addons/auth_password_policy_signup/views/signup_templates.xml
+++ b/addons/auth_password_policy_signup/views/signup_templates.xml
@@ -5,7 +5,7 @@
             <owl-component name="password_meter" props='{"selector": "input[name=password]"}'/>
         </xpath>
         <xpath expr="//input[@name='password']" position="attributes">
-            <attribute name="t-att-data-minlength">password_minimum_length</attribute>
+            <attribute name="t-att-minlength">password_minimum_length</attribute>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
When trying to sign in (for a new user) after making a purchase (existing token), we can choose a password of less than the minimum length allowed in the configuration. The _check_password_policy method prevents the save of the password to the user but arrives too late in the flow as the initiation of the user creation is half done leading to an Invalid token issue at the next attempt (no partner found for the existing token with _signup_retrieve_partner).

By adding the minlength attribute in the form of the sign up, we force the respect of the password policy minimum length in the front end and minimize the risk to encounter the issue.

previous PR unmerged: https://github.com/odoo/odoo/pull/186622 
opw-4514350

