### PR TITLE
[IMP] l10n_ee: new VAT rates for 2025

### DIFF
--- a/addons/l10n_ee/__manifest__.py
+++ b/addons/l10n_ee/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Estonia - Accounting',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
 This is the base module to manage the accounting chart for Estonia in Odoo.

--- a/addons/l10n_ee/data/account_fiscal_position_template_data.xml
+++ b/addons/l10n_ee/data/account_fiscal_position_template_data.xml
@@ -93,6 +93,13 @@
         <field name="tax_dest_id" ref="l10n_ee_vat_out_0_eu_g"/>
     </record>
 
+    <!-- Sales of Goods 24% -> Sales of Goods in EU 0% IC -->
+    <record id="afptt_eu_ic_1_24" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="afpt_eu_ic"/>
+        <field name="tax_src_id" ref="l10n_ee_vat_out_24_g"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_out_0_eu_g"/>
+    </record>
+
     <!-- Sales of Services 20% -> Sales of Services in EU 0% IC -->
     <record id="afptt_eu_ic_2" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_eu_ic"/>
@@ -104,6 +111,13 @@
     <record id="afptt_eu_ic_2_22" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_eu_ic"/>
         <field name="tax_src_id" ref="l10n_ee_vat_out_22_s"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_out_0_eu_s"/>
+    </record>
+
+    <!-- Sales of Services 24% -> Sales of Services in EU 0% IC -->
+    <record id="afptt_eu_ic_2_24" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="afpt_eu_ic"/>
+        <field name="tax_src_id" ref="l10n_ee_vat_out_24_s"/>
         <field name="tax_dest_id" ref="l10n_ee_vat_out_0_eu_s"/>
     </record>
 
@@ -163,6 +177,21 @@
         <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_g_22"/>
     </record>
 
+    <!-- Purchase of Goods 22% -> Purchase of Goods in EU 0% IC -->
+    <record id="afptt_eu_ic_19" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="afpt_eu_ic"/>
+        <field name="tax_src_id" ref="l10n_ee_vat_in_22_g"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_g_22"/>
+    </record>
+
+    <!-- Purchase of Goods 24% -> Purchase of Goods in EU 0% IC -->
+    <record id="afptt_eu_ic_20" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="afpt_eu_ic"/>
+        <field name="tax_src_id" ref="l10n_ee_vat_in_24_g"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_g_24"/>
+    </record>
+
+
     <!-- Purchase of Services 20% -> Purchase of Services in EU 0% IC -->
     <record id="afptt_eu_ic_10" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_eu_ic"/>
@@ -175,6 +204,13 @@
         <field name="position_id" ref="afpt_eu_ic"/>
         <field name="tax_src_id" ref="l10n_ee_vat_in_22_s"/>
         <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_s_22"/>
+    </record>
+
+    <!-- Purchase of Services 24% -> Purchase of Services in EU 0% IC -->
+    <record id="afptt_eu_ic_10_24" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="afpt_eu_ic"/>
+        <field name="tax_src_id" ref="l10n_ee_vat_in_24_s"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_s_24"/>
     </record>
 
     <!-- Purchase of Services 13% -> Purchase of Services in EU 0% IC -->
@@ -242,6 +278,13 @@
         <field name="tax_dest_id" ref="l10n_ee_vat_out_0_exp_g"/>
     </record>
 
+    <!-- Sales of Goods 24% -> Export of Goods 0% -->
+    <record id="afptt_imp_exp_1_24" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="afpt_imp_exp"/>
+        <field name="tax_src_id" ref="l10n_ee_vat_out_24_g"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_out_0_exp_g"/>
+    </record>
+
     <!-- Sales of Services 20% -> Export of Services 0% -->
     <record id="afptt_imp_exp_2" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_imp_exp"/>
@@ -253,6 +296,13 @@
     <record id="afptt_imp_exp_2_22" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_imp_exp"/>
         <field name="tax_src_id" ref="l10n_ee_vat_out_22_s"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_out_0_exp_s"/>
+    </record>
+
+    <!-- Sales of Services 24% -> Export of Services 0% -->
+    <record id="afptt_imp_exp_2_24" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="afpt_imp_exp"/>
+        <field name="tax_src_id" ref="l10n_ee_vat_out_24_s"/>
         <field name="tax_dest_id" ref="l10n_ee_vat_out_0_exp_s"/>
     </record>
 
