### PR TITLE
[IMP] mail, test_mail: show email alongside name in recipient selection

### DIFF
--- a/addons/mail/models/mail_notification.py
+++ b/addons/mail/models/mail_notification.py
@@ -124,5 +124,5 @@ class MailNotification(models.Model):
             "mail_message_id",
             "notification_status",
             "notification_type",
-            Store.One("res_partner_id", ["name"], rename="persona"),
+            Store.One("res_partner_id", ["name", "email"], rename="persona"),
         ]

--- a/addons/mail/static/src/core/common/message_notification_popover.xml
+++ b/addons/mail/static/src/core/common/message_notification_popover.xml
@@ -6,8 +6,11 @@
             <t t-set="otherNotifications" t-value="this.props.message.notification_ids.filter((notif) => !notif._proxy.isFollowerNotification)"/>
             <t t-set="followerNotifications" t-value="this.props.message.notification_ids.filter((notif) => notif._proxy.isFollowerNotification)"/>
             <div t-foreach="otherNotifications" t-as="notification" t-key="notification.id">
-                <i class="me-2" t-att-class="notification.statusIcon" t-att-title="notification.statusTitle" role="img"/>
-                <span t-if="notification.persona" t-esc="notification.persona.name"/>
+                <i class="me-2 fa-fw" t-att-class="notification.statusIcon" t-att-title="notification.statusTitle" role="img"/>
+                <span t-if="notification.persona">
+                    <t t-esc="notification.persona.name"/>
+                    <t t-if="notification.persona.email"> (<t t-out="notification.persona.email"/>)</t>
+                </span>
             </div>
             <div t-if="props.message.incoming_email_cc or props.message.incoming_email_to" t-foreach="(props.message.incoming_email_cc || []).concat(props.message.incoming_email_to || [])" t-as="incomingEmail" t-key="incomingEmail_index">
                 <i class="me-2 fa fa-fw fa-send-o"/>
@@ -15,8 +18,11 @@
                 <span t-if="incomingEmail[1]" t-out="incomingEmail[1]" class="ps-1"/>
             </div>
             <div t-foreach="followerNotifications" t-as="notification" t-key="notification.id">
-                <i class="me-2" t-att-class="notification.statusIcon" t-att-title="notification.statusTitle" role="img"/>
-                <span t-if="notification.persona" t-esc="notification.persona.name"/>
+                <i class="me-2 fa-fw" t-att-class="notification.statusIcon" t-att-title="notification.statusTitle" role="img"/>
+                <span t-if="notification.persona">
+                    <t t-esc="notification.persona.name"/>
+                    <t t-if="notification.persona.email"> (<t t-out="notification.persona.email"/>)</t>
+                </span>
             </div>
         </div>
     </t>

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -139,7 +139,8 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
         },
         {
             content: "Check message has correct recipients",
-            trigger: ".o-mail-MessageNotificationPopover:contains('Not A Demo User\nJane')",
+            trigger:
+                ".o-mail-MessageNotificationPopover:contains('Not A Demo User (NotADemoUser@mail.com)\nJane (jane@example.com)')",
         },
         {
             content: "Check message contains the first attachment",

--- a/addons/snailmail/static/src/core_ui/snailmail_notification_popover.xml
+++ b/addons/snailmail/static/src/core_ui/snailmail_notification_popover.xml
@@ -5,7 +5,7 @@
         <xpath expr="//div[hasclass('o-mail-MessageNotificationPopover')]" position="replace">
             <t t-if="props.message.message_type === 'snailmail'">
                 <div class="o-snailmail-SnailmailNotificationPopover m-2" t-attf-class="{{ className }}">
-                    <i class="me-2" t-att-class="props.message.notification_ids[0].statusIcon" role="img"/>
+                    <i class="me-2 fa-fw" t-att-class="props.message.notification_ids[0].statusIcon" role="img"/>
                     <span t-esc="props.message.notification_ids[0].statusTitle"/>
                 </div>
             </t>

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1540,10 +1540,12 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                             ),
                             "res.partner": self._filter_partners_fields(
                                 {
+                                    "email": self.user_test_inbox.partner_id.email,
                                     "id": self.user_test_inbox.partner_id.id,
                                     "name": "Paulette Testouille",
                                 },
                                 {
+                                    "email": self.user_test_inbox_2.partner_id.email,
                                     "id": self.user_test_inbox_2.partner_id.id,
                                     "name": "Jeannette Testouille",
                                 },
@@ -1648,10 +1650,12 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                             ),
                             "res.partner": self._filter_partners_fields(
                                 {
+                                    "email": self.user_test_inbox.partner_id.email,
                                     "id": self.user_test_inbox.partner_id.id,
                                     "name": "Paulette Testouille",
                                 },
                                 {
+                                    "email": self.user_test_inbox_2.partner_id.email,
                                     "id": self.user_test_inbox_2.partner_id.id,
                                     "name": "Jeannette Testouille",
                                 },


### PR DESCRIPTION
**Current behavior before PR:**

Only the contact’s name was displayed when selecting an email recipient, making it
difficult to distinguish between contacts with the same name.

**Desired behavior after PR is merged:**

The recipient selection now displays 'name (email)'

![image](https://github.com/user-attachments/assets/128d9b1f-9a91-4a40-8740-806c3976553e)

**Task**-4599521

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
