### PR TITLE
[FIX] website_sale: do not check for payment error if confirmed

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1891,8 +1891,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             order = request.env['sale.order'].sudo().browse(sale_order_id)
             assert order.id == request.session.get('sale_last_order_id')
 
-        errors = self._get_shop_payment_errors(order)
-        if errors:
+        if order.state != 'sale' and (errors := self._get_shop_payment_errors(order)):
             first_error = errors[0]  # only display first error
             error_msg = f"{first_error[0]}\n{first_error[1]}"
             raise ValidationError(error_msg)


### PR DESCRIPTION
Steps to reproduce:
 1) Enable Click and Collect
 2) Configure pick up in store and add a store in US
 3) Set the available country to Belgium
 4) Enable Pay at the store and set the country to Belgium
 5) Go to /shop page and add a storable product
 6) Proceed to payment and pay choosing pickup in store delivery method
    and pay on site payment method
 7) Observe an error

 Reason:
 /shop/payment/validate checks for payment errors even after the order
 was confirmed and payment went through. When confirming a sales order
 with pickup in-store dm the partner_shipping_id is changed to the
 selected pickup point address. If the countries/zipcodes are not
 matched with the ones set on the delivery method or some information is
 missing then the result of `_get_delivery_methods` called by
 `get_shop_payment_errors` can be empty which causes and error.

 Solution:
 No need to check for payment errors after payment.

opw-4592939