### PR TITLE
[FIX] im_livechat: start bus on other tabs when chat is created

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -112,6 +112,7 @@ class LivechatController(http.Controller):
         store = Store()
         user_id = None
         country_id = None
+        guest = request.env["mail.guest"]
         # if the user is identifiy (eg: portal user on the frontend), don't use the anonymous name. The user will be added to session.
         if request.session.uid:
             user_id = request.env.user.id
@@ -194,7 +195,8 @@ class LivechatController(http.Controller):
             )
             if guest:
                 store.add_global_values(guest_token=guest._format_auth_cookie())
-        request.env["res.users"]._init_store_data(store)
+        request.env["res.users"].with_context(guest=guest)._init_store_data(store)
+        guest._bus_send_store(store)
         return store.get_result()
 
     def _post_feedback_message(self, channel, rating, reason):

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -94,19 +94,15 @@ export class LivechatService {
                 ? SESSION_STATE.PERSISTED
                 : SESSION_STATE.CREATED;
         }
-        if (this.state === SESSION_STATE.PERSISTED) {
-            await this.busService.addChannel(`mail.guest_${this.guestToken}`);
-        } else {
+        if (this.state !== SESSION_STATE.PERSISTED) {
             this.store.chatHub.preFirstFetchPromise.then(() => {
                 if (!this.store.fetchParams.length) {
                     return;
                 }
                 this.store.initialize({ force: true });
-                this.store.env.services.bus_service.start();
             });
         }
         this.initialized = true;
-        this.env.services["im_livechat.initialized"].ready.resolve();
     }
 
     /**
@@ -142,7 +138,6 @@ export class LivechatService {
         }
         this.thread.fetchNewMessages();
         this.env.services["mail.store"].initialize();
-        this.busService.addChannel(`mail.guest_${this.guestToken}`);
         this.thread.readyToSwapDeferred.then(async () => {
             if (!this.thread) {
                 return;
@@ -194,10 +189,6 @@ export class LivechatService {
      * @param {Object} [saveData]
      */
     _saveLivechatState(saveData) {
-        const { guest_token } = this.store;
-        if (guest_token) {
-            expirableStorage.setItem(GUEST_TOKEN_STORAGE_KEY, guest_token);
-        }
         const ONE_DAY_TTL = 60 * 60 * 24;
         if (this.thread.uuid) {
             cookie.set(LIVECHAT_UUID_COOKIE, this.thread.uuid, ONE_DAY_TTL);
@@ -281,7 +272,9 @@ export const livechatService = {
                 await livechat.leave({ notifyServer: false });
             }
             if (livechat.available) {
-                livechat.initialize();
+                livechat
+                    .initialize()
+                    .then(() => services["im_livechat.initialized"].ready.resolve());
             }
         })();
         return livechat;

