### PR TITLE
[FIX] web: no captcha when using passkeys

### DIFF
--- a/addons/web/models/res_users.py
+++ b/addons/web/models/res_users.py
@@ -25,3 +25,6 @@ class ResUsers(models.Model):
 
     def _on_webclient_bootstrap(self):
         self.ensure_one()
+
+    def _should_captcha_login(self, credential):
+        return credential['type'] == 'password'


### PR DESCRIPTION
Before this commit a captcha would always be required upon submitting to /web/login. This makes sense to prevent brute force attacks against passwords. However this does not make sense in the context of webauthn.

Therefore we make sure captcha is only verified when using the password credential type.