### PR TITLE
[FIX] point_of_sale: adopt the search result without fuzzy search

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -206,16 +206,16 @@ export class ProductProduct extends Base {
     }
 
     get searchString() {
-        const fields = ["display_name", "default_code"];
+        const fields = ["display_name", "barcode", "default_code"];
         return fields
             .map((field) => this[field] || "")
             .filter(Boolean)
             .join(" ");
     }
 
-    exactMatch(searchWord) {
-        const fields = ["barcode"];
-        return fields.some((field) => this[field] && this[field].toLowerCase() == searchWord);
+    exactMatch() {
+        // this method is kept for backward compatibility
+        return [];
     }
 
     _isArchivedCombination(attributeValueIds) {

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -387,17 +387,9 @@ export class ProductScreen extends Component {
             ? this.getProductsByCategory(this.pos.selectedCategory)
             : this.products;
 
-        const exactMatches = products.filter((product) => product.exactMatch(words));
-
-        if (exactMatches.length > 0 && words.length > 2) {
-            return exactMatches;
-        }
-
-        const matches = products.filter((p) =>
+        return products.filter((p) =>
             unaccent(p.searchString, false).toLowerCase().includes(words)
         );
-
-        return Array.from(new Set([...exactMatches, ...matches]));
     }
 
     addMainProductsToDisplay(products) {


### PR DESCRIPTION
Since the fuzzy search has been removed, it is no longer necessary to exclusively display only exact match results. This commit updates the search functionality to adopt and return all relevant search results, ensuring consistency with the new behavior.

opw-4535250

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
