### PR TITLE
[FIX] website_sale: handle countries without states

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1663,7 +1663,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         country = request.env["res.country"].search([
             ('code', '=', address.pop('country')),
         ], limit=1)
-        if state_code := address.pop('state'):
+        if state_code := address.pop('state', False):
             state = request.env['res.country.state'].search([
                 ('code', '=', state_code),
                 ('country_id', '=', country.id),


### PR DESCRIPTION
Versions
--------
- 17.4
- 18.0
- 18.1

Cause of issue was fixed during forward-porting.

Steps
-----
1. Do express checkout from a country without state.

Issue
-----
`RPC_ERROR` caused by a `KeyError`.

Cause
-----
Returned address doesn't have an `state` field, leading to a key error on `address.pop('state')`, which was added in commit 80507191ab26b.

Solution
--------
Add a default value `False` to skip state lookup.

opw-4396024