### PR TITLE
[FIX] survey: Internal user with access to surevey can print it

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -629,7 +629,7 @@ class Survey(http.Controller):
         grab the answers of the user_input_id that has <answer_token>.'''
         access_data = self._get_access_data(survey_token, answer_token, ensure_token=False, check_partner=False)
         if access_data['validity_code'] is not True and (
-                access_data['has_survey_access'] or
+                not access_data['has_survey_access'] or
                 access_data['validity_code'] not in ['token_required', 'survey_closed', 'survey_void', 'answer_deadline']):
             return self._redirect_with_error(access_data, access_data['validity_code'])
 


### PR DESCRIPTION
Steps to reproduce:

- Let's consider an internal user U with acces rights to Survey
- Let's consider a survey S with access mode set to 'Invited People only'
- Try to print survey S with U

Bug:

U is redirected to a blank page
When a survey is set to 'Invited People only', internal users could not print the survey.

opw:4576125