@@ -319,6 +369,13 @@
         <field name="tax_dest_id" ref="l10n_ee_vat_in_22_imp_kms_38"/>
     </record>
 
+    <!-- Purchase of Goods 24% -> Import 24% -->
+    <record id="afptt_imp_exp_9_24" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="afpt_imp_exp"/>
+        <field name="tax_src_id" ref="l10n_ee_vat_in_24_g"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_24_imp_kms_38"/>
+    </record>
+
     <!-- Purchase of Services 20% -> Import 20% -->
     <record id="afptt_imp_exp_10" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_imp_exp"/>
@@ -331,6 +388,13 @@
         <field name="position_id" ref="afpt_imp_exp"/>
         <field name="tax_src_id" ref="l10n_ee_vat_in_22_s"/>
         <field name="tax_dest_id" ref="l10n_ee_vat_in_22_imp_kms_38"/>
+    </record>
+
+    <!-- Purchase of Services 24% -> Import 24% -->
+    <record id="afptt_imp_exp_10_24" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="afpt_imp_exp"/>
+        <field name="tax_src_id" ref="l10n_ee_vat_in_24_s"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_24_imp_kms_38"/>
     </record>
 
     <!-- Purchase of Services 13% -> Import 13% -->

--- a/addons/l10n_ee/data/account_tax_group_data.xml
+++ b/addons/l10n_ee/data/account_tax_group_data.xml
@@ -11,6 +11,11 @@
             <field name="country_id" ref="base.ee"/>
         </record>
 
+        <record id="tax_group_vat_24" model="account.tax.group">
+            <field name="name">VAT 24%</field>
+            <field name="country_id" ref="base.ee"/>
+        </record>
+
         <record id="tax_group_vat_13" model="account.tax.group">
             <field name="name">VAT 13%</field>
             <field name="country_id" ref="base.ee"/>

--- a/addons/l10n_ee/data/account_tax_template_data.xml
+++ b/addons/l10n_ee/data/account_tax_template_data.xml
@@ -67,6 +67,38 @@
         ]"/>
     </record>
 
+    <!-- Sales of Goods 24% -->
+    <record id="l10n_ee_vat_out_24_g" model="account.tax.template">
+        <field name="sequence">12</field>
+        <field name="name">24% G</field>
+        <field name="type_tax_use">sale</field>
+        <field name="amount">24</field>
+        <field name="amount_type">percent</field>
+        <field name="description">24%</field>
+        <field name="tax_group_id" ref="tax_group_vat_24"/>
+        <field name="chart_template_id" ref="l10nee_chart_template"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'plus_report_expression_ids': [ref('tax_report_line_1_tag')],
+            }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'minus_report_expression_ids': [ref('tax_report_line_1_tag')],
+            }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+            }),
+        ]"/>
+    </record>
+
     <!-- Sales of Services 20% -->
     <record id="l10n_ee_vat_out_20_s" model="account.tax.template">
         <field name="sequence">20</field>
@@ -109,6 +141,38 @@
         <field name="amount_type">percent</field>
         <field name="description">22%</field>
         <field name="tax_group_id" ref="tax_group_vat_22"/>
+        <field name="chart_template_id" ref="l10nee_chart_template"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'plus_report_expression_ids': [ref('tax_report_line_1_tag')],
+            }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'minus_report_expression_ids': [ref('tax_report_line_1_tag')],
+            }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+            }),
+        ]"/>
+    </record>
+
+    <!-- Sales of Services 24% -->
+    <record id="l10n_ee_vat_out_24_s" model="account.tax.template">
+        <field name="sequence">22</field>
+        <field name="name">24% S</field>
+        <field name="type_tax_use">sale</field>
+        <field name="amount">24</field>
+        <field name="amount_type">percent</field>
+        <field name="description">24%</field>
+        <field name="tax_group_id" ref="tax_group_vat_24"/>
         <field name="chart_template_id" ref="l10nee_chart_template"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
@@ -702,6 +766,34 @@
         ]"/>
     </record>
 
