### PR TITLE
[FIX] web_editor: give correct error for too large image upload

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -313,10 +313,10 @@ class Web_Editor(http.Controller):
                 mimetype = guess_mimetype(data)
                 if mimetype not in SUPPORTED_IMAGE_MIMETYPES:
                     return {'error': format_error_msg}
-            except UserError:
+            except UserError as e:
                 # considered as an image by the browser file input, but not
                 # recognized as such by PIL, eg .webp
-                return {'error': format_error_msg}
+                return {'error': e.args[0]}
             except ValueError as e:
                 return {'error': e.args[0]}
 


### PR DESCRIPTION
Before this PR:
- When uploading an image that is too large, the error message notification was showing wrong message.

After this PR:
- The error message notification will show the correct message.

task-4606136

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
