### PR TITLE
[FIX] website_event: show card details on list view for events

### DIFF
--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -314,7 +314,7 @@
                             <t t-call="website.record_cover">
                                 <t t-set="_record" t-value="event"/>
                                 <meta itemprop="startDate" t-att-content="event.date_begin.isoformat()"/>
-                                <!-- Short date + Country Flag -->
+                                <!-- Short date + (optional) Country Flag -->
                                 <div t-if="opt_events_event_location" t-attf-class="o_wevent_date_with_flag o_wevent_event_date position-absolute shadow-sm o_not_editable #{(not opt_events_list_columns) and 'left'} ">
                                     <div class="o_wevent_event_date_text">
                                         <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'LLL'}" class="o_wevent_event_month"/>
@@ -325,7 +325,6 @@
                                         <i t-elif="not event.country_id" class="fa fa-video-camera h-100"/>
                                     </div>
                                 </div>
-                                <!-- Short Date -->
                                 <div t-else="" t-attf-class="o_wevent_event_date position-absolute shadow-sm o_not_editable #{(not opt_events_list_columns) and 'left'} ">
                                     <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'LLL'}" class="o_wevent_event_month"/>
                                     <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'dd'}" class="o_wevent_event_day oe_hide_on_date_edit"/>


### PR DESCRIPTION
When changing the website view of the events from grid to list, we are losing the "Sold out, Unpublished, etc" information that was displayed on the card. This is due to loading the event calendar date widget before the rest of the elements which is provoking them to not properly load.

opw-4597647

## Before:

![image](https://github.com/user-attachments/assets/c335f7fd-fd8f-40ad-8202-6e39a7277b4b)


## After:

![image](https://github.com/user-attachments/assets/c02aca35-c2c6-4c43-902a-7748708c104d)
