### PR TITLE
[FIX] account_payment: Correct write-off computation in payment transactions

### DIFF
--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -163,8 +163,8 @@ class PaymentTransaction(models.Model):
             **extra_create_values,
         }
 
-        if self.invoice_ids:
-            next_payment_values = self.invoice_ids._get_invoice_next_payment_values()
+        for invoice in self.invoice_ids:
+            next_payment_values = invoice._get_invoice_next_payment_values()
             if next_payment_values['installment_state'] == 'epd' and self.amount == next_payment_values['amount_due']:
                 aml = next_payment_values['epd_line']
                 epd_aml_values_list = [({


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
While payment links do not allow association with more than one invoice, there are possibilities through the ORM and third-party modules.

The commit https://github.com/odoo/odoo/commit/b9abe46c1492b09e369434e76ec8196c6b02dd19 improved the behavior of early discounts in payment transactions,
but payment transactions related to more than one invoice fail during the execution of the `_create_payment` method.

Current behavior before PR:
Transactions related to more than one invoice can be created and validated, but they fail during the execution of the _reconcile_after_done method.

Desired behavior after PR is merged:
Transactions related to more than one invoice can be created, validated, and completed successfully without errors in _reconcile_after_done.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
