### PR TITLE
[FIX] pos_loyalty: "buy x get y" auto apply

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -92,6 +92,16 @@ patch(PosStore.prototype, {
                         (reward.reward_type !== "product" ||
                             (reward.reward_type == "product" && !reward.multi_product))
                     ) {
+                        if (
+                            (reward.reward_type == "product" &&
+                                reward.program_id.applies_on !== "both") ||
+                            (reward.program_id.applies_on == "both" && reward.reward_product_qty)
+                        ) {
+                            this.addLineToCurrentOrder({
+                                product_id: reward.reward_product_id,
+                                qty: reward.reward_product_qty || 1,
+                            });
+                        }
                         order._applyReward(reward, coupon_id);
                         changed = true;
                     }

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
@@ -80,11 +80,10 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
             ProductScreen.clickDisplayedProduct("Magnetic Board"),
             ProductScreen.selectedOrderlineHas("Magnetic Board", "2.00"),
             ProductScreen.clickDisplayedProduct("Magnetic Board"),
-            ProductScreen.selectedOrderlineHas("Magnetic Board", "3.00"),
             PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1.00"),
             PosLoyalty.isRewardButtonHighlighted(false),
 
-            PosLoyalty.orderTotalIs("5.94"),
+            PosLoyalty.orderTotalIs("9.14"),
             PosLoyalty.finalizeOrder("Cash", "10"),
 
             // Promotion: 2 items of shelves, get desk_pad/monitor_stand free
@@ -139,6 +138,20 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour2", {
             SelectionPopup.has("Free Product - Test Product A", { run: "click" }),
             PosLoyalty.hasRewardLine("Free Product - Test Product A", "-11.50", "1.00"),
             PosLoyalty.isRewardButtonHighlighted(false),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_loyalty_free_product_rewards_2", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+
+            ProductScreen.clickDisplayedProduct("Desk Organizer"),
+            ProductScreen.clickDisplayedProduct("Desk Organizer"),
+            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-5.10", "1.00"),
+            PosLoyalty.orderTotalIs("10.20"),
+            PosLoyalty.finalizeOrder("Cash", "10.20"),
         ].flat(),
 });
 

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -404,6 +404,36 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertEqual(loyalty_program.pos_order_count, 1)
         self.assertAlmostEqual(aaa_loyalty_card.points, 5.2)
 
+    def test_loyalty_free_product_rewards_2(self):
+        free_product = self.env['loyalty.program'].create({
+            'name': 'Buy 2 Take 1 desk_organizer',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [(0, 0, {
+                'product_ids': self.desk_organizer,
+                'reward_point_amount': 1,
+                'reward_point_mode': 'order',
+                'minimum_qty': 2,
+            })],
+            'reward_ids': [(0, 0, {
+                'reward_type': 'product',
+                'reward_product_id': self.desk_organizer.id,
+                'reward_product_qty': 1,
+                'required_points': 1,
+            })],
+        })
+        (self.promo_programs | self.coupon_program).write({'active': False})
+
+        self.pos_user.write({
+            'groups_id': [
+                (4, self.env.ref('stock.group_stock_user').id),
+            ]
+        })
+        self.start_pos_tour("test_loyalty_free_product_rewards_2")
+
+        self.assertEqual(free_product.pos_order_count, 1)
+
     def test_pos_loyalty_tour_max_amount(self):
         """Test the loyalty program with a maximum amount and product with different taxe."""
 


### PR DESCRIPTION
In Point of sale promotion program may be auto applied to the order
whenever the conditions of the promotions are satisfied.
However, a promo 'buy x get y' is auto applied inconsistently when
comparing the output with the reward button (or applying the promotion on a sales
order)

Steps to reproduce:
- Have a promo program like follows:
  - Program Type: Buy X Get Y
  - Condition:
    - Minimum quantity: 2
    - Grant: 1 credit per order
    - Product: [PRODUCT]
  - Reward:
    - In exchange of: 1 credit
    - Product: [PRODUCT]
    - Quantity rewarded: 1
- Open POS Session
- Add 2x [Product]

Issue:
- "Free" [PRODUCT] line is added to the order with negative price

So the customer will buy 1 [PRODUCT] and get 2 that is not what we want
with the promo program
If we delete the reward line, click on reward button and choose again
the same promo we get the correct behavior:
- Exisitng [PRODUCT] line quantity raised to 3
- "Free" [PRODUCT] line added to the order with negative price

opw-4563825