### PR TITLE
[FIX] website_sale: fix dialog box close method

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_reorder.js
+++ b/addons/website_sale/static/src/js/website_sale_reorder.js
@@ -99,7 +99,19 @@ export class ReorderDialogWrapper extends Component {
 }
 ReorderDialogWrapper.template = xml``;
 
-export class ReorderConfirmationDialog extends ConfirmationDialog {}
+export class ReorderConfirmationDialog extends ConfirmationDialog {
+    /**
+     * @override
+     * 
+     * In ConfirmationDialog class cancel button and close button's behavior is the same
+     * so we need to override the default behavior of close button. Because on cancel
+     * we add products to cart without clearing the cart.
+     * */
+    setup() {
+        super.setup();
+        this.env.dialogData.close = () => this.props.close();
+    }
+}
 ReorderConfirmationDialog.template = "website_sale.ReorderConfirmationDialog";
 
 export class ReorderDialog extends Component {


### PR DESCRIPTION
**Steps:**
- Install Ecom
- Add some products to the cart
- Go to my/orders
- select any order then click on Order again
- Click on the Add To Cart button
- You'll see one confirmation dialog, click on the close button of that dialog

**Issue:**
- By clicking on close dialog should get closed but instead, products are added in the cart

**Cause:**
- Default close method provided in the setup method of the confirmation dialog component

**Fix:**
- While extending the confirmation dialog we overwrite the default close method defined in Confirmation Dialog component

affected version-16.0
opw-4566505
