### PR TITLE
[FIX] stock_landed_costs: order layers in test

### DIFF
--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_lots.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_lots.py
@@ -68,7 +68,7 @@ class TestStockLandedCostsLots(TestLotValuation):
         (picking_1 | picking_2).move_ids.picked = True
         (picking_1 | picking_2).button_validate()
 
-        og_layer = picking_2.move_ids.stock_valuation_layer_ids | picking_1.move_ids.stock_valuation_layer_ids
+        og_layer = (picking_2.move_ids.stock_valuation_layer_ids | picking_1.move_ids.stock_valuation_layer_ids).sorted('product_id')
         lc_form = Form(self.env['stock.landed.cost'])
         lc_form.picking_ids = (picking_1 | picking_2)
         with lc_form.cost_lines.new() as cost_line:


### PR DESCRIPTION
This commit orders the stock valuation layer of multiple stock moves by product to make sure the assert targets the right layer index in the loop.

runbot: 99086

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
