### PR TITLE
[FIX] payment: single email for partner_email

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -12,7 +12,7 @@ from markupsafe import Markup
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import format_amount
+from odoo.tools import email_normalize_all, format_amount
 
 from odoo.addons.payment import utils as payment_utils
 
@@ -167,11 +167,12 @@ class PaymentTransaction(models.Model):
 
             # Duplicate partner values.
             partner = self.env['res.partner'].browse(values['partner_id'])
+            partner_emails = email_normalize_all(partner.email)
             values.update({
                 # Use the parent partner as fallback if the invoicing address has no name.
                 'partner_name': partner.name or partner.parent_id.name,
                 'partner_lang': partner.lang,
-                'partner_email': partner.email,
+                'partner_email': partner_emails[0] if partner_emails else None,
                 'partner_address': payment_utils.format_partner_address(
                     partner.street, partner.street2
                 ),


### PR DESCRIPTION
If the email field is provided, it must be unique as Stripe doesn't handle multiple emails per payment request. In Odoo, the field partner_email is designed for more than 1 email in order to send documents easily to multiple recipients. Considering the first email only for Stripe in case of multiple emails.

opw-4576386
