### PR TITLE
[FIX] mass_mailing: ensure 'View Online' links work in mass mailing test

### DIFF
--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -57,7 +57,7 @@ class MailMail(models.Model):
         view links by email-specific links. Also add headers to allow
         unsubscribe from email managers. """
         email_list = super()._prepare_outgoing_list(recipients_follower_status)
-        if not self.res_id or not self.mailing_id:
+        if (not self.res_id and self.res_id != 0) or not self.mailing_id:
             return email_list
 
         base_url = self.mailing_id.get_base_url()

--- a/addons/mass_mailing/wizard/mailing_mailing_test.py
+++ b/addons/mass_mailing/wizard/mailing_mailing_test.py
@@ -67,8 +67,8 @@ class TestMassMailing(models.TransientModel):
                 'attachment_ids': [(4, attachment.id) for attachment in mailing.attachment_ids],
                 'auto_delete': False,  # they are manually deleted after notifying the document
                 'mail_server_id': mailing.mail_server_id.id,
-                'model': 'res.users',
-                'res_id': self.env.user.id,
+                'model': mailing.mailing_model_real,
+                'res_id': record.id or 0,
             }
             mail = self.env['mail.mail'].sudo().create(mail_values)
             mails_sudo |= mail


### PR DESCRIPTION
Currently, sending a test mass mailing email that includes both the 'View Online' widget and a dynamic placeholder results in a link that leads to a traceback.

### Steps to Reproduce

1. Start a database **without** demo data.
2. Install the `mass_mailing` module.
3. Create a new Mailing where recipient is a mailing list
4. Ensure the mail body contains the "View Online" widget and a dynamic placeholder.
5. Click on the "Test" button to test the mailing.
6. Open the mail that is sent and click the "View Online" link.

You will encounter a traceback:
```
odoo.exceptions.MissingError: Record does not exist or has been deleted.
```

### Cause

The issue was introduced in commit
2d9da403d09ad2536b3f1dc4d18e450c69601cac, which made it so that when sending a test mass mailing, the mail is rendered on the `res.users` model with the `res_id` of the current user. The "View Online" widget generates a URL with this `res_id`. However, when the link is clicked, the system expects the `res_id` to refer to a `mailing.contact` record because the model is taken from the mailing itself, causing a crash if the id does not exist in `mailing.contact`, or displaying incorrect data if it does.

opw-4487325