### PR TITLE
[FIX] mail: cannot open chat windows when chat hub is compact

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -3,10 +3,9 @@
 
 <t t-name="mail.ChatHub">
     <div class="o-mail-ChatHub" t-if="isShown or ui.isSmall">
-        <t t-if="!store.chatHub.compact">
-            <t t-foreach="chatHub.opened" t-as="cw" t-key="cw.localId">
-                <ChatWindow chatWindow="cw" right="env.embedLivechat ? chatHub.WINDOW_GAP : (chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (chatHub.opened.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2))"/>
-            </t>
+        <t t-set="visibleChatWindows" t-value="chatHub.compact ? chatHub.opened.filter(({ bypassCompact }) => bypassCompact) : chatHub.opened "/>
+        <t t-foreach="visibleChatWindows" t-as="cw" t-key="cw.localId">
+            <ChatWindow chatWindow="cw" right="env.embedLivechat ? chatHub.WINDOW_GAP : (chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (visibleChatWindows.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2))"/>
         </t>
         <div class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto', 'o-liftUp': busMonitoring.hasConnectionIssues }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
             <div class="d-flex flex-column align-content-start justify-content-end align-items-center gap-1">
@@ -17,7 +16,7 @@
                     <Dropdown t-if="(chatHub.opened.length + chatHub.folded.length) gt 0" state="options" position="'top-end'" menuClass="'d-flex flex-column bg-100 shadow-sm m-0 p-0 mb-1 border-secondary'">
                         <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-100 mt-1" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !options.isOpen and !isMobileOS, 'text-500': bubblesHover.isHover and !options.isOpen and !isMobileOS, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"/>
                         <t t-set-slot="content">
-                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.compact = true"><i class="fa fa-fw fa-eye-slash"></i>Hide all conversations</button>
+                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.hideAll()"><i class="fa fa-fw fa-eye-slash"></i>Hide all conversations</button>
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close"></i>Close all conversations</button>
                         </t>
                     </Dropdown>

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -64,6 +64,13 @@ export class ChatHub extends Record {
         this.save(); // sync only once at the end
     }
 
+    hideAll() {
+        for (const cw of this.opened) {
+            cw.bypassCompact = false;
+        }
+        this.compact = true;
+    }
+
     onRecompute() {
         while (this.opened.length > this.maxOpened) {
             const cw = this.opened.pop();

--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -21,6 +21,7 @@ export class ChatWindow extends Record {
     }
 
     actionsDisabled = false;
+    bypassCompact = false;
     thread = Record.one("Thread");
     autofocus = 0;
     jumpToNewMessage = 0;
@@ -69,6 +70,7 @@ export class ChatWindow extends Record {
         this.store.chatHub.folded.delete(this);
         this.store.chatHub.folded.unshift(this);
         this.store.chatHub.save();
+        this.bypassCompact = false;
     }
 
     async open({ focus = false, notifyState = true, jumpToNewMessage = false } = {}) {

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -699,14 +699,14 @@ export class Thread extends Record {
     /** @param {Object} [options] */
     open(options) {}
 
-    async openChatWindow({ focus = false, fromMessagingMenu } = {}) {
+    async openChatWindow({ focus = false, fromMessagingMenu, bypassCompact } = {}) {
         const thread = await this.store.Thread.getOrFetch(this);
         if (!thread) {
             return;
         }
         await this.store.chatHub.initPromise;
         const cw = this.store.ChatWindow.insert(
-            assignDefined({ thread: this }, { fromMessagingMenu })
+            assignDefined({ thread: this }, { fromMessagingMenu, bypassCompact })
         );
         cw.open({ focus: focus });
         if (isMobileOS()) {

--- a/addons/mail/static/src/core/public_web/messaging_menu.js
+++ b/addons/mail/static/src/core/public_web/messaging_menu.js
@@ -137,7 +137,7 @@ export class MessagingMenu extends Component {
     }
 
     openDiscussion(thread) {
-        thread.open({ focus: true, fromMessagingMenu: true });
+        thread.open({ focus: true, fromMessagingMenu: true, bypassCompact: true });
         this.dropdown.close();
     }
 

--- a/addons/mail/static/src/discuss/core/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/store_service_patch.js
@@ -67,13 +67,13 @@ const storeServicePatch = {
         const partners_to = [...new Set([this.self.id, ...partnerIds])];
         if (partners_to.length === 1) {
             const chat = await this.joinChat(partners_to[0], true);
-            chat.open({ focus: true });
+            chat.open({ focus: true, bypassCompact: true });
         } else if (partners_to.length === 2) {
             const correspondentId = partners_to.find(
                 (partnerId) => partnerId !== this.store.self.id
             );
             const chat = await this.joinChat(correspondentId, true);
-            chat.open({ focus: true });
+            chat.open({ focus: true, bypassCompact: true });
         } else {
             await this.createGroupChat({ partners_to });
         }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
@@ -119,7 +119,7 @@ async function makeNewChannel(name, store) {
     });
     const { Thread } = store.insert(data);
     const [channel] = Thread;
-    channel.open({ focus: true });
+    channel.open({ focus: true, bypassCompact: true });
 }
 
 export class DiscussCommandPalette {
@@ -224,7 +224,7 @@ export class DiscussCommandPalette {
                 Component: DiscussCommand,
                 action: async () => {
                     const channel = await this.store.Thread.getOrFetch(thread);
-                    channel.open({ focus: true });
+                    channel.open({ focus: true, bypassCompact: true });
                 },
                 name: thread.displayName,
                 category,


### PR DESCRIPTION
The chat hub's compact mode hides all chat windows to prevent
disturbances, mainly from automatic actions. However, users should
still be able to open chats explicitly (e.g., via the command palette
or messaging menu).

This PR allows user-initiated chats to open even in compact mode,
balancing distraction-free usage with accessibility.