### PR TITLE
[FIX] base: only set model if not set when creating field

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -983,9 +983,8 @@ class IrModelFields(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         IrModel = self.env['ir.model']
-        models = set()
         for vals in vals_list:
-            if 'model_id' in vals:
+            if 'model_id' in vals and 'model' not in vals:
                 vals['model'] = IrModel.browse(vals['model_id']).model
 
         # for self._get_ids() in _update_selection()


### PR DESCRIPTION
Why setting `model` again in vals when already is set? Let's avoid this.

When this matters? When there is a row in `ir_model` table which is not loaded yet into the enviroment registry list of models. Suppose you want to create a field for that model, and when you do it, filling both model and model_id, and without this fix, the code sets `model = False`, which is not desired.

Enterprise https://github.com/odoo/enterprise/pull/109725.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr