### PR TITLE
[FIX] hw_drivers: remove `_(...)` usage which crash on IoT

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py
@@ -107,7 +107,7 @@ class SerialDriver(Driver):
                 self._actions[data['action']](data)
                 time.sleep(self._protocol.commandDelay)
             except Exception:
-                msg = _(f'An error occurred while performing action "{data}" on "{self.device_name}"')
+                msg = f'An error occurred while performing action "{data}" on "{self.device_name}"'
                 _logger.exception(msg)
                 self._status = {'status': self.STATUS_ERROR, 'message_title': msg, 'message_body': traceback.format_exc()}
                 self._push_status()


### PR DESCRIPTION
This line would consistently crash with:
`NameError: name '_' is not defined`