### PR TITLE
[FIX] purchase_stock: trigger intercompany buy routes

### DIFF
--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -54,12 +54,13 @@ class StockRule(models.Model):
             procurement_date_planned = fields.Datetime.from_string(procurement.values['date_planned'])
 
             supplier = False
+            company_id = rule.company_id or procurement.company_id
             if procurement.values.get('supplierinfo_id'):
                 supplier = procurement.values['supplierinfo_id']
             elif procurement.values.get('orderpoint_id') and procurement.values['orderpoint_id'].supplier_id:
                 supplier = procurement.values['orderpoint_id'].supplier_id
             else:
-                supplier = procurement.product_id.with_company(procurement.company_id.id)._select_seller(
+                supplier = procurement.product_id.with_company(company_id.id)._select_seller(
                     partner_id=self._get_partner_id(procurement.values, rule),
                     quantity=procurement.product_qty,
                     date=max(procurement_date_planned.date(), fields.Date.today()),
@@ -68,7 +69,7 @@ class StockRule(models.Model):
             # Fall back on a supplier for which no price may be defined. Not ideal, but better than
             # blocking the user.
             supplier = supplier or procurement.product_id._prepare_sellers(False).filtered(
-                lambda s: not s.company_id or s.company_id == procurement.company_id
+                lambda s: not s.company_id or s.company_id == company_id
             )[:1]
 
             if not supplier:
@@ -80,7 +81,7 @@ class StockRule(models.Model):
             procurement.values['supplier'] = supplier
             procurement.values['propagate_cancel'] = rule.propagate_cancel
 
-            domain = rule._make_po_get_domain(procurement.company_id, procurement.values, partner)
+            domain = rule._make_po_get_domain(company_id, procurement.values, partner)
             procurements_by_po_domain[domain].append((procurement, rule))
 
         if errors:
@@ -96,7 +97,7 @@ class StockRule(models.Model):
             origins = set([p.origin for p in procurements if p.origin])
             # Check if a PO exists for the current domain.
             po = self.env['purchase.order'].sudo().search([dom for dom in domain], limit=1)
-            company_id = procurements[0].company_id
+            company_id = rules[0].company_id or procurements[0].company_id
             if not po:
                 positive_values = [p.values for p in procurements if float_compare(p.product_qty, 0.0, precision_rounding=p.product_uom.rounding) >= 0]
                 if positive_values:

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -1357,3 +1357,73 @@ class TestReorderingRule(TransactionCase):
             [("product_id", "=", self.product_01.id)])
         self.assertTrue(po_line)
         self.assertEqual(po_line.order_id.currency_id, foreign_currency)
+
+    def test_intercompany_reordering_rules(self):
+        """
+        Have 2 companies, create a procurment to fulfil a demand in COMP1 using custom route
+        with 2 rules: an intercompany transit from COMP2 to COMP1 and a buy rule linked to COMP2.
+
+        Check that the purchase order is created in COMP2, using its set of supplier.
+        """
+        company_a, company_b = self.env['res.company'].create([
+            {'name': 'Company A'},
+            {'name': 'Company B'},
+        ])
+        warehouse_a, warehouse_b = self.env['stock.warehouse'].search([('company_id', 'in', [company_a.id, company_b.id])], limit=2).sorted('company_id')
+        route_resupply_from_intercomp = self.env['stock.route'].create([
+            {
+                'name': 'ressuply from intercomp',
+                'active': True,
+                'company_id': False,
+                'product_selectable': True,
+                'rule_ids': [
+                    Command.create({
+                        'name': 'inter-comp -> Stock A',
+                        'action': 'pull',
+                        'picking_type_id': warehouse_a.int_type_id.id,
+                        'location_src_id': self.ref('stock.stock_location_inter_company'),
+                        'location_dest_id': warehouse_a.lot_stock_id.id,
+                        'company_id': company_a.id,
+                        'procure_method': 'make_to_order',
+                    }),
+                    Command.create({
+                        'name': 'Stock B -> inter-comp',
+                        'action': 'buy',
+                        'picking_type_id': warehouse_b.out_type_id.id,
+                        'location_src_id': warehouse_b.lot_stock_id.id,
+                        'location_dest_id': self.ref('stock.stock_location_inter_company'),
+                        'company_id': company_b.id,
+                        'procure_method': 'make_to_order',
+                    }),
+                    Command.create({
+                        'name': 'Buy -> Stock B',
+                        'action': 'buy',
+                        'picking_type_id': warehouse_b.in_type_id.id,
+                        'location_dest_id': warehouse_b.lot_stock_id.id,
+                        'company_id': company_b.id,
+                        'procure_method': 'make_to_stock',
+                    })
+                ]
+            },
+        ])
+        product = self.env['product.product'].create({
+            'name': 'super product',
+            'is_storable': True,
+            'route_ids': [Command.set(route_resupply_from_intercomp.ids)],
+            'seller_ids': [Command.create({'partner_id': self.partner.id, 'company_id': company_b.id})],
+        })
+        orderpoint = self.env['stock.warehouse.orderpoint'].with_company(company_a).create({
+            'name': 'RR for %s' % product.name,
+            'warehouse_id': warehouse_a.id,
+            'location_id': warehouse_a.lot_stock_id.id,
+            'trigger': 'manual',
+            'product_id': product.id,
+            'product_min_qty': 10,
+            'product_max_qty': 10,
+            'route_id': route_resupply_from_intercomp.id,
+        })
+        orderpoint.action_replenish()
+        # check that the a PO was created in company B for 10 units
+        self.assertRecordValues(self.env['purchase.order'].search([('company_id', '=', company_b.id), ('partner_id', '=', self.partner.id)], limit=1).order_line, [{
+            'product_id': product.id, 'product_uom_qty': 10,
+        }])


### PR DESCRIPTION
### Issue:

Currently, running a procurment to fulfill a demand in COMP1 linked to a buy rule of COMP2 toaward the inter-company transit will use seller's set in COMP1 and generate a PO in COMP1 rather than COMP2.

### Steps to reproduce:

- In the settings enable Multi-steps routes
- Have two companies: COMP1 and COMP2
- Create a routes without set companies with 3 rules:
  - rule 1 (comp1): - Pull from Virtual Locations/Inter-company transit to WH1/Stock supply method: Trigger an other rule.
  - rule 2 (comp2):  - Pull from  WH2/Stock to Virtual Locations/Inter-company transit, supply method: Trigger an other rule.
  - rule 3 (comp2): - Buy from Partner/vendors to WH2/Stock using a custom operation type towards Virtual Locations/Inter-company transit.
- Create a storable product with both routes set.
- With COMP2: set a vendor on that product.
- In COMP1, your product > Reordering rules create a new rule using the COMP1 route to replenish WH1/Stock.
- With both COMP1 and COMP2 as active order once.
> The PO could not find a vendor as it looked for suppliers in COMP1 and if such a supplier was set in COMP1, the PO would be created in COMP1.

### Cause of the issue:

While the rule of COMP2 is found and used to run the procurment here: https://github.com/odoo/odoo/blob/2cd3d6a76db6bedba8bbb3233690b0cd72f87876/addons/stock/models/stock_rule.py#L484 the procurement was created and is linked to the company owning the move creating the demand (that is COMP1):
https://github.com/odoo/odoo/blob/2cd3d6a76db6bedba8bbb3233690b0cd72f87876/addons/stock/models/stock_move.py#L1494-L1498 However, the `company_id` used in the `_run_buy` notably for the data's of the PO will be the company linked to the procurement rather than the company linked to the buy rule. Since the buy rule should generate a purchase order in company it uses, this is incorrect.

opw-4578965
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
