### PR TITLE
[FIX] base_import: fix missing model_name key

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -368,14 +368,16 @@ class Import(models.TransientModel):
 
             if field['type'] in ('many2many', 'many2one'):
                 field_value['fields'] = [
-                    dict(field_value, name='id', string=_("External ID"), type='id'),
-                    dict(field_value, name='.id', string=_("Database ID"), type='id'),
+                    dict(field_value, model_name=field['relation'], name='id', string=_("External ID"), type='id'),
+                    dict(field_value, model_name=field['relation'], name='.id', string=_("Database ID"), type='id'),
                 ]
                 field_value['comodel_name'] = field['relation']
             elif field['type'] == 'one2many':
                 field_value['fields'] = self.get_fields_tree(field['relation'], depth=depth-1)
                 if self.env.user.has_group('base.group_no_one'):
-                    field_value['fields'].append({'id': '.id', 'name': '.id', 'string': _("Database ID"), 'required': False, 'fields': [], 'type': 'id'})
+                    field_value['fields'].append(
+                        dict(field_value, model_name=field['relation'], fields=[], name='.id', string=_("Database ID"), type='id')
+                    )
                 field_value['comodel_name'] = field['relation']
 
             importable_fields.append(field_value)

--- a/addons/test_import_export/tests/test_import.py
+++ b/addons/test_import_export/tests/test_import.py
@@ -89,8 +89,8 @@ class TestBasicFields(BaseImportCase):
         self.assertEqualFields(self.get_fields('m2o'), make_field(
             field_type='many2one', comodel_name='import.m2o.related', model_name='import.m2o',
             fields=[
-                {'id': 'value', 'name': 'id', 'string': 'External ID', 'required': False, 'fields': [], 'type': 'id', 'model_name': 'import.m2o'},
-                {'id': 'value', 'name': '.id', 'string': 'Database ID', 'required': False, 'fields': [], 'type': 'id', 'model_name': 'import.m2o'},
+                {'id': 'value', 'name': 'id', 'string': 'External ID', 'required': False, 'fields': [], 'type': 'id', 'model_name': 'import.m2o.related'},
+                {'id': 'value', 'name': '.id', 'string': 'Database ID', 'required': False, 'fields': [], 'type': 'id', 'model_name': 'import.m2o.related'},
         ]))
 
     def test_m2o_required(self):
@@ -101,19 +101,17 @@ class TestBasicFields(BaseImportCase):
         self.assertEqualFields(self.get_fields('m2o.required'), make_field(
             field_type='many2one', required=True, comodel_name='import.m2o.required.related', model_name='import.m2o.required',
             fields=[
-                {'id': 'value', 'name': 'id', 'string': 'External ID', 'required': True, 'fields': [], 'type': 'id', 'model_name': 'import.m2o.required'},
-                {'id': 'value', 'name': '.id', 'string': 'Database ID', 'required': True, 'fields': [], 'type': 'id', 'model_name': 'import.m2o.required'},
+                {'id': 'value', 'name': 'id', 'string': 'External ID', 'required': True, 'fields': [], 'type': 'id', 'model_name': 'import.m2o.required.related'},
+                {'id': 'value', 'name': '.id', 'string': 'Database ID', 'required': True, 'fields': [], 'type': 'id', 'model_name': 'import.m2o.required.related'},
         ]))
 
 
 class TestO2M(BaseImportCase):
 
-    def get_fields(self, field):
-        return self.env['base_import.import'].get_fields_tree(f"import.{field}")
-
     def test_shallow(self):
         self.assertEqualFields(
-            self.get_fields('o2m'), [
+            self.env['base_import.import'].get_fields_tree("import.o2m"), 
+            [
                 get_id_field("import.o2m"),
                 {'id': 'name', 'name': 'name', 'string': "Name", 'required': False, 'fields': [], 'type': 'char', 'model_name': 'import.o2m'},
                 {
@@ -125,10 +123,10 @@ class TestO2M(BaseImportCase):
                             'id': 'parent_id', 'name': 'parent_id', 'model_name': 'import.o2m.child',
                             'string': 'Parent', 'type': 'many2one', 'comodel_name': 'import.o2m',
                             'required': False, 'fields': [
-                                {'id': 'parent_id', 'name': 'id', 'model_name': 'import.o2m.child',
+                                {'id': 'parent_id', 'name': 'id', 'model_name': 'import.o2m',
                                  'string': 'External ID', 'required': False,
                                  'fields': [], 'type': 'id'},
-                                {'id': 'parent_id', 'name': '.id', 'model_name': 'import.o2m.child',
+                                {'id': 'parent_id', 'name': '.id', 'model_name': 'import.o2m',
                                  'string': 'Database ID', 'required': False,
                                  'fields': [], 'type': 'id'},
                             ]
@@ -140,6 +138,39 @@ class TestO2M(BaseImportCase):
                 }
             ]
         )
+
+    def test_shallow_debug(self):
+        with self.debug_mode():
+            self.assertEqualFields(
+                self.env['base_import.import'].get_fields_tree("import.o2m"),
+                [
+                    get_id_field("import.o2m"),
+                    {'id': 'name', 'name': 'name', 'string': "Name", 'required': False, 'fields': [], 'type': 'char', 'model_name': 'import.o2m'},
+                    {
+                        'id': 'value', 'name': 'value', 'string': 'Value', 'model_name': 'import.o2m',
+                        'required': False, 'type': 'one2many', 'comodel_name': 'import.o2m.child',
+                        'fields': [
+                            get_id_field("import.o2m.child"),
+                            {
+                                'id': 'parent_id', 'name': 'parent_id', 'model_name': 'import.o2m.child',
+                                'string': 'Parent', 'type': 'many2one', 'comodel_name': 'import.o2m',
+                                'required': False, 'fields': [
+                                    {'id': 'parent_id', 'name': 'id', 'model_name': 'import.o2m',
+                                    'string': 'External ID', 'required': False,
+                                    'fields': [], 'type': 'id'},
+                                    {'id': 'parent_id', 'name': '.id', 'model_name': 'import.o2m',
+                                    'string': 'Database ID', 'required': False,
+                                    'fields': [], 'type': 'id'},
+                                ]
+                            },
+                            {'id': 'value', 'name': 'value', 'string': 'Value',
+                            'required': False, 'fields': [], 'type': 'integer', 'model_name': 'import.o2m.child',
+                            },
+                            {'id': 'value', 'name': '.id', 'string': 'Database ID', 'required': False, 'fields': [], 'type': 'id', 'model_name': 'import.o2m.child'}
+                        ]
+                    }
+                ]
+            )
 
 
 class TestMatchHeadersSingle(TransactionCase):


### PR DESCRIPTION
In debug mode, import previews were failing with a "'model_name'" KeyError when column headers included one2many/id fields. This occurred because the 'model_name' is missing from the field definition dictionary returned by `get_fields_tree` for '.id' in debug mode in case of one2many. 

Since the introduction of https://github.com/odoo/odoo/pull/174366, 'model_name' should be always included in these field definitions. 

Additionally, this commit corrects the 'model_name' for relational ID fields. Previously, these fields incorrectly targeted the current model instead of the comodel. This fix prevents `_get_mapping_suggestion` from targeting the wrong model during its fallback mechanism, which relies on 'model_name'. 