### PR TITLE
[FIX] base: disable mail server when initializing

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -381,8 +381,8 @@ class IrMail_Server(models.Model):
     @classmethod
     def _disable_send(cls):
         """Whether to disable sending e-mails"""
-        # no e-mails during testing or when registry is not ready
-        return modules.module.current_test or not cls.pool._init
+        # no e-mails during testing or when registry is initializing
+        return modules.module.current_test or cls.pool._init
 
     def connect(self, host=None, port=None, user=None, password=None, encryption=None,
                 smtp_from=None, ssl_certificate=None, ssl_private_key=None, smtp_debug=False, mail_server_id=None,


### PR DESCRIPTION
The condition should be to disable during the initialization.

Solves: https://github.com/odoo/odoo/pull/186884#discussion_r1973728440


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
