### PR TITLE
[FIX] product_expiry: one line warning

### DIFF
--- a/addons/product_expiry/views/production_lot_views.xml
+++ b/addons/product_expiry/views/production_lot_views.xml
@@ -63,8 +63,11 @@
                 <field name="product_expiry_alert"/>
             </xpath>
             <xpath expr="//field[@name='name']" position="after">
-                <span title="Alert" class="fa fa-exclamation-triangle text-danger ms-2" invisible="product_qty &lt;= 0 or not product_expiry_alert or not expiration_date"/>
-                <field name="alert_date" widget='remaining_days' class="ms-2"/>
+                <div>
+                    <span title="Alert" class="fa fa-exclamation-triangle text-danger me-2"
+                          invisible="product_qty &lt;= 0 or not product_expiry_alert or not expiration_date"/>
+                    <field name="alert_date" widget='remaining_days' class="d-inline-block"/>
+                </div>
             </xpath>
             <xpath expr="//field[@name='product_id']" position="after">
                 <div invisible="not expiration_date">


### PR DESCRIPTION
Before this commit, in the lot kanban view, if a lot was expired, the alert icon and the overpass days were on different lines. This commit fixes that so the alert icon is just beside the date.

Before / After:
![Screenshot from 2025-02-27 11-38-07](https://github.com/user-attachments/assets/15cb773a-62cc-4e72-91ef-4143731755bc) ![Screenshot from 2025-02-27 11-38-19](https://github.com/user-attachments/assets/e0173be1-f949-4f4b-adea-4a249aafded7)


Enterprise PR: odoo/enterprise#80338
