### PR TITLE
[IMP] account: add non-stored related fields for easier configuration of consolidation reports

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -103,6 +103,8 @@ class AccountMoveLine(models.Model):
         check_company=True,
         tracking=True,
     )
+    account_name = fields.Char(related='account_id.name') # Used for easy configuration of consolidation in the reports
+    account_code = fields.Char(related='account_id.code') # Used for easy configuration of consolidation in the reports
     name = fields.Char(
         string='Label',
         compute='_compute_name', store=True, readonly=False, precompute=True,


### PR DESCRIPTION
Since https://github.com/odoo/enterprise/commit/a94227b6f305ffabbe18a5ea98335a3b17659d2d, it is possible in standard report engines to group by non-stored related fields. Thanks to this, it is now possible to greatly improve the configuration of consolidation reports, by grouping the move lines by account_id.code, then account_id.name, provided that non-stored related fields are added on account.move.line for those values. This way, it becomes possible to configure multiple accounts mapped to the same code, without having to ensure a 1 to 1 relationship between the accounts of the source and consolidating company.

We received a lot of feedback from people wanting to avoir the 1 to 1 mapping, and needing to configure such customized groupby on the report. The add of a related fields is a bit too technical to be explained in any kind of functional documentation; therefore we make the choice to add them in the standard code. They are non-stored, and will have no impact on any other flow.

Note that this groupby customization only works on standard engines at the moment. Custom engines still need to be adapted, but this will come in a future PR.
