### PR TITLE
[17.0][IMP] account: Keep account digits when a new account is created

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -373,7 +373,9 @@ class AccountAccount(models.Model):
     @api.model
     def _search_new_account_code(self, company, digits, prefix, cache=None):
         for num in range(1, 10000):
-            new_code = str(prefix.ljust(digits - 1, '0')) + str(num)
+            num_str = str(num)
+            num_digits = min(len(num_str), digits - len(prefix))
+            new_code = str(prefix.ljust(digits - num_digits, '0')) + num_str
             if new_code in (cache or []):
                 continue
             rec = self.search([('code', '=', new_code), ('company_id', 'child_of', company.root_id.id)], limit=1)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When user creates a new company bank account the new account created has not expected lenght when last digits are more than 1

**Current behavior before PR:**
account digits = 6
last bank account = **572009**
create new bank account = **5720010**

**Desired behavior after PR is merged:**
account digits = 6
last bank account = **572009**
create new bank account = **572010**

cc @Tecnativa 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
