### PR TITLE
[IMP] *: avoid excessive sub transactions

### DIFF
--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -336,7 +336,7 @@ class TestAccountAccount(TestAccountMergeCommon):
         move.line_ids.filtered(lambda line: line.account_id == account).reconcile()
 
         # Try to set the account as a not-reconcile one.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError):
             account.reconcile = False
 
     def test_remove_account_from_account_group(self):

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -798,7 +798,8 @@ class TestAccountAccount(TestAccountMergeCommon):
 
         # Create the merged account by merging `accounts`
         wizard = self._create_account_merge_wizard(accounts)
-        wizard.action_merge()
+        with self.patched_savepoints():
+            wizard.action_merge()
         self.assertFalse(accounts[1].exists())
 
         # Check that the merged account has correct values

--- a/addons/account/tests/test_account_analytic.py
+++ b/addons/account/tests/test_account_analytic.py
@@ -42,7 +42,7 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon, AnalyticCommon):
         })
 
         # Set a different company on the analytic account.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError):
             self.analytic_account_3.company_id = self.company_data_2['company']
 
         # Making the analytic account not company dependent is allowed.

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -344,7 +344,7 @@ class TestAccountBankStatementLine(AccountTestInvoicingCommon):
 
     def test_constraints(self):
         def assertStatementLineConstraint(statement_line_vals):
-            with self.assertRaises(Exception), self.cr.savepoint():
+            with self.assertRaises(Exception):
                 self.env['account.bank.statement.line'].create(statement_line_vals)
 
         statement_line_vals = {
@@ -390,12 +390,12 @@ class TestAccountBankStatementLine(AccountTestInvoicingCommon):
                 'move_id': st_line.move_id.id,
             },
         ]
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError):
             st_line.move_id.write({
                 'line_ids': [(0, 0, vals) for vals in addition_lines_to_create]
             })
 
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError):
             st_line.line_ids.create(addition_lines_to_create)
 
     def test_statement_line_move_onchange_1(self):

--- a/addons/account/tests/test_account_inalterable_hash.py
+++ b/addons/account/tests/test_account_inalterable_hash.py
@@ -1,3 +1,5 @@
+from contextlib import closing
+
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.models import Model
 from odoo.tests import Form, tagged
@@ -353,11 +355,11 @@ class TestAccountMoveInalterableHash(AccountTestInvoicingCommon):
 
         self.company_data['default_journal_sale'].restrict_mode_hash_table = True
 
-        with self.assertRaisesRegex(UserError, "An error occurred when computing the inalterability. A gap has been detected in the sequence."), self.env.cr.savepoint():
+        with self.assertRaisesRegex(UserError, "An error occurred when computing the inalterability. A gap has been detected in the sequence."):
             move3.button_hash()
 
         move1.button_hash()  # Afterwards move2 is a hole at the beginning of the unhashed part of the chain [move1 (hashed), move2, move3]
-        with self.assertRaisesRegex(UserError, "An error occurred when computing the inalterability. A gap has been detected in the sequence."), self.env.cr.savepoint():
+        with self.assertRaisesRegex(UserError, "An error occurred when computing the inalterability. A gap has been detected in the sequence."):
             move3.button_hash()
 
         with self._skip_hash_moves():
@@ -491,7 +493,7 @@ class TestAccountMoveInalterableHash(AccountTestInvoicingCommon):
                 'fiscalyear_lock_date',
                 'sale_lock_date',
         ]:
-            with self.subTest(lock_date_field=lock_date_field), self.env.cr.savepoint() as sp:
+            with self.subTest(lock_date_field=lock_date_field), closing(self.env.cr.savepoint()):
                 move1 = self.init_invoice('out_invoice', self.partner_a, "2024-01-01", amounts=[1000], post=True)
                 move2 = self.init_invoice('out_invoice', self.partner_a, "2024-01-02", amounts=[1000], post=True)
                 move3 = self.init_invoice('out_invoice', self.partner_a, "2024-01-03", amounts=[1000], post=True)
@@ -527,8 +529,6 @@ class TestAccountMoveInalterableHash(AccountTestInvoicingCommon):
                     self.assertNotEqual(move.inalterable_hash, False)
                 self.company_data['default_journal_sale'].restrict_mode_hash_table = True  # to run integrity check
                 self._verify_integrity(move5, "Entries are correctly hashed", move1, move5)
-
-                sp.close()  # Rollback to ensure all subtests start in the same situation
 
     def test_retroactive_hashing_before_current(self):
         """Test that we hash entries before the current recordset of moves, not the ones after"""
@@ -591,7 +591,7 @@ class TestAccountMoveInalterableHash(AccountTestInvoicingCommon):
         moves_v3_pre_restrict_mode[-1]._hash_moves(raise_if_no_document=False)  # Shouldn't raise
         self.assertFalse(moves_v3_pre_restrict_mode[-1].inalterable_hash)
 
-        with self.assertRaisesRegex(UserError, "This move could not be locked either because.*"), self.env.cr.savepoint():
+        with self.assertRaisesRegex(UserError, "This move could not be locked either because.*"):
             moves_v3_pre_restrict_mode.button_hash()
 
         # Test that we allow holes that are not in the moves_to_hash and
@@ -674,7 +674,7 @@ class TestAccountMoveInalterableHash(AccountTestInvoicingCommon):
         })
         unreconciled_move = unreconciled_bank_statement_line.move_id
         unreconciled_move.journal_id.restrict_mode_hash_table = True
-        with self.assertRaisesRegex(UserError, "An error occurred when computing the inalterability. All entries have to be reconciled."), self.env.cr.savepoint():
+        with self.assertRaisesRegex(UserError, "An error occurred when computing the inalterability. All entries have to be reconciled."):
             unreconciled_move.button_hash()
 
     def test_wizard_hashes_all_journals(self):
@@ -785,13 +785,12 @@ class TestAccountMoveInalterableHash(AccountTestInvoicingCommon):
         self.assertEqual(wizard.move_to_hash_ids, moves_v4)
 
         # We can still hash the remaining moves
-        with self.subTest(msg="Hash the remaining moves"), self.env.cr.savepoint() as sp:
+        with self.subTest(msg="Hash the remaining moves"), closing(self.env.cr.savepoint()):
             wizard.action_secure_entries()
             for move in moves_v3_pre_restrict_mode:
                 self.assertFalse(move.inalterable_hash)
             for move in moves_v4:
                 self.assertNotEqual(move.inalterable_hash, False)
-            sp.close()  # Rollback
 
         # We can ignore the moves by setting the hard lock date:
         self.assertEqual(wizard.max_hash_date, fields.Date.from_string("2023-12-31"))

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -27,7 +27,7 @@ class TestAccountJournal(AccountTestInvoicingCommon):
         journal_bank.currency_id = self.other_currency
 
         # Try to set a different currency on the 'debit' account.
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             journal_bank.default_account_id.currency_id = self.company_data['currency']
 
     def test_changing_journal_company(self):
@@ -40,7 +40,7 @@ class TestAccountJournal(AccountTestInvoicingCommon):
             'journal_id': self.company_data['default_journal_sale'].id,
         })
 
-        with self.assertRaisesRegex(UserError, "entries linked to it"), self.cr.savepoint():
+        with self.assertRaisesRegex(UserError, "entries linked to it"):
             self.company_data['default_journal_sale'].company_id = self.company_data_2['company']
 
     def test_account_journal_add_new_payment_method_multi(self):

--- a/addons/account/tests/test_account_lock_exception.py
+++ b/addons/account/tests/test_account_lock_exception.py
@@ -1,3 +1,5 @@
+from contextlib import closing
+
 from datetime import timedelta
 
 from freezegun import freeze_time
@@ -43,12 +45,12 @@ class TestAccountLockException(AccountTestInvoicingCommon):
         Test that an exception for a specific user only works for that user.
         """
         for lock_date_field, move_type in self.soft_lock_date_info:
-            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), self.cr.savepoint() as sp:
+            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), closing(self.cr.savepoint()):
                 move = self.init_invoice(move_type, invoice_date='2016-01-01', post=True, amounts=[1000.0], taxes=self.tax_sale_a)
 
                 # Lock the move
                 self.company[lock_date_field] = fields.Date.to_date('2020-01-01')
-                with self.assertRaises(UserError), self.cr.savepoint():
+                with self.assertRaises(UserError):
                     move.button_draft()
 
                 # Add an exception to make the move editable (for the current user)
@@ -63,21 +65,20 @@ class TestAccountLockException(AccountTestInvoicingCommon):
                 move.action_post()
 
                 # Check that the exception does not apply to other users
-                with self.assertRaises(UserError), self.cr.savepoint():
+                with self.assertRaises(UserError):
                     move.with_user(self.other_user).button_draft()
-                sp.close()  # Rollback to ensure all subtests start in the same situation
 
     def test_global_exception_move_edit_multi_user(self):
         """
         Test that an exception without a specified user works for any user.
         """
         for lock_date_field, move_type in self.soft_lock_date_info:
-            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), self.cr.savepoint() as sp:
+            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), closing(self.cr.savepoint()):
                 move = self.init_invoice(move_type, invoice_date='2016-01-01', post=True, amounts=[1000.0], taxes=self.tax_sale_a)
 
                 # Lock the move
                 self.company[lock_date_field] = fields.Date.to_date('2020-01-01')
-                with self.assertRaises(UserError), self.cr.savepoint():
+                with self.assertRaises(UserError):
                     move.button_draft()
 
                 # Add a global exception to make the move editable for everyone
@@ -94,7 +95,6 @@ class TestAccountLockException(AccountTestInvoicingCommon):
 
                 move.with_user(self.other_user).button_draft()
 
-                sp.close()  # Rollback to ensure all subtests start in the same situation
 
     def test_user_exception_branch(self):
         """
