### PR TITLE
[IMP] event: reset mail scheduler when postponing events

### DIFF
--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -135,7 +135,12 @@ class EventMailScheduler(models.Model):
             else:
                 date, sign = scheduler.event_id.date_end, 1
 
-            scheduler.scheduled_date = date.replace(microsecond=0) + _INTERVALS[scheduler.interval_unit](sign * scheduler.interval_nbr) if date else False
+            new_scheduled_date = date.replace(microsecond=0) + _INTERVALS[scheduler.interval_unit](sign * scheduler.interval_nbr) if date else False
+            if (scheduler.scheduled_date and new_scheduled_date and
+                new_scheduled_date > scheduler.scheduled_date and
+                scheduler.mail_done):
+                scheduler.mail_done = False
+            scheduler.scheduled_date = new_scheduled_date
 
     @api.depends('interval_type', 'scheduled_date', 'mail_done')
     def _compute_mail_state(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Support tickets are often opened, with customers noticing that on some of their events, Reminders are not sent while they appear to be scheduled.

Current behavior before PR:
Before this commit, if an event had an Event Reminder which had already activated, postponing the event to a later date would not remove/reactivate the Schedulers, while the Scheduled date would be displayed with its updated values.

Desired behavior after PR is merged:
After this commit, the `mail_done` field is set back to False whenever an event is rescheduled to a later time. This is enough to set the `mail_state` back to "Scheduled"

opw-4518387, opw-4543874

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
