### PR TITLE
[DRAFT][IMP] account: switch qrcode to link in payment register wizard

### DIFF
--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -126,8 +126,11 @@
                                    invisible="not can_edit_wizard or (can_group_payments and not group_payment)"/>
                         </group>
                         <field name="qr_code" invisible="1"/>
-                        <div invisible="not qr_code" colspan="2" class="text-center">
+                        <div invisible="not qr_code" colspan="2" class="text-center d-none d-lg-block">
                             <field name="qr_code"/>
+                        </div>
+                        <div invisible="not qr_code" colspan="2" class="text-center d-block d-lg-none">
+                            <button string="Pay with your banking app" name="action_open_bank_app" type="object" class="btn btn-secondary"/>
                         </div>
                     </group>
                     <footer>


### PR DESCRIPTION
WIP

This commit remove the QR code in the register payment in mobile. Instead, we add a link as a QR code on a mobile doesn't really make sense.

task-4563391