+    <!-- Purchase of Goods 24% -->
+    <record id="l10n_ee_vat_in_24_g" model="account.tax.template">
+        <field name="sequence">172</field>
+        <field name="name">24% G</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="amount">24</field>
+        <field name="amount_type">percent</field>
+        <field name="description">24%</field>
+        <field name="tax_group_id" ref="tax_group_vat_24"/>
+        <field name="chart_template_id" ref="l10nee_chart_template"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, { 'repartition_type': 'base' }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'plus_report_expression_ids': [ref('tax_report_line_5_tag')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, { 'repartition_type': 'base' }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'minus_report_expression_ids': [ref('tax_report_line_5_tag')],
+            }),
+        ]"/>
+    </record>
+
     <!-- Purchase of Services 20% -->
     <record id="l10n_ee_vat_in_20_s" model="account.tax.template">
         <field name="sequence">180</field>
@@ -740,6 +832,34 @@
         <field name="amount_type">percent</field>
         <field name="description">22%</field>
         <field name="tax_group_id" ref="tax_group_vat_22"/>
+        <field name="chart_template_id" ref="l10nee_chart_template"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, { 'repartition_type': 'base' }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'plus_report_expression_ids': [ref('tax_report_line_5_tag')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, { 'repartition_type': 'base' }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'minus_report_expression_ids': [ref('tax_report_line_5_tag')],
+            }),
+        ]"/>
+    </record>
+
+    <!-- Purchase of Services 24% -->
+    <record id="l10n_ee_vat_in_24_s" model="account.tax.template">
+        <field name="sequence">182</field>
+        <field name="name">24% S</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="amount">24</field>
+        <field name="amount_type">percent</field>
+        <field name="description">24%</field>
+        <field name="tax_group_id" ref="tax_group_vat_24"/>
         <field name="chart_template_id" ref="l10nee_chart_template"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, { 'repartition_type': 'base' }),
@@ -1048,6 +1168,58 @@
         ]"/>
     </record>
 
+    <!-- Purchase of Goods in EU 0% IC 24 %-->
+    <record id="l10n_ee_vat_in_0_eu_g_24" model="account.tax.template">
+        <field name="sequence">252</field>
+        <field name="name">0% EU G 24%</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="amount">24</field>
+        <field name="amount_type">percent</field>
+        <field name="description">0% EU</field>
+        <field name="tax_group_id" ref="tax_group_vat_0"/>
+        <field name="chart_template_id" ref="l10nee_chart_template"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'plus_report_expression_ids': [
+                    ref('tax_report_line_1_tag'),
+                    ref('tax_report_line_6_1_tag'),
+                ],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'plus_report_expression_ids': [ref('tax_report_line_5_tag')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'minus_report_expression_ids': [
+                    ref('tax_report_line_1_tag'),
+                    ref('tax_report_line_6_1_tag'),
+                ],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'minus_report_expression_ids': [ref('tax_report_line_5_tag')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+            }),
+        ]"/>
+    </record>
+
     <!-- Purchase of Services in EU 0% IC -->
     <record id="l10n_ee_vat_in_0_eu_s" model="account.tax.template">
         <field name="sequence">260</field>
@@ -1107,6 +1279,58 @@
         <field name="name">0% EU S 22%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount">22</field>
+        <field name="amount_type">percent</field>
+        <field name="description">0% EU</field>
+        <field name="tax_group_id" ref="tax_group_vat_0"/>
+        <field name="chart_template_id" ref="l10nee_chart_template"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'plus_report_expression_ids': [
+                    ref('tax_report_line_1_tag'),
+                    ref('tax_report_line_6_tag'),
+                ],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'plus_report_expression_ids': [ref('tax_report_line_5_tag')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'minus_report_expression_ids': [
+                    ref('tax_report_line_1_tag'),
+                    ref('tax_report_line_6_tag'),
+                ],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'minus_report_expression_ids': [ref('tax_report_line_5_tag')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+            }),
+        ]"/>
+    </record>
+
+    <!-- Purchase of Services in EU 0% IC 24 %-->
+    <record id="l10n_ee_vat_in_0_eu_s_24" model="account.tax.template">
+        <field name="sequence">262</field>
+        <field name="name">0% EU S 24%</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="amount">24</field>
         <field name="amount_type">percent</field>
         <field name="description">0% EU</field>
         <field name="tax_group_id" ref="tax_group_vat_0"/>
@@ -1261,6 +1485,38 @@
         ]"/>
     </record>
 
