### PR TITLE
[FIX] sale: misformatted fields in add product form in build

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -393,6 +393,7 @@
                                 <group>
                                     <group invisible="display_type">
                                         <field name="product_updatable" invisible="1"/>
+                                        <label for="product_id"/>
                                         <div class="d-flex align-items-baseline">
                                             <span class="fa fa-exclamation-triangle text-warning me-1"
                                                 title="This product is archived"


### PR DESCRIPTION
Steps:
- Install sales app.
- Open a sale order and toggle studio.
- Click on list view, select 'Edit list view'
- Select 'Open form view' for 'when creating record' under 'views' side panel.
- Go back to sale order. Add Product in sale order line.
- Create Order Lines form opens.

Issue:
- Fields (quantity, delivered, etc.) are misformatted and not in sequence.
- Product field has no label.

Cause:
- There was no label defined for product field as done for others that was breaking the flow and sequence.

Fix:
- Added a Label to product field which solves the issue.

opw-4455197
