### PR TITLE
[DRAFT][FIX] stock: resolve inventory quantity line decoration warning for products

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1070,8 +1070,7 @@ class StockQuant(models.Model):
         date_by_location = {loc: loc._get_next_inventory_date() for loc in self.mapped('location_id')}
         for quant in self:
             quant.inventory_date = date_by_location[quant.location_id]
-        self.write({'inventory_quantity': 0, 'user_id': False})
-        self.write({'inventory_diff_quantity': 0})
+        self.action_clear_inventory_quantity()
 
     @api.model
     def _update_available_quantity(self, product_id, location_id, quantity=False, reserved_quantity=False, lot_id=None, package_id=None, owner_id=None, in_date=None):


### PR DESCRIPTION
Before this PR, Setting the on-hand quantity from the product form 
would correctly set the product's quantity but also reset the inventory
quantity to 0. While this behavior is correct,it caused a line decoration 
warning to appear in the Inventory Adjustment tree view.

Steps to Reproduce
===================
- Create a storable, non-tracked product.
- Update its quantity by clicking the "Update Quantity" button, ensuring 
  multi-location is disabled.
- Go to Inventory Adjustment and locate the newly created product. 
  The inventory quantity is correctly set to 0, but it is highlighted with a warning.

Issue
======
Although the inventory quantity is correctly set to 0, the `inventory quantity set` 
field is not reverted, causing the line decoration warning to appear.

This commit resolves the issue by using an existing method that clears the 
inventory quantity and sets the `inventory quantity set` field to false.


task: [4579053](https://www.odoo.com/odoo/my-tasks/4579053)