### PR TITLE
[IMP] pos_self_order: configure preset in config

### DIFF
--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -112,8 +112,8 @@ class PosConfig(models.Model):
             'pos_restaurant.food',
             'pos_restaurant.drinks',
         ])
+        default_preset = self.env.ref('pos_restaurant.pos_takein_preset', False) or self.env['pos.preset'].search([('identification', '=', 'none')], limit=1)
         presets = self.get_record_by_ref([
-            'pos_restaurant.pos_takein_preset',
             'pos_restaurant.pos_takeout_preset',
             'pos_restaurant.pos_delivery_preset',
         ])
@@ -126,9 +126,9 @@ class PosConfig(models.Model):
             'iface_available_categ_ids': restaurant_categories,
             'iface_splitbill': True,
             'module_pos_restaurant': True,
-            'use_presets': True,
-            'default_preset_id': presets[0] if presets else False,
-            'available_preset_ids': [(6, 0, presets[1:])],
+            'use_presets': True if default_preset else False,
+            'default_preset_id': default_preset.id if default_preset else False,
+            'available_preset_ids': [(6, 0, ([default_preset.id] + presets) if default_preset else presets)],
         })
         self.env['ir.model.data']._update_xmlids([{
             'xml_id': self._get_suffixed_ref_name(ref_name),

--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -8,6 +8,7 @@
     "auto_install": ["pos_restaurant"],
     "data": [
         "security/ir.model.access.csv",
+        "data/preset_data.xml",
         "views/pos_self_order.index.xml",
         "views/qr_code.xml",
         "views/pos_category_views.xml",
@@ -22,7 +23,6 @@
         "views/point_of_sale_dashboard.xml",
     ],
     "demo": [
-        "data/preset_data.xml",
         "data/kiosk_demo_data.xml",
     ],
     "assets": {


### PR DESCRIPTION
Before this commit:
===
- Preset data was not updated for self order (without demo data)

After this commit:
===
- Preset data updated in pos self order (without demo data)
- If there are no presets found, set 'use_presets' as False
- if there is any manually created preset, add it to the default preset

Related PR: odoo/odoo#194777
Related PR: odoo/odoo#199161

Task: 4501570, 4612542
