### PR TITLE
[FIX] website_sale: prevent error if custom_value key is missing

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_product_configurator.js
+++ b/addons/website_sale/static/src/js/website_sale_product_configurator.js
@@ -114,7 +114,7 @@ WebsiteSale.include({
             if (selectedCustomPtav) {
                 serializedProduct.product_custom_attribute_values.push({
                     custom_product_template_attribute_value_id: selectedCustomPtav.id,
-                    custom_value: ptal.customValue,
+                    custom_value: ptal.customValue || '',
                 });
             }
         }


### PR DESCRIPTION
Currently, an exception is raised when a user tries to add a custom product as an optional product for another product and attempts to add it to the cart without providing a custom value.

Steps to Reproduce:

1. Install the website_sale module.
2. Go to Website -> eCommerce -> Products.
3. Create a product and add a custom product as an optional product.
4. Navigate to Site -> HomePage -> Shop.
5. Select the newly created product and click Add to Cart, including the optional product that has a custom attribute, but leave the value empty.
6. Click Continue Shopping.
7. An error occurs.

Error:
`KeyError
'custom_value'
`

This issue [1] occurs because when the user selects a custom attribute without providing a custom value, the `product_custom_attribute_values` dictionary does not contain the custom_value key.

[1] - https://github.com/odoo/odoo/blob/6a2284ef1e04e9576e44a4be2376f5449bf29dc7/addons/website_sale/models/sale_order.py#L458

This fix resolves the issue by ensuring that if the custom_value key is missing, an empty string is assigned.

sentry-5763345162

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
