### PR TITLE
[IMP] mail: discuss style improvements

### DIFF
--- a/addons/mail/static/src/chatter/web_portal/chatter.scss
+++ b/addons/mail/static/src/chatter/web_portal/chatter.scss
@@ -18,8 +18,16 @@
 .o-mail-Chatter-top, .o-mail-Chatter-content {
     --Chatter-default-padding-x: #{$o-spacer};
 
-    padding-left: var(--ChatterAsideForm-padding-left, var(--Chatter-default-padding-x));
     padding-right: var(--Chatter-default-padding-x);
+}
+
+.o-mail-Chatter-top {
+    padding-left: var(--ChatterAsideForm-padding-left, var(--Chatter-default-padding-x));
+}
+
+.o-mail-Chatter-content {
+    --mail-Chatter-contentPaddingLeft: var(--ChatterAsideForm-padding-left, var(--Chatter-default-padding-x));
+    padding-left: calc(var(--mail-Chatter-contentPaddingLeft) - #{($o-mail-Message-sidebarWidth - $o-mail-Avatar-size) / 2});
 }
 
 .o-mail-Followers-button:focus {

--- a/addons/mail/static/src/core/common/chat_window.dark.scss
+++ b/addons/mail/static/src/core/common/chat_window.dark.scss
@@ -1,3 +1,7 @@
+.o-mail-ChatWindow {
+    --mail-ChatWindow-borderDesktopOpacity: .1;
+}
+
 .o-mail-ChatWindow-command {
     --mail-ChatWindow-commandHoverColor: white;
 }

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -3,7 +3,7 @@
 
     z-index: $zindex-sticky;
     &:not(.o-mobile) {
-        --border-opacity: .15;
+        --border-opacity: var(--mail-ChatWindow-borderDesktopOpacity, .15);
         aspect-ratio: 9 / 15;
     }
     outline: none;

--- a/addons/mail/static/src/core/common/composer.dark.scss
+++ b/addons/mail/static/src/core/common/composer.dark.scss
@@ -1,5 +1,10 @@
 .o-mail-Composer {
     --mail-Composer-bg: #{mix($gray-100, $o-view-background-color)};
+    --mail-Composer-inputContainerFocusedOpacity: .25
+}
+
+.o-mail-Composer-bg {
+    --border-opacity: 0;
 }
 
 .o-mail-Composer-actions {

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -11,8 +11,7 @@
     }
 
     .o-mail-Composer-sidebarMain {
-        padding-top: 0.1875rem; // avatar centered with composer text input: 36px (avatar) + 2*3px (this value) = 20px + 2 * { 10px (padding) + 1px (border) }
-        width: 48px;
+        width: $o-mail-Message-sidebarWidth;
     }
 
     .o-mail-Composer-coreHeader {
@@ -206,7 +205,7 @@
     }
 
     &:has(textarea:focus) {
-        --border-opacity: 0.35;
+        --border-opacity: var(--mail-Composer-inputContainerFocusedOpacity, 0.35);
         border-color: rgba($o-action, var(--border-opacity)) !important;
     }
 }

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -14,7 +14,7 @@
                     'pb-2': extended and !props.composer.message,
                     'o-extended': extended,
                     'o-isUiSmall': ui.isSmall,
-                    'px-3 pb-2': normal,
+                    'ps-3 pe-4 pb-2': normal,
                     'o-hasSelfAvatar': showComposerAvatar,
                     'o-focused': props.composer.isFocused,
                     'o-editing': props.composer.message,
@@ -29,7 +29,7 @@
                 </t>
             </FileUploader>
             <div t-if="showComposerAvatar" class="o-mail-Composer-sidebarMain flex-shrink-0">
-                <img class="o-mail-Composer-avatar o_avatar rounded" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>
+                <img class="o-mail-Composer-avatar mx-auto o_avatar rounded" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>
             </div>
             <div class="o-mail-Composer-coreHeader text-truncate small p-2" t-if="props.composer.thread and props.messageToReplyTo?.thread?.eq(props.composer.thread)">
                 <span class="cursor-pointer" t-on-click="() => env.messageHighlight?.highlightMessage(props.messageToReplyTo.message, props.composer.thread)">

--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -17,26 +17,26 @@
 .o-mail-Message-bubble {
     &.o-blue {
         background-color: mix($gray-100, $info, 87.5%) !important;
-        border-color: lighten(mix($gray-100, $info, 87.5%), 5%) !important;
-
+        border-color: lighten(mix($gray-100, $info, 87.5%), 2.5%) !important;
+    
         &.o-muted {
-            background-color: mix($gray-100, mix($gray-100, $info, 87.5%)) !important;
+            background-color: darken(mix($gray-100, $info, 87.5%), 5%) !important;
         }
     }
     &.o-green {
         background-color: mix($gray-100, $success, 87.5%) !important;
-        border-color: lighten(mix($gray-100, $success, 87.5%), 5%) !important;
-
+        border-color: lighten(mix($gray-100, $success, 87.5%), 2.5%) !important;
+    
         &.o-muted {
-            background-color: mix($gray-100, mix($gray-100, $success, 87.5%)) !important;
+            background-color: darken(mix($gray-100, $success, 87.5%), 5%) !important;
         }
     }
     &.o-orange {
         background-color: mix($gray-100, $warning, 72.5%) !important;
-        border-color: lighten(mix($gray-100, $warning, 72.5%), 5%) !important;
-
+        border-color: lighten(mix($gray-100, $warning, 72.5%), 2.5%) !important;
+    
         &.o-muted {
-            background-color: mix($gray-100, mix($gray-100, $warning, 72.5%), 85%) !important;
+            background-color: darken(mix($gray-100, $warning, 72.5%), 10%) !important;
         }
     }
 }

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -215,7 +215,7 @@ export class Message extends Component {
                 this.props.thread &&
                 !this.env.messageCard &&
                 !this.props.asCard,
-            "px-2": this.props.isInChatWindow,
+            "px-1": this.props.isInChatWindow,
             "opacity-50": this.props.messageToReplyTo?.isNotSelected(
                 this.props.thread,
                 this.props.message

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -149,9 +149,13 @@
     z-index: $o-mail-NavigableList-zIndex;
 }
 
-.o-mail-Message-openActionMobile:active {
-    opacity: 75% !important;
-}
+.o-mail-Message-openActionMobile {
+    opacity: 15% !important;
+
+    &:active {
+        opacity: 75% !important;
+    }
+} 
 
 .o-mail-Message-pendingProgress {
     animation: o-mail-message-pendingProgress-animation 0s ease-in 0.5s forwards;

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -18,7 +18,7 @@
                 t-if="message.exists()"
             >
                 <div class="o-mail-Message-core position-relative d-flex flex-shrink-0">
-                    <div class="o-mail-Message-sidebar d-flex flex-shrink-0" t-att-class="{ 'justify-content-end': isAlignedRight, 'align-items-start justify-content-start': !isAlignedRight, 'o-inChatWindow': env.inChatWindow }">
+                    <div class="o-mail-Message-sidebar d-flex flex-shrink-0 justify-content-center" t-att-class="{ 'align-items-start': !isAlignedRight, 'o-inChatWindow': env.inChatWindow }">
                         <div t-if="!props.squashed" class="o-mail-Message-avatarContainer position-relative bg-view" t-att-class="getAvatarContainerAttClass()">
                             <img class="o-mail-Message-avatar w-100 h-100 rounded" t-att-src="authorAvatarUrl" t-att-class="authorAvatarAttClass"/>
                         </div>
@@ -179,7 +179,7 @@
 
 <t t-name="mail.Message.expandAction">
     <button class="btn border-0 rounded-0 o-mail-Message-expandBtn" t-att-title="expandText" t-on-click="openMobileActions" t-att-class="{
-        'o-mail-Message-openActionMobile opacity-25 p-2 mt-n2 rounded-circle user-select-none': isMobileOS and !mobileExpanded,
+        'o-mail-Message-openActionMobile p-2 mt-n2 rounded-circle user-select-none': isMobileOS and !mobileExpanded,
         'me-n2': isMobileOS and !mobileExpanded and isAlignedRight,
         'ms-n2': isMobileOS and !mobileExpanded and !isAlignedRight,
         'px-2 py-0': !isMobileOS,

--- a/addons/mail/static/src/core/common/primary_variables.scss
+++ b/addons/mail/static/src/core/common/primary_variables.scss
@@ -1,5 +1,5 @@
-$o-mail-Avatar-size: 36px !default;
-$o-mail-Avatar-sizeSmall: 28px !default;
+$o-mail-Avatar-size: 38px !default;
+$o-mail-Avatar-sizeSmall: 24px !default;
 $o-mail-ChatWindow-width: 380px !default; // same value as WINDOW
 $o-mail-ChatHub-bubblesWidth: 56px !default; // same value as BUBBLE
 $o-mail-ChatHub-bubblesMargin: 10px !default; // same value as BUBBLE_OUTER
@@ -15,8 +15,8 @@ $o-mail-LinkPreview-width: 320px !default;
 $o-mail-LinkPreview-height: 240px !default;
 $o-mail-LinkPreviewCard-height: 80px !default;
 
-$o-mail-Message-sidebarSmallWidth: 34px !default;
-$o-mail-Message-sidebarWidth: 42px !default;
+$o-mail-Message-sidebarSmallWidth: 38px !default;
+$o-mail-Message-sidebarWidth: 60px !default;
 $o-mail-NavigableList-zIndex: 21;
 $o-mail-Chatter-minWidth: 530px !default;
 $o-mail-Discuss-inspector: 300px !default; // same value as INSPECTOR_WIDTH

--- a/addons/mail/static/src/core/public_web/discuss.dark.scss
+++ b/addons/mail/static/src/core/public_web/discuss.dark.scss
@@ -3,6 +3,7 @@
 }
 
 .o-mail-Discuss-header {
+    --border-opacity: 0;
     background-color: mix($o-gray-100, $o-gray-200, 15%);
 }
 
@@ -20,6 +21,6 @@
     }
 }
 