@@ -112,7 +112,7 @@ class TestAccountLockException(AccountTestInvoicingCommon):
         branch = root_company.child_ids
 
         for lock_date_field, move_type in self.soft_lock_date_info:
-            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), self.cr.savepoint() as sp:
+            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), closing(self.cr.savepoint()):
                 # Create a move in the branch
                 branch_move = self.init_invoice(
                     move_type, invoice_date='2016-01-01', post=True, amounts=[1000.0], taxes=self.tax_sale_a, company=branch,
@@ -127,7 +127,7 @@ class TestAccountLockException(AccountTestInvoicingCommon):
                 branch[lock_date_field] = fields.Date.to_date('2020-01-01')
 
                 # The branch_move is locked while the root_move is not
-                with self.assertRaises(UserError), self.cr.savepoint():
+                with self.assertRaises(UserError):
                     branch_move.button_draft()
                 root_move.button_draft()
                 root_move.action_post()
@@ -148,7 +148,7 @@ class TestAccountLockException(AccountTestInvoicingCommon):
 
                 # Check that both moves are locked now (the branch exception alone is insufficient)
                 for move in [branch_move, root_move]:
-                    with self.assertRaises(UserError), self.cr.savepoint():
+                    with self.assertRaises(UserError):
                         move.button_draft()
 
                 # Add an exception in the parent company to make both moves editable (for the current user)
@@ -163,18 +163,17 @@ class TestAccountLockException(AccountTestInvoicingCommon):
                     move.button_draft()
                     move.action_post()
 
-                sp.close()  # Rollback to ensure all subtests start in the same situation
 
     def test_user_exception_wrong_company(self):
         """
         Test that an exception only works for the specified company.
         """
         for lock_date_field, move_type in self.soft_lock_date_info:
-            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), self.cr.savepoint() as sp:
+            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), closing(self.cr.savepoint()):
                 move = self.init_invoice(move_type, invoice_date='2016-01-01', post=True, amounts=[1000.0], taxes=self.tax_sale_a)
                 # Lock the move
                 self.company[lock_date_field] = fields.Date.to_date('2020-01-01')
-                with self.assertRaises(UserError), self.cr.savepoint():
+                with self.assertRaises(UserError):
                     move.button_draft()
 
                 # Add an exception for another company
@@ -187,22 +186,21 @@ class TestAccountLockException(AccountTestInvoicingCommon):
                 })
 
                 # Check that the exception is insufficient
-                with self.assertRaises(UserError), self.cr.savepoint():
+                with self.assertRaises(UserError):
                     move.button_draft()
 
-                sp.close()  # Rollback to ensure all subtests start in the same situation
 
     def test_user_exception_insufficient(self):
         """
         Test that the exception only works if the specified lock date is actually before the accounting date.
         """
         for lock_date_field, move_type in self.soft_lock_date_info:
-            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), self.cr.savepoint() as sp:
+            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), closing(self.cr.savepoint()):
                 move = self.init_invoice(move_type, invoice_date='2016-01-01', post=True, amounts=[1000.0], taxes=self.tax_sale_a)
 
                 # Lock the move
                 self.company[lock_date_field] = fields.Date.to_date('2020-01-01')
-                with self.assertRaises(UserError), self.cr.savepoint():
+                with self.assertRaises(UserError):
                     move.button_draft()
 
                 # Add an exception before the lock date but not before the date of the test_invoice
@@ -215,22 +213,21 @@ class TestAccountLockException(AccountTestInvoicingCommon):
                 })
 
                 # Check that the exception is insufficient
-                with self.assertRaises(UserError), self.cr.savepoint():
+                with self.assertRaises(UserError):
                     move.button_draft()
 
-                sp.close()  # Rollback to ensure all subtests start in the same situation
 
     def test_expired_exception(self):
         """
         Test that the exception does not work if we are past the `end_datetime` of the exception.
         """
         for lock_date_field, move_type in self.soft_lock_date_info:
-            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), self.cr.savepoint() as sp:
+            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), closing(self.cr.savepoint()):
                 move = self.init_invoice(move_type, invoice_date='2016-01-01', post=True, amounts=[1000.0], taxes=self.tax_sale_a)
 
                 # Lock the move
                 self.company[lock_date_field] = fields.Date.to_date('2020-01-01')
-                with self.assertRaises(UserError), self.cr.savepoint():
+                with self.assertRaises(UserError):
                     move.button_draft()
 
                 # Add an expired exception
@@ -242,19 +239,18 @@ class TestAccountLockException(AccountTestInvoicingCommon):
                     'end_datetime': self.fakenow - timedelta(milliseconds=1),
                     'reason': 'test_expired_exception',
                 })
-                with self.assertRaises(UserError), self.cr.savepoint():
+                with self.assertRaises(UserError):
                     move.button_draft()
 
-                sp.close()  # Rollback to ensure all subtests start in the same situation
 
     def test_revoked_exception(self):
         for lock_date_field, move_type in self.soft_lock_date_info:
-            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), self.cr.savepoint() as sp:
+            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), closing(self.cr.savepoint()):
                 move = self.init_invoice(move_type, invoice_date='2016-01-01', post=True, amounts=[1000.0], taxes=self.tax_sale_a)
 
                 # Lock the move
                 self.company[lock_date_field] = fields.Date.to_date('2020-01-01')
-                with self.assertRaises(UserError), self.cr.savepoint():
+                with self.assertRaises(UserError):
                     move.button_draft()
 
                 # Add an exception to make the move editable (for the current user)
@@ -271,10 +267,9 @@ class TestAccountLockException(AccountTestInvoicingCommon):
                 exception.action_revoke()
 
                 # Check that the exception does not work anymore
-                with self.assertRaises(UserError), self.cr.savepoint():
+                with self.assertRaises(UserError):
                     move.button_draft()
 
-                sp.close()  # Rollback to ensure all subtests start in the same situation
 
     def test_user_exception_wrong_field(self):
         for lock_date_field, move_type, exception_lock_date_field in [
@@ -283,11 +278,11 @@ class TestAccountLockException(AccountTestInvoicingCommon):
             ('sale_lock_date', 'out_invoice', 'purchase_lock_date'),
             ('purchase_lock_date', 'in_invoice', 'sale_lock_date'),
         ]:
-            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), self.cr.savepoint() as sp:
+            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), closing(self.cr.savepoint()):
                 move = self.init_invoice(move_type, invoice_date='2016-01-01', post=True, amounts=[1000.0], taxes=self.tax_sale_a)
                 # Lock the move
                 self.company[lock_date_field] = fields.Date.to_date('2020-01-01')
-                with self.assertRaises(UserError), self.cr.savepoint():
+                with self.assertRaises(UserError):
                     move.button_draft()
 
                 # Add an exception for a different lock date field
@@ -300,10 +295,9 @@ class TestAccountLockException(AccountTestInvoicingCommon):
                 })
 
                 # Check that the exception is insufficient
-                with self.assertRaises(UserError), self.cr.savepoint():
+                with self.assertRaises(UserError):
                     move.button_draft()
 
-                sp.close()  # Rollback to ensure all subtests start in the same situation
 
     def test_hard_lock_date(self):
         """
@@ -317,11 +311,11 @@ class TestAccountLockException(AccountTestInvoicingCommon):
         self.company.hard_lock_date = fields.Date.to_date('2020-01-01')
 
         # Check that we cannot remove the hard lock date.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError):
             self.company.hard_lock_date = False
 
         # Check that we cannot decrease the hard lock date.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError):
             self.company.hard_lock_date = fields.Date.to_date('2019-01-01')
 
         # Create exceptions for all lock date fields except the hard lock date
@@ -338,7 +332,7 @@ class TestAccountLockException(AccountTestInvoicingCommon):
 
         # Check that the exceptions are insufficient
         for move in [in_move, out_move]:
-            with self.assertRaises(UserError), self.cr.savepoint():
+            with self.assertRaises(UserError):
                 move.button_draft()
 
     def test_company_lock_date(self):
@@ -350,7 +344,7 @@ class TestAccountLockException(AccountTestInvoicingCommon):
         """
         self.env['account.lock_exception'].search([]).sudo().unlink()
         for lock_date_field, move_type in self.soft_lock_date_info:
