### PR TITLE
[FIX] l10n_hu_edi: Fix company logo size on invoice

### DIFF
--- a/addons/l10n_hu_edi/views/report_invoice.xml
+++ b/addons/l10n_hu_edi/views/report_invoice.xml
@@ -117,7 +117,7 @@
     <template id="custom_header">
         <div class="row mb8">
             <div class="col-6">
-                <img t-if="company.logo" t-att-src="image_data_uri(company.logo)" alt="Logo"/>
+                <img t-if="company.logo" class="o_company_logo_small" t-att-src="image_data_uri(company.logo)" alt="Logo"/>
             </div>
             <div class="col-6 text-end mb4">
                 <div class="mt0 h4" t-field="company.report_header"/>


### PR DESCRIPTION
The company logo on the hungarian invoices are too big if the used picture is big, because the size is not limited on the PDF report.

So we set the class "o_company_logo_small" on the picture just like on everywhere in Odoo.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
