### PR TITLE
[FIX] html_editor: handle table menu on `th` elements

### DIFF
--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -37,7 +37,8 @@ export class TableMenu extends Component {
     get hasCustomSize() {
         return (
             !!this.props.target.closest("tr").style.height ||
-            !!this.props.target.closest("td").style.width
+            !!this.props.target.closest("td")?.style?.width ||
+            !!this.props.target.closest("th")?.style?.width
         );
     }
 

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -176,7 +176,9 @@ export class TablePlugin extends Plugin {
         const columnIndex = getColumnIndex(reference);
         const table = closestElement(reference, "table");
         const tableWidth = table.style.width && parseFloat(table.style.width);
-        const referenceColumn = table.querySelectorAll(`tr td:nth-of-type(${columnIndex + 1})`);
+        const referenceColumn = table.querySelectorAll(
+            `tr td:nth-of-type(${columnIndex + 1}), tr th:nth-of-type(${columnIndex + 1})`
+        );
         const referenceCellWidth = reference.style.width
             ? parseFloat(reference.style.width)
             : reference.clientWidth;
@@ -201,7 +203,7 @@ export class TablePlugin extends Plugin {
             }
         }
         referenceColumn.forEach((cell, rowIndex) => {
-            const newCell = this.document.createElement("td");
+            const newCell = this.document.createElement(cell.tagName);
             const baseContainer = this.dependencies.baseContainer.createBaseContainer();
             baseContainer.append(this.document.createElement("br"));
             newCell.append(baseContainer);
@@ -233,11 +235,11 @@ export class TablePlugin extends Plugin {
         if (referenceRowHeight) {
             newRow.style.height = referenceRowHeight + "px";
         }
-        const cells = reference.querySelectorAll("td");
+        const cells = reference.querySelectorAll("td, th");
         const referenceRowWidths = [...cells].map((cell) => cell.style.width);
         newRow.append(
-            ...Array.from(Array(cells.length)).map(() => {
-                const td = this.document.createElement("td");
+            ...Array.from(cells).map((cell) => {
+                const td = this.document.createElement(cell.tagName);
                 const baseContainer = this.dependencies.baseContainer.createBaseContainer();
                 baseContainer.append(this.document.createElement("br"));
                 td.append(baseContainer);

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -106,7 +106,7 @@ export class TableUIPlugin extends Plugin {
             return;
         }
         if (
-            ev.target.tagName === "TD" &&
+            ["TD", "TH"].includes(target.tagName) &&
             target !== this.activeTd &&
             this.editable.contains(target)
         ) {
@@ -118,7 +118,7 @@ export class TableUIPlugin extends Plugin {
             if (isOverlay) {
                 return;
             }
-            const parentTd = closestElement(target, "td");
+            const parentTd = closestElement(target, "td, th");
             if (!parentTd) {
                 this.setActiveTd(null);
             }

--- a/addons/html_editor/static/tests/table/children.test.js
+++ b/addons/html_editor/static/tests/table/children.test.js
@@ -16,7 +16,7 @@ function addRow(position) {
 function addColumn(position) {
     return (editor) => {
         const selection = editor.shared.selection.getEditableSelection();
-        editor.shared.table.addColumn(position, findInSelection(selection, "td"));
+        editor.shared.table.addColumn(position, findInSelection(selection, "td, th"));
     };
 }
 
@@ -265,6 +265,36 @@ describe("column", () => {
             });
         });
 
+        test("should add a `TH` column before", async () => {
+            await testEditor({
+                contentBefore:
+                    '<table style="width: 150px;"><tbody><tr style="height: 20px;">' +
+                    '<th style="width: 40px;">ab[]</th>' +
+                    '<th style="width: 50px;">cd</th>' +
+                    '<th style="width: 60px;">ef</th>' +
+                    "</tr>" +
+                    '<tr style="height: 30px;">' +
+                    "<td>ab</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef</td>" +
+                    "</tr></tbody></table>",
+                stepFunction: addColumn("before"),
+                contentAfter:
+                    '<table style="width: 150px;"><tbody><tr style="height: 20px;">' +
+                    '<th style="width: 32px;"><p><br></p></th>' +
+                    '<th style="width: 32px;">ab[]</th>' +
+                    '<th style="width: 40px;">cd</th>' +
+                    '<th style="width: 45px;">ef</th>' +
+                    "</tr>" +
+                    '<tr style="height: 30px;">' +
+                    "<td><p><br></p></td>" +
+                    "<td>ab</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef</td>" +
+                    "</tr></tbody></table>",
+            });
+        });
+
         test("should add a column left of the middle column", async () => {
             await testEditor({
                 contentBefore:
@@ -337,6 +367,36 @@ describe("column", () => {
                     "<td>cd</td>" +
                     "<td>ef</td>" +
                     "<td><p><br></p></td>" +
+                    "</tr></tbody></table>",
+            });
+        });
+
+        test("should add a `TH` column after", async () => {
+            await testEditor({
+                contentBefore:
+                    '<table style="width: 150px;"><tbody><tr style="height: 20px;">' +
+                    '<th style="width: 40px;">ab</th>' +
+                    '<th style="width: 50px;">cd[]</th>' +
+                    '<th style="width: 60px;">ef</th>' +
+                    "</tr>" +
+                    '<tr style="height: 30px;">' +
+                    "<td>ab</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef</td>" +
+                    "</tr></tbody></table>",
+                stepFunction: addColumn("after"),
+                contentAfter:
+                    '<table style="width: 150px;"><tbody><tr style="height: 20px;">' +
+                    '<th style="width: 30px;">ab</th>' +
+                    '<th style="width: 38px;">cd[]</th>' +
+                    '<th style="width: 38px;"><p><br></p></th>' +
+                    '<th style="width: 43px;">ef</th>' +
+                    "</tr>" +
+                    '<tr style="height: 30px;">' +
+                    "<td>ab</td>" +
+                    "<td>cd</td>" +
+                    "<td><p><br></p></td>" +
+                    "<td>ef</td>" +
                     "</tr></tbody></table>",
             });
         });

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -78,6 +78,18 @@ test("should not display the table ui menu if we leave the editor content", asyn
     expect(".o-we-table-menu").toHaveCount(0);
 });
 
+test("should display the table ui menu when hovering on TH", async () => {
+    const { el } = await setupEditor(`
+        <table><tbody><tr>
+            <th>11[]</th>
+        </tr></tbody></table>`);
+    expect(".o-we-table-menu").toHaveCount(0);
+
+    await hover(el.querySelector("th"));
+    await animationFrame();
+    expect(".o-we-table-menu").toHaveCount(2);
+});
+
 test.tags("desktop");
 test("should display the resizeCursor if the table element isContentEditable=true", async () => {
     const { el } = await setupEditor(`


### PR DESCRIPTION
**Problem**:
The table menu doesn't appear when hovering over `th` elements.

**Solution**:
Treat `th` elements the same way as `td` to ensure the menu appears.

**Steps to Reproduce**:
1. Setup an editor with the following HTML structure:

   `<table class="table table-bordered o_table">` `  <tbody>`
   `    <tr>`
   `      <th><div class="o-paragraph">Header 1</div></th>`
   `      <th><div class="o-paragraph">Header 2</div></th>`
   `    </tr>`
   `    <tr>`
   `      <td><div class="o-paragraph">Content 1</div></td>`
   `      <td><div class="o-paragraph">Content 2</div></td>`
   `    </tr>`
   `  </tbody>`
   `</table>`

2. Hover over "Header 1".
3. The table menu does not appear.

opw-4610578

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
