### PR TITLE
[FIX] stock: Hide Lot/SN column on Detailed Operations

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -250,6 +250,10 @@ class StockQuant(models.Model):
     def copy(self, default=None):
         raise UserError(_('You cannot duplicate stock quants.'))
 
+    @api.model
+    def name_create(self, name):
+        return False
+
     @api.model_create_multi
     def create(self, vals_list):
         """ Override to handle the "inventory mode" and create a quant as

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -266,9 +266,9 @@
                         context="{'default_location_id': location_id, 'default_product_id': product_id, 'search_view_ref': 'stock.quant_search_view', 'tree_view_ref': 'stock.view_stock_quant_tree_simple', 'form_view_ref': 'stock.view_stock_quant_form', 'readonly_form': False}"
                         readonly="state in ('done', 'cancel') and is_locked"
                         widget="pick_from"
-                        options="{'no_open': True, 'no_create': True}"/>
-                    <field name="lot_id" column_invisible="context.get('show_lots_text')" groups="stock.group_production_lot" invisible="not lots_visible" readonly="state in ('done', 'cancel') and is_locked" context="{'default_product_id': product_id, 'default_company_id': company_id, 'active_picking_id': picking_id}" optional="show"/>
-                    <field name="lot_name" column_invisible="not context.get('show_lots_text')"  groups="stock.group_production_lot" invisible="not lots_visible" readonly="state in ('done', 'cancel') and is_locked" context="{'default_product_id': product_id}"/>
+                        options="{'no_open': True}"/>
+                    <field name="lot_id" column_invisible="context.get('picking_code') != 'incoming' or context.get('show_lots_text')" groups="stock.group_production_lot" invisible="not lots_visible" readonly="state in ('done', 'cancel') and is_locked" context="{'default_product_id': product_id, 'default_company_id': company_id, 'active_picking_id': picking_id}" optional="show"/>
+                    <field name="lot_name" column_invisible="context.get('picking_code') != 'incoming' or not context.get('show_lots_text')"  groups="stock.group_production_lot" invisible="not lots_visible" readonly="state in ('done', 'cancel') and is_locked" context="{'default_product_id': product_id}"/>
                     <field name="location_dest_id" options="{'no_create': True}" column_invisible="context.get('picking_code') == 'outgoing'" readonly="state in ('done', 'cancel') and is_locked" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', picking_location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"/>
                     <field name="package_id" readonly="state in ('done', 'cancel') and is_locked" column_invisible="True"/>
                     <field name="result_package_id" column_invisible="True"/>


### PR DESCRIPTION
The "Lot / SN" column is redundant with the "Pick From" column. When Pick From is displayed, we can hide the "Lot/SN".

However, if the user does not have the lot/serial number in a quant, they still need a way to select it, so we allow for a quant creation.

In order to not re-introduce the bug fixed by this commit: 60d95aa8304c11698e49336391d98926861e640d , we overwrite the name_create to return False, aka no action is done.

---

## Step To Reproduce:
- Create product P tracked by SN
- Create 1 SN for P (not on hand)
- Create Delivery transfer for 1 unit of P > Confirm
- !! You must not have any Stock on Hand for P
- Manually set the Operation Quantity to 1
- Go to "Detailed Operations" menu
- Set the SN in the "Lot/Serial Number" Column
- Validate the transfer
=> On Hand quantity is '-1' on a quant without SN

---

## BEFORE
https://github.com/user-attachments/assets/7e6c5a6a-ed86-4564-bcb5-51c94a5a4ae4

- Selecting a SN is very fast
- We can easily use an unavailable SN
- The unavailable SN is taken from a quant without lot
- Lot is displayed twice (pick from & lot/sn)


## AFTER
https://github.com/user-attachments/assets/f5bd7cc6-d77e-410c-a1aa-8ad6ba6d0020

- Selecting a SN is a bit harder
- Selecting an unavailable SN is even more complicated
- The unavailable SN is taken from a quant with its lot


OPW-4485159

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
