### PR TITLE
[FIX] web: fix traceback on external id export

### DIFF
--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -417,6 +417,7 @@ class Export(http.Controller):
             }
             if len(ident.split('/')) < 3 and 'relation' in field:
                 field_dict['value'] += '/id'
+                field_dict['type'] = '#!pseudocode   ID'
                 field_dict['params'] = {
                     'model': field['relation'],
                     'prefix': ident,


### PR DESCRIPTION
Steps:
- Install sales app.
- Go to product menu and group list view by category
- Export products with only `Product/Product/External ID`

Issue:
- Traceback.

Cause:
- Directly try to access `type` key from dict without checking dict contain `type` key or not. Before [this]
PR we were checking if it contain type or not.

Fix:
- Check dictionary contain `type` or not.

[this]: https://github.com/odoo/odoo/pull/178214

opw-4585879
