### PR TITLE
[FIX] survey: fix responsible field alignment

### DIFF
--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -58,12 +58,12 @@
                         </h1>
                     </div>
                     <group>
-                        <group>
+                        <group class="ps-md-0">
                             <field name="user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
                             <field name="active" invisible="1"/>
                             <field name="has_conditional_questions" invisible="1"/>
                         </group>
-                        <group>
+                        <group class="ps-3 ps-md-0 ps-lg-3">
                             <field name="restrict_user_ids" widget="many2many_tags_avatar"/>
                         </group>
                     </group>


### PR DESCRIPTION
In the survey form view, on screens of size medium and larger, the line containing the 'responsible' and 'restrict_user_ids' fields is not correctly aligned with the line below. This seems to be due to the background image taking up space occupied by the above two fields.

To solve the problem, we modify the padding left of the fields, for the relevant screen widths (breakpoints).

task-4605729

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
