### PR TITLE
[IMP] account, analytic, purchase, sale, sale_project: combine analytic distribution from SO/PO, projects, and analytic models

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1060,6 +1060,11 @@ class AccountMoveLine(models.Model):
         cache = {}
         for line in self:
             if line.display_type == 'product' or not line.move_id.is_invoice(include_receipts=True):
+                related_distribution = line._related_analytic_distribution()
+                root_plans = self.env['account.analytic.account'].browse(
+                    list({int(account_id) for ids in related_distribution for account_id in ids.split(',')})
+                ).root_plan_id
+
                 arguments = frozendict({
                     "product_id": line.product_id.id,
                     "product_categ_id": line.product_id.categ_id.id,
@@ -1067,10 +1072,11 @@ class AccountMoveLine(models.Model):
                     "partner_category_id": line.partner_id.category_id.ids,
                     "account_prefix": line.account_id.code,
                     "company_id": line.company_id.id,
+                    "related_root_plan_ids": root_plans,
                 })
                 if arguments not in cache:
                     cache[arguments] = self.env['account.analytic.distribution.model']._get_distribution(arguments)
-                line.analytic_distribution = cache[arguments] or line.analytic_distribution
+                line.analytic_distribution = related_distribution | cache[arguments] or line.analytic_distribution
 
     @api.depends('discount_date', 'date_maturity')
     def _compute_payment_date(self):
@@ -3186,6 +3192,10 @@ class AccountMoveLine(models.Model):
             'company_id': self.company_id.id or self.env.company.id,
             'category': 'invoice' if self.move_id.is_sale_document() else 'vendor_bill' if self.move_id.is_purchase_document() else 'other',
         }
+
+    def _related_analytic_distribution(self):
+        """ Returns the analytic distribution set on the record which triggered the creation of this line. """
+        return {}
 
     # -------------------------------------------------------------------------
     # INSTALLMENTS

--- a/addons/analytic/models/analytic_distribution_model.py
+++ b/addons/analytic/models/analytic_distribution_model.py
@@ -61,10 +61,10 @@ class AccountAnalyticDistributionModel(models.Model):
     def _get_distribution(self, vals):
         """ Returns the combined distribution from all matching models based on the vals dict provided
             This method should be called to prefill analytic distribution field on several models """
-        applicable_models = self._get_applicable_models(vals)
+        applicable_models = self._get_applicable_models({k: v for k, v in vals.items() if k != 'related_root_plan_ids'})
 
         res = {}
-        applied_plans = self.env['account.analytic.plan']
+        applied_plans = vals.get('related_root_plan_ids', self.env['account.analytic.plan'])
         for model in applicable_models:
             # ignore model if it contains an account having a root plan that was already applied
             if not applied_plans & model.distribution_analytic_account_ids.root_plan_id:

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -533,3 +533,10 @@ class AccountMoveLine(models.Model):
             }
             for line in self
         ]
+
+    def _related_analytic_distribution(self):
+        # EXTENDS 'account'
+        vals = super()._related_analytic_distribution()
+        if self.purchase_line_id and not self.analytic_distribution:
+            vals |= self.purchase_line_id.analytic_distribution or {}
+        return vals

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -565,8 +565,6 @@ class PurchaseOrderLine(models.Model):
             'purchase_line_id': self.id,
             'is_downpayment': self.is_downpayment,
         }
-        if self.analytic_distribution and not self.display_type:
-            res['analytic_distribution'] = self.analytic_distribution
         return res
 
     @api.model

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -450,7 +450,8 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
         """
         Test whether, when an analytic plan is set within the scope (applicability) of purchase
         and with an account prefix set in the distribution model,
-        the default analytic account is correctly set during the conversion from po to invoice
+        the default analytic account is correctly set during the conversion from po to invoice.
+        An additional analytic account set manually in another plan is also passed to the invoice.
         """
         self.env.user.groups_id += self.env.ref('analytic.group_analytic_accounting')
         analytic_plan_default = self.env['account.analytic.plan'].create({
@@ -461,6 +462,10 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             })]
         })
         analytic_account_default = self.env['account.analytic.account'].create({'name': 'default', 'plan_id': analytic_plan_default.id})
+        # Create an additional analytic account in another plan
+        analytic_plan_2 = self.env['account.analytic.plan'].create({'name': 'Plan Test'})
+        analytic_account_2 = self.env['account.analytic.account'].create({'name': 'manual', 'plan_id': analytic_plan_2.id})
+        analytic_distribution_manual = {str(analytic_account_2.id): 100}
 
         analytic_distribution_model = self.env['account.analytic.distribution.model'].create({
             'account_prefix': '600',
@@ -475,11 +480,14 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_id': self.product_a.id
         })
         self.assertFalse(po.order_line.analytic_distribution, "There should be no analytic set.")
