### PR TITLE
[FIX] purchase_mrp, sale_mrp: inter company delivered and received qty for kit

### DIFF
--- a/addons/purchase_mrp/models/purchase.py
+++ b/addons/purchase_mrp/models/purchase.py
@@ -67,7 +67,7 @@ class PurchaseOrderLine(models.Model):
                 moves = line.move_ids.filtered(lambda m: m.state == 'done' and not m.scrapped)
                 order_qty = line.product_uom._compute_quantity(line.product_uom_qty, kit_bom.product_uom_id)
                 filters = {
-                    'incoming_moves': lambda m: m.location_id.usage == 'supplier' and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
+                    'incoming_moves': lambda m: m.location_id.usage in ['supplier', 'transit'] and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
                     'outgoing_moves': lambda m: m.location_id.usage != 'supplier' and m.to_refund
                 }
                 line.qty_received = moves._compute_kit_quantities(line.product_id, order_qty, kit_bom, filters)

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -1275,3 +1275,36 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
         self.assertEqual(lot_a.standard_price, 10)
         self.assertEqual(lot_a.quantity_svl, 4)
         self.assertEqual(lot_a.value_svl, 40)
+
+    def test_inter_company_received_qty_with_kit(self):
+        """
+        Test that the received quantity on a purchase order lines gets updated when purchasing a kit
+        through an inter-company transaction.
+        """
+        # Create the purchase order with a partner that uses the inter company location
+        inter_comp_location = self.env.ref('stock.stock_location_inter_company')
+        partner = self.env['res.partner'].create({'name': 'Testing Partner'})
+        partner.property_stock_customer = inter_comp_location
+        partner.property_stock_supplier = inter_comp_location
+        po = self.env['purchase.order'].create({
+            'partner_id': partner.id,
+            'order_line': [
+                (0, 0,
+                 {
+                     'name': self.kit_1.name,
+                     'product_id': self.kit_1.id,
+                     'product_qty': 1,
+                 })
+            ]
+        })
+        po.button_confirm()
+
+        self.assertTrue(po.picking_ids)
+        self.assertEqual(po.order_line.qty_received, 0)
+
+        picking = po.picking_ids
+        for move in picking.move_ids:
+            move.write({'quantity': move.product_uom_qty, 'picked': True})
+        picking.button_validate()
+
+        self.assertEqual(po.order_line.qty_received, 1)

--- a/addons/sale_mrp/models/sale_order_line.py
+++ b/addons/sale_mrp/models/sale_order_line.py
@@ -66,7 +66,7 @@ class SaleOrderLine(models.Model):
                         continue
                     moves = order_line.move_ids.filtered(lambda m: m.state == 'done' and not m.scrapped)
                     filters = {
-                        'incoming_moves': lambda m: m.location_dest_id.usage == 'customer' and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
+                        'incoming_moves': lambda m: m.location_dest_id.usage in ['customer', 'transit'] and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
                         'outgoing_moves': lambda m: m.location_dest_id.usage != 'customer' and m.to_refund
                     }
                     order_qty = order_line.product_uom._compute_quantity(order_line.product_uom_qty, relevant_bom.product_uom_id)

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -658,3 +658,46 @@ class TestSaleMrpKitBom(TransactionCase):
         sol.with_user(user_admin).write({'product_uom_qty': 5})
 
         self.assertEqual(sum(sol.move_ids.mapped('product_uom_qty')), 5)
+
+    def test_inter_company_qty_delivered_with_kit(self):
+        """
+        Test that the delivered quantity is updated on a sale order line when selling a kit
+        through an inter-company transaction.
+        """
+        # Create the kit product and BoM
+        kit_product = self._create_product('Kit', 'product', 1)
+        component_product = self._create_product('Component', 'product', 1)
+        self.env['mrp.bom'].create({
+            'product_id': kit_product.id,
+            'product_tmpl_id': kit_product.product_tmpl_id.id,
+            'product_qty': 1,
+            'consumption': 'flexible',
+            'type': 'phantom',
+            'bom_line_ids': [(0, 0, {'product_id': component_product.id, 'product_qty': 1})]
+        })
+
+        # Create the sale order with a partner that uses the inter company location
+        inter_comp_location = self.env.ref('stock.stock_location_inter_company')
+        partner = self.env['res.partner'].create({'name': 'Testing Partner'})
+        partner.property_stock_customer = inter_comp_location
+        partner.property_stock_supplier = inter_comp_location
+        so = self.env['sale.order'].create({
+            'partner_id': partner.id,
+            'order_line': [
+                (0, 0, {
+                    'name': kit_product.name,
+                    'product_id': kit_product.id,
+                    'product_uom_qty': 1.0,
+                })
+            ]
+        })
+        so.action_confirm()
+
+        self.assertTrue(so.picking_ids)
+        self.assertEqual(so.order_line.qty_delivered, 0)
+
+        picking = so.picking_ids
+        picking.move_ids.write({'quantity': 1, 'picked': True})
+        picking.button_validate()
+
+        self.assertEqual(so.order_line.qty_delivered, 1)


### PR DESCRIPTION
Problem: The delivered and received quantities on sale order and purchase order lines don’t get updated during intercompany transactions for kit products. This is because the transit location is used instead of the supplier and customer locations.

Purpose: Updating the filter to include transit locations will allow stock moves to and from the transit locations to be included in the delivered and received quantities.

Steps to Reproduce on Runbot:
1. Enable Inter-Company Transactions for both companies, with Generate Sales Orders, Generate Purchase Orders, and Synchronize Deliveries to your Receipts selected.
2. Create a product and create a kit type bill of materials for it. Remove the company from the bill of materials so it is available for both companies.
3. Create a sale order for this kit product with the customer set to another one of your companies.
4. Confirm the sale order and validate the picking.
5. Observe the delivered quantity on the sale order line is still 0.
6. Switch to the company you sold the kit to.
7. Navigate to the purchase order that was created and confirm it.
8. Validate the picking.
9. Observe the received quantity is still 0.

opw-4536144

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
