### PR TITLE
[FIX] website_sale: hide same address warning on new address

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2411,7 +2411,7 @@
                                     </t>
                                 </t>
                                 <div
-                                    t-if="use_delivery_as_billing and not only_services"
+                                    t-if="use_delivery_as_billing and not only_services and partner_sudo"
                                     class="alert alert-warning"
                                     role="alert"
                                     groups="account.group_delivery_invoice_address"


### PR DESCRIPTION
Steps:
- Install Ecom.
- Go to shop page.
- Add a product in cart goto address section in checkout.
- Try to add new address.

Issue:
- Warning displaying for of same address for billing and delivery even though we are create new address

Cause:
- Missing condition to check if address is existing or new one.

Fix:
- Add condition on warning section to display it only for existing addresses.

opw-4522138