-            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), self.cr.savepoint() as sp:
+            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), closing(self.cr.savepoint()):
                 self.company[lock_date_field] = fields.Date.to_date('2020-01-01')
 
                 revoked_exception = self.env['account.lock_exception'].create({
@@ -393,14 +387,13 @@ class TestAccountLockException(AccountTestInvoicingCommon):
                     'reason': 'test_exception_recreated_on_lock_date_change active',
                 }])
 
-                sp.close()  # Rollback to ensure all subtests start in the same situation
 
     def test_user_exception_remove_lock_date(self):
         """
         Test that an exception removing a lock date (instead of just decreasing it) works.
         """
         for lock_date_field, move_type in self.soft_lock_date_info:
-            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), self.cr.savepoint() as sp:
+            with self.subTest(lock_date_field=lock_date_field, move_type=move_type), closing(self.cr.savepoint()):
                 move = self.init_invoice(move_type, invoice_date='2016-01-01', post=True, amounts=[1000.0], taxes=self.tax_sale_a)
 
                 # Lock the move
@@ -418,4 +411,3 @@ class TestAccountLockException(AccountTestInvoicingCommon):
                 })
                 move.button_draft()
 
-                sp.close()  # Rollback to ensure all subtests start in the same situation

--- a/addons/account/tests/test_account_merge_wizard.py
+++ b/addons/account/tests/test_account_merge_wizard.py
@@ -133,7 +133,8 @@ class TestAccountMergeWizard(TestAccountMergeCommon):
         self.assertRecordValues(wizard.wizard_line_ids, expected_wizard_line_vals)
 
         # 3. Perform the merge
-        wizard.action_merge()
+        with self.patched_savepoints():
+            wizard.action_merge()
 
         # 4. Check that the accounts other than the ones to merge into are deleted.
         self.assertFalse(self.accounts[2:].exists())
@@ -240,7 +241,8 @@ class TestAccountMergeWizard(TestAccountMergeCommon):
         self.assertRecordValues(wizard.wizard_line_ids, expected_wizard_line_vals)
 
         # 2. Perform the merge
-        wizard.action_merge()
+        with self.patched_savepoints():
+            wizard.action_merge()
 
         # 3. Check that the non-hashed account is deleted.
         self.assertFalse(self.accounts[0].exists())
@@ -276,7 +278,8 @@ class TestAccountMergeWizard(TestAccountMergeCommon):
         payable_accounts = self.env['account.account'].search([('name', '=', 'Account Payable')])
         self.assertEqual(len(payable_accounts), 2)
         wizard = self._create_account_merge_wizard(payable_accounts)
-        wizard.action_merge()
+        with self.patched_savepoints():
+            wizard.action_merge()
         payable_accounts = self.env['account.account'].search([('name', '=', 'Account Payable')])
         self.assertEqual(len(payable_accounts), 1)
         for company in self.env.companies:

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -2236,11 +2236,11 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         not_receivable_lines = move.line_ids - receivable_lines
 
         # Write a receivable account on a not-receivable line.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError):
             not_receivable_lines.write({'account_id': receivable_lines[0].account_id.copy().id})
 
         # Write a not-receivable account on a receivable line.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError):
             receivable_lines.write({'account_id': not_receivable_lines[0].account_id.copy().id})
 
         # Write another receivable account on a receivable line.
@@ -3886,7 +3886,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             ],
         })
         self.product_a.property_account_income_id.deprecated = True
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError):
             move.action_post()
 
     def test_change_currency_id(self):

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -806,7 +806,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             .with_context(active_model='account.move', active_ids=self.out_invoice_2.ids)\
             .create({})\
             ._create_payments()
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError):
             self.env['account.payment.register']\
                 .with_context(active_model='account.move', active_ids=self.out_invoice_2.ids)\
                 .create({})

--- a/addons/account/tests/test_account_tax.py
+++ b/addons/account/tests/test_account_tax.py
@@ -71,7 +71,7 @@ class TestAccountTax(AccountTestInvoicingCommon):
             ],
         })
 
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError):
             self.company_data['default_tax_sale'].company_id = self.company_data_2['company']
 
     def test_logging_of_tax_update_when_tax_is_used(self):

--- a/addons/account/tests/test_chart_template.py
+++ b/addons/account/tests/test_chart_template.py
@@ -673,10 +673,7 @@ class TestChartTemplate(AccountTestInvoicingCommon):
 
         with patch.object(AccountChartTemplate, '_get_chart_template_data', side_effect=local_get_data, autospec=True):
             # hard fail the loading if the context key is set to ensure `test_all_l10n` works as expected
-            with (
-                self.assertRaisesRegex(ValueError, 'unknown_company_key'),
-                self.env.cr.savepoint(),
-            ):
+            with self.assertRaisesRegex(ValueError, 'unknown_company_key'):
                 self.env['account.chart.template'].with_context(l10n_check_fields_complete=True).try_loading('test', company=company, install_demo=False)
 
             # silently ignore if the field doesn't exist (yet)

--- a/addons/account/tests/test_company_branch.py
+++ b/addons/account/tests/test_company_branch.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from contextlib import nullcontext
+from contextlib import nullcontext, closing
 from freezegun import freeze_time
 from functools import partial
 
@@ -166,7 +166,7 @@ class TestCompanyBranch(AccountTestInvoicingCommon):
                     invoice_date=invoice_date,
                     move_type=move_type,
                     company=company.name,
-                ), self.env.cr.savepoint() as sp:
+                ), closing(self.env.cr.savepoint()):
                     check = partial(self.assertRaises, UserError) if failure_expected else nullcontext
                     move = self.init_invoice(
                         move_type, amounts=[100], taxes=self.root_company.account_sale_tax_id,
@@ -178,7 +178,6 @@ class TestCompanyBranch(AccountTestInvoicingCommon):
                         self.branch_a[lock] = branch_lock
                     with check():
                         move.button_draft()
-                    sp.close()
 
     def test_change_record_company(self):
         account = self.env['account.account'].create({

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -501,7 +501,7 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         self.assertMoveName(copies[5], 'XMISC/2019/00004')
 
         # Can't have twice the same name
-        with self.assertRaises(psycopg2.DatabaseError), mute_logger('odoo.sql_db'), self.env.cr.savepoint():
+        with self.assertRaises(psycopg2.DatabaseError), mute_logger('odoo.sql_db'):
             copies[0].name = 'XMISC/2019/00001'
 
         # Lets remove the order by date

--- a/addons/account_peppol/tests/test_peppol_participant.py
+++ b/addons/account_peppol/tests/test_peppol_participant.py
@@ -110,7 +110,7 @@ class TestPeppolParticipant(TransactionCase):
             'peppol_eas': False,
             'peppol_endpoint': False,
         })
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             wizard.button_register_peppol_participant()
 
     def test_create_success_sender(self):
@@ -167,7 +167,7 @@ class TestPeppolParticipant(TransactionCase):
         # should not be possible to create a duplicate participant
         wizard = self.env['peppol.registration'].create(self._get_participant_vals())
         wizard.button_register_peppol_participant()
-        with self.assertRaises(IntegrityError), self.cr.savepoint():
+        with self.assertRaises(IntegrityError):
             wizard.account_peppol_proxy_state = 'not_registered'
             wizard.button_register_peppol_participant()
 

--- a/addons/barcodes/tests/test_barcode_nomenclature.py
+++ b/addons/barcodes/tests/test_barcode_nomenclature.py
@@ -62,23 +62,23 @@ class TestBarcodeNomenclature(common.TransactionCase):
             'encoding': 'ean8',
         })
 
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             # Must fail because empty braces.
             barcode_rule.pattern = '......{}..'
 
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             # Must fail because decimal can't be before integer.
             barcode_rule.pattern = '......{DN}'
 
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             # Must fail because a pattern can't have multiple braces group.
             barcode_rule.pattern = '....{NN}{DD}'
 
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             # Must fail because '*' isn't accepted (should be '.*' instead).
             barcode_rule.pattern = '*'
 
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             # Must fail because '**' isn't even a valid regular expression.
             barcode_rule.pattern = '**>>>{ND}'
         # Allowed since it leads to a valid regular expression.

--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -54,7 +54,7 @@ class TestStructure(TransactionCase):
         # reactivate it and correct the vat number
         with patch('odoo.addons.base_vat.models.res_partner.check_vies', type(self)._vies_check_func):
             self.env.user.company_id.vat_check_vies = True
