### PR TITLE
[FIX] website_sale: don't merge combo item lines

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -343,6 +343,7 @@ class SaleOrder(models.Model):
             ('product_id', '=', product_id),
             ('product_custom_attribute_value_ids', '=', False),
             ('linked_line_id', '=', linked_line_id),
+            ('combo_item_id', '=', False),
         ]
 
         filtered_sol = self.order_line.filtered_domain(domain)


### PR DESCRIPTION
If different combo choices in a same combo product contain identical products,
and the user selects them, then they will be merged in the cart. This shouldn't
be the case, as the price can be different, even if the products are the same.