### PR TITLE
[FIX] survey: fix traceback on checking question options

### DIFF
--- a/addons/survey/static/tests/components/update_flag_field_tests.js
+++ b/addons/survey/static/tests/components/update_flag_field_tests.js
@@ -81,12 +81,10 @@ QUnit.module("UpdateFlagFields", (hooks) => {
                                 <field name="is_time_customized"/>
                                 <field name="is_time_limited" readonly="0"
                                     widget="boolean_update_flag" 
-                                    options="{'flagFieldName': 'is_time_customized'}" 
-                                    context="{'referenceValue': parent.session_speed_rating}"/>
+                                    options="{'flagFieldName': 'is_time_customized'}"/>
                                 <field name="time_limit" readonly="0"
                                     widget="integer_update_flag"
-                                    options="{'flagFieldName': 'is_time_customized'}" 
-                                    context="{'referenceValue': parent.session_speed_rating_time_limit}"/>
+                                    options="{'flagFieldName': 'is_time_customized'}"/>
                             </group>
                         </form>
                     </field>

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -270,12 +270,10 @@
                                     <div invisible="not session_available">
                                         <field name="is_time_limited" nolabel="1" class="oe_inline"
                                             widget="boolean_update_flag"
-                                            options="{'flagFieldName': 'is_time_customized'}"
-                                            context="{'referenceValue': parent.session_speed_rating}"/>
+                                            options="{'flagFieldName': 'is_time_customized'}"/>
                                         <field name="time_limit" nolabel="1" class="oe_inline"
                                             widget="integer_update_flag"
                                             options="{'flagFieldName': 'is_time_customized'}"
-                                            context="{'referenceValue': parent.session_speed_rating_time_limit}"
                                             invisible="not is_time_limited" />
                                     </div>
                                 </group>


### PR DESCRIPTION
The issue concerns surveys with a live session available ('live_session' and 'custom' types).

When you want to consult the options of a question:
- if you do it from the survey's form view, no problem
- if you do it from the navbar's 'Questions and Answers' menu, you'll get an EvalError indicating that the name 'parent' is not defined.

'parent' here refers to a survey container record and works only inside sub-views of relational fields.

To fix it, we replace calls to 'parent.field' by searchRead calls on the survey model when parent is unavailable.
task-4592388

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