--- a/addons/im_livechat/static/src/embed/common/store_service_patch.js
+++ b/addons/im_livechat/static/src/embed/common/store_service_patch.js
@@ -14,6 +14,7 @@ patch(Store.prototype, {
         if (livechatService.state === SESSION_STATE.PERSISTED || force) {
             try {
                 await super.initialize();
+                await this.fetchDeferred;
                 livechatService.thread ??= this.store.Thread.get({
                     id: livechatService.savedState?.store["discuss.channel"][0].id,
                     model: "discuss.channel",

--- a/addons/im_livechat/static/src/embed/cors/store_service_patch.js
+++ b/addons/im_livechat/static/src/embed/cors/store_service_patch.js
@@ -1,0 +1,29 @@
+import { patch } from "@web/core/utils/patch";
+import { Store } from "@mail/model/store";
+import { Record } from "@mail/model/record";
+import { expirableStorage } from "@im_livechat/embed/common/expirable_storage";
+
+export const GUEST_TOKEN_STORAGE_KEY = "im_livechat_guest_token";
+patch(Store.prototype, {
+    setup() {
+        super.setup(...arguments);
+        expirableStorage.onChange(GUEST_TOKEN_STORAGE_KEY, (value) => (this.guest_token = value));
+        this.guest_token = Record.attr(null, {
+            compute() {
+                return expirableStorage.getItem(GUEST_TOKEN_STORAGE_KEY);
+            },
+            onUpdate() {
+                if (this.guest_token) {
+                    expirableStorage.setItem(GUEST_TOKEN_STORAGE_KEY, this.guest_token);
+                    this.store.env.services.bus_service.addChannel(
+                        `mail.guest_${this.guest_token}`
+                    );
+                    return;
+                }
+                expirableStorage.removeItem(GUEST_TOKEN_STORAGE_KEY);
+                this.store.env.services.bus_service.deleteChannel(`mail.guest_${this.guest_token}`);
+            },
+            eager: true,
+        });
+    },
+});

--- a/addons/im_livechat/static/tests/embed/expirable_storage.test.js
+++ b/addons/im_livechat/static/tests/embed/expirable_storage.test.js
@@ -2,10 +2,11 @@ import { expirableStorage } from "@im_livechat/embed/common/expirable_storage";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { mockDate } from "@odoo/hoot-mock";
+import { asyncStep, waitForSteps } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 
-test("value is removed from expirable storage after expiration", async () => {
+test("value is removed from expirable storage after expiration", () => {
     mockDate("2023-01-01 00:00:00");
     const ONE_DAY = 60 * 60 * 24;
     expirableStorage.setItem("foo", "bar", ONE_DAY);
@@ -14,4 +15,21 @@ test("value is removed from expirable storage after expiration", async () => {
     expect(expirableStorage.getItem("foo")).toBe("bar");
     mockDate("2023-01-02 00:00:01");
     expect(expirableStorage.getItem("foo")).toBe(null);
+});
+
+test("subscribe/unsubscribe to storage changes", async () => {
+    const fooCallback = (value) => asyncStep(`foo - ${value}`);
+    const barCallback = (value) => asyncStep(`bar - ${value}`);
+    expirableStorage.onChange("foo", fooCallback);
+    expirableStorage.onChange("bar", barCallback);
+    expirableStorage.setItem("foo", 1);
+    await waitForSteps(["foo - 1"]);
+    expirableStorage.setItem("bar", 2);
+    await waitForSteps(["bar - 2"]);
+    expirableStorage.removeItem("foo");
+    await waitForSteps(["foo - null"]);
+    expirableStorage.offChange("foo", fooCallback);
+    expirableStorage.setItem("foo", 3);
+    expirableStorage.removeItem("bar");
+    await waitForSteps(["bar - null"]);
 });

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -82,6 +82,15 @@ export class Store extends BaseStore {
 
     /** This is the current logged partner / guest */
     self = Record.one("Persona");
+    allChannels = Record.many("Thread", {
+        inverse: "storeAsAllChannels",
+        onUpdate() {
+            const busService = this.store.env.services.bus_service;
+            if (!busService.isActive && this.allChannels.some((t) => !t.isTransient)) {
+                busService.start();
+            }
+        },
+    });
     /**
      * Indicates whether the current user is using the application through the
      * public page.

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -68,6 +68,14 @@ export class Thread extends Record {
     allMessages = Record.many("mail.message", {
         inverse: "thread",
     });
+    storeAsAllChannels = Record.one("Store", {
+        compute() {
+            if (this.model === "discuss.channel") {
+                return this.store;
+            }
+        },
+        eager: true,
+    });
     /** @type {boolean} */
     areAttachmentsLoaded = false;
     group_public_id = Record.one("res.groups");

--- a/addons/mail/static/src/core/web/mail_core_web_service.js
+++ b/addons/mail/static/src/core/web/mail_core_web_service.js
@@ -80,7 +80,6 @@ export class MailCoreWeb {
                 inbox.fetchMoreMessages();
             }
         });
-        this.busService.start();
     }
 }
 

--- a/addons/mail/static/src/discuss/core/public/discuss_core_public_service.js
+++ b/addons/mail/static/src/discuss/core/public/discuss_core_public_service.js
@@ -6,9 +6,7 @@ export const discussCorePublic = {
      * @param {import("@web/env").OdooEnv} env
      * @param {import("services").ServiceFactories} services
      */
-    start(env, services) {
-        services.bus_service.start();
-    },
+    start(env, services) {},
 };
 
 registry.category("services").add("discuss.core.public", discussCorePublic);

--- a/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
@@ -41,7 +41,6 @@ export class DiscussCoreWeb {
                 this.store.channels.fetch();
             }
         });
-        this.busService.start();
     }
 }
 


### PR DESCRIPTION
Before this PR, creating a live chat in a first tab would correctly open the chat window in a second tab. However, messages were not received in real-time before the second tab reload. This issue occurs because the bus service is not started in the second tab.

To solve this issue, the bus service is now started when there is at least one thread known locally. The behavior stays lazy, nothing is starting until required.

part of task-4607689

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
