### PR TITLE
[IMP] bus: uniformize websocket worker event

### DIFF
--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -241,7 +241,7 @@ export class WebsocketWorker {
         if (this.newestStartTs && this.newestStartTs > startTs) {
             this.debugModeByClient.set(client, debug);
             this.isDebug = [...this.debugModeByClient.values()].some(Boolean);
-            this.sendToClient(client, "update_state", this.state);
+            this.sendToClient(client, "worker_state_updated", this.state);
             this.sendToClient(client, "initialized");
             return;
         }
@@ -263,7 +263,7 @@ export class WebsocketWorker {
             }
             this.channelsByClient.forEach((_, key) => this.channelsByClient.set(key, []));
         }
-        this.sendToClient(client, "update_state", this.state);
+        this.sendToClient(client, "worker_state_updated", this.state);
         this.sendToClient(client, "initialized");
         if (!this.active) {
             this.sendToClient(client, "outdated");

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -958,7 +958,7 @@ class WebsocketConnectionHandler:
     # Latest version of the websocket worker. This version should be incremented
     # every time `websocket_worker.js` is modified to force the browser to fetch
     # the new worker bundle.
-    _VERSION = "18.0-3"
+    _VERSION = "saas-18.3-1"
 
     @classmethod
     def websocket_allowed(cls, request):


### PR DESCRIPTION
The websocket worker sends two similar events "update_state" and "worker_state_updated". Those two events basically provide the same information. This PR only keeps the "worker_state_updated" event.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
