### PR TITLE
[IMP] html_editor: minor tweaks to enable portal attachment access

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -601,7 +601,9 @@ class HTML_Editor(Controller):
         for id, url in response.json().items():
             req = requests.get(url)
             name = '_'.join([media[id]['query'], url.split('/')[-1]])
-            IrAttachment = request.env['ir.attachment']
+            # Need to bypass security check to search/write image with mimetype image/svg+xml
+            # ok because svgs come from whitelisted origin
+            IrAttachment = request.env['ir.attachment'].with_user(SUPERUSER_ID)
             attachment_data = {
                 'name': name,
                 'mimetype': req.headers['content-type'],
@@ -611,10 +613,8 @@ class HTML_Editor(Controller):
                 'res_id': 0,
             }
             attachment = get_existing_attachment(IrAttachment, attachment_data)
-            # Need to bypass security check to write image with mimetype image/svg+xml
-            # ok because svgs come from whitelisted origin
             if not attachment:
-                attachment = IrAttachment.with_user(SUPERUSER_ID).create(attachment_data)
+                attachment = IrAttachment.create(attachment_data)
             if media[id]['is_dynamic_svg']:
                 colorParams = werkzeug.urls.url_encode(media[id]['dynamic_colors'])
                 attachment['url'] = '/html_editor/shape/illustration/%s?%s' % (slug(attachment), colorParams)

--- a/addons/html_editor/static/src/main/media/media_dialog/file_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/file_selector.js
@@ -5,6 +5,7 @@ import { useService } from "@web/core/utils/hooks";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { Dialog } from "@web/core/dialog/dialog";
 import { KeepLast } from "@web/core/utils/concurrency";
+import { user } from "@web/core/user";
 import { useDebounced } from "@web/core/utils/timing";
 import { SearchMedia } from "./search_media";
 
@@ -273,41 +274,36 @@ export class FileSelector extends Component {
     }
 
     async fetchAttachments(limit, offset) {
-        this.state.isFetchingAttachments = true;
-        let attachments = [];
-        try {
-            attachments = await this.orm.call("ir.attachment", "search_read", [], {
-                domain: this.attachmentsDomain,
-                fields: [
-                    "name",
-                    "mimetype",
-                    "description",
-                    "checksum",
-                    "url",
-                    "type",
-                    "res_id",
-                    "res_model",
-                    "public",
-                    "access_token",
-                    "image_src",
-                    "image_width",
-                    "image_height",
-                    "original_id",
-                ],
-                order: "id desc",
-                // Try to fetch first record of next page just to know whether there is a next page.
-                limit,
-                offset,
-            });
-            attachments.forEach((attachment) => (attachment.mediaType = "attachment"));
-        } catch (e) {
+        if (!user.isInternalUser) {
             // Reading attachments as a portal user is not permitted and will raise
-            // an access error so we catch the error silently and don't return any
-            // attachment so he can still use the wizard and upload an attachment
-            if (e.exceptionName !== "odoo.exceptions.AccessError") {
-                throw e;
-            }
+            // an access error so we don't return any attachment
+            return [];
         }
+        this.state.isFetchingAttachments = true;
+        const attachments = await this.orm.call("ir.attachment", "search_read", [], {
+            domain: this.attachmentsDomain,
+            fields: [
+                "name",
+                "mimetype",
+                "description",
+                "checksum",
+                "url",
+                "type",
+                "res_id",
+                "res_model",
+                "public",
+                "access_token",
+                "image_src",
+                "image_width",
+                "image_height",
+                "original_id",
+            ],
+            order: "id desc",
+            // Try to fetch first record of next page just to know whether there is a next page.
+            limit,
+            offset,
+        });
+        attachments.forEach((attachment) => (attachment.mediaType = "attachment"));
         this.state.canLoadMoreAttachments =
             attachments.length >= this.NUMBER_OF_ATTACHMENTS_TO_DISPLAY;
         this.state.isFetchingAttachments = false;


### PR DESCRIPTION
This PR bypasses the access rights of the attachments for
saving/searching the images received from the media library. It is
especially useful when a portal user wants to upload an image in the
editor and adapts `fetchAttachments` of `FileSelector`.

See commits for details.

 Task-4334962
