### PR TITLE
[FIX] portal, web, website: fix used Interaction.waitFor.then and more

### DIFF
--- a/addons/portal/static/src/interactions/portal_security.js
+++ b/addons/portal/static/src/interactions/portal_security.js
@@ -107,12 +107,14 @@ export class PortalSecurity extends Interaction {
         });
     }
     async onRemoveApiKeyClick(ev) {
-        await handleCheckIdentity(
-            this.waitFor(
-                this.services.orm.call("res.users.apikeys", "remove", [parseInt(ev.target.id)])
-            ),
-            this.services.orm,
-            this.services.dialog
+        await this.waitFor(
+            await handleCheckIdentity(
+                this.waitFor(
+                    this.services.orm.call("res.users.apikeys", "remove", [parseInt(ev.target.id)])
+                ),
+                this.services.orm,
+                this.services.dialog
+            )
         );
         window.location.reload();
     }

--- a/addons/web/static/src/public/colibri.js
+++ b/addons/web/static/src/public/colibri.js
@@ -345,4 +345,14 @@ export class Colibri {
         this.isDestroyed = true;
         this.isReady = false;
     }
+
+    /**
+     * Patchable mechanism to handle context-specific protection of a specific
+     * chunk of synchronous code after returning from an asynchronous one.
+     * This should typically be used around code that follows an
+     * await waitFor(...).
+     */
+    protectSyncAfterAsync(interaction, name, fn) {
+        return fn.bind(interaction);
+    }
 }

