### PR TITLE
[FIX] link_tracker: fix missing query params in redirect url

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -1,14 +1,14 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import random
-import requests
 import string
+
+import requests
 
 from lxml import html
 from werkzeug import urls
 
-from odoo import tools, models, fields, api, _
+from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError
 from odoo.osv import expression
 
@@ -102,16 +102,15 @@ class LinkTracker(models.Model):
                 tracker.redirected_url = parsed.to_url()
                 continue
 
-            utms = {}
+            query = parsed.decode_query()
             for key, field_name, cook in self.env['utm.mixin'].tracking_fields():
                 field = self._fields[field_name]
                 attr = tracker[field_name]
                 if field.type == 'many2one':
                     attr = attr.name
                 if attr:
-                    utms[key] = attr
-            utms.update(parsed.decode_query())
-            tracker.redirected_url = parsed.replace(query=urls.url_encode(utms)).to_url()
+                    query[key] = attr
+            tracker.redirected_url = parsed.replace(query=urls.url_encode(query)).to_url()
 
     @api.model
     @api.depends('url')


### PR DESCRIPTION
If the target url had duplicate keys in its query params, the redirect url would only contain the key-value pair corresponding to the first occurrence of the key. This is incorrect, as a shop url typically contains multiple attribute values in its query params. The issue was caused by an accidental cast from MultiDict to Dict when handling the query params.

opw-4466925