### PR TITLE
[FIX] web,sale_pdf_quote_builder: restrict uploading non-supported files

### DIFF
--- a/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
+++ b/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
@@ -18,7 +18,7 @@
                                 <field
                                     name="datas"
                                     filename="name"
-                                    options="{'accepted_file_extensions': '.pdf'}"
+                                    options="{'accepted_file_extensions': '.pdf', 'allowed_mime_type' : 'application/pdf'}"
                                     class="oe_inline"
                                 />
                                 <button

--- a/addons/web/static/src/views/fields/binary/binary_field.js
+++ b/addons/web/static/src/views/fields/binary/binary_field.js
@@ -18,6 +18,8 @@ export class BinaryField extends Component {
     static props = {
         ...standardFieldProps,
         acceptedFileExtensions: { type: String, optional: true },
+        // See https://www.iana.org/assignments/media-types/media-types.xhtml
+        allowedMIMETypes: { type: String, optional: true },
         fileNameField: { type: String, optional: true },
     };
     static defaultProps = {
@@ -80,10 +82,16 @@ export const binaryField = {
             name: "accepted_file_extensions",
             type: "string",
         },
+        {
+            label: _t("Allowed file mimetype"),
+            name: "allowed_mime_type",
+            type: "string",
+        },
     ],
     supportedTypes: ["binary"],
     extractProps: ({ attrs, options }) => ({
         acceptedFileExtensions: options.accepted_file_extensions,
+        allowedMIMETypes: options.allowed_mime_type,
         fileNameField: attrs.filename,
     }),
 };

--- a/addons/web/static/src/views/fields/binary/binary_field.xml
+++ b/addons/web/static/src/views/fields/binary/binary_field.xml
@@ -7,6 +7,7 @@
                 <div class="w-100 d-inline-flex gap-1">
                     <FileUploader
                         acceptedFileExtensions="props.acceptedFileExtensions"
+                        allowedMIMETypes="props.allowedMIMETypes"
                         onUploaded.bind="update"
                     >
                         <t name="download" t-if="props.record.resId and !props.record.dirty">
@@ -41,6 +42,7 @@
                 <label class="o_select_file_button btn btn-primary">
                     <FileUploader
                         acceptedFileExtensions="props.acceptedFileExtensions"
+                        allowedMIMETypes="props.allowedMIMETypes"
                         onUploaded.bind="update"
                     >
                         <t t-set-slot="toggler">

--- a/addons/web/static/tests/views/fields/binary_field.test.js
+++ b/addons/web/static/tests/views/fields/binary_field.test.js
@@ -429,3 +429,38 @@ test("isUploading state should be set to false after upload", async () => {
     expect.verifyErrors([/RPC_ERROR/]);
     expect(`.o_select_file_button`).toHaveText("Upload your file");
 });
+
+test("should accept file with allowed MIME type and reject others", async () => {
+    await mountView({
+        resModel: "res.partner",
+        resId: 1,
+        type: "form",
+        arch: `
+            <form>
+                <field name="document" filename="foo" widget="binary" options="{'allowed_mime_type' : 'application/pdf'}"/>
+            </form>
+        `,
+    });
+
+    await click(`.o_select_file_button`);
+    await animationFrame();
+    const pdfFile = new File(["test"], "fake_pdf.pdf", { type: "application/pdf" });
+    await setInputFiles([pdfFile]);
+
+    await waitFor(`.o_form_button_save:visible`);
+    expect(`.o_field_binary input[type=text]`).toHaveAttribute("readonly");
+    expect(`.o_field_binary input[type=text]`).toHaveValue("fake_pdf.pdf");
+
+    await click(`.o_clear_file_button`);
+    await animationFrame();
+
+    await click(`.o_select_file_button`);
+    await animationFrame();
+    const textFile = new File(["test"], "text_file.txt", { type: "text/plain"});
+    await setInputFiles([textFile]);
+    await animationFrame();
+
+    expect(".o_notification").toHaveCount(1);
+    expect(".o_notification_content").toHaveText("Oops! 'text_file.txt' didn’t upload since its format isn’t allowed.");
+    expect(".o_notification_bar").toHaveClass("bg-danger");
+});


### PR DESCRIPTION
Currently an exception is generated when a user uploads an image or non-PDF file in the `File Content (datas)` field of the quotation document.

Steps to produce an error:
- Install `sale_management` and go to `Sales`
- Click Configuration > Headers/Footers > Click on New
- Click `"Upload your file"` and upload a non-PDF (Select `All Files` instead of `.pdf` while uploading the file.)

Error:  `PdfReadError: EOF marker not found`

The `accepted_file_extensions` tag is avaliable that only shows `.pdf` files when users try to upload files, but many users select `All Files` instead of `.pdf` if they do not see the pdf file in the list and try to upload non-pdf  files. Also, the error will occur if users have a file with a `.pdf` extension, but different type.

This commit will fix the above issue by restricting uploading non-supported files that were uploaded by users.

By introducing the `allowed_mime_type` option in binary fields, it prevents users from uploading only supported file if we provide the field option. `accepted_file_extensions` option is avaliable but it works on a browser level, showing PDF files for uploading, but users may select another file by selecting `All files` while uploading.

sentry-6112968654, 6161120972



