### PR TITLE
[IMP] web: use FullCalendar option instead of monkey patching the DOM

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
+++ b/addons/hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
@@ -4,7 +4,6 @@ import { useService } from "@web/core/utils/hooks";
 import { useMandatoryDays } from "../../hooks";
 import { useCalendarPopover } from "@web/views/calendar/hooks";
 import { TimeOffCalendarYearPopover } from "./calendar_year_popover";
-import { useEffect } from "@odoo/owl";
 
 export class TimeOffCalendarYearRenderer extends CalendarYearRenderer {
     setup() {
@@ -13,22 +12,6 @@ export class TimeOffCalendarYearRenderer extends CalendarYearRenderer {
         this.mandatoryDays = useMandatoryDays(this.props);
         this.mandatoryDaysList = [];
         this.mandatoryDayPopover = useCalendarPopover(TimeOffCalendarYearPopover);
-
-        useEffect(
-            (el) => {
-                for (const lastWeek of el) {
-                    // Remove the week if the week is empty.
-                    // FullCalendar always displays 6 weeks even when empty.
-                    if (!lastWeek.querySelector("[data-date]")) {
-                        lastWeek.remove();
-                    }
-                }
-            },
-            () => [
-                this.rootRef.el &&
-                    this.rootRef.el.querySelectorAll(".fc-scrollgrid-sync-table tr:nth-child(6)"),
-            ]
-        );
     }
 
     get options() {

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -122,6 +122,7 @@ export class CalendarCommonRenderer extends Component {
             eventDisplay: "block", // Restore old render in daygrid view for single-day timed events
             viewDidMount: this.viewDidMount,
             moreLinkDidMount: this.wrapMoreLink,
+            fixedWeekCount: false,
         };
     }
 

--- a/addons/web/static/src/views/calendar/calendar_year/calendar_year_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_year/calendar_year_renderer.js
@@ -78,6 +78,7 @@ export class CalendarYearRenderer extends Component {
             eventContent: this.onEventContent,
             viewDidMount: this.viewDidMount,
             weekends: this.props.isWeekendVisible,
+            fixedWeekCount: false,
         };
     }
 

--- a/addons/web/static/tests/views/calendar/calendar_common_renderer.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_common_renderer.test.js
@@ -160,3 +160,8 @@ test(`Week: automatically scroll to 6am`, async () => {
     const dayStartDimensions = queryRect(`.fc-timegrid-slot[data-time="06:00:00"]:eq(0)`);
     expect(Math.abs(dayStartDimensions.y - containerDimensions.y)).toBeLessThan(2);
 });
+
+test("Month: remove row when no day of current month", async () => {
+    await start({ model: { ...FAKE_MODEL, scale: "month" } });
+    expect(".fc-day-other, .fc-day-disabled").toHaveCount(4);
+});

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -3568,16 +3568,6 @@ test(`timezone does not affect calendar with date field on desktop`, async () =>
     expect(
         `.o_cw_popover .o_cw_popover_fields_secondary .list-group-item .o_field_date`
     ).toHaveText("11/27/2016");
-
-    await closeCwPopOver();
-    await moveEventToDate(8, "2017-01-07");
-    expect.verifySteps(["write 2017-01-07"]);
-
-    await clickEvent(8);
-    expect(`.o_cw_popover`).toHaveCount(1);
-    expect(
-        `.o_cw_popover .o_cw_popover_fields_secondary .list-group-item .o_field_date`
-    ).toHaveText("01/07/2017");
 });
 
 test.tags("mobile");
@@ -3628,16 +3618,6 @@ test(`timezone does not affect calendar with date field on mobile`, async () => 
     expect(`.modal`).toHaveCount(1);
     expect(`.modal .o_cw_popover_fields_secondary .list-group-item .o_field_date`).toHaveText(
         "11/27/2016"
-    );
-
-    await closeCwPopOver();
-    await moveEventToDate(8, "2017-01-07");
-    expect.verifySteps(["write 2017-01-07"]);
-
-    await clickEvent(8);
-    expect(`.modal`).toHaveCount(1);
-    expect(`.modal .o_cw_popover_fields_secondary .list-group-item .o_field_date`).toHaveText(
-        "01/07/2017"
     );
 });
 
