### PR TITLE
[FIX] website_sale_collect: add state to pickup location data

### DIFF
--- a/addons/website_sale_collect/models/delivery_carrier.py
+++ b/addons/website_sale_collect/models/delivery_carrier.py
@@ -92,6 +92,7 @@ class DeliveryCarrier(models.Model):
                     'city': wh_location.city.title(),
                     'zip_code': wh_location.zip,
                     'country_code': wh_location.country_code,
+                    'state': wh_location.state_id.code,
                     'latitude': wh_location.partner_latitude,
                     'longitude': wh_location.partner_longitude,
                     'additional_data': {'in_store_stock': in_store_stock_data},

--- a/addons/website_sale_collect/tests/test_delivery_carrier.py
+++ b/addons/website_sale_collect/tests/test_delivery_carrier.py
@@ -84,6 +84,7 @@ class TestDeliveryCarrier(ClickAndCollectCommon, WebsiteSaleStockCommon):
                     'street': wh_address_partner['street'].title(),
                     'city': wh_address_partner.city.title(),
                     'zip_code': wh_address_partner.zip,
+                    'state': wh_address_partner.state_id.code,
                     'country_code': wh_address_partner.country_code,
                     'latitude': wh_address_partner.partner_latitude,
                     'longitude': wh_address_partner.partner_longitude,


### PR DESCRIPTION
Steps to reproduce:
 1) Enable Click and Collect
 2) Configure pick up in store and add a store in US with state set
 3) Set the available country to US and available state as in the
    store's partner
 4) Enable Pay on site
 5) Go to /shop page and add a storable product
 6) Proceed to payment and pay choosing pickup in store delivery method
    and pay on site payment method
 7) Observe an error

 Reason:
 /shop/payment/validate checks for payment errors. When confirming a
 sales order with pickup in-store dm the partner_shipping_id is set to
 the created partner from the selected pickup point address.
 However, the state was missing which resulted in creating a partner
 with an empty state causing the `_get_delivery_methods` called by
 `_get_shop_payment_errors` show an error.
 Solution:
Save a state for pickup location data

opw-4592939