--- a/addons/web/static/src/public/interaction.js
+++ b/addons/web/static/src/public/interaction.js
@@ -195,10 +195,21 @@ export class Interaction {
     }
 
     /**
+     * Mechanism to handle context-specific protection of a specific
+     * chunk of synchronous code after returning from an asynchronous one.
+     * This should typically be used around code that follows an
+     * await waitFor(...).
+     */
+    protectSyncAfterAsync(fn) {
+        return this.__colibri__.protectSyncAfterAsync(this, "protectSyncAfterAsync", fn);
+    }
+
+    /**
      * Wait for a specific timeout, then execute the given function (unless the
      * interaction has been destroyed). The dynamic content is then applied.
      */
     waitForTimeout(fn, delay) {
+        fn = this.__colibri__.protectSyncAfterAsync(this, "waitForTimeout", fn);
         return setTimeout(() => {
             if (!this.isDestroyed) {
                 fn.call(this);
@@ -214,6 +225,7 @@ export class Interaction {
      * interaction has been destroyed). The dynamic content is then applied.
      */
     waitForAnimationFrame(fn) {
+        fn = this.__colibri__.protectSyncAfterAsync(this, "waitForAnimationFrame", fn);
         return window.requestAnimationFrame(() => {
             if (!this.isDestroyed) {
                 fn.call(this);
@@ -228,6 +240,7 @@ export class Interaction {
      * Debounces a function and makes sure it is cancelled upon destroy.
      */
     debounced(fn, delay) {
+        fn = this.__colibri__.protectSyncAfterAsync(this, "debounced", fn);
         const debouncedFn = debounce(async (...args) => {
             await fn.apply(this, args);
             if (this.isReady && !this.isDestroyed) {
@@ -254,6 +267,7 @@ export class Interaction {
      * Throttles a function for animation and makes sure it is cancelled upon destroy.
      */
     throttled(fn) {
+        fn = this.__colibri__.protectSyncAfterAsync(this, "throttled", fn);
         const throttledFn = throttleForAnimation(async (...args) => {
             await fn.apply(this, args);
             if (this.isReady && !this.isDestroyed) {
@@ -282,6 +296,7 @@ export class Interaction {
      * more than 400ms.
      */
     locked(fn, useLoadingAnimation = false) {
+        fn = this.__colibri__.protectSyncAfterAsync(this, "locked", fn);
         if (useLoadingAnimation) {
             return makeButtonHandler(fn);
         } else {

--- a/addons/web/static/tests/public/interaction.test.js
+++ b/addons/web/static/tests/public/interaction.test.js
@@ -41,6 +41,23 @@ const getTemplateWithAttribute = function (attribute) {
     </div>`;
 };
 
+function installProtect() {
+    patchWithCleanup(Colibri.prototype, {
+        updateContent() {
+            expect.step("updateContent");
+            super.updateContent();
+        },
+        protectSyncAfterAsync(interaction, name, fn) {
+            fn = super.protectSyncAfterAsync(interaction, name, fn);
+            return (...args) => {
+                expect.step("protect");
+                fn(...args);
+                expect.step("unprotect");
+            };
+        },
+    });
+}
+
 describe("adding listeners", () => {
     test("can add a listener on a single element", async () => {
         let clicked = 0;
@@ -594,9 +611,9 @@ describe("handling crashes", () => {
             static selector = ".test";
             dynamicContent = { "t-on-click": () => {} };
         }
-        await expect(startInteraction(Test, TemplateTest))
-            .rejects
-            .toThrow("Selector missing for key t-on-click in dynamicContent (interaction 'Test')");
+        await expect(startInteraction(Test, TemplateTest)).rejects.toThrow(
+            "Selector missing for key t-on-click in dynamicContent (interaction 'Test')"
+        );
     });
 });
 
@@ -1060,6 +1077,22 @@ describe("waitFor...", () => {
             await advanceTime(50);
             expect.verifySteps(["named function"]);
         });
+
+        test("waitForTimeout runs through protect", async () => {
+            installProtect();
+            class Test extends Interaction {
+                static selector = ".test";
+                setup() {
+                    this.waitForTimeout(() => {
+                        expect.step("done");
+                    }, 100);
+                }
+            }
+            await startInteraction(Test, TemplateTest);
+            expect.verifySteps(["updateContent"]);
+            await advanceTime(100);
+            expect.verifySteps(["protect", "done", "unprotect", "updateContent"]);
+        });
     });
 
     describe("waitForAnimationFrame", () => {
@@ -1109,6 +1142,22 @@ describe("waitFor...", () => {
             await animationFrame();
             expect.verifySteps(["named function", "anonymous function"]);
         });
+    });
+
+    test("waitForAnimationFrame runs through protect", async () => {
+        installProtect();
+        class Test extends Interaction {
+            static selector = ".test";
+            setup() {
+                this.waitForAnimationFrame(() => {
+                    expect.step("done");
+                });
+            }
+        }
+        await startInteraction(Test, TemplateTest);
+        expect.verifySteps(["updateContent"]);
+        await animationFrame();
+        expect.verifySteps(["protect", "done", "unprotect", "updateContent"]);
     });
 });
 
@@ -1977,6 +2026,24 @@ describe("locked", () => {
         await click("button");
         expect.verifySteps(["value"]);
     });
+
+    test("locked event handler runs through protect", async () => {
+        installProtect();
+        class Test extends Interaction {
+            static selector = ".test";
+            dynamicContent = {
+                _root: {
+                    "t-on-click": this.locked(() => {
+                        expect.step("done");
+                    }),
+                },
+            };
+        }
+        await startInteraction(Test, TemplateTest);
+        expect.verifySteps(["updateContent"]);
+        await click(queryOne(".test"));
+        expect.verifySteps(["protect", "done", "unprotect", "updateContent"]);
+    });
 });
 
 describe("debounced (1)", () => {
@@ -2197,6 +2264,26 @@ describe("debounced (2)", () => {
         expect(clicked).toBe(1);
         expect("span").toHaveAttribute("x", "1");
     });
+
+    test("debounced event handler runs through protect", async () => {
+        installProtect();
+        class Test extends Interaction {
+            static selector = ".test";
+            dynamicContent = {
+                _root: {
+                    "t-on-click": this.debounced(() => {
+                        expect.step("done");
+                    }, 100),
+                },
+            };
+        }
+        await startInteraction(Test, TemplateTest);
+        expect.verifySteps(["updateContent"]);
+        await click(queryOne(".test"));
+        expect.verifySteps([]);
+        await advanceTime(100);
+        expect.verifySteps(["protect", "done", "unprotect", "updateContent"]);
+    });
 });
 
 describe("throttled_for_animation (1)", () => {
@@ -2374,6 +2461,30 @@ describe("throttled_for_animation (2)", () => {
         await animationFrame();
         expect(clicked).toBe(1);
         expect("span").toHaveAttribute("x", "1");
+    });
+
+    test("throttled event handler runs through protect", async () => {
+        installProtect();
+        class Test extends Interaction {
+            static selector = ".test";
+            dynamicContent = {
+                _root: {
+                    "t-on-click": this.throttled(() => {
+                        expect.step("done");
+                    }),
+                },
+            };
+        }
+        await startInteraction(Test, TemplateTest);
+        expect.verifySteps(["updateContent"]);
+        const testEl = queryOne(".test");
+        await click(testEl);
+        await click(testEl);
+        expect.verifySteps(["protect", "done", "unprotect", "updateContent"]);
+        await animationFrame();
+        expect.verifySteps(["protect", "done", "unprotect", "updateContent"]);
+        await animationFrame();
+        expect.verifySteps([]);
     });
 });
 

--- a/addons/website/static/src/core/website_edit_service.js
+++ b/addons/website/static/src/core/website_edit_service.js
@@ -95,6 +95,18 @@ PublicRoot.include({
 // Patch Colibri.
 
 patch(Colibri.prototype, {
+    protectSyncAfterAsync(interaction, name, fn) {
+        fn = super.protectSyncAfterAsync(interaction, name, fn);
+        const fullName = `${interaction.constructor.name}/${name}`;
+        return (...args) => {
+            // TODO No jQuery ?
+            const wysiwyg = window.$?.("#wrapwrap").data("wysiwyg");
+            wysiwyg?.odooEditor.observerUnactive(fullName);
+            const result = fn(...args);
+            wysiwyg?.odooEditor.observerActive(fullName);
+            return result;
+        };
+    },
     addListener(target, event, fn, options) {
         fn = fn.bind(this.interaction);
         let stealth = true;

--- a/addons/website/static/src/interactions/video/background_video.js
+++ b/addons/website/static/src/interactions/video/background_video.js
@@ -46,7 +46,7 @@ export class BackgroundVideo extends Interaction {
         const promise = setupAutoplay(this.videoSrc, !!this.el.dataset.needCookiesApproval);
         if (promise) {
             this.videoSrc += "&enablejsapi=1";
-            this.waitFor(promise).then(() => this.appendBgVideo());
+            this.waitFor(promise).then(this.protectSyncAfterAsync(this.appendBgVideo));
         }
     }
 

--- a/addons/website/static/src/interactions/video/media_video.js
+++ b/addons/website/static/src/interactions/video/media_video.js
@@ -30,7 +30,7 @@ export class MediaVideo extends Interaction {
         if (iframeEl.hasAttribute('src')) {
             const promise = setupAutoplay(iframeEl.getAttribute('src'), !!this.el.dataset.needCookiesApproval);
             if (promise) {
-                this.waitFor(promise).then(() => triggerAutoplay(iframeEl));
+                this.waitFor(promise).then(this.protectSyncAfterAsync(() => triggerAutoplay(iframeEl)));
             }
         }
     }

--- a/addons/website_forum/static/src/interactions/website_forum_spam.js
+++ b/addons/website_forum/static/src/interactions/website_forum_spam.js
@@ -30,7 +30,7 @@ export class WebsiteForumSpam extends Interaction {
      */
     async onSpamSearchInput(ev) {
         const toSearch = ev.target.value;
-        const posts = await this.keepLast.add(
+        const posts = await this.waitFor(this.keepLast.add(
             this.waitFor(this.services.orm.searchRead(
                 "forum.post",
                 [["id", "in", this.spamIDs],
@@ -39,7 +39,7 @@ export class WebsiteForumSpam extends Interaction {
                 ["content", "ilike", toSearch]],
                 ["name", "content"]
             ))
-        );
+        ));
         const postSpamEl = this.el.querySelector("div.post_spam");
         const postSpamElContent = postSpamEl.children;
         postSpamEl.replaceChildren();


### PR DESCRIPTION
    [FIX] web, website: wrap interaction's indirect functions

    In website, the behavior of interactions is supposed to not impact the
    edition state. However some asynchronous code was not protected against
    this:
    - A: code inside the functions given to `debounced`, `throttled`,
    `locked`, `waitForTimeout` or `waitForAnimationFrame`.
    - B: code after an `await this.waitFor()`

    This commit fixes this by wrapping the function given to the calls in
    (A) when used in edit mode, and by allowing a second function parameter
    for `waitFor` which also gets wrapped in edit mode.

---

    In Interactions, the purpose of `waitFor` is to make sure that further
    code is not executed if the Interaction was destroyed before the
    operation completed.
    However, when used in website, it will also serve the purpose of knowing
    that Interaction code is running - typically to possibly handle the
    changes in the DOM differently within the history.
    Because of this, using `.then` on the result of a `waitFor` is wrong.

    This commit adapts code that did it.

    task-4367641
