### PR TITLE
[FIX] website_sale_collect: hide widget if combination does not exist

### DIFF
--- a/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.js
+++ b/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.js
@@ -11,9 +11,13 @@ export class ClickAndCollectAvailability extends Component {
     static template = 'website_sale_collect.ClickAndCollectAvailability';
     static props = {
         productId: Number,
+        active: {type: Boolean, optional: true},
         zipCode: { type: String, optional: true },
         selectedWhLocation: { type: Object, optional: true },
         inStoreStock: { type: Object, optional: true },
+    }
+    static defaultProps = {
+        active: true,
     }
     setup() {
         super.setup();
@@ -22,6 +26,7 @@ export class ClickAndCollectAvailability extends Component {
             productId: this.props.productId,
             selectedWhLocation: this.props.selectedWhLocation,
             inStoreStock: this.props.inStoreStock,
+            active: this.props.active,
         });
         const updateState = this._updateStateWithCombinationInfo.bind(this);
         this.env.bus.addEventListener('updateCombinationInfo', res => updateState(res.detail));
@@ -38,6 +43,7 @@ export class ClickAndCollectAvailability extends Component {
     _updateStateWithCombinationInfo (combinationInfo) {
         this.state.productId = combinationInfo.product_id;
         this.state.inStoreStock = combinationInfo.in_store_stock;
+        this.state.active = combinationInfo.is_combination_possible;
     }
 
     /**

--- a/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
+++ b/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
@@ -5,6 +5,7 @@
         <div
             t-on-click="openLocationSelector"
             class="o_click_and_collect_availability btn d-flex align-items-center gap-3 border border-1 mb-3 text-start"
+            t-att-class="{'disabled': !this.state.active}"
         >
             <div>
                 <strong>
@@ -18,7 +19,7 @@
                 <div t-if="!this.state.selectedWhLocation.id" class="text-muted">
                     Check availability
                 </div>
-                <t t-elif="!!this.state.inStoreStock.in_stock">
+                <t t-elif="!!this.state.inStoreStock?.in_stock">
                     <div t-if="!!this.state.inStoreStock.show_quantity" class="text-warning">
                         <i class="fa fa-circle"/>
                         Only <t t-out="this.state.inStoreStock.quantity"/> available


### PR DESCRIPTION
Steps to reproduce:
 1) Configure pick up in store dm and publish it
 2) Go to product page of a customizable desk
 3) Choose the impossible combination (Aluminium and black)
 4) Observe traceback

Reason:
Necessary fields are absent in combination info when the combination is not possible.

Solution:
Do not render the widget when a combination is not possible.
