### PR TITLE
[MOV] account,purchase: Vendor Bills smart button to account

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -127,6 +127,24 @@
             </field>
         </record>
 
+        <record id="res_partner_action_supplier_bills" model="ir.actions.act_window">
+            <field name="name">Vendor Bills</field>
+            <field name="res_model">account.move</field>
+            <field name="view_mode">list,form,graph</field>
+            <field name="domain">[('move_type','in',('in_invoice', 'in_refund'))]</field>
+            <field name="context">{'search_default_partner_id': active_id, 'default_move_type': 'in_invoice', 'default_partner_id': active_id}</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    Record a new vendor bill
+                </p><p>
+                Vendors bills can be pre-generated based on purchase
+                orders or receipts. This allows you to control bills
+                you receive from your vendor according to the draft
+                document in Odoo.
+            </p>
+            </field>
+        </record>
+
         <record model="ir.ui.view" id="partner_view_buttons">
             <field name="name">partner.view.buttons</field>
             <field name="model">res.partner</field>
@@ -144,6 +162,16 @@
                             </span>
                             <span class="o_stat_text">Invoiced</span>
                         </div>
+                    </button>
+                    <button
+                        class="oe_stat_button"
+                        type="action"
+                        name="%(account.res_partner_action_supplier_bills)d"
+                        groups="account.group_account_invoice"
+                        icon="fa-pencil-square-o" help="Vendor Bills"
+                        invisible="supplier_invoice_count == 0"
+                    >
+                        <field string="Vendor Bills" name="supplier_invoice_count" widget="statinfo"/>
                     </button>
                 </div>
 

--- a/addons/purchase/models/res_partner.py
+++ b/addons/purchase/models/res_partner.py
@@ -29,27 +29,6 @@ class ResPartner(models.Model):
                     partner.purchase_order_count += count
                 partner = partner.parent_id
 
-    def _compute_supplier_invoice_count(self):
-        # retrieve all children partners and prefetch 'parent_id' on them
-        all_partners = self.with_context(active_test=False).search_fetch(
-            [('id', 'child_of', self.ids)],
-            ['parent_id'],
-        )
-        supplier_invoice_groups = self.env['account.move']._read_group(
-            domain=[('partner_id', 'in', all_partners.ids),
-                    *self.env['account.move']._check_company_domain(self.env.company),
-                    ('move_type', 'in', ('in_invoice', 'in_refund'))],
-            groupby=['partner_id'], aggregates=['__count']
-        )
-        self_ids = set(self._ids)
-
-        self.supplier_invoice_count = 0
-        for partner, count in supplier_invoice_groups:
-            while partner:
-                if partner.id in self_ids:
-                    partner.supplier_invoice_count += count
-                partner = partner.parent_id
-
     @api.model
     def _commercial_fields(self):
         return super()._commercial_fields()
@@ -62,7 +41,6 @@ class ResPartner(models.Model):
         groups='purchase.group_purchase_user',
         compute='_compute_purchase_order_count',
     )
-    supplier_invoice_count = fields.Integer(compute='_compute_supplier_invoice_count', string='# Vendor Bills')
     purchase_warn = fields.Selection(WARNING_MESSAGE, 'Purchase Order Warning', help=WARNING_HELP, default="no-message")
     purchase_warn_msg = fields.Text('Message for Purchase Order')
 

--- a/addons/purchase/views/res_partner_views.xml
+++ b/addons/purchase/views/res_partner_views.xml
@@ -113,20 +113,4 @@
                 </page>
             </field>
         </record>
-
-        <record id="res_partner_view_purchase_account_buttons" model="ir.ui.view">
-            <field name="name">res.partner.view.purchase.account.buttons</field>
-            <field name="model">res.partner</field>
-            <field name="inherit_id" ref="base.view_partner_form" />
-            <field name="priority" eval="12"/>
-            <field name="arch" type="xml">
-                <div name="button_box" position="inside">
-                    <button class="oe_stat_button" name="%(purchase.act_res_partner_2_supplier_invoices)d" type="action"
-                        groups="account.group_account_invoice"
-                        icon="fa-pencil-square-o" help="Vendor Bills">
-                        <field string="Vendor Bills" name="supplier_invoice_count" widget="statinfo"/>
-                    </button>
-                </div>
-            </field>
-        </record>
 </odoo>


### PR DESCRIPTION
Move the Vendor Bills smart button from the `purchase` module to the `account` module.

task-4584035

Upgrade PR: https://github.com/odoo/upgrade/pull/7309