### PR TITLE
[FIX] point_of_sale: register user on residual order

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -45,6 +45,10 @@ export class PosOrder extends Base {
             this.lines = [];
         }
 
+        if (!this.user_id && this.models["res.users"]) {
+            this.user_id = this.user;
+        }
+
         // !!Keep all uiState in one object!!
         if (!this.uiState) {
             this.uiState = {

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -472,3 +472,36 @@ registry.category("web_tour.tours").add("MultiPreparationPrinter", {
             Dialog.confirm(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("LeaveResidualOrder", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.totalAmountIs("2.20"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Chrome.clickPlanButton(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("FinishResidualOrder", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.totalAmountIs("2.20"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -453,3 +453,12 @@ class TestFrontend(TestFrontendCommon):
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'MultiPreparationPrinter', login="pos_user")
+
+    def test_user_on_residual_order(self):
+        self.pos_config.write({'printer_ids': False})
+        self.pos_config.with_user(self.pos_admin).open_ui()
+        self.start_pos_tour('LeaveResidualOrder', login="pos_admin")
+        self.start_pos_tour('FinishResidualOrder', login="pos_user")
+        orders = self.env['pos.order'].search([])
+        self.assertEqual(orders[0].user_id.id, self.pos_user.id, "Pos user not registered on order")
+        self.assertEqual(orders[1].user_id.id, self.pos_admin.id, "Pos admin not registered on order")


### PR DESCRIPTION
Currently, when using the same pos session with different users can result in some order being created without user_id.

Steps to reproduce:
-------------------
* Open register as Mitchell Admin
* Make a pos order, pay with cash, validate, select 'new order'
* Log out
* Log with Marc Demo and open the pos
* Make a pos order, pay with cash, validate
* In the backend, see both orders
> Observation: For the second order, Mard Demo is written in the chatter
as the one who created the order but on the form no user is registered

Why the fix:
------------
This happens because when selecting 'new order', an order gets created which will then be loaded back when logging with the second user.

When loaded the order has an unidentified user but still has a user_id in the vals of the setup. We do not want to use this user as it is the one that created the order, not the one who finalized it.

opw-4566194
