### PR TITLE
[MOV] account,purchase: Vendor Bills smart button to account

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -80,6 +80,17 @@ msgid "# Reconciled Statement Lines"
 msgstr ""
 
 #. module: account
+#: model:ir.model.fields,field_description:account.field_res_partner__supplier_invoice_count
+#: model:ir.model.fields,field_description:account.field_res_users__supplier_invoice_count
+msgid "# Vendor Bills"
+msgstr ""
+
+#. module: account
+#: model:ir.model.fields,field_description:account.field_account_chart_template__code_digits
+msgid "# of Digits"
+msgstr ""
+
+#. module: account
 #. odoo-python
 #: code:addons/account/models/account_move.py:0
 msgid "#Created by: %s"
@@ -12449,6 +12460,11 @@ msgid "Reconciliation Parts"
 msgstr ""
 
 #. module: account
+#: model_terms:ir.actions.act_window,help:account.res_partner_action_supplier_bills
+msgid "Record a new vendor bill"
+msgstr ""
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_message_tree_audit_log_search
 msgid "Record"
 msgstr ""
@@ -16829,9 +16845,11 @@ msgstr ""
 #. odoo-python
 #: code:addons/account/models/account_analytic_account.py:0
 #: code:addons/account/models/account_journal.py:0
+#: model:ir.actions.act_window,name:account.res_partner_action_supplier_bills
 #: model:ir.model.fields.selection,name:account.selection__account_reconcile_model__counterpart_type__purchase
 #: model:ir.model.fields.selection,name:account.selection__res_company__quick_edit_mode__in_invoices
 #: model_terms:ir.ui.view,arch_db:account.account_analytic_account_view_form_inherit
+#: model_terms:ir.ui.view,arch_db:account.partner_view_buttons
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 #: model_terms:ir.ui.view,arch_db:account.res_partner_view_search
 msgid "Vendor Bills"
@@ -16879,6 +16897,15 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.view_account_invoice_report_search
 #: model_terms:ir.ui.view,arch_db:account.view_partner_bank_search_inherit
 msgid "Vendors"
+msgstr ""
+
+#. module: account
+#: model_terms:ir.actions.act_window,help:account.res_partner_action_supplier_bills
+msgid ""
+"Vendors bills can be pre-generated based on purchase\n"
+"                orders or receipts. This allows you to control bills\n"
+"                you receive from your vendor according to the draft\n"
+"                document in Odoo."
 msgstr ""
 
 #. module: account

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -564,6 +564,7 @@ class ResPartner(models.Model):
     )
     ref_company_ids = fields.One2many('res.company', 'partner_id',
         string='Companies that refers to partner')
+    supplier_invoice_count = fields.Integer(compute='_compute_supplier_invoice_count', string='# Vendor Bills')
     invoice_ids = fields.One2many('account.move', 'partner_id', string='Invoices', readonly=True, copy=False)
     contract_ids = fields.One2many('account.analytic.account', 'partner_id', string='Partner Contracts', readonly=True)
     bank_account_count = fields.Integer(compute='_compute_bank_count', string="Bank")
@@ -635,6 +636,27 @@ class ResPartner(models.Model):
         mapped_data = {partner.id: count for partner, count in bank_data}
         for partner in self:
             partner.bank_account_count = mapped_data.get(partner.id, 0)
+
+    def _compute_supplier_invoice_count(self):
+        # retrieve all children partners and prefetch 'parent_id' on them
+        all_partners = self.with_context(active_test=False).search_fetch(
+            [('id', 'child_of', self.ids)],
+            ['parent_id'],
+        )
+        supplier_invoice_groups = self.env['account.move']._read_group(
+            domain=[('partner_id', 'in', all_partners.ids),
+                    *self.env['account.move']._check_company_domain(self.env.company),
+                    ('move_type', 'in', ('in_invoice', 'in_refund'))],
+            groupby=['partner_id'], aggregates=['__count']
+        )
+        self_ids = set(self._ids)
+
+        self.supplier_invoice_count = 0
+        for partner, count in supplier_invoice_groups:
+            while partner:
+                if partner.id in self_ids:
+                    partner.supplier_invoice_count += count
+                partner = partner.parent_id
 
     def _get_duplicated_bank_accounts(self):
         self.ensure_one()

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -127,6 +127,24 @@
             </field>
         </record>
 