+    <!-- Purchase 24% - Car -->
+    <record id="l10n_ee_vat_in_24_car" model="account.tax.template">
+        <field name="sequence">272</field>
+        <field name="name">24% Car</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="amount">24</field>
+        <field name="amount_type">percent</field>
+        <field name="description">24%</field>
+        <field name="tax_group_id" ref="tax_group_vat_24"/>
+        <field name="chart_template_id" ref="l10nee_chart_template"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, { 'repartition_type': 'base' }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'plus_report_expression_ids': [
+                    ref('tax_report_line_5_3_tag'),
+                ],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, { 'repartition_type': 'base' }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'minus_report_expression_ids': [
+                    ref('tax_report_line_5_3_tag'),
+                ],
+            }),
+        ]"/>
+    </record>
+
     <!-- Purchase 22% - Car 50% -->
     <record id="l10n_ee_vat_in_22_car_part" model="account.tax.template">
         <field name="sequence">281</field>
@@ -1271,6 +1527,49 @@
         <field name="description">22%</field>
         <field name="active" eval="False"/>
         <field name="tax_group_id" ref="tax_group_vat_22"/>
+        <field name="chart_template_id" ref="l10nee_chart_template"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, { 'repartition_type': 'base' }),
+            (0,0, {
+                'factor_percent': 50,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'plus_report_expression_ids': [
+                    ref('tax_report_line_5_4_tag'),
+                ],
+            }),
+            (0,0, {
+                'factor_percent': 50,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, { 'repartition_type': 'base' }),
+            (0,0, {
+                'factor_percent': 50,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'minus_report_expression_ids': [
+                    ref('tax_report_line_5_4_tag'),
+                ],
+            }),
+            (0,0, {
+                'factor_percent': 50,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+    </record>
+
+    <!-- Purchase 24% - Car 50% -->
+    <record id="l10n_ee_vat_in_24_car_part" model="account.tax.template">
+        <field name="sequence">282</field>
+        <field name="name">24% Car 50%</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="amount">24</field>
+        <field name="amount_type">percent</field>
+        <field name="description">24%</field>
+        <field name="active" eval="False"/>
+        <field name="tax_group_id" ref="tax_group_vat_24"/>
         <field name="chart_template_id" ref="l10nee_chart_template"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, { 'repartition_type': 'base' }),
@@ -1347,6 +1646,39 @@
         <field name="description">22%</field>
         <field name="active" eval="False"/>
         <field name="tax_group_id" ref="tax_group_vat_22"/>
+        <field name="chart_template_id" ref="l10nee_chart_template"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, { 'repartition_type': 'base' }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201202'),
+                'plus_report_expression_ids': [
+                    ref('tax_report_line_5_2_tag'),
+                ],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, { 'repartition_type': 'base' }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201202'),
+                'minus_report_expression_ids': [
+                    ref('tax_report_line_5_2_tag'),
+                ],
+            }),
+        ]"/>
+    </record>
+
+    <!-- Purchase 24% - Fixed Assets -->
+    <record id="l10n_ee_vat_in_24_assets" model="account.tax.template">
+        <field name="sequence">292</field>
+        <field name="name">24% Fixed Assets</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="amount">24</field>
+        <field name="amount_type">percent</field>
+        <field name="description">24%</field>
+        <field name="active" eval="False"/>
+        <field name="tax_group_id" ref="tax_group_vat_24"/>
         <field name="chart_template_id" ref="l10nee_chart_template"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, { 'repartition_type': 'base' }),
@@ -1457,6 +1789,53 @@
         <field name="description">22%</field>
         <field name="active" eval="False"/>
         <field name="tax_group_id" ref="tax_group_vat_22"/>
+        <field name="chart_template_id" ref="l10nee_chart_template"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, { 'repartition_type': 'base' }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'plus_report_expression_ids': [
+                    ref('tax_report_line_5_1_tag'),
+                ],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+                'minus_report_expression_ids': [ref('tax_report_line_4_1_tag')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, { 'repartition_type': 'base' }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'minus_report_expression_ids': [
+                    ref('tax_report_line_5_1_tag'),
+                ],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+                'plus_report_expression_ids': [ref('tax_report_line_4_1_tag')],
+            }),
+        ]"/>
+    </record>
+
+    <!-- Import 24% (KMS §38 - Reverse Charge) -->
+    <record id="l10n_ee_vat_in_24_imp_kms_38" model="account.tax.template">
+        <field name="sequence">312</field>
+        <field name="name">24% EX KMS §38</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="amount">24</field>
+        <field name="amount_type">percent</field>
+        <field name="description">24%</field>
+        <field name="active" eval="False"/>
+        <field name="tax_group_id" ref="tax_group_vat_24"/>
         <field name="chart_template_id" ref="l10nee_chart_template"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, { 'repartition_type': 'base' }),

