### PR TITLE
[FIX] stock: orderpoint list view button fixes

### DIFF
--- a/addons/stock/static/src/views/stock_orderpoint_list_controller.js
+++ b/addons/stock/static/src/views/stock_orderpoint_list_controller.js
@@ -11,6 +11,10 @@ export class StockOrderpointListController extends ListController {
         DropdownItem,
     }
 
+    get nbSelected() {
+        return this.model.root.selection.length;
+    }
+
     async onClickOrder(force_to_max) {
         const resIds = await this.model.root.getResIds(true);
         const action = await this.model.orm.call(this.props.resModel, 'action_replenish', [resIds], {

--- a/addons/stock/static/src/views/stock_orderpoint_list_controller.js
+++ b/addons/stock/static/src/views/stock_orderpoint_list_controller.js
@@ -24,20 +24,14 @@ export class StockOrderpointListController extends ListController {
         if (action) {
             await this.actionService.doAction(action);
         }
-        return this.actionService.doAction('stock.action_replenishment', {
-            stackPosition: 'replaceCurrentAction',
-        });
+        return this.actionService.doAction({type: 'ir.actions.client', tag: 'reload'});
     }
 
     async onClickSnooze() {
         const resIds = await this.model.root.getResIds(true);
-        this.actionService.doAction('stock.action_orderpoint_snooze', {
+        return this.actionService.doAction('stock.action_orderpoint_snooze', {
             additionalContext: { default_orderpoint_ids: resIds },
-            onClose: () => {
-                this.actionService.doAction('stock.action_replenishment', {
-                    stackPosition: 'replaceCurrentAction',
-                });
-            }
+            onClose: () => { this.actionService.doAction({type: 'ir.actions.client', tag: 'reload'}); },
         });
     }
 }


### PR DESCRIPTION
Buttons in the `stock.StockOrderpoint.listView` template depend on the `nbSelected` method that was moved out of the main list controller, so we're adding it to our local list controller.

In addition, the snooze button, when pressed in a product's Reordering Rules view, should not return to the Replenishments view but remain in the Reordering Rules view.

Task ID: [4614152](https://www.odoo.com/odoo/project/966/tasks/4614152)

### Notes:
* **Fixed.** — The behaviour of returning from a product's Reordering Rules view to the general Replenishment view also exists in the Order and Order to Max buttons. I'm looking into whether this is intended behaviour.
* **Tests removed. Ignore this bulletpoint.** — This is my first time writing a test class from scratch, so a deeper look would be appreciated.
  * I've also written tests for the Reordering Rules view but had to scrap them because the Reordering Rules button calls the `action_view_orderpoints()` routine rather than an action with an xmlid that we can pass in the URL. Short of making a new action record for it (verboten in stable) or manually entering the domain for the product in the tour (which defeats the point), we can't test a product's Reordering Rules.
  * Replenishments view has the filter for automatic orderpoints and we can only snooze manual orderpoints, so the filter has to be removed after each action.
  * The tour suffers from race conditions due to the orderpoints not loading fast enough (exacerbated by the fact that the replenish action is called async unlike the snooze action). That is to say, after a snooze or order operation is run, the tour picks the next orderpoints too quickly, which either fails or gets reset, meaning it can't find the buttons. Setting a `step_delay` helps, but slows down the whole test, so I added delay steps only where they're needed. Unfortunately, the loading speed of the orderpoints varies by environment (eg my machine vs runbot), so I'm trying to find the minimum delay interval long enough for most machines.
  * The tour will fail if `purchase` is installed, because it will try to run `_run_buy()` when an orderpoint is ordered, which will fail since no vendors are defined. But we don't want a purchase order in a stock test.
* **Fixed.** — Snoozing a second time in the Reordering Rules will lose the active ids & the active model in the context (leading to an empty domain) for esoteric reasons I gave up on trying to figure out. If this is determined to be a bug, a separate task can be opened for it.