### PR TITLE
[IMP] web: ask for confirmation before duplicating multiple records

### DIFF
--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -5314,6 +5314,13 @@ test(`duplicate all records`, async () => {
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await toggleMenuItem("Duplicate");
 
+    // A confirmation dialog should appear when duplicating multiple records.
+    expect(`.modal`).toHaveCount(1);
+    expect(`.modal-body`).toHaveText(
+        "Are you sure that you want to duplicate all the selected records?"
+    );
+    await contains(`.modal footer button.btn-primary`).click();
+
     // Final state: there should be 8 records
     expect(`tbody tr`).toHaveCount(8, { message: "should have 8 rows" });
 });


### PR DESCRIPTION
**specifications:**

- A confirmation dialog must appear before duplicating multiple records.
- To enhance code reusability, a new method, `copy`, has been introduced
  inside `_duplicateRecords`.

**purpose:**

- When a user selects multiple records and accidentally clicks on duplicate,
  the records are duplicated unintentionally. This issue can be avoided
  by prompting the user for confirmation before proceeding with duplication.

task-4575334

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
