### PR TITLE
[FIX] *sale*: fix zero-price sale for combos

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1558,3 +1558,9 @@ class SaleOrderLine(models.Model):
                 [('product_id', 'not in', discount_products_ids)],
             ])
         return domain
+
+    def _get_lines_with_price(self):
+        """ A combo product line always has a zero price (by design). The actual price of the combo
+        product can be computed by summing the prices of its combo items (i.e. its linked lines).
+        """
+        return self.linked_line_ids if self.product_type == 'combo' else self

--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -2,6 +2,7 @@
 
 import itertools
 import random
+
 from collections import defaultdict
 
 from odoo import _, api, fields, models
@@ -345,7 +346,7 @@ class SaleOrder(models.Model):
             ):
                 continue
             if not cheapest_line or cheapest_line_price_unit > line_price_unit:
-                cheapest_line = self._get_order_lines_with_price(line)
+                cheapest_line = line._get_lines_with_price()
                 cheapest_line_price_unit = line_price_unit
         return cheapest_line
 
@@ -384,7 +385,7 @@ class SaleOrder(models.Model):
                 and not line.combo_item_id
                 and line.product_id.filtered_domain(domain)
             ):
-                discountable_lines |= self._get_order_lines_with_price(line)
+                discountable_lines |= line._get_lines_with_price()
         return discountable_lines
 
     def _discountable_specific(self, reward):
@@ -1105,11 +1106,7 @@ class SaleOrder(models.Model):
         return self.order_line.filtered(lambda line: line.product_id and not line.reward_id)
 
     def _get_order_line_price(self, order_line, price_type):
-        return sum(self._get_order_lines_with_price(order_line).mapped(price_type))
-
-    @staticmethod
-    def _get_order_lines_with_price(order_line):
-        return order_line.linked_line_ids if order_line.product_type == 'combo' else order_line
+        return sum(order_line._get_lines_with_price().mapped(price_type))
 
     def _program_check_compute_points(self, programs):
         """
@@ -1147,7 +1144,7 @@ class SaleOrder(models.Model):
                 for rule in program.rule_ids:
                     # Skip lines to which the rule doesn't apply.
                     if line.product_id in so_products_per_rule.get(rule, []):
-                        lines_per_rule[rule] |= self._get_order_lines_with_price(line)
+                        lines_per_rule[rule] |= line._get_lines_with_price()
 
         result = {}
         for program in programs:

--- a/addons/website_sale/controllers/combo_configurator.py
+++ b/addons/website_sale/controllers/combo_configurator.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+from odoo import _
+from odoo.exceptions import UserError
 from odoo.http import request, route
 
 from odoo.addons.sale.controllers.combo_configurator import SaleComboConfiguratorController
@@ -76,6 +77,17 @@ class WebsiteSaleComboConfiguratorController(SaleComboConfiguratorController, We
                 )
                 line_ids.append(item_values['line_id'])
 
+        # The price of a combo product (and thus whether it can be added to the cart) can only be
+        # computed after creating all of its combo item lines.
+        combo_product_line = request.env['sale.order.line'].browse(values['line_id'])
+        if (
+            combo_product_line
+            and sum(combo_product_line._get_lines_with_price().mapped('price_unit')) == 0
+            and combo_product_line.order_id.website_id.prevent_zero_price_sale
+        ):
+            raise UserError(_(
+                "The given product does not have a price therefore it cannot be added to cart.",
+            ))
         values['notification_info'] = self._get_cart_notification_information(order_sudo, line_ids)
         values['cart_quantity'] = order_sudo.cart_quantity
         request.session['website_sale_cart_quantity'] = order_sudo.cart_quantity

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -329,7 +329,9 @@ class SaleOrder(models.Model):
 
         if (
             order_line
+            # Combo product lines will be checked after creating all of their combo item lines.
             and order_line.product_template_id.type != 'combo'
+            and not order_line.combo_item_id
             and order_line.price_unit == 0
             and self.website_id.prevent_zero_price_sale
             and product.service_tracking not in self.env['product.template']._get_product_types_allow_zero_price()

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -63,10 +63,9 @@ class SaleOrderLine(models.Model):
 
     def _get_cart_display_price(self):
         self.ensure_one()
-        is_combo = self.product_type == 'combo'
         price_type = (
             'price_subtotal'
             if self.order_id.website_id.show_line_subtotals_tax_selection == 'tax_excluded'
             else 'price_total'
         )
-        return sum(self.linked_line_ids.mapped(price_type)) if is_combo else self[price_type]
+        return sum(self._get_lines_with_price().mapped(price_type))


### PR DESCRIPTION
Previously:
- Zero-priced combo products could always be sold on eCommerce. However, this shouldn't be allowed if `prevent_zero_price_sale` is enabled.
- Zero-priced combo items couldn't be sold on eCommerce if `prevent_zero_price_sale` was enabled. However, this should always be allowed since only the price of the combo product matters (not its items).