### PR TITLE
[FIX] pos_self_order: send preparation before payment

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -10,6 +10,10 @@ from werkzeug.exceptions import NotFound, BadRequest, Unauthorized
 class PosSelfOrderController(http.Controller):
     @http.route("/pos-self-order/process-order/<device_type>/", auth="public", type="json", website=True)
     def process_order(self, order, access_token, table_identifier, device_type):
+        return self.process_order_args(order, access_token, table_identifier, device_type, **{})
+
+    @http.route("/pos-self-order/process-order-args/<device_type>/", auth="public", type="json", website=True)
+    def process_order_args(self, order, access_token, table_identifier, device_type, **kwargs):
         is_takeaway = order.get('takeaway')
         pos_config, table = self._verify_authorization(access_token, table_identifier, is_takeaway)
         pos_session = pos_config.current_session_id

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -338,7 +338,7 @@ export class SelfOrder extends Reactive {
             return;
         }
 
-        order = await this.sendDraftOrderToServer();
+        order = await this.sendDraftOrderToServer(paymentMethods.length > 0);
 
         if (!order) {
             return;
@@ -360,7 +360,7 @@ export class SelfOrder extends Reactive {
             // if the order is already saved on the server, we redirect him to the payment page
             // In each mode, we redirect the customer to the payment page directly
             if (payAfter === "meal" && Object.keys(order.changes).length > 0) {
-                await this.sendDraftOrderToServer();
+                await this.sendDraftOrderToServer(paymentMethods.length > 0);
                 this.confirmationPage("order", device, order.access_token);
             } else {
                 this.router.navigate("payment");
@@ -606,7 +606,7 @@ export class SelfOrder extends Reactive {
         }
     }
 
-    async sendDraftOrderToServer() {
+    async sendDraftOrderToServer(to_pay_on_kiosk = false) {
         if (
             Object.keys(this.currentOrder.changes).length === 0 ||
             this.currentOrder.lines.length === 0
@@ -617,11 +617,14 @@ export class SelfOrder extends Reactive {
         try {
             this.currentOrder.recomputeOrderData();
             const data = await rpc(
-                `/pos-self-order/process-order/${this.config.self_ordering_mode}`,
+                `/pos-self-order/process-order-args/${this.config.self_ordering_mode}`,
                 {
                     order: this.currentOrder.serialize({ orm: true }),
                     access_token: this.access_token,
                     table_identifier: this.currentOrder?.table_id?.identifier || false,
+                    context: {
+                        to_pay_on_kiosk,
+                    },
                 }
             );
             const result = this.models.loadData(data);


### PR DESCRIPTION
to reproduce:
=============
- Setup kiosk on POS shop using Stripe or other payment terminal
- Open the Preparation display for the shop and start the kiosk
- When an order is sent to the terminal on the kiosk, the order appears on the prep display immediately before payment is completed

Problem:
========
the issue is introduced when we allowed for he customer to pay on the counter, the order is sent to the preparation display before the payment is completed

Solution:
=========
add a flag in context to tell if payment should be done in kiosk or on the counter

opw-4556029
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