+        <record id="res_partner_action_supplier_bills" model="ir.actions.act_window">
+            <field name="name">Vendor Bills</field>
+            <field name="res_model">account.move</field>
+            <field name="view_mode">list,form,graph</field>
+            <field name="domain">[('move_type','in',('in_invoice', 'in_refund'))]</field>
+            <field name="context">{'search_default_partner_id': active_id, 'default_move_type': 'in_invoice', 'default_partner_id': active_id}</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    Record a new vendor bill
+                </p><p>
+                Vendors bills can be pre-generated based on purchase
+                orders or receipts. This allows you to control bills
+                you receive from your vendor according to the draft
+                document in Odoo.
+            </p>
+            </field>
+        </record>
+
         <record model="ir.ui.view" id="partner_view_buttons">
             <field name="name">partner.view.buttons</field>
             <field name="model">res.partner</field>
@@ -144,6 +162,16 @@
                             </span>
                             <span class="o_stat_text">Invoiced</span>
                         </div>
+                    </button>
+                    <button
+                        class="oe_stat_button"
+                        type="action"
+                        name="%(account.res_partner_action_supplier_bills)d"
+                        groups="account.group_account_invoice"
+                        icon="fa-pencil-square-o" help="Vendor Bills"
+                        invisible="supplier_invoice_count == 0"
+                    >
+                        <field string="Vendor Bills" name="supplier_invoice_count" widget="statinfo"/>
                     </button>
                 </div>
 

--- a/addons/purchase/models/res_partner.py
+++ b/addons/purchase/models/res_partner.py
@@ -29,27 +29,6 @@ class ResPartner(models.Model):
                     partner.purchase_order_count += count
                 partner = partner.parent_id
 
-    def _compute_supplier_invoice_count(self):
-        # retrieve all children partners and prefetch 'parent_id' on them
-        all_partners = self.with_context(active_test=False).search_fetch(
-            [('id', 'child_of', self.ids)],
-            ['parent_id'],
-        )
-        supplier_invoice_groups = self.env['account.move']._read_group(
-            domain=[('partner_id', 'in', all_partners.ids),
-                    *self.env['account.move']._check_company_domain(self.env.company),
-                    ('move_type', 'in', ('in_invoice', 'in_refund'))],
-            groupby=['partner_id'], aggregates=['__count']
-        )
-        self_ids = set(self._ids)
-
-        self.supplier_invoice_count = 0
-        for partner, count in supplier_invoice_groups:
-            while partner:
-                if partner.id in self_ids:
-                    partner.supplier_invoice_count += count
-                partner = partner.parent_id
-
     @api.model
     def _commercial_fields(self):
         return super()._commercial_fields()
@@ -62,7 +41,6 @@ class ResPartner(models.Model):
         groups='purchase.group_purchase_user',
         compute='_compute_purchase_order_count',
     )
-    supplier_invoice_count = fields.Integer(compute='_compute_supplier_invoice_count', string='# Vendor Bills')
     purchase_warn = fields.Selection(WARNING_MESSAGE, 'Purchase Order Warning', help=WARNING_HELP, default="no-message")
     purchase_warn_msg = fields.Text('Message for Purchase Order')
 

--- a/addons/purchase/views/res_partner_views.xml
+++ b/addons/purchase/views/res_partner_views.xml
@@ -121,11 +121,6 @@
             <field name="priority" eval="12"/>
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
-                    <button class="oe_stat_button" name="%(purchase.act_res_partner_2_supplier_invoices)d" type="action"
-                        groups="account.group_account_invoice"
-                        icon="fa-pencil-square-o" help="Vendor Bills">
-                        <field string="Vendor Bills" name="supplier_invoice_count" widget="statinfo"/>
-                    </button>
                 </div>
             </field>
         </record>


### PR DESCRIPTION
Move the Vendor Bills smart button from the `purchase` module to the `account` module.

The views records in `purchase` module are kept as but made empty so that if the user updates the `account` module, it will also update the `purchase` module and hide the smart button from the `purchase` to only keep the new one from the `account` module.

task-4584035