### PR TITLE
Backport of structured reference + add NL case + check values in sepa qr code

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -11,7 +11,7 @@ import re
 from textwrap import shorten
 
 from odoo import api, fields, models, _, Command
-from odoo.addons.account.tools import format_rf_reference
+from odoo.addons.account.tools import format_structured_reference_iso
 from odoo.exceptions import UserError, ValidationError, AccessError, RedirectWarning
 from odoo.tools.misc import clean_context
 from odoo.tools import (
@@ -2604,7 +2604,7 @@ class AccountMove(models.Model):
             is 07 so the reference will be 'RF07 43'.
         """
         self.ensure_one()
-        return format_rf_reference(self.id)
+        return format_structured_reference_iso(self.id)
 
     def _get_invoice_reference_euro_partner(self):
         """ This computes the reference based on the RF Creditor Reference.
@@ -2621,7 +2621,7 @@ class AccountMove(models.Model):
         partner_ref = self.partner_id.ref
         partner_ref_nr = re.sub(r'\D', '', partner_ref or '')[-21:] or str(self.partner_id.id)[-21:]
         partner_ref_nr = partner_ref_nr[-21:]
-        return format_rf_reference(partner_ref_nr)
+        return format_structured_reference_iso(partner_ref_nr)
 
     def _get_invoice_reference_odoo_invoice(self):
         """ This computes the reference based on the Odoo format.

--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from . import test_account_move_reconcile
 from . import test_account_move_payments_widget
 from . import test_account_move_out_invoice
@@ -43,3 +41,4 @@ from . import test_early_payment_discount
 from . import test_ir_actions_report
 from . import test_download_xsds
 from . import test_mail_tracking_value
+from . import test_structured_reference

--- a/addons/account/tests/test_structured_reference.py
+++ b/addons/account/tests/test_structured_reference.py
@@ -1,0 +1,68 @@
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+from odoo.addons.account.tools import (
+    is_valid_structured_reference_be,
+    is_valid_structured_reference_fi,
+    is_valid_structured_reference_no_se,
+    is_valid_structured_reference_iso,
+)
+
+
+@tagged('standard', 'at_install')
+class StructuredReferenceTest(TransactionCase):
+
+    def test_structured_reference_iso(self):
+        # Accepts references in structured format
+        self.assertTrue(is_valid_structured_reference_iso(' RF18 5390 0754 7034 '))
+        # Accept references in unstructured format
+        self.assertTrue(is_valid_structured_reference_iso(' RF18539007547034'))
+        # Validates with zero's added in front
+        self.assertTrue(is_valid_structured_reference_iso('RF18000000000539007547034'))
+
+        # Does not validate invalid structured format
+        self.assertFalse(is_valid_structured_reference_iso('18539007547034RF'))
+        # Does not validate invalid checksum
+        self.assertFalse(is_valid_structured_reference_iso('RF17539007547034'))
+
+    def test_structured_reference_be(self):
+        # Accepts references in both structured formats
+        self.assertTrue(is_valid_structured_reference_be(' +++020/3430/57642+++'))
+        self.assertTrue(is_valid_structured_reference_be('***020/3430/57642*** '))
+        # Accept references in unstructured format
+        self.assertTrue(is_valid_structured_reference_be(' 020343057642'))
+        # Validates edge case where result of % 97 = 0
+        self.assertTrue(is_valid_structured_reference_be('020343053497'))
+
+        # Does not validate invalid structured format
+        self.assertFalse(is_valid_structured_reference_be('***02/03430/57642***'))
+        # Does not validate invalid checksum
+        self.assertFalse(is_valid_structured_reference_be('020343057641'))
+
+    def test_structured_reference_fi(self):
+        # Accepts references in structured format
+        self.assertTrue(is_valid_structured_reference_fi('2023 0000 98'))
+        # Accept references in unstructured format
+        self.assertTrue(is_valid_structured_reference_fi('2023000098'))
+        # Validates with zero's added in front
+        self.assertTrue(is_valid_structured_reference_fi('00000000002023000098'))
+
+        # Does not validate invalid structured format
+        self.assertFalse(is_valid_structured_reference_fi('2023/0000/98'))
+        # Does not validate invalid length
+        self.assertFalse(is_valid_structured_reference_fi('000000000002023000098'))
+        # Does not validate invalid checksum
+        self.assertFalse(is_valid_structured_reference_fi('2023000095'))
+
+    def test_structured_reference_no_se(self):
+        # Accepts references in structured format
+        self.assertTrue(is_valid_structured_reference_no_se('1234 5678 97'))
+        # Accept references in unstructured format
+        self.assertTrue(is_valid_structured_reference_no_se('1234567897'))
+        # Validates with zero's added in front
+        self.assertTrue(is_valid_structured_reference_no_se('000001234567897'))
+
+        # Does not validate invalid structured format
+        self.assertFalse(is_valid_structured_reference_no_se('1234/5678/97'))
+        # Does not validate invalid checksum
+        self.assertFalse(is_valid_structured_reference_no_se('1234567898'))

--- a/addons/account/tests/test_structured_reference.py
+++ b/addons/account/tests/test_structured_reference.py
@@ -6,6 +6,7 @@ from odoo.addons.account.tools import (
     is_valid_structured_reference_fi,
     is_valid_structured_reference_no_se,
     is_valid_structured_reference_iso,
+    is_valid_structured_reference,
 )
 
 
@@ -66,3 +67,31 @@ class StructuredReferenceTest(TransactionCase):
         self.assertFalse(is_valid_structured_reference_no_se('1234/5678/97'))
         # Does not validate invalid checksum
         self.assertFalse(is_valid_structured_reference_no_se('1234567898'))
+
+    def test_structured_reference(self):
+        # Accepts references in structured format
+        self.assertTrue(is_valid_structured_reference(' RF18 5390 0754 7034 '))  # ISO
+        self.assertTrue(is_valid_structured_reference(' +++020/3430/57642+++'))  # BE
+        self.assertTrue(is_valid_structured_reference('***020/3430/57642*** '))  # BE
+        self.assertTrue(is_valid_structured_reference('2023 0000 98'))  # FI
+        self.assertTrue(is_valid_structured_reference('1234 5678 97'))  # NO-SE
+        # Accept references in unstructured format
+        self.assertTrue(is_valid_structured_reference(' RF18539007547034'))  # ISO
+        self.assertTrue(is_valid_structured_reference(' 020343057642'))  # BE
+        self.assertTrue(is_valid_structured_reference('2023000098'))  # FI
+        self.assertTrue(is_valid_structured_reference('1234567897'))  # NO-SE
+        # Validates with zero's added in front
+        self.assertTrue(is_valid_structured_reference('RF18000000000539007547034'))  # ISO
+        self.assertTrue(is_valid_structured_reference('00000000002023000098'))  # FI
+        self.assertTrue(is_valid_structured_reference('000001234567897'))  # NO-SE
+
+        # Does not validate invalid structured format
+        self.assertFalse(is_valid_structured_reference('18539007547034RF'))  # ISO
+        self.assertFalse(is_valid_structured_reference('***02/03430/57642***'))  # BE
+        self.assertFalse(is_valid_structured_reference('2023/0000/98'))  # FI
+        self.assertFalse(is_valid_structured_reference('1234/5678/97'))  # NO-SE
+        # Does not validate invalid checksum
+        self.assertFalse(is_valid_structured_reference('RF17539007547034'))  # ISO
+        self.assertFalse(is_valid_structured_reference('020343057641'))  # BE
+        self.assertFalse(is_valid_structured_reference('2023000095'))  # FI
+        self.assertFalse(is_valid_structured_reference('1234567898'))  # NO-SE

--- a/addons/account/tests/test_structured_reference.py
+++ b/addons/account/tests/test_structured_reference.py
@@ -5,6 +5,7 @@ from odoo.addons.account.tools import (
     is_valid_structured_reference_be,
     is_valid_structured_reference_fi,
     is_valid_structured_reference_no_se,
+    is_valid_structured_reference_nl,
     is_valid_structured_reference_iso,
     is_valid_structured_reference,
 )
@@ -76,6 +77,37 @@ class StructuredReferenceTest(TransactionCase):
         # Validates the entire string
         self.assertFalse(is_valid_structured_reference_no_se('1234567897-OTHER-RANDOM-STUFF'))
 
+    def test_structured_reference_nl(self):
+        # Accepts 7 digits
+        self.assertTrue(is_valid_structured_reference_nl('1234567'))
+
+        # Accepts 9 digits
+        self.assertTrue(is_valid_structured_reference_nl('271234567'))
+
+        # Accepts 14 digits
+        self.assertTrue(is_valid_structured_reference_nl('42234567890123'))
+
+        # Accepts 16 digits
+        self.assertTrue(is_valid_structured_reference_nl('5000056789012345'))
+
+        # Accepts particular chase (check = 11 or 10)
+        self.assertTrue(is_valid_structured_reference_nl('0123456788'))  # Check of 123456788 == 11 then check = 0
+        self.assertTrue(is_valid_structured_reference_nl('123456789107'))  # Check of 23456789107 == 10 then check = 1
+
+        # Accepts spaces
+        self.assertTrue(is_valid_structured_reference_nl('5 000 0567 8901 2345'))
+        self.assertTrue(is_valid_structured_reference_nl('   5000056789012345   '))
+
+        # Check the length
+        self.assertFalse(is_valid_structured_reference_nl('123456'))
+        self.assertFalse(is_valid_structured_reference_nl('12345678'))
+        self.assertFalse(is_valid_structured_reference_nl('123456789012345'))
+        self.assertFalse(is_valid_structured_reference_nl('12345678901234567'))
+        # Check the checksum
+        self.assertFalse(is_valid_structured_reference_nl('4000056789012345'))
+        # Check the entire string
+        self.assertFalse(is_valid_structured_reference_nl('5000056789012345-OTHER-RANDOM-STUFF'))
+
     def test_structured_reference(self):
         # Accepts references in structured format
         self.assertTrue(is_valid_structured_reference(' RF18 5390 0754 7034 '))  # ISO
@@ -83,11 +115,13 @@ class StructuredReferenceTest(TransactionCase):
         self.assertTrue(is_valid_structured_reference('***020/3430/57642*** '))  # BE
         self.assertTrue(is_valid_structured_reference('2023 0000 98'))  # FI
         self.assertTrue(is_valid_structured_reference('1234 5678 97'))  # NO-SE
+        self.assertTrue(is_valid_structured_reference('5000056789012345'))  # NL
         # Accept references in unstructured format
         self.assertTrue(is_valid_structured_reference(' RF18539007547034'))  # ISO
         self.assertTrue(is_valid_structured_reference(' 020343057642'))  # BE
         self.assertTrue(is_valid_structured_reference('2023000098'))  # FI
         self.assertTrue(is_valid_structured_reference('1234567897'))  # NO-SE
+        self.assertTrue(is_valid_structured_reference('5 000 0567 8901 2345'))  # NL
         # Validates with zero's added in front
         self.assertTrue(is_valid_structured_reference('RF18000000000539007547034'))  # ISO
         self.assertTrue(is_valid_structured_reference('00000000002023000098'))  # FI
@@ -98,8 +132,10 @@ class StructuredReferenceTest(TransactionCase):
         self.assertFalse(is_valid_structured_reference('***02/03430/57642***'))  # BE
         self.assertFalse(is_valid_structured_reference('2023/0000/98'))  # FI
         self.assertFalse(is_valid_structured_reference('1234/5678/97'))  # NO-SE
+        self.assertFalse(is_valid_structured_reference('(5)000 0567 8901 2345'))  # NL
         # Does not validate invalid checksum
         self.assertFalse(is_valid_structured_reference('RF17539007547034'))  # ISO
         self.assertFalse(is_valid_structured_reference('020343057641'))  # BE
         self.assertFalse(is_valid_structured_reference('2023000095'))  # FI
         self.assertFalse(is_valid_structured_reference('1234567898'))  # NO-SE
+        self.assertFalse(is_valid_structured_reference('6000056789012345'))  # NL

--- a/addons/account/tests/test_structured_reference.py
+++ b/addons/account/tests/test_structured_reference.py
@@ -25,6 +25,8 @@ class StructuredReferenceTest(TransactionCase):
         self.assertFalse(is_valid_structured_reference_iso('18539007547034RF'))
         # Does not validate invalid checksum
         self.assertFalse(is_valid_structured_reference_iso('RF17539007547034'))
+        # Validates the entire string
+        self.assertFalse(is_valid_structured_reference_be('RF18539007547034-OTHER-RANDOM-STUFF'))
 
     def test_structured_reference_be(self):
         # Accepts references in both structured formats
@@ -39,6 +41,8 @@ class StructuredReferenceTest(TransactionCase):
         self.assertFalse(is_valid_structured_reference_be('***02/03430/57642***'))
         # Does not validate invalid checksum
         self.assertFalse(is_valid_structured_reference_be('020343057641'))
+        # Validates the entire string
+        self.assertFalse(is_valid_structured_reference_be('020343053497-OTHER-RANDOM-STUFF'))
 
     def test_structured_reference_fi(self):
         # Accepts references in structured format
@@ -54,6 +58,8 @@ class StructuredReferenceTest(TransactionCase):
         self.assertFalse(is_valid_structured_reference_fi('000000000002023000098'))
         # Does not validate invalid checksum
         self.assertFalse(is_valid_structured_reference_fi('2023000095'))
+        # Validates the entire string
+        self.assertFalse(is_valid_structured_reference_fi('2023000098-OTHER-RANDOM-STUFF'))
 
     def test_structured_reference_no_se(self):
         # Accepts references in structured format
@@ -67,6 +73,8 @@ class StructuredReferenceTest(TransactionCase):
         self.assertFalse(is_valid_structured_reference_no_se('1234/5678/97'))
         # Does not validate invalid checksum
         self.assertFalse(is_valid_structured_reference_no_se('1234567898'))
+        # Validates the entire string
+        self.assertFalse(is_valid_structured_reference_no_se('1234567897-OTHER-RANDOM-STUFF'))
 
     def test_structured_reference(self):
         # Accepts references in structured format

--- a/addons/account/tools/__init__.py
+++ b/addons/account/tools/__init__.py
@@ -1,28 +1,7 @@
-from itertools import zip_longest
 import requests
 from urllib3.util.ssl_ import create_urllib3_context
 
-
-def calc_check_digits(number: str) -> str:
-    """Calculate the extra digits that should be appended to the number to make it a valid number.
-    Source: python-stdnum iso7064.mod_97_10.calc_check_digits
-    """
-    number_base10 = ''.join(str(int(x, 36)) for x in number)
-    checksum = int(number_base10) % 97
-    return '%02d' % ((98 - 100 * checksum) % 97)
-
-
-def format_rf_reference(number: str) -> str:
-    """Format a string into a Structured Creditor Reference.
-
-    The Creditor Reference is an international standard (ISO 11649).
-    Example: `123456789` -> `RF18 1234 5678 9`
-    """
-    check_digits = calc_check_digits('{}RF'.format(number))
-    return 'RF{} {}'.format(
-        check_digits,
-        " ".join("".join(x) for x in zip_longest(*[iter(str(number))]*4, fillvalue=""))
-    )
+from .structured_reference import *
 
 
 class LegacyHTTPAdapter(requests.adapters.HTTPAdapter):

--- a/addons/account/tools/structured_reference.py
+++ b/addons/account/tools/structured_reference.py
@@ -1,0 +1,69 @@
+import re
+
+from itertools import zip_longest
+from stdnum import iso11649, luhn
+from stdnum.iso7064 import mod_97_10
+
+
+def sanitize_structured_reference(reference):
+    """Removes whitespace and specific characters from Belgian structured references:
+
+    Example: ` RF18 1234 5678 9  ` -> `RF18123456789`
+             `+++020/3430/57642+++` -> `020343057642`
+             `***020/3430/57642***` -> `020343057642`
+    """
+    ref = re.sub(r'\s', '', reference)
+    if re.match(r'(\+{3}|\*{3})\d{3}/\d{4}/\d{5}(\+{3}|\*{3})', ref):
+        return re.sub(r'[+*/]', '', ref)
+    return ref
+
+def format_structured_reference_iso(number):
+    """Format a string into a Structured Creditor Reference.
+
+    The Creditor Reference is an international standard (ISO 11649).
+    Example: `123456789` -> `RF18 1234 5678 9`
+    """
+    check_digits = mod_97_10.calc_check_digits('{}RF'.format(number))
+    return 'RF{} {}'.format(
+        check_digits,
+        ' '.join(''.join(x) for x in zip_longest(*[iter(str(number))]*4, fillvalue=''))
+    )
+
+def is_valid_structured_reference_iso(reference):
+    """Check whether the provided reference is a valid Structured Creditor Reference (ISO).
+
+    :param reference: the reference to check
+    """
+    ref = sanitize_structured_reference(reference)
+    return iso11649.is_valid(ref)
+
+def is_valid_structured_reference_be(reference):
+    """Check whether the provided reference is a valid structured reference for Belgium.
+
+    :param reference: the reference to check
+    """
+    ref = sanitize_structured_reference(reference)
+    be_ref = re.match(r'(\d{10})(\d{2})', ref)
+    return be_ref and int(be_ref.group(1)) % 97 == int(be_ref.group(2)) % 97
+
+def is_valid_structured_reference_fi(reference):
+    """Check whether the provided reference is a valid structured reference for Finland.
+
+    :param reference: the reference to check
+    """
+    ref = sanitize_structured_reference(reference)
+    fi_ref = re.match(r'(\d{1,19})(\d)', ref)
+    if not fi_ref:
+        return False
+    total = sum((7, 3, 1)[idx % 3] * int(val) for idx, val in enumerate(fi_ref.group(1)[::-1]))
+    check_digit = (10 - (total % 10)) % 10
+    return check_digit == int(fi_ref.group(2))
+
+def is_valid_structured_reference_no_se(reference):
+    """Check whether the provided reference is a valid structured reference for Norway or Sweden.
+
+    :param reference: the reference to check
+    """
+    ref = sanitize_structured_reference(reference)
+    no_se_ref = re.match(r'\d+', ref)
+    return no_se_ref and luhn.is_valid(ref)

--- a/addons/account/tools/structured_reference.py
+++ b/addons/account/tools/structured_reference.py
@@ -67,3 +67,19 @@ def is_valid_structured_reference_no_se(reference):
     ref = sanitize_structured_reference(reference)
     no_se_ref = re.match(r'\d+', ref)
     return no_se_ref and luhn.is_valid(ref)
+
+
+def is_valid_structured_reference(reference):
+    """Check whether the provided reference is a valid structured reference.
+    This is currently supporting SEPA enabled countries. More specifically countries covered by functions in this file.
+
+    :param reference: the reference to check
+    """
+    reference = sanitize_structured_reference(reference or '')
+
+    return (
+        is_valid_structured_reference_be(reference) or
+        is_valid_structured_reference_fi(reference) or
+        is_valid_structured_reference_no_se(reference) or
+        is_valid_structured_reference_iso(reference)
+    )

--- a/addons/account/tools/structured_reference.py
+++ b/addons/account/tools/structured_reference.py
@@ -68,6 +68,44 @@ def is_valid_structured_reference_no_se(reference):
     no_se_ref = re.fullmatch(r'\d+', ref)
     return no_se_ref and luhn.is_valid(ref)
 
+def is_valid_structured_reference_nl(reference):
+    """ Generates a valid Dutch structured payment reference (betalingskenmerk)
+        by ensuring it follows the correct format.
+
+        Valid reference lengths:
+        - 7 digits: Simple reference with no check digit.
+        - 9-14 digits: Includes a check digit and a length code.
+        - 16 digits: Contains only a check digit, commonly used for wire transfers.
+
+        :param reference: the reference to check
+        :return: True if reference is a structured reference, False otherwise
+    """
+    sanitized_reference = sanitize_structured_reference(reference)
+
+    if re.fullmatch(r'\d{7}', sanitized_reference):
+        return True
+
+    if not re.fullmatch(r'\d{9,16}', sanitized_reference):
+        return False
+
+    if len(sanitized_reference) == 15:
+        return False
+
+    check, reference_to_check = sanitized_reference[0], sanitized_reference[1:]
+    weigths = [2, 4, 8, 5, 10, 9, 7, 3, 6, 1]
+    reference_to_check = reference_to_check.zfill(16)[::-1]
+
+    total = sum(
+        int(digit) * weigths[index % len(weigths)]
+        for index, digit in enumerate(reference_to_check)
+    )
+    computed_check = 11 - (total % 11)
+    if computed_check == 11:
+        computed_check = 0
+    elif computed_check == 10:
+        computed_check = 1
+
+    return computed_check == int(check)
 
 def is_valid_structured_reference(reference):
     """Check whether the provided reference is a valid structured reference.
@@ -81,5 +119,6 @@ def is_valid_structured_reference(reference):
         is_valid_structured_reference_be(reference) or
         is_valid_structured_reference_fi(reference) or
         is_valid_structured_reference_no_se(reference) or
+        is_valid_structured_reference_nl(reference) or
         is_valid_structured_reference_iso(reference)
     )

