### PR TITLE
[FIX] account: prevent error when description is removed from section

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -167,7 +167,7 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
     }
 
     get productName() {
-        return this.props.record.data[this.props.name][1];
+        return this.props.record.data[this.props.name]?.[1] ?? "";
     }
 
     get label() {


### PR DESCRIPTION
This error occurs when a user `adds a section` in an `invoice line`, enters a description, and then remove the description.

Step to reproduce :

- Install module `Invoicing`.
- Create a `new Invoice`.
- In the Invoice Line, `add a section`.
- Enter a description and save.
- Remove the description and click anywhere on the screen.

KeyError: `name`

This error occurs when the system tries to update an invoice line section but the `name` field is missing from the update values, causing a KeyError.

This commit fixes the issue by using optional chaining and nullish coalescing to ensure productName returns an empty string instead of undefined.

Sentry - 6327760196

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