--- a/addons/l10n_ee/i18n/et.po
+++ b/addons/l10n_ee/i18n/et.po
@@ -23,11 +23,23 @@ msgstr ""
 #: model:account.tax,description:l10n_ee.1_l10n_ee_vat_out_0_eu_g
 #: model:account.tax,description:l10n_ee.1_l10n_ee_vat_out_0_eu_s
 #: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_0_eu_g
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_0_eu_g_22
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_0_eu_g_24
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_0_eu_g_22
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_0_eu_g_24
 #: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_0_eu_s
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_0_eu_s_22
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_0_eu_s_24
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_0_eu_s_22
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_0_eu_s_24
 #: model:account.tax,description:l10n_ee.2_l10n_ee_vat_out_0_eu_g
 #: model:account.tax,description:l10n_ee.2_l10n_ee_vat_out_0_eu_s
 #: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_0_eu_g
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_0_eu_g_22
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_0_eu_g_24
 #: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_0_eu_s
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_0_eu_s_22
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_0_eu_s_24
 #: model:account.tax.template,description:l10n_ee.l10n_ee_vat_out_0_eu_g
 #: model:account.tax.template,description:l10n_ee.l10n_ee_vat_out_0_eu_s
 msgid "0% EU"
@@ -53,6 +65,12 @@ msgstr "0% EL K 20%"
 #: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_0_eu_g_22
 msgid "0% EU G 22%"
 msgstr "0% EL K 22%"
+
+#. module: l10n_ee
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_0_eu_g_24
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_0_eu_g_24
+msgid "0% EU G 24%"
+msgstr "0% EL K 24%"
 
 #. module: l10n_ee
 #: model:account.tax,name:l10n_ee.1_l10n_ee_vat_out_0_eu_g_t
@@ -81,6 +99,12 @@ msgstr "0% EL T 20%"
 #: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_0_eu_s_22
 msgid "0% EU S 22%"
 msgstr "0% EL T 22%"
+
+#. module: l10n_ee
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_0_eu_s_24
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_0_eu_s_24
+msgid "0% EU S 24%"
+msgstr "0% EL T 24%"
 
 #. module: l10n_ee
 #: model:account.tax,description:l10n_ee.1_l10n_ee_vat_out_0_eu_g_t
@@ -131,9 +155,15 @@ msgstr "0% K"
 #: model:account.tax,name:l10n_ee.1_l10n_ee_vat_in_0_kms_41_1
 #: model:account.tax,name:l10n_ee.1_l10n_ee_vat_out_0_kms_41_1
 #: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_0_kms_41_1
+#: model:account.tax,name:l10n_ee.1_l10n_ee_vat_in_0_kms_41_2
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_0_kms_41_2
 #: model:account.tax,name:l10n_ee.2_l10n_ee_vat_out_0_kms_41_1
+#: model:account.tax,name:l10n_ee.1_l10n_ee_vat_out_0_kms_41_2
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_out_0_kms_41_2
 #: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_0_kms_41_1
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_0_kms_41_2
 #: model:account.tax.template,name:l10n_ee.l10n_ee_vat_out_0_kms_41_1
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_out_0_kms_41_2
 msgid "0% KMS §41¹"
 msgstr "0% KMS §41¹"
 
@@ -359,6 +389,89 @@ msgstr "22% T"
 #: model:account.tax.template,description:l10n_ee.l10n_ee_vat_out_0_kms_41_2
 msgid "22% Special"
 msgstr "22% Erikord"
