### PR TITLE
[FIX] im_livechat: do not trigger steps after forward

### DIFF
--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -45,6 +45,12 @@ class LivechatChatbotScriptController(http.Controller):
         next_step = False
         # sudo: chatbot.script.step - visitor can access current step of the script
         if current_step := discuss_channel.sudo().chatbot_current_step_id:
+            if (
+                current_step.is_forward_operator
+                and discuss_channel.livechat_operator_id
+                != current_step.chatbot_script_id.operator_partner_id
+            ):
+                return None
             chatbot = current_step.chatbot_script_id
             domain = [
                 ("author_id", "!=", chatbot.operator_partner_id.id),

--- a/addons/website_livechat/tests/__init__.py
+++ b/addons/website_livechat/tests/__init__.py
@@ -3,6 +3,7 @@
 from . import common
 from . import test_ui
 from . import test_chatbot_ui
+from . import test_fw_operator
 from . import test_lazy_frontend_bus
 from . import test_livechat_basic_flow
 from . import test_livechat_request

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -203,54 +203,6 @@ class TestLivechatChatbotUI(TestGetOperatorCommon, TestWebsiteLivechatCommon, Ch
         self.env.ref("website.default_website").channel_id = livechat_channel.id
         self.start_tour("/contactus", "website_livechat.chatbot_trigger_selection")
 
-    def test_chatbot_removed_after_forward_to_operator(self):
-        chatbot_fw_script = self.env["chatbot.script"].create({"title": "Forward Bot"})
-        question_step, _ = tuple(
-            self.env["chatbot.script.step"].create(
-                [
-                    {
-                        "chatbot_script_id": chatbot_fw_script.id,
-                        "message": "Hello, what can I do for you?",
-                        "step_type": "question_selection",
-                    },
-                    {
-                        "chatbot_script_id": chatbot_fw_script.id,
-                        "message": "I'll forward you to an operator.",
-                        "step_type": "forward_operator",
-                    },
-                ]
-            )
-        )
-        self.env["chatbot.script.answer"].create(
-            {
-                "name": "Forward to operator",
-                "script_step_id": question_step.id,
-            }
-        )
-        livechat_channel = self.env["im_livechat.channel"].create(
-            {
-                "name": "Forward to operator channel",
-                "rule_ids": [
-                    Command.create(
-                        {
-                            "regex_url": "/",
-                            "chatbot_script_id": chatbot_fw_script.id,
-                        }
-                    )
-                ],
-                "user_ids": [self.operator.id],
-            }
-        )
-        default_website = self.env.ref("website.default_website")
-        default_website.channel_id = livechat_channel.id
-        self.env.ref("website.default_website").channel_id = livechat_channel.id
-        self.start_tour("/", "website_livechat.chatbot_forward")
-        channel = self.env["discuss.channel"].search(
-            [("livechat_channel_id", "=", livechat_channel.id)]
-        )
-        self.assertEqual(channel.livechat_operator_id, self.operator.partner_id)
-        self.assertNotIn(chatbot_fw_script.operator_partner_id, channel.channel_member_ids.partner_id)
-
     def test_chatbot_fw_operator_matching_lang(self):
         fr_op = self._create_operator(lang_code="fr_FR")
         en_op = self._create_operator(lang_code="en_US")

--- a/addons/website_livechat/tests/test_fw_operator.py
+++ b/addons/website_livechat/tests/test_fw_operator.py
@@ -1,0 +1,79 @@
+from odoo import Command
+from odoo.tests import HttpCase, tagged
+from odoo.addons.website_livechat.tests.common import TestLivechatCommon
+from odoo.addons.im_livechat.tests.chatbot_common import ChatbotCase
+
+
+@tagged("post_install", "-at_install")
+class TestFwOperator(ChatbotCase, HttpCase, TestLivechatCommon):
+    def setUp(self):
+        super().setUp()
+        self.chatbot_fw_script = self.env["chatbot.script"].create({"title": "Forward Bot"})
+        question_step, *_ = tuple(
+            self.env["chatbot.script.step"].create(
+                [
+                    {
+                        "chatbot_script_id": self.chatbot_fw_script.id,
+                        "message": "Hello, what can I do for you?",
+                        "step_type": "question_selection",
+                    },
+                    {
+                        "chatbot_script_id": self.chatbot_fw_script.id,
+                        "message": "I'll forward you to an operator.",
+                        "step_type": "forward_operator",
+                    },
+                    {
+                        "chatbot_script_id": self.chatbot_fw_script.id,
+                        "message": "I could not find an operator to help you.",
+                        "step_type": "text",
+                    }
+                ]
+            )
+        )
+        self.fw_to_operator_answer = self.env["chatbot.script.answer"].create(
+            {
+                "name": "Forward to operator",
+                "script_step_id": question_step.id,
+            }
+        )
+        self.livechat_channel = self.env["im_livechat.channel"].create(
+            {
+                "name": "Forward to operator channel",
+                "rule_ids": [
+                    Command.create(
+                        {
+                            "regex_url": "/",
+                            "chatbot_script_id": self.chatbot_fw_script.id,
+                        }
+                    )
+                ],
+                "user_ids": [self.operator.id],
+            }
+        )
+        default_website = self.env.ref("website.default_website")
+        default_website.channel_id = self.livechat_channel.id
+
+    def test_chatbot_removed_after_forward_to_operator(self):
+        self.start_tour("/", "website_livechat.chatbot_forward")
+        channel = self.env["discuss.channel"].search(
+            [("livechat_channel_id", "=", self.livechat_channel.id)]
+        )
+        self.assertEqual(channel.livechat_operator_id, self.operator.partner_id)
+        self.assertNotIn(
+            self.chatbot_fw_script.operator_partner_id, channel.channel_member_ids.partner_id
+        )
+
+    def test_chatbot_trigger_blocked_after_forward_to_operator(self):
+        data = self.make_jsonrpc_request("/im_livechat/get_session", {
+            "anonymous_name": "Visitor #1",
+            "channel_id": self.livechat_channel.id,
+            "chatbot_script_id": self.chatbot_fw_script.id
+        })
+        channel = self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"])
+        self.assertEqual(channel.chatbot_current_step_id.step_type, "question_selection")
+        self._post_answer_and_trigger_next_step(channel, self.fw_to_operator_answer.id)
+        self.assertEqual(channel.livechat_operator_id, self.operator.partner_id)
+        self.assertEqual(channel.chatbot_current_step_id.step_type, "forward_operator")
+        next_step_data = self.make_jsonrpc_request("/chatbot/step/trigger", {"channel_id": channel.id})
+        self.assertFalse(next_step_data)
+        self.assertEqual(channel.chatbot_current_step_id.step_type, "forward_operator")


### PR DESCRIPTION
Once an operator has been found, the chat bot should not do anything else. However, it can happen that a step trigger is requested by the client. While this should and will be prevented in another PR, the "/chatbot/trigger" route is perfectly aware of the state of the chat and should not do anything in this case. This PR fixes this issue.

task-4607689

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
