### PR TITLE
[FIX] website_sale: None when no state in the address

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1663,7 +1663,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         country = request.env["res.country"].search([
             ('code', '=', address.pop('country')),
         ], limit=1)
-        if state_code := address.pop('state'):
+        if state_code := address.pop('state', None):
             state = request.env['res.country.state'].search([
                 ('code', '=', state_code),
                 ('country_id', '=', country.id),


### PR DESCRIPTION
Traceback when state (which is a non required field) is empty.
Fix the express checkout flow.
Bug introduced in 80507191

opw-4577470