-            with self.assertRaises(ValidationError), self.env.cr.savepoint():
+            with self.assertRaises(ValidationError):
                 company.vat = "BE0987654321"  # VIES refused, don't fallback on other check
             company.vat = "BE0477472701"
 

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -274,7 +274,7 @@ class TestHrEmployee(TestHrCommon):
         employee_form = Form(self.env['hr.employee'].with_user(self.res_users_hr_officer).with_company(company=test_company.id))
         employee_form.name = "Second employee"
         employee_form.user_id = self.res_users_hr_officer
-        with mute_logger('odoo.sql_db'), self.assertRaises(UniqueViolation), self.assertRaises(ValidationError), self.cr.savepoint():
+        with mute_logger('odoo.sql_db'), self.assertRaises(UniqueViolation), self.assertRaises(ValidationError):
             employee_form.save()
 
         employee_2 = self.env['hr.employee'].create({
@@ -285,7 +285,7 @@ class TestHrEmployee(TestHrCommon):
         # Try to set the user with existing employee in the company, on another existing employee
         employee_2_form = Form(employee_2.with_user(self.res_users_hr_officer).with_company(company=test_company.id))
         employee_2_form.user_id = self.res_users_hr_officer
-        with mute_logger('odoo.sql_db'), self.assertRaises(UniqueViolation), self.assertRaises(ValidationError), self.cr.savepoint():
+        with mute_logger('odoo.sql_db'), self.assertRaises(UniqueViolation), self.assertRaises(ValidationError):
             employee_2_form.save()
 
 
@@ -394,7 +394,7 @@ class TestHrEmployee(TestHrCommon):
             'company_id': company_A.id,
         })
         # User cannot be assigned to more than one employee in the same company. work_contact_id should not be removed.
-        with mute_logger('odoo.sql_db'), self.assertRaises(UniqueViolation), self.assertRaises(ValidationError), self.cr.savepoint():
+        with mute_logger('odoo.sql_db'), self.assertRaises(UniqueViolation), self.assertRaises(ValidationError):
             self.env['hr.employee'].create({
                 'name': 'new_employee_B',
                 'user_id': user.id,

--- a/addons/hr_holidays/tests/test_access_rights.py
+++ b/addons/hr_holidays/tests/test_access_rights.py
@@ -443,7 +443,7 @@ class TestAccessRightsRead(TestHrHolidaysAccessRightsCommon):
             'request_date_from': date.today(),
             'request_date_to': date.today() + relativedelta(days=1),
         })
-        with self.assertRaises(AccessError), self.cr.savepoint():
+        with self.assertRaises(AccessError):
             res = other_leave.with_user(self.user_employee_id).read(['number_of_days', 'state', 'name'])
 
     @mute_logger('odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')
@@ -457,7 +457,7 @@ class TestAccessRightsRead(TestHrHolidaysAccessRightsCommon):
             'request_date_from': date.today(),
             'request_date_to': date.today() + relativedelta(days=1),
         })
-        with self.assertRaises(AccessError), self.cr.savepoint():
+        with self.assertRaises(AccessError):
             other_leave.invalidate_model(['name'])
             name = other_leave.with_user(self.user_employee_id).name
 
@@ -697,7 +697,7 @@ class TestAccessRightsUnlink(TestHrHolidaysAccessRightsCommon):
             'state': 'confirm',
         }
         leave = self.request_leave(self.user_employee_id, date.today() + relativedelta(days=-4), 1, values)
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError):
             leave.with_user(self.user_employee.id).unlink()
 
     def test_leave_unlink_validate_by_user(self):
@@ -709,7 +709,7 @@ class TestAccessRightsUnlink(TestHrHolidaysAccessRightsCommon):
         }
         leave = self.request_leave(self.user_employee_id, date.today() + relativedelta(days=6), 1, values)
         leave.with_user(self.user_hrmanager_id).write({'state': 'validate'})
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError):
             leave.with_user(self.user_employee.id).unlink()
 
 class TestMultiCompany(TestHrHolidaysCommon):

--- a/addons/hr_holidays/tests/test_holidays_flow.py
+++ b/addons/hr_holidays/tests/test_holidays_flow.py
@@ -260,10 +260,8 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             'request_date_to': date.today() + relativedelta(day=10),
             'employee_id': self.ref('hr.employee_admin'),
         }
-        with mute_logger('odoo.sql_db'):
-            with self.assertRaises(IntegrityError):
-                with self.cr.savepoint():
-                    self.env['hr.leave'].create(leave_vals)
+        with mute_logger('odoo.sql_db'), self.assertRaises(IntegrityError):
+            self.env['hr.leave'].create(leave_vals)
 
         leave_vals = {
             'name': 'Sick Time Off',
@@ -274,10 +272,8 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
         }
         leave = self.env['hr.leave'].create(leave_vals)
 
-        with mute_logger('odoo.sql_db'):
-            with self.assertRaises(IntegrityError):  # No ValidationError
-                with self.cr.savepoint():
-                    leave.write({
-                        'request_date_from': date.today() + relativedelta(day=11),
-                        'request_date_to': date.today() + relativedelta(day=10),
-                    })
+        with mute_logger('odoo.sql_db'), self.assertRaises(IntegrityError):
+            leave.write({
+                'request_date_from': date.today() + relativedelta(day=11),
+                'request_date_to': date.today() + relativedelta(day=10),
+            })

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1122,7 +1122,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             raise RuntimeError()
 
         for leave_validation_type in types:
-            with self.assertRaises(RuntimeError), self.env.cr.savepoint():
+            with self.assertRaises(RuntimeError):
                 run_validation_flow(leave_validation_type)
 
     @freeze_time('2019-11-01')

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -68,7 +68,7 @@ class TestHolidaysOvertime(TransactionCase):
         with self.with_user('user'):
             self.assertEqual(self.user.total_overtime, 0, 'No overtime')
 
