### PR TITLE
[FIX] portal: prevent traceback when "Show Header" is disabled

### DIFF
--- a/addons/portal/static/src/chatter/frontend/chatter_patch.js
+++ b/addons/portal/static/src/chatter/frontend/chatter_patch.js
@@ -11,12 +11,8 @@ patch(Chatter.prototype, {
             // Keep the composer position under the page header on scrolling 
             // unless the header is on the side.
             const headerEl = document.querySelector("#wrapwrap header");
-            if (!this.props.twoColumns && !headerEl.matches(".o_header_sidebar")) {
-                const paddingTop = headerEl
-                    ? headerEl.getBoundingClientRect().height +
-                      15 +
-                      "px"
-                    : "";
+            if (!this.props.twoColumns && headerEl && !headerEl.matches(".o_header_sidebar")) {
+                const paddingTop = headerEl.getBoundingClientRect().height + 15 + "px";
                 this.observer = new window.IntersectionObserver(
                     ([e]) =>
                         (e.target.style.paddingTop =


### PR DESCRIPTION
**Problem**:
After commit [9cf7726](https://github.com/odoo/odoo/commit/9cf7726d0402353ccef551148010aaff8a2059be), `headerEl` can be `null` if the "Show Header" option is turned off, causing a traceback.

**Solution**:
Check if `#wrapwrap header` exists and ensure `headerEl` is not `null`.

**Steps to Reproduce**:
1. Install **E-learning**.
2. Open **Website > Site > Courses**.
3. Open any course.
4. Switch to **Edit mode**.
5. In the editor menu, disable **"Show Header"** under **Theme > Advanced**.
6. Save.
7. A traceback occurs.

opw-4565265

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
