### PR TITLE
[FIX] discuss: restore the invite to call & channel feature

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -19,6 +19,7 @@ export class ChannelInvitation extends Component {
         this.discussCoreCommonService = useState(useService("discuss.core.common"));
         this.orm = useService("orm");
         this.store = useState(useService("mail.store"));
+        this.rtc = useService("discuss.rtc");
         this.notification = useService("notification");
         this.threadService = useState(useService("mail.thread"));
         this.suggestionService = useService("mail.suggestion");
@@ -101,6 +102,7 @@ export class ChannelInvitation extends Component {
         } else {
             await this.orm.call("discuss.channel", "add_members", [[this.props.thread.id]], {
                 partner_ids: this.state.selectedPartners.map((partner) => partner.id),
+                invite_to_rtc_call: this.rtc.state.channel?.eq(this.props.thread),
             });
         }
         this.props.close();

--- a/addons/mail/static/tests/discuss/call/call_tests.js
+++ b/addons/mail/static/tests/discuss/call/call_tests.js
@@ -250,3 +250,26 @@ QUnit.test("join/leave sounds are only played on main tab", async () => {
     await contains(".o-discuss-Call", { target: tab2.target, count: 0 });
     await assertSteps(["tab1 - play - channel-leave"]);
 });
+
+QUnit.test("should also invite to the call when inviting to the channel", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({
+        email: "testpartner@odoo.com",
+        name: "TestPartner",
+    });
+    pyEnv["res.users"].create({ partner_id: partnerId });
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "TestChanel",
+        channel_member_ids: [Command.create({ partner_id: pyEnv.currentPartnerId })],
+        channel_type: "channel",
+    });
+    const { openDiscuss } = await start();
+    await openDiscuss(channelId);
+    await click("[title='Start a Call']");
+    await contains(".o-discuss-Call");
+    await click(".o-mail-Discuss-header button[title='Add Users']");
+    await contains(".o-discuss-ChannelInvitation");
+    await click(".o-discuss-ChannelInvitation-selectable", { text: "TestPartner" });
+    await click("[title='Invite to Channel']:enabled");
+    await contains(".o-discuss-CallParticipantCard.o-isInvitation");
+});

--- a/addons/mail/static/tests/helpers/mock_server/models/discuss_channel.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/discuss_channel.js
@@ -98,7 +98,12 @@ patch(MockServer.prototype, {
         if (args.model === "discuss.channel" && args.method === "add_members") {
             const ids = args.args[0];
             const partner_ids = args.args[1] || args.kwargs.partner_ids;
-            return this._mockDiscussChannelAddMembers(ids, partner_ids, args.kwargs.context);
+            return this._mockDiscussChannelAddMembers(
+                ids,
+                partner_ids,
+                args.kwargs.invite_to_rtc_call,
+                args.kwargs.context
+            );
         }
         if (args.model === "discuss.channel" && args.method === "channel_pin") {
             const ids = args.args[0];
@@ -284,9 +289,10 @@ patch(MockServer.prototype, {
      *
      * @private
      * @param {integer[]} ids
+     * @param {boolean} invite_to_rtc_call
      * @param {integer[]} partner_ids
      */
-    _mockDiscussChannelAddMembers(ids, partner_ids, context = {}) {
+    _mockDiscussChannelAddMembers(ids, partner_ids, invite_to_rtc_call, context = {}) {
         const [channel] = this.getRecords("discuss.channel", [["id", "in", ids]]);
         const partners = this.getRecords("res.partner", [["id", "in", partner_ids]]);
         for (const partner of partners) {
@@ -326,7 +332,7 @@ patch(MockServer.prototype, {
                 ["channel_id", "=", channel.id],
             ]) > 0;
         if (isSelfMember) {
-            this.pyEnv["bus.bus"]._sendone(channel, "mail.record/insert", {
+            const data = {
                 Thread: {
                     id: channel.id,
                     channelMembers: [
@@ -342,7 +348,18 @@ patch(MockServer.prototype, {
                     ]),
                     model: "discuss.channel",
                 },
-            });
+            };
+            if (invite_to_rtc_call) {
+                data.Thread.invitedMembers = [
+                    [
+                        "ADD",
+                        this._mockDiscussChannelMember_DiscussChannelMemberFormat(
+                            insertedChannelMembers
+                        ),
+                    ],
+                ];
+            }
+            this.pyEnv["bus.bus"]._sendone(channel, "mail.record/insert", data);
         }
     },
     /**


### PR DESCRIPTION
Before this commit and since https://github.com/odoo/odoo/pull/110188,

The people invited to a channel by someone in a call in that channel wouldn't receive a call invitation, as the invitation parameter was omitted during the refactor. This commit fixes this issue.