@@ -3879,8 +3859,8 @@ test(`default week start (US) month mode on desktop`, async () => {
     expect(`.fc-daygrid-day:eq(0) .fc-daygrid-week-number`).toHaveText("36");
     expect(`.fc-daygrid-day:eq(0) .fc-daygrid-day-number`).toHaveText("1");
     expect(`.fc-daygrid-day:eq(0)`).toHaveAttribute("data-date", "2019-09-01");
-    expect(`.fc-daygrid-day:eq(-1) .fc-daygrid-day-number`).toHaveText("12");
-    expect(`.fc-daygrid-day:eq(-1)`).toHaveAttribute("data-date", "2019-10-12");
+    expect(`.fc-daygrid-day:eq(-1) .fc-daygrid-day-number`).toHaveText("5");
+    expect(`.fc-daygrid-day:eq(-1)`).toHaveAttribute("data-date", "2019-10-05");
 });
 
 test.tags("mobile");
@@ -3906,8 +3886,8 @@ test(`default week start (US) month mode on mobile`, async () => {
     expect(`.o-fc-week:eq(0)`).toHaveText("36");
     expect(`.fc-daygrid-day:eq(0) .fc-daygrid-day-number`).toHaveText("1");
     expect(`.fc-daygrid-day:eq(0)`).toHaveAttribute("data-date", "2019-09-01");
-    expect(`.fc-daygrid-day:eq(-1) .fc-daygrid-day-number`).toHaveText("12");
-    expect(`.fc-daygrid-day:eq(-1)`).toHaveAttribute("data-date", "2019-10-12");
+    expect(`.fc-daygrid-day:eq(-1) .fc-daygrid-day-number`).toHaveText("5");
+    expect(`.fc-daygrid-day:eq(-1)`).toHaveAttribute("data-date", "2019-10-05");
 });
 
 test.tags("desktop");
@@ -4677,14 +4657,6 @@ test(`calendar with option month_overflow not set (default)`, async () => {
             user_id: serverState.userId,
             partner_id: 1,
         },
-        {
-            id: 3,
-            name: "event january",
-            start: "2017-01-02 10:00:00",
-            stop: "2016-01-02 15:00:00",
-            user_id: serverState.userId,
-            partner_id: 1,
-        },
     ];
 
     onRpc("search_read", ({ kwargs }) => {
@@ -4703,7 +4675,7 @@ test(`calendar with option month_overflow not set (default)`, async () => {
             </calendar>
         `,
     });
-    expect(`.o_event`).toHaveCount(3);
+    expect(`.o_event`).toHaveCount(2);
     expect(".fc-day-disabled").toHaveCount(0);
     expect.verifySteps(["search_read"]);
 });
@@ -4753,7 +4725,7 @@ test(`calendar with option month_overflow set to false`, async () => {
         `,
     });
     expect(".o_event").toHaveCount(1);
-    expect(".fc-day-disabled").toHaveCount(11);
+    expect(".fc-day-disabled").toHaveCount(4);
     expect.verifySteps(["search_read"]);
 });
 

--- a/addons/web/static/tests/views/calendar/calendar_year_renderer.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_year_renderer.test.js
@@ -133,3 +133,8 @@ test(`display correct column header for days, independent of the timezone`, asyn
         "S",
     ]);
 });
+
+test("remove row when no day of current month", async () => {
+    await start();
+    expect(".fc-day-other, .fc-day-disabled").toHaveCount(76);
+});


### PR DESCRIPTION
FullCalendar offer the option `fixedWeekCount` to force will always be 6 weeks tall and the default value is `true`.

In `hr_holidays` we don't want to have 6 weeks, so before this commit we removed the "line" directly in the DOM in a `useEffect`.

This commit simplify the code using FullCalendar option.

task-4614300

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
