### PR TITLE
[IMP] website_event: allow creating pages as part of an event

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -158,11 +158,16 @@ class WebsiteEventController(http.Controller):
             'event': event,
         }
 
+        base_page_name = page
         if '.' not in page:
             page = 'website_event.%s' % page
 
         view = request.env["website.event.menu"].sudo().search([
-            ("event_id", "=", event.id), ("view_id.key", "ilike", page)], limit=1).view_id
+            ("event_id", "=", event.id),
+            '|',
+              ("view_id.key", "ilike", page),
+              ("view_id.key", "ilike", f'website_event.{event.name}-{base_page_name.split("/")[-1]}'),
+        ], limit=1).view_id
 
         try:
             # Every event page view should have its own SEO.

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -265,6 +265,12 @@ class EventEvent(models.Model):
             default_menu_values = {'event_id': new_event.id}
             new_event.menu_id = old_event.menu_id.copy({'name': new_event.name, 'website_id': new_event.website_id.id})
             new_event.introduction_menu_ids = old_event.introduction_menu_ids.copy(default_menu_values)
+            custom_page_menus = old_event.community_menu_ids.filtered(lambda menu: menu.view_id)
+            if custom_page_menus:
+                # workaround for stable, 'regular' community menus are not supposed to be duplicated
+                # remove this if in master, see 'website.menu#save' method override
+                custom_page_menus.copy(default_menu_values)
+
             new_event.location_menu_ids = old_event.location_menu_ids.copy(default_menu_values)
             (new_event.introduction_menu_ids + new_event.location_menu_ids + new_event.community_menu_ids + new_event.register_menu_ids).menu_id.parent_id = new_event.menu_id
 

--- a/addons/website_event/models/website.py
+++ b/addons/website_event/models/website.py
@@ -1,11 +1,47 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, _
+from odoo import api, models, _
 
 
 class Website(models.Model):
     _inherit = "website"
+
+    @api.model
+    def new_page(self, name=False, add_menu=False, template='website.default_page', ispage=True, namespace=None, page_values=None, menu_values=None, sections_arch=None):
+        """ Override the page creation in the context of events.
+
+         When creating a page for an event, the page needs to be embedded inside the
+         'website_event.layout' template, otherwise it is not visually contained within that event.
+         Note that to create an event page, one has to first create a menu entry in that event.
+
+         To determine if this page is an event page:
+         - Check that the path starts with 'event/', this should avoid extra requests in other contexts
+         - Fetch a website.menu linked to this path
+         - Check if we have a website.event.menu linked to that website.menu.
+
+         In addition, we attach the created view to the website.event.menu and adapt they view key
+         to make it unique in the context of our event, which makes it possible to find the view in
+         the event pages controller.
+
+         See: website.menu#save override """
+
+        website_event_menu = False
+        if template == 'website.default_page' and name and name.startswith('event/'):
+            website_menu = self.env["website.menu"].sudo().search([('url', '=', '/' + name)], limit=1)
+            website_event_menu = self.env["website.event.menu"].sudo().search([
+                ('menu_id', '=', website_menu.id)
+            ], limit=1)
+            if website_event_menu:
+                template = "website_event.layout"
+
+        new_page = super().new_page(name, add_menu, template, ispage, namespace, page_values, menu_values, sections_arch)
+
+        if website_event_menu and new_page.get('view_id'):
+            website_event_menu.view_id = new_page['view_id']
+            website_event_menu.view_id.key = f'website_event.{website_event_menu.event_id.name}-{name.split("/")[-1]}'
+
+        return new_page
 
     def get_suggested_controllers(self):
         suggested_controllers = super(Website, self).get_suggested_controllers()

--- a/addons/website_event/models/website_event_menu.py
+++ b/addons/website_event/models/website_event_menu.py
@@ -42,9 +42,18 @@ class WebsiteEventMenu(models.Model):
                 'website_id': view.website_id.id,
             })
             self._copy_children_views(new_menu.view_id, view.inherit_children_ids, old_menu.event_id.website_id.id)
-            new_menu.menu_id = old_menu.menu_id.copy({
-                'url': f"/event/{self.env['ir.http']._slug(new_menu.event_id)}/page/{new_menu.view_id.key.split('.')[-1]}"
-            })
+            new_url = f"/event/{self.env['ir.http']._slug(new_menu.event_id)}/page/{new_menu.view_id.key.split('.')[-1]}"
+            new_menu_defaults = {
+                'url': new_url
+            }
+
+            if old_menu.menu_id.page_id:
+                new_page = old_menu.menu_id.page_id.copy({
+                    'url': new_url
+                })
+                new_menu_defaults['page_id'] = new_page.id
+
+            new_menu.menu_id = old_menu.menu_id.copy(new_menu_defaults)
         return new_menus
 
     @api.model

