### PR TITLE
[FIX] web_editor: give correct error for too large image upload

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -309,15 +309,13 @@ class Web_Editor(http.Controller):
         if is_image:
             format_error_msg = _("Uploaded image's format is not supported. Try with: %s", ', '.join(SUPPORTED_IMAGE_EXTENSIONS))
             try:
-                data = tools.image_process(data, size=(width, height), quality=quality, verify_resolution=True)
                 mimetype = guess_mimetype(data)
                 if mimetype not in SUPPORTED_IMAGE_MIMETYPES:
                     return {'error': format_error_msg}
-            except UserError:
-                # considered as an image by the browser file input, but not
-                # recognized as such by PIL, eg .webp
-                return {'error': format_error_msg}
-            except ValueError as e:
+                data = tools.image_process(data, size=(width, height), quality=quality, verify_resolution=True)
+            except (ValueError, UserError) as e:
+                # When UserError thrown, browser considers file input an
+                # image but not recognized as such by PIL, eg .webp
                 return {'error': e.args[0]}
 
         self._clean_context()

--- a/odoo/tools/image.py
+++ b/odoo/tools/image.py
@@ -91,7 +91,7 @@ class ImageProcess():
 
             w, h = self.image.size
             if verify_resolution and w * h > IMAGE_MAX_RESOLUTION:
-                raise UserError(_("Image size excessive, uploaded images must be smaller than %s million pixels.", str(IMAGE_MAX_RESOLUTION / 1e6)))
+                raise UserError(_("Too large image (above %sMpx), reduce the image size.", str(IMAGE_MAX_RESOLUTION / 1e6)))
 
     def image_quality(self, quality=0, output_format=''):
         """Return the image resulting of all the image processing


### PR DESCRIPTION
Even though uploaded image was .png it gives such error, reason behind this was `DecompressionBombWarning` occurred in `PIL (Pillow)`
![image](https://github.com/user-attachments/assets/bd410cd3-e808-4603-8989-4772c2e13bdf)


Before this PR:

- When uploading an image that is too large, the error message notification was showing wrong message.

After this PR:

- The error message notification will show the correct message.

task-4606136



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
