### PR TITLE
[IMP] project: add more granularity on tasks priority

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -364,8 +364,14 @@ class ProjectCustomerPortal(CustomerPortal):
                 return [('priority', 'in', priority_selections.mapped('value'))]
             return Domain.FALSE
         elif search_in == 'status':
-            state_dict = dict(map(reversed, request.env['project.task']._fields['state']._description_selection(request.env)))
-            return [('state', 'ilike', state_dict.get(search, search))]
+            state_selections = request.env['ir.model.fields.selection'].sudo().search([
+                ('field_id.model', '=', 'project.task'),
+                ('field_id.name', '=', 'state'),
+                ('name', 'ilike', search),
+            ])
+            if state_selections:
+                return [('state', 'in', state_selections.mapped('value'))]
+            return Domain.FALSE
         elif search_in in self._task_get_searchbar_inputs(milestones_allowed, project):
             return [(search_in, 'ilike', search)]
         else:

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -147,8 +147,10 @@ class ProjectTask(models.Model):
     name = fields.Char(string='Title', tracking=True, required=True, index='trigram')
     description = fields.Html(string='Description', sanitize_attributes=False)
     priority = fields.Selection([
-        ('0', 'Low'),
-        ('1', 'High'),
+        ('0', 'Low priority'),
+        ('1', 'Medium priority'),
+        ('2', 'High priority'),
+        ('3', 'Urgent'),
     ], default='0', index=True, string="Priority", tracking=True)
     sequence = fields.Integer(string='Sequence', default=10, export_string_translation=False)
     stage_id = fields.Many2one('project.task.type', string='Stage', compute='_compute_stage_id',

--- a/addons/project/report/project_report.py
+++ b/addons/project/report/project_report.py
@@ -33,8 +33,10 @@ class ReportProjectTaskUser(models.Model):
     rating_last_value = fields.Float('Last Rating (1-5)', aggregator="avg", readonly=True, groups="project.group_project_rating")
     rating_avg = fields.Float('Average Rating (1-5)', readonly=True, aggregator='avg', groups="project.group_project_rating")
     priority = fields.Selection([
-        ('0', 'Low'),
-        ('1', 'High')
+        ('0', 'Low priority'),
+        ('1', 'Medium priority'),
+        ('2', 'High priority'),
+        ('3', 'Urgent'),
         ], readonly=True, string="Priority")
 
     state = fields.Selection([

--- a/addons/project/static/src/views/project_task_form/project_task_form_view.scss
+++ b/addons/project/static/src/views/project_task_form/project_task_form_view.scss
@@ -20,8 +20,4 @@
     .o_form_project_recurrence_message *:last-child {
         margin-bottom: 0;
     }
-
-    &.o_form_editable .oe_title {
-        max-width: initial;
-    }
 }

--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="portal_my_tasks_priority_widget_template" name="Priority Widget Template">
-        <span t-attf-class="o_priority_star d-inline-block fa fa-star#{' text-warning' if task.priority == '1' else '-o opacity-75'} #{classes if classes else ''}" t-attf-title="Priority: {{'Important' if task.priority == '1' else 'Normal'}}"/>
+        <t t-set="priority_label" t-value="priority_labels[task.priority]"/>
+        <span t-attf-class="o_priority_star d-inline-block fa fa-star#{' text-warning' if task.priority != '0' else '-o opacity-75'} #{classes if classes else ''}" t-att-title="priority_label"/>
+        <span t-attf-class="o_priority_star d-inline-block fa fa-star#{' text-warning' if task.priority in ['2', '3'] else '-o opacity-75'} #{classes if classes else ''}" t-att-title="priority_label"/>
+        <span t-attf-class="o_priority_star d-inline-block fa fa-star#{' text-warning' if task.priority == '3' else '-o opacity-75'} #{classes if classes else ''}" t-att-title="priority_label"/>
     </template>
 
     <template id="portal_my_tasks_state_widget_template" name="Status Widget Template">
@@ -229,7 +232,6 @@
                                 <div class="col-12 col-md-9">
                                     <div class="d-flex gap-2">
                                         <h3 class="my-0">
-                                            <t t-call="project.portal_my_tasks_priority_widget_template"/>
                                             <span t-field="task.name"/>
                                             <small class="text-muted d-none d-md-inline">(#<span t-field="task.id"/>)</small>
                                         </h3>
@@ -251,8 +253,12 @@
                                 <div class="col-12 col-md-6 flex-grow-1">
                                     <div t-if="project_accessible"><strong>Project:</strong> <a t-attf-href="/my/projects/#{task.project_id.id}" t-field="task.project_id"/></div>
                                     <div t-else=""><strong>Project:</strong> <a t-field="task.project_id"/></div>
-                                    <div t-if="task.date_deadline"><strong>Deadline:</strong> <span t-field="task.date_deadline" t-options='{"widget": "datetime"}'/></div>
                                     <div t-if="task.milestone_id and task.allow_milestones"><strong>Milestone:</strong> <span t-field="task.milestone_id"/></div>
+                                    <div>
+                                        <strong>Priority:</strong>
+                                        <t t-call="project.portal_my_tasks_priority_widget_template"/>
+                                    </div>
+                                    <div t-if="task.date_deadline"><strong>Deadline:</strong> <span t-field="task.date_deadline" t-options='{"widget": "datetime"}'/></div>
                                     <div name="portal_my_task_allocated_hours">
                                         <strong t-if="task.allocated_hours > 0">Allocated Time:</strong>
                                         <t t-call="project.portal_my_task_allocated_hours_template"/>

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -144,7 +144,6 @@
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <div class="oe_title pe-0">
                         <h1 class="d-flex flex-row justify-content-between">
-                            <field name="priority" widget="priority" class="me-3"/>
                             <field name="name" class="o_task_name text-truncate" placeholder="Task Title..."/>
                             <div class="d-flex justify-content-end o_state_container" invisible="not active">
                                 <field name="state" widget="project_task_state_selection" class="o_task_state_widget"/>
@@ -167,6 +166,7 @@
                             <field name="portal_user_names"
                                 string="Assignees"
                                 class="o_task_user_field"/>
+                            <field name="priority" widget="priority"/>
                             <field name="tag_ids" context="{'project_id': project_id}" widget="many2many_tags" options="{'color_field': 'color', 'no_create': True, 'no_edit': True, 'no_edit_color': True}"/>
                         </group>
                         <group>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -15,8 +15,6 @@
                     <filter string="Unassigned" name="unassigned" domain="[('user_ids', '=', False)]"/>
                     <separator invisible="context.get('default_project_id')"/>
                     <filter string="Favorite Projects" name="favorite_projects" domain="[('project_id.is_favorite', '=', True)]" invisible="context.get('default_project_id')"/>
-                    <separator/>
-                    <filter string="Starred" name="starred_tasks" domain="[('priority', '=', '1')]"/>
                     <separator groups="project.group_project_task_dependencies"/>
                     <filter string="Blocked" name="blocked" domain="[('state', '=', '04_waiting_normal')]" groups="project.group_project_task_dependencies"/>
                     <filter string="Blocking" name="blocking" domain="[('is_closed', '=', False), ('dependent_ids', '!=', False)]" groups="project.group_project_task_dependencies"/>
@@ -34,6 +32,7 @@
                     <group expand="0" string="Group By">
                         <filter string="Stage" name="stage" context="{'group_by': 'stage_id'}"/>
                         <filter string="Milestone" name="milestone" context="{'group_by': 'milestone_id'}" groups="project.group_project_milestone"/>
+                        <filter string="Priority" name="groupby_priority" context="{'group_by': 'priority'}"/>
                         <filter string="Tags" name="tags" context="{'group_by': 'tag_ids'}"/>
                         <filter string="Customer" name="customer" context="{'group_by': 'partner_id'}"/>
                         <filter string="Company" name="company_id" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>
@@ -385,20 +384,17 @@
                         <span id="end_button_box" invisible="1"/>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
-                    <div class="oe_title pe-0">
-                        <h1 class="d-flex justify-content-between align-items-center">
-                            <div class="d-flex w-100">
-                                <field name="priority" widget="priority_switch" class="me-3"/>
-                                <field name="name" options="{'line_breaks': False}" widget="text" class="o_task_name text-truncate w-md-75 w-100 pe-2" placeholder="Task Title..."/>
-                            </div>
-                            <div class="d-flex justify-content-end o_state_container" invisible="not active">
-                                <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
-                            </div>
-                            <div class="d-flex justify-content-start o_state_container w-100 w-md-50 w-lg-25" invisible="active">
-                                <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
-                            </div>
-                        </h1>
-                    </div>
+                    <h1 class="d-flex justify-content-between align-items-center">
+                        <div class="d-flex w-100">
+                            <field name="name" options="{'line_breaks': False}" widget="text" class="o_task_name text-truncate w-md-75 w-100 pe-2" placeholder="Task Title..."/>
+                        </div>
+                        <div class="d-flex justify-content-end o_state_container" invisible="not active">
+                            <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
+                        </div>
+                        <div class="d-flex justify-content-start o_state_container w-100 w-md-50 w-lg-25" invisible="active">
+                            <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
+                        </div>
+                    </h1>
                     <group>
                         <group>
                             <field name="project_id"
@@ -413,6 +409,7 @@
                                 class="o_task_user_field"
                                 options="{'no_open': True, 'no_quick_create': True}"
                                 widget="many2many_avatar_user"/>
+                            <field name="priority" widget="priority_switch"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" context="{'project_id': project_id}"/>
                         </group>
                         <group>
@@ -465,7 +462,7 @@
                                     <field name="sequence" widget="handle"/>
                                     <field name="id" optional="hide" options="{'enable_formatting': False}"/>
                                     <field name="parent_id" column_invisible="True"/>
-                                    <field name="priority" widget="priority" nolabel="1" width="20px"/>
+                                    <field name="priority" widget="priority" optional="show" width="70px"/>
                                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px"/>
                                     <field name="name" widget="name_with_subtask_count"/>
                                     <field name="subtask_count" column_invisible="True"/>
@@ -659,7 +656,7 @@
                                 <div class="text-muted d-flex flex-column">
                                     <field t-if="record.parent_id.raw_value" invisible="context.get('default_parent_id', False)" name="parent_id"/>
                                     <field invisible="context.get('default_project_id', False)" name="project_id" options="{'no_open': True}"/>
-                                    <field name="partner_id"/>    
+                                    <field name="partner_id"/>
                                     <field t-if="record.allow_milestones.raw_value and record.milestone_id.raw_value" t-att-class="record.has_late_and_unreached_milestone.raw_value and !record.state.raw_value.startsWith('1_') ? 'text-danger' : ''" name="milestone_id" options="{'no_open': True}"/>
                                 </div>
                                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
@@ -720,8 +717,7 @@
                     <field name="subtask_count" column_invisible="True"/>
                     <field name="closed_subtask_count" column_invisible="True"/>
                     <field name="id" optional="hide" options="{'enable_formatting': False}"/>
-                    <field name="priority" widget="priority" nolabel="1" width="20px"/>
-                    <field name="state" widget="project_task_state_selection" nolabel="1" width="20px" options="{'is_toggle_mode': false}"/>
+                    <field name="priority" widget="priority" optional="show" width="70px"/>
                     <field name="name" string="Title" widget="name_with_subtask_count"/>
                     <field name="project_id" widget="project" optional="show" options="{'no_open': 1}" readonly="1" column_invisible="context.get('default_project_id')"/>
                     <field name="milestone_id" invisible="not allow_milestones" context="{'default_project_id': project_id}" groups="project.group_project_milestone" optional="hide"/>
@@ -732,6 +728,7 @@
                     <field name="date_deadline" optional="hide" widget="remaining_days" invisible="state in ['1_done', '1_canceled']"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show" context="{'project_id': project_id}"/>
                     <field name="date_last_stage_update" optional="hide"/>
+                    <field name="state" widget="project_task_state_selection" nolabel="1" width="20px" options="{'is_toggle_mode': false}"/>
                     <field name="stage_id" column_invisible="context.get('set_visible', False)" optional="show"/>
                 </list>
             </field>

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -63,10 +63,10 @@
                   multi_edit="1"
                   open_form_view="True"
                   js_class="todo_list">
-                <field name="priority" widget="priority" nolabel="1"/>
-                <field name="state" widget="todo_done_checkmark" nolabel="1"/>
+                <field name="state" widget="todo_done_checkmark" nolabel="1" width="20px"/>
                 <field name="name"/>
                 <field name="user_ids" optional="show" required="1" widget="many2many_avatar_user" options="{'no_quick_create': True}"/>
+                <field name="priority" widget="priority" optional="hidden" width="70px"/>
                 <field name="date_deadline" optional="show" widget="remaining_days"/>
                 <field name="activity_ids" optional="show" widget="list_activity"/>
                 <field name="tag_ids" optional="show" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
@@ -95,7 +95,6 @@
                     <div class="oe_title pe-0">
                         <h1 class="d-flex justify-content-between align-items-center">
                             <div class="d-flex w-100">
-                                <field name="priority" widget="priority_switch" class="me-3"/>
                                 <field name="name" options="{'line_breaks': False}" widget="text" class="o_task_name text-truncate w-md-75 w-100 pe-2" placeholder="To-do..."/>
                             </div>
                             <div class="d-flex justify-content-end o_state_container">
@@ -110,16 +109,15 @@
                                 required="1"
                                 options="{'no_quick_create': True}"
                                 placeholder="Assignees"/>
-                        </group>
-                        <group>
-                            <field name="date_deadline"
-                                decoration-danger="date_deadline &lt; current_date"/>
-                        </group>
-                        <group>
                             <field name="tag_ids"
                                 widget="many2many_tags"
                                 options="{'color_field': 'color', 'no_create_edit': True}"
                                 class="me-2"/>
+                        </group>
+                        <group>
+                            <field name="priority" widget="priority_switch" class="me-3"/>
+                            <field name="date_deadline"
+                                decoration-danger="date_deadline &lt; current_date"/>
                         </group>
                     </group>
                     <field name="description" type="html" class="oe_description" default_focus="1" options="{'resizable': false, 'collaborative': true}"
@@ -231,7 +229,6 @@
                 <field name="tag_ids"/>
                 <field name="user_ids"/>
                 <field name="personal_stage_type_ids" string="Stage"/>
-                <filter string="Starred" name="starred_tasks" domain="[('priority', '=', '1')]"/>
                 <separator/>
                 <filter name="open_tasks" string="Open" domain="[('is_closed', '=', False)]"/>
                 <filter name="closed_tasks" string="Closed" domain="[('is_closed', '=', True)]"/>
@@ -247,6 +244,7 @@
                 <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                         domain="[('my_activity_date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))]"/>
                 <group expand="0" string="Group By">
+                    <filter string="Priority" name="groupby_priority" context="{'group_by': 'priority'}"/>
                     <filter string="Tags" name="tags" help="By assigned tags" context="{'group_by':'tag_ids'}"/>
                     <filter string="Assignees" name="user_ids" context="{'group_by': 'user_ids'}"/>
                     <filter string="Stage" name="stage" help="By personal stages" context="{'group_by':'personal_stage_type_id'}"/>


### PR DESCRIPTION
Before this commit, the user can mark the task as urgent thanks to the star icon displayed to represent the priority. However, it does not give many granularities, either the task is priority one or not.

This commit replaces the star by 3 stars to have more granularities on tasks priority. Now, 4 levels of priority will be displayed:
- 0 star selected = "Low priority"
- 1 star selected = "Medium priority"
- 2 stars selected = "High priority"
- 3 stars selected = "Urgent"

task-4613436
