### PR TITLE
[FIX] website: theme preview kanban shouldn't display actions in CP

### DIFF
--- a/addons/website/static/src/components/views/theme_preview.xml
+++ b/addons/website/static/src/components/views/theme_preview.xml
@@ -68,6 +68,7 @@
         <xpath expr="//t[@t-else]/Breadcrumbs" position="replace">
             <t t-call="website.ThemePreviewKanban.ControlPanel.BreadCrumbs"/>
         </xpath>
+        <xpath expr="//div[hasclass('o_control_panel_actions')]" position="replace"/>
         <xpath expr="//div[hasclass('o_control_panel_navigation')]" position="replace">
             <a class="btn btn-secondary align-self-center" t-on-click="this.close" aria-label="Close" data-tooltip="Close">
                 <i class="fa fa-times" role="img" aria-label="close"/>

--- a/addons/website/static/src/components/views/theme_preview_kanban.js
+++ b/addons/website/static/src/components/views/theme_preview_kanban.js
@@ -26,13 +26,6 @@ class ThemePreviewControlPanel extends ControlPanel {
     close() {
         this.website.goToWebsite();
     }
-
-    get display() {
-        return {
-            layoutActions: false,
-            ...this.props.display,
-        };
-    }
 }
 class ThemePreviewKanbanrecord extends KanbanRecord {
 
@@ -54,9 +47,6 @@ const ThemePreviewKanbanView = {
     Controller: ThemePreviewKanbanController,
     ControlPanel: ThemePreviewControlPanel,
     Renderer: ThemePreviewKanbanRenderer,
-    display: {
-        controlPanel: {},
-    },
 };
 
 


### PR DESCRIPTION
Since the commit [1] introducing the record selection in Kanban, the
Website's theme picker displays the SearchBar in the ControlPanel.

This commit fixes it by completely removing the ControlPanel's actions
container as it isn't used, similar to what's used for the navigation
container.

Note: it also prevents the SelectionBox & Actions menu from appearing.

[1]: https://github.com/odoo/odoo/commit/877895cc10b1218396f77f995dc7c87a9d22f585