### PR TITLE
[FIX] mail, im_livechat: cannot reset operatorFound after finding one

### DIFF
--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_step_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_step_model.js
@@ -3,7 +3,16 @@ import { AND, Record } from "@mail/core/common/record";
 export class ChatbotStep extends Record {
     static id = AND("scriptStep", "message");
 
-    operatorFound = false;
+    operatorFound = Record.attr(false, {
+        /**
+         * Cannot change from having found an operator to not having found one.
+         *
+         * @this {import("models").ChatbotStep}
+         */
+        ignoreUpdateWhen(new_val) {
+            return this.operatorFound && !new_val;
+        },
+    });
     scriptStep = Record.one("chatbot.script.step");
     message = Record.one("mail.message", { inverse: "chatbotStep" });
     answers = Record.many("chatbot.script.answer", {

--- a/addons/mail/static/src/model/model_internal.js
+++ b/addons/mail/static/src/model/model_internal.js
@@ -17,6 +17,8 @@ export class ModelInternal {
     fieldsCompute = new Map();
     /** @type {Map<string, boolean>} */
     fieldsEager = new Map();
+    /** @type {Map<string, function>} */
+    fieldsIgnoreUpdateWhen = new Map();
     /** @type {Map<string, string>} */
     fieldsInverse = new Map();
     /** @type {Map<string, () => void>} */
@@ -68,6 +70,10 @@ export class ModelInternal {
                 }
                 case "sort": {
                     this.fieldsSort.set(fieldName, value);
+                    break;
+                }
+                case "ignoreUpdateWhen": {
+                    this.fieldsIgnoreUpdateWhen.set(fieldName, value);
                     break;
                 }
                 case "inverse": {

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -1048,3 +1048,28 @@ test("insert with id relation keeps existing field values", async () => {
     expect(member2.channel.eq(channel1)).toBe(true);
     expect(member2.is_internal).toBe(true);
 });
+
+test("ignores update when condition matches", async () => {
+    (class Persona extends Record {
+        static id = "name";
+        name;
+        neverFalseAgain = Record.attr(undefined, {
+            ignoreUpdateWhen(new_val) {
+                return this.neverFalseAgain && !new_val;
+            },
+        });
+    }).register(localRegistry);
+    const store = await start();
+    const john = store.Persona.insert("John");
+    expect(john.neverFalseAgain).toBe(undefined);
+    john.neverFalseAgain = false;
+    expect(john.neverFalseAgain).toBe(false);
+    john.neverFalseAgain = undefined;
+    expect(john.neverFalseAgain).toBe(undefined);
+    john.neverFalseAgain = true;
+    expect(john.neverFalseAgain).toBe(true);
+    john.neverFalseAgain = false;
+    expect(john.neverFalseAgain).toBe(true);
+    john.neverFalseAgain = undefined;
+    expect(john.neverFalseAgain).toBe(true);
+});


### PR DESCRIPTION
Race condition in flows could lead to resetting operatorFound after finding one, which should never be allowed in practice.