+        # Add another analytic account to the line. It should be passed to the invoice
+        po.order_line.analytic_distribution = analytic_distribution_manual
         po.button_confirm()
         po.order_line.qty_received = 1
         po.action_create_invoice()
-        self.assertRecordValues(po.invoice_ids.invoice_line_ids,
-                                [{'analytic_distribution': analytic_distribution_model.analytic_distribution}])
+        self.assertRecordValues(po.invoice_ids.invoice_line_ids, [{
+            'analytic_distribution': analytic_distribution_model.analytic_distribution | analytic_distribution_manual
+        }])
 
     def test_sequence_invoice_lines_from_multiple_purchases(self):
         """Test if the invoice lines are sequenced by purchase order when creating an invoice

--- a/addons/sale/models/account_move_line.py
+++ b/addons/sale/models/account_move_line.py
@@ -20,6 +20,13 @@ class AccountMoveLine(models.Model):
         super(AccountMoveLine, self)._copy_data_extend_business_fields(values)
         values['sale_line_ids'] = [(6, None, self.sale_line_ids.ids)]
 
+    def _related_analytic_distribution(self):
+        # EXTENDS 'account'
+        vals = super()._related_analytic_distribution()
+        if self.sale_line_ids and not self.analytic_distribution:
+            vals |= self.sale_line_ids.analytic_distribution or {}
+        return vals
+
     def _prepare_analytic_lines(self):
         """ Note: This method is called only on the move.line that having an analytic distribution, and
             so that should create analytic entries.

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1401,7 +1401,6 @@ class SaleOrderLine(models.Model):
             'sale_line_ids': [Command.link(self.id)],
             'is_downpayment': self.is_downpayment,
         }
-        self._set_analytic_distribution(res, **optional_values)
         downpayment_lines = self.invoice_lines.filtered('is_downpayment')
         if self.is_downpayment and downpayment_lines:
             res['account_id'] = downpayment_lines.account_id[:1].id

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -792,8 +792,8 @@ class TestSaleToInvoice(TestSaleCommon):
     def test_invoice_analytic_rule_with_account_prefix(self):
         """
         Test whether, when an analytic account rule is set within the scope (applicability) of invoice
-        and with an account prefix set,
-        the default analytic account is correctly set during the conversion from so to invoice
+        and with an account prefix set, the default analytic account is correctly set during the conversion from
+        so to invoice. An additional analytic account set manually in another plan is also passed to the invoice.
         """
         self.env.user.groups_id += self.env.ref('analytic.group_analytic_accounting')
         analytic_plan_default = self.env['account.analytic.plan'].create({
@@ -804,6 +804,10 @@ class TestSaleToInvoice(TestSaleCommon):
             })]
         })
         analytic_account_default = self.env['account.analytic.account'].create({'name': 'default', 'plan_id': analytic_plan_default.id})
+        # Create an additional analytic account in another plan
+        analytic_plan_2 = self.env['account.analytic.plan'].create({'name': 'manual'})
+        analytic_account_2 = self.env['account.analytic.account'].create({'name': 'manual', 'plan_id': analytic_plan_2.id})
+        analytic_distribution_manual = {str(analytic_account_2.id): 100}
 
         analytic_distribution_model = self.env['account.analytic.distribution.model'].create({
             'account_prefix': '400000',
@@ -818,10 +822,11 @@ class TestSaleToInvoice(TestSaleCommon):
             'product_id': self.product_a.id
         })
         self.assertFalse(so.order_line.analytic_distribution, "There should be no tag set.")
+        so.order_line.analytic_distribution = analytic_distribution_manual
         so.action_confirm()
         so.order_line.qty_delivered = 1
         aml = so._create_invoices().invoice_line_ids