-.o-mail-Discuss-headerActionsGroup {
-    --border-opacity: .1;
+.o-mail-Discuss-panelContainer {
+    --border-opacity: 0;
 }

--- a/addons/mail/static/src/core/public_web/discuss.scss
+++ b/addons/mail/static/src/core/public_web/discuss.scss
@@ -62,8 +62,8 @@
 
 .o-mail-Discuss-threadAvatar {
     img {
-        height: 32px;
-        width: 32px;
+        height: $o-mail-Avatar-size;
+        width: $o-mail-Avatar-size;
     }
 
     a {

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -8,7 +8,7 @@
         <div t-if="!(ui.isSmall and store.discuss.activeTab !== 'main')" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 overflow-auto" t-ref="content">
             <div class="o-mail-Discuss-header px-3 d-flex flex-shrink-0 align-items-center border-bottom border-secondary z-1 flex-grow-0" t-ref="header">
                 <t t-if="thread">
-                    <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mt-2 mb-2 me-2">
+                    <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mx-2 my-1">
                         <img class="rounded o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
                         <FileUploader t-if="!thread.parent_channel_id and thread.is_editable and thread.channel_type !== 'chat'" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
                             <t t-set-slot="toggler">
@@ -19,7 +19,7 @@
                         </FileUploader>
                     </div>
                     <t t-else="">
-                        <ThreadIcon className="'me-2 align-self-center'" size="'large'" thread="thread"/>
+                        <ThreadIcon className="'mx-2 align-self-center fs-2 my-2 opacity-75'" size="'large'" thread="thread"/>
                     </t>
                     <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-Discuss-headerCountry border'"/>
                     <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" className="'me-1'" member="thread.correspondent" />

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.dark.scss
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.dark.scss
@@ -1,0 +1,3 @@
+.o-mail-DiscussSidebar {
+    --border-opacity: 0;
+}

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.xml
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebar">
         <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto flex-shrink-0 h-100 border-end border-secondary z-1 o-mail-discussSidebarBgColor gap-1" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
-            <div class="o-mail-DiscussSidebar-top position-sticky justify-content-center top-0 z-2 o-mail-discussSidebarBgColor" t-att-class="{ 'pt-2 pb-1': !store.inPublicPage, 'pt-1': store.inPublicPage }">
+            <div class="o-mail-DiscussSidebar-top position-sticky justify-content-center top-0 z-2 o-mail-discussSidebarBgColor" t-att-class="{ 'pt-2 mt-1 pb-1': !store.inPublicPage, 'pt-1': store.inPublicPage }">
                 <div class="d-flex align-items-center justify-content-center" t-att-class="{ 'flex-column gap-2': store.discuss.isSidebarCompact }">
                     <t name="options-btn">
                         <Dropdown position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary px-0 py-1 mx-2 my-0 min-w-0 shadow-sm'">

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.DiscussSidebarMailboxes">
-        <div class="d-flex flex-column flex-grow-0 o-gap-0_5 mt-2">
+        <div class="d-flex flex-column flex-grow-0 o-gap-0_5 mt-1">
             <Mailbox mailbox="store.inbox"/>
             <Mailbox mailbox="store.starred"/>
             <Mailbox mailbox="store.history"/>
@@ -35,7 +35,7 @@
             t-on-click="(ev) => this.openThread(ev)"
             t-ref="root"
         >
-            <ThreadIcon className="'bg-inherit ' + (store.discuss.isSidebarCompact ? '' : 'mx-2')" thread="mailbox"/>
+            <ThreadIcon className="'bg-inherit ' + (store.discuss.isSidebarCompact ? '' : 'mx-2 opacity-75')" thread="mailbox" size="store.discuss.isSidebarCompact ? 'large' : undefined"/>
             <t t-if="!store.discuss.isSidebarCompact">
                 <div class="me-2 text-truncate small" style="line-height: 1.65;" t-esc="mailbox.display_name"/>
                 <div t-attf-class="flex-grow-1 {{ mailbox.counter === 0 ? 'me-3': '' }}"/>

--- a/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
@@ -15,6 +15,6 @@
     </t>
 
     <t t-name="mail.DiscussSidebar.startMeetingButton">
-        <button class="btn btn-primary rounded d-flex align-items-center gap-1 mx-5" t-att-class="{ 'py-2': store.discuss.isSidebarCompact, 'btn-sm': !store.discuss.isSidebarCompact }" t-on-click="store.startMeeting" data-hotkey="m" t-ref="meeting-btn"><i class="fa fa-fw fa-users opacity-75"/><span t-if="!store.discuss.isSidebarCompact" t-esc="startMeetingText"/></button>
+        <button class="btn btn-primary rounded d-flex align-items-center gap-1 mx-5" t-att-class="{ 'py-2': store.discuss.isSidebarCompact, 'btn-sm': !store.discuss.isSidebarCompact }" t-on-click="store.startMeeting" data-hotkey="m" t-ref="meeting-btn"><i class="fa fa-fw fa-users opacity-75" t-att-class="{ 'fa-lg': store.discuss.isSidebarCompact }"/><span t-if="!store.discuss.isSidebarCompact" t-esc="startMeetingText"/></button>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
@@ -1,4 +1,4 @@
 .o-mail-DiscussSidebar-item {
     --mail-DiscussSidebar-itemActiveBgColor: #{mix($gray-200, $gray-300)};
-    --mail-DiscussSidebar-itemActiveOutlineColor: #{rgba($gray-400, .5)};
+    --mail-DiscussSidebar-itemActiveOutlineColor: #{rgba($gray-400, .25)};
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
@@ -12,6 +12,7 @@
 }
 
 .o-mail-DiscussSidebarCategories-search {
+    --border-opacity: .5;
     --mail-DiscussSidebarCategories-searchContainerBg: #{$white};
     --mail-DiscussSidebarCategories-searchContainerBgHover: #{$gray-100};
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -2,14 +2,14 @@
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCategories">
         <Dropdown t-if="store.discuss.isSidebarCompact" state="searchFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary mx-2 my-0 min-w-0 p-0 shadow-sm'" manual="true">
-            <button class="o-mail-DiscussSidebarCategories-searchBtn btn btn-light d-flex align-items-center justify-content-center px-1 mx-2 border opacity-75" t-on-click="onClickFindOrStartConversation" t-ref="search-btn"><i class="fa fa-search"/></button>
+            <button class="o-mail-DiscussSidebarCategories-searchBtn btn btn-light d-flex align-items-center justify-content-center border-0 px-1 mx-2 opacity-75" t-on-click="onClickFindOrStartConversation" t-ref="search-btn"><i class="fa fa-lg fa-fw fa-search"/></button>
             <t t-set-slot="content">
                 <div class="p-2" t-ref="search-floating">
                     <span class="text-muted user-select-none">Find or start a conversation</span>
                 </div>
             </t>
         </Dropdown>
-        <div t-else="" class="o-mail-DiscussSidebarCategories-search rounded mx-3 my-2 border position-relative d-flex align-items-center justify-content-center gap-1" t-on-click="onClickFindOrStartConversation">
+        <div t-else="" class="o-mail-DiscussSidebarCategories-search rounded mx-3 my-2 border border-secondary position-relative d-flex align-items-center justify-content-center gap-1" t-on-click="onClickFindOrStartConversation">
             <input class="form-control rounded-3 border-0 bg-inherit" t-att-class="{ 'lh-1': !ui.isSmall }" disabled="true" placeholder="Find or start a conversation" tabindex="0"/>
             <div class="o-mail-DiscussSidebarCategories-searchClickable position-absolute z-1 opacity-0 cursor-pointer w-100 h-100"/>
         </div>
@@ -155,7 +155,7 @@
             t-ref="root"
         >
             <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0" t-att-class="{ 'overflow-hidden': !store.discuss.isSidebarCompact }" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName">
-                <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:26px;height:26px" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
+                <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:32px;height:32px" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
                     <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 p-1 me-n1 mb-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                     <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'position-absolute o-mail-DiscussSidebarChannel-country border'"/>

--- a/addons/mail/static/src/scss/variables/primary_variables.scss
+++ b/addons/mail/static/src/scss/variables/primary_variables.scss
@@ -1,12 +1,12 @@
 $o-mail-Avatar-size: 42px !default;
 $o-mail-ChatWindow-width: 380px !default; // same value as WINDOW
 $o-mail-Discuss-inspector: 300px !default;
-$o-mail-Avatar-sizeSmall: 28px !default;
+$o-mail-Avatar-sizeSmall: 24px !default;
 // Needed because $border-radius variations are all set to 0 in enterprise.
 $o-RoundedRectangle-small: .2rem !default;
 $o-RoundedRectangle-large: 3 * $o-RoundedRectangle-small !default;
 
-$o-mail-Message-sidebarWidth: 42px !default;
+$o-mail-Message-sidebarWidth: 60px !default;
 
 $o-mail-LinkPreview-width: 320px !default;
 $o-mail-LinkPreview-height: 240px !default;


### PR DESCRIPTION
This PR makes a few improvements to message list spacing, avatar sizes, dark theme border opacity

1. more spacing between avatar and message horizontally in non-chat windows

Reasons:
- spacing with discuss sidebar was too narrow,
- spacing between avatar and message bubble was too small
- increased sidebar width gives more room for AM/PM timestamp

2. bigger avatars in discuss sidebar, message and composer

Reason:
- avatar in sidebar were too small so barely visible,
- avatar size of message author and discuss header are consistent
- composer avatar looks more centered with input

3. message "..." expand action in mobile is less visible

Reason: was too distracting in message list of mobile.

4. message bubble border is softer in dark theme

Reason: white theme needs clear border to pops items without heavy coloring, when items are dark the bg color does already most of the job, so very slight border is enough.

5. no border in discuss sidebar / header / panel in dark theme

Reason: same idea as with message bubble but the UI elements are big and static enough to not need border.

6. reduced border in dark theme for composer input and chat window

Reason: same idea, including reduced effect when input has focus, as the dark theme doesn't need much color or opacity difference to be clearly visible compared to white theme. Chat window reduced border is to make chat window feel less "in-a-box" but still present to not fuse with content under the chat window.

Before
<img width="2557" alt="Screenshot 2025-02-27 at 15 56 04" src="https://github.com/user-attachments/assets/7a1c7cda-0962-4609-aaec-838af70f3d5d" />


After
<img width="2559" alt="Screenshot 2025-02-27 at 15 54 46" src="https://github.com/user-attachments/assets/76aff7e7-8f5b-4ebf-9c64-e1e8db778c52" />

