### PR TITLE
[FIX] pos_self_order: translate self-order screens

### DIFF
--- a/addons/pos_self_order/controllers/self_entry.py
+++ b/addons/pos_self_order/controllers/self_entry.py
@@ -26,7 +26,7 @@ class PosSelfKiosk(http.Controller):
                 }
             )
 
-    @http.route("/pos-self/data/<config_id>", type='json', auth='public')
+    @http.route("/pos-self/data/<config_id>", type='json', auth='public', website=True)
     def get_self_ordering_data(self, config_id=None, access_token=None, table_identifier=None):
         pos_config, _, _ = self._verify_entry_access(config_id, access_token, table_identifier)
         data = pos_config.load_self_data()

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -133,7 +133,14 @@ registry.category("web_tour.tours").add("self_order_language_changes", {
     steps: () => [
         LandingPage.checkLanguageSelected("English"),
         LandingPage.checkCountryFlagShown("us"),
-        Utils.openLanguageSelector(),
-        Utils.checkLanguageIsAvailable("French"),
+
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Test Product"),
+        ...ProductPage.clickCancel(),
+
+        ...Utils.changeLanguage("French"),
+
+        Utils.clickBtn("Commander maintenant"),
+        ProductPage.clickProduct("Produit Test"),
     ],
 });

--- a/addons/pos_self_order/static/tests/tours/utils/common.js
+++ b/addons/pos_self_order/static/tests/tours/utils/common.js
@@ -55,3 +55,19 @@ export function openLanguageSelector() {
         run: "click",
     };
 }
+
+export function changeLanguage(language) {
+    return [
+        openLanguageSelector(),
+        {
+            content: `Check that the language is available`,
+            trigger: `.self_order_language_popup .btn:contains(${language})`,
+            in_modal: false,
+            run: "click",
+        },
+        {
+            content: `Check that the language changed`,
+            trigger: `.self_order_language_selector:contains(${language})`,
+        },
+    ];
+}

--- a/addons/pos_self_order/tests/test_self_order_kiosk.py
+++ b/addons/pos_self_order/tests/test_self_order_kiosk.py
@@ -61,6 +61,15 @@ class TestSelfOrderKiosk(SelfOrderCommonTest):
 
     def test_self_order_language_changes(self):
         self.env['res.lang']._activate_lang('fr_FR')
+
+        product = self.env['product.product'].create({
+            'name': "Test Product",
+            'list_price': 100,
+            'taxes_id': False,
+            'available_in_pos': True,
+        })
+        product.with_context(lang='fr_FR').name = "Produit Test"
+
         self.pos_config.write({
             'self_ordering_available_language_ids': [Command.link(lang.id) for lang in self.env['res.lang'].search([])],
             'self_ordering_takeaway': False,
@@ -68,6 +77,12 @@ class TestSelfOrderKiosk(SelfOrderCommonTest):
             'self_ordering_pay_after': 'each'
         })
 
+        link = self.env['pos_self_order.custom_link'].search(
+            [('pos_config_ids', '=', self.pos_config.id), ('name', '=', 'Order Now')]
+        )
+        link.with_context(lang='fr_FR').name = "Commander maintenant"
+
+        self.env['pos_self_order.custom_link']
         self.pos_config.with_user(self.pos_user).open_ui()
         self_route = self.pos_config._get_self_order_route()
-        self.start_tour(self_route, "self_order_language_changes")
+        self.start_tour(self_route, 'self_order_language_changes')


### PR DESCRIPTION
Currently, the self-ordering kiosk does not correctly display translations for product names, and other UI elements in the selected language. Some elements remain in English or the database language, even when translations are available.

### Steps to reproduce

1) Open Point of Sale, go to Configuration > Settings.
2) Select a Point of Sale that has Kiosk/Self-ordering enabled. 
3) Add additional languages to the Kiosk, then save the changes. 4) Open a product available in the Kiosk POS and add translations for the product title.
5) Start a new Kiosk session, switch to the Kiosk window, and change the language.
6) Notice that products remain in English.

### Cause

The `/pos-self/data/<config_id>` route is missing the `website=True` attribute. Without this, the route does not resolve language settings from the frontend.

opw-4557569
opw-4471819
opw-4436306