### PR TITLE
[IMP] website, *: improve popover orientation for insert snippet modal

### DIFF
--- a/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
+++ b/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
@@ -61,6 +61,8 @@ export class AddSnippetDialog extends Component {
         this.state = useState({
             groupSelected: [],
             search: "",
+            hasNoSearchResults: false,
+            isIframeContentLoaded: false,
         });
 
         onMounted(async () => {
@@ -138,6 +140,7 @@ export class AddSnippetDialog extends Component {
                     || strMatches(snippet.displayName)
                     || strMatches(snippet.data.oeKeywords || '');
             });
+            this.state.hasNoSearchResults = !Boolean(snippetsToDisplay.length);
             // Make sure to show the snippets that "better" match first
             if (selectorSearch) {
                 snippetsToDisplay.sort((snippetA, snippetB) => {
@@ -363,6 +366,7 @@ export class AddSnippetDialog extends Component {
                 for (const el of colItemEls) {
                     colEl.appendChild(el);
                     el.classList.remove("invisible");
+                    this.state.isIframeContentLoaded = true;
                 }
             }
 

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2887,6 +2887,17 @@ we-select.o_grid we-toggler {
 }
 
 // Add snippets dialog iframe.
+.o_add_snippet_dialog_iframe_loader {
+    // This loader will appear after a 1s delay, ensuring it doesn't disrupt the
+    // experience for users with a good connection.
+    visibility: hidden;
+    animation: showLoader 0s 1s forwards;
+}
+@keyframes showLoader {
+    to {
+        visibility: visible;
+    }
+}
 .o_add_snippets_preview {
     overflow: hidden;
 

--- a/addons/web_editor/static/src/xml/add_snippet_dialog.xml
+++ b/addons/web_editor/static/src/xml/add_snippet_dialog.xml
@@ -28,9 +28,21 @@
                     </div>
                 </aside>
                 <div class="position-relative flex-grow-1 flex-shrink-1">
-                    <div class="spinner-grow position-absolute top-50 start-50 translate-middle" role="status">
-                        <span class="visually-hidden">Loading...</span>
-                    </div>
+                    <t t-if="state.search and state.hasNoSearchResults">
+                        <div class="d-flex flex-column justify-content-center text-center h-100 p-4" role="status">
+                            <img src="/web/static/img/smiling_face.svg" alt="No snippets found" class="h-25 mb-3"/>
+                            <p class="h2 mb-2">Oops! No snippets found.</p>
+                            <p class="h4">Take a look at the search bar, there might be a small typo!</p>
+                        </div>
+                    </t>
+                    <t t-elif="!state.isIframeContentLoaded">
+                        <div class="o_add_snippet_dialog_iframe_loader d-flex flex-column justify-content-center text-center h-100 p-4" role="status">
+                            <i class="fa fa-3x fa-circle-o-notch fa-spin"></i>
+                            <p class="h3 mt-3">
+                                Almost there! Snippets are incoming, grab a coffee and relax!
+                            </p>
+                        </div>
+                    </t>
                     <iframe class="border-0 fade bg-200 position-relative o_add_snippet_iframe" tabindex="-1" t-ref="iframe" src="about:blank" height="333%" width="333%"/>
                 </div>
             </div>

--- a/addons/website/static/tests/tours/add_snippet_dialog.js
+++ b/addons/website/static/tests/tours/add_snippet_dialog.js
@@ -1,0 +1,31 @@
+import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "website_add_snippet_dialog",
+    {
+        edition: true,
+        url: "/",
+    },
+    () => [
+        {
+            content: "Click on any snippet to open the 'Insert Snippet' dialog.",
+            trigger: ".o_panel_body div.oe_snippet",
+            run: "click",
+        },
+        {
+            content: "Ensure that snippets are displayed.",
+            trigger: ":iframe .o_add_snippets_preview [data-snippet-id]",
+        },
+        {
+            content:
+                "Enter a search term that does not match any snippet to test empty results behavior.",
+            trigger: ".modal input",
+            run: "edit NoSnippetsAvailable",
+        },
+        {
+            content: "Verify that the appropriate message is displayed when no snippets are found.",
+            trigger:
+                "p:contains('Oops! No snippets found.'), p:contains('Take a look at the search bar, there might be a small typo!')",
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -744,3 +744,6 @@ class TestUi(HttpCaseWithWebsiteUser):
 
     def test_website_seo_notification(self):
         self.start_tour(self.env['website'].get_client_action_url("/"), "website_seo_notification", login="admin")
+
+    def test_website_add_snippet_dialog(self):
+        self.start_tour("/", "website_add_snippet_dialog", login="admin")


### PR DESCRIPTION
\*: web_editor

This PR enhances the popover orientation in the insert snippet modal by adding engaging visual feedback. It also highlights user typos while searching for snippets.

Key changes:
1. Improve visual feedback when snippets take time to load due to slow internet connections.
2. Provide a helpful message to guide users toward the correct input.

task-4592140