### PR TITLE
[FIX] purchase: prevent error when print a purchase quotation report

### DIFF
--- a/addons/purchase/i18n/purchase.pot
+++ b/addons/purchase/i18n/purchase.pot
@@ -3120,6 +3120,13 @@ msgid ""
 msgstr ""
 
 #. module: purchase
+#. odoo-python
+#: code:addons/purchase/models/ir_actions_actions.py:0
+#, python-format
+msgid "You cannot delete %s"
+msgstr ""
+
+#. module: purchase
 #: model_terms:ir.actions.act_window,help:purchase.product_product_action
 msgid ""
 "You must define a product for everything you sell or purchase,\n"

--- a/addons/purchase/models/__init__.py
+++ b/addons/purchase/models/__init__.py
@@ -5,6 +5,7 @@ from . import account_invoice
 from . import account_tax
 from . import analytic_account
 from . import analytic_applicability
+from . import ir_actions_actions
 from . import purchase_order
 from . import purchase_order_line
 from . import product

--- a/addons/purchase/models/ir_actions_actions.py
+++ b/addons/purchase/models/ir_actions_actions.py
@@ -1,0 +1,12 @@
+from odoo import models, api, _
+from odoo.exceptions import UserError
+
+
+class IrActionsReport(models.Model):
+    _inherit = 'ir.actions.report'
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_master_action(self):
+        action_report_quotation = self.env["ir.actions.actions"]._for_xml_id("purchase.report_purchase_quotation")
+        if action_report_quotation.get("id") in self.ids:
+            raise UserError(_("You cannot delete %s", action_report_quotation.get("name")))


### PR DESCRIPTION
Currently, an error occurs when printing the purchase quotation report, and external id not available of it.

Steps to produce:

- Install the `purchase` module.
- Enable debug mode.
- Go to Settings / Technical / Actions / Reports, and delete the report name 'Request for Quotation'.
- Create a new purchase order and add a customer.
- Click on 'Print RFQ'.

`ValueError: External ID not found in the system: purchase.report_purchase_quotation`

An error occurs when the system tries to retrieve an external ID of the 'Request for Quotation' report at [1], but it has been deleted.

Link [1]: https://github.com/odoo/odoo/blob/8ec4108b978f00b0a373a28f602780d87aa0d000/addons/purchase/models/purchase_order.py#L488

To resolve this issue, restrict the deletion of the 'Request for Quotation' report from the ir actions, To ensure that users cannot delete it (except during the module uninstallation).

Sentry-6337362999

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
