### PR TITLE
[FIX] web_editor: fix banner test for Chrome 133

### DIFF
--- a/addons/web_editor/static/tests/banner_tests.js
+++ b/addons/web_editor/static/tests/banner_tests.js
@@ -6,6 +6,7 @@ import { Wysiwyg } from "@web_editor/js/wysiwyg/wysiwyg";
 import {
     triggerEvent,
     insertText,
+    deleteBackward,
 } from "@web_editor/js/editor/odoo-editor/test/utils";
 
 function onMount() {;
@@ -141,7 +142,7 @@ QUnit.module(
             insertText(editor, 'Test2');
             triggerEvent(editor.editable, "keydown", { key: "a", ctrlKey: true });
             await nextTick();
-            triggerEvent(editor.editable, "input", { inputType: "deleteContentBackward" });
+            await deleteBackward(editor);
             await nextTick();
             assert.strictEqual(
                 editable.innerHTML,


### PR DESCRIPTION
The sequence of events leads to slightly different results in Chrome 133 which results in the test failing. This commit changes the sequence of events so that the test passes in Chrome 133 as well as the prior versions.