--- a/addons/website_event/models/website_menu.py
+++ b/addons/website_event/models/website_menu.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from datetime import datetime
+
+from odoo import api, models
 
 
 class WebsiteMenu(models.Model):
@@ -14,6 +16,10 @@ class WebsiteMenu(models.Model):
         for event_menu in website_event_menus:
             to_update = event_updates.setdefault(event_menu.event_id, list())
             for menu_type, fname in event_menu.event_id._get_menu_type_field_matching().items():
+                # workaround for stable, remove this if in master, see 'save' method override
+                if menu_type == 'community' and event_menu.view_id:
+                    continue
+
                 if event_menu.menu_type == menu_type:
                     to_update.append(fname)
 
@@ -26,5 +32,81 @@ class WebsiteMenu(models.Model):
         for event, to_update in event_updates.items():
             if to_update:
                 event.write(dict((fname, False) for fname in to_update))
+
+        return res
+
+    @api.model
+    def save(self, website_id, data):
+        """
+        Method context:
+
+        This method takes a data argument that follows the following format:
+         [
+           { 'id': 4, url: '/mypage' },
+           { 'id': 'menu_xxx_...', url: '/anotherpage' }
+         ]
+
+         The new menu entries are identified by their ID being a string and not an integer value.
+         Note that when going through super() call, those id entries are replaced by their created
+         menu ID (integer), so we need to identify new menu entries before calling super.
+
+         Override purpose:
+
+         All sub-menus of an event are children of a 'main' website.menu, linking to the event main page.
+
+         We abuse that information to determine if the added menu is part of an event or not:
+         If we find a website.event.menu item that has the same parent as the menu we just created
+         -> it means that we just created a menu inside an event.
+
+         Once we have identified that, we force its URL to be part of the event pages, and we create
+         a matching website.event.menu record for it. """
+
+        old_menu_ids = [menu['id'] for menu in data['data'] if isinstance(menu['id'], int)]
+        has_new_menus = any(isinstance(menu['id'], str) for menu in data['data'])
+        res = super().save(website_id, data)
+
+        if not has_new_menus:
+            return res
+
+        menus_by_parent_id = {}
+        for menu in data['data']:
+            if menu.get('parent_id') and not menus_by_parent_id.get(menu['parent_id']):
+                menus_by_parent_id[menu['parent_id']] = []
+
+            menus_by_parent_id[menu['parent_id']].append(menu)
+
+        for parent_id, menus in menus_by_parent_id.items():
+            new_menus = filter(lambda menu: menu['id'] not in old_menu_ids, menus)
+            if not new_menus:
+                continue
+
+            parent = self.env['website.menu'].browse(parent_id)
+            while parent.parent_id:  # get the top-most parent to handle sub-menus
+                parent = parent.parent_id
+
+            if parent_event_menu := self.env['website.event.menu'].search([
+                ('menu_id.parent_id', '=', parent.id)
+            ], limit=1):
+                event_url = parent_event_menu.event_id.website_url.rstrip('/')
+                event_menu_values = []
+                for new_menu in new_menus:
+                    menu_record = self.env['website.menu'].browse(new_menu['id'])
+                    menu_record_url = menu_record.url.lstrip("/")
+                    if not menu_record_url or menu_record_url == '#':
+                        # prevent blank URLs, use 't' prefix to avoid slug syntax
+                        menu_record_url = f"t{int(datetime.now().timestamp())}"
+
+                    menu_record.write({
+                        'url': f'{event_url}/page/{menu_record_url}'
+                    })
+                    event_menu_values.append({
+                        'menu_id': menu_record.id,
+                        'event_id': parent_event_menu.event_id.id,
+                        'menu_type': 'community',  # dummy value for required field, adapt in master
+                    })
+
+                # if the current user can create website.menu, then he should be able to
+                # create website.event.menu (e.g: website designer group)
+                self.env['website.event.menu'].sudo().create(event_menu_values)
 
         return res


### PR DESCRIPTION
It is currently not possible to complement your event with custom pages.

This commit makes this possible by allowing to add menu entries and then creating new web pages from there.

Note that this is relatively tricky as it plays with website.menu and website.event.menu relationship to try to determine the context of event page creation.

Additional note: this was requested to be done in stable, meaning we had to take some shortcuts to have stable-compliant code.

Task-3661323
