### PR TITLE
[FIX] stock: add `nbSelected` accessor to list controller

### DIFF
--- a/addons/stock/static/src/views/stock_orderpoint_list_controller.js
+++ b/addons/stock/static/src/views/stock_orderpoint_list_controller.js
@@ -11,6 +11,10 @@ export class StockOrderpointListController extends ListController {
         DropdownItem,
     }
 
+    get nbSelected() {
+        return this.model.root.selection.length;
+    }
+
     async onClickOrder(force_to_max) {
         const resIds = await this.model.root.getResIds(true);
         const action = await this.model.orm.call(this.props.resModel, 'action_replenish', [resIds], {


### PR DESCRIPTION
Buttons in the `stock.StockOrderpoint.listView` template depend on the `nbSelected` method that was moved out of the list controller, so we're adding it back.

Task ID: [4614152](https://www.odoo.com/odoo/project/966/tasks/4614152)
