### PR TITLE
[IMP] web: kanban: do not generate class oe_kanban_card_undefined

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -252,7 +252,9 @@ export class KanbanRecord extends Component {
             const { fieldName, colors } = progressBarState.progressAttributes;
             const value = record.data[fieldName];
             const color = colors[value];
-            classes.push(`oe_kanban_card_${color}`);
+            if (color) {
+                classes.push(`oe_kanban_card_${color}`);
+            }
         }
         if (archInfo.cardColorField) {
             const value = record.data[archInfo.cardColorField];


### PR DESCRIPTION
In a kanban view with progressbar, when no bar is clicked in a column, records of that column have the oe_kanban_card_undefined classname (whereas when a bar is selected, it has a classname like oe_kanban_card_success for instance).

This commit prevents from generating the weird classname with undefined, as it looks buggy and is useless anyway.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