-            with self.assertRaises(ValidationError), self.cr.savepoint():
+            with self.assertRaises(ValidationError):
                 self.env['hr.leave'].create({
                     'name': 'no overtime',
                     'employee_id': self.employee.id,
@@ -92,11 +92,11 @@ class TestHolidaysOvertime(TransactionCase):
             overtime = leave.sudo().overtime_id.with_user(self.user)
 
             # An employee cannot delete an overtime adjustment
-            with self.assertRaises(AccessError), self.cr.savepoint():
+            with self.assertRaises(AccessError):
                 overtime.unlink()
 
             # ... nor change its duration
-            with self.assertRaises(AccessError), self.cr.savepoint():
+            with self.assertRaises(AccessError):
                 overtime.duration = 8
 
     def test_leave_adjust_overtime(self):
@@ -145,7 +145,7 @@ class TestHolidaysOvertime(TransactionCase):
 
         leave.date_to = datetime(2021, 1, 5)
         self.assertEqual(self.employee.total_overtime, 0)
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             leave.date_to = datetime(2021, 1, 6)
 
         leave.date_to = datetime(2021, 1, 4)
@@ -154,7 +154,7 @@ class TestHolidaysOvertime(TransactionCase):
     def test_employee_create_allocation(self):
         with self.with_user('user'):
             self.assertEqual(self.employee.total_overtime, 0)
-            with self.assertRaises(ValidationError), self.cr.savepoint():
+            with self.assertRaises(ValidationError):
                 self.env['hr.leave.allocation'].create({
                     'name': 'test allocation',
                     'holiday_status_id': self.leave_type_employee_allocation.id,
@@ -215,7 +215,7 @@ class TestHolidaysOvertime(TransactionCase):
         })
         self.assertEqual(self.employee.total_overtime, 8)
 
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             alloc.number_of_days = 3
 
         alloc.number_of_days = 2

--- a/addons/hr_work_entry_contract/tests/test_work_entry.py
+++ b/addons/hr_work_entry_contract/tests/test_work_entry.py
@@ -204,10 +204,8 @@ class TestWorkEntry(TestWorkEntryBase):
         work_entry_2 = self.create_work_entry(datetime(2018, 10, 10, 8, 0), datetime(2018, 10, 10, 10, 0))
         self.assertEqual(work_entry_1.state, 'conflict')
 
-        with mute_logger('odoo.sql_db'):
-            with self.assertRaises(IntegrityError):
-                with self.cr.savepoint():
-                    (work_entry_1 + work_entry_2).write({'state': 'validated'})
+        with mute_logger('odoo.sql_db'), self.assertRaises(IntegrityError):
+            (work_entry_1 + work_entry_2).write({'state': 'validated'})
 
     def test_work_entry_timezone(self):
         """ Test work entries with different timezone """

--- a/addons/hr_work_entry_holidays/tests/test_work_entry.py
+++ b/addons/hr_work_entry_holidays/tests/test_work_entry.py
@@ -142,7 +142,7 @@ class TestWorkeEntryHolidaysWorkEntry(TestWorkEntryHolidaysBase):
         # TODO I don't know what this test is supposed to test, but I feel that
         # in any case it should raise a Validation Error, as it's trying to
         # validate a leave in a period the employee is not supposed to work.
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             leave.action_approve()
             leave.action_validate()
 

--- a/addons/l10n_id_efaktur/tests/test_l10n_id_efaktur.py
+++ b/addons/l10n_id_efaktur/tests/test_l10n_id_efaktur.py
@@ -334,7 +334,7 @@ class TestIndonesianEfaktur(AccountTestInvoicingCommon):
         # No codes have been consumed.
         self.assertEqual(self.efaktur.available, available_code)
 
-        with self.assertRaises(ValidationError, msg='E-faktur is not available for invoices without any taxes.'), self.cr.savepoint():
+        with self.assertRaises(ValidationError, msg='E-faktur is not available for invoices without any taxes.'):
             out_invoice_no_taxes.download_efaktur()
 
     def test_efaktur_consume_code(self):

--- a/addons/l10n_latam_check/tests/test_third_party_checks.py
+++ b/addons/l10n_latam_check/tests/test_third_party_checks.py
@@ -54,7 +54,7 @@ class TestThirdChecks(L10nLatamCheckTest):
         delivery.action_post()
         self.assertFalse(check.current_journal_id, 'Current journal was not computed properly on delivery')
         # check dont delivery twice
-        with self.assertRaisesRegex(ValidationError, "it seems it has been moved by another payment"), self.cr.savepoint():
+        with self.assertRaisesRegex(ValidationError, "it seems it has been moved by another payment"):
             self.env['account.payment'].create(vals).action_post()
 
         # Check Return / Rejection
@@ -70,7 +70,7 @@ class TestThirdChecks(L10nLatamCheckTest):
         supplier_return.action_post()
         self.assertEqual(check.current_journal_id, self.rejected_check_journal, 'Current journal was not computed properly on return')
         # check dont return twice
-        with self.assertRaisesRegex(ValidationError, "Some checks are already in hand and can't be received again"), self.cr.savepoint():
+        with self.assertRaisesRegex(ValidationError, "Some checks are already in hand and can't be received again"):
             self.env['account.payment'].create(vals).action_post()
 
         # Check Claim/Return to customer
@@ -85,7 +85,7 @@ class TestThirdChecks(L10nLatamCheckTest):
         customer_return.action_post()
         self.assertFalse(check.current_journal_id, 'Current journal was not computed properly on customer return')
         # check dont claim twice
-        with self.assertRaisesRegex(ValidationError, "Some checks are not anymore in journal,"), self.cr.savepoint():
+        with self.assertRaisesRegex(ValidationError, "Some checks are not anymore in journal,"):
             self.env['account.payment'].create(vals).action_post()
 
         operations = self.env['account.payment'].search([('l10n_latam_move_check_ids', '=', check.id), ('state', '!=', 'draft')], order="date desc, id desc")

--- a/addons/loyalty/tests/test_loyalty.py
+++ b/addons/loyalty/tests/test_loyalty.py
@@ -51,10 +51,8 @@ class TestLoyalty(TransactionCase):
 
     def test_discount_product_unlink(self):
         # Test that we can not unlink discount line product id
-        with mute_logger('odoo.sql_db'):
-            with self.assertRaises(IntegrityError):
-                with self.cr.savepoint():
-                    self.program.reward_ids.discount_line_product_id.unlink()
+        with mute_logger('odoo.sql_db'), self.assertRaises(IntegrityError):
+            self.program.reward_ids.discount_line_product_id.unlink()
 
     def test_loyalty_mail(self):
         # Test basic loyalty_mail functionalities

--- a/addons/loyalty/tests/test_loyalty.py
+++ b/addons/loyalty/tests/test_loyalty.py
@@ -241,9 +241,10 @@ class TestLoyalty(TransactionCase):
             }
         ])
 
