### PR TITLE
[FIX] hr_holidays: fix half day visibility in overview

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_model.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_model.js
@@ -34,7 +34,7 @@ export class TimeOffCalendarModel extends CalendarModel {
                 result.title = [employee, result.title].join(" ");
             }
         }
-        if (rawRecord.request_unit_half) result.request_date_from_period = rawRecord.request_date_from_period
+        if (rawRecord.request_unit_half) result.request_date_from_period = rawRecord.request_date_from_period;
         return result;
     }
 
@@ -105,7 +105,7 @@ export class TimeOffCalendarModel extends CalendarModel {
         if (!this.employeeId) {
             context["short_name"] = 1;
         }
-        const fieldNamesToAdd = ["request_unit_half", "request_date_from_period"]
+        const fieldNamesToAdd = resModel === "hr.leave" ? ["request_unit_half", "request_date_from_period"] : [];
         return this.orm.searchRead(resModel, this.computeDomain(data), [...fieldNames, ...fieldNamesToAdd], { context });
     }
 


### PR DESCRIPTION
Problem
----------
In the timeoff overview, an error occurs on the calendar view. hr.leave.report.calendar and hr.leave models use the same js class with a different renderer but the same model. In this model "request_unit_half" and "request_date_from_period" field are used but these fields are only in hr.leave ...

Objective
----------
Fix the calendar view from overview (half days don't have to be visible)

Solution
----------
Add "request_unit_half" and "request_date_from_period"  fieldsName if the model == "hr.leave"

task-4613265