### PR TITLE
[FIX] html_editor: no background color on tab

### DIFF
--- a/addons/html_editor/static/src/main/tabulation_plugin.js
+++ b/addons/html_editor/static/src/main/tabulation_plugin.js
@@ -1,8 +1,13 @@
 import { Plugin } from "@html_editor/plugin";
-import { closestBlock } from "@html_editor/utils/blocks";
+import { closestBlock, isBlock } from "@html_editor/utils/blocks";
 import { splitTextNode } from "@html_editor/utils/dom";
 import { isEditorTab, isTextNode, isZWS } from "@html_editor/utils/dom_info";
-import { descendants, getAdjacentPreviousSiblings } from "@html_editor/utils/dom_traversal";
+import {
+    descendants,
+    getAdjacentPreviousSiblings,
+    closestElement,
+    firstLeaf,
+} from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
 import { DIRECTIONS, childNodeIndex } from "@html_editor/utils/position";
 
@@ -81,7 +86,17 @@ export class TabulationPlugin extends Plugin {
     }
 
     insertTab() {
-        this.dependencies.dom.insert(parseHTML(this.document, tabHtml));
+        const selection = this.dependencies.selection.getEditableSelection();
+        const element = closestElement(selection.anchorNode);
+        const isSelectionAtStart =
+            firstLeaf(element) === selection.anchorNode &&
+            (selection.anchorOffset === 0 || element.textContent === "\u200B");
+        const tab = parseHTML(this.document, tabHtml);
+        if (isSelectionAtStart && !isBlock(element)) {
+            element.before(tab);
+        } else {
+            this.dependencies.dom.insert(tab);
+        }
     }
 
     /**

--- a/addons/html_editor/static/tests/tabs.test.js
+++ b/addons/html_editor/static/tests/tabs.test.js
@@ -62,6 +62,96 @@ describe("insert tabulation", () => {
         });
     });
 
+    test("tab should not be colored when inserting tab at the beginning of a text having background color", async () => {
+        await testTabulation({
+            contentBefore: `<p><font style="background-color: rgb(255,255,0);">[]ab</font></p>`,
+            stepFunction: keydownTab,
+            contentAfterEdit: `<p>${oeTab(
+                TAB_WIDTH,
+                false
+            )}<font style="background-color: rgb(255,255,0);">[]ab</font></p>`,
+            contentAfter: `<p>${oeTab(
+                TAB_WIDTH
+            )}<font style="background-color: rgb(255,255,0);">[]ab</font></p>`,
+        });
+    });
+
+    test("tab should not be colored when inserting tab at the beginning of a text having background color (2)", async () => {
+        await testTabulation({
+            contentBefore: `<p><font style="background-color: rgb(255,255,0);">\u200B[]</font></p>`,
+            stepFunction: keydownTab,
+            contentAfterEdit: `<p>${oeTab(
+                TAB_WIDTH,
+                false
+            )}<font style="background-color: rgb(255,255,0);">\u200B[]</font></p>`,
+            contentAfter: `<p>${oeTab(
+                TAB_WIDTH
+            )}<font style="background-color: rgb(255,255,0);">\u200B[]</font></p>`,
+        });
+    });
+
+    test("tabs should not be colored when inserting multiple tabs at the beginning of a text having background color", async () => {
+        await testTabulation({
+            contentBefore: `<p><font style="background-color: rgb(255,255,0);">[]ab</font></p>`,
+            stepFunction: async (editor) => {
+                await keydownTab(editor);
+                await keydownTab(editor);
+            },
+            contentAfterEdit: `<p>${oeTab(TAB_WIDTH, false)}${oeTab(
+                TAB_WIDTH,
+                false
+            )}<font style="background-color: rgb(255,255,0);">[]ab</font></p>`,
+            contentAfter: `<p>${oeTab(TAB_WIDTH)}${oeTab(
+                TAB_WIDTH
+            )}<font style="background-color: rgb(255,255,0);">[]ab</font></p>`,
+        });
+    });
+
+    test("tab should be colored when inserting a tab in the middle of text having background color", async () => {
+        const expectedTabWidth = TAB_WIDTH - getCharWidth("p", "a");
+        await testTabulation({
+            contentBefore: `<p><font style="background-color: rgb(255,255,0);">a[]b</font></p>`,
+            stepFunction: keydownTab,
+            contentAfterEdit: `<p><font style="background-color: rgb(255,255,0);">a${oeTab(
+                expectedTabWidth,
+                false
+            )}[]b</font></p>`,
+            contentAfter: `<p><font style="background-color: rgb(255,255,0);">a${oeTab(
+                expectedTabWidth
+            )}[]b</font></p>`,
+        });
+    });
+
+    test("tab should be colored when inserting a tab in the middle of text having background color (2)", async () => {
+        const expectedTabWidth = TAB_WIDTH - (getCharWidth("p", "a") + getCharWidth("p", "b"));
+        await testTabulation({
+            contentBefore: `<p><font style="background-color: rgb(255,255,0);">ab<strong>[]cd</strong></font></p>`,
+            stepFunction: keydownTab,
+            contentAfterEdit: `<p><font style="background-color: rgb(255,255,0);">ab${oeTab(
+                expectedTabWidth,
+                false
+            )}<strong>[]cd</strong></font></p>`,
+            contentAfter: `<p><font style="background-color: rgb(255,255,0);">ab${oeTab(
+                expectedTabWidth
+            )}<strong>[]cd</strong></font></p>`,
+        });
+    });
+
+    test("tab should be colored when inserting a tab in the end of text having background color", async () => {
+        const expectedTabWidth = TAB_WIDTH - (getCharWidth("p", "a") + getCharWidth("p", "b"));
+        await testTabulation({
+            contentBefore: `<p><font style="background-color: rgb(255,255,0);">ab[]</font></p>`,
+            stepFunction: keydownTab,
+            contentAfterEdit: `<p><font style="background-color: rgb(255,255,0);">ab${oeTab(
+                expectedTabWidth,
+                false
+            )}[]</font></p>`,
+            contentAfter: `<p><font style="background-color: rgb(255,255,0);">ab${oeTab(
+                expectedTabWidth
+            )}[]</font></p>`,
+        });
+    });
+
     test("should insert tab characters at the beginning of two separate paragraphs", async () => {
         await testTabulation({
             contentBefore: `<p>a[b</p>` + `<p>c]d</p>`,


### PR DESCRIPTION
**Current behaviour before PR:**

When there is a text having background color, inserting a tab at the beginning of text creates a tab with background color.

**Desired behaviour after PR is merged:**

Now, if there is a text having background color,

- Inserting tab at the beginning of text, tab will not have background color.
- Inserting tab in the middle of a text, tab will have a background color corresponding to the text.
- Inserting tab in the end of text, tab will have a background color corresponding to the text.

task-4381135



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
