### PR TITLE
[FIX] sale: combo configurator dialog showing archived products

### DIFF
--- a/addons/sale/controllers/combo_configurator.py
+++ b/addons/sale/controllers/combo_configurator.py
@@ -70,7 +70,7 @@ class SaleComboConfiguratorController(Controller):
                        currency,
                        pricelist,
                        **kwargs,
-                   ) for combo_item in combo.combo_item_ids
+                   ) for combo_item in combo.combo_item_ids if combo_item.product_id.active
                 ],
             } for combo in product_template.combo_ids.sudo()],
             'currency_id': currency_id,


### PR DESCRIPTION
steps:
- create a combo product with 1 or more combo items
- archive a product part of this combo
- create an SO and add this combo product

issue:
- it shows archived product

cause:
- when product is archived the linked combo item line is not archived

fix:
- added an active filter in combo_configurator get data

opw-4579038

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