--- a/addons/account/tools/structured_reference.py
+++ b/addons/account/tools/structured_reference.py
@@ -43,7 +43,7 @@ def is_valid_structured_reference_be(reference):
     :param reference: the reference to check
     """
     ref = sanitize_structured_reference(reference)
-    be_ref = re.match(r'(\d{10})(\d{2})', ref)
+    be_ref = re.fullmatch(r'(\d{10})(\d{2})', ref)
     return be_ref and int(be_ref.group(1)) % 97 == int(be_ref.group(2)) % 97
 
 def is_valid_structured_reference_fi(reference):
@@ -52,7 +52,7 @@ def is_valid_structured_reference_fi(reference):
     :param reference: the reference to check
     """
     ref = sanitize_structured_reference(reference)
-    fi_ref = re.match(r'(\d{1,19})(\d)', ref)
+    fi_ref = re.fullmatch(r'(\d{1,19})(\d)', ref)
     if not fi_ref:
         return False
     total = sum((7, 3, 1)[idx % 3] * int(val) for idx, val in enumerate(fi_ref.group(1)[::-1]))
@@ -65,7 +65,7 @@ def is_valid_structured_reference_no_se(reference):
     :param reference: the reference to check
     """
     ref = sanitize_structured_reference(reference)
-    no_se_ref = re.match(r'\d+', ref)
+    no_se_ref = re.fullmatch(r'\d+', ref)
     return no_se_ref and luhn.is_valid(ref)
 
 

--- a/addons/account_qr_code_sepa/models/res_bank.py
+++ b/addons/account_qr_code_sepa/models/res_bank.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from odoo import models, fields, api, _
+from odoo.addons.account.tools import is_valid_structured_reference, sanitize_structured_reference
 
 
 class ResPartnerBank(models.Model):
@@ -8,7 +9,12 @@ class ResPartnerBank(models.Model):
 
     def _get_qr_vals(self, qr_method, amount, currency, debtor_partner, free_communication, structured_communication):
         if qr_method == 'sct_qr':
-            comment = (free_communication or '') if not structured_communication else ''
+            if structured_communication and is_valid_structured_reference(structured_communication):
+                structured_communication = sanitize_structured_reference(structured_communication)
+                comment = ''
+            else:
+                structured_communication = ''
+                comment = free_communication or ''
 
             qr_code_vals = [
                 'BCD',                                                  # Service Tag
@@ -20,7 +26,7 @@ class ResPartnerBank(models.Model):
                 self.sanitized_acc_number,                              # Account Number of the Beneficiary
                 currency.name + str(amount),                            # Currency + Amount of the Transfer in EUR
                 '',                                                     # Purpose of the Transfer
-                (structured_communication or '')[:36],                  # Remittance Information (Structured)
+                structured_communication,                               # Remittance Information (Structured)
                 comment[:141],                                          # Remittance Information (Unstructured) (can't be set if there is a structured one)
                 '',                                                     # Beneficiary to Originator Information
             ]

--- a/addons/account_qr_code_sepa/tests/test_sepa_qr.py
+++ b/addons/account_qr_code_sepa/tests/test_sepa_qr.py
@@ -76,3 +76,61 @@ class TestSEPAQRCode(AccountTestInvoicingCommon):
         reverse_move = self.env['account.move'].browse(reversal['res_id'])
 
         self.assertFalse(reverse_move.qr_code_method, "qr_code_method for credit note should be None")
+
+    def test_get_qr_vals_communication(self):
+        """ The aim of this test is making sure that we only provide a structured
+            reference (or communication) in the qr code values if the communication
+            is well-structured. If the communication is not structured, we provide
+            it through the unstructured communication value.
+        """
+        result = self.acc_sepa_iban._get_qr_vals(
+            qr_method='sct_qr',
+            amount=100.0,
+            currency=self.env.ref('base.EUR'),
+            debtor_partner=None,
+            free_communication='A free communication',
+            structured_communication='A free communication',
+        )
+        self.assertEqual(
+            result,
+            [
+                'BCD',
+                '002',
+                '1',
+                'SCT',
+                '',
+                'company_1_data',
+                'BE15001559627230',
+                'EUR100.0',
+                '',
+                '',
+                'A free communication',
+                '',
+            ]
+        )
+
+        result = self.acc_sepa_iban._get_qr_vals(
+            qr_method='sct_qr',
+            amount=100.0,
+            currency=self.env.ref('base.EUR'),
+            debtor_partner=None,
+            free_communication=' 5 000 0567 89012345 ',  # NL Structured reference
+            structured_communication=' 5 000 0567 89012345 ',  # NL Structured reference
+        )
+        self.assertEqual(
+            result,
+            [
+                'BCD',
+                '002',
+                '1',
+                'SCT',
+                '',
+                'company_1_data',
+                'BE15001559627230',
+                'EUR100.0',
+                '',
+                '5000056789012345',
+                '',
+                '',
+            ]
+        )


### PR DESCRIPTION
This PR backports some commits to add the tool functions to check structured reference/communication.
It also add a new function for Netherlands and finally apply a check during the qr code values generation to make sure that we don't pass unstructured communication as structured one.

See all the commit messages.

Doc for NL case:
- https://www.betaalvereniging.nl/betalingsverkeer/giraal-betalingsverkeer/betalingskenmerken/
- https://nl.wikipedia.org/wiki/Elfproef

opw-4575004


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