+
+#. module: l10n_ee
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_24_assets
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_24_car
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_24_car_part
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_24_g
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_24_imp_kms_38
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_24_s
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_out_24_g
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_out_24_s
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_24_assets
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_24_car
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_24_car_part
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_24_g
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_24_imp_kms_38
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_24_s
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_out_24_g
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_out_24_s
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_24_assets
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_24_car
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_24_car_part
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_24_g
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_24_imp_kms_38
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_24_s
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_out_24_g
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_out_24_s
+msgid "24%"
+msgstr ""
+
+#. module: l10n_ee
+#: model:account.tax,name:l10n_ee.1_l10n_ee_vat_in_24_car
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_24_car
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_24_car
+msgid "24% Car"
+msgstr "24% Auto"
+
+#. module: l10n_ee
+#: model:account.tax,name:l10n_ee.1_l10n_ee_vat_in_24_car_part
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_24_car_part
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_24_car_part
+msgid "24% Car 50%"
+msgstr "24% Auto 50%"
+
+#. module: l10n_ee
+#: model:account.tax,name:l10n_ee.1_l10n_ee_vat_in_24_imp_kms_38
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_24_imp_kms_38
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_24_imp_kms_38
+msgid "24% EX KMS §38"
+msgstr "24% EX KMS §38"
+
+#. module: l10n_ee
+#: model:account.tax,name:l10n_ee.1_l10n_ee_vat_in_24_assets
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_24_assets
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_24_assets
+msgid "24% Fixed Assets"
+msgstr "24% Põhivara"
+
+#. module: l10n_ee
+#: model:account.tax,name:l10n_ee.1_l10n_ee_vat_in_24_g
+#: model:account.tax,name:l10n_ee.1_l10n_ee_vat_out_24_g
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_24_g
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_out_24_g
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_24_g
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_out_24_g
+msgid "24% G"
+msgstr "24% K"
+
+#. module: l10n_ee
+#: model:account.tax,name:l10n_ee.1_l10n_ee_vat_in_24_s
+#: model:account.tax,name:l10n_ee.1_l10n_ee_vat_out_24_s
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_24_s
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_out_24_s
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_24_s
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_out_24_s
+msgid "24% S"
+msgstr "24% T"
+
+#. module: l10n_ee
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_out_0_kms_41_2
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_out_0_kms_41_2
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_out_0_kms_41_2
+msgid "24% Special"
+msgstr "24% Erikord"
 
 #. module: l10n_ee
 #: model:account.report.line,name:l10n_ee.tax_report_line_2_1
@@ -2527,6 +2640,11 @@ msgstr "KM 20%"
 #: model:account.tax.group,name:l10n_ee.tax_group_vat_22
 msgid "VAT 22%"
 msgstr "KM 22%"
+
+#. module: l10n_ee
+#: model:account.tax.group,name:l10n_ee.tax_group_vat_24
+msgid "VAT 24%"
+msgstr "KM 24%"
 
 #. module: l10n_ee
 #: model:account.tax.group,name:l10n_ee.tax_group_vat_20_special

--- a/addons/l10n_ee/i18n/l10n_ee.pot
+++ b/addons/l10n_ee/i18n/l10n_ee.pot
@@ -21,11 +21,23 @@ msgstr ""
 #: model:account.tax,description:l10n_ee.1_l10n_ee_vat_out_0_eu_g
 #: model:account.tax,description:l10n_ee.1_l10n_ee_vat_out_0_eu_s
 #: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_0_eu_g
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_0_eu_g_22
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_0_eu_g_24
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_0_eu_g_22
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_0_eu_g_24
 #: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_0_eu_s
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_0_eu_s_22
+#: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_0_eu_s_24
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_0_eu_s_22
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_0_eu_s_24
 #: model:account.tax,description:l10n_ee.2_l10n_ee_vat_out_0_eu_g
 #: model:account.tax,description:l10n_ee.2_l10n_ee_vat_out_0_eu_s
 #: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_0_eu_g
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_0_eu_g_22
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_0_eu_g_24
 #: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_0_eu_s
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_0_eu_s_22
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_0_eu_s_24
 #: model:account.tax.template,description:l10n_ee.l10n_ee_vat_out_0_eu_g
 #: model:account.tax.template,description:l10n_ee.l10n_ee_vat_out_0_eu_s
 msgid "0% EU"
@@ -50,6 +62,12 @@ msgstr ""
 #: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_0_eu_g_22
 #: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_0_eu_g_22
 msgid "0% EU G 22%"
+msgstr ""
+
+#. module: l10n_ee
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_0_eu_g_24
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_0_eu_g_24
+msgid "0% EU G 24%"
 msgstr ""
 
 #. module: l10n_ee
