### PR TITLE
[IMP] web: improve form oh snap dialog test coverage

### DIFF
--- a/addons/web/static/src/views/form/form_error_dialog/form_error_dialog.xml
+++ b/addons/web/static/src/views/form/form_error_dialog/form_error_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.FormErrorDialog">
-        <Dialog header="false" size="'md'" contentClass="'o_error_dialog'">
+        <Dialog header="false" size="'md'" contentClass="'o_error_dialog o_form_error_dialog'">
             <div role="alert">
                 <h1 class="text-danger">Oh snap!</h1>
                 <p t-esc="props.message" class="text-prewrap"/>

--- a/addons/web/static/tests/views/form/auto_save.test.js
+++ b/addons/web/static/tests/views/form/auto_save.test.js
@@ -236,7 +236,7 @@ test(`error on save when breadcrumb clicked`, async () => {
     await contains(`.breadcrumb-item.o_back_button`).click();
     expect.verifySteps(["web_save"]);
     await animationFrame();
-    expect(`.o_error_dialog`).toHaveCount(1);
+    expect(`.o_form_error_dialog`).toHaveCount(1);
 });
 
 test.tags("desktop");
@@ -814,7 +814,7 @@ test("error on save when action button clicked", async () => {
     await contains(`.o-dropdown--menu .dropdown-item`).click();
     expect.verifySteps(["save"]);
     await animationFrame();
-    expect(`.o_error_dialog`).toHaveCount(1);
+    expect(`.o_form_error_dialog`).toHaveCount(1);
 });
 
 test.tags("desktop");
@@ -852,7 +852,7 @@ test("error on save when create button clicked", async () => {
     await contains(`.o_form_button_create`).click();
     expect.verifySteps(["save"]);
     await animationFrame();
-    expect(`.o_error_dialog`).toHaveCount(1);
+    expect(`.o_form_error_dialog`).toHaveCount(1);
 });
 
 test("doesn't autosave when in dialog (visibility change)", async () => {

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -10424,6 +10424,33 @@ test(`company_dependent field in form view, not in multi company group`, async (
     expect(`.o-tooltip .o-tooltip--help`).toHaveText("this is a tooltip");
 });
 
+test(`no 'oh snap' error when clicking on a save button`, async () => {
+    expect.errors(1);
+
+    onRpc("web_save", () => {
+        throw makeServerError({ message: "Some business message" });
+    });
+    onRpc(({ method }) => expect.step(method));
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `
+            <form>
+                <button name="do_it" type="object" string="Do it"/>
+                <field name="name"/>
+            </form>
+        `,
+    });
+    expect.verifySteps(["get_views", "onchange"]);
+
+    await contains(`.o_form_button_save`).click();
+    await animationFrame();
+    expect.verifyErrors(["Some business message"]);
+    expect.verifySteps(["web_save"]);
+    expect(`.o_error_dialog`).toHaveCount(1);
+    expect(`.o_form_error_dialog`).toHaveCount(0);
+});
+
 test(`no 'oh snap' error when clicking on a view button`, async () => {
     expect.errors(1);
 
@@ -10447,7 +10474,7 @@ test(`no 'oh snap' error when clicking on a view button`, async () => {
     await animationFrame();
     expect.verifyErrors(["Some business message"]);
     expect.verifySteps(["web_save"]);
-    expect(`.modal`).toHaveCount(1);
+    expect(`.o_error_dialog`).toHaveCount(1);
     expect(`.o_form_error_dialog`).toHaveCount(0);
 });
 
@@ -10485,6 +10512,7 @@ test(`no 'oh snap' error in form view in dialog`, async () => {
     await animationFrame();
     expect(`.modal`).toHaveCount(2);
     expect(`.o_error_dialog`).toHaveCount(1);
+    expect(`.o_form_error_dialog`).toHaveCount(0);
 });
 
 test(`field "length" with value 0: can apply onchange`, async () => {


### PR DESCRIPTION
This commit improves the tests of the oh snap dialog feature in form view. Some existing tests relied on the presence of classname `o_form_error_dialog` to be relevant. However, that classname did not exist (anymore?). We thus re-introduce it. Moreover, there was no test asserting that clicking on the save button doesn't trigger that dialog. We introduce one.

Spotted when reviewing odoo/odoo#199287

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
