### PR TITLE
[FIX] web: no crash on add discuss message reaction

### DIFF
--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -122,6 +122,31 @@ test("Edit message (mobile)", async () => {
     await contains(".o-mail-Message-content", { text: "edited message (edited)" });
 });
 
+test.tags("mobile");
+test("Can add reaction to a message on an ipad", async () => {
+    // most ipad users have large screen (landscape) but touch device, thus should use mobile UI/UX
+    patchUiSize({ size: SIZES.LG });
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "general",
+        channel_type: "channel",
+    });
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: "Hello world",
+        model: "discuss.channel",
+        res_id: channelId,
+        message_type: "comment",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message");
+    await click(".o-mail-Message [title='Expand']");
+    await click("button:contains('Add a Reaction')");
+    await click(".o-EmojiPicker-content .o-Emoji:contains('😀')");
+    await contains(".o-mail-MessageReaction:contains('😀\n1')");
+});
+
 test("Editing message keeps the mentioned channels", async () => {
     const pyEnv = await startServer();
     const channelId1 = pyEnv["discuss.channel"].create({

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -544,7 +544,7 @@ export function usePicker(PickerComponent, ref, props, options = {}) {
 
     function open(ref, openProps) {
         state.isOpen = true;
-        if (ui.isSmall) {
+        if (ui.isSmall || isMobileOS()) {
             const def = new Deferred();
             const pickerMobileProps = {
                 PickerComponent,


### PR DESCRIPTION
Before this commit, when using an ipad in portrait mode, clicking on message action "add a reaction" resulted to the following crash:

```
Uncaught Promise > Cannot read properties of undefined (reading 'getRootNode')
```

This happens because in mobile, the message actions are displayed with mobile action menu. Clicking on "Add a reaction" opens the emoji picker, which should open the mobile version of the emoji picker. However, the inner-code of emoji picker was attempting to use the desktop emoji picker, due to relying on screen size rather than `isMobileOS()`. The desktop mode of emoji picker needs a anchor target, which is the quick message action "add a reaction" in desktop. In mobile this doesn't exist, thus the anchor was `undefined`, and inner-code of popover crashes when the anchor el is undefined.

This commit fixes the issue by using the mobile emoji picker mode using `isMobileOS()` rather than `ui.isSmall`. This makes showing of mobile emoji picker consistent for all mobile devices, which matches the expected UX/UI in Discuss.

opw-4606671