### PR TITLE
[IMP] mrp: not overwrite qty to produce when multiple from the BoM qty

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -398,7 +398,7 @@ class MrpProduction(models.Model):
         for production in self:
             if production.state != 'draft':
                 continue
-            if production.bom_id and production._origin.bom_id != production.bom_id:
+            if production.bom_id and production._origin.bom_id != production.bom_id and production.product_qty % production.bom_id.product_qty != 0:
                 production.product_qty = production.bom_id.product_qty
             elif not production.bom_id:
                 production.product_qty = 1.0

--- a/doc/cla/corporate/forgeflow.md
+++ b/doc/cla/corporate/forgeflow.md
@@ -23,3 +23,4 @@ Joan Sisquella joan.sisquella@forgeflow.com https://github.com/JoanSForgeFlow
 Laura Cazorla laura.cazorla@forgeflow.com https://github.com/LauraCForgeFlow
 Arnau Cruz arnau.cruz@forgeflow.com https://github.com/ArnauCForgeFlow
 Ricard Calvo ricard.calvo@forgeflow.com https://github.com/RicardCForgeFlow
+Guillem Casassas guillem.casassas@forgeflow.com https://github.com/GuillemCForgeFlow


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
For the cases where the BoM is being updated on a MO, only if the quantity to produce assigned before is not multiple from the to be produced quantity in the BoM, the quantity should be updated.

Current behavior before PR:
Now, for the case that you assign a product without a BoM, you could then update the quantity to produce to then assign a product which has a BoM (which will be assigned by default). This will cause the quantity to go back to the default quantity to produce set on the BoM, when it shouldn't be needed.

Steps to reproduce:
1. Assign a product to manufacture which doesn't have a BoM created and set the quantity to produce to 5 (or set it even before assigning the product)
2. Assign a product which has a BoM created.
3. The quantity to produce is updated to the one in the BoM for all scenarios.

Desired behavior after PR is merged:
When above steps are reproduced, the quantity should be updated according to the two following scenarios:
1. If the BoM qty is 2, then the quantity to produce in the MO should be updated to 2, as 5 is not a multiple of 2.
2. If the BoM qty is 1, the quantity should be kept to 5 in the MO.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
