### PR TITLE
[FIX] website_sale: adapt test flow with version 18 changes

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
-import { goToCart, assertCartContains } from '@website_sale/js/tours/tour_utils';
-import { registerWebsitePreviewTour, clickOnEditAndWaitEditMode, clickOnSnippet, insertSnippet, selectElementInWeSelectWidget, clickOnSave, clickOnElement, assertPathName } from '@website/js/tours/tour_utils';
+import { assertCartContains } from '@website_sale/js/tours/tour_utils';
+import { registerWebsitePreviewTour, clickOnEditAndWaitEditMode, clickOnSnippet, insertSnippet, selectElementInWeSelectWidget, clickOnSave, clickOnElement } from '@website/js/tours/tour_utils';
 
 
 function editAddToCartSnippet() {
@@ -42,16 +42,14 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         ...editAddToCartSnippet(),
         ...selectElementInWeSelectWidget('product_template_picker_opt', 'Product No Variant', true),
         ...selectElementInWeSelectWidget('action_picker_opt', 'Buy Now'),
+        // At this point the "Add to cart" button was changed to a "Buy Now" button
         ...clickOnSave(),
-        clickOnElement('add to cart button', ':iframe .s_add_to_cart_btn'),
+        clickOnElement('"Buy Now" button', ':iframe .s_add_to_cart_btn'),
         {
             // wait for the page to load, as the next check was sometimes too fast
-            content: "Wait for the redirection to the payment page",
+            content: "Wait for the redirection to the cart page",
             trigger: ":iframe h3:contains(order overview)",
         },
-        assertPathName('/shop/payment', ':iframe a[href="/shop/cart"]'),
-
-        goToCart({quantity: 4, backend: true}),
         assertCartContains({productName: 'Product No Variant', backend: true}),
         assertCartContains({productName: 'Product Yes Variant 1 (Red)', backend: true}),
         assertCartContains({productName: 'Product Yes Variant 2 (Pink)', backend: true}),


### PR DESCRIPTION
Before this commit:
This test was ignored by the runbot platform as the test was consistently failing.

Starting version 18, the flow of the "Buy Now" button did change to redirect to the card after being pressed rather than the payment page as intended in the PR:
https://github.com/odoo/odoo/pull/149020

After this commit:
Remove irelevant part of the test to make it successful

rb-56459