-        self.env['base.partner.merge.automatic.wizard']._merge(
-            [partner_1.id, partner_2.id, dest_partner.id], dest_partner
-        )
+        with self.patched_savepoints():
+            self.env['base.partner.merge.automatic.wizard']._merge(
+                [partner_1.id, partner_2.id, dest_partner.id], dest_partner
+            )
 
         dest_partner_loyalty_cards = self.env['loyalty.card'].search([
             ('partner_id', '=', dest_partner.id),

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -592,11 +592,9 @@ class TestMailRenderSecurity(TestMailRenderCommon):
 
         # sanity check, make sure the expressions are not allowed before the test (not in default allow list, etc...)
         with self.assertRaises(AccessError, msg="Complex inline expression should fail if it is not the default."):
-            with self.cr.savepoint():
-                template.lang = template_defaults['lang']
+            template.lang = template_defaults['lang']
         with self.assertRaises(AccessError, msg="Complex qweb expression should fail if it is not the default."):
-            with self.cr.savepoint():
-                template.body_html = template_defaults['body_html']
+            template.body_html = template_defaults['body_html']
 
         with patch(
             'odoo.addons.base.models.res_partner.ResPartner._mail_template_default_values',
@@ -612,8 +610,7 @@ class TestMailRenderSecurity(TestMailRenderCommon):
             self.assertEqual(template.body_html, template_defaults['body_html'])
 
             with self.assertRaises(AccessError, msg="Complex expressions should only be allowed if they are the default for that field."):
-                with self.cr.savepoint():
-                    template.email_cc = template_defaults['lang']
+                template.email_cc = template_defaults['lang']
 
     @users('user_rendering_restricted')
     def test_render_template_qweb_restricted(self):

--- a/addons/mail/tests/test_mail_template.py
+++ b/addons/mail/tests/test_mail_template.py
@@ -59,7 +59,7 @@ class TestMailTemplate(MailCommon):
     def test_mail_template_abstract_model(self):
         """Check abstract models cannot be set on templates."""
         # create
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             self.env['mail.template'].create({
                 'name': 'Test abstract template',
                 'model_id': self.env['ir.model']._get('mail.thread').id, # abstract model
@@ -69,7 +69,7 @@ class TestMailTemplate(MailCommon):
             'name': 'Test abstract template',
             'model_id': self.env['ir.model']._get('res.partner').id,
         })
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             template.write({
                 'name': 'Test abstract template',
                 'model_id': self.env['ir.model']._get('mail.thread').id,

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1177,7 +1177,7 @@ class TestBoM(TestMrpCommon):
             line.product_id = finished
             line.product_uom_id = uom_unit
             line.product_qty = 5
-        with self.assertRaises(exceptions.ValidationError), self.cr.savepoint():
+        with self.assertRaises(exceptions.ValidationError):
             bom_finished = bom_finished.save()
 
     def test_validate_no_bom_line_with_same_product_variant(self):
@@ -1193,7 +1193,7 @@ class TestBoM(TestMrpCommon):
             line.product_id = self.product_7_3
             line.product_uom_id = uom_unit
             line.product_qty = 5
-        with self.assertRaises(exceptions.ValidationError), self.cr.savepoint():
+        with self.assertRaises(exceptions.ValidationError):
             bom_finished = bom_finished.save()
 
     def test_validate_bom_line_with_different_product_variant(self):

--- a/addons/mrp/tests/test_byproduct.py
+++ b/addons/mrp/tests/test_byproduct.py
@@ -383,17 +383,17 @@ class TestMrpByProduct(common.TransactionCase):
             })
 
         # Update byproduct has cost share > 100%
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             byproduct_1.cost_share = 120
             mo.write({'move_byproduct_ids': [(4, byproduct_1.id)]})
 
         # Update byproduct has cost share < 0%
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             byproduct_1.cost_share = -10
             mo.write({'move_byproduct_ids': [(4, byproduct_1.id)]})
 
         # Update byproducts have total cost share > 100%
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             byproduct_1.cost_share = 60
             byproduct_2.cost_share = 70
             mo.write({'move_byproduct_ids': [(6, 0, [byproduct_1.id, byproduct_2.id])]})

--- a/addons/product/tests/test_product_attribute_value_config.py
+++ b/addons/product/tests/test_product_attribute_value_config.py
@@ -442,7 +442,7 @@ class TestProductAttributeValueConfig(TestProductAttributeValueCommon):
         self.assertEqual(self.computer._get_first_possible_combination(), computer_ssd_512 + computer_ram_32 + computer_hdd_4)
 
         # Not possible to add an exclusion when only one variant is left -> it deletes the product template associated to it
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError):
             self._add_exclude(computer_ram_32, computer_hdd_4)
 
         # If an exclusion rule deletes all variants at once it does not delete the template.

--- a/addons/project/tests/test_task_dependencies.py
+++ b/addons/project/tests/test_task_dependencies.py
@@ -80,14 +80,14 @@ class TestTaskDependencies(TestProjectCommon):
         self.assertEqual(len(self.task_2.depend_on_ids), 1, "The task 2 should have one dependency.")
 
         # 4) Add task1 as dependency in task3 and check a validation error is raised
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             self.task_3.write({
                 'depend_on_ids': [Command.link(self.task_1.id)],
             })
         self.assertEqual(len(self.task_3.depend_on_ids), 0, "The dependency should not be added in the task 3 because of a cyclic dependency.")
 
         # 5) Add task1 as dependency in task2 and check a validation error is raised
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             self.task_2.write({
                 'depend_on_ids': [Command.link(self.task_1.id)],
             })

--- a/addons/stock/tests/test_robustness.py
+++ b/addons/stock/tests/test_robustness.py
@@ -91,8 +91,7 @@ class TestRobustness(TransactionCase):
         self.assertEqual(move.state, 'done')
 
         # change the stock usage
-        with self.cr.savepoint():
-            test_stock_location.scrap_location = False
+        test_stock_location.scrap_location = False
 
         # make some stock again
         self.env['stock.quant']._update_available_quantity(
@@ -103,8 +102,7 @@ class TestRobustness(TransactionCase):
 
         # change the stock usage again
         with self.assertRaises(UserError):
-            with self.cr.savepoint():
-                test_stock_location.scrap_location = True
+            test_stock_location.scrap_location = True
 
     def test_package_unpack(self):
         """ Unpack a package that contains quants with a reservation

--- a/addons/test_mail/tests/test_mail_alias.py
+++ b/addons/test_mail/tests/test_mail_alias.py
@@ -124,19 +124,19 @@ class TestMailAlias(TestMailAliasCommon):
         self.assertEqual((new_mail_alias + other_alias).alias_domain_id, mail_alias_domain)
 
         # test you cannot create  or update aliases matching bounce / catchall of same alias domain
-        with self.assertRaises(exceptions.ValidationError), self.cr.savepoint():
+        with self.assertRaises(exceptions.ValidationError):
             self.env['mail.alias'].create({
                 'alias_model_id': alias_model_id,
                 'alias_name': mail_alias_domain.catchall_alias,
             })
-        with self.assertRaises(exceptions.ValidationError), self.cr.savepoint():
+        with self.assertRaises(exceptions.ValidationError):
             self.env['mail.alias'].create({
                 'alias_model_id': alias_model_id,
                 'alias_name': mail_alias_domain.bounce_alias,
             })
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError):
             new_mail_alias.write({'alias_name': mail_alias_domain.catchall_alias})
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError):
             new_mail_alias.write({'alias_name': mail_alias_domain.bounce_alias})
 
         # other domains bounce / catchall do not prevent
@@ -150,17 +150,17 @@ class TestMailAlias(TestMailAliasCommon):
         new_mail_alias.write({'alias_name': mail_alias_domain_c2.bounce_alias})
         other_alias.write({'alias_name': mail_alias_domain_c2.catchall_alias})
         # changing domain would clash with existing catchall
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError):
             new_mail_alias.write({'alias_domain_id': mail_alias_domain_c2.id,})
 
         new_mail_alias.write({'alias_name': 'unused.test.alias'})
         # test that alias {name, alias_domain_id} should be unique
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError):
             self.env['mail.alias'].create({
                 'alias_model_id': alias_model_id,
                 'alias_name': 'unused.test.alias',
             })
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError):
             self.env['mail.alias'].create([
                 {
                     'alias_model_id': alias_model_id,
@@ -168,7 +168,7 @@ class TestMailAlias(TestMailAliasCommon):
                 }
                 for alias_name in ('new.alias.1', 'new.alias.2', 'new.alias.1')
             ])
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError):
             other_alias.write({'alias_name': 'unused.test.alias'})
 
         # also valid for void domain
@@ -178,13 +178,13 @@ class TestMailAlias(TestMailAliasCommon):
             'alias_name': 'no.domain',
         })
         self.assertFalse(nodom_alias.alias_domain_id)
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError):
             self.env['mail.alias'].create({
                 'alias_domain_id': False,
                 'alias_model_id': alias_model_id,
                 'alias_name': 'no.domain',
             })
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError):
             self.env['mail.alias'].create([
                 {
                     'alias_domain_id': False,
@@ -192,7 +192,7 @@ class TestMailAlias(TestMailAliasCommon):
                     'alias_name': 'dupes.wo.domain',
                 } for _x in range(2)
             ])
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError):
             other_alias.write({
                 'alias_domain_id': False,
                 'alias_name': 'no.domain',
@@ -206,7 +206,7 @@ class TestMailAlias(TestMailAliasCommon):
         })
         self.assertEqual(other_domain_alias.alias_domain_id, mail_alias_domain_c2)
         # changing domain would violate uniqueness
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError):
             other_domain_alias.write({'alias_domain_id': mail_alias_domain.id})
 
     @users('admin')
@@ -219,7 +219,7 @@ class TestMailAlias(TestMailAliasCommon):
             'alias_name': 'unused.test.alias'
         })
 
-        with mute_logger('odoo.sql_db'), self.assertRaises(psycopg2.errors.UniqueViolation), self.cr.savepoint():
+        with mute_logger('odoo.sql_db'), self.assertRaises(psycopg2.errors.UniqueViolation):
             new_mail_alias.copy({'alias_name': 'unused.test.alias'})
 
         # test that duplicating an alias should have blank name
@@ -458,7 +458,7 @@ class TestAliasCompany(TestMailAliasCommon):
         self.assertEqual(self.company_2.alias_domain_id, mail_alias_domain_c2)
 
         # cannot unlink alias domain as there are aliases linked to it
-        with self.assertRaises(psycopg2.errors.ForeignKeyViolation), self.cr.savepoint(), mute_logger('odoo.sql_db'):
+        with self.assertRaises(psycopg2.errors.ForeignKeyViolation), mute_logger('odoo.sql_db'):
             mail_alias_domain.unlink()
 
         # eject linked aliases then remove alias domain of first company; should
@@ -589,9 +589,9 @@ class TestMailAliasDomain(TestMailAliasCommon):
 
         # should not clash with existing aliases, to avoid valid aliases be
         # considered as bounce / catchall
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError):
             alias_domain.write({'bounce_alias': self.test_alias_mc.alias_name})
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError):
             alias_domain.write({'catchall_alias': self.test_alias_mc.alias_name})
 
     @users('admin')
@@ -601,7 +601,7 @@ class TestMailAliasDomain(TestMailAliasCommon):
         alias_domain = self.mail_alias_domain.with_env(self.env)
 
         # copying directly would duplicate bounce / catchall emails
-        with mute_logger('odoo.sql_db'), self.assertRaises(psycopg2.errors.UniqueViolation), self.cr.savepoint():
+        with mute_logger('odoo.sql_db'), self.assertRaises(psycopg2.errors.UniqueViolation):
             new_alias_domain = alias_domain.copy()
 
         # same domain name is authorized if bounce and catchall are different
@@ -620,12 +620,12 @@ class TestMailAliasDomain(TestMailAliasCommon):
             'name': alias_domain.name,
         })
         # any not unique should raise UniqueViolation (SQL constraint fired after check)
-        with mute_logger('odoo.sql_db'), self.assertRaises(psycopg2.errors.UniqueViolation), self.cr.savepoint():
+        with mute_logger('odoo.sql_db'), self.assertRaises(psycopg2.errors.UniqueViolation):
             self.env['mail.alias.domain'].create({
                 'bounce_alias': alias_domain.bounce_alias,
                 'name': alias_domain.name,
             })
-        with mute_logger('odoo.sql_db'), self.assertRaises(psycopg2.errors.UniqueViolation), self.cr.savepoint():
+        with mute_logger('odoo.sql_db'), self.assertRaises(psycopg2.errors.UniqueViolation):
             self.env['mail.alias.domain'].create({
                 'catchall_alias': alias_domain.catchall_alias,
                 'name': alias_domain.name,

--- a/addons/web/tests/test_ir_model.py
+++ b/addons/web/tests/test_ir_model.py
@@ -156,7 +156,7 @@ class TestIrModel(TransactionCase):
 
         INVALID_ORDERS = ['', 'x_wat', 'id esc', 'create_uid,', 'id, x_is_yellow']
         for order in INVALID_ORDERS:
-            with self.assertRaises(ValidationError), self.cr.savepoint():
+            with self.assertRaises(ValidationError):
                 self.bananas_model.order = order
 
         # check that the constraint is checked at model creation

--- a/addons/web/tests/test_reports.py
+++ b/addons/web/tests/test_reports.py
@@ -60,7 +60,8 @@ class TestReports(odoo.tests.HttpCase):
         report = report.with_user(admin)
         with MockRequest(report.env) as mock_request:
             mock_request.session = self.authenticate(admin.login, admin.login)
-            report.with_context(force_report_rendering=True)._render_qweb_pdf(report.id, [partner_id])
+            with odoo.tests.patch_savepoint():
+                report.with_context(force_report_rendering=True)._render_qweb_pdf(report.id, [partner_id])
         # Check that no device logs have been generated
         admin_device_log_count_after = self.env['res.device.log'].search_count([('user_id', '=', admin.id)])
         self.assertFalse(admin_device_log_count_after - admin_device_log_count_before)

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -3,7 +3,7 @@
 import logging
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal, HttpCaseWithUserDemo
 
-from contextlib import nullcontext
+from contextlib import closing
 
 from odoo.sql_db import categorize_query
 from odoo.tools import mute_logger
@@ -194,7 +194,7 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
         # standard untracked website.page
         for readonly_enabled in (True, False):
             self.env.registry.test_readonly_enabled = readonly_enabled
-            with self.subTest(readonly_enabled=readonly_enabled), self.env.cr.savepoint() as savepoint:
+            with self.subTest(readonly_enabled=readonly_enabled), closing(self.env.cr.savepoint()):
                 select_tables_perf = {
                     'orm_signaling_registry': 1,
                     'ir_attachment': 1,
@@ -213,13 +213,12 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                 self.menu.unlink()  # page being or not in menu shouldn't add queries
                 self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf)
                 self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 10)
-                savepoint.rollback()
 
     def test_15_perf_sql_queries_page(self):
         # standard tracked website.page
         for readonly_enabled in (True, False):
             self.env.registry.test_readonly_enabled = readonly_enabled
-            with self.subTest(readonly_enabled=readonly_enabled), self.env.cr.savepoint() as savepoint:
+            with self.subTest(readonly_enabled=readonly_enabled), closing(self.env.cr.savepoint()):
                 select_tables_perf = {
                     'orm_signaling_registry': 1,
                     'ir_attachment': 1,
@@ -247,13 +246,12 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                 self.menu.unlink()  # page being or not in menu shouldn't add queries
                 self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf, insert_tables_perf)
                 self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), expected_query_count_no_cache)
-                savepoint.rollback()
 
     def test_20_perf_sql_queries_homepage(self):
         # homepage "/" has its own controller
         for readonly_enabled in (True, False):
             self.env.registry.test_readonly_enabled = readonly_enabled
-            with self.subTest(readonly=readonly_enabled), self.env.cr.savepoint() as savepoint:
+            with self.subTest(readonly=readonly_enabled), closing(self.env.cr.savepoint()):
                 select_tables_perf = {
                     'orm_signaling_registry': 1,
                     'website_menu': 1,
@@ -276,7 +274,6 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     expected_query_count_no_cache += 1
                 self._check_url_hot_query('/', expected_query_count, select_tables_perf, insert_tables_perf)
                 self.assertEqual(self._get_url_hot_query('/', cache=False), expected_query_count_no_cache)
-                savepoint.rollback()
 
     def test_30_perf_sql_queries_page_no_layout(self):
         # untrack website.page with no call to layout templates

--- a/addons/website/tests/test_website_visitor.py
+++ b/addons/website/tests/test_website_visitor.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.website.models.website_visitor import WebsiteVisitor
-from odoo.tests import common, tagged, HttpCase
+from odoo.tests import common, tagged, HttpCase, patch_savepoint
 
 
 class MockVisitor(common.BaseCase):
@@ -431,10 +431,11 @@ class WebsiteVisitorTests(WebsiteVisitorTestsCommon):
         self.assertEqual(visitor_admin.website_track_ids.url, '/admin')
 
         # Merge admin_duplicate partner (no user associated) in admin partner
-        self.env['base.partner.merge.automatic.wizard']._merge(
-            (self.partner_admin + self.partner_admin_duplicate).ids,
-            self.partner_admin
-        )
+        with patch_savepoint(): # There are no errors so no need for savepoints.
+            self.env['base.partner.merge.automatic.wizard']._merge(
+                (self.partner_admin + self.partner_admin_duplicate).ids,
+                self.partner_admin
+            )
         # Should be
         # | id | access_token | partner_id |
         # | -- | ------------ | ---------- |
@@ -489,10 +490,11 @@ class WebsiteVisitorTests(WebsiteVisitorTestsCommon):
                         self.partner_admin_duplicate.id)
 
         # Merge admin_duplicate partner (no user associated) in admin partner
-        self.env['base.partner.merge.automatic.wizard']._merge(
-            (self.partner_admin + self.partner_admin_duplicate).ids,
-            self.partner_admin
-        )
+        with patch_savepoint(): # There are no errors so no need for savepoints.
+            self.env['base.partner.merge.automatic.wizard']._merge(
+                (self.partner_admin + self.partner_admin_duplicate).ids,
+                self.partner_admin
+            )
         # This should not happen..
         # | id | access_token           | partner_id |
         # | -- | ---------------------- | ---------- |

--- a/addons/website_forum/tests/test_forum_karma_access.py
+++ b/addons/website_forum/tests/test_forum_karma_access.py
@@ -94,19 +94,17 @@ class TestForumCRUD(TestForumCommon):
 
         with mute_logger('odoo.sql_db'):
             with self.assertRaises(IntegrityError):
-                with self.cr.savepoint():
-                    # One should not be able to vote more than once on a same post
-                    Vote.with_user(self.user_employee).create({
-                        'post_id': self.admin_post.id,
-                        'vote': '1',
-                    })
+                # One should not be able to vote more than once on a same post
+                Vote.with_user(self.user_employee).create({
+                    'post_id': self.admin_post.id,
+                    'vote': '1',
+                })
             with self.assertRaises(IntegrityError):
-                with self.cr.savepoint():
-                    # One should not be able to vote more than once on a same post
-                    Vote.with_user(self.user_employee).create({
-                        'post_id': self.admin_post.id,
-                        'vote': '1',
-                    })
+                # One should not be able to vote more than once on a same post
+                Vote.with_user(self.user_employee).create({
+                    'post_id': self.admin_post.id,
+                    'vote': '1',
+                })
 
         # One should not be able to create a vote for someone else
         new_employee_vote = Vote.with_user(self.user_employee).create({

--- a/addons/website_slides/tests/test_slide_slide.py
+++ b/addons/website_slides/tests/test_slide_slide.py
@@ -50,7 +50,7 @@ class TestSlideInternals(slides_common.SlidesCase):
     @users('user_manager')
     def test_slide_create_vote_constraint(self):
         # test vote value must be 1, 0 and -1.
-        with self.assertRaises(psycopg2.errors.CheckViolation), self.cr.savepoint():
+        with self.assertRaises(psycopg2.errors.CheckViolation):
             self.env['slide.slide.partner'].create({
                 'slide_id': self.slide.id,
                 'channel_id': self.channel.id,

--- a/odoo/addons/base/tests/test_display_name.py
+++ b/odoo/addons/base/tests/test_display_name.py
@@ -57,5 +57,5 @@ class TestEveryModel(TransactionCase):
                     continue
 
                 with self.subTest(msg=f"Compute method of {field} should work on new record."):
-                    with self.env.cr.savepoint():
+                    with contextlib.closing(self.env.cr.savepoint()):
                         model.new()[field.name]

--- a/odoo/addons/base/tests/test_ir_attachment.py
+++ b/odoo/addons/base/tests/test_ir_attachment.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 import io
 import os
+import contextlib
 
 from PIL import Image
 
@@ -247,14 +248,13 @@ class TestIrAttachment(TransactionCaseWithUserDemo):
         self.assertFalse(os.path.isfile(store_path), 'file removed')
 
     def test_13_rollback(self):
-        savepoint = self.cr.savepoint()
         # the data needs to be unique so that no other attachment link
         # the file so that the gc removes it
         unique_blob = os.urandom(16)
-        a1 = self.env['ir.attachment'].create({'name': 'a1', 'raw': unique_blob})
-        store_path = os.path.join(self.filestore, a1.store_fname)
-        self.assertTrue(os.path.isfile(store_path), 'file exists')
-        savepoint.rollback()
+        with contextlib.closing(self.cr.savepoint()):
+            a1 = self.env['ir.attachment'].create({'name': 'a1', 'raw': unique_blob})
+            store_path = os.path.join(self.filestore, a1.store_fname)
+            self.assertTrue(os.path.isfile(store_path), 'file exists')
         self.env['ir.attachment']._gc_file_store_unsafe()
         self.assertFalse(os.path.isfile(store_path), 'file removed')
 

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -616,7 +616,7 @@ class TestPartnerAddressCompany(TransactionCase):
         test_partner_company.write({'company_id': False})
         self.assertFalse(test_user.partner_id.company_id.id, "If the company_id is deleted from the partner company, it should be propagated to its children")
 
-        with self.assertRaises(UserError, msg="You should not be able to update the company_id of the partner company if the linked user of a child partner is not an allowed to be assigned to that company"), self.cr.savepoint():
+        with self.assertRaises(UserError, msg="You should not be able to update the company_id of the partner company if the linked user of a child partner is not an allowed to be assigned to that company"):
             test_partner_company.write({'company_id': company_2.id})
 
     def test_display_address_missing_key(self):

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -48,13 +48,12 @@ class ViewCase(TransactionCaseWithUserDemo):
     def assertInvalid(self, arch, expected_message=None, name='invalid view', inherit_id=False, model='ir.ui.view'):
         with mute_logger('odoo.addons.base.models.ir_ui_view'):
             with self.assertRaises(ValidationError) as catcher:
-                with self.cr.savepoint():
-                    self.View.create({
-                        'name': name,
-                        'model': model,
-                        'inherit_id': inherit_id,
-                        'arch': arch,
-                    })
+                self.View.create({
+                    'name': name,
+                    'model': model,
+                    'inherit_id': inherit_id,
+                    'arch': arch,
+                })
         message = str(catcher.exception.args[0])
         self.assertEqual(catcher.exception.context['name'], name)
         if expected_message:
@@ -282,18 +281,18 @@ class TestViewInheritance(ViewCase):
 
     def test_no_recursion(self):
         r1 = self.makeView('R1')
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             r1.write({'inherit_id': r1.id})
 
         r2 = self.makeView('R2', r1.id)
         r3 = self.makeView('R3', r2.id)
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             r2.write({'inherit_id': r3.id})
 
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             r1.write({'inherit_id': r3.id})
 
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError):
             r1.write({
                 'inherit_id': r1.id,
                 'arch': self.arch_for('itself', parent=True),

--- a/odoo/addons/test_new_api/tests/test_autovacuum.py
+++ b/odoo/addons/test_new_api/tests/test_autovacuum.py
@@ -9,7 +9,7 @@ class TestAutovacuum(common.TransactionCase):
         self.assertTrue(instance.exists())
 
         # Run the autovacuum cron
-        with self.enter_registry_test_mode():
+        with self.enter_registry_test_mode(), self.patched_savepoints():
             self.env.ref('base.autovacuum_job').method_direct_trigger()
 
         # Check the record has been vacuumed.

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -2877,7 +2877,7 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         self.assertEqual(image_data_uri(record.image_256)[:30], 'data:image/png;base64,iVBORw0K')
 
         # ensure invalid image raises
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError):
             record.write({
                 'image': 'invalid image',
             })
@@ -3258,7 +3258,7 @@ class TestX2many(TransactionExpressionCase):
             'a_restricted_b_ids': [Command.set(record_b.ids)],
         })
         with self.assertRaises(psycopg2.IntegrityError):
-            with mute_logger('odoo.sql_db'), self.cr.savepoint():
+            with mute_logger('odoo.sql_db'):
                 record_a.unlink()
         # Test B is still cascade.
         record_b.unlink()
@@ -3272,7 +3272,7 @@ class TestX2many(TransactionExpressionCase):
             'b_restricted_b_ids': [Command.set(record_b.ids)],
         })
         with self.assertRaises(psycopg2.IntegrityError):
-            with mute_logger('odoo.sql_db'), self.cr.savepoint():
+            with mute_logger('odoo.sql_db'):
                 record_b.unlink()
         # Test A is still cascade.
         record_a.unlink()

--- a/odoo/addons/test_new_api/tests/test_ui.py
+++ b/odoo/addons/test_new_api/tests/test_ui.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.http import request
 import odoo.tests
 from odoo.tools import mute_logger
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
@@ -38,4 +39,8 @@ class TestUiTranslation(odoo.tests.HttpCase):
         # the message is translated (_load_module_terms is also) rollbacked.
         # Test individually the external id and loading of translation.
         self.start_tour("/odoo/action-test_new_api.action_categories",
-            'sql_constaint', login="admin")
+            'sql_constaint', login="admin",
+            # The tour relies on checking an sql constraint and does not cause
+            # subtransaction overflow.
+            patch_savepoints=False,
+        )

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -16,6 +16,7 @@ import time
 import typing
 import uuid
 import warnings
+import weakref
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from inspect import currentframe
@@ -84,6 +85,76 @@ sql_counter: int = 0
 MAX_IDLE_TIMEOUT = 60 * 10
 
 
+savepoint_counters = weakref.WeakKeyDictionary() # psycopg2 cursor -> SubXActCache
+SUB_XACT_CACHE_MAX = 64
+
+_subxact_logger = _logger.getChild('SubXActCache')
+
+class SubXActCache:
+    """
+    This class attempts to track sub transactions (savepoints) the same way postgres
+    does internally.
+
+    For simplicity we will store savepoint name instead of transaction id.
+
+    Postgres stores only a certain amount of sub transaction ids in cache before
+    starting to use the disk, in certain situations this can lead to significant
+    performance drop, or even database halts.
+
+    Postgres keeps a reference to sub transaction ids (and grand-sub transaction ids)
+    as long as one of those conditions is met:
+     - The sub transaction is alive
+     - The sub transaction was Released without being rolled back (equivalent to commit)
+        and queries were made during the sub transaction
+
+    Failure to meet those condition means dropping the sub transaction as well as
+    it's children.
+
+    For all intents and purpose rolling back to a savepoint without releasing is equivalent
+    to starting a new savepoint.
+
+    Unfortunately it would be impossible to track activity during a savepoint so we
+    always assume that some activity happened (transaction id was set).
+    """
+
+    def __init__(self):
+        self._sp_stack = []
+        self._last_rollback = ''
+
+    def start(self, name):
+        if len(self._sp_stack) == SUB_XACT_CACHE_MAX:
+            if odoo.modules.module.current_test:
+                raise AssertionError(
+                    'Savepoint limit (%s) reached.\n'
+                    'See https://github.com/odoo/odoo/pull/199596 for troubleshooting and fixes.',
+                    SUB_XACT_CACHE_MAX
+                )
+            else:
+                _subxact_logger.warning(
+                    'Savepoint limit (%s) reached.', SUB_XACT_CACHE_MAX, stack_info=True
+                )
+        self._sp_stack.append(name)
+        self._last_rollback = ''
+        _subxact_logger.debug('Starting savepoint: %s', name)
+
+    def rollback(self, name):
+        self._last_rollback = name
+        _subxact_logger.debug('Rollback savepoint: %s', name)
+
+    def release(self, name):
+        _subxact_logger.debug('Trying to release savepoint: %s', name)
+        if self._last_rollback != name:
+            return
+        for idx in reversed(range(len(self._sp_stack))):
+            if self._sp_stack[idx] == name:
+                break
+        else:
+            raise AssertionError('Tried to release unknown savepoint %s', name)
+        self._sp_stack = self._sp_stack[:idx]
+        self._last_rollback = ''
+        _subxact_logger.debug('Released savepoint: %s', name)
+
+
 class Savepoint:
     """ Reifies an active breakpoint, allows :meth:`BaseCursor.savepoint` users
     to internally rollback the savepoint (as many times as they want) without
@@ -113,6 +184,20 @@ class Savepoint:
         cr.execute('SAVEPOINT "%s"' % self.name)
         if self._readonly:
             cr.execute('SET TRANSACTION READ ONLY')
+        self.__subxactcache.start(self.name)
+
+    @property
+    def __subxactcache(self) -> SubXActCache:
+        return savepoint_counters.setdefault(self.__obj, SubXActCache())
+
+    @property
+    def __obj(self):
+        # Get Psycopg2 cursor from Cursor impl
+        if hasattr(self._cr, 'cr'): # TestCursor
+            return self._cr.cr._obj
+        elif hasattr(self._cr, '_obj'): # Cursor
+            return self._cr._obj
+        return self._cr
 
     def __enter__(self):
         return self
@@ -126,11 +211,13 @@ class Savepoint:
 
     def rollback(self):
         self._cr.execute('ROLLBACK TO SAVEPOINT "%s"' % self.name)
+        self.__subxactcache.rollback(self.name)
 
     def _close(self, rollback: bool):
         if rollback or self._readonly:
             self.rollback()
         self._cr.execute('RELEASE SAVEPOINT "%s"' % self.name)
+        self.__subxactcache.release(self.name)
         self.closed = True
 
 
@@ -554,6 +641,8 @@ class Cursor(BaseCursor):
         self.prerollback.clear()
         self.postrollback.clear()
         self.postcommit.run()
+        if '_obj' in self.__dict__:
+            savepoint_counters[self._obj] = SubXActCache()
 
     def rollback(self) -> None:
         """ Perform an SQL `ROLLBACK` """
@@ -563,6 +652,8 @@ class Cursor(BaseCursor):
         self._cnx.rollback()
         self._now = None
         self.postrollback.run()
+        if '_obj' in self.__dict__:
+            savepoint_counters[self._obj] = SubXActCache()
 
     def __getattr__(self, name):
         if self._closed and name == '_obj':


### PR DESCRIPTION
Please refer to https://github.com/odoo/odoo/pull/71395#issuecomment-851440042 for more information about why this is being done.

This PR tries to achieve the following:
 - Tracking of sub transaction state and overflow.
 - Reduce unnecessary uses of savepoints in tests.
 - Disallow overflowing the sub transaction cache during tests.
 - Provide tools to properly handle sub transaction cache overflow.
 - Fix the tests that were otherwise causing sub transaction overflows.