@@ -78,6 +96,12 @@ msgstr ""
 #: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_0_eu_s_22
 #: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_0_eu_s_22
 msgid "0% EU S 22%"
+msgstr ""
+
+#. module: l10n_ee
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_0_eu_s_24
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_0_eu_s_24
+msgid "0% EU S 24%"
 msgstr ""
 
 #. module: l10n_ee
@@ -129,9 +153,15 @@ msgstr ""
 #: model:account.tax,name:l10n_ee.1_l10n_ee_vat_in_0_kms_41_1
 #: model:account.tax,name:l10n_ee.1_l10n_ee_vat_out_0_kms_41_1
 #: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_0_kms_41_1
+#: model:account.tax,name:l10n_ee.1_l10n_ee_vat_in_0_kms_41_2
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_0_kms_41_2
 #: model:account.tax,name:l10n_ee.2_l10n_ee_vat_out_0_kms_41_1
+#: model:account.tax,name:l10n_ee.1_l10n_ee_vat_out_0_kms_41_2
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_out_0_kms_41_2
 #: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_0_kms_41_1
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_0_kms_41_2
 #: model:account.tax.template,name:l10n_ee.l10n_ee_vat_out_0_kms_41_1
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_out_0_kms_41_2
 msgid "0% KMS §41¹"
 msgstr ""
 
@@ -356,6 +386,66 @@ msgstr ""
 #: model:account.tax,description:l10n_ee.2_l10n_ee_vat_out_0_kms_41_2
 #: model:account.tax.template,description:l10n_ee.l10n_ee_vat_out_0_kms_41_2
 msgid "22% Special"
+msgstr ""
+
+#. module: l10n_ee
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_24_assets
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_24_car
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_24_car_part
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_24_g
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_24_imp_kms_38
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_in_24_s
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_out_24_g
+#: model:account.tax,description:l10n_ee.2_l10n_ee_vat_out_24_s
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_24_assets
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_24_car
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_24_car_part
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_24_g
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_24_imp_kms_38
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_in_24_s
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_out_24_g
+#: model:account.tax.template,description:l10n_ee.l10n_ee_vat_out_24_s
+msgid "24%"
+msgstr ""
+
+#. module: l10n_ee
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_24_car
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_24_car
+msgid "24% Car"
+msgstr ""
+
+#. module: l10n_ee
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_24_car_part
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_24_car_part
+msgid "24% Car 50%"
+msgstr ""
+
+#. module: l10n_ee
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_24_imp_kms_38
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_24_imp_kms_38
+msgid "24% EX KMS §38"
+msgstr ""
+
+#. module: l10n_ee
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_24_assets
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_24_assets
+msgid "24% Fixed Assets"
+msgstr ""
+
+#. module: l10n_ee
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_24_g
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_out_24_g
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_24_g
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_out_24_g
+msgid "24% G"
+msgstr ""
+
+#. module: l10n_ee
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_in_24_s
+#: model:account.tax,name:l10n_ee.2_l10n_ee_vat_out_24_s
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_in_24_s
+#: model:account.tax.template,name:l10n_ee.l10n_ee_vat_out_24_s
+msgid "24% S"
 msgstr ""
 
 #. module: l10n_ee
@@ -2506,6 +2596,11 @@ msgstr ""
 #. module: l10n_ee
 #: model:account.tax.group,name:l10n_ee.tax_group_vat_22
 msgid "VAT 22%"
+msgstr ""
+
+#. module: l10n_ee
+#: model:account.tax.group,name:l10n_ee.tax_group_vat_24
+msgid "VAT 24%"
 msgstr ""
 
 #. module: l10n_ee

--- a/addons/l10n_ee/migrations/1.2/post-migrate_update_taxes.py
+++ b/addons/l10n_ee/migrations/1.2/post-migrate_update_taxes.py
@@ -1,0 +1,5 @@
+from odoo.addons.account.models.chart_template import update_taxes_from_templates
+
+
+def migrate(cr, version):
+    update_taxes_from_templates(cr, 'l10n_ee.l10nee_chart_template')


### PR DESCRIPTION
From the first of July 2025, the standard rate of VAT in Estonia is 24% instead of the current 22%. This commit adds the new tax. Also, one of the EU Intra-Community mappings was missing, specifically the 22% G (Purchases) -> 0% EU G 22% (Purchases). This was also added.

task-4595806
