### PR TITLE
[IMP] fleet: added attachment preview to driver history attachments

### DIFF
--- a/addons/hr_fleet/models/__init__.py
+++ b/addons/hr_fleet/models/__init__.py
@@ -8,4 +8,5 @@ from . import fleet_vehicle
 from . import fleet_vehicle_log_contract
 from . import fleet_vehicle_log_services
 from . import fleet_vehicle_odometer
+from . import ir_attachment
 from . import mail_activity_plan_template

--- a/addons/hr_fleet/models/ir_attachment.py
+++ b/addons/hr_fleet/models/ir_attachment.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrAttachment(models.Model):
+    _inherit = 'ir.attachment'
+
+    def action_preview_attachment(self):
+        return {
+            'type': 'ir.actions.act_url',
+            'url': '/web/content/%s/%s' % (self.id, self.name),
+            'target': 'new',
+        }

--- a/addons/hr_fleet/views/fleet_vehicle_views.xml
+++ b/addons/hr_fleet/views/fleet_vehicle_views.xml
@@ -113,6 +113,8 @@
        <field name="arch" type="xml">
            <xpath expr="//kanban" position="attributes">
                 <attribute name="js_class">hr_fleet_kanban_view</attribute>
+                <attribute name="type">object</attribute>
+                <attribute name="action">action_preview_attachment</attribute>
             </xpath>
             <t t-name="menu">
                 <a role="menuitem" type="delete" class="dropdown-item">Delete</a>


### PR DESCRIPTION
- added an on-click action to kanban cards of attachments
- inherited `ir.attachment` and added `action_preview_attachment` URL action.
- can open preview of the attachment by clicking on them, without downloading.

task-4603710