### PR TITLE
[FIX] web: disable refresh count button for invalid domains

### DIFF
--- a/addons/web/static/src/views/fields/domain/domain_field.xml
+++ b/addons/web/static/src/views/fields/domain/domain_field.xml
@@ -70,7 +70,7 @@
                             </t>
                             <t t-if="!!env.debug and !props.readonly">
                                 <button
-                                    class="btn btn-sm btn-icon fa fa-refresh o_refresh_count"
+                                    t-att-class="'btn btn-sm btn-icon fa fa-refresh o_refresh_count' + (state.isValid ? '' : ' disabled')"
                                     role="img"
                                     aria-label="Refresh"
                                     title="Refresh"


### PR DESCRIPTION
Currently, an error occurs when clicking the **Refresh** button for computing record counts with an invalid field of the model.

**Steps to reproduce:**
- Install the `mass_mailing` module.
- Create a new mailing record with **Recipients: Contact**
- Add an invalid domain using the code editor (e.g., `[('test', '=', False)]`).
- Click the **Refresh** button below the editor.
- Observe the error in the back-end logs.

**Error:**
`ValueError: Invalid field res.country.country_id in condition ('country_id.name', '=', 'India')`

The error occurs because the system attempts to fetch the `country_id.name` field of the `res.country` model. During this process, a `KeyError` is encountered, which subsequently results in a `ValueError.`

This commit ensures that the **Refresh** button is disabled when the domain is invalid. This prevents the `search_count` method from being invoked through the UI with invalid input, avoiding the error.

Sentry - 6285599608, 6424158746, 6505582094, 6536603548, 6626159650, 6606355035

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