-        self.assertRecordValues(aml, [{'analytic_distribution': analytic_distribution_model.analytic_distribution}])
+        self.assertRecordValues(aml, [{'analytic_distribution': analytic_distribution_model.analytic_distribution | analytic_distribution_manual}])
 
     def test_invoice_after_product_return_price_not_default(self):
         so = self.env['sale.order'].create({

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -137,12 +137,20 @@ class SaleOrderLine(models.Model):
     def _compute_analytic_distribution(self):
         super()._compute_analytic_distribution()
         for line in self:
-            if line.display_type or line.analytic_distribution or not line.product_id:
-                continue
             project = line.product_id.project_id or line.order_id.project_id
-            distribution = project._get_analytic_distribution()
-            if distribution:
-                line.analytic_distribution = distribution
+            if line.display_type or not line.product_id or not project:
+                continue
+
+            if line.analytic_distribution:
+                applied_root_plans = self.env['account.analytic.account'].browse(
+                    list({int(account_id) for ids in line.analytic_distribution for account_id in ids.split(",")})
+                ).root_plan_id
+                if accounts_to_add := project._get_analytic_accounts().filtered(
+                    lambda account: account.root_plan_id not in applied_root_plans
+                ):
+                    line.analytic_distribution |= {",".join(str(account_id.id) for account_id in accounts_to_add): 100}
+            else:
+                line.analytic_distribution = project._get_analytic_distribution()
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -431,7 +439,7 @@ class SaleOrderLine(models.Model):
             to this sale order line, or the analytic account of the project which uses this sale order line, if it exists.
         """
         values = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
-        if not values.get('analytic_distribution'):
+        if not values.get('analytic_distribution') and not self.analytic_distribution:
             if self.task_id.project_id.account_id:
                 values['analytic_distribution'] = {self.task_id.project_id.account_id.id: 100}
             elif self.project_id.account_id:

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -518,6 +518,63 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         self.assertEqual(sale_order.project_id[analytic_plan_name], sale_order.project_ids[analytic_plan_name], "The project created for the SO and the project of the SO should have the same account.")
         self.assertEqual(self.env.company, sale_order.project_ids.company_id, "The project created for the SO should have the same company as its account.")
 
+    def test_project_creation_on_so_with_manual_analytic(self):
+        """ Tests that the manually added analytic account (of a plan other than projects) and the project account
+            created when SO is confirmed are both still in the line after confirmation.
+        """
+        analytic_distribution_manual = {str(self.analytic_account_sale.id): 100}
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'partner_invoice_id': self.partner.id,
+            'partner_shipping_id': self.partner.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product_order_service3.id,
+                    'analytic_distribution': analytic_distribution_manual,
+                }),
+            ],
+        })
+        self.assertEqual(sale_order.order_line.analytic_distribution, analytic_distribution_manual)
+        sale_order.action_confirm()
+        expected_analytic_distribution = analytic_distribution_manual | {str(sale_order.order_line.project_id.account_id.id): 100}
+        self.assertEqual(sale_order.order_line.analytic_distribution, expected_analytic_distribution)
+
+    def test_project_on_sol_with_analytic_distribution_model(self):
+        """ If a line has a distribution coming from an analytic distribution model, and the sale order has a project,
+            both the project account and the accounts from the ADM should still be in the line after confirmation.
+        """
+        distribution_model = self.env['account.analytic.distribution.model'].create({
+            'product_id': self.product_a.id,
+            'analytic_distribution': {self.analytic_account_sale.id: 100},
+            'company_id': self.company.id,
+        })
+        project = self.env['project.project'].create({
+            'name': 'Project Test',
+            'account_id': self.analytic_account.id,
+            'allow_billable': True,
+        })
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'partner_invoice_id': self.partner.id,
+            'partner_shipping_id': self.partner.id,
+            'project_id': project.id,
+            'order_line': [
+                Command.create({'product_id': self.product_a.id}),
+            ],
+        })
+
+        expected_analytic_distribution = distribution_model.analytic_distribution | {str(project.account_id.id): 100}
+        self.assertEqual(sale_order.order_line.analytic_distribution, expected_analytic_distribution)
+
+        # If the project is removed from the SO, only the product's analytic distribution is still in the line
+        sale_order.project_id = None
+        self.assertEqual(sale_order.order_line.analytic_distribution, distribution_model.analytic_distribution)
+
+        # If project is added and the SO is confirmed, both analytic distributions are in the line
+        sale_order.project_id = project
+        sale_order.action_confirm()
+        self.assertEqual(sale_order.order_line.analytic_distribution, expected_analytic_distribution)
+
     def test_include_archived_projects_in_stat_btn_related_view(self):
         """Checks if the project stat-button action includes both archived and active projects."""
         # Setup


### PR DESCRIPTION
The commits in this PR address two points:

1. An account move created from a Purchase Order or Sales Order with an Analytic Distribution only has the analytical distribution from the PO/SO. The invoice/vendor bill does not add the Analytic Accounts expected from matching Analytic Distribution Models.
2. When confirming a SO with a product that creates a project, the Analytic Distribution of the line is filled with the Analytic Account of the project. But this does not happen if there is already another AA in the line before confirming the SO. Another AA may be there because it was added manually or because of an existing distribution model set on the partner or the product.

More information on each can be found in the commit messages.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
